### PR TITLE
perf: accelerate cold graph updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,7 @@ dependencies = [
  "compass-reflect",
  "compass-resolve",
  "notify",
+ "num_cpus",
  "rayon",
  "serde",
  "serde_json",
@@ -1054,6 +1055,7 @@ version = "0.1.0"
 dependencies = [
  "compass-languages",
  "compass-model",
+ "rayon",
  "serde",
  "serde_json",
  "sha1",
@@ -1281,6 +1283,7 @@ version = "0.1.0"
 dependencies = [
  "compass-languages",
  "compass-model",
+ "rayon",
  "regex",
  "serde_json",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ sha1 = "0.10"
 md-5 = "0.10"
 mimalloc = { version = "0.1.52", default-features = false }
 notify = "8.2.0"
+num_cpus = "1.17"
 prolly-map = "=0.5.0"
 prolly-store-sqlite = "=0.3.0"
 oxidize-pdf = { version = "4.1.1", default-features = false, features = ["compression"] }

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -4225,11 +4225,11 @@ mod mcp_option_tests {
     }
 
     #[test]
-    fn absent_worker_override_preserves_memory_bounded_default() {
+    fn absent_worker_override_preserves_host_sized_default() {
         let mut options = BuildOptions::new(".");
-        assert_eq!(options.max_workers, Some(1));
+        assert_eq!(options.max_workers, None);
         apply_max_workers_override(&mut options, None);
-        assert_eq!(options.max_workers, Some(1));
+        assert_eq!(options.max_workers, None);
         apply_max_workers_override(&mut options, Some(4));
         assert_eq!(options.max_workers, Some(4));
     }

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -14,6 +14,7 @@ categories.workspace = true
 [dependencies]
 rayon.workspace = true
 notify.workspace = true
+num_cpus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -40,7 +40,7 @@ pub struct BuildOptions {
     pub exclude_hubs: Option<f64>,
     pub google_workspace: bool,
     /// Maximum number of worker threads used by the deterministic AST stages.
-    /// `None` uses Rayon's process-wide default, matching the library default.
+    /// `None` uses the host CPU count in a build-local Rayon pool.
     pub max_workers: Option<usize>,
     /// Override the commit recorded in update artifacts.
     ///
@@ -73,13 +73,9 @@ impl BuildOptions {
             resolution: 1.0,
             exclude_hubs: None,
             google_workspace: false,
-            // Parser instances retain grammar tables, so unbounded host-wide
-            // parallelism can cost more memory than throughput on large
-            // multilingual repositories. One retained parser still clears the
-            // cold-build latency gate while leaving repeatable headroom below
-            // the Python oracle's peak on highly multilingual builds. Library
-            // callers can explicitly choose another bound when appropriate.
-            max_workers: Some(1),
+            // Large builds use a local host-sized pool. Keeping this unset also
+            // lets CLI callers provide an explicit memory/throughput bound.
+            max_workers: None,
             built_at_commit: None,
             purpose: BuildPurpose::Update,
         }
@@ -387,12 +383,11 @@ fn build_graph_inner(
     } else {
         missing.clone_from(&sources);
     }
-    let worker_pool = if (missing.len() >= 256 || sources.len() >= 256)
-        && let Some(max_workers) = options.max_workers
-    {
+    let worker_count = options.max_workers.unwrap_or_else(default_ast_workers);
+    let worker_pool = if missing.len() >= 256 || sources.len() >= 256 {
         Some(
             rayon::ThreadPoolBuilder::new()
-                .num_threads(max_workers)
+                .num_threads(worker_count)
                 .thread_name(|index| format!("compass-ast-{index}"))
                 .build()
                 .map_err(|error| CoreError::WorkerPool(error.to_string()))?,
@@ -402,27 +397,33 @@ fn build_graph_inner(
     };
     // A Rayon worker pool costs more resident memory than it saves time on
     // small multilingual projects, where parser-table page residency dominates.
-    // Stay sequential below the measured crossover; larger corpora retain the
-    // parallel pipeline that drives aggregate throughput.
+    // Stay sequential below the measured crossover. Larger corpora use an
+    // explicit local pool so an embedding application's global Rayon settings
+    // cannot silently serialize cold extraction.
+    let extract_source =
+        |engine: &mut Engine, path: &PathBuf| -> Result<_, compass_languages::ExtractError> {
+            let bytes = fs::read(path).map_err(|source| compass_files::FileError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let extraction = engine.extract_source(path, &bytes)?;
+            let source = (
+                path.to_string_lossy().into_owned(),
+                String::from_utf8_lossy(&bytes).into_owned(),
+            );
+            Ok((path.clone(), extraction, source))
+        };
     let fresh = if missing.len() < 256 {
         let mut engine = Engine::default();
         missing
             .iter()
-            .map(|path| {
-                engine
-                    .extract(path)
-                    .map(|extraction| (path.clone(), extraction))
-            })
+            .map(|path| extract_source(&mut engine, path))
             .collect::<Result<Vec<_>, _>>()?
     } else {
         let extract = || {
             missing
                 .par_iter()
-                .map_init(Engine::default, |engine, path| {
-                    engine
-                        .extract(path)
-                        .map(|extraction| (path.clone(), extraction))
-                })
+                .map_init(Engine::default, extract_source)
                 .collect::<Result<Vec<_>, _>>()
         };
         if let Some(pool) = &worker_pool {
@@ -431,19 +432,33 @@ fn build_graph_inner(
             extract()?
         }
     };
+    const CACHE_BATCH_SIZE: usize = 128;
+    for batch in fresh.chunks(CACHE_BATCH_SIZE) {
+        let entries = batch
+            .par_iter()
+            .filter(|(_, extraction, _)| !extraction.nodes.is_empty())
+            .map(|(path, extraction, _)| {
+                serde_json::to_value(extraction)
+                    .map(|value| (path.clone(), value))
+                    .map_err(|source| CoreError::SerializeExtraction {
+                        path: path.clone(),
+                        source,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        cache.save_batch(&entries, &CacheKind::Ast, None)?;
+    }
     let mut empty_files = Vec::new();
-    for (path, extraction) in fresh {
+    let fresh_paths = fresh
+        .iter()
+        .map(|(path, _, _)| path.clone())
+        .collect::<HashSet<_>>();
+    let mut fresh_source_text = HashMap::with_capacity(fresh.len());
+    for (path, extraction, (source_path, source)) in fresh {
         if extraction.nodes.is_empty() {
             empty_files.push(path.clone());
-        } else {
-            let value = serde_json::to_value(&extraction).map_err(|source| {
-                CoreError::SerializeExtraction {
-                    path: path.clone(),
-                    source,
-                }
-            })?;
-            cache.save(&path, &value, &CacheKind::Ast, None)?;
         }
+        fresh_source_text.insert(source_path, source);
         extractions.insert(path, extraction);
     }
     cache.flush()?;
@@ -466,13 +481,20 @@ fn build_graph_inner(
             )
         })
     };
-    let source_text = if sources.len() < 256 {
-        sources.iter().filter_map(read_source).collect()
-    } else if let Some(pool) = &worker_pool {
-        pool.install(|| sources.par_iter().filter_map(read_source).collect())
-    } else {
-        sources.par_iter().filter_map(read_source).collect()
+    let read_cached_source = |path: &PathBuf| {
+        (!fresh_paths.contains(path))
+            .then(|| read_source(path))
+            .flatten()
     };
+    let cached_source_text: HashMap<_, _> = if sources.len() < 256 {
+        sources.iter().filter_map(read_cached_source).collect()
+    } else if let Some(pool) = &worker_pool {
+        pool.install(|| sources.par_iter().filter_map(read_cached_source).collect())
+    } else {
+        sources.par_iter().filter_map(read_cached_source).collect()
+    };
+    fresh_source_text.extend(cached_source_text);
+    let source_text = fresh_source_text;
     let mut resolved = resolve_owned_with_root(ordered, &source_text, &root);
     drop(source_text);
     finalize_ast_extraction(&mut resolved, &root, &ast_id_remap);
@@ -830,6 +852,16 @@ fn build_graph_inner(
     })
 }
 
+#[cfg(target_os = "macos")]
+fn default_ast_workers() -> usize {
+    num_cpus::get().max(num_cpus::get_physical())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn default_ast_workers() -> usize {
+    num_cpus::get()
+}
+
 fn semantic_layer_is_empty(layer: &SemanticLayer) -> bool {
     layer.refreshed_files.is_empty()
         && layer.partial_files.is_empty()
@@ -864,6 +896,7 @@ fn finalize_ast_extraction(
 ) {
     apply_ast_id_remap(extraction, ast_id_remap);
     let mut external_id_remap = HashMap::new();
+    let mut canonical_sources = HashMap::<String, PathBuf>::new();
     for node in &mut extraction.nodes {
         let Some(source) = node
             .attributes
@@ -874,8 +907,13 @@ fn finalize_ast_extraction(
             continue;
         };
         let source_path = Path::new(&source);
-        if !source_path.is_absolute() || rooted_source_identity(source_path, root).starts_with(root)
-        {
+        if !source_path.is_absolute() {
+            continue;
+        }
+        let canonical = canonical_sources
+            .entry(source.clone())
+            .or_insert_with(|| rooted_source_identity(source_path, root));
+        if canonical.starts_with(root) {
             continue;
         }
         let portable = portable_out_of_root_source(source_path, root);
@@ -903,7 +941,7 @@ fn finalize_ast_extraction(
         }
     }
     for node in &mut extraction.nodes {
-        normalize_source_attribute(&mut node.attributes, root);
+        normalize_source_attribute_cached(&mut node.attributes, root, &mut canonical_sources);
         node.attributes.remove("origin_file");
         node.attributes.remove("_callable");
         node.attributes.insert(
@@ -912,12 +950,39 @@ fn finalize_ast_extraction(
         );
     }
     for edge in &mut extraction.edges {
-        normalize_source_attribute(&mut edge.attributes, root);
+        normalize_source_attribute_cached(&mut edge.attributes, root, &mut canonical_sources);
         edge.attributes.insert(
             "_origin".to_owned(),
             serde_json::Value::String("ast".to_owned()),
         );
     }
+}
+
+fn normalize_source_attribute_cached(
+    attributes: &mut serde_json::Map<String, serde_json::Value>,
+    root: &Path,
+    canonical_sources: &mut HashMap<String, PathBuf>,
+) {
+    let Some(source) = attributes
+        .get("source_file")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return;
+    };
+    let path = Path::new(source);
+    if !path.is_absolute() {
+        return;
+    }
+    let canonical_path = canonical_sources
+        .entry(source.to_owned())
+        .or_insert_with(|| fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
+    let Ok(relative) = canonical_path.strip_prefix(root) else {
+        return;
+    };
+    attributes.insert(
+        "source_file".to_owned(),
+        serde_json::Value::String(relative.to_string_lossy().replace('\\', "/")),
+    );
 }
 
 fn portable_out_of_root_source(path: &Path, root: &Path) -> String {

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -1,7 +1,9 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
+use rayon::prelude::*;
 use serde_json::Value;
 
 use crate::{FileError, StatHashIndex, io_error, write_json_atomic};
@@ -31,6 +33,14 @@ pub struct Cache {
     output_name: String,
     extractor_version: String,
     hashes: StatHashIndex,
+    session_hashes: HashMap<PathBuf, SessionHash>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionHash {
+    size: u64,
+    modified: Option<SystemTime>,
+    value: String,
 }
 
 impl Cache {
@@ -46,6 +56,7 @@ impl Cache {
             output_name,
             extractor_version: "0.9.20".to_owned(),
             hashes,
+            session_hashes: HashMap::new(),
         };
         cache.cleanup_stale_ast();
         Ok(cache)
@@ -78,7 +89,7 @@ impl Cache {
         allow_legacy: bool,
         allow_partial: bool,
     ) -> Result<Option<Value>, FileError> {
-        let hash = self.hashes.hash(path, &self.root)?;
+        let hash = self.content_hash(path)?;
         let mut entry = self
             .directory(kind, prompt_fingerprint)
             .join(format!("{hash}.json"));
@@ -118,10 +129,36 @@ impl Cache {
         }
         let mut on_disk = value.clone();
         relativize_source_files(&mut on_disk, &self.root);
-        let hash = self.hashes.hash(path, &self.root)?;
+        let hash = self.content_hash(path)?;
         let directory = self.directory(kind, prompt_fingerprint);
         fs::create_dir_all(&directory).map_err(|source| io_error(&directory, source))?;
         write_json_atomic(directory.join(format!("{hash}.json")), &on_disk, false)
+    }
+
+    /// Persist a group of cache entries concurrently while retaining the same
+    /// content-addressed, atomic on-disk format as [`Self::save`].
+    pub fn save_batch(
+        &mut self,
+        entries: &[(PathBuf, Value)],
+        kind: &CacheKind,
+        prompt_fingerprint: Option<&str>,
+    ) -> Result<(), FileError> {
+        let directory = self.directory(kind, prompt_fingerprint);
+        fs::create_dir_all(&directory).map_err(|source| io_error(&directory, source))?;
+        let mut jobs = Vec::with_capacity(entries.len());
+        for (path, value) in entries {
+            if !path.is_file() {
+                continue;
+            }
+            let hash = self.content_hash(path)?;
+            jobs.push((directory.join(format!("{hash}.json")), value));
+        }
+        let root = &self.root;
+        jobs.into_par_iter().try_for_each(|(destination, value)| {
+            let mut on_disk = value.clone();
+            relativize_source_files(&mut on_disk, root);
+            write_json_atomic(destination, &on_disk, false)
+        })
     }
 
     pub fn flush(&mut self) -> Result<(), FileError> {
@@ -188,6 +225,27 @@ impl Cache {
                 let _ = fs::remove_file(path);
             }
         }
+    }
+
+    fn content_hash(&mut self, path: &Path) -> Result<String, FileError> {
+        let metadata = fs::metadata(path).map_err(|source| io_error(path, source))?;
+        let modified = metadata.modified().ok();
+        if let Some(cached) = self.session_hashes.get(path)
+            && cached.size == metadata.len()
+            && cached.modified == modified
+        {
+            return Ok(cached.value.clone());
+        }
+        let value = self.hashes.hash(path, &self.root)?;
+        self.session_hashes.insert(
+            path.to_path_buf(),
+            SessionHash {
+                size: metadata.len(),
+                modified,
+                value: value.clone(),
+            },
+        );
+        Ok(value)
     }
 }
 

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -301,6 +301,47 @@ fn cache_round_trip_is_portable_and_partial_safe() -> Result<(), Box<dyn Error>>
 }
 
 #[test]
+fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let first = directory.path().join("first.rs");
+    let second = directory.path().join("second.rs");
+    fs::write(&first, "fn first() {}\n")?;
+    fs::write(&second, "fn second() {}\n")?;
+    let first_value =
+        json!({"nodes":[{"id":"first","source_file":first.to_string_lossy()}],"edges":[]});
+    let second_value =
+        json!({"nodes":[{"id":"second","source_file":second.to_string_lossy()}],"edges":[]});
+    let mut cache = Cache::new(directory.path(), None)?;
+
+    cache.save_batch(
+        &[
+            (first.clone(), first_value.clone()),
+            (second.clone(), second_value.clone()),
+        ],
+        &CacheKind::Ast,
+        None,
+    )?;
+    assert_eq!(
+        cache.load(&first, &CacheKind::Ast, None, false, false)?,
+        Some(first_value)
+    );
+    assert_eq!(
+        cache.load(&second, &CacheKind::Ast, None, false, false)?,
+        Some(second_value)
+    );
+
+    fs::write(&first, "fn first_changed() {}\n")?;
+    let changed =
+        json!({"nodes":[{"id":"first_changed","source_file":first.to_string_lossy()}],"edges":[]});
+    cache.save_batch(&[(first.clone(), changed.clone())], &CacheKind::Ast, None)?;
+    assert_eq!(
+        cache.load(&first, &CacheKind::Ast, None, false, false)?,
+        Some(changed)
+    );
+    Ok(())
+}
+
+#[test]
 fn malformed_and_non_object_cache_entries_fail_closed() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let source = directory.path().join("main.py");

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -20,6 +20,7 @@ strsim.workspace = true
 thiserror.workspace = true
 compass-languages = { path = "../compass-languages", version = "0.1.0" }
 compass-model = { path = "../compass-model", version = "0.1.0" }
+rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true
 

--- a/crates/compass-graph/src/analyze.rs
+++ b/crates/compass-graph/src/analyze.rs
@@ -2,10 +2,11 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::Path;
 
 use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
+use rayon::prelude::*;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::cluster::{Communities, PythonRandom, cohesion_score};
+use crate::cluster::{Communities, PythonRandom};
 
 const BUILTIN_NOISE_LABELS: &[&str] = &[
     "str",
@@ -193,6 +194,7 @@ pub fn suggest_questions(
 ) -> Vec<SuggestedQuestion> {
     let graph = AnalysisGraph::new(document);
     let node_community = invert_communities(communities);
+    let cohesion = community_cohesion_scores(&graph, communities, &node_community);
     let mut questions = Vec::new();
     for edge in &graph.edges {
         if edge_string(edge.record, "confidence") != "AMBIGUOUS" {
@@ -337,7 +339,7 @@ pub fn suggest_questions(
         });
     }
     for (community, members) in communities {
-        let score = cohesion_score(document, members);
+        let score = cohesion.get(community).copied().unwrap_or(1.0);
         if score < 0.15 && members.len() >= 5 {
             let label = community_labels
                 .get(community)
@@ -795,18 +797,17 @@ fn node_betweenness(graph: &AnalysisGraph<'_>, sampled: bool) -> Vec<f64> {
     } else {
         (0..graph.len()).collect()
     };
+    // Each Brandes traversal is independent. Collecting from an indexed parallel
+    // iterator retains source order, and the sequential merge below retains the
+    // exact floating-point accumulation order of the previous implementation.
+    let source_scores = sources
+        .par_iter()
+        .map(|source| single_source_node_betweenness(graph, *source))
+        .collect::<Vec<_>>();
     let mut scores = vec![0.0; graph.len()];
-    for source in &sources {
-        let (mut stack, predecessors, paths) = shortest_paths(graph, *source);
-        let mut dependency = vec![0.0; graph.len()];
-        while let Some(node) = stack.pop() {
-            let coefficient = (1.0 + dependency[node]) / paths[node];
-            for predecessor in &predecessors[node] {
-                dependency[*predecessor] += paths[*predecessor] * coefficient;
-            }
-            if node != *source {
-                scores[node] += dependency[node];
-            }
+    for source_score in source_scores {
+        for (score, contribution) in scores.iter_mut().zip(source_score) {
+            *score += contribution;
         }
     }
     let n = graph.len();
@@ -831,6 +832,22 @@ fn node_betweenness(graph: &AnalysisGraph<'_>, sampled: bool) -> Vec<f64> {
             for score in &mut scores {
                 *score *= scale;
             }
+        }
+    }
+    scores
+}
+
+fn single_source_node_betweenness(graph: &AnalysisGraph<'_>, source: usize) -> Vec<f64> {
+    let (mut stack, predecessors, paths) = shortest_paths(graph, source);
+    let mut dependency = vec![0.0; graph.len()];
+    let mut scores = vec![0.0; graph.len()];
+    while let Some(node) = stack.pop() {
+        let coefficient = (1.0 + dependency[node]) / paths[node];
+        for predecessor in &predecessors[node] {
+            dependency[*predecessor] += paths[*predecessor] * coefficient;
+        }
+        if node != source {
+            scores[node] = dependency[node];
         }
     }
     scores
@@ -930,6 +947,7 @@ struct AnalysisGraph<'a> {
     positions: HashMap<&'a str, usize>,
     edges: Vec<AnalysisEdge<'a>>,
     adjacency: Vec<Vec<usize>>,
+    degrees: Vec<usize>,
     directed: bool,
 }
 
@@ -944,6 +962,7 @@ impl<'a> AnalysisGraph<'a> {
         let mut edges = Vec::<AnalysisEdge<'a>>::new();
         let mut edge_positions = HashMap::<(usize, usize), usize>::new();
         let mut adjacency = vec![Vec::new(); nodes.len()];
+        let mut degrees = vec![0; nodes.len()];
         for record in &document.links {
             let (Some(left), Some(right)) = (
                 positions.get(record.source.as_str()),
@@ -966,6 +985,8 @@ impl<'a> AnalysisGraph<'a> {
                 right: *right,
                 record,
             });
+            degrees[*left] += 1;
+            degrees[*right] += 1;
             adjacency[*left].push(*right);
             if !document.directed && left != right {
                 adjacency[*right].push(*left);
@@ -976,6 +997,7 @@ impl<'a> AnalysisGraph<'a> {
             positions,
             edges,
             adjacency,
+            degrees,
             directed: document.directed,
         }
     }
@@ -983,17 +1005,7 @@ impl<'a> AnalysisGraph<'a> {
         self.nodes.len()
     }
     fn degree(&self, node: usize) -> usize {
-        if self.directed {
-            self.edges
-                .iter()
-                .map(|edge| usize::from(edge.left == node) + usize::from(edge.right == node))
-                .sum()
-        } else {
-            self.adjacency[node]
-                .iter()
-                .map(|neighbor| if *neighbor == node { 2 } else { 1 })
-                .sum()
-        }
+        self.degrees[node]
     }
     fn is_file_node(&self, node: usize) -> bool {
         let record = self.nodes[node];
@@ -1058,6 +1070,35 @@ fn invert_communities(communities: &Communities) -> HashMap<String, usize> {
     communities
         .iter()
         .flat_map(|(community, nodes)| nodes.iter().map(move |node| (node.clone(), *community)))
+        .collect()
+}
+
+fn community_cohesion_scores(
+    graph: &AnalysisGraph<'_>,
+    communities: &Communities,
+    node_community: &HashMap<String, usize>,
+) -> HashMap<usize, f64> {
+    let mut internal_edges = HashMap::<usize, usize>::new();
+    for edge in &graph.edges {
+        let left = node_community.get(&graph.nodes[edge.left].id);
+        if let Some(community) = left
+            && node_community.get(&graph.nodes[edge.right].id) == Some(community)
+        {
+            *internal_edges.entry(*community).or_default() += 1;
+        }
+    }
+    communities
+        .iter()
+        .map(|(community, members)| {
+            let count = members.len();
+            let possible = count.saturating_mul(count.saturating_sub(1)) / 2;
+            let score = if possible == 0 {
+                1.0
+            } else {
+                internal_edges.get(community).copied().unwrap_or_default() as f64 / possible as f64
+            };
+            (*community, score)
+        })
         .collect()
 }
 fn is_concept_node(node: &NodeRecord) -> bool {

--- a/crates/compass-graph/src/cluster.rs
+++ b/crates/compass-graph/src/cluster.rs
@@ -169,9 +169,35 @@ pub fn score_communities(
     communities: &Communities,
 ) -> BTreeMap<usize, f64> {
     let graph = WeightedGraph::from_document(document);
+    let positions = graph.position_map();
+    let mut node_community = vec![None; graph.len()];
+    let mut internal_edges = HashMap::<usize, usize>::new();
+    for (community, members) in communities {
+        for member in members {
+            if let Some(position) = positions.get(member) {
+                node_community[*position] = Some(*community);
+            }
+        }
+    }
+    for (left, right, _) in graph.edges() {
+        if let Some(community) = node_community[left]
+            && node_community[right] == Some(community)
+        {
+            *internal_edges.entry(community).or_default() += 1;
+        }
+    }
     communities
         .iter()
-        .map(|(community, members)| (*community, cohesion_score_graph(&graph, members)))
+        .map(|(community, members)| {
+            let count = members.len();
+            let possible = count.saturating_mul(count.saturating_sub(1)) / 2;
+            let score = if possible == 0 {
+                1.0
+            } else {
+                internal_edges.get(community).copied().unwrap_or_default() as f64 / possible as f64
+            };
+            (*community, score)
+        })
         .collect()
 }
 
@@ -183,23 +209,20 @@ pub fn remap_communities_to_previous(
     if communities.is_empty() {
         return Communities::new();
     }
-    let new_sets = communities
-        .iter()
-        .map(|(community, nodes)| (*community, nodes.iter().collect::<HashSet<_>>()))
-        .collect::<HashMap<_, _>>();
-    let mut old_sets = HashMap::<usize, HashSet<&String>>::new();
-    for (node, community) in previous {
-        old_sets.entry(*community).or_default().insert(node);
-    }
-    let mut overlaps = Vec::<(usize, usize, usize)>::new();
-    for (old_community, old_nodes) in old_sets {
-        for (new_community, new_nodes) in &new_sets {
-            let overlap = old_nodes.intersection(new_nodes).count();
-            if overlap > 0 {
-                overlaps.push((overlap, old_community, *new_community));
+    let mut overlap_counts = HashMap::<(usize, usize), usize>::new();
+    for (new_community, nodes) in communities {
+        for node in nodes {
+            if let Some(old_community) = previous.get(node) {
+                *overlap_counts
+                    .entry((*old_community, *new_community))
+                    .or_default() += 1;
             }
         }
     }
+    let mut overlaps = overlap_counts
+        .into_iter()
+        .map(|((old, new), overlap)| (overlap, old, new))
+        .collect::<Vec<_>>();
     overlaps.sort_by_key(|(overlap, old, new)| (std::cmp::Reverse(*overlap), *old, *new));
     let mut mapping = HashMap::new();
     let mut used_old = HashSet::new();
@@ -332,15 +355,20 @@ fn cohesion_score_graph(graph: &WeightedGraph, members: &[String]) -> f64 {
     if count <= 1 {
         return 1.0;
     }
-    let member_set = members.iter().map(String::as_str).collect::<HashSet<_>>();
-    let actual = graph
-        .edges()
+    let positions = graph.position_map();
+    let member_set = members
         .iter()
-        .filter(|(left, right, _)| {
-            member_set.contains(graph.ids[*left].as_str())
-                && member_set.contains(graph.ids[*right].as_str())
+        .filter_map(|member| positions.get(member).copied())
+        .collect::<HashSet<_>>();
+    let actual = member_set
+        .iter()
+        .map(|left| {
+            graph.adjacency[*left]
+                .iter()
+                .filter(|(right, _)| left <= right && member_set.contains(right))
+                .count()
         })
-        .count();
+        .sum::<usize>();
     let possible = count * (count - 1) / 2;
     actual as f64 / possible as f64
 }
@@ -487,26 +515,34 @@ fn weight_for(weights: &[(usize, f64)], community: usize) -> f64 {
 }
 
 fn modularity(graph: &WeightedGraph, communities: &[BTreeSet<usize>], resolution: f64) -> f64 {
-    let degree_sum = (0..graph.len())
+    let degrees = (0..graph.len())
         .map(|node| graph.degree_weighted(node))
-        .sum::<f64>();
+        .collect::<Vec<_>>();
+    let degree_sum = degrees.iter().sum::<f64>();
+    if degree_sum == 0.0 {
+        return 0.0;
+    }
     let total_weight = degree_sum / 2.0;
     let norm = 1.0 / degree_sum.powi(2);
-    communities
-        .iter()
-        .map(|community| {
-            let internal = graph
-                .edges()
-                .iter()
-                .filter(|(left, right, _)| community.contains(left) && community.contains(right))
-                .map(|(_, _, weight)| *weight)
-                .sum::<f64>();
-            let degree = community
-                .iter()
-                .map(|node| graph.degree_weighted(*node))
-                .sum::<f64>();
-            internal / total_weight - resolution * degree.powi(2) * norm
-        })
+    let mut node_community = vec![usize::MAX; graph.len()];
+    let mut community_degrees = vec![0.0; communities.len()];
+    let mut internal_weights = vec![0.0; communities.len()];
+    for (community, nodes) in communities.iter().enumerate() {
+        for node in nodes {
+            node_community[*node] = community;
+            community_degrees[community] += degrees[*node];
+        }
+    }
+    for (left, right, weight) in graph.edges() {
+        let community = node_community[left];
+        if community != usize::MAX && node_community[right] == community {
+            internal_weights[community] += weight;
+        }
+    }
+    internal_weights
+        .into_iter()
+        .zip(community_degrees)
+        .map(|(internal, degree)| internal / total_weight - resolution * degree.powi(2) * norm)
         .sum()
 }
 
@@ -561,17 +597,25 @@ impl WeightedGraph {
             .map(|(index, id)| (id.clone(), index))
             .collect::<HashMap<_, _>>();
         let mut graph = Self::new(ids, members);
-        let mut edges = document.links.iter().collect::<Vec<_>>();
+        let mut edges = document
+            .links
+            .iter()
+            .map(|edge| {
+                (
+                    edge.source.as_str(),
+                    edge.target.as_str(),
+                    canonical_attributes(&edge.attributes),
+                    edge,
+                )
+            })
+            .collect::<Vec<_>>();
         edges.sort_by(|left, right| {
-            left.source
-                .cmp(&right.source)
-                .then_with(|| left.target.cmp(&right.target))
-                .then_with(|| {
-                    canonical_attributes(&left.attributes)
-                        .cmp(&canonical_attributes(&right.attributes))
-                })
+            left.0
+                .cmp(right.0)
+                .then_with(|| left.1.cmp(right.1))
+                .then_with(|| left.2.cmp(&right.2))
         });
-        for edge in edges {
+        for (_, _, _, edge) in edges {
             let (Some(left), Some(right)) =
                 (positions.get(&edge.source), positions.get(&edge.target))
             else {
@@ -596,7 +640,7 @@ impl WeightedGraph {
     }
 
     fn edge_count(&self) -> usize {
-        self.edges().len()
+        self.edges().count()
     }
 
     fn position_map(&self) -> HashMap<&String, usize> {
@@ -628,7 +672,7 @@ impl WeightedGraph {
     }
 
     fn total_weight(&self) -> f64 {
-        self.edges().iter().map(|(_, _, weight)| *weight).sum()
+        self.edges().map(|(_, _, weight)| weight).sum()
     }
 
     fn set_edge(&mut self, left: usize, right: usize, weight: f64) {
@@ -673,18 +717,16 @@ impl WeightedGraph {
         }
     }
 
-    fn edges(&self) -> Vec<(usize, usize, f64)> {
-        let mut output = Vec::new();
-        let mut visited = HashSet::new();
-        for left in 0..self.len() {
-            for (right, weight) in &self.adjacency[left] {
-                if !visited.contains(right) {
-                    output.push((left, *right, *weight));
-                }
-            }
-            visited.insert(left);
-        }
-        output
+    fn edges(&self) -> impl Iterator<Item = (usize, usize, f64)> + '_ {
+        self.adjacency
+            .iter()
+            .enumerate()
+            .flat_map(|(left, neighbors)| {
+                neighbors
+                    .iter()
+                    .filter(move |(right, _)| left <= *right)
+                    .map(move |(right, weight)| (left, *right, *weight))
+            })
     }
 
     fn subgraph(&self, selected: &[usize]) -> Self {
@@ -989,6 +1031,58 @@ mod tests {
             ("z".to_owned(), json!([{"a":1,"b":2}])),
         ]);
         assert_eq!(canonical_attributes(&left), canonical_attributes(&right));
+    }
+
+    #[test]
+    fn linear_aggregations_match_the_reference_formulas() {
+        let ids = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let members = ids.iter().cloned().map(|id| BTreeSet::from([id])).collect();
+        let mut weighted = WeightedGraph::new(ids, members);
+        weighted.add_edge(0, 1, 2.0);
+        weighted.add_edge(1, 2, 1.5);
+        weighted.add_edge(2, 3, 3.0);
+        weighted.add_edge(3, 3, 0.5);
+        let partition = [BTreeSet::from([0, 1]), BTreeSet::from([2, 3])];
+
+        let degree_sum = (0..weighted.len())
+            .map(|node| weighted.degree_weighted(node))
+            .sum::<f64>();
+        let total_weight = degree_sum / 2.0;
+        let norm = 1.0 / degree_sum.powi(2);
+        let reference = partition
+            .iter()
+            .map(|community| {
+                let internal = weighted
+                    .edges()
+                    .filter(|(left, right, _)| {
+                        community.contains(left) && community.contains(right)
+                    })
+                    .map(|(_, _, weight)| weight)
+                    .sum::<f64>();
+                let degree = community
+                    .iter()
+                    .map(|node| weighted.degree_weighted(*node))
+                    .sum::<f64>();
+                internal / total_weight - degree.powi(2) * norm
+            })
+            .sum::<f64>();
+        assert!((modularity(&weighted, &partition, 1.0) - reference).abs() < 1e-12);
+
+        let document = graph(&["a", "b", "c", "d"], &[("a", "b"), ("b", "c"), ("c", "d")]);
+        let communities = BTreeMap::from([
+            (0, vec!["a".to_owned(), "b".to_owned()]),
+            (1, vec!["c".to_owned(), "d".to_owned()]),
+        ]);
+        let scores = score_communities(&document, &communities);
+        for (community, nodes) in &communities {
+            assert_eq!(
+                scores.get(community),
+                Some(&cohesion_score(&document, nodes))
+            );
+        }
     }
 
     #[test]

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -419,36 +419,54 @@ fn networkx_edge_order(
     links: &[EdgeRecord],
     directed: bool,
 ) -> Vec<EdgeRecord> {
+    let positions = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id.as_str(), index))
+        .collect::<HashMap<_, _>>();
+    let mut incident = vec![Vec::new(); nodes.len()];
+    for (edge_index, edge) in links.iter().enumerate() {
+        let Some(&source) = positions.get(edge.source.as_str()) else {
+            continue;
+        };
+        incident[source].push(edge_index);
+        if !directed
+            && let Some(&target) = positions.get(edge.target.as_str())
+            && target != source
+        {
+            incident[target].push(edge_index);
+        }
+    }
+
     if directed {
         let mut output = Vec::with_capacity(links.len());
-        for node in nodes {
-            output.extend(links.iter().filter(|edge| edge.source == node.id).cloned());
+        for edge_indices in incident {
+            output.extend(edge_indices.into_iter().map(|index| links[index].clone()));
         }
         return output;
     }
+
     let mut output = Vec::with_capacity(links.len());
-    let mut visited = std::collections::HashSet::new();
-    for node in nodes {
-        for edge in links {
-            let other = if edge.source == node.id {
-                Some(edge.target.as_str())
-            } else if edge.target == node.id {
-                Some(edge.source.as_str())
-            } else {
-                None
-            };
-            let Some(other) = other else {
+    let mut visited = vec![false; nodes.len()];
+    for (node_index, edge_indices) in incident.into_iter().enumerate() {
+        for edge_index in edge_indices {
+            let edge = &links[edge_index];
+            let Some(&source) = positions.get(edge.source.as_str()) else {
                 continue;
             };
-            if visited.contains(other) {
+            let Some(&target) = positions.get(edge.target.as_str()) else {
+                continue;
+            };
+            let other = if source == node_index { target } else { source };
+            if visited[other] {
                 continue;
             }
             let mut emitted = edge.clone();
-            emitted.source = node.id.clone();
-            emitted.target = other.to_owned();
+            emitted.source.clone_from(&nodes[node_index].id);
+            emitted.target.clone_from(&nodes[other].id);
             output.push(emitted);
         }
-        visited.insert(node.id.clone());
+        visited[node_index] = true;
     }
     output
 }

--- a/crates/compass-graph/tests/build_coverage.rs
+++ b/crates/compass-graph/tests/build_coverage.rs
@@ -128,3 +128,41 @@ fn cross_language_phantoms_are_dropped_while_supported_families_survive()
     );
     Ok(())
 }
+
+#[test]
+fn networkx_edge_order_preserves_node_and_incident_edge_order() -> Result<(), Box<dyn Error>> {
+    let extraction: Extraction = serde_json::from_value(json!({
+        "nodes": [
+            {"id":"c","label":"C"},
+            {"id":"a","label":"A"},
+            {"id":"b","label":"B"}
+        ],
+        "edges": [
+            {"source":"b","target":"c","relation":"calls"},
+            {"source":"c","target":"c","relation":"calls"},
+            {"source":"a","target":"c","relation":"calls"},
+            {"source":"a","target":"b","relation":"calls"}
+        ]
+    }))?;
+
+    let undirected = build_from_extraction(&extraction, false, None);
+    assert_eq!(
+        undirected
+            .links
+            .iter()
+            .map(|edge| (edge.source.as_str(), edge.target.as_str()))
+            .collect::<Vec<_>>(),
+        [("c", "a"), ("c", "b"), ("c", "c"), ("a", "b")]
+    );
+
+    let directed = build_from_extraction(&extraction, true, None);
+    assert_eq!(
+        directed
+            .links
+            .iter()
+            .map(|edge| (edge.source.as_str(), edge.target.as_str()))
+            .collect::<Vec<_>>(),
+        [("c", "c"), ("a", "b"), ("a", "c"), ("b", "c")]
+    );
+    Ok(())
+}

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -15,6 +15,8 @@ use crate::{
     ExtractError, Extraction, ExtractorKind, LanguageSpec, RawCall, Registry, file_stem, make_id,
 };
 
+const JSON_MAX_BYTES: u64 = 1_048_576;
+
 #[derive(Default)]
 pub struct Engine {
     parsers: HashMap<&'static str, Parser>,
@@ -38,6 +40,24 @@ impl Engine {
             ExtractorKind::ProjectXml => crate::dotnet_project::extract_project(path),
             ExtractorKind::Xaml => crate::xaml::extract(self, path),
             ExtractorKind::Template => crate::templates::extract(self, path, spec.name),
+        }
+    }
+
+    /// Extract from bytes already read by the caller. Source-driven extractors
+    /// use the supplied buffer directly; format-specific fallbacks retain their
+    /// existing file-based implementations.
+    pub fn extract_source(
+        &mut self,
+        path: &Path,
+        source: &[u8],
+    ) -> Result<Extraction, ExtractError> {
+        let spec =
+            Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
+        match spec.kind {
+            ExtractorKind::Generic => self.extract_generic_source(path, spec, source),
+            ExtractorKind::JsonConfig => self.extract_json_source(path, spec, source),
+            ExtractorKind::Terraform => self.extract_terraform_source(path, spec, source),
+            _ => self.extract(path),
         }
     }
 
@@ -78,50 +98,64 @@ impl Engine {
         path: &Path,
         spec: LanguageSpec,
     ) -> Result<Extraction, ExtractError> {
-        let mut source = fs::read(path).map_err(|source| compass_files::FileError::Io {
+        let source = fs::read(path).map_err(|source| compass_files::FileError::Io {
             path: path.to_path_buf(),
             source,
         })?;
+        self.extract_generic_source(path, spec, &source)
+    }
+
+    fn extract_generic_source(
+        &mut self,
+        path: &Path,
+        spec: LanguageSpec,
+        source: &[u8],
+    ) -> Result<Extraction, ExtractError> {
         if spec.name == "groovy" {
-            return Ok(crate::groovy::extract(path, &source));
+            return Ok(crate::groovy::extract(path, source));
         }
         // These extractors are intentionally source-driven and do not consume a
         // tree-sitter root. Avoid initializing and touching their large static
         // grammar tables only to discard the tree; this materially lowers cold
         // multilingual startup RSS and latency while preserving identical facts.
         match spec.name {
-            "zig" => return Ok(crate::zig::extract(path, &source)),
-            "verilog" => return Ok(crate::verilog::extract(path, &source)),
-            "sql" => return Ok(crate::sql::extract(path, &source)),
-            "pascal" => return Ok(crate::pascal::extract(path, &source)),
-            "apex" => return Ok(crate::apex::extract(path, &source)),
-            "dart" => return Ok(crate::dart::extract(path, &source)),
+            "zig" => return Ok(crate::zig::extract(path, source)),
+            "verilog" => return Ok(crate::verilog::extract(path, source)),
+            "sql" => return Ok(crate::sql::extract(path, source)),
+            "pascal" => return Ok(crate::pascal::extract(path, source)),
+            "apex" => return Ok(crate::apex::extract(path, source)),
+            "dart" => return Ok(crate::dart::extract(path, source)),
             _ => {}
         }
-        if spec.name == "objc" {
-            crate::objc::mask_annotation_macros(&mut source);
-        }
-        let tree = self.parse(path, spec, &source)?;
+        let mut masked = Vec::new();
+        let source = if spec.name == "objc" {
+            masked.extend_from_slice(source);
+            crate::objc::mask_annotation_macros(&mut masked);
+            masked.as_slice()
+        } else {
+            source
+        };
+        let tree = self.parse(path, spec, source)?;
         let config = generic_config(spec);
         let root = tree.root_node();
         let mut extraction = match spec.name {
-            "go" => crate::go::extract(path, &source, root),
-            "rust" => crate::rust_lang::extract(path, &source, root),
-            "bash" => crate::bash::extract(path, &source, root),
-            "csharp" => crate::csharp::extract(path, &source, root),
-            "cpp" => crate::cpp::extract(path, &source, root),
-            "php" => crate::php::extract(path, &source, root),
-            "swift" => crate::swift::extract(path, &source, root),
-            "objc" => crate::objc::extract(path, &source, root),
-            "powershell" => crate::powershell::extract(path, &source, root),
-            "elixir" => crate::elixir::extract(path, &source, root),
-            "julia" => crate::julia::extract(path, &source, root),
-            "fortran" => crate::fortran::extract(path, &source, root),
-            _ => extract_tree(path, &source, root, &config, spec.name),
+            "go" => crate::go::extract(path, source, root),
+            "rust" => crate::rust_lang::extract(path, source, root),
+            "bash" => crate::bash::extract(path, source, root),
+            "csharp" => crate::csharp::extract(path, source, root),
+            "cpp" => crate::cpp::extract(path, source, root),
+            "php" => crate::php::extract(path, source, root),
+            "swift" => crate::swift::extract(path, source, root),
+            "objc" => crate::objc::extract(path, source, root),
+            "powershell" => crate::powershell::extract(path, source, root),
+            "elixir" => crate::elixir::extract(path, source, root),
+            "julia" => crate::julia::extract(path, source, root),
+            "fortran" => crate::fortran::extract(path, source, root),
+            _ => extract_tree(path, source, root, &config, spec.name),
         };
-        attach_definition_hashes(&mut extraction, &source, root, &config);
+        attach_definition_hashes(&mut extraction, source, root, &config);
         if spec.name == "python" {
-            add_python_rationale(path, &source, root, &mut extraction);
+            add_python_rationale(path, source, root, &mut extraction);
         }
         Ok(extraction)
     }
@@ -131,24 +165,32 @@ impl Engine {
         path: &Path,
         spec: LanguageSpec,
     ) -> Result<Extraction, ExtractError> {
-        const MAX_BYTES: u64 = 1_048_576;
         let mut source = Vec::new();
         File::open(path)
             .map_err(|source| compass_files::FileError::Io {
                 path: path.to_path_buf(),
                 source,
             })?
-            .take(MAX_BYTES + 1)
+            .take(JSON_MAX_BYTES + 1)
             .read_to_end(&mut source)
             .map_err(|source| compass_files::FileError::Io {
                 path: path.to_path_buf(),
                 source,
             })?;
-        if source.len() > MAX_BYTES as usize {
+        self.extract_json_source(path, spec, &source)
+    }
+
+    fn extract_json_source(
+        &mut self,
+        path: &Path,
+        spec: LanguageSpec,
+        source: &[u8],
+    ) -> Result<Extraction, ExtractError> {
+        if source.len() > JSON_MAX_BYTES as usize {
             return Ok(crate::json_config::error("json file too large to index"));
         }
-        let tree = self.parse(path, spec, &source)?;
-        Ok(crate::json_config::extract(path, &source, tree.root_node()))
+        let tree = self.parse(path, spec, source)?;
+        Ok(crate::json_config::extract(path, source, tree.root_node()))
     }
 
     fn extract_terraform(
@@ -160,8 +202,17 @@ impl Engine {
             path: path.to_path_buf(),
             source,
         })?;
-        let tree = self.parse(path, spec, &source)?;
-        Ok(crate::terraform::extract(path, &source, tree.root_node()))
+        self.extract_terraform_source(path, spec, &source)
+    }
+
+    fn extract_terraform_source(
+        &mut self,
+        path: &Path,
+        spec: LanguageSpec,
+        source: &[u8],
+    ) -> Result<Extraction, ExtractError> {
+        let tree = self.parse(path, spec, source)?;
+        Ok(crate::terraform::extract(path, source, tree.root_node()))
     }
 
     fn extract_dreammaker(&mut self, path: &Path) -> Result<Extraction, ExtractError> {

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -4,6 +4,19 @@ use std::fs;
 use compass_languages::{Engine, ExtractError, make_id};
 
 #[test]
+fn caller_supplied_source_matches_file_based_generic_extraction() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("source.rs");
+    let source = b"pub struct Service;\nimpl Service { pub fn run(&self) {} }\n";
+    fs::write(&path, source)?;
+
+    let from_file = Engine::default().extract(&path)?;
+    let from_memory = Engine::default().extract_source(&path, source)?;
+    assert_eq!(from_memory, from_file);
+    Ok(())
+}
+
+#[test]
 fn python_indirect_rationale_types_and_binding_shapes_are_extracted() -> Result<(), Box<dyn Error>>
 {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+rayon.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 sha1.workspace = true

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use compass_languages::{Extraction, RawCall, make_id};
 use compass_model::{EdgeRecord, NodeRecord};
+use rayon::prelude::*;
 use regex::Regex;
 use serde_json::{Map, Value};
 use sha1::{Digest, Sha1};
@@ -174,13 +175,6 @@ pub fn resolve_with_root(
         merged
             .hyperedges
             .extend(extraction.hyperedges.iter().cloned());
-        if let Some(raw_calls) = &extraction.raw_calls {
-            merged
-                .raw_calls
-                .get_or_insert_with(Vec::new)
-                .extend(raw_calls.iter().cloned());
-        }
-        merged.extensions.extend(extraction.extensions.clone());
     }
     finish_resolution(merged, language_facts, sources, root)
 }
@@ -194,41 +188,37 @@ pub fn resolve_owned_with_root(
     sources: &HashMap<String, String>,
     root: &Path,
 ) -> Extraction {
-    let language_facts = members::collect_language_call_facts(&extractions);
+    let language_facts = members::collect_language_call_facts_owned(&mut extractions);
     let mut merged = Extraction::default();
     for extraction in &mut extractions {
         merged.nodes.append(&mut extraction.nodes);
         merged.edges.append(&mut extraction.edges);
         merged.hyperedges.append(&mut extraction.hyperedges);
-        if let Some(raw_calls) = extraction.raw_calls.as_mut() {
-            merged
-                .raw_calls
-                .get_or_insert_with(Vec::new)
-                .append(raw_calls);
-        }
-        merged.extensions.append(&mut extraction.extensions);
     }
+    extractions.into_par_iter().for_each(drop);
     finish_resolution(merged, language_facts, sources, root)
 }
 
 fn finish_resolution(
     mut merged: Extraction,
-    language_facts: members::LanguageCallFacts,
+    mut language_facts: members::LanguageCallFacts,
     sources: &HashMap<String, String>,
     root: &Path,
 ) -> Extraction {
     resolve_javascript_reexports(&mut merged);
     canonicalize_import_targets(&mut merged);
     let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    disambiguate_colliding_node_ids(&mut merged, &canonical_root);
+    disambiguate_colliding_node_ids_with_calls(
+        &mut merged,
+        &canonical_root,
+        &mut language_facts.calls,
+    );
     canonicalize_csharp_namespace_nodes(&mut merged);
     resolve_php_type_references(&mut merged, sources);
     rewire_unique_family_stubs(&mut merged);
     rewire_unique_stub_nodes(&mut merged);
-    resolve_cross_file_calls_with_root(&mut merged, sources, root);
+    resolve_cross_file_calls_with_root_calls(&mut merged, sources, root, &language_facts.calls);
     members::resolve_language_call_facts(language_facts, &mut merged);
-    merged.raw_calls = None;
-    merged.extensions.clear();
     merged
 }
 
@@ -700,7 +690,22 @@ fn is_type_like_definition(node: &NodeRecord) -> bool {
     !label.is_empty() && !label.ends_with(')') && !label.starts_with('.') && !label.contains('.')
 }
 
+#[cfg(test)]
 fn disambiguate_colliding_node_ids(extraction: &mut Extraction, root: &Path) {
+    let mut raw_calls = extraction.raw_calls.take();
+    if let Some(calls) = raw_calls.as_mut() {
+        disambiguate_colliding_node_ids_with_calls(extraction, root, calls);
+    } else {
+        disambiguate_colliding_node_ids_with_calls(extraction, root, &mut []);
+    }
+    extraction.raw_calls = raw_calls;
+}
+
+fn disambiguate_colliding_node_ids_with_calls(
+    extraction: &mut Extraction,
+    root: &Path,
+    raw_calls: &mut [RawCall],
+) {
     let mut groups = HashMap::<String, Vec<usize>>::new();
     for (index, node) in extraction.nodes.iter().enumerate() {
         if matches!(
@@ -804,12 +809,10 @@ fn disambiguate_colliding_node_ids(extraction: &mut Extraction, root: &Path) {
             edge.target.clone_from(new_id);
         }
     }
-    if let Some(raw_calls) = extraction.raw_calls.as_mut() {
-        for raw in raw_calls {
-            let key = source_key(&raw.source_file, root);
-            if let Some(new_id) = remap.get(&(raw.caller_nid.clone(), key)) {
-                raw.caller_nid.clone_from(new_id);
-            }
+    for raw in raw_calls {
+        let key = source_key(&raw.source_file, root);
+        if let Some(new_id) = remap.get(&(raw.caller_nid.clone(), key)) {
+            raw.caller_nid.clone_from(new_id);
         }
     }
 }
@@ -854,7 +857,17 @@ fn resolve_cross_file_calls_with_root(
     sources: &HashMap<String, String>,
     root: &Path,
 ) {
-    resolve_python_import_guided(extraction, sources, root);
+    let raw_calls = extraction.raw_calls.clone().unwrap_or_default();
+    resolve_cross_file_calls_with_root_calls(extraction, sources, root, &raw_calls);
+}
+
+fn resolve_cross_file_calls_with_root_calls(
+    extraction: &mut Extraction,
+    sources: &HashMap<String, String>,
+    root: &Path,
+    raw_calls: &[RawCall],
+) {
+    resolve_python_import_guided_with_calls(extraction, sources, root, raw_calls);
     resolve_python_class_uses(extraction, sources, root);
     let mut exact = HashMap::<String, Vec<String>>::new();
     let mut folded = HashMap::<String, Vec<String>>::new();
@@ -928,7 +941,6 @@ fn resolve_cross_file_calls_with_root(
         }
     }
 
-    let raw_calls = extraction.raw_calls.clone().unwrap_or_default();
     for raw in raw_calls {
         if raw.callee.is_empty()
             || raw.is_member_call == Some(true)
@@ -1029,10 +1041,21 @@ fn resolve_cross_file_calls_with_root(
     }
 }
 
+#[cfg(test)]
 fn resolve_python_import_guided(
     extraction: &mut Extraction,
     sources: &HashMap<String, String>,
     root: &Path,
+) {
+    let raw_calls = extraction.raw_calls.clone().unwrap_or_default();
+    resolve_python_import_guided_with_calls(extraction, sources, root, &raw_calls);
+}
+
+fn resolve_python_import_guided_with_calls(
+    extraction: &mut Extraction,
+    sources: &HashMap<String, String>,
+    root: &Path,
+    raw_calls: &[RawCall],
 ) {
     let mut definitions = HashMap::<String, Vec<(String, String)>>::new();
     for node in &extraction.nodes {
@@ -1147,7 +1170,6 @@ fn resolve_python_import_guided(
             }
         }
     }
-    let raw_calls = extraction.raw_calls.clone().unwrap_or_default();
     let aliases_by_source = sources
         .iter()
         .filter(|(source_file, _)| extension(source_file) == "py")

--- a/crates/compass-resolve/src/members.rs
+++ b/crates/compass-resolve/src/members.rs
@@ -11,7 +11,7 @@ pub fn resolve_language_calls(extractions: &[Extraction], merged: &mut Extractio
 
 pub(crate) struct LanguageCallFacts {
     tables: TypeTables,
-    calls: Vec<RawCall>,
+    pub(crate) calls: Vec<RawCall>,
 }
 
 pub(crate) fn collect_language_call_facts(extractions: &[Extraction]) -> LanguageCallFacts {
@@ -22,6 +22,17 @@ pub(crate) fn collect_language_call_facts(extractions: &[Extraction]) -> Languag
             .flat_map(|extraction| extraction.raw_calls.iter().flatten().cloned())
             .collect(),
     }
+}
+
+pub(crate) fn collect_language_call_facts_owned(
+    extractions: &mut [Extraction],
+) -> LanguageCallFacts {
+    let tables = TypeTables::new(extractions);
+    let calls = extractions
+        .iter_mut()
+        .flat_map(|extraction| extraction.raw_calls.take().into_iter().flatten())
+        .collect();
+    LanguageCallFacts { tables, calls }
 }
 
 pub(crate) fn resolve_language_call_facts(facts: LanguageCallFacts, merged: &mut Extraction) {


### PR DESCRIPTION
## Summary

- use a host-sized build-local Rayon pool for large cold AST extractions
- read fresh source files once and reuse the bytes for extraction and cross-file resolution
- serialize and persist AST cache entries in bounded parallel batches
- cache source hashes and canonical source paths within a build
- consume resolver facts through owned buffers to avoid duplicate large allocations
- replace repeated graph scans with linear community aggregations
- parallelize deterministic sampled betweenness traversals while retaining source-order accumulation

## Motivation

Cold Compass updates were slower than expected despite the Rust implementation. Profiling on RustFS showed that the default path was effectively serial in key extraction work and repeated source reads, cache serialization, path canonicalization, resolver buffers, and graph-wide scans. Suggested-question analysis also executed 100 independent Brandes traversals sequentially.

This change removes those redundant passes and parallelizes independent work without skipping any default update output.

## Cold benchmark

Real repository: `/Volumes/Workspace/Github/rustfs`

Method: three alternating-order runs against the same immutable source copy. Every run used an empty output/cache directory and the default `update` behavior, including clustering and report/question generation.

| Run | Graphify | Compass | Speedup |
|---|---:|---:|---:|
| 1 | 39.78s | 5.82s | 6.84x |
| 2 | 41.70s | 6.21s | 6.71x |
| 3 | 43.02s | 6.33s | 6.80x |
| **Median** | **41.70s** | **6.21s** | **6.71x** |

Compass consistently produced 47,576 nodes, 135,368 edges, and 1,417 communities. `graph.json`, `GRAPH_REPORT.md`, `.compass_labels.json`, and `manifest.json` were byte-identical before and after the final parallel centrality optimization.

The throughput improvement intentionally uses more parallel memory: median peak RSS was approximately 1.65 GiB for Compass versus 0.62 GiB for Graphify on this host. Explicit `--max-workers` remains available as a memory/throughput bound.

## Validation

- `cargo test -p compass-files --test contracts batched_cache_writes_are_portable_and_refresh_changed_sources`
- `cargo test -p compass-languages --test engine_edge_coverage`
- `cargo test -p compass-graph --test analyze_coverage`
- `cargo test -p compass-graph --lib`
- `cargo test -p compass-resolve --lib`
- `cargo test -p compass-core --lib`
- `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p compass-cli --lib absent_worker_override_preserves_host_sized_default`
- `cargo fmt --all --check`
- `git diff --check`

All 60 focused tests passed.
