### PR TITLE
feat(history): harden versioned graph diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha1",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.19",
  "toml 1.1.3+spec-1.1.0",

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -32,6 +32,7 @@ glob.workspace = true
 mimalloc.workspace = true
 regex.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
 compass-core = { path = "../compass-core", version = "0.1.0" }
@@ -53,9 +54,6 @@ compass-query = { path = "../compass-query", version = "0.1.0" }
 compass-reflect = { path = "../compass-reflect", version = "0.1.0" }
 compass-semantic = { path = "../compass-semantic", version = "0.1.0" }
 url.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -25,6 +25,7 @@ pub(crate) struct ParsedBuildCommand {
     pub(crate) revision: String,
     pub(crate) format: String,
     pub(crate) replace_corrupt: bool,
+    pub(crate) profile_from: Option<String>,
     pub(crate) options: HistoryBuildOptions,
 }
 
@@ -513,6 +514,7 @@ pub(crate) fn parse_build_command(
     let mut revision = None;
     let mut format = None;
     let mut replace_corrupt = false;
+    let mut profile_from = None;
     let mut seen = std::collections::BTreeSet::new();
     let mut options = true;
     let mut index = 0;
@@ -550,7 +552,7 @@ pub(crate) fn parse_build_command(
                 }
             }
             "--backend" | "--model" | "--mode" | "--token-budget" | "--resolution"
-            | "--exclude-hubs" | "--format" => {
+            | "--exclude-hubs" | "--format" | "--profile-from" => {
                 if !seen.insert(name.to_owned()) {
                     return Err(format!("duplicate {name}"));
                 }
@@ -564,6 +566,7 @@ pub(crate) fn parse_build_command(
                     "--resolution" => values.resolution = positive_float(name, value)?,
                     "--exclude-hubs" => values.exclude_hubs = Some(finite_float(name, value)?),
                     "--format" => format = Some(value.to_owned()),
+                    "--profile-from" => profile_from = Some(nonempty(name, value)?.to_owned()),
                     _ => unreachable!(),
                 }
             }
@@ -593,11 +596,24 @@ pub(crate) fn parse_build_command(
     if replace_corrupt && command != "rebuild" {
         return Err("--replace-corrupt is only valid for history rebuild".to_owned());
     }
+    if profile_from.is_some() && command != "build" {
+        return Err("--profile-from is only valid for history build".to_owned());
+    }
+    let direct_profile_option = seen.iter().any(|option| {
+        !matches!(
+            option.as_str(),
+            "--format" | "--profile-from" | "--replace-corrupt"
+        )
+    }) || !values.excludes.is_empty();
+    if profile_from.is_some() && direct_profile_option {
+        return Err("--profile-from cannot be combined with build-profile options".to_owned());
+    }
     let options = HistoryBuildOptions::from_values(values).map_err(|error| error.to_string())?;
     Ok(ParsedBuildCommand {
         revision,
         format,
         replace_corrupt,
+        profile_from,
         options,
     })
 }
@@ -944,6 +960,26 @@ mod tests {
         assert_eq!(parsed.revision, "HEAD");
         assert_eq!(parsed.format, "json");
         assert_eq!(parsed.options.profile().value("token_budget"), Some("4096"));
+        let inherited = parse_build_command(
+            "build",
+            &[
+                "HEAD".to_owned(),
+                "--profile-from".to_owned(),
+                "HEAD~1".to_owned(),
+            ],
+        )?;
+        assert_eq!(inherited.profile_from.as_deref(), Some("HEAD~1"));
+        assert!(
+            parse_build_command(
+                "build",
+                &[
+                    "HEAD".to_owned(),
+                    "--profile-from=HEAD~1".to_owned(),
+                    "--cargo".to_owned(),
+                ],
+            )
+            .is_err()
+        );
         assert!(
             parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()]).is_err()
         );

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -1,4 +1,5 @@
-use std::io::Write;
+use std::fs::File;
+use std::io::{Seek, SeekFrom, Write};
 
 use compass_core::LoadedGraph;
 use compass_core::{
@@ -6,9 +7,10 @@ use compass_core::{
     materialize_history_with_observer,
 };
 use compass_history::{
-    ArtifactClass, ChangeKind, ChangeSink, ClaimedJob, CommitId, ExtractionFingerprint,
-    GitTargetLimitation, GraphChange, HistoryConfig, HistoryError, HistoryQueue, HistoryStore,
-    JobRequest, JobState, PublishedVersion, RealizationId, RecordKind, Repository,
+    ArtifactClass, BuildProfile, ChangeKind, ChangeSink, ClaimedJob, CommitId,
+    ExtractionFingerprint, GitTargetLimitation, GraphChange, HistoryConfig, HistoryError,
+    HistoryQueue, HistoryStore, JobRequest, JobState, PublishedVersion, RealizationId, RecordKind,
+    Repository,
 };
 
 use crate::history_build::{HistoryBuildOptions, parse_build_command, parse_enable_options};
@@ -21,7 +23,7 @@ pub(crate) fn help(frontend: Frontend) -> String {
         "graphify"
     };
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  status [REV] [--format text|json]\n  build REV [build-profile options] [--format text|json]\n  rebuild REV [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|graphify-out --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  status [REV] [--format text|json]\n  build REV [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|graphify-out --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]"
     )
 }
 
@@ -51,7 +53,11 @@ pub(crate) fn diff_help(frontend: Frontend) -> String {
         Frontend::Compass => "compass",
         Frontend::Graphify => "graphify",
     };
-    format!("Usage: {prefix} diff OLD NEW [--detailed|--format text|json] [--topology-only]")
+    format!(
+        "Usage: {prefix} diff OLD NEW [--detailed] [--format text|json] [--topology-only] \
+[--include-locations] [--include-analysis] [--include-metadata] [--fingerprint SHA] \
+[--allow-profile-mismatch]"
+    )
 }
 
 pub(crate) fn load_graph_at(
@@ -65,7 +71,7 @@ pub(crate) fn load_graph_at(
     let commit = repository
         .resolve(revision)
         .map_err(|error| error.to_string())?;
-    let options = HistoryBuildOptions::defaults().map_err(|error| error.to_string())?;
+    let options = configured_build_options(&repository)?;
     let (history, preferred) = resolve_or_materialize(&repository, commit, &options, false, false)?;
     let activity = history.activity().map_err(|error| error.to_string())?;
     // `artifacts` performs full realization validation before reconstruction.
@@ -83,6 +89,19 @@ fn resolve_or_materialize(
     rebuild: bool,
     replace_corrupt: bool,
 ) -> Result<(HistoryStore, PublishedVersion), String> {
+    let existing = HistoryStore::open_existing(repository).map_err(|error| error.to_string())?;
+    if !rebuild && let Some(history) = existing {
+        match history.preferred(&commit) {
+            Ok(Some(preferred)) => {
+                history
+                    .validate(&preferred.id)
+                    .map_err(|error| error.to_string())?;
+                return Ok((history, preferred));
+            }
+            Ok(None) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+    }
     let history =
         match HistoryStore::open_existing(repository).map_err(|error| error.to_string())? {
             Some(history) => history,
@@ -149,14 +168,27 @@ fn resolve_or_materialize(
     }
 }
 
+fn configured_build_options(repository: &Repository) -> Result<HistoryBuildOptions, String> {
+    let config = HistoryConfig::load(repository).map_err(|error| error.to_string())?;
+    if config.enabled
+        && let Some(profile) = config.profile
+    {
+        return HistoryBuildOptions::from_profile(profile).map_err(|error| error.to_string());
+    }
+    HistoryBuildOptions::defaults().map_err(|error| error.to_string())
+}
+
 pub(crate) fn command_diff(frontend: Frontend, args: &[String]) -> Outcome {
     let mut bytes = Vec::new();
-    let result = command_diff_to_writer(frontend, args, &mut bytes);
+    let mut result = command_diff_to_writer(frontend, args, &mut bytes);
     if result.code != 0 {
         return result;
     }
     match String::from_utf8(bytes) {
-        Ok(stdout) => Outcome::success_exact(stdout),
+        Ok(stdout) => {
+            result.stdout = stdout;
+            result
+        }
         Err(error) => Outcome::failure(format!("error: diff output was not UTF-8: {error}")),
     }
 }
@@ -175,7 +207,20 @@ pub(crate) fn command_diff_to_writer(
             Err(error) => outcome(Err(runtime(output_error(error)))),
         };
     }
-    outcome(execute_diff(frontend, args, writer).map(|()| String::new()))
+    match execute_diff(frontend, args, writer) {
+        Ok(execution) => Outcome {
+            code: 0,
+            stdout: String::new(),
+            stderr: execution.warning.unwrap_or_default(),
+            stdout_trailing_newline: false,
+            stderr_trailing_newline: true,
+        },
+        Err(error) => outcome(Err(error)),
+    }
+}
+
+struct DiffExecution {
+    warning: Option<String>,
 }
 
 fn outcome(result: Result<String, CommandFailure>) -> Outcome {
@@ -206,29 +251,160 @@ enum DiffOutput {
     Json,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct DiffOptions {
     output: DiffOutput,
     topology_only: bool,
+    include_locations: bool,
+    include_analysis: bool,
+    include_metadata: bool,
+    fingerprint: Option<String>,
+    allow_profile_mismatch: bool,
 }
 
 fn execute_diff(
     _frontend: Frontend,
     args: &[String],
     writer: &mut dyn Write,
-) -> Result<(), CommandFailure> {
+) -> Result<DiffExecution, CommandFailure> {
     let (revisions, diff_options) = parse_diff(args).map_err(usage)?;
     let repository =
         Repository::discover(&std::env::current_dir().map_err(runtime)?).map_err(runtime)?;
     let old_commit = repository.resolve(&revisions[0]).map_err(runtime)?;
     let new_commit = repository.resolve(&revisions[1]).map_err(runtime)?;
-    let build_options = HistoryBuildOptions::defaults().map_err(runtime)?;
-    let (_, old) = resolve_or_materialize(&repository, old_commit, &build_options, false, false)
-        .map_err(runtime)?;
-    let (history, new) =
-        resolve_or_materialize(&repository, new_commit, &build_options, false, false)
-            .map_err(runtime)?;
-    render_diff(&history, &old.id, &new.id, diff_options, writer).map_err(runtime)
+    let resolved = resolve_comparable_pair(
+        &repository,
+        old_commit,
+        new_commit,
+        diff_options.fingerprint.as_deref(),
+        diff_options.allow_profile_mismatch,
+    )
+    .map_err(runtime)?;
+    render_diff(
+        &resolved.history,
+        &resolved.old,
+        &resolved.new,
+        resolved.profile_mismatch,
+        &diff_options,
+        writer,
+    )
+    .map_err(runtime)?;
+    Ok(DiffExecution {
+        warning: (resolved.profile_mismatch && diff_options.output != DiffOutput::Json).then(|| {
+            format!(
+                "warning: comparing realizations with different extraction fingerprints ({} != {}); results may reflect profile differences",
+                resolved.old.version.extraction_fingerprint,
+                resolved.new.version.extraction_fingerprint
+            )
+        }),
+    })
+}
+
+struct ResolvedDiff {
+    history: HistoryStore,
+    old: PublishedVersion,
+    new: PublishedVersion,
+    profile_mismatch: bool,
+}
+
+fn resolve_comparable_pair(
+    repository: &Repository,
+    old_commit: CommitId,
+    new_commit: CommitId,
+    required_fingerprint: Option<&str>,
+    allow_profile_mismatch: bool,
+) -> Result<ResolvedDiff, String> {
+    let existing = HistoryStore::open_existing(repository).map_err(|error| error.to_string())?;
+    let old = select_existing(existing.as_ref(), &old_commit, required_fingerprint)?;
+    let new = select_existing(existing.as_ref(), &new_commit, required_fingerprint)?;
+    if required_fingerprint.is_some() && (old.is_none() || new.is_none()) {
+        return Err("the requested fingerprint is not materialized at both commits".to_owned());
+    }
+
+    let (history, old, new) = match (old, new) {
+        (Some(old), Some(new)) => (
+            existing.ok_or_else(|| "history store disappeared".to_owned())?,
+            old,
+            new,
+        ),
+        (Some(old), None) => {
+            let options = HistoryBuildOptions::from_profile(old.version.build_profile.clone())
+                .map_err(|error| error.to_string())?;
+            let (history, new) =
+                resolve_or_materialize(repository, new_commit, &options, false, false)?;
+            (history, old, new)
+        }
+        (None, Some(new)) => {
+            let options = HistoryBuildOptions::from_profile(new.version.build_profile.clone())
+                .map_err(|error| error.to_string())?;
+            let (history, old) =
+                resolve_or_materialize(repository, old_commit, &options, false, false)?;
+            (history, old, new)
+        }
+        (None, None) => {
+            let options = configured_build_options(repository)?;
+            let (_, old) = resolve_or_materialize(repository, old_commit, &options, false, false)?;
+            let (history, new) =
+                resolve_or_materialize(repository, new_commit, &options, false, false)?;
+            (history, old, new)
+        }
+    };
+    let profile_mismatch = old.version.extraction_fingerprint != new.version.extraction_fingerprint;
+    if profile_mismatch && !allow_profile_mismatch {
+        return Err(format!(
+            "realizations are not semantically comparable\n\nOLD {} ({}) fingerprint: {}\nNEW {} ({}) fingerprint: {}\n\nBuild a comparable realization:\n  compass history build {} --profile-from {}\n\nOr inspect intentionally:\n  compass diff {} {} --allow-profile-mismatch",
+            old.version.git_commit,
+            old.id,
+            old.version.extraction_fingerprint,
+            new.version.git_commit,
+            new.id,
+            new.version.extraction_fingerprint,
+            new.version.git_commit,
+            old.version.git_commit,
+            old.version.git_commit,
+            new.version.git_commit,
+        ));
+    }
+    Ok(ResolvedDiff {
+        history,
+        old,
+        new,
+        profile_mismatch,
+    })
+}
+
+fn select_existing(
+    history: Option<&HistoryStore>,
+    commit: &CommitId,
+    required_fingerprint: Option<&str>,
+) -> Result<Option<PublishedVersion>, String> {
+    let Some(history) = history else {
+        return Ok(None);
+    };
+    let selected = if let Some(fingerprint) = required_fingerprint {
+        let mut matches = history
+            .list(Some(commit))
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|version| version.version.extraction_fingerprint == fingerprint)
+            .collect::<Vec<_>>();
+        if matches.len() > 1 {
+            return Err(format!(
+                "multiple realizations at {commit} have fingerprint {fingerprint}"
+            ));
+        }
+        matches.pop()
+    } else {
+        history
+            .preferred(commit)
+            .map_err(|error| error.to_string())?
+    };
+    if let Some(selected) = &selected {
+        history
+            .validate(&selected.id)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(selected)
 }
 
 fn parse_diff(args: &[String]) -> Result<(Vec<String>, DiffOptions), String> {
@@ -236,6 +412,11 @@ fn parse_diff(args: &[String]) -> Result<(Vec<String>, DiffOptions), String> {
     let mut format = None;
     let mut detailed = false;
     let mut topology_only = false;
+    let mut include_locations = false;
+    let mut include_analysis = false;
+    let mut include_metadata = false;
+    let mut fingerprint = None;
+    let mut allow_profile_mismatch = false;
     let mut options = true;
     let mut index = 0;
     while index < args.len() {
@@ -252,6 +433,46 @@ fn parse_diff(args: &[String]) -> Result<(Vec<String>, DiffOptions), String> {
                     return Err("duplicate --topology-only".to_owned());
                 }
                 topology_only = true;
+            }
+            "--include-locations" if options => {
+                if include_locations {
+                    return Err("duplicate --include-locations".to_owned());
+                }
+                include_locations = true;
+            }
+            "--include-analysis" if options => {
+                if include_analysis {
+                    return Err("duplicate --include-analysis".to_owned());
+                }
+                include_analysis = true;
+            }
+            "--include-metadata" if options => {
+                if include_metadata {
+                    return Err("duplicate --include-metadata".to_owned());
+                }
+                include_metadata = true;
+            }
+            "--allow-profile-mismatch" if options => {
+                if allow_profile_mismatch {
+                    return Err("duplicate --allow-profile-mismatch".to_owned());
+                }
+                allow_profile_mismatch = true;
+            }
+            "--fingerprint" if options => {
+                index += 1;
+                let value = args.get(index).ok_or("--fingerprint requires a value")?;
+                if fingerprint.replace(value.clone()).is_some() {
+                    return Err("duplicate --fingerprint".to_owned());
+                }
+            }
+            value if options && value.starts_with("--fingerprint=") => {
+                let value = &value[14..];
+                if value.is_empty() {
+                    return Err("--fingerprint requires a value".to_owned());
+                }
+                if fingerprint.replace(value.to_owned()).is_some() {
+                    return Err("duplicate --fingerprint".to_owned());
+                }
             }
             "--format" if options => {
                 index += 1;
@@ -286,6 +507,14 @@ fn parse_diff(args: &[String]) -> Result<(Vec<String>, DiffOptions), String> {
     if detailed && format == "json" {
         return Err("--detailed cannot be combined with --format json".to_owned());
     }
+    if let Some(value) = &fingerprint {
+        value
+            .parse::<ExtractionFingerprint>()
+            .map_err(|_| "--fingerprint must be a lowercase SHA-256 digest".to_owned())?;
+    }
+    if fingerprint.is_some() && allow_profile_mismatch {
+        return Err("--fingerprint cannot be combined with --allow-profile-mismatch".to_owned());
+    }
     Ok((
         revisions,
         DiffOptions {
@@ -297,155 +526,258 @@ fn parse_diff(args: &[String]) -> Result<(Vec<String>, DiffOptions), String> {
                 DiffOutput::Summary
             },
             topology_only,
+            include_locations,
+            include_analysis,
+            include_metadata,
+            fingerprint,
+            allow_profile_mismatch,
         },
     ))
 }
 
 fn render_diff(
     history: &HistoryStore,
-    old: &RealizationId,
-    new: &RealizationId,
-    options: DiffOptions,
+    old: &PublishedVersion,
+    new: &PublishedVersion,
+    profile_mismatch: bool,
+    options: &DiffOptions,
     writer: &mut dyn Write,
 ) -> Result<(), HistoryError> {
     match options.output {
-        DiffOutput::Summary => {
-            let mut sink = SummarySink::new(options.topology_only);
-            history.diff(old, new, &mut sink)?;
-            sink.render(writer)
-        }
-        DiffOutput::Detailed => {
-            let mut sink = DetailedSink::new(writer, options.topology_only);
-            history.diff(old, new, &mut sink)?;
-            sink.finish()
+        DiffOutput::Summary | DiffOutput::Detailed => {
+            let mut sink = TextSink::new(options)?;
+            history.diff(&old.id, &new.id, &mut sink)?;
+            sink.finish(writer)
         }
         DiffOutput::Json => {
-            writer.write_all(b"[").map_err(output_error)?;
+            writer
+                .write_all(b"{\"schema_version\":2,\"comparison\":")
+                .map_err(output_error)?;
+            serde_json::to_writer(
+                &mut *writer,
+                &serde_json::json!({
+                    "old_commit": old.version.git_commit,
+                    "new_commit": new.version.git_commit,
+                    "old_realization": old.id,
+                    "new_realization": new.id,
+                    "old_fingerprint": old.version.extraction_fingerprint,
+                    "new_fingerprint": new.version.extraction_fingerprint,
+                    "profile_mismatch": profile_mismatch,
+                }),
+            )
+            .map_err(json_output_error)?;
+            writer.write_all(b",\"changes\":[").map_err(output_error)?;
             let mut sink = JsonSink::new(writer, options.topology_only);
-            history.diff(old, new, &mut sink)?;
+            history.diff(&old.id, &new.id, &mut sink)?;
             sink.finish()
         }
     }
 }
 
-#[derive(Default)]
-struct SummaryCell {
-    count: u64,
-    examples: Vec<String>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChangeCategory {
+    Semantic,
+    Textual,
+    Location,
+    Analysis,
+    Metadata,
 }
 
-struct SummarySink {
-    cells: Vec<SummaryCell>,
-    topology_only: bool,
-}
-
-impl SummarySink {
-    fn new(topology_only: bool) -> Self {
-        Self {
-            cells: (0..15).map(|_| SummaryCell::default()).collect(),
-            topology_only,
+impl ChangeCategory {
+    fn index(self) -> usize {
+        match self {
+            Self::Semantic => 0,
+            Self::Textual => 1,
+            Self::Location => 2,
+            Self::Analysis => 3,
+            Self::Metadata => 4,
         }
     }
 
-    fn render(&self, writer: &mut dyn Write) -> Result<(), HistoryError> {
-        if self.cells.iter().all(|cell| cell.count == 0) {
-            return writer
-                .write_all(b"no graph changes\n")
-                .map_err(output_error);
+    fn name(self) -> &'static str {
+        match self {
+            Self::Semantic => "semantic",
+            Self::Textual => "textual",
+            Self::Location => "location",
+            Self::Analysis => "analysis",
+            Self::Metadata => "metadata",
         }
-        for record in RECORD_ORDER {
-            for change in CHANGE_ORDER {
-                let cell = &self.cells[summary_index(record, change)];
-                if cell.count == 0 {
-                    continue;
+    }
+
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Semantic => "Semantic graph changes",
+            Self::Textual => "Textual changes",
+            Self::Location => "Location changes",
+            Self::Analysis => "Analysis changes",
+            Self::Metadata => "Metadata changes",
+        }
+    }
+}
+
+const CATEGORY_ORDER: [ChangeCategory; 5] = [
+    ChangeCategory::Semantic,
+    ChangeCategory::Textual,
+    ChangeCategory::Analysis,
+    ChangeCategory::Location,
+    ChangeCategory::Metadata,
+];
+
+struct TextSink {
+    counts: [[u64; 15]; 5],
+    examples: Vec<Vec<String>>,
+    details: Vec<File>,
+    output: DiffOutput,
+    topology_only: bool,
+    include_locations: bool,
+    include_analysis: bool,
+    include_metadata: bool,
+}
+
+impl TextSink {
+    fn new(options: &DiffOptions) -> Result<Self, HistoryError> {
+        let mut details = Vec::with_capacity(5);
+        for _ in 0..5 {
+            details.push(tempfile::tempfile().map_err(output_error)?);
+        }
+        Ok(Self {
+            counts: [[0; 15]; 5],
+            examples: (0..75).map(|_| Vec::new()).collect(),
+            details,
+            output: options.output,
+            topology_only: options.topology_only,
+            include_locations: options.include_locations,
+            include_analysis: options.include_analysis,
+            include_metadata: options.include_metadata,
+        })
+    }
+
+    fn expanded(&self, category: ChangeCategory) -> bool {
+        match category {
+            ChangeCategory::Semantic | ChangeCategory::Textual => {
+                self.output == DiffOutput::Detailed
+            }
+            ChangeCategory::Location => self.include_locations,
+            ChangeCategory::Analysis => self.include_analysis,
+            ChangeCategory::Metadata => self.include_metadata,
+        }
+    }
+
+    fn finish(&mut self, writer: &mut dyn Write) -> Result<(), HistoryError> {
+        let total = self.counts.iter().flatten().copied().sum::<u64>();
+        if total == 0 {
+            let message = if self.topology_only {
+                b"no topology changes\n".as_slice()
+            } else {
+                b"no graph changes\n".as_slice()
+            };
+            return writer.write_all(message).map_err(output_error);
+        }
+        let mut first_section = true;
+        for category in CATEGORY_ORDER {
+            let category_counts = &self.counts[category.index()];
+            let category_total = category_counts.iter().copied().sum::<u64>();
+            if category_total == 0 {
+                continue;
+            }
+            if !first_section {
+                writer.write_all(b"\n").map_err(output_error)?;
+            }
+            first_section = false;
+            writeln!(writer, "{}", category.heading()).map_err(output_error)?;
+            for record in RECORD_ORDER {
+                for change in CHANGE_ORDER {
+                    let index = summary_index(record, change);
+                    let count = category_counts[index];
+                    if count == 0 {
+                        continue;
+                    }
+                    writeln!(
+                        writer,
+                        "  {count} {} {}",
+                        record_name(record, count),
+                        change_name(change)
+                    )
+                    .map_err(output_error)?;
+                    if !self.expanded(category)
+                        && matches!(category, ChangeCategory::Semantic | ChangeCategory::Textual)
+                    {
+                        for example in &self.examples[category.index() * 15 + index] {
+                            writeln!(writer, "    {example}").map_err(output_error)?;
+                        }
+                    }
                 }
+            }
+            if self.expanded(category) {
+                let detail = &mut self.details[category.index()];
+                detail.seek(SeekFrom::Start(0)).map_err(output_error)?;
+                std::io::copy(detail, writer).map_err(output_error)?;
+            } else if matches!(
+                category,
+                ChangeCategory::Location | ChangeCategory::Analysis | ChangeCategory::Metadata
+            ) {
                 writeln!(
                     writer,
-                    "{} {} {}",
-                    cell.count,
-                    record_name(record, cell.count),
-                    change_name(change)
+                    "  (collapsed; use --include-{} to expand)",
+                    match category {
+                        ChangeCategory::Location => "locations",
+                        ChangeCategory::Analysis => "analysis",
+                        ChangeCategory::Metadata => "metadata",
+                        _ => unreachable!(),
+                    }
                 )
                 .map_err(output_error)?;
-                for example in &cell.examples {
-                    writeln!(writer, "  {example}").map_err(output_error)?;
-                }
             }
         }
         Ok(())
     }
 }
 
-impl ChangeSink for SummarySink {
+impl ChangeSink for TextSink {
     fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
-        if excluded(change.record, self.topology_only) {
+        if topology_excluded(&change, self.topology_only) {
             return Ok(());
         }
-        let cell = &mut self.cells[summary_index(change.record, change.change)];
-        cell.count = cell.count.saturating_add(1);
-        if cell.examples.len() < 20 {
-            cell.examples.push(change.key.join("/"));
+        let category = classify_change(&change);
+        let index = summary_index(change.record, change.change);
+        self.counts[category.index()][index] =
+            self.counts[category.index()][index].saturating_add(1);
+        let examples = &mut self.examples[category.index() * 15 + index];
+        if examples.len() < 20 {
+            examples.push(change.key.join("/"));
+        }
+        if self.expanded(category) {
+            write_change_line(&mut self.details[category.index()], &change)?;
         }
         Ok(())
     }
 }
 
-struct DetailedSink<'a> {
-    writer: &'a mut dyn Write,
-    topology_only: bool,
-    count: u64,
-}
-
-impl<'a> DetailedSink<'a> {
-    fn new(writer: &'a mut dyn Write, topology_only: bool) -> Self {
-        Self {
-            writer,
-            topology_only,
-            count: 0,
-        }
+fn write_change_line(writer: &mut dyn Write, change: &GraphChange) -> Result<(), HistoryError> {
+    write!(
+        writer,
+        "  {} {} {}",
+        record_name(change.record, 1),
+        change_name(change.change),
+        change.key.join("/")
+    )
+    .map_err(output_error)?;
+    if let Some(old) = &change.old {
+        writer.write_all(b"\told=").map_err(output_error)?;
+        serde_json::to_writer(&mut *writer, old).map_err(json_output_error)?;
     }
-
-    fn finish(&mut self) -> Result<(), HistoryError> {
-        if self.count == 0 {
-            self.writer
-                .write_all(b"no graph changes\n")
-                .map_err(output_error)?;
-        }
-        Ok(())
+    if let Some(new) = &change.new {
+        writer.write_all(b"\tnew=").map_err(output_error)?;
+        serde_json::to_writer(&mut *writer, new).map_err(json_output_error)?;
     }
-}
-
-impl ChangeSink for DetailedSink<'_> {
-    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
-        if excluded(change.record, self.topology_only) {
-            return Ok(());
-        }
-        write!(
-            self.writer,
-            "{} {} {}",
-            record_name(change.record, 1),
-            change_name(change.change),
-            change.key.join("/")
-        )
-        .map_err(output_error)?;
-        if let Some(old) = &change.old {
-            self.writer.write_all(b"\told=").map_err(output_error)?;
-            serde_json::to_writer(&mut *self.writer, old).map_err(json_output_error)?;
-        }
-        if let Some(new) = &change.new {
-            self.writer.write_all(b"\tnew=").map_err(output_error)?;
-            serde_json::to_writer(&mut *self.writer, new).map_err(json_output_error)?;
-        }
-        self.writer.write_all(b"\n").map_err(output_error)?;
-        self.count = self.count.saturating_add(1);
-        Ok(())
-    }
+    writer.write_all(b"\n").map_err(output_error)
 }
 
 struct JsonSink<'a> {
     writer: &'a mut dyn Write,
     topology_only: bool,
     first: bool,
+    summary: [u64; 5],
 }
 
 impl<'a> JsonSink<'a> {
@@ -454,25 +786,59 @@ impl<'a> JsonSink<'a> {
             writer,
             topology_only,
             first: true,
+            summary: [0; 5],
         }
     }
 
     fn finish(&mut self) -> Result<(), HistoryError> {
-        self.writer.write_all(b"]\n").map_err(output_error)
+        writeln!(
+            self.writer,
+            "],\"summary\":{{\"semantic\":{},\"textual\":{},\"location\":{},\"analysis\":{},\"metadata\":{}}}}}",
+            self.summary[ChangeCategory::Semantic.index()],
+            self.summary[ChangeCategory::Textual.index()],
+            self.summary[ChangeCategory::Location.index()],
+            self.summary[ChangeCategory::Analysis.index()],
+            self.summary[ChangeCategory::Metadata.index()],
+        )
+        .map_err(output_error)
     }
 }
 
 impl ChangeSink for JsonSink<'_> {
     fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
-        if excluded(change.record, self.topology_only) {
+        if topology_excluded(&change, self.topology_only) {
             return Ok(());
         }
+        let category = classify_change(&change);
+        self.summary[category.index()] = self.summary[category.index()].saturating_add(1);
         if self.first {
             self.first = false;
         } else {
             self.writer.write_all(b",").map_err(output_error)?;
         }
-        serde_json::to_writer(&mut *self.writer, &change).map_err(json_output_error)
+        self.writer
+            .write_all(b"{\"category\":")
+            .map_err(output_error)?;
+        serde_json::to_writer(&mut *self.writer, category.name()).map_err(json_output_error)?;
+        self.writer
+            .write_all(b",\"record\":")
+            .map_err(output_error)?;
+        serde_json::to_writer(&mut *self.writer, &change.record).map_err(json_output_error)?;
+        self.writer
+            .write_all(b",\"change\":")
+            .map_err(output_error)?;
+        serde_json::to_writer(&mut *self.writer, &change.change).map_err(json_output_error)?;
+        self.writer.write_all(b",\"key\":").map_err(output_error)?;
+        serde_json::to_writer(&mut *self.writer, &change.key).map_err(json_output_error)?;
+        if let Some(old) = &change.old {
+            self.writer.write_all(b",\"old\":").map_err(output_error)?;
+            serde_json::to_writer(&mut *self.writer, old).map_err(json_output_error)?;
+        }
+        if let Some(new) = &change.new {
+            self.writer.write_all(b",\"new\":").map_err(output_error)?;
+            serde_json::to_writer(&mut *self.writer, new).map_err(json_output_error)?;
+        }
+        self.writer.write_all(b"}").map_err(output_error)
     }
 }
 
@@ -501,8 +867,93 @@ fn summary_index(record: RecordKind, change: ChangeKind) -> usize {
     record * 3 + change
 }
 
-fn excluded(record: RecordKind, topology_only: bool) -> bool {
-    topology_only && matches!(record, RecordKind::Analysis | RecordKind::Metadata)
+fn classify_change(change: &GraphChange) -> ChangeCategory {
+    match change.record {
+        RecordKind::Analysis => return ChangeCategory::Analysis,
+        RecordKind::Metadata => return ChangeCategory::Metadata,
+        RecordKind::Node | RecordKind::Edge | RecordKind::Hyperedge => {}
+    }
+    if change.change != ChangeKind::Changed {
+        return ChangeCategory::Semantic;
+    }
+    let (Some(old), Some(new)) = (&change.old, &change.new) else {
+        return ChangeCategory::Semantic;
+    };
+    if equal_without_location(old, new) {
+        return ChangeCategory::Location;
+    }
+    if exact_source_only_changed(old, new) {
+        return ChangeCategory::Textual;
+    }
+    ChangeCategory::Semantic
+}
+
+fn equal_without_location(old: &serde_json::Value, new: &serde_json::Value) -> bool {
+    stripped(old, StripMode::Location) == stripped(new, StripMode::Location)
+}
+
+fn exact_source_only_changed(old: &serde_json::Value, new: &serde_json::Value) -> bool {
+    let old_source = old.get("source_hash");
+    let new_source = new.get("source_hash");
+    if old_source.is_none() || new_source.is_none() || old_source == new_source {
+        return false;
+    }
+    if old.get("signature_hash") != new.get("signature_hash")
+        || old.get("implementation_hash") != new.get("implementation_hash")
+    {
+        return false;
+    }
+    stripped(old, StripMode::LocationAndSourceHash)
+        == stripped(new, StripMode::LocationAndSourceHash)
+}
+
+#[derive(Clone, Copy)]
+enum StripMode {
+    Location,
+    LocationAndSourceHash,
+}
+
+fn stripped(value: &serde_json::Value, mode: StripMode) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.iter()
+                .filter(|(key, _)| {
+                    !location_field(key)
+                        && !(matches!(mode, StripMode::LocationAndSourceHash)
+                            && key.as_str() == "source_hash")
+                })
+                .map(|(key, value)| (key.clone(), stripped(value, mode)))
+                .collect(),
+        ),
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.iter().map(|value| stripped(value, mode)).collect())
+        }
+        value => value.clone(),
+    }
+}
+
+fn location_field(key: &str) -> bool {
+    matches!(
+        key,
+        "source_file"
+            | "source_location"
+            | "location"
+            | "span"
+            | "line"
+            | "column"
+            | "start_line"
+            | "start_column"
+            | "end_line"
+            | "end_column"
+            | "start_position"
+            | "end_position"
+    )
+}
+
+fn topology_excluded(change: &GraphChange, topology_only: bool) -> bool {
+    topology_only
+        && (change.change == ChangeKind::Changed
+            || !matches!(change.record, RecordKind::Node | RecordKind::Edge))
 }
 
 fn record_name(record: RecordKind, count: u64) -> &'static str {
@@ -830,7 +1281,7 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
             exact(&positionals, 1, "export requires REV")?;
             let output = output.ok_or_else(|| usage("export requires --output PATH"))?;
             let commit = repository.resolve(&positionals[0]).map_err(runtime)?;
-            let build_options = HistoryBuildOptions::defaults().map_err(runtime)?;
+            let build_options = configured_build_options(&repository).map_err(runtime)?;
             let (history, preferred) =
                 resolve_or_materialize(&repository, commit, &build_options, false, false)
                     .map_err(runtime)?;
@@ -1204,11 +1655,28 @@ fn execute_build(
 ) -> Result<String, CommandFailure> {
     let parsed = parse_build_command(command, args).map_err(usage)?;
     let commit = repository.resolve(&parsed.revision).map_err(runtime)?;
+    let options = if let Some(source) = &parsed.profile_from {
+        HistoryBuildOptions::from_profile(stored_profile(repository, source).map_err(runtime)?)
+            .map_err(runtime)?
+    } else {
+        parsed.options
+    };
+    let profile_rebuild = if parsed.profile_from.is_some() {
+        match HistoryStore::open_existing(repository).map_err(runtime)? {
+            Some(history) => history
+                .preferred(&commit)
+                .map_err(runtime)?
+                .is_some_and(|preferred| preferred.version.build_profile != options.profile()),
+            None => false,
+        }
+    } else {
+        false
+    };
     let (_history, published) = resolve_or_materialize(
         repository,
         commit,
-        &parsed.options,
-        command == "rebuild",
+        &options,
+        command == "rebuild" || profile_rebuild,
         parsed.replace_corrupt,
     )
     .map_err(runtime)?;
@@ -1239,6 +1707,30 @@ fn execute_build(
             published.preferred
         ))
     }
+}
+
+fn stored_profile(repository: &Repository, source: &str) -> Result<BuildProfile, String> {
+    let history = HistoryStore::open_existing(repository)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "no graph history is materialized".to_owned())?;
+    if let Ok(commit) = repository.resolve(source) {
+        let version = history
+            .preferred(&commit)
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| format!("no preferred realization exists for {source}"))?;
+        history
+            .validate(&version.id)
+            .map_err(|error| error.to_string())?;
+        return Ok(version.version.build_profile);
+    }
+    let id = source
+        .parse::<RealizationId>()
+        .map_err(|_| format!("--profile-from must name a revision or realization, got {source}"))?;
+    let version = history.get(&id).map_err(|error| error.to_string())?;
+    history
+        .validate(&version.id)
+        .map_err(|error| error.to_string())?;
+    Ok(version.version.build_profile)
 }
 
 fn parse(args: &[String]) -> Result<(Vec<String>, String, Option<std::path::PathBuf>), String> {
@@ -1390,6 +1882,32 @@ mod tests {
         assert_eq!(revisions, ["old", "new"]);
         assert_eq!(options.output, DiffOutput::Json);
         assert!(options.topology_only);
+        let fingerprint = "a".repeat(64);
+        let parsed = parse_diff(&[
+            "old".to_owned(),
+            "new".to_owned(),
+            "--include-locations".to_owned(),
+            "--include-analysis".to_owned(),
+            "--include-metadata".to_owned(),
+            format!("--fingerprint={fingerprint}"),
+        ]);
+        let Ok(parsed) = parsed else {
+            assert!(parsed.is_ok());
+            return;
+        };
+        assert!(parsed.1.include_locations);
+        assert!(parsed.1.include_analysis);
+        assert!(parsed.1.include_metadata);
+        assert_eq!(parsed.1.fingerprint.as_deref(), Some(fingerprint.as_str()));
+        assert!(
+            parse_diff(&[
+                "old".to_owned(),
+                "new".to_owned(),
+                format!("--fingerprint={fingerprint}"),
+                "--allow-profile-mismatch".to_owned(),
+            ])
+            .is_err()
+        );
         assert!(
             parse_diff(&[
                 "old".to_owned(),
@@ -1424,6 +1942,48 @@ mod tests {
         assert_eq!(
             parsed.map(|value| value.0),
             Ok(vec!["-old".to_owned(), "-new".to_owned()])
+        );
+    }
+
+    #[test]
+    fn graph_changes_are_classified_by_meaning_before_location_churn() {
+        let location = change(
+            RecordKind::Node,
+            ChangeKind::Changed,
+            Some(json!({"id":"n","implementation_hash":"a","source_location":"L1"})),
+            Some(json!({"id":"n","implementation_hash":"a","source_location":"L9"})),
+        );
+        assert_eq!(classify_change(&location), ChangeCategory::Location);
+
+        let textual = change(
+            RecordKind::Node,
+            ChangeKind::Changed,
+            Some(json!({
+                "id":"n","signature_hash":"s","implementation_hash":"i",
+                "source_hash":"old","source_location":"L1"
+            })),
+            Some(json!({
+                "id":"n","signature_hash":"s","implementation_hash":"i",
+                "source_hash":"new","source_location":"L2"
+            })),
+        );
+        assert_eq!(classify_change(&textual), ChangeCategory::Textual);
+
+        let semantic = change(
+            RecordKind::Node,
+            ChangeKind::Changed,
+            Some(json!({"id":"n","implementation_hash":"old","source_hash":"old"})),
+            Some(json!({"id":"n","implementation_hash":"new","source_hash":"new"})),
+        );
+        assert_eq!(classify_change(&semantic), ChangeCategory::Semantic);
+        assert_eq!(
+            classify_change(&change(
+                RecordKind::Analysis,
+                ChangeKind::Added,
+                None,
+                Some(json!({"community":1})),
+            )),
+            ChangeCategory::Analysis
         );
     }
 
@@ -1473,7 +2033,16 @@ mod tests {
             RecordKind::Metadata,
         ];
         let changes = [ChangeKind::Added, ChangeKind::Removed, ChangeKind::Changed];
-        let mut summary = SummarySink::new(false);
+        let summary_options = DiffOptions {
+            output: DiffOutput::Summary,
+            topology_only: false,
+            include_locations: false,
+            include_analysis: false,
+            include_metadata: false,
+            fingerprint: None,
+            allow_profile_mismatch: false,
+        };
+        let mut summary = TextSink::new(&summary_options)?;
         for record in records {
             for kind in changes {
                 summary.change(change(record, kind, None, None))?;
@@ -1489,7 +2058,7 @@ mod tests {
             })?;
         }
         let mut rendered = Vec::new();
-        summary.render(&mut rendered)?;
+        summary.finish(&mut rendered)?;
         let rendered = String::from_utf8(rendered)?;
         assert!(rendered.contains("26 nodes added"));
         assert!(rendered.contains("analysis record"));
@@ -1504,9 +2073,13 @@ mod tests {
         }
 
         let mut empty = Vec::new();
-        SummarySink::new(true).render(&mut empty)?;
-        assert_eq!(empty, b"no graph changes\n");
-        let mut topology = SummarySink::new(true);
+        let topology_options = DiffOptions {
+            topology_only: true,
+            ..summary_options.clone()
+        };
+        TextSink::new(&topology_options)?.finish(&mut empty)?;
+        assert_eq!(empty, b"no topology changes\n");
+        let mut topology = TextSink::new(&topology_options)?;
         topology.change(change(
             RecordKind::Analysis,
             ChangeKind::Changed,
@@ -1514,11 +2087,15 @@ mod tests {
             None,
         ))?;
         let mut filtered = Vec::new();
-        topology.render(&mut filtered)?;
-        assert_eq!(filtered, b"no graph changes\n");
+        topology.finish(&mut filtered)?;
+        assert_eq!(filtered, b"no topology changes\n");
 
         let mut detailed_bytes = Vec::new();
-        let mut detailed = DetailedSink::new(&mut detailed_bytes, false);
+        let detailed_options = DiffOptions {
+            output: DiffOutput::Detailed,
+            ..summary_options.clone()
+        };
+        let mut detailed = TextSink::new(&detailed_options)?;
         detailed.change(change(
             RecordKind::Edge,
             ChangeKind::Changed,
@@ -1526,14 +2103,14 @@ mod tests {
             Some(json!({"confidence": 0.9})),
         ))?;
         detailed.change(change(RecordKind::Node, ChangeKind::Added, None, None))?;
-        detailed.finish()?;
+        detailed.finish(&mut detailed_bytes)?;
         assert!(String::from_utf8(detailed_bytes)?.contains("old="));
 
         let mut no_details = Vec::new();
-        DetailedSink::new(&mut no_details, true).finish()?;
-        assert_eq!(no_details, b"no graph changes\n");
+        TextSink::new(&topology_options)?.finish(&mut no_details)?;
+        assert_eq!(no_details, b"no topology changes\n");
 
-        let mut json_bytes = b"[".to_vec();
+        let mut json_bytes = b"{\"changes\":[".to_vec();
         let mut json_sink = JsonSink::new(&mut json_bytes, true);
         json_sink.change(change(
             RecordKind::Metadata,
@@ -1545,7 +2122,13 @@ mod tests {
         json_sink.change(change(RecordKind::Edge, ChangeKind::Removed, None, None))?;
         json_sink.finish()?;
         let decoded: serde_json::Value = serde_json::from_slice(&json_bytes)?;
-        assert_eq!(decoded.as_array().map(Vec::len), Some(2));
+        assert_eq!(
+            decoded
+                .get("changes")
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::len),
+            Some(2)
+        );
         Ok(())
     }
 
@@ -1612,12 +2195,12 @@ mod tests {
         };
 
         let mut short = ShortWriter(Vec::new());
-        short.write_all(b"[")?;
+        short.write_all(b"{\"changes\":[")?;
         let mut sink = JsonSink::new(&mut short, false);
         sink.change(change.clone())?;
         sink.finish()?;
-        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&short.0)?;
-        assert_eq!(parsed.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_slice(&short.0)?;
+        assert_eq!(parsed["changes"].as_array().map(Vec::len), Some(1));
 
         let mut broken = BrokenWriter;
         let mut sink = JsonSink::new(&mut broken, false);

--- a/crates/compass-cli/tests/extract_cli.rs
+++ b/crates/compass-cli/tests/extract_cli.rs
@@ -82,6 +82,20 @@ fn artifact(root: &Path, name: &str) -> Result<Vec<u8>, Box<dyn Error>> {
     Ok(fs::read(root.join("graphify-out").join(name))?)
 }
 
+fn graph_without_definition_hashes(bytes: &[u8]) -> Result<Value, Box<dyn Error>> {
+    let mut graph: Value = serde_json::from_slice(bytes)?;
+    if let Some(nodes) = graph.get_mut("nodes").and_then(Value::as_array_mut) {
+        for node in nodes {
+            if let Some(attributes) = node.as_object_mut() {
+                attributes.remove("signature_hash");
+                attributes.remove("implementation_hash");
+                attributes.remove("source_hash");
+            }
+        }
+    }
+    Ok(graph)
+}
+
 fn fixture(root: &Path) -> Result<(), Box<dyn Error>> {
     fs::write(
         root.join("auth.py"),
@@ -146,11 +160,16 @@ fn cold_force_and_raw_extract_match_python() -> Result<(), Box<dyn Error>> {
         let actual = run_rust(&arguments, home.path())?;
         assert_same_output(&expected, &actual);
         for (name, expected) in names.into_iter().zip(expected_artifacts) {
-            assert_eq!(
-                artifact(directory.path(), name)?,
-                expected,
-                "{name} mismatch"
-            );
+            let actual = artifact(directory.path(), name)?;
+            if name == "graph.json" {
+                assert_eq!(
+                    graph_without_definition_hashes(&actual)?,
+                    graph_without_definition_hashes(&expected)?,
+                    "{name} mismatch outside definition hashes"
+                );
+            } else {
+                assert_eq!(actual, expected, "{name} mismatch");
+            }
         }
     }
     Ok(())
@@ -170,16 +189,16 @@ fn warm_clustered_and_raw_extract_match_python() -> Result<(), Box<dyn Error>> {
 
         assert!(run_python(&arguments, home.path())?.status.success());
         let expected = run_python(&arguments, home.path())?;
-        let expected_graph: Value =
-            serde_json::from_slice(&artifact(directory.path(), "graph.json")?)?;
+        let expected_graph =
+            graph_without_definition_hashes(&artifact(directory.path(), "graph.json")?)?;
         let expected_manifest = artifact(directory.path(), "manifest.json")?;
         remove_output(directory.path())?;
 
         assert!(run_rust(&arguments, home.path())?.status.success());
         let actual = run_rust(&arguments, home.path())?;
         assert_same_output(&expected, &actual);
-        let actual_graph: Value =
-            serde_json::from_slice(&artifact(directory.path(), "graph.json")?)?;
+        let actual_graph =
+            graph_without_definition_hashes(&artifact(directory.path(), "graph.json")?)?;
         assert_eq!(actual_graph, expected_graph);
         assert_eq!(
             artifact(directory.path(), "manifest.json")?,

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -255,7 +255,8 @@ fn worker_reconciles_catalog_and_preferred_crash_windows() -> Result<(), Box<dyn
     let candidate = history.publish(PublishRequest {
         commit: commit.clone(),
         parents: repository.parents(&commit)?,
-        fingerprint: std::iter::repeat_n('d', 64)
+        profile: compass_history::BuildProfile::default(),
+        fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
         artifacts: GraphArtifacts {
@@ -368,6 +369,7 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
         Ok(history.publish(PublishRequest {
             commit: commit.clone(),
             parents: repository.parents(&commit)?,
+            profile: compass_history::BuildProfile::default(),
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,
@@ -584,6 +586,7 @@ fn gc_requires_explicit_confirmation_for_non_preferred_realizations()
         history.publish(PublishRequest {
             commit: commit.clone(),
             parents: Vec::new(),
+            profile: compass_history::BuildProfile::default(),
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,
@@ -752,6 +755,7 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
     history.publish(PublishRequest {
         commit: old_commit.clone(),
         parents: repository.parents(&old_commit)?,
+        profile: compass_history::BuildProfile::default(),
         fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -790,19 +794,21 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
         ],
         "built_at_commit":new_commit
     }))?;
+    let new_artifacts = GraphArtifacts {
+        document: new_document,
+        analysis: Some(json!({"communities":{"0":["b"],"1":["a","c"]}})),
+        labels: None,
+        manifest: None,
+        authoritative_sidecars: BTreeMap::new(),
+    };
     history.publish(PublishRequest {
         commit: new_commit.clone(),
         parents: repository.parents(&new_commit)?,
-        fingerprint: std::iter::repeat_n('d', 64)
+        profile: compass_history::BuildProfile::default(),
+        fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
-        artifacts: GraphArtifacts {
-            document: new_document,
-            analysis: Some(json!({"communities":{"0":["b"],"1":["a","c"]}})),
-            labels: None,
-            manifest: None,
-            authoritative_sidecars: BTreeMap::new(),
-        },
+        artifacts: new_artifacts.clone(),
         completion: CompletionEvidence {
             extraction_succeeded: true,
             allow_partial: false,
@@ -830,7 +836,10 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
         &["diff", "HEAD~1", "HEAD", "--format", "json"],
     )?;
     assert!(json_output.status.success());
-    let changes: Vec<serde_json::Value> = serde_json::from_slice(&json_output.stdout)?;
+    let envelope: serde_json::Value = serde_json::from_slice(&json_output.stdout)?;
+    assert_eq!(envelope["schema_version"], 2);
+    assert_eq!(envelope["comparison"]["profile_mismatch"], false);
+    let changes = envelope["changes"].as_array().ok_or("missing changes")?;
     assert!(changes.iter().any(|change| change["record"] == "edge"));
     assert!(
         changes
@@ -855,7 +864,10 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
         directory.path(),
         &["diff", "HEAD~1", "HEAD", "--format=json", "--topology-only"],
     )?;
-    let topology_changes: Vec<serde_json::Value> = serde_json::from_slice(&topology.stdout)?;
+    let topology_envelope: serde_json::Value = serde_json::from_slice(&topology.stdout)?;
+    let topology_changes = topology_envelope["changes"]
+        .as_array()
+        .ok_or("missing topology changes")?;
     assert!(
         topology_changes
             .iter()
@@ -880,6 +892,43 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
     assert_eq!(json_output.status.code(), alias.status.code());
     assert_eq!(json_output.stdout, alias.stdout);
     assert_eq!(json_output.stderr, alias.stderr);
+
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    history.publish(PublishRequest {
+        commit: new_commit,
+        parents: repository.parents(&repository.resolve("HEAD")?)?,
+        profile: compass_history::BuildProfile::default(),
+        fingerprint: std::iter::repeat_n('d', 64)
+            .collect::<String>()
+            .parse::<ExtractionFingerprint>()?,
+        artifacts: new_artifacts,
+        completion: CompletionEvidence {
+            extraction_succeeded: true,
+            allow_partial: false,
+            semantic_files_expected: 0,
+            semantic_files_completed: 0,
+            failed_chunks: 0,
+        },
+        make_preferred: true,
+    })?;
+    drop(history);
+    let mismatch = run(compass, directory.path(), &["diff", "HEAD~1", "HEAD"])?;
+    assert_eq!(mismatch.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&mismatch.stderr).contains("not semantically comparable"));
+    let allowed = run(
+        compass,
+        directory.path(),
+        &[
+            "diff",
+            "HEAD~1",
+            "HEAD",
+            "--format=json",
+            "--allow-profile-mismatch",
+        ],
+    )?;
+    assert!(allowed.status.success());
+    let allowed: serde_json::Value = serde_json::from_slice(&allowed.stdout)?;
+    assert_eq!(allowed["comparison"]["profile_mismatch"], true);
     Ok(())
 }
 
@@ -919,6 +968,7 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
         history.publish(PublishRequest {
             parents: repository.parents(&commit)?,
             commit,
+            profile: compass_history::BuildProfile::default(),
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,
@@ -1019,6 +1069,10 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
     )?;
     assert_eq!(query.status.code(), alias.status.code());
     assert_eq!(query.stdout, alias.stdout);
+    assert!(
+        HistoryQueue::open_existing(&repository)?.is_none(),
+        "reading existing realizations must not create a durable job queue"
+    );
 
     Ok(())
 }
@@ -1058,7 +1112,6 @@ fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std:
     );
     assert!(String::from_utf8_lossy(&query.stdout).contains("OldService"));
     assert!(!directory.path().join("graphify-out").exists());
-
     let status = run(compass, directory.path(), &["history", "status", "HEAD~1"])?;
     assert!(status.status.success());
     assert!(String::from_utf8_lossy(&status.stdout).contains("validation: valid"));
@@ -1089,6 +1142,12 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
     git(directory.path(), &["commit", "--quiet", "-m", "second"])?;
 
     let compass = env!("CARGO_BIN_EXE_compass");
+    let enabled = run(
+        compass,
+        directory.path(),
+        &["history", "enable", "--exclude", "generated/**"],
+    )?;
+    assert!(enabled.status.success());
     let diff = run(
         compass,
         directory.path(),
@@ -1099,7 +1158,17 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
         "{}",
         String::from_utf8_lossy(&diff.stderr)
     );
-    let _: Vec<serde_json::Value> = serde_json::from_slice(&diff.stdout)?;
+    let envelope: serde_json::Value = serde_json::from_slice(&diff.stdout)?;
+    assert_eq!(envelope["schema_version"], 2);
+    assert!(envelope["changes"].is_array());
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    let versions = history.list(None)?;
+    assert_eq!(versions.len(), 2);
+    assert!(versions.iter().all(|version| {
+        version.version.build_profile.value("exclude.000000") == Some("generated/**")
+    }));
+    drop(history);
     let progress = String::from_utf8_lossy(&diff.stderr);
     assert!(progress.contains("building complete graph"));
     assert!(progress.contains("publishing immutable realization"));

--- a/crates/compass-cli/tests/update_cli.rs
+++ b/crates/compass-cli/tests/update_cli.rs
@@ -185,6 +185,9 @@ fn normalize_json(value: &mut serde_json::Value, fixture: &Fixture) {
         serde_json::Value::Object(object) => {
             object.remove("built_at");
             object.remove("built_at_commit");
+            object.remove("signature_hash");
+            object.remove("implementation_hash");
+            object.remove("source_hash");
             for value in object.values_mut() {
                 normalize_json(value, fixture);
             }

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -168,6 +168,7 @@ fn run_materialization(
         PublishRequest {
             commit: request.commit.clone(),
             parents: request.repository.parents(&request.commit)?,
+            profile: request.profile.clone(),
             fingerprint,
             artifacts: completed.artifacts,
             completion: completed.completion,
@@ -255,6 +256,7 @@ fn resolve_fingerprint(
 ) -> Result<ExtractionFingerprint, MaterializeError> {
     let mut input =
         ExtractionFingerprintInput::new(env!("CARGO_PKG_VERSION"), "networkx-node-link/v1");
+    input.insert("definition_hash_version", "tree-sitter-ast/v1")?;
     input.insert("build_profile_digest", &hex(&profile.digest()?))?;
     input.insert(
         "commit_configuration_digest",

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1859,10 +1859,50 @@ mod tests {
         let changed = build_local_graph(&options)?;
         assert_eq!(changed.files_extracted, 1);
         assert_eq!(changed.files_cached, 1);
+        let changed_graph = GraphDocument::load(&changed.output_dir.join("graph.json"))?;
+        let changed_graph_bytes = fs::read(changed.output_dir.join("graph.json"))?;
+        assert_ne!(
+            changed_graph_bytes, cold_graph_bytes,
+            "a body-only edit must update definition hashes"
+        );
+        let identities = |document: &GraphDocument| {
+            (
+                document
+                    .nodes
+                    .iter()
+                    .map(|node| node.id.clone())
+                    .collect::<HashSet<_>>(),
+                document
+                    .links
+                    .iter()
+                    .map(|edge| {
+                        (
+                            edge.source.clone(),
+                            edge.target.clone(),
+                            edge.string("relation"),
+                        )
+                    })
+                    .collect::<HashSet<_>>(),
+            )
+        };
+        assert_eq!(identities(&changed_graph), identities(&cold_graph));
+        let implementation_hash = |document: &GraphDocument| {
+            document
+                .nodes
+                .iter()
+                .find(|node| node.label() == "work()")
+                .map(|node| node.string("implementation_hash"))
+        };
+        assert_ne!(
+            implementation_hash(&changed_graph),
+            implementation_hash(&cold_graph)
+        );
+        let warm_changed = build_local_graph(&options)?;
+        assert_eq!(warm_changed.files_extracted, 0);
         assert_eq!(
-            fs::read(changed.output_dir.join("graph.json"))?,
-            cold_graph_bytes,
-            "a body-only incremental edit must preserve cold-build topology"
+            fs::read(warm_changed.output_dir.join("graph.json"))?,
+            changed_graph_bytes,
+            "cached and freshly extracted definition hashes must agree"
         );
 
         fs::remove_file(root.join("helper.py"))?;

--- a/crates/compass-graph/src/dedup.rs
+++ b/crates/compass-graph/src/dedup.rs
@@ -606,8 +606,9 @@ fn slug_segment(value: &str) -> String {
     output.trim_matches('_').to_owned()
 }
 
-fn collision_rank(node: &NodeRecord) -> (bool, usize, String, String) {
+fn collision_rank(node: &NodeRecord) -> (bool, bool, usize, String, String) {
     (
+        !node.attributes.contains_key("implementation_hash"),
         !defines_id(node),
         node.label().chars().count(),
         node.label().to_owned(),
@@ -793,6 +794,34 @@ mod tests {
         ];
         let result = deduplicate_entities(&nodes, &[], &HashMap::new())?;
         assert_eq!(result.nodes.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn exact_id_collision_prefers_a_hashed_definition_over_a_declaration() -> Result<(), DedupError>
+    {
+        let mut definition = node(
+            "db_db_impl_dbimpl_compact",
+            "DBImpl::Compact()",
+            "db/db_impl.cc",
+        );
+        definition.attributes.insert(
+            "implementation_hash".to_owned(),
+            json!("implementation-digest"),
+        );
+        let declaration = node("db_db_impl_dbimpl_compact", "Compact", "db/db_impl.h");
+
+        let result = deduplicate_entities(&[definition, declaration], &[], &HashMap::new())?;
+
+        assert_eq!(result.nodes.len(), 1);
+        assert_eq!(source_file(&result.nodes[0]), "db/db_impl.cc");
+        assert_eq!(
+            result.nodes[0]
+                .attributes
+                .get("implementation_hash")
+                .and_then(Value::as_str),
+            Some("implementation-digest")
+        );
         Ok(())
     }
 

--- a/crates/compass-history/src/model.rs
+++ b/crates/compass-history/src/model.rs
@@ -5,10 +5,12 @@ use prolly::{Cid, Config, RuntimeConfig, Tree, TreeFormat};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 
-use crate::{ExtractionFingerprint, GraphArtifacts, HistoryError, canonical_json_bytes};
+use crate::{
+    BuildProfile, ExtractionFingerprint, GraphArtifacts, HistoryError, canonical_json_bytes,
+};
 
 /// Version of the Compass history realization schema.
-pub const HISTORY_SCHEMA_VERSION: u32 = 1;
+pub const HISTORY_SCHEMA_VERSION: u32 = 2;
 
 /// Persistence treatment for one realization artifact.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -99,6 +101,10 @@ pub struct GraphVersion {
     pub schema_version: u32,
     pub git_commit: String,
     pub git_parents: Vec<String>,
+    #[serde(default)]
+    pub build_profile: BuildProfile,
+    #[serde(default)]
+    pub profile_digest: String,
     pub extraction_fingerprint: String,
     pub nodes_root: StoredTree,
     pub edges_root: StoredTree,
@@ -244,6 +250,7 @@ impl CompletionEvidence {
 pub struct PublishRequest {
     pub commit: CommitId,
     pub parents: Vec<CommitId>,
+    pub profile: BuildProfile,
     pub fingerprint: ExtractionFingerprint,
     pub artifacts: GraphArtifacts,
     pub completion: CompletionEvidence,

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -173,10 +173,13 @@ impl HistoryStore {
         let hyperedges = self.build_tree(partitioned.hyperedges)?;
         let analysis = self.build_tree(partitioned.analysis)?;
         let metadata = self.build_tree(partitioned.metadata)?;
+        let profile_digest = hex(&request.profile.digest()?);
         let version = GraphVersion {
             schema_version: crate::HISTORY_SCHEMA_VERSION,
             git_commit: request.commit.to_string(),
             git_parents: request.parents.iter().map(ToString::to_string).collect(),
+            build_profile: request.profile,
+            profile_digest,
             extraction_fingerprint: request.fingerprint.to_string(),
             nodes_root: StoredTree::from_tree(&nodes),
             edges_root: StoredTree::from_tree(&edges),
@@ -724,6 +727,11 @@ impl HistoryStore {
             let _: CommitId = parent.parse()?;
         }
         let _: crate::ExtractionFingerprint = version.extraction_fingerprint.parse()?;
+        if version.profile_digest != hex(&version.build_profile.digest()?) {
+            return Err(HistoryError::CorruptHistory(
+                "realization build profile digest does not match its canonical profile".to_owned(),
+            ));
+        }
         let id = RealizationId::for_version(&version)?;
         Ok(PublishedVersion {
             id,
@@ -843,6 +851,16 @@ fn preferred_root_name(commit: &CommitId) -> Vec<u8> {
 fn count(value: usize) -> Result<u64, HistoryError> {
     u64::try_from(value)
         .map_err(|_| HistoryError::InvalidArtifacts("record count exceeds u64".to_owned()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut value = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
 }
 
 struct HistoryPaths {

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -64,6 +64,7 @@ fn request(
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: Vec::new(),
+        profile: compass_history::BuildProfile::default(),
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,

--- a/crates/compass-history/tests/maintenance.rs
+++ b/crates/compass-history/tests/maintenance.rs
@@ -63,6 +63,7 @@ fn request(fingerprint: char, label: &str) -> Result<PublishRequest, Box<dyn std
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: Vec::new(),
+        profile: compass_history::BuildProfile::default(),
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -72,6 +72,7 @@ fn request(
     let commit = repository.resolve("HEAD")?;
     Ok(PublishRequest {
         parents: repository.parents(&commit)?,
+        profile: compass_history::BuildProfile::default(),
         artifacts: GraphArtifacts {
             document: graph(commit.as_str(), changed)?,
             analysis: Some(json!({"communities": 16, "fixture": true})),

--- a/crates/compass-history/tests/publication.rs
+++ b/crates/compass-history/tests/publication.rs
@@ -68,6 +68,7 @@ fn request(
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse()?],
+        profile: compass_history::BuildProfile::default(),
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -95,11 +96,15 @@ fn publication_is_atomic_reopenable_and_content_idempotent()
     let fixture = Fixture::new()?;
     let repository = Repository::discover(&fixture.path)?;
     let history = HistoryStore::create(&repository)?;
-    let publish = request('a', false)?;
+    let mut publish = request('a', false)?;
+    publish.profile.insert("provider", "none")?;
+    let expected_profile = publish.profile.clone();
     let first = history.publish(publish.clone())?;
     let second = history.publish(publish)?;
     assert_eq!(first.id, second.id);
     assert!(first.preferred && second.preferred);
+    assert_eq!(first.version.build_profile, expected_profile);
+    assert_eq!(first.version.profile_digest.len(), 64);
     drop(history);
 
     let reopened = HistoryStore::open_existing(&repository)?

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -19,6 +19,7 @@ flate2.workspace = true
 roxmltree.workspace = true
 serde_yaml_ng.workspace = true
 sha1.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 compass-files = { path = "../compass-files", version = "0.1.0" }

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use compass_model::{EdgeRecord, NodeRecord};
 use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
 use tree_sitter::{Node, Parser, Tree};
 
 use crate::builtins::LANGUAGE_BUILTIN_GLOBALS;
@@ -60,6 +61,12 @@ impl Engine {
             &generic_config(spec),
             language,
         );
+        attach_definition_hashes(
+            &mut extraction,
+            source,
+            tree.root_node(),
+            &generic_config(spec),
+        );
         if language == "python" {
             add_python_rationale(path, source, tree.root_node(), &mut extraction);
         }
@@ -97,43 +104,22 @@ impl Engine {
         let tree = self.parse(path, spec, &source)?;
         let config = generic_config(spec);
         let root = tree.root_node();
-        if spec.name == "go" {
-            return Ok(crate::go::extract(path, &source, root));
-        }
-        if spec.name == "rust" {
-            return Ok(crate::rust_lang::extract(path, &source, root));
-        }
-        if spec.name == "bash" {
-            return Ok(crate::bash::extract(path, &source, root));
-        }
-        if spec.name == "csharp" {
-            return Ok(crate::csharp::extract(path, &source, root));
-        }
-        if spec.name == "cpp" {
-            return Ok(crate::cpp::extract(path, &source, root));
-        }
-        if spec.name == "php" {
-            return Ok(crate::php::extract(path, &source, root));
-        }
-        if spec.name == "swift" {
-            return Ok(crate::swift::extract(path, &source, root));
-        }
-        if spec.name == "objc" {
-            return Ok(crate::objc::extract(path, &source, root));
-        }
-        if spec.name == "powershell" {
-            return Ok(crate::powershell::extract(path, &source, root));
-        }
-        if spec.name == "elixir" {
-            return Ok(crate::elixir::extract(path, &source, root));
-        }
-        if spec.name == "julia" {
-            return Ok(crate::julia::extract(path, &source, root));
-        }
-        if spec.name == "fortran" {
-            return Ok(crate::fortran::extract(path, &source, root));
-        }
-        let mut extraction = extract_tree(path, &source, root, &config, spec.name);
+        let mut extraction = match spec.name {
+            "go" => crate::go::extract(path, &source, root),
+            "rust" => crate::rust_lang::extract(path, &source, root),
+            "bash" => crate::bash::extract(path, &source, root),
+            "csharp" => crate::csharp::extract(path, &source, root),
+            "cpp" => crate::cpp::extract(path, &source, root),
+            "php" => crate::php::extract(path, &source, root),
+            "swift" => crate::swift::extract(path, &source, root),
+            "objc" => crate::objc::extract(path, &source, root),
+            "powershell" => crate::powershell::extract(path, &source, root),
+            "elixir" => crate::elixir::extract(path, &source, root),
+            "julia" => crate::julia::extract(path, &source, root),
+            "fortran" => crate::fortran::extract(path, &source, root),
+            _ => extract_tree(path, &source, root, &config, spec.name),
+        };
+        attach_definition_hashes(&mut extraction, &source, root, &config);
         if spec.name == "python" {
             add_python_rationale(path, &source, root, &mut extraction);
         }
@@ -312,6 +298,136 @@ fn extract_tree(
     }
     state.walk_function_calls();
     state.extraction
+}
+
+fn attach_definition_hashes(
+    extraction: &mut Extraction,
+    source: &[u8],
+    root: Node<'_>,
+    config: &GenericConfig,
+) {
+    let mut candidates = HashMap::<usize, Vec<usize>>::new();
+    for (index, node) in extraction.nodes.iter().enumerate() {
+        if node.attributes.get("_callable").and_then(Value::as_bool) != Some(true) {
+            continue;
+        }
+        let Some(line) = node
+            .attributes
+            .get("source_location")
+            .and_then(Value::as_str)
+            .and_then(source_line)
+        else {
+            continue;
+        };
+        candidates.entry(line).or_default().push(index);
+    }
+    let mut definitions = Vec::new();
+    collect_definitions(root, config, &mut definitions);
+    for definition in definitions {
+        let at_line = definition.start_position().row + 1;
+        let Some(indices) = candidates.get_mut(&at_line) else {
+            continue;
+        };
+        let Some(index) = indices.first().copied() else {
+            continue;
+        };
+        indices.remove(0);
+        let body = definition.child_by_field_name("body").or_else(|| {
+            let mut cursor = definition.walk();
+            definition.children(&mut cursor).find(|child| {
+                matches!(
+                    child.kind(),
+                    "body" | "block" | "compound_statement" | "class_body" | "declaration_list"
+                )
+            })
+        });
+        let signature_hash = ast_hash(definition, source, body.map(|body| body.id()));
+        let source_hash = source
+            .get(definition.start_byte()..definition.end_byte())
+            .map(normalized_source_hash);
+        let attributes = &mut extraction.nodes[index].attributes;
+        attributes.insert("signature_hash".to_owned(), Value::String(signature_hash));
+        if let Some(body) = body {
+            attributes.insert(
+                "implementation_hash".to_owned(),
+                Value::String(ast_hash(body, source, None)),
+            );
+        }
+        if let Some(source_hash) = source_hash {
+            attributes.insert("source_hash".to_owned(), Value::String(source_hash));
+        }
+    }
+}
+
+fn source_line(location: &str) -> Option<usize> {
+    let location = location.strip_prefix('L')?;
+    let digits = location.split_once('-').map_or(location, |value| value.0);
+    digits.parse().ok()
+}
+
+fn collect_definitions<'tree>(
+    node: Node<'tree>,
+    config: &GenericConfig,
+    output: &mut Vec<Node<'tree>>,
+) {
+    if config.class_types.contains(&node.kind()) || config.function_types.contains(&node.kind()) {
+        output.push(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_definitions(child, config, output);
+    }
+}
+
+fn ast_hash(node: Node<'_>, source: &[u8], excluded: Option<usize>) -> String {
+    let mut digest = Sha256::new();
+    hash_ast_node(node, source, excluded, &mut digest);
+    hex_digest(&digest.finalize())
+}
+
+fn hash_ast_node(node: Node<'_>, source: &[u8], excluded: Option<usize>, digest: &mut Sha256) {
+    if excluded == Some(node.id()) || node.kind().contains("comment") {
+        return;
+    }
+    digest.update(b"(");
+    digest.update(node.kind().as_bytes());
+    if node.child_count() == 0 {
+        digest.update(b":");
+        if let Some(bytes) = source.get(node.start_byte()..node.end_byte()) {
+            digest.update(bytes);
+        }
+    } else {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            hash_ast_node(child, source, excluded, digest);
+        }
+    }
+    digest.update(b")");
+}
+
+fn normalized_source_hash(source: &[u8]) -> String {
+    let mut normalized = Vec::with_capacity(source.len());
+    let mut index = 0;
+    while index < source.len() {
+        if source[index] == b'\r' && source.get(index + 1) == Some(&b'\n') {
+            normalized.push(b'\n');
+            index += 2;
+        } else {
+            normalized.push(source[index]);
+            index += 1;
+        }
+    }
+    hex_digest(&Sha256::digest(normalized))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut value = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
 }
 
 fn add_python_rationale(path: &Path, source: &[u8], root: Node<'_>, extraction: &mut Extraction) {
@@ -2864,6 +2980,70 @@ fn resolve_js_import_path(path: &Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod rationale_tests {
     use super::*;
+
+    #[test]
+    fn definition_hashes_separate_signature_implementation_and_source_changes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("fixture.cpp");
+        let mut engine = Engine::default();
+        let extract_hashes = |engine: &mut Engine,
+                              path: &Path,
+                              text: &str|
+         -> Result<[String; 3], Box<dyn std::error::Error>> {
+            fs::write(path, text)?;
+            let extraction = engine.extract(path)?;
+            let node = extraction
+                .nodes
+                .iter()
+                .find(|node| node.label() == "value()")
+                .ok_or("missing value function")?;
+            Ok([
+                node.string("signature_hash"),
+                node.string("implementation_hash"),
+                node.string("source_hash"),
+            ])
+        };
+        let original = extract_hashes(&mut engine, &source, "int value() { return 1; }\n")?;
+        let formatted = extract_hashes(
+            &mut engine,
+            &source,
+            "int value() {\n  // retained only by source_hash\n  return 1;\n}\n",
+        )?;
+        let changed = extract_hashes(&mut engine, &source, "int value() { return 2; }\n")?;
+
+        assert_eq!(original[0], formatted[0]);
+        assert_eq!(original[1], formatted[1]);
+        assert_ne!(original[2], formatted[2]);
+        assert_eq!(original[0], changed[0]);
+        assert_ne!(original[1], changed[1]);
+        assert_ne!(original[2], changed[2]);
+        assert!(original.iter().all(|digest| digest.len() == 64));
+        Ok(())
+    }
+
+    #[test]
+    fn definition_hashes_attach_to_qualified_cpp_methods() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("db_impl.cc");
+        fs::write(
+            &source,
+            "int DBImpl::Compact() {\n  return shutting_down ? 0 : 1;\n}\n",
+        )?;
+
+        let extraction = Engine::default().extract(&source)?;
+        let node = extraction
+            .nodes
+            .iter()
+            .find(|node| node.label() == "DBImpl::Compact()")
+            .ok_or("missing qualified C++ method")?;
+
+        assert_eq!(node.string("signature_hash").len(), 64);
+        assert_eq!(node.string("implementation_hash").len(), 64);
+        assert_eq!(node.string("source_hash").len(), 64);
+        Ok(())
+    }
 
     #[test]
     fn python_import_alias_uses_match_top_level_function_scan()

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -41,6 +41,7 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
     }
 
     let mut dropped = HashSet::<(usize, usize)>::new();
+    let mut definition_hashes = Vec::<((usize, usize), Vec<(String, Value)>)>::new();
     for entries in groups.values().filter(|entries| entries.len() > 1) {
         let mut sibling_keys = HashSet::new();
         let mut headers = Vec::new();
@@ -79,6 +80,39 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
         }
         if eligible && sibling_keys.len() == 1 && headers.len() == 1 {
             let keeper = headers[0];
+            if let Some((extraction_index, node_index, _)) = entries
+                .iter()
+                .filter(|(extraction_index, node_index, source)| {
+                    let suffix = Path::new(source)
+                        .extension()
+                        .and_then(|extension| extension.to_str())
+                        .unwrap_or_default()
+                        .to_ascii_lowercase();
+                    IMPLEMENTATION_SUFFIXES.contains(&suffix.as_str())
+                        && extractions[*extraction_index].nodes[*node_index]
+                            .attributes
+                            .contains_key("implementation_hash")
+                })
+                .min_by_key(|(_, _, source)| source)
+            {
+                let definition = &extractions[*extraction_index].nodes[*node_index];
+                let hashes = [
+                    "_callable",
+                    "signature_hash",
+                    "implementation_hash",
+                    "source_hash",
+                ]
+                .into_iter()
+                .filter_map(|key| {
+                    definition
+                        .attributes
+                        .get(key)
+                        .cloned()
+                        .map(|value| (key.to_owned(), value))
+                })
+                .collect::<Vec<_>>();
+                definition_hashes.push((keeper, hashes));
+            }
             dropped.extend(
                 entries
                     .iter()
@@ -89,6 +123,12 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
     }
     if dropped.is_empty() {
         return;
+    }
+
+    for ((extraction_index, node_index), hashes) in definition_hashes {
+        extractions[extraction_index].nodes[node_index]
+            .attributes
+            .extend(hashes);
     }
 
     for (extraction_index, extraction) in extractions.iter_mut().enumerate() {
@@ -2352,13 +2392,26 @@ mod tests {
             edges: vec![edge("widget", "widget_draw", "method", "native/Widget.h")],
             ..Extraction::default()
         };
+        let mut implementation_node = node(
+            "widget_draw",
+            "Widget::draw()",
+            "native/Widget.cpp",
+            "method",
+        );
+        implementation_node.attributes.insert(
+            "implementation_hash".to_owned(),
+            Value::String("body-digest".to_owned()),
+        );
+        implementation_node.attributes.insert(
+            "signature_hash".to_owned(),
+            Value::String("signature-digest".to_owned()),
+        );
+        implementation_node.attributes.insert(
+            "source_hash".to_owned(),
+            Value::String("source-digest".to_owned()),
+        );
         let implementation = Extraction {
-            nodes: vec![node(
-                "widget_draw",
-                "Widget::draw()",
-                "native/Widget.cpp",
-                "method",
-            )],
+            nodes: vec![implementation_node],
             edges: vec![
                 edge("widget", "widget_draw", "method", "native/Widget.cpp"),
                 edge("widget_draw", "widget_draw", "calls", "native/Widget.cpp"),
@@ -2384,6 +2437,9 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].label(), "draw");
         assert_eq!(merged[0].string("source_file"), "native/Widget.h");
+        assert_eq!(merged[0].string("implementation_hash"), "body-digest");
+        assert_eq!(merged[0].string("signature_hash"), "signature-digest");
+        assert_eq!(merged[0].string("source_hash"), "source-digest");
         assert_eq!(
             extractions
                 .iter()


### PR DESCRIPTION
## What changed

- record and validate the complete build profile on every immutable realization
- resolve historical comparisons with the stored profile, including `--profile-from`, explicit fingerprint selection, and mismatch protection
- add stable signature, implementation, and source hashes for tree-sitter definitions while preserving C/C++ definition hashes through header/implementation merging
- classify streamed diffs into semantic, textual, location, analysis, and metadata sections, with semantic changes first and optional collapsed sections
- emit the versioned JSON diff schema with comparison provenance and category summaries
- keep topology-only output limited to literal node and edge additions/removals

## Why

Location churn and extraction-profile drift previously obscured meaningful code changes. Historical lazy builds also needed to reproduce the profile used by their comparison counterpart. These changes make commit-to-commit graph comparisons reproducible and put semantic changes ahead of collapsed location noise.

## User impact

`compass diff OLD NEW` now fails closed on incompatible fingerprints, supports explicit profile/fingerprint controls, and presents semantic changes before location changes. Existing preferred realizations remain immutable, and missing history is still materialized lazily in the SQLite-backed Prolly store.

## Verification

- full tests for `compass-history`, `compass-languages`, `compass-resolve`, `compass-graph`, `compass-core`, and `compass-cli`
- Clippy for all targets in those crates with warnings denied
- `cargo fmt --all` and `git diff --check`
- real LevelDB history comparison: body-only change `78a352f..4a0c572` produced one semantic node change and no topology changes
- real LevelDB topology comparison: `bfae97f..1d6e8d6` produced Zstd-related node and edge additions/removals
