### PR TITLE
fix(history): qualify real repository graph diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ compass history gc
 compass history disable
 ```
 
+For a fully local code graph with no model credentials, select a code-only
+history profile explicitly:
+
+```bash
+compass history enable --code-only
+compass diff HEAD~1 HEAD --topology-only
+```
+
+Code-only and semantic realizations have different extraction fingerprints and
+are never mixed by a normal diff. Compass does not silently downgrade a
+semantic profile when provider credentials are missing.
+
+To qualify history correctness and performance against two commits in a clean
+real repository checkout, run:
+
+```bash
+scripts/qualify_history_real_repo.sh /path/to/repository OLD NEW
+```
+
+The harness builds in an isolated shared clone, checks deterministic and
+reverse-symmetric JSON, reopens the SQLite store, verifies topology filtering,
+and requires topology-only diff to be at least twice as fast as a full diff.
+
 `compass history enable` records a repository-wide build profile and installs
 managed `post-commit` and `post-merge` hooks. The hooks capture the resulting
 commit SHA and durably enqueue work, then return without waiting for extraction.

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -17,6 +17,7 @@ pub(crate) struct HistoryBuildOptions {
     forwarded: Vec<String>,
     gitignore: bool,
     excludes: Vec<String>,
+    code_only: bool,
     semantic_environment: Vec<(String, String)>,
     semantic_environment_remove: Vec<String>,
 }
@@ -46,11 +47,15 @@ impl HistoryBuildOptions {
             .filter(|(key, _)| key.starts_with("exclude."))
             .map(|(_, value)| value.to_owned())
             .collect::<Vec<_>>();
+        let code_only = profile.value("code_only") == Some("true");
         let mut forwarded = Vec::new();
         push_profile_option(&profile, &mut forwarded, "provider", "--backend", "none");
         push_profile_option(&profile, &mut forwarded, "model", "--model", "none");
         if profile.value("semantic_mode") == Some("deep") {
             forwarded.extend(["--mode".to_owned(), "deep".to_owned()]);
+        }
+        if code_only {
+            forwarded.push("--code-only".to_owned());
         }
         for (key, flag) in [("cargo", "--cargo"), ("dedup_llm", "--dedup-llm")] {
             if profile.value(key) == Some("true") {
@@ -93,6 +98,7 @@ impl HistoryBuildOptions {
             forwarded,
             gitignore,
             excludes,
+            code_only,
         })
     }
 
@@ -102,13 +108,27 @@ impl HistoryBuildOptions {
             forwarded: self.forwarded.clone(),
             gitignore: self.gitignore,
             excludes: self.excludes.clone(),
+            code_only: self.code_only,
             semantic_environment: self.semantic_environment.clone(),
             semantic_environment_remove: self.semantic_environment_remove.clone(),
         }
     }
 
     fn from_values(mut values: HistoryBuildValues) -> Result<Self, HistoryError> {
-        resolve_provider(&mut values)?;
+        if values.code_only {
+            if values.backend.is_some()
+                || values.model.is_some()
+                || values.deep
+                || values.dedup_llm
+                || values.token_budget.is_some()
+            {
+                return Err(HistoryError::InvalidFingerprint(
+                    "--code-only cannot be combined with semantic-provider options".to_owned(),
+                ));
+            }
+        } else {
+            resolve_provider(&mut values)?;
+        }
         let mut profile = BuildProfile::default();
         for (key, value) in [
             ("compass_version", env!("CARGO_PKG_VERSION").to_owned()),
@@ -121,6 +141,7 @@ impl HistoryBuildOptions {
             ("cluster_algorithm", "seeded-louvain/v1".to_owned()),
             ("cluster_seed", "42".to_owned()),
             ("gitignore", values.gitignore.to_string()),
+            ("code_only", values.code_only.to_string()),
             ("cargo", values.cargo.to_string()),
             ("dedup_llm", values.dedup_llm.to_string()),
             (
@@ -192,6 +213,9 @@ impl HistoryBuildOptions {
         if let Some(model) = &values.model {
             forwarded.extend(["--model".to_owned(), model.clone()]);
         }
+        if values.code_only {
+            forwarded.push("--code-only".to_owned());
+        }
         if values.deep {
             forwarded.extend(["--mode".to_owned(), "deep".to_owned()]);
         }
@@ -227,6 +251,7 @@ impl HistoryBuildOptions {
             forwarded,
             gitignore: values.gitignore,
             excludes: values.excludes,
+            code_only: values.code_only,
         })
     }
 }
@@ -245,6 +270,7 @@ fn validate_persisted_profile(profile: &BuildProfile) -> Result<(), HistoryError
                 | "cluster_algorithm"
                 | "cluster_seed"
                 | "gitignore"
+                | "code_only"
                 | "cargo"
                 | "dedup_llm"
                 | "semantic_mode"
@@ -288,6 +314,11 @@ fn validate_persisted_profile(profile: &BuildProfile) -> Result<(), HistoryError
                 "persisted {key} is not boolean"
             )));
         }
+    }
+    if !matches!(profile.value("code_only"), None | Some("true" | "false")) {
+        return Err(HistoryError::InvalidFingerprint(
+            "persisted code_only is not boolean".to_owned(),
+        ));
     }
     let resolution = profile
         .value("resolution")
@@ -471,6 +502,7 @@ fn pinned_provider_environment(profile: &BuildProfile) -> (Vec<(String, String)>
 struct HistoryBuildValues {
     backend: Option<String>,
     model: Option<String>,
+    code_only: bool,
     deep: bool,
     cargo: bool,
     dedup_llm: bool,
@@ -490,6 +522,7 @@ impl Default for HistoryBuildValues {
         Self {
             backend: None,
             model: None,
+            code_only: false,
             deep: false,
             cargo: false,
             dedup_llm: false,
@@ -536,7 +569,7 @@ pub(crate) fn parse_build_command(
             .split_once('=')
             .map_or((argument, None), |(name, value)| (name, Some(value)));
         match name {
-            "--cargo" | "--dedup-llm" | "--no-gitignore" | "--replace-corrupt" => {
+            "--cargo" | "--code-only" | "--dedup-llm" | "--no-gitignore" | "--replace-corrupt" => {
                 if inline.is_some() {
                     return Err(format!("{name} does not accept a value"));
                 }
@@ -545,6 +578,7 @@ pub(crate) fn parse_build_command(
                 }
                 match name {
                     "--cargo" => values.cargo = true,
+                    "--code-only" => values.code_only = true,
                     "--dedup-llm" => values.dedup_llm = true,
                     "--no-gitignore" => values.gitignore = false,
                     "--replace-corrupt" => replace_corrupt = true,
@@ -574,7 +608,7 @@ pub(crate) fn parse_build_command(
                 let value = option_value(args, &mut index, name, inline)?;
                 values.excludes.push(nonempty(name, value)?.to_owned());
             }
-            "--allow-partial" | "--code-only" | "--no-cluster" => {
+            "--allow-partial" | "--no-cluster" => {
                 return Err(format!(
                     "{name} is incompatible with complete graph history"
                 ));
@@ -749,6 +783,7 @@ pub(crate) struct NativeCompleteGraphBuilder {
     forwarded: Vec<String>,
     gitignore: bool,
     excludes: Vec<String>,
+    code_only: bool,
     semantic_environment: Vec<(String, String)>,
     semantic_environment_remove: Vec<String>,
 }
@@ -811,11 +846,15 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
                 ..DetectOptions::default()
             },
         )?;
-        let semantic = ["document", "paper", "image", "video"]
-            .into_iter()
-            .flat_map(|kind| detection.files.get(kind).into_iter().flatten())
-            .map(PathBuf::from)
-            .collect::<Vec<_>>();
+        let semantic = if self.code_only {
+            Vec::new()
+        } else {
+            ["document", "paper", "image", "video"]
+                .into_iter()
+                .flat_map(|kind| detection.files.get(kind).into_iter().flatten())
+                .map(PathBuf::from)
+                .collect::<Vec<_>>()
+        };
         let manifest = Manifest::load(&output_dir.join("manifest.json"), Some(checkout));
         let completed = semantic
             .iter()
@@ -980,8 +1019,26 @@ mod tests {
             )
             .is_err()
         );
+        let code_only =
+            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])?;
+        assert_eq!(code_only.options.profile().value("code_only"), Some("true"));
+        assert_eq!(code_only.options.profile().value("provider"), Some("none"));
         assert!(
-            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()]).is_err()
+            code_only
+                .options
+                .forwarded
+                .contains(&"--code-only".to_owned())
+        );
+        assert!(
+            parse_build_command(
+                "build",
+                &[
+                    "HEAD".to_owned(),
+                    "--code-only".to_owned(),
+                    "--backend=openai".to_owned(),
+                ],
+            )
+            .is_err()
         );
         assert!(
             parse_build_command(
@@ -1057,7 +1114,6 @@ mod tests {
             vec!["HEAD", "--format", "yaml"],
             vec!["HEAD", "--unknown"],
             vec!["HEAD", "--allow-partial"],
-            vec!["HEAD", "--code-only"],
             vec!["HEAD", "--no-cluster"],
             vec!["HEAD", "--google-workspace"],
             vec!["HEAD", "--postgres"],

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -23,7 +23,7 @@ pub(crate) fn help(frontend: Frontend) -> String {
         "graphify"
     };
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  status [REV] [--format text|json]\n  build REV [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|compass-out --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  status [REV] [--format text|json]\n  build REV [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|compass-out --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
     )
 }
 
@@ -399,11 +399,12 @@ fn select_existing(
             .preferred(commit)
             .map_err(|error| error.to_string())?
     };
-    if let Some(selected) = &selected {
-        history
-            .validate(&selected.id)
-            .map_err(|error| error.to_string())?;
-    }
+    // Publication validates the complete immutable realization before making
+    // it visible, while `preferred`/`list` authenticate the manifest and its
+    // direct roots. The diff traversal then verifies every Prolly node it
+    // actually reads. Re-scanning and reconstructing all five trees here made
+    // even a topology-only diff pay the full graph-validation cost twice and
+    // defeated structural sharing.
     Ok(selected)
 }
 
@@ -546,7 +547,7 @@ fn render_diff(
     match options.output {
         DiffOutput::Summary | DiffOutput::Detailed => {
             let mut sink = TextSink::new(options)?;
-            history.diff(&old.id, &new.id, &mut sink)?;
+            stream_diff(history, old, new, options.topology_only, &mut sink)?;
             sink.finish(writer)
         }
         DiffOutput::Json => {
@@ -568,9 +569,28 @@ fn render_diff(
             .map_err(json_output_error)?;
             writer.write_all(b",\"changes\":[").map_err(output_error)?;
             let mut sink = JsonSink::new(writer, options.topology_only);
-            history.diff(&old.id, &new.id, &mut sink)?;
+            stream_diff(history, old, new, options.topology_only, &mut sink)?;
             sink.finish()
         }
+    }
+}
+
+fn stream_diff(
+    history: &HistoryStore,
+    old: &PublishedVersion,
+    new: &PublishedVersion,
+    topology_only: bool,
+    sink: &mut dyn ChangeSink,
+) -> Result<(), HistoryError> {
+    if topology_only {
+        history.diff_records(
+            &old.id,
+            &new.id,
+            &[RecordKind::Node, RecordKind::Edge],
+            sink,
+        )
+    } else {
+        history.diff(&old.id, &new.id, sink)
     }
 }
 

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -48,7 +48,6 @@ fn history_help_and_empty_status_are_actionable_and_non_mutating()
     git(directory.path(), &["commit", "--quiet", "-m", "fixture"])?;
 
     let compass = env!("CARGO_BIN_EXE_compass");
-    let graphify = env!("CARGO_BIN_EXE_graphify");
     let help = run(compass, directory.path(), &["history", "--help"])?;
     assert!(help.status.success());
     assert!(String::from_utf8_lossy(&help.stdout).contains("build REV"));
@@ -66,11 +65,6 @@ fn history_help_and_empty_status_are_actionable_and_non_mutating()
         false
     );
     assert!(!directory.path().join(".git/compass").exists());
-    let alias = run(graphify, directory.path(), &["history", "status", "HEAD"])?;
-    assert_eq!(status.status.code(), alias.status.code());
-    assert_eq!(status.stdout, alias.stdout);
-    assert_eq!(status.stderr, alias.stderr);
-
     let repository = Repository::discover(directory.path())?;
     let history = HistoryStore::create(&repository)?;
     let database = history.database_path().to_path_buf();
@@ -113,7 +107,7 @@ fn enable_disable_are_explicit_idempotent_and_invalid_profiles_roll_back()
     let invalid = run(
         compass,
         directory.path(),
-        &["history", "enable", "--code-only"],
+        &["history", "enable", "--allow-partial"],
     )?;
     assert_eq!(invalid.status.code(), Some(2));
     assert_eq!(std::fs::read(&config)?, before);
@@ -398,7 +392,6 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
     drop(history);
 
     let compass = env!("CARGO_BIN_EXE_compass");
-    let graphify = env!("CARGO_BIN_EXE_graphify");
     let list = run(
         compass,
         directory.path(),
@@ -410,13 +403,6 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
     let list_text = run(compass, directory.path(), &["history", "list", "HEAD"])?;
     assert!(list_text.status.success());
     assert!(String::from_utf8_lossy(&list_text.stdout).contains("alternate"));
-    let alias = run(
-        graphify,
-        directory.path(),
-        &["history", "list", "HEAD", "--format", "json"],
-    )?;
-    assert_eq!(list.stdout, alias.stdout);
-
     let show = run(
         compass,
         directory.path(),
@@ -496,14 +482,14 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
 
     let bundle = directory.path().join("historical-out");
     let export = run(
-        graphify,
+        compass,
         directory.path(),
         &[
             "history",
             "export",
             "HEAD",
             "--format",
-            "graphify-out",
+            "compass-out",
             "--output",
             bundle.to_str().ok_or("path")?,
         ],
@@ -527,7 +513,7 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
             "history",
             "export",
             "HEAD",
-            "--format=graphify-out",
+            "--format=compass-out",
             "--output",
             bundle.to_str().ok_or("path")?,
         ],
@@ -821,7 +807,6 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
     drop(history);
 
     let compass = env!("CARGO_BIN_EXE_compass");
-    let graphify = env!("CARGO_BIN_EXE_graphify");
     let summary = run(compass, directory.path(), &["diff", "HEAD~1", "HEAD"])?;
     assert!(
         summary.status.success(),
@@ -868,11 +853,10 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
     let topology_changes = topology_envelope["changes"]
         .as_array()
         .ok_or("missing topology changes")?;
-    assert!(
-        topology_changes
-            .iter()
-            .all(|change| { !matches!(change["record"].as_str(), Some("analysis" | "metadata")) })
-    );
+    assert!(topology_changes.iter().all(|change| {
+        matches!(change["record"].as_str(), Some("node" | "edge"))
+            && matches!(change["change"].as_str(), Some("added" | "removed"))
+    }));
 
     let detailed = run(
         compass,
@@ -884,15 +868,6 @@ fn diff_supports_summary_details_streaming_json_and_topology_filtering()
 
     let empty = run(compass, directory.path(), &["diff", "HEAD", "HEAD"])?;
     assert_eq!(String::from_utf8_lossy(&empty.stdout), "no graph changes\n");
-    let alias = run(
-        graphify,
-        directory.path(),
-        &["diff", "HEAD~1", "HEAD", "--format", "json"],
-    )?;
-    assert_eq!(json_output.status.code(), alias.status.code());
-    assert_eq!(json_output.stdout, alias.stdout);
-    assert_eq!(json_output.stderr, alias.stderr);
-
     let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
     history.publish(PublishRequest {
         commit: new_commit,
@@ -1003,7 +978,6 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
     drop(history);
 
     let compass = env!("CARGO_BIN_EXE_compass");
-    let graphify = env!("CARGO_BIN_EXE_graphify");
     let query = run(
         compass,
         directory.path(),
@@ -1062,13 +1036,6 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
     );
     assert!(String::from_utf8_lossy(&explain.stdout).contains("Database"));
 
-    let alias = run(
-        graphify,
-        directory.path(),
-        &["query", "legacy service", "--at", "HEAD~1"],
-    )?;
-    assert_eq!(query.status.code(), alias.status.code());
-    assert_eq!(query.stdout, alias.stdout);
     assert!(
         HistoryQueue::open_existing(&repository)?.is_none(),
         "reading existing realizations must not create a durable job queue"
@@ -1111,7 +1078,7 @@ fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std:
         String::from_utf8_lossy(&query.stderr)
     );
     assert!(String::from_utf8_lossy(&query.stdout).contains("OldService"));
-    assert!(!directory.path().join("graphify-out").exists());
+    assert!(!directory.path().join("compass-out").exists());
     let status = run(compass, directory.path(), &["history", "status", "HEAD~1"])?;
     assert!(status.status.success());
     assert!(String::from_utf8_lossy(&status.stdout).contains("validation: valid"));
@@ -1132,7 +1099,11 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
         directory.path().join("service.rs"),
         "pub struct FirstService;\n",
     )?;
-    git(directory.path(), &["add", "service.rs"])?;
+    std::fs::write(
+        directory.path().join("README.md"),
+        "A semantic document that code-only history deliberately excludes.\n",
+    )?;
+    git(directory.path(), &["add", "service.rs", "README.md"])?;
     git(directory.path(), &["commit", "--quiet", "-m", "first"])?;
     std::fs::write(
         directory.path().join("service.rs"),
@@ -1145,7 +1116,13 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
     let enabled = run(
         compass,
         directory.path(),
-        &["history", "enable", "--exclude", "generated/**"],
+        &[
+            "history",
+            "enable",
+            "--code-only",
+            "--exclude",
+            "generated/**",
+        ],
     )?;
     assert!(enabled.status.success());
     let diff = run(
@@ -1167,6 +1144,7 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
     assert_eq!(versions.len(), 2);
     assert!(versions.iter().all(|version| {
         version.version.build_profile.value("exclude.000000") == Some("generated/**")
+            && version.version.build_profile.value("code_only") == Some("true")
     }));
     drop(history);
     let progress = String::from_utf8_lossy(&diff.stderr);
@@ -1202,6 +1180,7 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
             "history",
             "rebuild",
             "HEAD",
+            "--code-only",
             "--resolution=2",
             "--format=json",
         ],
@@ -1302,7 +1281,7 @@ fn historical_build_uses_only_the_exact_commit_tree_and_historical_ignore_policy
         )?;
         assert!(!String::from_utf8_lossy(&query.stdout).contains(absent));
     }
-    assert!(!directory.path().join("graphify-out").exists());
+    assert!(!directory.path().join("compass-out").exists());
     Ok(())
 }
 
@@ -1423,7 +1402,7 @@ fn normal_graph_export_and_historical_queries_are_semantically_identical()
         "{}",
         String::from_utf8_lossy(&extracted.stderr)
     );
-    let graph_path = directory.path().join("graphify-out/graph.json");
+    let graph_path = directory.path().join("compass-out/graph.json");
     let original: serde_json::Value = serde_json::from_slice(&std::fs::read(&graph_path)?)?;
 
     let built = run(compass, directory.path(), &["history", "build", "HEAD"])?;

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -371,10 +371,14 @@ fn validate_completed(
             ..DetectOptions::default()
         },
     )?;
-    let semantic_files = ["document", "paper", "image", "video"]
-        .into_iter()
-        .flat_map(|kind| detection.files.get(kind).into_iter().flatten())
-        .collect::<Vec<_>>();
+    let semantic_files = if profile.value("code_only") == Some("true") {
+        Vec::new()
+    } else {
+        ["document", "paper", "image", "video"]
+            .into_iter()
+            .flat_map(|kind| detection.files.get(kind).into_iter().flatten())
+            .collect::<Vec<_>>()
+    };
     let semantic_expected = u64::try_from(semantic_files.len())
         .map_err(|_| MaterializeError::Incomplete("semantic inventory exceeds u64".to_owned()))?;
     if completed.completion.semantic_files_expected != semantic_expected {

--- a/crates/compass-history/src/diff.rs
+++ b/crates/compass-history/src/diff.rs
@@ -46,6 +46,32 @@ impl HistoryStore {
         new: &RealizationId,
         sink: &mut dyn ChangeSink,
     ) -> Result<(), HistoryError> {
+        self.diff_records(
+            old,
+            new,
+            &[
+                RecordKind::Node,
+                RecordKind::Edge,
+                RecordKind::Hyperedge,
+                RecordKind::Analysis,
+                RecordKind::Metadata,
+            ],
+            sink,
+        )
+    }
+
+    /// Stream only the requested record roots.
+    ///
+    /// This is more than a presentation filter: omitted Prolly roots are never
+    /// opened or traversed. Callers such as topology-only diff can therefore
+    /// avoid decoding analysis and reconstruction metadata entirely.
+    pub fn diff_records(
+        &self,
+        old: &RealizationId,
+        new: &RealizationId,
+        records: &[RecordKind],
+        sink: &mut dyn ChangeSink,
+    ) -> Result<(), HistoryError> {
         let activity = self.activity()?;
         let old = self.get_with_activity(old, &activity)?;
         let new = self.get_with_activity(new, &activity)?;
@@ -76,7 +102,9 @@ impl HistoryStore {
                 &new.version.metadata_root,
             ),
         ] {
-            self.diff_root(kind, left, right, sink)?;
+            if records.contains(&kind) {
+                self.diff_root(kind, left, right, sink)?;
+            }
         }
         Ok(())
     }

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -124,6 +124,19 @@ fn diff_reports_topology_attribute_and_analysis_changes() -> Result<(), Box<dyn 
             .iter()
             .any(|change| change.record == RecordKind::Analysis)
     );
+    let mut topology_roots = VecSink::default();
+    history.diff_records(
+        &old.id,
+        &new.id,
+        &[RecordKind::Node, RecordKind::Edge],
+        &mut topology_roots,
+    )?;
+    assert!(
+        topology_roots
+            .0
+            .iter()
+            .all(|change| matches!(change.record, RecordKind::Node | RecordKind::Edge))
+    );
     Ok(())
 }
 

--- a/scripts/qualify_history_real_repo.sh
+++ b/scripts/qualify_history_real_repo.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 REPOSITORY OLD NEW" >&2
+  exit 2
+fi
+
+repository=$1
+old_revision=$2
+new_revision=$3
+script_dir=$(cd "$(dirname "$0")" && pwd)
+compass_root=$(cd "$script_dir/.." && pwd)
+compass_bin=${COMPASS_BIN:-$compass_root/target/debug/compass}
+if [[ $compass_bin != /* ]]; then
+  compass_bin=$(cd "$(dirname "$compass_bin")" && pwd)/$(basename "$compass_bin")
+fi
+if [[ ! -x $compass_bin ]]; then
+  echo "error: Compass binary is not executable: $compass_bin" >&2
+  exit 1
+fi
+
+for command in git jq cmp perl; do
+  command -v "$command" >/dev/null || {
+    echo "error: required command not found: $command" >&2
+    exit 1
+  }
+done
+
+repository=$(git -C "$repository" rev-parse --show-toplevel)
+if [[ -n $(git -C "$repository" status --porcelain=v1 --untracked-files=all) ]]; then
+  echo "error: qualification repository must start clean: $repository" >&2
+  exit 1
+fi
+old_commit=$(git -C "$repository" rev-parse --verify "$old_revision^{commit}")
+new_commit=$(git -C "$repository" rev-parse --verify "$new_revision^{commit}")
+
+validation_root=$(mktemp -d "${TMPDIR:-/tmp}/compass-history-real.XXXXXX")
+trap 'rm -rf -- "$validation_root"' EXIT
+validation_repo=$validation_root/repository
+git clone --quiet --shared --no-checkout "$repository" "$validation_repo"
+git -C "$validation_repo" checkout --quiet --detach "$new_commit"
+
+old_json=$validation_root/old.json
+new_json=$validation_root/new.json
+forward_json=$validation_root/forward.json
+repeat_json=$validation_root/repeat.json
+reverse_json=$validation_root/reverse.json
+topology_json=$validation_root/topology.json
+
+now_millis() {
+  perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000'
+}
+
+(cd "$validation_repo" && "$compass_bin" history build "$old_commit" --code-only --format=json) >"$old_json"
+(cd "$validation_repo" && "$compass_bin" history build "$new_commit" --profile-from "$old_commit" --format=json) >"$new_json"
+(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --format=json) >"$forward_json"
+full_started=$(now_millis)
+(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --format=json) >"$repeat_json"
+full_millis=$(( $(now_millis) - full_started ))
+cmp "$forward_json" "$repeat_json"
+(cd "$validation_repo" && "$compass_bin" diff "$new_commit" "$old_commit" --format=json) >"$reverse_json"
+
+jq -S '[.changes[] | {
+  record,
+  key,
+  change:(if .change == "added" then "removed" elif .change == "removed" then "added" else .change end),
+  old:(.new // null),
+  new:(.old // null)
+}] | sort_by(.record, (.key | tostring), .change)' "$forward_json" >"$validation_root/forward-reversed.json"
+jq -S '[.changes[] | {
+  record,
+  key,
+  change,
+  old:(.old // null),
+  new:(.new // null)
+}] | sort_by(.record, (.key | tostring), .change)' "$reverse_json" >"$validation_root/reverse-normalized.json"
+cmp "$validation_root/forward-reversed.json" "$validation_root/reverse-normalized.json"
+
+topology_started=$(now_millis)
+(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --topology-only --format=json) >"$topology_json"
+topology_millis=$(( $(now_millis) - topology_started ))
+jq -e 'all(.changes[]; ((.record == "node" or .record == "edge") and (.change == "added" or .change == "removed")))' "$topology_json" >/dev/null
+if (( topology_millis * 2 >= full_millis )); then
+  echo "error: topology-only diff was not at least twice as fast as full diff (${topology_millis}ms vs ${full_millis}ms)" >&2
+  exit 1
+fi
+(cd "$validation_repo" && "$compass_bin" history status "$new_commit" --format=json) |
+  jq -e '.validation.valid == true' >/dev/null
+
+if [[ -n $(git -C "$repository" status --porcelain=v1 --untracked-files=all) ]]; then
+  echo "error: qualification changed the original repository" >&2
+  exit 1
+fi
+
+jq -n \
+  --arg repository "$repository" \
+  --arg old "$old_commit" \
+  --arg new "$new_commit" \
+  --argjson old_graph "$(jq '{nodes,edges,hyperedges,analysis_records,metadata_records}' "$old_json")" \
+  --argjson new_graph "$(jq '{nodes,edges,hyperedges,analysis_records,metadata_records}' "$new_json")" \
+  --argjson diff_summary "$(jq '.summary' "$forward_json")" \
+  --argjson topology_summary "$(jq '.summary' "$topology_json")" \
+  --argjson full_millis "$full_millis" \
+  --argjson topology_millis "$topology_millis" \
+  '{repository:$repository,old:$old,new:$new,old_graph:$old_graph,new_graph:$new_graph,diff_summary:$diff_summary,topology_summary:$topology_summary,timing:{full_millis:$full_millis,topology_millis:$topology_millis},json_deterministic:true,reverse_symmetric:true,topology_materially_faster:true,original_checkout_clean:true}'


### PR DESCRIPTION
## Summary

- add an explicit, fingerprinted `--code-only` profile for history enable/build/rebuild
- make topology-only diff traverse only node and edge Prolly roots
- remove redundant full-realization rescans from graph diff selection
- update Compass-only history integration coverage and remove obsolete `graphify` binary assumptions
- add a real-repository qualification harness for deterministic, symmetric, SQLite-backed history diffs

## Why

Real-repository validation exposed two usability and performance problems. Code-only history was recommended when no model credentials were available, but history commands rejected the flag. Topology-only diff filtered output only after scanning and validating the complete graph twice, so it cost approximately as much as a full diff.

This change makes code-only behavior explicit and part of the extraction fingerprint. Diff selection authenticates immutable manifests and direct roots, while Prolly verifies content during traversal. Topology-only mode never opens analysis, metadata, or hyperedge roots.

## User impact

Users can now build local history without model credentials:

```bash
compass history enable --code-only
compass diff HEAD~1 HEAD --topology-only
```

Semantic and code-only realizations remain distinct and are not silently mixed.

## Validation

- `cargo test -p compass-history --test diff`: 2 passed
- `cargo test -p compass-cli --test history_cli`: 15 passed
- real repository: `redb`, commits `f427933a73af87099d3561bed112cea71fb36ad8..fe0141159c73cc304c360092f513b90caed6a732`
- deterministic JSON: passed
- reverse symmetry: passed
- SQLite reopen and validation: passed
- original checkout remained clean: passed
- full diff: 885 ms
- topology-only diff: 93 ms (about 9.5x faster)
