### PR TITLE
Improve Compass CLI help and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ compass prs
 compass hook
 ```
 
+Run `compass --help` to see commands grouped by workflow. Run
+`compass help <command>` or `compass <command> --help` for arguments,
+option descriptions, defaults, examples, and related-command tips. Nested help
+accepts the full path, such as `compass help history build`.
+
 ### Versioned graph history
 
 Compass can materialize a complete immutable graph for an exact Git commit and

--- a/crates/compass-cli/src/bin/compass.rs
+++ b/crates/compass-cli/src/bin/compass.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 use std::process::ExitCode;
 
 #[global_allocator]
@@ -6,6 +6,18 @@ static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 fn main() -> ExitCode {
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    let style = compass_cli::HelpStyle::detect(
+        io::stdout().is_terminal(),
+        std::env::var_os("NO_COLOR").as_deref(),
+        std::env::var_os("TERM").as_deref(),
+    );
+    if let Some(outcome) = compass_cli::compass_help_request(&arguments, style) {
+        return ExitCode::from(compass_cli::write_outcome(
+            &outcome,
+            &mut io::stdout(),
+            &mut io::stderr(),
+        ));
+    }
     if arguments.first().and_then(|value| value.to_str()) == Some("diff") {
         return ExitCode::from(compass_cli::run_diff(
             compass_cli::Frontend::Compass,

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -1,0 +1,1037 @@
+use std::ffi::{OsStr, OsString};
+
+use crate::Outcome;
+
+const WIDTH: usize = 92;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HelpStyle {
+    Plain,
+    Ansi,
+}
+
+impl HelpStyle {
+    #[must_use]
+    pub fn detect(is_terminal: bool, no_color: Option<&OsStr>, term: Option<&OsStr>) -> Self {
+        if !is_terminal
+            || no_color.is_some()
+            || term.is_some_and(|value| value.to_string_lossy().eq_ignore_ascii_case("dumb"))
+        {
+            Self::Plain
+        } else {
+            Self::Ansi
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Visibility {
+    Public,
+    Internal,
+}
+
+#[derive(Clone, Copy)]
+struct Page {
+    path: &'static str,
+    summary: &'static str,
+    usage: &'static [&'static str],
+    details: &'static str,
+    visibility: Visibility,
+}
+
+macro_rules! page {
+    ($path:literal, $summary:literal, [$($usage:literal),+ $(,)?], $details:literal) => {
+        Page {
+            path: $path,
+            summary: $summary,
+            usage: &[$($usage),+],
+            details: $details,
+            visibility: Visibility::Public,
+        }
+    };
+}
+
+macro_rules! internal_page {
+    ($path:literal, $summary:literal, [$($usage:literal),+ $(,)?], $details:literal) => {
+        Page {
+            path: $path,
+            summary: $summary,
+            usage: &[$($usage),+],
+            details: $details,
+            visibility: Visibility::Internal,
+        }
+    };
+}
+
+struct Group {
+    title: &'static str,
+    commands: &'static [&'static str],
+}
+
+const GROUPS: &[Group] = &[
+    Group {
+        title: "Build and maintain",
+        commands: &[
+            "update",
+            "extract",
+            "watch",
+            "cluster-only",
+            "label",
+            "merge-graphs",
+            "cache-check",
+            "merge-chunks",
+            "merge-semantic",
+        ],
+    },
+    Group {
+        title: "Explore",
+        commands: &["query", "path", "explain", "affected", "benchmark"],
+    },
+    Group {
+        title: "History",
+        commands: &["history", "diff"],
+    },
+    Group {
+        title: "Visualize and export",
+        commands: &["tree", "export"],
+    },
+    Group {
+        title: "Integrate and automate",
+        commands: &[
+            "serve",
+            "global",
+            "clone",
+            "add",
+            "prs",
+            "hook",
+            "install",
+            "uninstall",
+            "provider",
+            "save-result",
+            "reflect",
+        ],
+    },
+    Group {
+        title: "Diagnose and support",
+        commands: &[
+            "diagnose",
+            "check-update",
+            "merge-driver",
+            "hook-check",
+            "hook-guard",
+        ],
+    },
+];
+
+const PAGES: &[Page] = &[
+    page!(
+        "update",
+        "Incrementally refresh the local knowledge graph",
+        ["compass update [PATH] [OPTIONS]"],
+        "Arguments:\n  [PATH]                  Project directory to scan [default: saved root or .]\n\nOptions:\n  --out <DIR>             Write artifacts below this directory\n  --force                 Rebuild even when inputs appear unchanged\n  --no-cluster            Skip community detection\n  --no-viz                Skip graph.html generation\n  --no-gitignore          Ignore .gitignore rules while scanning\n  --exclude <PATTERN>     Exclude a glob pattern; repeatable\n  --resolution <NUMBER>   Community-detection resolution [default: 1.0]\n  --exclude-hubs <NUMBER> Exclude high-degree hubs from clustering\n\nExamples:\n  compass update\n  compass update ./services/api --force\n  compass update --exclude \"vendor/**\"\n\nTips:\n  Use `compass watch` to refresh the graph whenever project files change."
+    ),
+    page!(
+        "extract",
+        "Build a graph with optional semantic sources and model enrichment",
+        [
+            "compass extract [PATH] [OPTIONS]",
+            "compass extract --postgres <DSN> [OPTIONS]"
+        ],
+        "Arguments:\n  [PATH]                       Project directory to scan\n\nOptions:\n  --code-only                  Extract structural code without semantic sources\n  --cargo                      Include Cargo metadata\n  --google-workspace           Include Google Workspace shortcuts\n  --postgres <DSN>             Extract PostgreSQL schema objects\n  --backend <NAME>             Semantic provider name\n  --model <MODEL>              Override the provider's default model\n  --mode <deep>                Use deep semantic extraction\n  --token-budget <N>           Maximum semantic token budget\n  --max-concurrency <N>        Maximum concurrent provider requests\n  --max-workers <N>            Maximum local extraction workers\n  --api-timeout <SECONDS>      Provider request timeout\n  --allow-partial              Publish results when semantic chunks fail\n  --dedup-llm                  Use the model to review likely duplicates\n  --timing                     Print stage timings\n  --global                     Merge the completed graph into the global graph\n  --as <TAG>                   Repository tag used with --global\n  --out <DIR>                  Output directory\n  --force                      Rebuild unchanged inputs\n  --no-cluster                 Skip community detection\n  --no-viz                     Skip graph.html generation\n  --no-gitignore               Ignore .gitignore rules\n  --exclude <PATTERN>          Exclude a glob pattern; repeatable\n  --resolution <NUMBER>        Community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>      Exclude high-degree clustering hubs\n\nExamples:\n  compass extract ./project --code-only\n  compass extract ./project --backend gemini --model gemini-2.5-flash\n  compass extract --postgres \"postgresql://localhost/app\" --code-only\n\nNotes:\n  Semantic extraction may require credentials for the selected provider."
+    ),
+    page!(
+        "watch",
+        "Rebuild the graph automatically when project files change",
+        ["compass watch [PATH] [OPTIONS]"],
+        "Arguments:\n  [PATH]                  Project directory to watch [default: .]\n\nOptions:\n  --debounce <SECONDS>    Wait after changes before rebuilding [default: 3]\n  --out <DIR>             Output directory\n  --no-cluster            Skip community detection\n  --no-viz                Skip graph.html generation\n  --no-gitignore          Ignore .gitignore rules\n  --exclude <PATTERN>     Exclude a glob pattern; repeatable\n  --poll                   Poll instead of using filesystem notifications\n\nExamples:\n  compass watch\n  compass watch ./services/api --debounce 1 --poll"
+    ),
+    page!(
+        "cluster-only",
+        "Recompute graph communities without re-extracting source files",
+        ["compass cluster-only [PATH] [OPTIONS]"],
+        "Arguments:\n  [PATH]                       Project or output directory [default: .]\n\nOptions:\n  --graph <PATH>               Graph JSON path\n  --no-viz                     Skip graph.html generation\n  --no-label                   Skip model-generated community labels\n  --missing-only               Compatibility flag; existing labels are preserved\n  --timing                     Print clustering timings\n  --resolution <NUMBER>        Community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>      Exclude high-degree hubs\n  --min-community-size=<N>     Minimum community size [default: 3]\n  --backend <NAME>             Accepted compatibility provider setting\n  --model <MODEL>              Accepted compatibility model setting\n  --max-concurrency <N>        Accepted compatibility request limit\n  --batch-size <N>             Accepted compatibility batch size\n\nExamples:\n  compass cluster-only\n  compass cluster-only --graph compass-out/graph.json --no-label --timing"
+    ),
+    page!(
+        "label",
+        "Generate readable labels for graph communities",
+        ["compass label [PATH] [OPTIONS]"],
+        "Arguments:\n  [PATH]                       Project or output directory [default: .]\n\nOptions:\n  --graph <PATH>               Graph JSON path\n  --backend <NAME>             Semantic provider\n  --model <MODEL>              Provider model\n  --missing-only               Preserve existing labels\n  --no-viz                     Skip graph.html regeneration\n  --resolution <NUMBER>        Community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>      Exclude high-degree hubs\n  --max-concurrency <N>        Concurrent provider requests\n  --batch-size <N>             Communities per request\n  --min-community-size=<N>     Minimum community size\n  --timing                     Print stage timings\n\nExamples:\n  compass label\n  compass label --backend gemini --missing-only --batch-size 8"
+    ),
+    page!(
+        "merge-graphs",
+        "Combine two or more graph JSON files",
+        ["compass merge-graphs <GRAPH> <GRAPH> [GRAPH...] [OPTIONS]"],
+        "Arguments:\n  <GRAPH>                 Input graph; provide at least two\n\nOptions:\n  --out <PATH>            Merged graph path [default: compass-out/merged-graph.json]\n\nExamples:\n  compass merge-graphs api.json web.json\n  compass merge-graphs api.json web.json jobs.json --out system.json"
+    ),
+    page!(
+        "cache-check",
+        "Inspect cached semantic extraction files",
+        ["compass cache-check <FILES_FROM> [OPTIONS]"],
+        "Arguments:\n  <FILES_FROM>             File containing source paths to inspect\n\nOptions:\n  --root <DIR>             Resolve source paths below this directory\n  --mode <MODE>            Semantic extraction mode\n  --deep                   Select deep semantic mode\n  --prompt-file <PATH>     Use a custom extraction prompt\n\nExamples:\n  compass cache-check files.txt\n  compass cache-check files.txt --root . --deep"
+    ),
+    page!(
+        "merge-chunks",
+        "Merge semantic chunk files into one result",
+        ["compass merge-chunks <CHUNK_FILES...> --out <PATH>"],
+        "Arguments:\n  <CHUNK_FILES...>        Semantic chunk JSON files\n\nOptions:\n  --out <PATH>            Required merged output path\n\nExamples:\n  compass merge-chunks chunks/*.json --out semantic.json"
+    ),
+    page!(
+        "merge-semantic",
+        "Merge cached and newly extracted semantic results",
+        ["compass merge-semantic --cached <PATH> --new <PATH> --out <PATH>"],
+        "Options:\n  --cached <PATH>         Existing semantic result\n  --new <PATH>            Newly extracted semantic result\n  --out <PATH>            Required merged output path\n\nExamples:\n  compass merge-semantic --cached old.json --new fresh.json --out semantic.json"
+    ),
+    page!(
+        "query",
+        "Search the graph with natural language or CompassQL",
+        [
+            "compass query <QUESTION> [OPTIONS]",
+            "compass query --cql <QUERY> [OPTIONS]",
+            "compass query --cql --file <PATH> [OPTIONS]",
+            "compass query --cql --stdin",
+            "compass query --cql --repl"
+        ],
+        "Arguments:\n  <QUESTION>                      Natural-language graph question\n  <QUERY>                         Inline CompassQL query\n\nOptions:\n  --dfs                           Use depth-first traversal\n  --context <VALUE>               Add query context\n  --budget <N>                    Limit returned context\n  --graph <PATH>                  Read a graph JSON file\n  --at <REV>                      Query an immutable Git revision; conflicts with --graph\n  --cql                           Use CompassQL mode\n  --file <PATH>                   Read CompassQL from a file\n  --stdin                         Read CompassQL from standard input\n  --repl                          Start the interactive CompassQL shell\n  --param <NAME=VALUE>            Bind a parameter; repeatable\n  --params-file <PATH>            Read parameters from JSON\n  --format <table|json|jsonl>     Result format [default: table]\n  --output <PATH>                 Write results to a file\n  --timeout-ms <N>                Execution timeout [default: 5000]\n  --max-rows <N>                  Row limit [default: 10000]\n  --max-path-depth <N>            Path-depth limit [default: 32]\n  --max-expanded-relationships <N> Relationship expansion limit [default: 5000000]\n  --max-memory-bytes <N>          Memory limit [default: 268435456]\n\nExamples:\n  compass query \"authentication flow\"\n  compass query \"payment service\" --at HEAD~10\n  compass query --cql \"MATCH (n) RETURN n LIMIT 10\" --format json\n  compass query --cql --file report.cql --params-file params.json\n\nTips:\n  Use `compass path` when you know both endpoints of the relationship to trace."
+    ),
+    page!(
+        "path",
+        "Find the shortest relationship path between two graph nodes",
+        ["compass path <SOURCE> <TARGET> [OPTIONS]"],
+        "Arguments:\n  <SOURCE>                Source node name or identifier\n  <TARGET>                Target node name or identifier\n\nOptions:\n  --graph <PATH>          Read a graph JSON file\n  --at <REV>              Use an immutable Git revision; conflicts with --graph\n\nExamples:\n  compass path CheckoutHandler PaymentGateway\n  compass path api route --at v1.2.0"
+    ),
+    page!(
+        "explain",
+        "Explain a node and its important relationships",
+        ["compass explain <NODE> [OPTIONS]"],
+        "Arguments:\n  <NODE>                  Node name, label, or identifier\n\nOptions:\n  --graph <PATH>          Read a graph JSON file\n  --at <REV>              Use an immutable Git revision; conflicts with --graph\n\nExamples:\n  compass explain PaymentService\n  compass explain auth --at HEAD~5"
+    ),
+    page!(
+        "affected",
+        "Find code reachable from a proposed change",
+        ["compass affected <NODE_OR_LABEL> [OPTIONS]"],
+        "Arguments:\n  <NODE_OR_LABEL>         Starting node or community label\n\nOptions:\n  --relation <RELATION>   Follow one relationship type; repeatable\n  --depth <N>             Maximum traversal depth\n  --graph <PATH>          Read a graph JSON file\n\nExamples:\n  compass affected PaymentGateway\n  compass affected auth --relation CALLS --depth 3"
+    ),
+    page!(
+        "benchmark",
+        "Measure graph query characteristics",
+        ["compass benchmark [GRAPH_JSON]"],
+        "Arguments:\n  [GRAPH_JSON]            Graph to benchmark [default: compass-out/graph.json]\n\nExamples:\n  compass benchmark\n  compass benchmark fixtures/large-graph.json"
+    ),
+    page!(
+        "history",
+        "Manage immutable graphs for Git revisions",
+        ["compass history <COMMAND>"],
+        "Examples:\n  compass history enable\n  compass history build HEAD\n  compass history status HEAD\n\nTips:\n  Run `compass help history <command>` for revision, format, and safety details."
+    ),
+    page!(
+        "history enable",
+        "Enable eager graph history for future commits",
+        ["compass history enable [BUILD_PROFILE_OPTIONS]"],
+        "Options:\n  --backend <NAME>         Pin a semantic provider\n  --model <MODEL>          Pin the provider model\n  --mode <deep>            Pin deep semantic extraction\n  --cargo                  Include Cargo metadata\n  --dedup-llm              Enable model-assisted deduplication\n  --token-budget <N>       Pin the semantic token budget\n  --resolution <NUMBER>    Pin community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>  Pin the hub-exclusion threshold\n  --no-gitignore           Ignore committed .gitignore rules\n  --exclude <PATTERN>      Pin an exclusion glob; repeatable\n\nExamples:\n  compass history enable\n  compass history enable --cargo --backend gemini --model gemini-2.5-flash\n\nNotes:\n  This installs managed post-commit and post-merge hooks."
+    ),
+    page!(
+        "history disable",
+        "Stop eager history builds while retaining stored graphs",
+        ["compass history disable"],
+        "Examples:\n  compass history disable\n\nNotes:\n  Explicit builds, historical queries, and existing realizations remain available."
+    ),
+    page!(
+        "history status",
+        "Show history configuration and realization status",
+        ["compass history status [REV] [OPTIONS]"],
+        "Arguments:\n  [REV]                   Git revision [default: HEAD]\n\nOptions:\n  --format <text|json>    Output format [default: text]\n\nExamples:\n  compass history status\n  compass history status HEAD~10 --format json"
+    ),
+    page!(
+        "history build",
+        "Materialize an immutable graph for a Git revision",
+        ["compass history build <REV> [BUILD_PROFILE_OPTIONS] [OPTIONS]"],
+        "Arguments:\n  <REV>                    Git revision to materialize\n\nOptions:\n  --profile-from <SOURCE>  Reuse a profile from a revision or realization\n  --format <text|json>      Output format [default: text]\n  --backend <NAME>          Pin a semantic provider\n  --model <MODEL>           Pin the provider model\n  --mode <deep>             Use deep semantic extraction\n  --cargo                   Include Cargo metadata\n  --dedup-llm               Enable model-assisted deduplication\n  --token-budget <N>        Semantic token budget\n  --resolution <NUMBER>     Community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>   Hub-exclusion threshold\n  --no-gitignore            Ignore committed .gitignore rules\n  --exclude <PATTERN>       Exclusion glob; repeatable\n\nExamples:\n  compass history build HEAD\n  compass history build v1.2.0 --profile-from HEAD --format json\n\nNotes:\n  --profile-from conflicts with build-profile options."
+    ),
+    page!(
+        "history rebuild",
+        "Build a new realization for an already materialized revision",
+        ["compass history rebuild <REV> [BUILD_PROFILE_OPTIONS] [OPTIONS]"],
+        "Arguments:\n  <REV>                    Git revision to rebuild\n\nOptions:\n  --replace-corrupt        Replace an unreadable preferred pointer\n  --format <text|json>      Output format [default: text]\n  --backend <NAME>          Pin a semantic provider\n  --model <MODEL>           Pin the provider model\n  --mode <deep>             Use deep semantic extraction\n  --cargo                   Include Cargo metadata\n  --dedup-llm               Enable model-assisted deduplication\n  --token-budget <N>        Semantic token budget\n  --resolution <NUMBER>     Community resolution [default: 1.0]\n  --exclude-hubs <NUMBER>   Hub-exclusion threshold\n  --no-gitignore            Ignore committed .gitignore rules\n  --exclude <PATTERN>       Exclusion glob; repeatable\n\nExamples:\n  compass history rebuild HEAD\n  compass history rebuild HEAD --replace-corrupt\n\nNotes:\n  Use --replace-corrupt only after status reports an unreadable preferred realization."
+    ),
+    page!(
+        "history list",
+        "List stored graph realizations",
+        ["compass history list [REV] [OPTIONS]"],
+        "Arguments:\n  [REV]                   Limit results to one Git revision\n\nOptions:\n  --format <text|json>    Output format [default: text]\n\nExamples:\n  compass history list\n  compass history list HEAD --format json"
+    ),
+    page!(
+        "history show",
+        "Show metadata for one graph realization",
+        ["compass history show <REALIZATION> [OPTIONS]"],
+        "Arguments:\n  <REALIZATION>           Realization identifier\n\nOptions:\n  --format <text|json>    Output format [default: text]\n\nExamples:\n  compass history show 0123456789abcdef\n  compass history show 0123456789abcdef --format json"
+    ),
+    page!(
+        "history prefer",
+        "Select the preferred realization for a revision",
+        ["compass history prefer <REV> <REALIZATION> [OPTIONS]"],
+        "Arguments:\n  <REV>                   Git revision\n  <REALIZATION>           Validated realization identifier\n\nOptions:\n  --format <text|json>    Output format [default: text]\n\nExamples:\n  compass history prefer HEAD 0123456789abcdef\n\nNotes:\n  Compass validates the realization before changing the preferred pointer."
+    ),
+    page!(
+        "history export",
+        "Restore a historical graph or Compass output bundle",
+        ["compass history export <REV> --format <FORMAT> --output <PATH>"],
+        "Arguments:\n  <REV>                         Git revision\n\nOptions:\n  --format <graph-json|compass-out> Required export format\n  --output <PATH>                Required destination\n\nExamples:\n  compass history export HEAD~10 --format graph-json --output old.json\n  compass history export v1.2.0 --format compass-out --output release-graph\n\nNotes:\n  A compass-out destination must not already exist."
+    ),
+    page!(
+        "history gc",
+        "Inspect or reclaim unreachable history storage",
+        ["compass history gc [OPTIONS]"],
+        "Options:\n  --prune-non-preferred    Include alternate realizations in the plan\n  --yes                    Apply non-preferred pruning; requires --prune-non-preferred\n  --format <text|json>     Output format [default: text]\n\nExamples:\n  compass history gc\n  compass history gc --prune-non-preferred\n  compass history gc --prune-non-preferred --yes\n\nNotes:\n  Non-preferred pruning is a dry run until repeated with --yes."
+    ),
+    page!(
+        "diff",
+        "Compare knowledge graphs from two Git revisions",
+        ["compass diff <OLD> <NEW> [OPTIONS]"],
+        "Arguments:\n  <OLD>                         Base Git revision\n  <NEW>                         Target Git revision\n\nOptions:\n  --detailed                    Include node and relationship details\n  --format <text|json>          Output format [default: text]\n  --topology-only               Compare only graph topology\n  --include-locations           Include source-location changes\n  --include-analysis            Include analysis artifact changes\n  --include-metadata            Include graph metadata changes\n  --fingerprint <SHA256>        Select one extraction fingerprint\n  --allow-profile-mismatch      Compare different extraction profiles\n\nExamples:\n  compass diff v1.2.0 HEAD\n  compass diff HEAD~1 HEAD --detailed --include-locations\n  compass diff main feature --format json --allow-profile-mismatch\n\nNotes:\n  --fingerprint conflicts with --allow-profile-mismatch; --detailed conflicts with JSON output."
+    ),
+    page!(
+        "tree",
+        "Generate an interactive filesystem and symbol tree",
+        ["compass tree [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON [default: compass-out/graph.json]\n  --output <HTML>         Output page [default: compass-out/GRAPH_TREE.html]\n  --root <PATH>           Filesystem root shown in the tree\n  --max-children <N>      Visible children per node [default: 200]\n  --top-k-edges <N>       Outbound edges per symbol [default: 12]\n  --label <NAME>          Project label shown in the header\n\nExamples:\n  compass tree\n  compass tree --root ./src --max-children 100"
+    ),
+    page!(
+        "export",
+        "Export or publish the graph in another format",
+        ["compass export <FORMAT> [OPTIONS]"],
+        "Examples:\n  compass export html\n  compass export graphml --graph compass-out/graph.json\n  compass export neo4j --push bolt://localhost:7687\n\nTips:\n  Run `compass help export <format>` for format-specific options."
+    ),
+    page!(
+        "export html",
+        "Generate the interactive graph HTML report",
+        ["compass export html [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON [default: compass-out/graph.json]\n  --labels <PATH>         Community-label JSON\n  --node-limit <N>        Maximum nodes rendered [default: 5000]\n  --no-viz                Skip visualization output\n\nExamples:\n  compass export html\n  compass export html --node-limit 2000"
+    ),
+    page!(
+        "export callflow-html",
+        "Generate a sectioned call-flow report",
+        ["compass export callflow-html [GRAPH_OR_DIR] [OPTIONS]"],
+        "Arguments:\n  [GRAPH_OR_DIR]               Graph JSON or project/output directory\n\nOptions:\n  --graph <PATH>               Graph JSON\n  --labels <PATH>              Community-label JSON\n  --report <PATH>              GRAPH_REPORT.md path\n  --sections <PATH>            JSON section definitions\n  --output <HTML>              Output page\n  --lang <LANG>                Report language [default: auto]\n  --max-sections <N>           Maximum derived sections [default: 15]\n  --diagram-scale <NUMBER>     Mermaid scale [default: 1.0]\n  --max-diagram-nodes <N>      Nodes per diagram [default: 18]\n  --max-diagram-edges <N>      Edges per diagram [default: 24]\n\nExamples:\n  compass export callflow-html\n  compass export callflow-html ./compass-out --lang en --max-sections 10"
+    ),
+    page!(
+        "export obsidian",
+        "Export graph notes for an Obsidian vault",
+        ["compass export obsidian [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n  --labels <PATH>         Community-label JSON\n  --dir <PATH>            Vault output directory [default: compass-out/obsidian]\n\nExamples:\n  compass export obsidian\n  compass export obsidian --dir ./notes/compass"
+    ),
+    page!(
+        "export wiki",
+        "Export a linked Markdown knowledge wiki",
+        ["compass export wiki [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n  --labels <PATH>         Community-label JSON\n\nExamples:\n  compass export wiki\n  compass export wiki --graph artifacts/graph.json"
+    ),
+    page!(
+        "export svg",
+        "Export a static SVG graph overview",
+        ["compass export svg [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n  --labels <PATH>         Community-label JSON\n\nExamples:\n  compass export svg\n  compass export svg --graph artifacts/graph.json"
+    ),
+    page!(
+        "export graphml",
+        "Export portable GraphML",
+        ["compass export graphml [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n\nExamples:\n  compass export graphml\n  compass export graphml --graph artifacts/graph.json"
+    ),
+    page!(
+        "export neo4j",
+        "Write Cypher or push the graph to Neo4j",
+        ["compass export neo4j [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n  --push <URI>            Neo4j Bolt URI\n  --user <NAME>           Database user [default: neo4j]\n  --password <PASSWORD>   Database password [env: NEO4J_PASSWORD]\n\nExamples:\n  compass export neo4j\n  compass export neo4j --push bolt://localhost:7687 --user neo4j\n\nNotes:\n  Prefer NEO4J_PASSWORD over entering a secret in shell history."
+    ),
+    page!(
+        "export falkordb",
+        "Write Cypher or push the graph to FalkorDB",
+        ["compass export falkordb [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON\n  --push <URI>            FalkorDB URI\n  --user <NAME>           Database user\n  --password <PASSWORD>   Database password [env: FALKORDB_PASSWORD]\n\nExamples:\n  compass export falkordb\n  compass export falkordb --push redis://localhost:6379\n\nNotes:\n  Prefer FALKORDB_PASSWORD over entering a secret in shell history."
+    ),
+    page!(
+        "serve",
+        "Serve the knowledge graph through the Model Context Protocol",
+        ["compass serve [GRAPH_PATH] [OPTIONS]"],
+        "Arguments:\n  [GRAPH_PATH]                   Graph JSON [default: compass-out/graph.json]\n\nOptions:\n  --graph <PATH>                 Graph JSON; conflicts with GRAPH_PATH\n  --transport <stdio|http>       Transport [default: stdio]\n  --host <HOST>                  HTTP bind host [default: 127.0.0.1]\n  --port <PORT>                  HTTP bind port [default: 8080]\n  --api-key <KEY>                HTTP bearer token [env: GRAPHIFY_API_KEY]\n  --path <PATH>                  HTTP endpoint [default: /mcp]\n  --json-response                Use JSON responses for HTTP\n  --stateless                    Disable HTTP sessions\n  --session-timeout <SECONDS>    Session timeout [default: 3600]\n\nExamples:\n  compass serve\n  compass serve --transport http --port 9000\n\nNotes:\n  HTTP transport requires an API key when binding outside a trusted local environment."
+    ),
+    page!(
+        "global",
+        "Manage a graph assembled from multiple repositories",
+        ["compass global <COMMAND>"],
+        "Examples:\n  compass global list\n  compass global add compass-out/graph.json --as api\n\nTips:\n  Run `compass help global <command>` for command-specific arguments."
+    ),
+    page!(
+        "global add",
+        "Add or refresh one repository in the global graph",
+        ["compass global add <GRAPH_JSON> [OPTIONS]"],
+        "Arguments:\n  <GRAPH_JSON>             Repository graph JSON\n\nOptions:\n  --as <TAG>               Stable repository tag\n\nExamples:\n  compass global add compass-out/graph.json --as api"
+    ),
+    page!(
+        "global remove",
+        "Remove one repository from the global graph",
+        ["compass global remove <TAG>"],
+        "Arguments:\n  <TAG>                    Repository tag\n\nExamples:\n  compass global remove api"
+    ),
+    page!(
+        "global list",
+        "List repositories in the global graph",
+        ["compass global list"],
+        "Examples:\n  compass global list"
+    ),
+    page!(
+        "global path",
+        "Print the global graph file path",
+        ["compass global path"],
+        "Examples:\n  compass global path"
+    ),
+    page!(
+        "clone",
+        "Clone or refresh a GitHub repository in Compass storage",
+        ["compass clone <GITHUB_URL> [OPTIONS]"],
+        "Arguments:\n  <GITHUB_URL>             GitHub HTTPS or SSH repository URL\n\nOptions:\n  --branch <BRANCH>        Clone or update one branch\n  --out <DIR>              Destination directory\n\nExamples:\n  compass clone https://github.com/org/project\n  compass clone git@github.com:org/project.git --branch main --out ./project"
+    ),
+    page!(
+        "add",
+        "Download a supported source into the ingestion directory",
+        ["compass add <URL> [OPTIONS]"],
+        "Arguments:\n  <URL>                    Source URL\n\nOptions:\n  --author <NAME>          Record the original author\n  --contributor <NAME>     Record the contributor\n  --dir <DIR>              Download directory [default: ./raw]\n\nExamples:\n  compass add https://example.com/paper.pdf\n  compass add https://example.com/post --author \"Ada Lovelace\" --dir ./research"
+    ),
+    page!(
+        "prs",
+        "Inspect and prioritize GitHub pull requests",
+        ["compass prs [NUMBER] [OPTIONS]"],
+        "Arguments:\n  [NUMBER]                 Pull request number for a detailed view\n\nOptions:\n  --triage                 Rank the review queue with a configured model\n  --worktrees              Show worktree, branch, and PR mapping\n  --conflicts              Show graph-community overlap\n  --wrong-base             Show pull requests targeting the wrong base\n  -b, --base <BRANCH>      Filter by base branch\n  -R, --repo <OWNER/REPO>  Select a GitHub repository\n  --graph <PATH>           Graph JSON used for conflict analysis\n\nExamples:\n  compass prs\n  compass prs 42\n  compass prs --conflicts --base main"
+    ),
+    page!(
+        "hook",
+        "Manage Compass Git hooks",
+        ["compass hook <COMMAND>"],
+        "Examples:\n  compass hook install\n  compass hook status\n  compass hook uninstall"
+    ),
+    page!(
+        "hook install",
+        "Install managed Compass Git hooks",
+        ["compass hook install"],
+        "Examples:\n  compass hook install"
+    ),
+    page!(
+        "hook uninstall",
+        "Remove managed Compass Git hooks",
+        ["compass hook uninstall"],
+        "Examples:\n  compass hook uninstall"
+    ),
+    page!(
+        "hook status",
+        "Show whether managed Compass Git hooks are installed",
+        ["compass hook status"],
+        "Examples:\n  compass hook status"
+    ),
+    page!(
+        "install",
+        "Install Compass guidance for coding assistants",
+        ["compass install [PLATFORM] [OPTIONS]"],
+        "Arguments:\n  [PLATFORM]               Assistant platform; may also use --platform\n\nOptions:\n  --platform <NAME>        claude, codex, opencode, kilo, aider, copilot, claw, droid, trae, trae-cn, hermes, kiro, pi, codebuddy, antigravity, antigravity-windows, windows, kimi, amp, agents, devin, gemini, or cursor\n  --project                Install into the current project\n  --strict                 Require an initial graph query; requires --project\n\nExamples:\n  compass install --platform codex\n  compass install claude --project --strict\n\nTips:\n  Direct aliases such as `compass codex install` remain available for compatibility."
+    ),
+    page!(
+        "uninstall",
+        "Remove installed Compass assistant guidance",
+        ["compass uninstall [PLATFORM] [OPTIONS]"],
+        "Arguments:\n  [PLATFORM]               Remove one assistant platform\n\nOptions:\n  --platform <NAME>        Select one assistant platform\n  --project                Remove project-scoped files\n  --purge                  Remove all installed Compass guidance\n\nExamples:\n  compass uninstall --platform codex\n  compass uninstall --project --purge"
+    ),
+    page!(
+        "provider",
+        "Manage custom semantic model providers",
+        ["compass provider <COMMAND>"],
+        "Examples:\n  compass provider list\n  compass provider show local\n\nTips:\n  Run `compass help provider add` for endpoint and credential configuration."
+    ),
+    page!(
+        "provider add",
+        "Register a custom OpenAI-compatible provider",
+        [
+            "compass provider add <NAME> --base-url <URL> --default-model <MODEL> --env-key <KEY> [OPTIONS]"
+        ],
+        "Arguments:\n  <NAME>                       Provider name\n\nOptions:\n  --base-url <URL>             API base URL\n  --default-model <MODEL>      Default model identifier\n  --env-key <KEY>              Environment variable containing credentials\n  --pricing-input <NUMBER>     Input price per million tokens [default: 0]\n  --pricing-output <NUMBER>    Output price per million tokens [default: 0]\n\nExamples:\n  compass provider add local --base-url http://localhost:11434/v1 --default-model qwen3 --env-key LOCAL_API_KEY"
+    ),
+    page!(
+        "provider list",
+        "List registered custom providers",
+        ["compass provider list"],
+        "Examples:\n  compass provider list"
+    ),
+    page!(
+        "provider show",
+        "Show one custom provider configuration",
+        ["compass provider show <NAME>"],
+        "Arguments:\n  <NAME>                   Provider name\n\nExamples:\n  compass provider show local"
+    ),
+    page!(
+        "provider remove",
+        "Remove a custom provider",
+        ["compass provider remove <NAME>"],
+        "Arguments:\n  <NAME>                   Provider name\n\nExamples:\n  compass provider remove local"
+    ),
+    page!(
+        "save-result",
+        "Store a graph question and its outcome as reusable memory",
+        [
+            "compass save-result --question <TEXT> (--answer <TEXT> | --answer-file <PATH>) [OPTIONS]"
+        ],
+        "Options:\n  --question <TEXT>        Required original question\n  --answer <TEXT>          Inline answer; conflicts with --answer-file\n  --answer-file <PATH>     Read the answer from a file; conflicts with --answer\n  --type <TYPE>            Query type\n  --nodes <NODE...>        Related graph nodes\n  --outcome <useful|dead_end|corrected> Result classification\n  --correction <TEXT>      Corrected answer or guidance\n  --memory-dir <DIR>       Memory directory\n\nExamples:\n  compass save-result --question \"Where is auth?\" --answer \"src/auth.rs\" --outcome useful\n  compass save-result --question \"Old path\" --answer-file answer.md --outcome corrected --correction \"Use src/session.rs\""
+    ),
+    page!(
+        "reflect",
+        "Consolidate saved query outcomes into durable lessons",
+        ["compass reflect [OPTIONS]"],
+        "Options:\n  --memory-dir <DIR>           Memory directory\n  --out <PATH>                 Lesson output path\n  --graph <PATH>               Graph JSON\n  --analysis <PATH>            Graph analysis JSON\n  --labels <PATH>              Community-label JSON\n  --half-life-days <N>         Evidence half-life\n  --min-corroboration <N>      Minimum supporting results\n  --if-stale                   Skip reflection when lessons are fresh\n\nExamples:\n  compass reflect\n  compass reflect --if-stale --min-corroboration 2"
+    ),
+    page!(
+        "diagnose",
+        "Inspect graph health and compatibility problems",
+        ["compass diagnose <COMMAND>"],
+        "Examples:\n  compass diagnose multigraph\n  compass diagnose multigraph --json"
+    ),
+    page!(
+        "diagnose multigraph",
+        "Diagnose duplicate and directed-edge behavior in a graph",
+        ["compass diagnose multigraph [OPTIONS]"],
+        "Options:\n  --graph <PATH>          Graph JSON [default: compass-out/graph.json]\n  --json                  Emit machine-readable JSON\n  --max-examples <N>      Limit diagnostic examples\n  --directed              Force directed interpretation; conflicts with --undirected\n  --undirected            Force undirected interpretation; conflicts with --directed\n  --extract-path <PATH>   Compare against extraction output\n\nExamples:\n  compass diagnose multigraph\n  compass diagnose multigraph --graph old.json --json --max-examples 20"
+    ),
+    page!(
+        "check-update",
+        "Check whether semantic inputs require a graph update",
+        ["compass check-update <PATH>"],
+        "Arguments:\n  <PATH>                   Project directory\n\nExamples:\n  compass check-update ."
+    ),
+    page!(
+        "merge-driver",
+        "Merge graph JSON files for Git's custom merge driver",
+        ["compass merge-driver <BASE> <CURRENT> <OTHER>"],
+        "Arguments:\n  <BASE>                   Common ancestor file\n  <CURRENT>                Current branch file\n  <OTHER>                  Other branch file\n\nExamples:\n  compass merge-driver %O %A %B\n\nNotes:\n  This command is normally invoked by Git after Compass installation."
+    ),
+    page!(
+        "hook-check",
+        "Run the lightweight installed-hook compatibility check",
+        ["compass hook-check"],
+        "Examples:\n  compass hook-check\n\nNotes:\n  Installed assistant integrations invoke this command automatically."
+    ),
+    page!(
+        "hook-guard",
+        "Evaluate an installed assistant tool guard",
+        ["compass hook-guard <KIND> [OPTIONS]"],
+        "Arguments:\n  <KIND>                   search, read, or gemini\n\nOptions:\n  --strict                 Enforce the first-read graph-query guard\n\nExamples:\n  compass hook-guard read --strict\n\nNotes:\n  Installed assistant integrations invoke this command with JSON on standard input."
+    ),
+    internal_page!(
+        "history-worker",
+        "Process queued immutable history builds",
+        ["compass history-worker"],
+        "Notes:\n  Internal command. Use `compass history status` to inspect public history state."
+    ),
+    internal_page!(
+        "hook-spawn",
+        "Start a managed background hook refresh",
+        ["compass hook-spawn [PATH]"],
+        "Notes:\n  Internal command. Use `compass hook status` to inspect managed hooks."
+    ),
+    internal_page!(
+        "hook-refresh",
+        "Refresh graph artifacts for a managed hook",
+        ["compass hook-refresh [PATH]"],
+        "Notes:\n  Internal command. Use `compass update` for an interactive refresh."
+    ),
+];
+
+pub fn request_os(arguments: &[OsString], style: HelpStyle) -> Option<Outcome> {
+    let arguments = arguments
+        .iter()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    request(&arguments, style)
+}
+
+pub(crate) fn request(arguments: &[String], style: HelpStyle) -> Option<Outcome> {
+    if arguments.is_empty() {
+        return Some(Outcome::success(render_root(style)));
+    }
+    let explicit_help = arguments.first().is_some_and(|value| value == "help");
+    let help_index = arguments
+        .iter()
+        .position(|value| matches!(value.as_str(), "-h" | "--help"));
+    if !explicit_help && help_index.is_none() {
+        return None;
+    }
+    let tokens = if explicit_help {
+        &arguments[1..]
+    } else {
+        &arguments[..help_index.unwrap_or(arguments.len())]
+    };
+    if tokens.is_empty() {
+        return Some(Outcome::success(render_root(style)));
+    }
+    if let Some(alias) = alias_page(tokens) {
+        return Some(Outcome::success(render_page(alias, style)));
+    }
+    if explicit_help {
+        let path = tokens.join(" ");
+        return Some(match page(&path) {
+            Some(page) => Outcome::success(render_page(page, style)),
+            None => help_path_error(tokens),
+        });
+    }
+    let leading = tokens
+        .iter()
+        .take_while(|value| !value.starts_with('-'))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let Some((matched, length)) = longest_page_prefix(&leading) else {
+        return Some(help_path_error(tokens));
+    };
+    if length < leading.len() && has_children(matched.path) {
+        return Some(unknown_child_error(matched.path, leading[length]));
+    }
+    Some(Outcome::success(render_page(matched, style)))
+}
+
+pub(crate) fn unknown_command(command: &str) -> String {
+    let mut message = format!("error: unknown command '{command}'");
+    if let Some(suggestion) = closest(command, root_commands()) {
+        message.push_str(&format!("\nDid you mean '{suggestion}'?"));
+    }
+    message.push_str("\nRun 'compass --help' for usage.");
+    message
+}
+
+pub(crate) fn append_usage_hint(
+    mut outcome: Outcome,
+    command: &str,
+    arguments: &[String],
+) -> Outcome {
+    if outcome.code != 2 || outcome.stderr.is_empty() || outcome.stderr.contains("--help") {
+        return outcome;
+    }
+    let mut tokens = vec![command];
+    tokens.extend(
+        arguments
+            .iter()
+            .take_while(|value| !value.starts_with('-'))
+            .map(String::as_str),
+    );
+    let path = longest_page_prefix(&tokens).map_or(command, |(page, _)| page.path);
+    outcome
+        .stderr
+        .push_str(&format!("\nRun `compass {path} --help` for usage."));
+    outcome
+}
+
+fn alias_page(tokens: &[String]) -> Option<&'static Page> {
+    const ALIASES: &[&str] = &[
+        "agents",
+        "skills",
+        "aider",
+        "amp",
+        "antigravity",
+        "claude",
+        "claw",
+        "codebuddy",
+        "codex",
+        "copilot",
+        "cursor",
+        "devin",
+        "droid",
+        "gemini",
+        "hermes",
+        "kilo",
+        "kiro",
+        "opencode",
+        "pi",
+        "trae",
+        "trae-cn",
+        "vscode",
+    ];
+    tokens
+        .first()
+        .filter(|name| ALIASES.contains(&name.as_str()))
+        .and_then(|_| page("install"))
+}
+
+fn page(path: &str) -> Option<&'static Page> {
+    PAGES.iter().find(|page| page.path == path)
+}
+
+fn longest_page_prefix(tokens: &[&str]) -> Option<(&'static Page, usize)> {
+    (1..=tokens.len()).rev().find_map(|length| {
+        let path = tokens[..length].join(" ");
+        page(&path).map(|page| (page, length))
+    })
+}
+
+fn help_path_error(tokens: &[String]) -> Outcome {
+    let borrowed = tokens.iter().map(String::as_str).collect::<Vec<_>>();
+    if let Some((parent, length)) = longest_page_prefix(&borrowed)
+        && length < borrowed.len()
+    {
+        return unknown_child_error(parent.path, borrowed[length]);
+    }
+    let unknown = borrowed.first().copied().unwrap_or_default();
+    Outcome::failure_with_code(unknown_help_message("", unknown), 2)
+}
+
+fn unknown_child_error(parent: &str, unknown: &str) -> Outcome {
+    Outcome::failure_with_code(unknown_help_message(parent, unknown), 2)
+}
+
+fn unknown_help_message(parent: &str, unknown: &str) -> String {
+    let noun = if parent.is_empty() {
+        "command"
+    } else {
+        "subcommand"
+    };
+    let mut message = format!("error: unknown {noun} '{unknown}'");
+    let candidates = if parent.is_empty() {
+        root_commands()
+    } else {
+        child_names(parent)
+    };
+    if let Some(suggestion) = closest(unknown, candidates) {
+        message.push_str(&format!("\nDid you mean '{suggestion}'?"));
+    }
+    let help = if parent.is_empty() {
+        "compass --help".to_owned()
+    } else {
+        format!("compass {parent} --help")
+    };
+    message.push_str(&format!("\nRun `{help}` for usage."));
+    message
+}
+
+fn render_root(style: HelpStyle) -> String {
+    let mut output = String::from(
+        "Compass: turn a codebase into a searchable knowledge graph\n\nUsage:\n  compass <COMMAND> [OPTIONS]",
+    );
+    for group in GROUPS {
+        output.push_str("\n\n");
+        output.push_str(group.title);
+        output.push_str(":\n");
+        let width = group
+            .commands
+            .iter()
+            .map(|command| command.len())
+            .max()
+            .unwrap_or(0);
+        for command in group.commands {
+            let summary = page(command).map_or("", |page| page.summary);
+            output.push_str(&format!("  {command:width$}  {summary}\n"));
+        }
+        let _ = output.pop();
+    }
+    output.push_str(
+        "\n\nOptions:\n  -h, --help     Show help\n  -V, --version  Show version\n\nRun `compass help <command>` for detailed help.",
+    );
+    finish(output, style)
+}
+
+fn render_page(page: &Page, style: HelpStyle) -> String {
+    let mut output = format!("{}\n\nUsage:", page.summary);
+    for usage in page.usage {
+        output.push_str("\n  ");
+        output.push_str(usage);
+    }
+    let children = children(page.path);
+    if !children.is_empty() {
+        output.push_str("\n\nCommands:\n");
+        let width = children
+            .iter()
+            .map(|child| child.path.rsplit(' ').next().unwrap_or(child.path).len())
+            .max()
+            .unwrap_or(0);
+        for child in children {
+            let name = child.path.rsplit(' ').next().unwrap_or(child.path);
+            output.push_str(&format!("  {name:width$}  {}\n", child.summary));
+        }
+        let _ = output.pop();
+    }
+    let details = add_help_option(page.details);
+    if !details.is_empty() {
+        output.push_str("\n\n");
+        output.push_str(&details);
+    }
+    finish(output, style)
+}
+
+fn add_help_option(details: &str) -> String {
+    let markers = ["\n\nExamples:", "\n\nTips:", "\n\nNotes:"];
+    let insert_at = markers
+        .iter()
+        .filter_map(|marker| details.find(marker))
+        .min()
+        .unwrap_or(details.len());
+    let (before, after) = details.split_at(insert_at);
+    let addition = if before.contains("Options:") {
+        let description_column = before
+            .rsplit_once("Options:\n")
+            .map_or(26, |(_, options)| option_description_column(options));
+        let padding = description_column.saturating_sub(2 + "-h, --help".len());
+        format!("\n  -h, --help{}Show this help", " ".repeat(padding))
+    } else {
+        "\n\nOptions:\n  -h, --help  Show this help".to_owned()
+    };
+    format!("{before}{addition}{after}")
+}
+
+fn option_description_column(options: &str) -> usize {
+    options
+        .lines()
+        .filter_map(|line| {
+            let bytes = line.as_bytes();
+            let gap = 2 + bytes.get(2..)?.windows(2).position(|pair| pair == b"  ")?;
+            let spaces = bytes[gap..]
+                .iter()
+                .take_while(|byte| **byte == b' ')
+                .count();
+            Some(gap + spaces)
+        })
+        .max()
+        .unwrap_or(26)
+}
+
+fn finish(output: String, style: HelpStyle) -> String {
+    let plain = output
+        .lines()
+        .flat_map(wrap_line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    match style {
+        HelpStyle::Plain => plain,
+        HelpStyle::Ansi => style_output(&plain),
+    }
+}
+
+fn wrap_line(line: &str) -> Vec<String> {
+    if line.chars().count() <= WIDTH {
+        return vec![line.to_owned()];
+    }
+    let leading = line.len().saturating_sub(line.trim_start().len());
+    let trimmed = line.trim_start();
+    let split = trimmed.as_bytes().windows(2).position(|pair| pair == b"  ");
+    let (prefix, text) = split.map_or_else(
+        || (" ".repeat(leading), trimmed),
+        |index| {
+            let description = trimmed[index..].trim_start();
+            (
+                format!("{}{}  ", " ".repeat(leading), &trimmed[..index]),
+                description,
+            )
+        },
+    );
+    let continuation = " ".repeat(prefix.chars().count());
+    wrap_words(text, &prefix, &continuation)
+}
+
+fn wrap_words(text: &str, first_prefix: &str, next_prefix: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = first_prefix.to_owned();
+    for word in text.split_whitespace() {
+        let separator = usize::from(!current.is_empty() && !current.ends_with(' '));
+        if current.chars().count() + separator + word.chars().count() > WIDTH
+            && current.trim() != first_prefix.trim()
+        {
+            lines.push(current);
+            current = next_prefix.to_owned();
+        }
+        if !current.is_empty() && !current.ends_with(' ') {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    lines.push(current);
+    lines
+}
+
+fn style_output(plain: &str) -> String {
+    const BOLD_CYAN: &str = "\x1b[1;36m";
+    const CYAN: &str = "\x1b[36m";
+    const RESET: &str = "\x1b[0m";
+    plain
+        .lines()
+        .enumerate()
+        .map(|(index, line)| {
+            if index == 0 {
+                return format!("{BOLD_CYAN}{line}{RESET}");
+            }
+            if !line.starts_with(' ') && line.ends_with(':') {
+                return format!("{BOLD_CYAN}{line}{RESET}");
+            }
+            if let Some(content) = line.strip_prefix("  ") {
+                let term_end = content
+                    .as_bytes()
+                    .windows(2)
+                    .position(|pair| pair == b"  ")
+                    .unwrap_or(content.len());
+                let (term, rest) = content.split_at(term_end);
+                if !term.is_empty() {
+                    return format!("  {CYAN}{term}{RESET}{rest}");
+                }
+            }
+            line.to_owned()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn has_children(path: &str) -> bool {
+    PAGES
+        .iter()
+        .any(|candidate| is_immediate_child(path, candidate.path))
+}
+
+fn children(path: &str) -> Vec<&'static Page> {
+    PAGES
+        .iter()
+        .filter(|candidate| {
+            candidate.visibility == Visibility::Public && is_immediate_child(path, candidate.path)
+        })
+        .collect()
+}
+
+fn child_names(path: &str) -> Vec<&'static str> {
+    children(path)
+        .into_iter()
+        .filter_map(|page| page.path.rsplit(' ').next())
+        .collect()
+}
+
+fn is_immediate_child(parent: &str, candidate: &str) -> bool {
+    candidate
+        .strip_prefix(parent)
+        .and_then(|suffix| suffix.strip_prefix(' '))
+        .is_some_and(|suffix| !suffix.contains(' '))
+}
+
+fn root_commands() -> Vec<&'static str> {
+    GROUPS
+        .iter()
+        .flat_map(|group| group.commands.iter().copied())
+        .collect()
+}
+
+fn closest<'a>(unknown: &str, candidates: Vec<&'a str>) -> Option<&'a str> {
+    let threshold = if unknown.chars().count() <= 3 { 1 } else { 2 };
+    candidates
+        .into_iter()
+        .map(|candidate| (levenshtein(unknown, candidate), candidate))
+        .filter(|(distance, _)| *distance <= threshold)
+        .min_by_key(|(distance, candidate)| (*distance, candidate.len()))
+        .map(|(_, candidate)| candidate)
+}
+
+fn levenshtein(left: &str, right: &str) -> usize {
+    let right = right.chars().collect::<Vec<_>>();
+    let mut previous = (0..=right.len()).collect::<Vec<_>>();
+    for (left_index, left_char) in left.chars().enumerate() {
+        let mut current = vec![left_index + 1];
+        for (right_index, right_char) in right.iter().enumerate() {
+            let substitution = previous[right_index] + usize::from(left_char != *right_char);
+            current.push(usize::min(
+                usize::min(previous[right_index + 1] + 1, current[right_index] + 1),
+                substitution,
+            ));
+        }
+        previous = current;
+    }
+    previous[right.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    #[test]
+    fn catalog_has_unique_complete_public_roots() {
+        let roots = root_commands();
+        assert_eq!(roots.len(), 34);
+        for root in roots {
+            let matches = PAGES.iter().filter(|page| page.path == root).count();
+            assert_eq!(matches, 1, "{root}");
+            assert_eq!(
+                page(root).map(|page| page.visibility),
+                Some(Visibility::Public)
+            );
+        }
+        for internal in ["history-worker", "hook-spawn", "hook-refresh"] {
+            assert_eq!(
+                page(internal).map(|page| page.visibility),
+                Some(Visibility::Internal)
+            );
+        }
+    }
+
+    #[test]
+    fn nested_help_forms_are_equivalent() {
+        let flag = request(&strings(&["history", "build", "--help"]), HelpStyle::Plain)
+            .expect("help request");
+        let command = request(&strings(&["help", "history", "build"]), HelpStyle::Plain)
+            .expect("help request");
+        assert_eq!(flag.code, 0);
+        assert_eq!(flag.stdout, command.stdout);
+        assert!(flag.stdout.contains("--profile-from"));
+        assert!(flag.stdout.contains("Examples:"));
+    }
+
+    #[test]
+    fn styling_policy_and_rendering_preserve_plain_text() {
+        assert_eq!(HelpStyle::detect(false, None, None), HelpStyle::Plain);
+        assert_eq!(
+            HelpStyle::detect(true, Some(OsStr::new("")), None),
+            HelpStyle::Plain
+        );
+        assert_eq!(
+            HelpStyle::detect(true, None, Some(OsStr::new("DUMB"))),
+            HelpStyle::Plain
+        );
+        assert_eq!(HelpStyle::detect(true, None, None), HelpStyle::Ansi);
+        let plain = render_page(page("update").expect("update page"), HelpStyle::Plain);
+        let styled = render_page(page("update").expect("update page"), HelpStyle::Ansi);
+        assert!(!plain.contains('\x1b'));
+        assert_eq!(strip_ansi(&styled), plain);
+        for page in PAGES {
+            let output = render_page(page, HelpStyle::Plain);
+            assert!(
+                output.lines().all(|line| line.chars().count() <= WIDTH),
+                "{}",
+                page.path
+            );
+        }
+    }
+
+    #[test]
+    fn typo_suggestions_are_conservative() {
+        assert!(unknown_command("udpate").contains("Did you mean 'update'?"));
+        assert!(!unknown_command("bananas").contains("Did you mean"));
+        let outcome = request(&strings(&["help", "history", "buidl"]), HelpStyle::Plain)
+            .expect("help request");
+        assert_eq!(outcome.code, 2);
+        assert!(outcome.stderr.contains("Did you mean 'build'?"));
+    }
+
+    fn strip_ansi(value: &str) -> String {
+        let mut output = String::new();
+        let mut chars = value.chars().peekable();
+        while let Some(character) = chars.next() {
+            if character == '\x1b' && chars.peek() == Some(&'[') {
+                let _ = chars.next();
+                for value in chars.by_ref() {
+                    if value == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                output.push(character);
+            }
+        }
+        output
+    }
+}

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -554,14 +554,16 @@ pub(crate) fn request(arguments: &[String], style: HelpStyle) -> Option<Outcome>
         return Some(Outcome::success(render_root(style)));
     }
     let explicit_help = arguments.first().is_some_and(|value| value == "help");
-    let help_index = arguments
-        .iter()
-        .position(|value| matches!(value.as_str(), "-h" | "--help"));
+    let help_index = arguments.iter().position(|value| is_help_flag(value));
     if !explicit_help && help_index.is_none() {
         return None;
     }
     let tokens = if explicit_help {
-        &arguments[1..]
+        let arguments = &arguments[1..];
+        &arguments[..arguments
+            .iter()
+            .position(|value| is_help_flag(value))
+            .unwrap_or(arguments.len())]
     } else {
         &arguments[..help_index.unwrap_or(arguments.len())]
     };
@@ -590,6 +592,10 @@ pub(crate) fn request(arguments: &[String], style: HelpStyle) -> Option<Outcome>
         return Some(unknown_child_error(matched.path, leading[length]));
     }
     Some(Outcome::success(render_page(matched, style)))
+}
+
+fn is_help_flag(value: &str) -> bool {
+    matches!(value, "-h" | "--help" | "-?")
 }
 
 pub(crate) fn unknown_command(command: &str) -> String {

--- a/crates/compass-cli/src/label_commands.rs
+++ b/crates/compass-cli/src/label_commands.rs
@@ -512,14 +512,6 @@ fn parse_positive(value: &str, option: &str) -> Result<usize, String> {
         .ok_or_else(|| format!("error: {option} requires a positive integer"))
 }
 
-pub(super) fn label_help(frontend: Frontend) -> String {
-    match frontend {
-        Frontend::Compass => "Usage: compass label [PATH] [--graph PATH] [--backend NAME] [--model NAME] [--missing-only] [--no-viz] [--resolution N] [--exclude-hubs N] [--max-concurrency N] [--batch-size N] [--min-community-size=N] [--timing]",
-        Frontend::Graphify => "Usage: graphify label [PATH] [--graph PATH] [--backend NAME] [--model NAME] [--missing-only] [--no-viz] [--resolution N] [--exclude-hubs N] [--max-concurrency N] [--batch-size N] [--min-community-size=N] [--timing]",
-    }
-    .to_owned()
-}
-
 #[cfg(test)]
 mod tests {
     use compass_model::GraphDocument;
@@ -584,7 +576,6 @@ mod tests {
         assert!(parse_number("inf", "--value").is_err());
         assert!(parse_positive("0", "--value").is_err());
         assert_eq!(python_repr("a'b\\c"), "'a\\'b\\\\c'");
-        assert!(label_help(Frontend::Graphify).starts_with("Usage: graphify"));
         Ok(())
     }
 

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -1,6 +1,7 @@
 //! Command compatibility layer for Compass and the Graphify compatibility binary.
 
 mod dedup_commands;
+mod help;
 mod history_build;
 mod history_commands;
 mod hook_commands;
@@ -49,6 +50,8 @@ use compass_semantic::{
     extract_builtin_corpus_cached, extract_custom_corpus_cached, load_custom_providers,
     resolve_builtin_backend, resolve_custom_backend,
 };
+
+pub use help::HelpStyle;
 
 static PROCESS_CANCELLED: AtomicBool = AtomicBool::new(false);
 static SIGNAL_HANDLER: OnceLock<Result<(), String>> = OnceLock::new();
@@ -153,8 +156,10 @@ pub fn run(frontend: Frontend, arguments: impl IntoIterator<Item = OsString>) ->
         .map(|argument| argument.to_string_lossy().into_owned())
         .collect::<Vec<_>>();
     if frontend == Frontend::Compass {
+        if let Some(outcome) = help::request(&args, HelpStyle::Plain) {
+            return outcome;
+        }
         match args.first().map(String::as_str) {
-            Some("--help" | "-h" | "help") => return Outcome::success(compass_help()),
             Some("--version" | "-V") => {
                 return Outcome::success(format!("compass {}", env!("CARGO_PKG_VERSION")));
             }
@@ -162,21 +167,10 @@ pub fn run(frontend: Frontend, arguments: impl IntoIterator<Item = OsString>) ->
         }
     }
     let Some(command) = args.first().cloned() else {
-        return Outcome::success(if frontend == Frontend::Compass {
-            compass_help()
-        } else {
-            graphify_help()
-        });
+        return Outcome::success(graphify_help());
     };
     args.remove(0);
-    if frontend == Frontend::Compass
-        && args
-            .iter()
-            .any(|argument| matches!(argument.as_str(), "--help" | "-h"))
-    {
-        return Outcome::success(compass_command_help(&command));
-    }
-    match command.as_str() {
+    let outcome = match command.as_str() {
         "history" => history_commands::command(frontend, &args),
         "history-worker" => history_commands::command_worker(frontend, &args),
         "diff" => history_commands::command_diff(frontend, &args),
@@ -223,11 +217,7 @@ pub fn run(frontend: Frontend, arguments: impl IntoIterator<Item = OsString>) ->
             "error: serve is a long-lived command and must be run from the compass binary"
                 .to_owned(),
         ),
-        "--help" | "-h" | "-?" | "help" => Outcome::success(if frontend == Frontend::Compass {
-            compass_help()
-        } else {
-            graphify_help()
-        }),
+        "--help" | "-h" | "-?" | "help" => Outcome::success(graphify_help()),
         "--version" | "-V" | "-v" | "version" => Outcome::success(match frontend {
             Frontend::Compass => format!("compass {}", env!("CARGO_PKG_VERSION")),
             Frontend::Graphify => format!("graphify {GRAPHIFY_COMPAT_VERSION}"),
@@ -235,10 +225,18 @@ pub fn run(frontend: Frontend, arguments: impl IntoIterator<Item = OsString>) ->
         _ if frontend == Frontend::Graphify => Outcome::failure(format!(
             "error: unknown command '{command}'\nRun 'graphify --help' for usage."
         )),
-        _ => Outcome::failure(format!(
-            "error: unknown command '{command}'\nRun 'compass --help' for usage."
-        )),
+        _ => Outcome::failure(help::unknown_command(&command)),
+    };
+    if frontend == Frontend::Compass {
+        help::append_usage_hint(outcome, &command, &args)
+    } else {
+        outcome
     }
+}
+
+#[must_use]
+pub fn compass_help_request(arguments: &[OsString], style: HelpStyle) -> Option<Outcome> {
+    help::request_os(arguments, style)
 }
 
 /// Run the graph-history diff command with direct streaming output.
@@ -3697,49 +3695,6 @@ fn graph_load_outcome(error: GraphError) -> Outcome {
             Outcome::failure("error: graph file must be a .json file".to_owned())
         }
         other => Outcome::failure(format!("error: could not load graph: {other}")),
-    }
-}
-
-fn compass_help() -> String {
-    "Usage: compass <command>\n\nCommands:\n  update\n  extract\n  watch\n  serve\n  cluster-only\n  label\n  query\n  path\n  explain\n  affected\n  tree\n  export\n  benchmark\n  diagnose multigraph\n  merge-graphs\n  merge-driver\n  global\n  clone\n  add\n  prs\n  hook\n  install\n  uninstall\n  cache-check\n  merge-chunks\n  merge-semantic\n  provider\n  save-result\n  reflect\n  check-update\n  hook-check\n  hook-guard"
-        .replacen("Commands:\n", "Commands:\n  history\n  diff\n", 1)
-}
-
-fn compass_command_help(command: &str) -> String {
-    match command {
-        "history" => history_commands::help(Frontend::Compass),
-        "diff" => history_commands::diff_help(Frontend::Compass),
-        "update" => "Usage: compass update [PATH] [--out DIR] [--no-cluster] [--force] [--no-viz] [--no-gitignore] [--exclude PATTERN] [--resolution N] [--exclude-hubs N]".to_owned(),
-        "extract" => extract_help(),
-        "watch" => watch_help(),
-        "serve" => mcp_help(McpFrontend::Compass),
-        "cluster-only" => "Usage: compass cluster-only [PATH] [--graph PATH] [--no-viz] [--no-label] [--resolution N] [--exclude-hubs N] [--min-community-size=N]".to_owned(),
-        "label" => label_commands::label_help(Frontend::Compass),
-        "prs" => prs_commands::prs_help(Frontend::Compass),
-        "query" => query_commands::query_help(),
-        "path" => path_help(Frontend::Compass),
-        "explain" => explain_help(Frontend::Compass),
-        "affected" => "Usage: compass affected \"<node-or-label>\" [--relation R] [--depth N] [--graph PATH]".to_owned(),
-        "tree" => tree_help(Frontend::Compass),
-        "export" => export_help().replacen("graphify export", "compass export", 1),
-        "benchmark" => "Usage: compass benchmark [GRAPH_JSON]".to_owned(),
-        "diagnose" => "Usage: compass diagnose multigraph [--graph PATH] [--json] [--max-examples N] [--directed|--undirected] [--extract-path PATH]".to_owned(),
-        "merge-graphs" => "Usage: compass merge-graphs <graph1.json> <graph2.json> [...] [--out merged.json]".to_owned(),
-        "cache-check" => semantic_commands::cache_check_help(Frontend::Compass),
-        "merge-chunks" => semantic_commands::merge_chunks_help(Frontend::Compass),
-        "merge-semantic" => semantic_commands::merge_semantic_help(Frontend::Compass),
-        "provider" => provider_commands::provider_help(Frontend::Compass),
-        "save-result" => result_commands::save_result_help(Frontend::Compass),
-        "reflect" => result_commands::reflect_help(Frontend::Compass),
-        "check-update" => integration_commands::check_update_help(Frontend::Compass),
-        "merge-driver" => integration_commands::merge_driver_help(Frontend::Compass),
-        "global" => integration_commands::global_help(Frontend::Compass),
-        "clone" => integration_commands::clone_help(Frontend::Compass),
-        "add" => ingest_commands::add_help(Frontend::Compass),
-        "hook" => hook_commands::hook_help(Frontend::Compass),
-        "install" => install_commands::command_install(Frontend::Compass, &["--help".to_owned()]).stdout,
-        "uninstall" => "Usage: compass uninstall [--project] [--purge] [--platform P|P]".to_owned(),
-        _ => compass_help(),
     }
 }
 

--- a/crates/compass-cli/src/query_commands.rs
+++ b/crates/compass-cli/src/query_commands.rs
@@ -41,12 +41,6 @@ pub(super) fn command_query(frontend: Frontend, args: &[String]) -> Outcome {
     }
 }
 
-#[must_use]
-pub(super) fn query_help() -> String {
-    "Usage: compass query \"<question>\" [--dfs] [--context VALUE] [--budget N] [--graph PATH|--at REV]\n       compass query --cql <QUERY> [--param NAME=VALUE] [--format table|json|jsonl] [--graph PATH|--at REV]\n       compass query --cql --file PATH [--params-file PATH] [--output PATH]\n       compass query --cql --stdin\n       compass query --cql --repl\n\nCompassQL limits:\n  --timeout-ms N\n  --max-rows N\n  --max-path-depth N\n  --max-expanded-relationships N\n  --max-memory-bytes N"
-        .to_owned()
-}
-
 #[derive(Clone, Copy)]
 enum OutputFormat {
     Table,

--- a/crates/compass-cli/tests/coverage_paths.rs
+++ b/crates/compass-cli/tests/coverage_paths.rs
@@ -151,12 +151,12 @@ fn completed_command_help_routes_and_parser_boundaries_are_total() {
         "hook",
         "install",
         "uninstall",
-        "not-real",
     ] {
         let outcome = invoke(Frontend::Compass, &[command, "--help"]);
         assert_eq!(outcome.code, 0, "{command}: {}", outcome.stderr);
         assert!(!outcome.stdout.is_empty(), "{command}");
     }
+    assert_eq!(invoke(Frontend::Compass, &["not-real", "--help"]).code, 2);
 
     for arguments in [
         vec!["cluster-only", "--resolution"],

--- a/crates/compass-cli/tests/help_cli.rs
+++ b/crates/compass-cli/tests/help_cli.rs
@@ -162,6 +162,21 @@ fn help_suggestions_and_terminal_policy_are_conservative() {
 }
 
 #[test]
+fn compatibility_help_flags_use_the_rich_renderer() {
+    let root = invoke(&["--help"]);
+    for arguments in [&["-?"][..], &["help", "--help"]] {
+        let outcome = invoke(arguments);
+        assert_eq!(outcome.code, 0, "{arguments:?}: {}", outcome.stderr);
+        assert_eq!(outcome.stdout, root.stdout, "{arguments:?}");
+    }
+
+    let query = invoke(&["query", "-?"]);
+    assert_eq!(query.code, 0, "{}", query.stderr);
+    assert!(query.stdout.contains("Search the graph"));
+    assert!(query.stdout.contains("Examples:"));
+}
+
+#[test]
 fn graphify_help_asset_remains_byte_for_byte_unchanged() {
     let outcome = run(Frontend::Graphify, [OsString::from("--help")]);
     assert_eq!(outcome.code, 0);

--- a/crates/compass-cli/tests/help_cli.rs
+++ b/crates/compass-cli/tests/help_cli.rs
@@ -1,0 +1,169 @@
+use std::ffi::{OsStr, OsString};
+
+use compass_cli::{Frontend, HelpStyle, run};
+
+fn invoke(arguments: &[&str]) -> compass_cli::Outcome {
+    run(
+        Frontend::Compass,
+        arguments.iter().map(|argument| OsString::from(*argument)),
+    )
+}
+
+#[test]
+fn root_help_groups_every_public_command_with_descriptions() {
+    let outcome = invoke(&["--help"]);
+    assert_eq!(outcome.code, 0);
+    assert!(outcome.stderr.is_empty());
+    for heading in [
+        "Build and maintain:",
+        "Explore:",
+        "History:",
+        "Visualize and export:",
+        "Integrate and automate:",
+        "Diagnose and support:",
+    ] {
+        assert!(outcome.stdout.contains(heading), "missing {heading}");
+    }
+    for command in [
+        "update",
+        "extract",
+        "watch",
+        "cluster-only",
+        "label",
+        "merge-graphs",
+        "cache-check",
+        "merge-chunks",
+        "merge-semantic",
+        "query",
+        "path",
+        "explain",
+        "affected",
+        "benchmark",
+        "history",
+        "diff",
+        "tree",
+        "export",
+        "serve",
+        "global",
+        "clone",
+        "add",
+        "prs",
+        "hook",
+        "install",
+        "uninstall",
+        "provider",
+        "save-result",
+        "reflect",
+        "diagnose",
+        "check-update",
+        "merge-driver",
+        "hook-check",
+        "hook-guard",
+    ] {
+        let line = outcome
+            .stdout
+            .lines()
+            .find(|line| line.trim_start().starts_with(command))
+            .unwrap_or_else(|| panic!("missing command {command}"));
+        assert_ne!(line.trim(), command, "missing summary for {command}");
+    }
+}
+
+#[test]
+fn command_and_nested_help_explain_options_and_examples() {
+    for arguments in [
+        &["update", "--help"][..],
+        &["query", "--help"],
+        &["history", "build", "--help"],
+        &["export", "neo4j", "--help"],
+        &["provider", "add", "--help"],
+        &["diagnose", "multigraph", "--help"],
+    ] {
+        let outcome = invoke(arguments);
+        assert_eq!(outcome.code, 0, "{}", outcome.stderr);
+        assert!(outcome.stdout.contains("Usage:"), "{arguments:?}");
+        assert!(outcome.stdout.contains("Options:"), "{arguments:?}");
+        assert!(outcome.stdout.contains("Examples:"), "{arguments:?}");
+        assert!(outcome.stdout.contains("-h, --help"), "{arguments:?}");
+        assert!(!outcome.stdout.contains('\x1b'), "{arguments:?}");
+    }
+
+    let flag = invoke(&["history", "build", "--help"]);
+    let command = invoke(&["help", "history", "build"]);
+    assert_eq!(flag.stdout, command.stdout);
+}
+
+#[test]
+fn every_public_nested_command_has_a_dedicated_page() {
+    for (parent, children) in [
+        (
+            "history",
+            &[
+                "enable", "disable", "status", "build", "rebuild", "list", "show", "prefer",
+                "export", "gc",
+            ][..],
+        ),
+        (
+            "export",
+            &[
+                "html",
+                "callflow-html",
+                "obsidian",
+                "wiki",
+                "svg",
+                "graphml",
+                "neo4j",
+                "falkordb",
+            ],
+        ),
+        ("provider", &["add", "list", "show", "remove"]),
+        ("global", &["add", "remove", "list", "path"]),
+        ("hook", &["install", "uninstall", "status"]),
+        ("diagnose", &["multigraph"]),
+    ] {
+        for child in children {
+            let outcome = invoke(&[parent, child, "--help"]);
+            assert_eq!(outcome.code, 0, "{parent} {child}: {}", outcome.stderr);
+            assert!(
+                outcome
+                    .stdout
+                    .contains(&format!("compass {parent} {child}")),
+                "{parent} {child}"
+            );
+            assert!(outcome.stdout.contains("Examples:"), "{parent} {child}");
+        }
+    }
+}
+
+#[test]
+fn help_suggestions_and_terminal_policy_are_conservative() {
+    let typo = invoke(&["udpate"]);
+    assert_eq!(typo.code, 1);
+    assert!(typo.stderr.contains("Did you mean 'update'?"));
+
+    let distant = invoke(&["bananas"]);
+    assert_eq!(distant.code, 1);
+    assert!(!distant.stderr.contains("Did you mean"));
+
+    let nested = invoke(&["help", "history", "buidl"]);
+    assert_eq!(nested.code, 2);
+    assert!(nested.stderr.contains("Did you mean 'build'?"));
+
+    assert_eq!(HelpStyle::detect(false, None, None), HelpStyle::Plain);
+    assert_eq!(
+        HelpStyle::detect(true, Some(OsStr::new("")), None),
+        HelpStyle::Plain
+    );
+    assert_eq!(
+        HelpStyle::detect(true, None, Some(OsStr::new("dumb"))),
+        HelpStyle::Plain
+    );
+    assert_eq!(HelpStyle::detect(true, None, None), HelpStyle::Ansi);
+}
+
+#[test]
+fn graphify_help_asset_remains_byte_for_byte_unchanged() {
+    let outcome = run(Frontend::Graphify, [OsString::from("--help")]);
+    assert_eq!(outcome.code, 0);
+    assert_eq!(outcome.stdout, include_str!("../assets/graphify-help.txt"));
+}

--- a/crates/compass-parity/src/lib.rs
+++ b/crates/compass-parity/src/lib.rs
@@ -1428,7 +1428,8 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
             let outcome =
                 compass_cli::run(Frontend::Compass, arguments.into_iter().map(OsString::from));
             assert_eq!(outcome.code, 0, "{}", outcome.stderr);
-            assert!(outcome.stdout.starts_with("Usage: compass"));
+            assert!(outcome.stdout.contains("Usage:"));
+            assert!(outcome.stdout.contains("compass "));
             assert!(outcome.stderr.is_empty());
         }
         let version = compass_cli::run(Frontend::Compass, [OsString::from("--version")]);

--- a/docs/superpowers/plans/2026-07-22-compass-cli-help.md
+++ b/docs/superpowers/plans/2026-07-22-compass-cli-help.md
@@ -1,0 +1,666 @@
+# Compass CLI help implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every Compass command descriptive, example-driven, terminal-aware help while preserving command behavior and the Graphify compatibility frontend.
+
+**Architecture:** Add a typed help catalog, deterministic renderer, and command-path router under `compass-cli/src/help/`. Keep existing parsers and executors unchanged. The library renders plain help by default; the `compass` binary requests ANSI styling only for an interactive terminal that permits color.
+
+**Tech Stack:** Rust 1.97.1, standard library `IsTerminal`, existing `compass-cli` outcome and test infrastructure, Cargo tests.
+
+## Global constraints
+
+- Preserve all normal command output, machine-readable output, and exit codes.
+- Preserve Graphify help and command routing byte for byte.
+- Add no command-line framework or styling dependency.
+- Render ANSI styling only for an interactive terminal when `NO_COLOR` is absent and `TERM` is not `dumb`.
+- Keep plain output deterministic and free of escape bytes.
+- Document every public command, nested command, accepted option, accepted value, default, conflict, requirement, and repeatability rule.
+- Keep internal worker and hook subprocess commands out of public root help.
+- Write a failing behavior test before each production change.
+- Run `graphify update .` from `/Users/haipingfu/graphify` after the final code change.
+
+---
+
+## File structure
+
+- Create `crates/compass-cli/src/help/mod.rs`: public help entry points, routing, usage hints, and typo suggestions
+- Create `crates/compass-cli/src/help/model.rs`: immutable help-page metadata and const builders
+- Create `crates/compass-cli/src/help/render.rs`: deterministic plain rendering, wrapping, and semantic ANSI styling
+- Create `crates/compass-cli/src/help/catalog/mod.rs`: page registry, root groups, aliases, and structural validation
+- Create `crates/compass-cli/src/help/catalog/build.rs`: build, extraction, and semantic-maintenance pages
+- Create `crates/compass-cli/src/help/catalog/explore.rs`: query, navigation, and benchmark pages
+- Create `crates/compass-cli/src/help/catalog/history.rs`: history, diff, and every history subcommand page
+- Create `crates/compass-cli/src/help/catalog/output.rs`: tree, export, and every export-format page
+- Create `crates/compass-cli/src/help/catalog/integrate.rs`: serve, global, clone, add, PR, hook, install, provider, result, and reflection pages
+- Create `crates/compass-cli/src/help/catalog/support.rs`: diagnose, update-check, merge-driver, and internal hook pages
+- Create `crates/compass-cli/tests/help_cli.rs`: public CLI help, Graphify regression, and error-routing tests
+- Modify `crates/compass-cli/src/lib.rs`: invoke the new plain help router and remove Compass-only string help dispatch
+- Modify `crates/compass-cli/src/bin/compass.rs`: resolve help before streaming commands and select terminal styling
+- Modify `README.md`: point the command-surface section to the new discoverable help forms
+
+### Task 1: Define help metadata and deterministic rendering
+
+**Files:**
+
+- Create: `crates/compass-cli/src/help/model.rs`
+- Create: `crates/compass-cli/src/help/render.rs`
+- Create: `crates/compass-cli/src/help/mod.rs`
+- Modify: `crates/compass-cli/src/lib.rs:1-15`
+
+**Interfaces:**
+
+- Produces: `HelpPage`, `HelpArgument`, `HelpOption`, `HelpVisibility`, `HelpGroup`, and const builder methods
+- Produces: public `HelpStyle::{Plain, Ansi}` for the binary entry point
+- Produces: `render_page(page: &HelpPage, children: &[&HelpPage], style: HelpStyle) -> String`
+- Produces: `render_root(groups: &[HelpGroup], pages: &[HelpPage], style: HelpStyle) -> String`
+- Consumes: no command parser state
+
+- [ ] **Step 1: Write failing model and renderer tests**
+
+Add `#[cfg(test)]` tests in `help/render.rs` that construct this page:
+
+```rust
+const SAMPLE: HelpPage = HelpPage::new(
+    &["sample"],
+    "Describe the sample command",
+    &["compass sample [PATH] [OPTIONS]"],
+)
+.description("A sentence long enough to verify deterministic wrapping without changing words.")
+.arguments(&[HelpArgument::new("[PATH]", "Project directory").default(".")])
+.options(&[
+    HelpOption::new(&["-o", "--out"], Some("DIR"), "Output directory")
+        .default("compass-out"),
+    HelpOption::new(&["--exclude"], Some("PATTERN"), "Exclude a matching path")
+        .repeatable(),
+])
+.examples(&["compass sample", "compass sample ./api --out build"])
+.tips(&["Use `compass watch` to refresh continuously."]);
+```
+
+Assert that plain output has the required section order, includes `[default: .]` and `[repeatable]`, wraps at 88 columns, and contains no `\x1b`. Assert that stripping ANSI sequences from styled output returns the plain output exactly.
+
+- [ ] **Step 2: Run the renderer test and verify the red state**
+
+Run: `cargo test -p compass-cli help::render::tests --lib -- --nocapture`
+
+Expected: FAIL because `help`, `HelpPage`, and `render_page` do not exist.
+
+- [ ] **Step 3: Implement immutable model types and const builders**
+
+Use these exact public shapes inside the crate:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HelpVisibility { Public, Internal }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HelpArgument {
+    pub(crate) syntax: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) default: Option<&'static str>,
+    pub(crate) required: bool,
+    pub(crate) repeatable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HelpOption {
+    pub(crate) names: &'static [&'static str],
+    pub(crate) value: Option<&'static str>,
+    pub(crate) description: &'static str,
+    pub(crate) accepted: &'static [&'static str],
+    pub(crate) default: Option<&'static str>,
+    pub(crate) conflicts: &'static [&'static str],
+    pub(crate) requires: &'static [&'static str],
+    pub(crate) repeatable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HelpPage {
+    pub(crate) path: &'static [&'static str],
+    pub(crate) summary: &'static str,
+    pub(crate) description: Option<&'static str>,
+    pub(crate) usages: &'static [&'static str],
+    pub(crate) arguments: &'static [HelpArgument],
+    pub(crate) options: &'static [HelpOption],
+    pub(crate) examples: &'static [&'static str],
+    pub(crate) tips: &'static [&'static str],
+    pub(crate) visibility: HelpVisibility,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HelpGroup {
+    pub(crate) title: &'static str,
+    pub(crate) commands: &'static [&'static str],
+}
+```
+
+Implement `const fn` builders for every field used by the sample. Builders return a modified copy so all catalog pages remain compile-time constants.
+
+Expose the style choice with this exact type:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HelpStyle { Plain, Ansi }
+```
+
+- [ ] **Step 4: Implement the plain renderer and semantic styling pass**
+
+Render at an 88-column maximum. Build plain output first, then style known line classes so ANSI removal cannot change text. Use these style codes:
+
+```rust
+const BOLD_CYAN: &str = "\x1b[1;36m";
+const CYAN: &str = "\x1b[36m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+```
+
+Color section headings with `BOLD_CYAN`, command and option terms with `CYAN`, tips with `YELLOW`, and annotations such as defaults with `DIM`. Do not style description prose.
+
+- [ ] **Step 5: Run the renderer tests and verify green**
+
+Run: `cargo test -p compass-cli help::render::tests --lib -- --nocapture`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 6: Commit the rendering foundation**
+
+```bash
+git add crates/compass-cli/src/help crates/compass-cli/src/lib.rs
+git commit -m "feat(cli): add structured help renderer"
+```
+
+### Task 2: Add the complete command registry, root help, and path routing
+
+**Files:**
+
+- Create: `crates/compass-cli/src/help/catalog/mod.rs`
+- Create: `crates/compass-cli/src/help/catalog/build.rs`
+- Create: `crates/compass-cli/src/help/catalog/explore.rs`
+- Create: `crates/compass-cli/src/help/catalog/history.rs`
+- Create: `crates/compass-cli/src/help/catalog/output.rs`
+- Create: `crates/compass-cli/src/help/catalog/integrate.rs`
+- Create: `crates/compass-cli/src/help/catalog/support.rs`
+- Modify: `crates/compass-cli/src/help/mod.rs`
+- Create: `crates/compass-cli/tests/help_cli.rs`
+- Modify: `crates/compass-cli/src/lib.rs:145-242,3703-3749`
+
+**Interfaces:**
+
+- Consumes: model and rendering interfaces from Task 1
+- Produces: `catalog::pages() -> &'static [HelpPage]`
+- Produces: `catalog::groups() -> &'static [HelpGroup]`
+- Produces: `request(args: &[String], style: HelpStyle) -> Option<Outcome>`
+- Produces: `closest_sibling(parent: &[&str], unknown: &str) -> Option<&'static str>`
+
+- [ ] **Step 1: Write failing registry and routing tests**
+
+Add unit tests that require the exact public root inventory:
+
+```rust
+const ROOT_COMMANDS: &[&str] = &[
+    "update", "extract", "watch", "cluster-only", "label", "merge-graphs",
+    "cache-check", "merge-chunks", "merge-semantic", "query", "path", "explain",
+    "affected", "benchmark", "history", "diff", "tree", "export", "serve",
+    "global", "clone", "add", "prs", "hook", "install", "uninstall", "provider",
+    "save-result", "reflect", "diagnose", "check-update", "merge-driver",
+    "hook-check", "hook-guard",
+];
+```
+
+Assert each name occurs once across the six groups and resolves to a public page. Assert `history-worker`, `hook-spawn`, and `hook-refresh` resolve as internal pages but never occur in a group. Assert these routes return the same text:
+
+```rust
+request(&s(&["history", "build", "--help"]), HelpStyle::Plain)
+request(&s(&["history", "build", "-h"]), HelpStyle::Plain)
+request(&s(&["help", "history", "build"]), HelpStyle::Plain)
+```
+
+In `tests/help_cli.rs`, assert root help contains all six headings and summaries for `update`, `query`, `history`, `export`, `serve`, and `diagnose`. Require root options for `-h, --help` and `-V, --version`. Require every command page to end its option section with `-h, --help` without repeating that option in page metadata.
+
+- [ ] **Step 2: Run the registry tests and verify the red state**
+
+Run: `cargo test -p compass-cli help -- --nocapture`
+
+Expected: FAIL because the catalog and request router do not exist.
+
+- [ ] **Step 3: Add root groups and one base page for every public command**
+
+Use these exact groups:
+
+```rust
+pub(crate) const GROUPS: &[HelpGroup] = &[
+    HelpGroup::new("Build and maintain", &[
+        "update", "extract", "watch", "cluster-only", "label", "merge-graphs",
+        "cache-check", "merge-chunks", "merge-semantic",
+    ]),
+    HelpGroup::new("Explore", &["query", "path", "explain", "affected", "benchmark"]),
+    HelpGroup::new("History", &["history", "diff"]),
+    HelpGroup::new("Visualize and export", &["tree", "export"]),
+    HelpGroup::new("Integrate and automate", &[
+        "serve", "global", "clone", "add", "prs", "hook", "install", "uninstall",
+        "provider", "save-result", "reflect",
+    ]),
+    HelpGroup::new("Diagnose and support", &[
+        "diagnose", "check-update", "merge-driver", "hook-check", "hook-guard",
+    ]),
+];
+```
+
+Each base page must contain its approved one-line summary, at least one current usage form, and at least one valid example. Add the nested paths from the design specification and internal pages for `history-worker`, `hook-spawn`, and `hook-refresh`.
+
+- [ ] **Step 4: Implement help request recognition and conservative suggestions**
+
+Recognize only these request shapes:
+
+```rust
+[]
+["--help"]
+["-h"]
+["help"]
+["help", command_path @ ..]
+[command_path @ .., "--help"]
+[command_path @ .., "-h"]
+```
+
+Resolve the longest registered command path. Map direct platform aliases such as `claude`, `codex`, `gemini`, and `vscode` to the public `install` page. Use case-sensitive Damerau-Levenshtein distance and suggest only when `distance <= max(1, unknown.chars().count() / 3)`.
+
+- [ ] **Step 5: Route Compass library help through the catalog**
+
+At the start of `run`, call `help::request(&args, HelpStyle::Plain)` only for `Frontend::Compass`. Remove `compass_help()` and `compass_command_help()`. Retain every Graphify help function because compatibility calls still use them.
+
+Change the unknown Compass command branch to:
+
+```rust
+_ => Outcome::failure(help::unknown_command(&command)),
+```
+
+Keep the existing exit code `1` for an unknown command. Update the existing `not-real --help` coverage assertion from success to exit code `2` because an unknown help path is a new routed usage error.
+
+- [ ] **Step 6: Run focused tests and verify green**
+
+Run: `cargo test -p compass-cli help -- --nocapture`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 7: Commit registry and routing**
+
+```bash
+git add crates/compass-cli/src/help crates/compass-cli/src/lib.rs crates/compass-cli/tests/help_cli.rs crates/compass-cli/tests/coverage_paths.rs
+git commit -m "feat(cli): route Compass help through command catalog"
+```
+
+### Task 3: Complete build and exploration help pages
+
+**Files:**
+
+- Modify: `crates/compass-cli/src/help/catalog/build.rs`
+- Modify: `crates/compass-cli/src/help/catalog/explore.rs`
+- Modify: `crates/compass-cli/tests/help_cli.rs`
+
+**Interfaces:**
+
+- Consumes: `HelpPage`, `HelpArgument`, and `HelpOption` const builders
+- Produces: complete pages for 14 build and exploration commands
+
+- [ ] **Step 1: Add failing table-driven option coverage tests**
+
+Require these option names on the named page:
+
+```rust
+const REQUIRED: &[(&[&str], &[&str])] = &[
+    (&["update"], &["--out", "--force", "--no-cluster", "--no-viz", "--no-gitignore", "--exclude", "--resolution", "--exclude-hubs"]),
+    (&["extract"], &["--code-only", "--cargo", "--google-workspace", "--postgres", "--backend", "--model", "--mode", "--token-budget", "--max-concurrency", "--max-workers", "--api-timeout", "--allow-partial", "--dedup-llm", "--timing", "--out", "--no-cluster", "--force", "--no-viz", "--no-gitignore", "--exclude", "--resolution", "--exclude-hubs", "--global", "--as"]),
+    (&["watch"], &["--debounce", "--out", "--no-cluster", "--no-viz", "--no-gitignore", "--exclude", "--poll"]),
+    (&["cluster-only"], &["--graph", "--no-viz", "--no-label", "--resolution", "--exclude-hubs", "--min-community-size"]),
+    (&["label"], &["--graph", "--backend", "--model", "--missing-only", "--no-viz", "--resolution", "--exclude-hubs", "--max-concurrency", "--batch-size", "--min-community-size", "--timing"]),
+    (&["merge-graphs"], &["--out"]),
+    (&["cache-check"], &["--root", "--mode", "--deep", "--prompt-file"]),
+    (&["merge-chunks"], &["--out"]),
+    (&["merge-semantic"], &["--cached", "--new", "--out"]),
+    (&["query"], &["--dfs", "--context", "--budget", "--graph", "--at", "--cql", "--file", "--stdin", "--repl", "--param", "--params-file", "--format", "--output", "--timeout-ms", "--max-rows", "--max-path-depth", "--max-expanded-relationships", "--max-memory-bytes"]),
+    (&["path"], &["--graph", "--at"]),
+    (&["explain"], &["--graph", "--at"]),
+    (&["affected"], &["--relation", "--depth", "--graph"]),
+];
+```
+
+Also assert `query --format` accepts `table`, `json`, and `jsonl`; `extract --mode` accepts only `deep`; and repeatable options mark `--exclude` and `--param` as repeatable.
+
+- [ ] **Step 2: Run the focused test and verify the red state**
+
+Run: `cargo test -p compass-cli --test help_cli build_and_explore_pages_document_options -- --exact --nocapture`
+
+Expected: FAIL on the first missing option.
+
+- [ ] **Step 3: Fill build and semantic-maintenance metadata**
+
+Read the match arms in `command_build_with_validation`, `run_watch`, `command_cluster_only`, `command_label`, `command_merge_graphs`, and `semantic_commands.rs`. Encode each accepted spelling once, identify values with uppercase placeholders, and add current defaults. Include examples for local-only extraction, semantic extraction, PostgreSQL extraction, continuous watch, manual clustering, graph merging, cache inspection, chunk merging, and semantic merge.
+
+- [ ] **Step 4: Fill exploration metadata**
+
+Document natural-language and CompassQL usage separately on `query`. Record source conflicts among inline CQL, `--file`, `--stdin`, and `--repl`; record `--output` requirements; and document the five CompassQL limits with current defaults. Add examples for natural queries, parameters, revision selection, shortest paths, explanations, affected-code traversal, and benchmark execution.
+
+- [ ] **Step 5: Run focused tests and verify green**
+
+Run: `cargo test -p compass-cli --test help_cli build_and_explore_pages_document_options -- --exact --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit build and exploration pages**
+
+```bash
+git add crates/compass-cli/src/help/catalog/build.rs crates/compass-cli/src/help/catalog/explore.rs crates/compass-cli/tests/help_cli.rs
+git commit -m "feat(cli): document build and exploration commands"
+```
+
+### Task 4: Complete history and export help pages
+
+**Files:**
+
+- Modify: `crates/compass-cli/src/help/catalog/history.rs`
+- Modify: `crates/compass-cli/src/help/catalog/output.rs`
+- Modify: `crates/compass-cli/tests/help_cli.rs`
+
+**Interfaces:**
+
+- Consumes: catalog and renderer from Tasks 1 and 2
+- Produces: 10 history child pages, 8 export child pages, `diff`, and `tree`
+
+- [ ] **Step 1: Add failing nested-page coverage tests**
+
+Require these exact child paths:
+
+```rust
+const HISTORY: &[&str] = &["enable", "disable", "status", "build", "rebuild", "list", "show", "prefer", "export", "gc"];
+const EXPORTS: &[&str] = &["html", "callflow-html", "obsidian", "wiki", "svg", "graphml", "neo4j", "falkordb"];
+```
+
+For each child, assert both `compass parent child --help` and `compass help parent child` return exit code `0`, identical plain output, the full usage path, and an `Examples:` section.
+
+Require these option contracts:
+
+```rust
+(&["history", "status"], &["--format"])
+(&["history", "build"], &["--profile-from", "--format"])
+(&["history", "rebuild"], &["--replace-corrupt", "--format"])
+(&["history", "list"], &["--format"])
+(&["history", "show"], &["--format"])
+(&["history", "prefer"], &["--format"])
+(&["history", "export"], &["--format", "--output"])
+(&["history", "gc"], &["--prune-non-preferred", "--yes", "--format"])
+(&["diff"], &["--detailed", "--format", "--topology-only", "--relation", "--path", "--community", "--limit", "--detect-renames", "--rename-threshold"])
+(&["tree"], &["--graph", "--output", "--root", "--max-children", "--top-k-edges", "--label"])
+```
+
+- [ ] **Step 2: Run the nested tests and verify the red state**
+
+Run: `cargo test -p compass-cli --test help_cli nested_history_and_export_help_is_complete -- --exact --nocapture`
+
+Expected: FAIL on incomplete child metadata.
+
+- [ ] **Step 3: Complete history pages**
+
+Document revision and realization positionals precisely. Record `text|json`, `graph-json|compass-out`, `--yes` requiring `--prune-non-preferred`, `--replace-corrupt`, build-profile options, and `diff` filters. Include a warning that `history export --format compass-out` rejects an existing destination and that destructive garbage collection needs explicit confirmation.
+
+- [ ] **Step 4: Complete tree and export pages**
+
+Create distinct child pages because each format accepts a different option subset. Document Neo4j and FalkorDB credential environment variables without printing credential values. Document callflow defaults: 15 sections, scale `1.0`, 18 nodes, and 24 edges. Document HTML's node limit and Obsidian's output directory.
+
+- [ ] **Step 5: Run the nested tests and verify green**
+
+Run: `cargo test -p compass-cli --test help_cli nested_history_and_export_help_is_complete -- --exact --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit history and export pages**
+
+```bash
+git add crates/compass-cli/src/help/catalog/history.rs crates/compass-cli/src/help/catalog/output.rs crates/compass-cli/tests/help_cli.rs
+git commit -m "feat(cli): document history and export commands"
+```
+
+### Task 5: Complete integration, configuration, and internal help pages
+
+**Files:**
+
+- Modify: `crates/compass-cli/src/help/catalog/integrate.rs`
+- Modify: `crates/compass-cli/src/help/catalog/support.rs`
+- Modify: `crates/compass-cli/tests/help_cli.rs`
+
+**Interfaces:**
+
+- Consumes: catalog and renderer from Tasks 1 and 2
+- Produces: complete remaining public and internal pages
+
+- [ ] **Step 1: Add failing nested and option inventory tests**
+
+Require child pages for `provider add|list|show|remove`, `global add|remove|list|path`, `hook install|uninstall|status`, and `diagnose multigraph`.
+
+Require these important option sets:
+
+```rust
+(&["serve"], &["--graph", "--transport", "--host", "--port", "--api-key", "--path", "--json-response", "--stateless", "--session-timeout"])
+(&["clone"], &["--branch", "--out"])
+(&["add"], &["--author", "--contributor", "--dir"])
+(&["prs"], &["--triage", "--worktrees", "--conflicts", "--wrong-base", "--base", "--repo", "--graph"])
+(&["install"], &["--project", "--strict", "--platform"])
+(&["uninstall"], &["--project", "--purge", "--platform"])
+(&["provider", "add"], &["--base-url", "--default-model", "--env-key", "--pricing-input", "--pricing-output"])
+(&["save-result"], &["--question", "--answer", "--answer-file", "--type", "--nodes", "--outcome", "--correction", "--memory-dir"])
+(&["reflect"], &["--memory-dir", "--out", "--graph", "--analysis", "--labels", "--half-life-days", "--min-corroboration", "--if-stale"])
+(&["diagnose", "multigraph"], &["--graph", "--json", "--max-examples", "--directed", "--undirected", "--extract-path"])
+```
+
+Assert internal pages have `HelpVisibility::Internal`, include “internal”, and name a public alternative.
+
+- [ ] **Step 2: Run the inventory tests and verify the red state**
+
+Run: `cargo test -p compass-cli --test help_cli integration_and_support_pages_document_options -- --exact --nocapture`
+
+Expected: FAIL on incomplete metadata.
+
+- [ ] **Step 3: Complete integration pages**
+
+Document transport defaults and API key environment fallback for `serve`; global graph operations; GitHub clone forms; ingest attribution; PR views; managed hooks; every install platform; provider pricing units; result outcomes; and reflection defaults. Mark mutually exclusive pairs such as `--answer` with `--answer-file` through structured conflict metadata.
+
+- [ ] **Step 4: Complete support and internal pages**
+
+Document `diagnose multigraph`, `check-update`, and `merge-driver`. Explain that `hook-check`, `hook-guard`, `history-worker`, `hook-spawn`, and `hook-refresh` support installed integrations and are not normal interactive workflows. Keep the last three out of root groups.
+
+- [ ] **Step 5: Add structural completeness validation**
+
+Add a unit test that rejects duplicate paths, missing parents, empty summaries, empty usage forms, public leaf pages without examples, grouped internal pages, public root pages absent from a group, and grouped names without a page. Add an explicit `EXPECTED_PUBLIC_OPTIONS` map in `catalog/mod.rs`; compare each page's flattened option names to that map so future parser additions require a help update in the same change.
+
+- [ ] **Step 6: Run integration and structural tests and verify green**
+
+Run: `cargo test -p compass-cli help -- --nocapture`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 7: Commit remaining catalog pages**
+
+```bash
+git add crates/compass-cli/src/help/catalog crates/compass-cli/tests/help_cli.rs
+git commit -m "feat(cli): document integration and support commands"
+```
+
+### Task 6: Enable terminal styling and focused usage recovery
+
+**Files:**
+
+- Modify: `crates/compass-cli/src/help/mod.rs`
+- Modify: `crates/compass-cli/src/bin/compass.rs`
+- Modify: `crates/compass-cli/src/lib.rs`
+- Modify: `crates/compass-cli/tests/help_cli.rs`
+
+**Interfaces:**
+
+- Produces: `HelpStyle::detect(is_terminal: bool, no_color: Option<&OsStr>, term: Option<&OsStr>) -> HelpStyle`
+- Produces: `pub fn compass_help_request(arguments: &[OsString], style: HelpStyle) -> Option<Outcome>`
+- Produces: `append_usage_hint(outcome: Outcome, path: &[&str]) -> Outcome`
+
+- [ ] **Step 1: Add failing style-policy and error-recovery tests**
+
+Use this exact table:
+
+```rust
+assert_eq!(HelpStyle::detect(false, None, None), HelpStyle::Plain);
+assert_eq!(HelpStyle::detect(true, Some(OsStr::new("")), None), HelpStyle::Plain);
+assert_eq!(HelpStyle::detect(true, None, Some(OsStr::new("dumb"))), HelpStyle::Plain);
+assert_eq!(HelpStyle::detect(true, None, Some(OsStr::new("DUMB"))), HelpStyle::Plain);
+assert_eq!(HelpStyle::detect(true, None, Some(OsStr::new("xterm-256color"))), HelpStyle::Ansi);
+```
+
+Assert `compass udpate` retains exit code `1`, suggests `update`, and points to `compass --help`. Assert a distant unknown command has no suggestion. Assert a history usage error with code `2` ends with `Run `compass history build --help` for usage.` and a runtime history failure with code `1` does not.
+
+- [ ] **Step 2: Run focused tests and verify the red state**
+
+Run: `cargo test -p compass-cli --test help_cli styling_and_usage_recovery_are_conservative -- --exact --nocapture`
+
+Expected: FAIL because style detection and usage hints are not connected.
+
+- [ ] **Step 3: Detect style before streaming dispatch**
+
+Update `compass.rs` to import `std::io::IsTerminal`. Before the `diff`, `watch`, and `serve` branches, calculate:
+
+```rust
+let style = compass_cli::HelpStyle::detect(
+    io::stdout().is_terminal(),
+    std::env::var_os("NO_COLOR").as_deref(),
+    std::env::var_os("TERM").as_deref(),
+);
+if let Some(outcome) = compass_cli::compass_help_request(&arguments, style) {
+    return ExitCode::from(compass_cli::write_outcome(
+        &outcome,
+        &mut io::stdout(),
+        &mut io::stderr(),
+    ));
+}
+```
+
+The early check ensures streaming commands receive the same styled help as ordinary commands.
+
+- [ ] **Step 4: Append help hints only to usage outcomes**
+
+After Compass dispatch, append a hint only when `Outcome.code == 2`, `stderr` is non-empty, and it does not already contain a help instruction. Resolve the longest valid command path from the supplied arguments. Do not modify code `1`, `3`, or `4` failures.
+
+- [ ] **Step 5: Run focused tests and verify green**
+
+Run: `cargo test -p compass-cli --test help_cli styling_and_usage_recovery_are_conservative -- --exact --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit terminal behavior**
+
+```bash
+git add crates/compass-cli/src/help/mod.rs crates/compass-cli/src/bin/compass.rs crates/compass-cli/src/lib.rs crates/compass-cli/tests/help_cli.rs
+git commit -m "feat(cli): add terminal styling and help recovery"
+```
+
+### Task 7: Preserve compatibility, update guidance, and verify the workspace
+
+**Files:**
+
+- Modify: `crates/compass-cli/tests/help_cli.rs`
+- Modify: `README.md`
+- Refresh: `/Users/haipingfu/graphify/graphify-out/`
+
+**Interfaces:**
+
+- Consumes: completed help system
+- Produces: compatibility evidence, user guidance, and refreshed repository graph
+
+- [ ] **Step 1: Add the failing Graphify byte-regression test**
+
+Add this integration assertion before changing documentation:
+
+```rust
+#[test]
+fn graphify_help_asset_remains_byte_for_byte_unchanged() {
+    let outcome = invoke(Frontend::Graphify, &["--help"]);
+    assert_eq!(outcome.code, 0);
+    assert_eq!(outcome.stdout, include_str!("../assets/graphify-help.txt"));
+}
+```
+
+Temporarily change the expected value by one byte, run the test to prove it fails, then restore the exact asset comparison.
+
+- [ ] **Step 2: Run the compatibility test and verify green after restoration**
+
+Run: `cargo test -p compass-cli --test help_cli graphify_help_asset_remains_byte_for_byte_unchanged -- --exact --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 3: Update README command discovery guidance**
+
+Below “Current native command surface,” add:
+
+```markdown
+Run `compass --help` for commands grouped by workflow. Run
+`compass help <command>` or `compass <command> --help` for arguments,
+options, defaults, examples, and related-command tips. Nested help accepts
+the full path, such as `compass help history build`.
+```
+
+- [ ] **Step 4: Format and run the complete CLI suite**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: exit `0` with no output.
+
+Run: `cargo test -p compass-cli --all-targets`
+
+Expected: all `compass-cli` unit and integration tests pass.
+
+- [ ] **Step 5: Run full workspace checks**
+
+Run: `cargo test --workspace --all-targets`
+
+Expected: all workspace tests pass.
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+
+Expected: exit `0` with no warnings.
+
+- [ ] **Step 6: Inspect representative output**
+
+Run:
+
+```bash
+target/debug/compass --help
+target/debug/compass update --help
+target/debug/compass help query
+target/debug/compass history build --help
+target/debug/compass export neo4j --help
+NO_COLOR=1 target/debug/compass --help
+target/debug/compass udpate
+```
+
+Expected: grouped root help, detailed option descriptions and examples, nested pages, no ANSI in the `NO_COLOR` run, and a conservative `update` suggestion.
+
+- [ ] **Step 7: Refresh the Graphify knowledge graph**
+
+Run from `/Users/haipingfu/graphify`:
+
+```bash
+graphify update .
+```
+
+Expected: exit `0` and `graphify-out/GRAPH_REPORT.md` reports a current graph.
+
+- [ ] **Step 8: Review the final diff and commit**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+Run: `git status --short`
+
+Expected: only the README, help tests, and any formatter changes from this task remain uncommitted.
+
+```bash
+git add README.md crates/compass-cli/tests/help_cli.rs
+git commit -m "docs(cli): explain Compass help discovery"
+```

--- a/docs/superpowers/specs/2026-07-22-compass-cli-help-design.md
+++ b/docs/superpowers/specs/2026-07-22-compass-cli-help-design.md
@@ -1,0 +1,176 @@
+# Make Compass command help descriptive and comfortable
+
+This specification defines a complete help experience for the native `compass` command. It covers every public command and user-facing nested command without changing command execution, machine-readable output, exit codes, or the Graphify compatibility frontend.
+
+## Goal and audience
+
+The change helps first-time and returning Compass users discover commands, understand options, and recover from command-name mistakes without opening the README. A successful implementation lets a user answer three questions from the terminal: what a command does, how to invoke it, and which options matter for their task.
+
+The implementation must:
+
+- Give every public command a concise summary in root help
+- Give every public command and user-facing nested command a dedicated help page
+- Explain positional arguments, options, accepted values, defaults, conflicts, and repeatability where applicable
+- Include runnable examples and relevant workflow tips
+- Support color on interactive terminals without adding control characters to redirected output
+- Preserve the Graphify compatibility frontend
+
+The work does not redesign command parsing, normal result output, machine-readable formats, or runtime diagnostics.
+
+## Help architecture
+
+Add a dedicated help module to `compass-cli`. The module owns typed page metadata, command-path lookup, typo suggestions, plain rendering, and styled rendering. Existing command modules continue to own parsing and execution.
+
+Each help page uses a data structure with these fields:
+
+- Command path and one-line summary
+- Long description when the summary cannot explain the command fully
+- One or more usage forms
+- Positional arguments
+- Options with value names, descriptions, accepted values, defaults, conflicts, requirements, and repeatability
+- Nested commands
+- Examples
+- Tips or operational notes
+- Visibility, either public or internal
+
+A single registry supplies root listings and path lookup. Root help must not maintain a second command-name list. Command modules may declare their detailed page metadata near the parser, but they register pages through the common catalog.
+
+Internal process commands, including history workers and hook subprocesses, remain absent from root listings. An explicit help request for an internal command returns a page that labels the command as internal and directs users to the public parent workflow.
+
+## Help routes
+
+Compass resolves the complete command path before rendering help. These forms return the same page:
+
+```text
+compass history build --help
+compass history build -h
+compass help history build
+```
+
+`compass help` and `compass --help` return root help. If a help path contains an unknown segment, Compass reports the unknown name, suggests one sufficiently close sibling, and points to the nearest valid help page.
+
+The help router must not alter Graphify behavior. `graphify --help`, Graphify command help, and Graphify parsing retain their current output and routing.
+
+## Root help layout
+
+Root help starts with a short product description and usage line. It groups public commands by the task a user wants to perform instead of presenting one undifferentiated list. The groups and their commands are:
+
+- Build and maintain: `update`, `extract`, `watch`, `cluster-only`, `label`, `merge-graphs`, `cache-check`, `merge-chunks`, and `merge-semantic`
+- Explore: `query`, `path`, `explain`, `affected`, and `benchmark`
+- History: `history` and `diff`
+- Visualize and export: `tree` and `export`
+- Integrate and automate: `serve`, `global`, `clone`, `add`, `prs`, `hook`, `install`, `uninstall`, `provider`, `save-result`, and `reflect`
+- Diagnose and support: `diagnose`, `check-update`, `merge-driver`, `hook-check`, and `hook-guard`
+
+Every row contains a command name and one-line summary. Nested command names do not appear as separate root commands. Root help ends with global options and a hint for `compass help <command>`.
+
+The plain-text shape follows this example:
+
+```text
+Compass: turn a codebase into a searchable knowledge graph
+
+Usage: compass <COMMAND> [OPTIONS]
+
+Build and maintain:
+  update          Incrementally refresh the local graph
+  extract         Build a graph with optional semantic extraction
+  watch           Rebuild automatically when project files change
+
+Explore:
+  query           Search the graph with natural language or CompassQL
+  path            Find the shortest path between two nodes
+  explain         Explain a node and its relationships
+
+Run `compass help <command>` for detailed help.
+```
+
+Every public command must appear exactly once in these groups. The root renders `diagnose` as a command; its `multigraph` operation appears on the detailed page.
+
+## Command help layout
+
+Every command page uses the same section order:
+
+1. Summary and optional description
+2. Usage
+3. Commands, when the page owns nested commands
+4. Arguments
+5. Options
+6. Examples
+7. Tips or operational notes
+
+The renderer omits empty sections. It aligns term descriptions within a section and wraps descriptions to a stable maximum width. Continuation lines align with the description, not the option name. The plain renderer produces deterministic output for tests, pipes, and documentation captures.
+
+Examples must use valid current syntax and show distinct tasks. Most leaf commands need two examples: the default workflow and one useful variation. Commands with destructive or credential-sensitive behavior must include the relevant warning or prerequisite as a note.
+
+Tips connect adjacent workflows only when the relationship helps a user choose their next command. For example, `update` can mention `watch`, while `query` can mention `path` for relationship tracing. Tips must not advertise unrelated features.
+
+## Terminal styling
+
+Styled help uses American National Standards Institute (ANSI) colors for headings, command names, value placeholders, and tips. Color never carries information that plain text omits.
+
+The `compass` binary enables styled help only when standard output is an interactive terminal and neither condition below applies:
+
+- `NO_COLOR` exists in the environment
+- `TERM` equals `dumb`, case-insensitively
+
+Redirected output, library-level help rendering, and tests use plain text. The implementation uses `std::io::IsTerminal` plus a small semantic style layer. It does not add a command-line framework solely for styling.
+
+## Usage errors and suggestions
+
+Unknown top-level commands and unknown help-path segments compare against visible sibling names. Compass prints one suggestion only when the edit distance passes a conservative threshold. A distant name receives no suggestion.
+
+Usage failures point to the most specific available page:
+
+```text
+Run `compass history build --help` for usage.
+```
+
+The implementation adds this hint only to failures that the current parser identifies as usage errors. Runtime, storage, provider, network, and graph-validation failures must not gain a help hint. Existing exit codes remain unchanged.
+
+This feature does not require fuzzy matching for every option parser. Detailed option descriptions and accepted values provide the primary option guidance. A command may suggest a close option only when its parser already distinguishes unknown options from other failures.
+
+## Coverage
+
+Full coverage means:
+
+- Every public command in the Compass dispatcher appears once in root help
+- Every public nested command has an addressable help page
+- Every accepted public option appears on its owning page
+- Every page identifies defaults and accepted values that affect behavior
+- Every leaf page includes at least one valid example
+- Hidden internal commands do not appear in public listings
+- Explicit internal-command help explains its status and public alternative
+
+The required nested page families are:
+
+- `history`: `enable`, `disable`, `status`, `build`, `rebuild`, `list`, `show`, `prefer`, `export`, and `gc`
+- `export`: `html`, `callflow-html`, `obsidian`, `wiki`, `svg`, `graphml`, `neo4j`, and `falkordb`
+- `provider`: `add`, `list`, `show`, and `remove`
+- `global`: `add`, `remove`, `list`, and `path`
+- `hook`: `install`, `uninstall`, and `status`
+- `diagnose`: `multigraph`
+
+Compatibility aliases and platform shortcuts may be grouped under their owning public command when listing each alias would overwhelm root help. Their accepted spelling must still appear on the detailed page.
+
+## Testing strategy
+
+Implement the help system with test-driven development. Add one failing behavior test before each implementation slice.
+
+Structural tests inspect the registry and require:
+
+- Unique command paths
+- One root placement for every public top-level command
+- Non-empty summaries and usage forms
+- At least one example on every public leaf page
+- Reachable parent pages for every nested page
+- No public child beneath an internal-only parent
+
+Rendering tests verify section order, alignment, wrapping, and omission of empty sections. Rendering the same page in plain and styled modes must produce identical text after stripping ANSI sequences. Plain output must contain no escape byte.
+
+Routing tests cover root forms, command forms, nested forms, internal pages, unknown segments, close suggestions, and distant names. Environment-policy tests cover terminal output, redirected output, `NO_COLOR`, and `TERM=dumb` through an injectable style decision rather than a real terminal.
+
+Regression tests capture the current Graphify compatibility help before the change and require byte-for-byte equality afterward. The existing CLI suite must continue to pass so the help work does not change parsing, result output, or exit codes.
+
+## Completion criteria
+
+The feature is complete when all public Compass commands meet the coverage rules, both help invocation styles resolve correctly, terminal styling follows the environment policy, typo recovery behaves conservatively, Graphify help remains unchanged, and the full Compass workspace test suite passes.


### PR DESCRIPTION
## Summary

- replace the command-only Compass help screen with workflow-oriented command groups and concise descriptions
- add detailed usage, arguments, options, defaults, examples, tips, and notes across all public commands and nested command families
- support equivalent `compass help <path>` and `compass <path> --help` forms, including compatibility `-?` routing
- add terminal-aware ANSI styling that respects pipes, `NO_COLOR`, and `TERM=dumb`
- suggest likely commands for conservative typo matches while preserving exit behavior
- keep Graphify compatibility help byte-for-byte unchanged
- document the approved design and implementation plan

## Why

Compass previously listed command names without explaining what they did or how their options worked. Users had to inspect source or encounter parser errors to discover command behavior. This change makes the CLI self-documenting and easier to navigate without changing normal command execution.

## User impact

Users get categorized root help, complete command-level guidance, nested help discovery, readable terminal presentation, and actionable typo feedback. Scripts and piped output remain deterministic and uncolored.

## Validation

- `cargo test -j1 -p compass-cli --test help_cli -- --nocapture` — 6 passed
- `cargo test -j1 -p compass-cli --lib help::tests -- --nocapture` — 4 passed
- `cargo test -j1 -p compass-parity --lib compass_help_and_version_do_not_execute_commands -- --nocapture` — 1 passed
- Compass product tests — 3 passed
- `rustfmt --edition 2024 --check` on changed Rust files
- `git diff --check`
- `graphify update .`
