### PR TITLE
docs: add comprehensive Compass documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,31 @@
 
 Compass turns source code and project artifacts into a searchable knowledge graph. Use it to find implementation paths, understand dependencies, estimate change impact, give coding assistants focused context, or export the graph to other tools.
 
-Compass is the native Rust implementation of [Graphify](https://github.com/Graphify-Labs/graphify). Structural extraction and graph queries run locally without Python, embeddings, a vector database, runtime grammar downloads, or separately installed native libraries. Semantic extraction is optional and uses the model provider you configure.
+Compass is inspired by [Graphify](https://github.com/Graphify-Labs/graphify),
+built natively in Rust, and evolving independently beyond its original
+compatibility baseline. Structural extraction and graph queries run locally
+without Python, embeddings, a vector database, runtime grammar downloads, or
+separately installed native libraries. Semantic extraction is optional and uses
+only the model provider you configure.
+
+> **Repository description:** Native, local-first knowledge graph engine for
+> code and project artifacts—inspired by Graphify, built in Rust, and evolving
+> beyond it.
+
+## Documentation
+
+Start with the path that matches your goal:
+
+| Reader | Start here |
+| --- | --- |
+| Evaluating Compass | [Getting started](docs/getting-started.md) → [How it works](docs/concepts/how-it-works.md) |
+| Using or integrating Compass | [Guides](docs/README.md#complete-a-task) → [Cookbook](docs/cookbook/README.md) → [Reference](docs/README.md#look-up-an-exact-contract) |
+| Extending the Rust workspace | [Design principles](docs/design/principles.md) → [Architecture](docs/design/architecture.md) → [Workspace tour](docs/implementation/workspace-tour.md) |
+
+The [documentation hub](docs/README.md) includes comprehensive guides for
+versioned history, CompassQL, assistant setup, security, operations,
+implementation, troubleshooting, and the status-qualified
+[roadmap](docs/roadmap.md). Diagrams use portable ASCII or accessible SVG.
 
 ## Command surface and graph history
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,203 @@
+# Compass documentation
+
+Compass is a native, local-first knowledge graph engine for source code and
+project artifacts. It discovers the entities in a project, records how they
+relate, and gives people and tools a smaller, structured way to explore a large
+codebase.
+
+> **Who this page is for:** evaluators, Compass users, integrators, and
+> contributors.
+>
+> **You will learn:** where to start, which documents answer which questions,
+> and which material describes current behavior versus future direction.
+>
+> **Prerequisites:** none.
+>
+> **Reading time:** about 5 minutes.
+
+Compass was inspired by
+[Graphify](https://github.com/Graphify-Labs/graphify), and its compatibility
+suite still uses a frozen Graphify release as an important behavioral oracle.
+Compass is not limited to being a port, however. It already includes
+Compass-native capabilities, such as CompassQL and versioned graph history, and
+its feature set is expected to evolve independently.
+
+![Three reader journeys through the Compass documentation](assets/diagrams/reader-journeys.svg)
+
+## Choose your path
+
+### I am evaluating Compass
+
+Start here if you want to understand the product before adopting it:
+
+1. [Getting started](getting-started.md) — install Compass, build a graph, and
+   answer a real question.
+2. [How Compass works](concepts/how-it-works.md) — understand the pipeline
+   without needing graph-database experience.
+3. [Graph model](concepts/graph-model.md) — learn what nodes, relationships,
+   communities, and provenance mean.
+4. [Security and privacy](design/security-and-privacy.md) — see what stays
+   local and when a configured provider may be contacted.
+5. [Compatibility](../COMPATIBILITY.md) and
+   [performance](../PERFORMANCE.md) — inspect the published evidence.
+
+### I use or integrate Compass
+
+Start with [Getting started](getting-started.md), then choose the task closest
+to yours:
+
+- [Explore an unfamiliar codebase](guides/exploring-a-codebase.md)
+- [Integrate Compass with other tools](guides/integrating-compass.md)
+- [Set up a coding assistant](guides/assistant-setup.md)
+- [Use versioned graph history](guides/versioned-history.md)
+- [Operate watch, serve, hooks, and providers](guides/operations.md)
+- [Solve a concrete problem](cookbook/README.md)
+- [Look up commands and contracts](reference/commands.md)
+
+### I contribute to Compass
+
+Read these in order when you need a durable mental model of the Rust
+workspace:
+
+1. [Design principles](design/principles.md)
+2. [System architecture](design/architecture.md)
+3. [Workspace and crate tour](implementation/workspace-tour.md)
+4. [Extraction pipeline](implementation/extraction-pipeline.md)
+5. [Query engine](implementation/query-engine.md)
+6. [Semantic pipeline](implementation/semantic-pipeline.md)
+7. [Extending Compass](implementation/extending-compass.md)
+8. [Contributing](../CONTRIBUTING.md)
+
+## Documentation map
+
+### Learn the concepts
+
+| Document | What it answers |
+| --- | --- |
+| [How Compass works](concepts/how-it-works.md) | How does a directory become a queryable graph? |
+| [Graph model](concepts/graph-model.md) | What do the entities and relationships mean? |
+| [Provenance](concepts/provenance.md) | How can I judge where an edge came from? |
+| [CompassQL concepts](concepts/compassql.md) | When should I use an exact structural query? |
+
+### Complete a task
+
+| Guide | Outcome |
+| --- | --- |
+| [Getting started](getting-started.md) | A working local graph and your first useful answers |
+| [Exploring a codebase](guides/exploring-a-codebase.md) | A repeatable architecture-reading workflow |
+| [Integrating Compass](guides/integrating-compass.md) | Stable, machine-readable data in another tool |
+| [Assistant setup](guides/assistant-setup.md) | A native Compass skill installed at the right scope |
+| [Versioned history](guides/versioned-history.md) | Immutable graphs and diffs for exact Git commits |
+| [Operations](guides/operations.md) | Safe operation of long-running and optional surfaces |
+
+### Understand the design
+
+| Document | Focus |
+| --- | --- |
+| [Design principles](design/principles.md) | Local-first, deterministic, bounded, inspectable behavior |
+| [Architecture](design/architecture.md) | Major layers and the data that crosses them |
+| [Storage and history](design/storage-and-history.md) | Incremental artifacts and immutable historical realizations |
+| [Security and privacy](design/security-and-privacy.md) | Trust boundaries, credentials, and offline behavior |
+
+### Work on the implementation
+
+| Document | Focus |
+| --- | --- |
+| [Workspace tour](implementation/workspace-tour.md) | Which crate owns which responsibility |
+| [Extraction pipeline](implementation/extraction-pipeline.md) | Discovery through atomic output publication |
+| [Query engine](implementation/query-engine.md) | Discovery queries, traversal, and CompassQL |
+| [Semantic pipeline](implementation/semantic-pipeline.md) | Optional provider-backed extraction |
+| [Extending Compass](implementation/extending-compass.md) | Adding languages, relations, integrations, and commands |
+
+### Copy a recipe
+
+The [cookbook index](cookbook/README.md) routes to:
+
+- [impact analysis](cookbook/impact-analysis.md);
+- [architecture discovery](cookbook/architecture-discovery.md);
+- [CI and automation](cookbook/ci-and-automation.md);
+- [troubleshooting](cookbook/troubleshooting.md).
+
+### Look up an exact contract
+
+| Reference | Contents |
+| --- | --- |
+| [Commands](reference/commands.md) | Command families, common inputs, output modes, and diagnostics |
+| [Configuration](reference/configuration.md) | Providers, environment, paths, and precedence |
+| [Outputs](reference/outputs.md) | `compass-out/`, graph JSON, query results, and history exports |
+| [Compatibility](reference/compatibility.md) | Graphify baseline, native additions, and portability |
+| [CompassQL 1](COMPASSQL.md) | Canonical language and runtime contract |
+| [CompassQL support](COMPASSQL_SUPPORT.md) | Checked syntax and feature matrix |
+
+## How these documents are written
+
+Compass documentation uses four document types:
+
+```text
+Concept     explains what something means and why it exists
+Guide       walks through a complete task
+Cookbook    solves one concrete scenario with a short recipe
+Reference   states an exact interface, option, format, or limit
+```
+
+This separation is deliberate. A guide should not force you through an
+exhaustive option table, and a reference should not hide a precise contract
+inside a long tutorial.
+
+Substantial pages begin with their audience, outcomes, prerequisites, and
+estimated reading time. They end with related pages and a recommended next
+step. Small diagrams are ASCII so they remain useful in any terminal. Larger
+architecture diagrams are checked-in SVG files with accessible titles and
+descriptions.
+
+## Current, planned, and aspirational
+
+Compass evolves quickly, so future-facing documentation uses explicit labels:
+
+- **Available now** means the behavior is implemented and supported by current
+  source, help text, tests, or release evidence.
+- **Planned** means a committed design or implementation plan describes the
+  work. A plan is evidence of intent, not evidence that the feature has
+  shipped.
+- **Aspirational** means the idea expresses a direction or problem worth
+  exploring. It has no promised release, compatibility, or delivery date.
+
+See the [roadmap](roadmap.md) for the combined view.
+
+## Canonical policy and evidence
+
+Some topics already have a single authoritative document. The learning guides
+summarize and link to these; they do not replace them:
+
+- [Compatibility ledger](../COMPATIBILITY.md)
+- [Migration guide](../MIGRATION.md)
+- [Performance qualification](../PERFORMANCE.md)
+- [Security policy](../SECURITY.md)
+- [Support guide](../SUPPORT.md)
+- [Contribution guide](../CONTRIBUTING.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [CompassQL language contract](COMPASSQL.md)
+
+If a summary and a canonical document ever disagree, follow the canonical
+document and open a documentation issue.
+
+## Product status in one paragraph
+
+Compass is a Rust workspace that ships the `compass` executable. Structural
+code extraction and graph queries run locally and do not require Python,
+embeddings, a vector database, or runtime grammar downloads. Semantic
+extraction for documents and other non-code sources is optional and may contact
+the provider you explicitly configure. The current release packaging and
+platform guarantees are recorded in the
+[compatibility ledger](../COMPATIBILITY.md), not inferred from what happens to
+compile on one developer machine.
+
+## Related pages
+
+- [Getting started](getting-started.md)
+- [How Compass works](concepts/how-it-works.md)
+- [Roadmap](roadmap.md)
+- [Support](../SUPPORT.md)
+
+**Next step:** follow [Getting started](getting-started.md) to build and query
+your first graph.

--- a/docs/assets/diagrams/first-graph.svg
+++ b/docs/assets/diagrams/first-graph.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="300" viewBox="0 0 1120 300" role="img" aria-labelledby="title desc">
+  <title id="title">From a source project to the first Compass answer</title>
+  <desc id="desc">A project directory enters Compass update, which writes graph JSON, a graph report, an optional HTML view, and a manifest. Query commands read the graph and return focused answers.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.box{fill:#fff;stroke:#49637a;stroke-width:2}.accent{fill:#d9eafd;stroke:#1d5f91;stroke-width:2}.head{font:700 19px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:15px ui-monospace,SFMono-Regular,monospace;fill:#334e68}.line{stroke:#627d98;stroke-width:4}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.box{fill:#1f2937;stroke:#9fb3c8}.accent{fill:#213f59;stroke:#78b7e5}.head{fill:#f3f4f6}.body{fill:#d1d5db}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1120" height="300" rx="24"/>
+  <rect class="box" x="30" y="70" width="220" height="150" rx="16"/>
+  <text class="head" x="140" y="110" text-anchor="middle">Project directory</text>
+  <text class="body" x="65" y="148">src/</text>
+  <text class="body" x="65" y="177">Cargo.toml</text>
+  <text class="body" x="65" y="206">docs/ ...</text>
+  <line class="line" x1="250" y1="145" x2="340" y2="145"/>
+  <polygon class="arrow" points="340,137 356,145 340,153"/>
+  <rect class="accent" x="356" y="88" width="220" height="114" rx="16"/>
+  <text class="head" x="466" y="128" text-anchor="middle">Compass</text>
+  <text class="body" x="466" y="166" text-anchor="middle">compass update .</text>
+  <line class="line" x1="576" y1="145" x2="666" y2="145"/>
+  <polygon class="arrow" points="666,137 682,145 666,153"/>
+  <rect class="box" x="682" y="45" width="200" height="200" rx="16"/>
+  <text class="head" x="782" y="83" text-anchor="middle">compass-out/</text>
+  <text class="body" x="712" y="122">graph.json</text>
+  <text class="body" x="712" y="151">GRAPH_REPORT.md</text>
+  <text class="body" x="712" y="180">graph.html</text>
+  <text class="body" x="712" y="209">manifest.json</text>
+  <line class="line" x1="882" y1="145" x2="948" y2="145"/>
+  <polygon class="arrow" points="948,137 964,145 948,153"/>
+  <rect class="accent" x="964" y="84" width="130" height="122" rx="16"/>
+  <text class="head" x="1029" y="124" text-anchor="middle">Answers</text>
+  <text class="body" x="1029" y="160" text-anchor="middle">query</text>
+  <text class="body" x="1029" y="184" text-anchor="middle">path / explain</text>
+</svg>

--- a/docs/assets/diagrams/graph-pipeline.svg
+++ b/docs/assets/diagrams/graph-pipeline.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="560" viewBox="0 0 1200 560" role="img" aria-labelledby="title desc">
+  <title id="title">Compass graph construction and query pipeline</title>
+  <desc id="desc">Source code, project metadata, and optional semantic sources flow through discovery, extraction, resolution, analysis, and atomic publication. Query commands then load indexed graph snapshots and return focused or exact results.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.box{fill:#fff;stroke:#486581;stroke-width:2}.local{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.optional{fill:#fff4d6;stroke:#9b6b00;stroke-width:2}.output{fill:#e5edff;stroke:#355ca8;stroke-width:2}.head{font:700 18px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:14px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.small{font:13px ui-monospace,SFMono-Regular,monospace;fill:#334e68}.line{fill:none;stroke:#627d98;stroke-width:3}.dash{stroke-dasharray:8 6}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.box{fill:#1f2937;stroke:#9fb3c8}.local{fill:#163b2a;stroke:#6bc993}.optional{fill:#3b3015;stroke:#e0b84e}.output{fill:#213659;stroke:#89aef2}.head{fill:#f3f4f6}.body,.small{fill:#d1d5db}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="560" rx="24"/>
+  <text class="head" x="35" y="42">Inputs</text>
+  <rect class="box" x="35" y="62" width="180" height="90" rx="14"/>
+  <text class="head" x="125" y="96" text-anchor="middle">Source code</text>
+  <text class="small" x="125" y="126" text-anchor="middle">.rs .py .ts ...</text>
+  <rect class="box" x="35" y="178" width="180" height="90" rx="14"/>
+  <text class="head" x="125" y="212" text-anchor="middle">Project metadata</text>
+  <text class="small" x="125" y="242" text-anchor="middle">manifests / schemas</text>
+  <rect class="optional" x="35" y="294" width="180" height="110" rx="14"/>
+  <text class="head" x="125" y="328" text-anchor="middle">Semantic sources</text>
+  <text class="small" x="125" y="358" text-anchor="middle">docs / media</text>
+  <text class="body" x="125" y="384" text-anchor="middle">optional provider path</text>
+  <path class="line" d="M215 107 H268 M215 223 H245 V107 H268 M215 349 H245 V107"/>
+  <polygon class="arrow" points="268,99 284,107 268,115"/>
+  <rect class="local" x="284" y="64" width="150" height="86" rx="14"/>
+  <text class="head" x="359" y="98" text-anchor="middle">Discover</text>
+  <text class="body" x="359" y="126" text-anchor="middle">classify + ignore</text>
+  <line class="line" x1="434" y1="107" x2="474" y2="107"/>
+  <polygon class="arrow" points="474,99 490,107 474,115"/>
+  <rect class="local" x="490" y="64" width="150" height="86" rx="14"/>
+  <text class="head" x="565" y="98" text-anchor="middle">Extract</text>
+  <text class="body" x="565" y="126" text-anchor="middle">per-file facts</text>
+  <line class="line" x1="640" y1="107" x2="680" y2="107"/>
+  <polygon class="arrow" points="680,99 696,107 680,115"/>
+  <rect class="local" x="696" y="64" width="150" height="86" rx="14"/>
+  <text class="head" x="771" y="98" text-anchor="middle">Resolve</text>
+  <text class="body" x="771" y="126" text-anchor="middle">cross-file links</text>
+  <line class="line" x1="846" y1="107" x2="886" y2="107"/>
+  <polygon class="arrow" points="886,99 902,107 886,115"/>
+  <rect class="local" x="902" y="64" width="150" height="86" rx="14"/>
+  <text class="head" x="977" y="98" text-anchor="middle">Analyze</text>
+  <text class="body" x="977" y="126" text-anchor="middle">cluster + report</text>
+  <path class="line" d="M977 150 V202"/>
+  <polygon class="arrow" points="969,202 977,218 985,202"/>
+  <rect class="output" x="860" y="218" width="235" height="150" rx="16"/>
+  <text class="head" x="977" y="252" text-anchor="middle">Atomic publication</text>
+  <text class="small" x="890" y="288">graph.json</text>
+  <text class="small" x="890" y="314">GRAPH_REPORT.md</text>
+  <text class="small" x="890" y="340">graph.html / manifest.json</text>
+  <path class="line" d="M860 293 H730"/>
+  <polygon class="arrow" points="746,285 730,293 746,301"/>
+  <rect class="box" x="472" y="218" width="258" height="150" rx="16"/>
+  <text class="head" x="601" y="252" text-anchor="middle">Indexed graph snapshot</text>
+  <text class="body" x="601" y="286" text-anchor="middle">stable IDs + adjacency</text>
+  <text class="body" x="601" y="314" text-anchor="middle">query index + schema fingerprint</text>
+  <text class="body" x="601" y="342" text-anchor="middle">bounded loading and caches</text>
+  <path class="line" d="M601 368 V416"/>
+  <polygon class="arrow" points="593,416 601,432 609,416"/>
+  <rect class="output" x="285" y="432" width="632" height="88" rx="16"/>
+  <text class="head" x="601" y="466" text-anchor="middle">Query surfaces</text>
+  <text class="small" x="601" y="496" text-anchor="middle">query · explain · path · affected · tree · CompassQL</text>
+</svg>

--- a/docs/assets/diagrams/history-materialization.svg
+++ b/docs/assets/diagrams/history-materialization.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1220" height="560" viewBox="0 0 1220 560" role="img" aria-labelledby="title desc">
+  <title id="title">Compass history materialization</title>
+  <desc id="desc">A Git revision resolves to an exact commit. Compass combines that commit with a build profile, creates a protected offline worktree, builds and validates artifacts, and publishes an immutable realization into a SQLite-backed Prolly store. Queries, diffs, and exports read validated preferred realizations.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.box{fill:#fff;stroke:#486581;stroke-width:2}.process{fill:#e5edff;stroke:#355ca8;stroke-width:2}.store{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.warn{fill:#fff4d6;stroke:#9b6b00;stroke-width:2}.head{font:700 18px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:14px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.mono{font:13px ui-monospace,SFMono-Regular,monospace;fill:#334e68}.line{fill:none;stroke:#627d98;stroke-width:3}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.box{fill:#1f2937;stroke:#9fb3c8}.process{fill:#213659;stroke:#89aef2}.store{fill:#163b2a;stroke:#6bc993}.warn{fill:#3b3015;stroke:#e0b84e}.head{fill:#f3f4f6}.body,.mono{fill:#d1d5db}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1220" height="560" rx="24"/>
+  <rect class="box" x="35" y="52" width="220" height="110" rx="16"/>
+  <text class="head" x="145" y="90" text-anchor="middle">Git revision</text>
+  <text class="mono" x="145" y="124" text-anchor="middle">HEAD~20 / tag / SHA</text>
+  <rect class="box" x="35" y="208" width="220" height="130" rx="16"/>
+  <text class="head" x="145" y="246" text-anchor="middle">Build profile</text>
+  <text class="body" x="145" y="278" text-anchor="middle">code-only or semantic</text>
+  <text class="body" x="145" y="306" text-anchor="middle">model · excludes · versions</text>
+  <path class="line" d="M255 107 H310 V190 H338 M255 273 H310 V190"/>
+  <polygon class="arrow" points="338,182 354,190 338,198"/>
+  <rect class="process" x="354" y="124" width="220" height="132" rx="16"/>
+  <text class="head" x="464" y="160" text-anchor="middle">Resolve + fingerprint</text>
+  <text class="body" x="464" y="193" text-anchor="middle">exact commit SHA</text>
+  <text class="body" x="464" y="221" text-anchor="middle">meaning-affecting inputs</text>
+  <line class="line" x1="574" y1="190" x2="632" y2="190"/>
+  <polygon class="arrow" points="632,182 648,190 632,198"/>
+  <rect class="process" x="648" y="95" width="235" height="190" rx="16"/>
+  <text class="head" x="765" y="132" text-anchor="middle">Protected worktree</text>
+  <text class="body" x="765" y="166" text-anchor="middle">detached · offline · no hooks</text>
+  <text class="body" x="765" y="194" text-anchor="middle">no fetch · no filter execution</text>
+  <text class="body" x="765" y="222" text-anchor="middle">build complete artifacts</text>
+  <text class="body" x="765" y="250" text-anchor="middle">validate before publication</text>
+  <line class="line" x1="883" y1="190" x2="940" y2="190"/>
+  <polygon class="arrow" points="940,182 956,190 940,198"/>
+  <rect class="store" x="956" y="80" width="230" height="220" rx="18"/>
+  <text class="head" x="1071" y="118" text-anchor="middle">History store</text>
+  <text class="body" x="1071" y="150" text-anchor="middle">SQLite + WAL durability</text>
+  <text class="body" x="1071" y="178" text-anchor="middle">content-addressed Prolly roots</text>
+  <text class="body" x="1071" y="206" text-anchor="middle">immutable realizations</text>
+  <text class="body" x="1071" y="234" text-anchor="middle">preferred pointer</text>
+  <text class="body" x="1071" y="262" text-anchor="middle">jobs · leases · locks beside DB</text>
+  <path class="line" d="M1071 300 V372 H830"/>
+  <polygon class="arrow" points="846,364 830,372 846,380"/>
+  <rect class="box" x="560" y="372" width="270" height="130" rx="16"/>
+  <text class="head" x="695" y="410" text-anchor="middle">Read surfaces</text>
+  <text class="body" x="695" y="444" text-anchor="middle">query --at · path --at · explain --at</text>
+  <text class="body" x="695" y="474" text-anchor="middle">diff · export · list / show</text>
+  <rect class="warn" x="35" y="398" width="370" height="104" rx="16"/>
+  <text class="head" x="220" y="434" text-anchor="middle">Comparable means same semantics</text>
+  <text class="body" x="220" y="465" text-anchor="middle">Different fingerprints require an explicit choice.</text>
+</svg>

--- a/docs/assets/diagrams/incremental-update.svg
+++ b/docs/assets/diagrams/incremental-update.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="600" viewBox="0 0 1240 600" role="img" aria-labelledby="title desc">
+  <title id="title">Cold and incremental Compass update paths</title>
+  <desc id="desc">A cold build extracts all discovered files. An incremental build compares the new filesystem snapshot with a manifest, reuses compatible unchanged extraction facts, extracts changed files, removes deleted facts, then always resolves and analyzes a complete logical corpus before atomically publishing graph and manifest together.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.box{fill:#fff;stroke:#486581;stroke-width:2}.cold{fill:#fff4d6;stroke:#9b6b00;stroke-width:2}.warm{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.join{fill:#e5edff;stroke:#355ca8;stroke-width:2}.head{font:700 18px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:14px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.line{fill:none;stroke:#627d98;stroke-width:3}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.box{fill:#1f2937;stroke:#9fb3c8}.cold{fill:#3b3015;stroke:#e0b84e}.warm{fill:#163b2a;stroke:#6bc993}.join{fill:#213659;stroke:#89aef2}.head{fill:#f3f4f6}.body{fill:#d1d5db}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1240" height="600" rx="24"/>
+  <rect class="box" x="455" y="35" width="330" height="75" rx="15"/>
+  <text class="head" x="620" y="67" text-anchor="middle">Discover current filesystem snapshot</text>
+  <text class="body" x="620" y="93" text-anchor="middle">classify · ignore · fingerprint</text>
+  <path class="line" d="M620 110 V150 H300 M620 150 H940"/>
+  <polygon class="arrow" points="292,142 308,142 300,158"/>
+  <polygon class="arrow" points="932,142 948,142 940,158"/>
+  <rect class="cold" x="90" y="158" width="420" height="150" rx="16"/>
+  <text class="head" x="300" y="195" text-anchor="middle">Cold build</text>
+  <text class="body" x="300" y="227" text-anchor="middle">no compatible manifest/cache</text>
+  <text class="body" x="300" y="255" text-anchor="middle">extract every supported file</text>
+  <text class="body" x="300" y="283" text-anchor="middle">create complete per-file fact set</text>
+  <rect class="warm" x="730" y="158" width="420" height="190" rx="16"/>
+  <text class="head" x="940" y="195" text-anchor="middle">Incremental build</text>
+  <text class="body" x="940" y="227" text-anchor="middle">compare manifest + compatible fingerprints</text>
+  <text class="body" x="940" y="255" text-anchor="middle">reuse unchanged extraction facts</text>
+  <text class="body" x="940" y="283" text-anchor="middle">extract added / changed / renamed</text>
+  <text class="body" x="940" y="311" text-anchor="middle">remove deleted facts</text>
+  <path class="line" d="M300 308 V365 H560 V385 M940 348 V365 H680 V385"/>
+  <polygon class="arrow" points="552,369 568,369 560,385"/>
+  <polygon class="arrow" points="672,369 688,369 680,385"/>
+  <rect class="join" x="420" y="385" width="400" height="90" rx="16"/>
+  <text class="head" x="620" y="420" text-anchor="middle">Complete logical corpus</text>
+  <text class="body" x="620" y="450" text-anchor="middle">resolve cross-file facts · build · cluster · analyze</text>
+  <line class="line" x1="620" y1="475" x2="620" y2="518"/>
+  <polygon class="arrow" points="612,518 620,534 628,518"/>
+  <rect class="join" x="365" y="534" width="510" height="52" rx="14"/>
+  <text class="head" x="620" y="567" text-anchor="middle">Atomically publish matching graph + report + manifest</text>
+</svg>

--- a/docs/assets/diagrams/integration-surfaces.svg
+++ b/docs/assets/diagrams/integration-surfaces.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="540" viewBox="0 0 1200 540" role="img" aria-labelledby="title desc">
+  <title id="title">Compass integration surfaces</title>
+  <desc id="desc">A validated Compass graph snapshot is exposed through human reports and HTML, versioned CompassQL JSON and JSONL, full graph JSON, MCP service tools, history exports, global graph registration, and external graph database exporters.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.core{fill:#16324f;stroke:#0d2236;stroke-width:2}.box{fill:#fff;stroke:#486581;stroke-width:2}.machine{fill:#e5edff;stroke:#355ca8;stroke-width:2}.human{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.head{font:700 18px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:14px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.coretext{font:700 22px ui-sans-serif,system-ui,sans-serif;fill:#fff}.line{fill:none;stroke:#627d98;stroke-width:3}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.core{fill:#315b7d;stroke:#9fb3c8}.box{fill:#1f2937;stroke:#9fb3c8}.machine{fill:#213659;stroke:#89aef2}.human{fill:#163b2a;stroke:#6bc993}.head{fill:#f3f4f6}.body{fill:#d1d5db}.line{stroke:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="540" rx="24"/>
+  <rect class="core" x="410" y="205" width="380" height="130" rx="20"/>
+  <text class="coretext" x="600" y="253" text-anchor="middle">Validated graph snapshot</text>
+  <text class="coretext" x="600" y="292" text-anchor="middle">stable IDs · directed edges</text>
+  <path class="line" d="M410 245 H345 V110 H310 M410 285 H345 V430 H310 M790 245 H855 V110 H890 M790 285 H855 V430 H890 M600 205 V140 M600 335 V400"/>
+  <rect class="human" x="40" y="55" width="270" height="110" rx="16"/>
+  <text class="head" x="175" y="93" text-anchor="middle">Human exploration</text>
+  <text class="body" x="175" y="123" text-anchor="middle">report · HTML · CLI text</text>
+  <rect class="machine" x="40" y="375" width="270" height="110" rx="16"/>
+  <text class="head" x="175" y="413" text-anchor="middle">Full graph consumers</text>
+  <text class="body" x="175" y="443" text-anchor="middle">graph.json · history export</text>
+  <rect class="machine" x="465" y="30" width="270" height="110" rx="16"/>
+  <text class="head" x="600" y="68" text-anchor="middle">Application queries</text>
+  <text class="body" x="600" y="98" text-anchor="middle">CompassQL JSON / JSONL</text>
+  <rect class="machine" x="465" y="400" width="270" height="110" rx="16"/>
+  <text class="head" x="600" y="438" text-anchor="middle">Assistant tools</text>
+  <text class="body" x="600" y="468" text-anchor="middle">MCP stdio / authenticated HTTP</text>
+  <rect class="box" x="890" y="55" width="270" height="110" rx="16"/>
+  <text class="head" x="1025" y="93" text-anchor="middle">Cross-repository index</text>
+  <text class="body" x="1025" y="123" text-anchor="middle">compass global</text>
+  <rect class="box" x="890" y="375" width="270" height="110" rx="16"/>
+  <text class="head" x="1025" y="413" text-anchor="middle">External graph systems</text>
+  <text class="body" x="1025" y="443" text-anchor="middle">Neo4j · FalkorDB exporters</text>
+</svg>

--- a/docs/assets/diagrams/provenance.svg
+++ b/docs/assets/diagrams/provenance.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="430" viewBox="0 0 1160 430" role="img" aria-labelledby="title desc">
+  <title id="title">Relationship provenance in Compass</title>
+  <desc id="desc">Direct source evidence produces extracted relationships. Multiple structural facts resolved to one stable target produce inferred relationships. Multiple viable targets preserve an ambiguous relationship that requires review.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.box{fill:#fff;stroke:#486581;stroke-width:2}.good{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.resolve{fill:#e5edff;stroke:#355ca8;stroke-width:2}.warn{fill:#fff0e5;stroke:#b45420;stroke-width:2}.head{font:700 19px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:15px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.mono{font:14px ui-monospace,SFMono-Regular,monospace;fill:#334e68}.line{fill:none;stroke:#627d98;stroke-width:3}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.box{fill:#1f2937;stroke:#9fb3c8}.good{fill:#163b2a;stroke:#6bc993}.resolve{fill:#213659;stroke:#89aef2}.warn{fill:#422519;stroke:#ef9a6d}.head{fill:#f3f4f6}.body,.mono{fill:#d1d5db}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1160" height="430" rx="24"/>
+  <rect class="box" x="30" y="52" width="270" height="112" rx="15"/>
+  <text class="head" x="165" y="88" text-anchor="middle">Direct evidence</text>
+  <text class="body" x="165" y="118" text-anchor="middle">syntax or authoritative input</text>
+  <text class="mono" x="165" y="145" text-anchor="middle">caller invokes target</text>
+  <line class="line" x1="300" y1="108" x2="380" y2="108"/>
+  <polygon class="arrow" points="380,100 396,108 380,116"/>
+  <rect class="good" x="396" y="52" width="330" height="112" rx="15"/>
+  <text class="head" x="561" y="91" text-anchor="middle">EXTRACTED</text>
+  <text class="body" x="561" y="122" text-anchor="middle">the exact relation is directly supported</text>
+  <text class="mono" x="561" y="147" text-anchor="middle">source --CALLS--> target</text>
+  <rect class="box" x="30" y="206" width="270" height="150" rx="15"/>
+  <text class="head" x="165" y="242" text-anchor="middle">Combined evidence</text>
+  <text class="body" x="165" y="274" text-anchor="middle">import + scope + call fact</text>
+  <text class="body" x="165" y="300" text-anchor="middle">member/type/project metadata</text>
+  <text class="mono" x="165" y="330" text-anchor="middle">resolver selects target(s)</text>
+  <path class="line" d="M300 281 H350 V238 H380"/>
+  <polygon class="arrow" points="380,230 396,238 380,246"/>
+  <rect class="resolve" x="396" y="182" width="330" height="112" rx="15"/>
+  <text class="head" x="561" y="221" text-anchor="middle">One stable target</text>
+  <text class="body" x="561" y="252" text-anchor="middle">resolved from structural facts</text>
+  <line class="line" x1="726" y1="238" x2="796" y2="238"/>
+  <polygon class="arrow" points="796,230 812,238 796,246"/>
+  <rect class="resolve" x="812" y="182" width="318" height="112" rx="15"/>
+  <text class="head" x="971" y="221" text-anchor="middle">INFERRED</text>
+  <text class="body" x="971" y="252" text-anchor="middle">derived, evidence-backed connection</text>
+  <path class="line" d="M350 281 V356 H796"/>
+  <polygon class="arrow" points="796,348 812,356 796,364"/>
+  <rect class="warn" x="812" y="320" width="318" height="82" rx="15"/>
+  <text class="head" x="971" y="353" text-anchor="middle">AMBIGUOUS</text>
+  <text class="body" x="971" y="382" text-anchor="middle">multiple viable interpretations remain</text>
+</svg>

--- a/docs/assets/diagrams/reader-journeys.svg
+++ b/docs/assets/diagrams/reader-journeys.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="520" viewBox="0 0 1120 520" role="img" aria-labelledby="title desc">
+  <title id="title">Three reader journeys through Compass documentation</title>
+  <desc id="desc">Evaluators, users and integrators, and contributors enter through the Compass documentation hub and follow separate paths to concepts, guides, references, and implementation details.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.panel{fill:#fff;stroke:#49637a;stroke-width:2}.hub{fill:#16324f;stroke:#0d2236;stroke-width:2}.head{font:700 22px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:16px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.hubtext{font:700 24px ui-sans-serif,system-ui,sans-serif;fill:#fff}.line{fill:none;stroke:#627d98;stroke-width:3}.arrow{fill:#627d98}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.panel{fill:#1f2937;stroke:#9fb3c8}.head{fill:#f3f4f6}.body{fill:#d1d5db}.hub{fill:#315b7d;stroke:#9fb3c8}.line{stroke:#9fb3c8}.arrow{fill:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1120" height="520" rx="24"/>
+  <rect class="hub" x="410" y="34" width="300" height="76" rx="16"/>
+  <text class="hubtext" x="560" y="80" text-anchor="middle">Compass docs hub</text>
+  <path class="line" d="M560 110 V158 H190 V190"/>
+  <path class="line" d="M560 158 V190"/>
+  <path class="line" d="M560 158 H930 V190"/>
+  <polygon class="arrow" points="184,181 196,181 190,193"/>
+  <polygon class="arrow" points="554,181 566,181 560,193"/>
+  <polygon class="arrow" points="924,181 936,181 930,193"/>
+  <rect class="panel" x="40" y="190" width="300" height="280" rx="18"/>
+  <text class="head" x="190" y="232" text-anchor="middle">Evaluating Compass</text>
+  <text class="body" x="70" y="275">1. Getting started</text>
+  <text class="body" x="70" y="310">2. How it works</text>
+  <text class="body" x="70" y="345">3. Graph model</text>
+  <text class="body" x="70" y="380">4. Security and privacy</text>
+  <text class="body" x="70" y="415">5. Compatibility and performance</text>
+  <rect class="panel" x="410" y="190" width="300" height="280" rx="18"/>
+  <text class="head" x="560" y="232" text-anchor="middle">Using and integrating</text>
+  <text class="body" x="440" y="275">1. Task guides</text>
+  <text class="body" x="440" y="310">2. Cookbook recipes</text>
+  <text class="body" x="440" y="345">3. CompassQL</text>
+  <text class="body" x="440" y="380">4. Commands and configuration</text>
+  <text class="body" x="440" y="415">5. Output contracts</text>
+  <rect class="panel" x="780" y="190" width="300" height="280" rx="18"/>
+  <text class="head" x="930" y="232" text-anchor="middle">Extending Compass</text>
+  <text class="body" x="810" y="275">1. Design principles</text>
+  <text class="body" x="810" y="310">2. Architecture</text>
+  <text class="body" x="810" y="345">3. Workspace tour</text>
+  <text class="body" x="810" y="380">4. Implementation pipelines</text>
+  <text class="body" x="810" y="415">5. Contribution workflow</text>
+</svg>

--- a/docs/assets/diagrams/workspace-architecture.svg
+++ b/docs/assets/diagrams/workspace-architecture.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1260" height="720" viewBox="0 0 1260 720" role="img" aria-labelledby="title desc">
+  <title id="title">Compass Rust workspace architecture</title>
+  <desc id="desc">Compass CLI and MCP interfaces call core application services. Core orchestrates file discovery, language extraction, cross-file resolution, graph algorithms, semantic integrations, query engines, outputs, and immutable history. Focused integration crates sit at explicit external boundaries.</desc>
+  <defs>
+    <style>
+      .bg{fill:#f7f9fc}.interface{fill:#16324f;stroke:#0d2236;stroke-width:2}.core{fill:#e5edff;stroke:#355ca8;stroke-width:2}.domain{fill:#e3f4ea;stroke:#287d4f;stroke-width:2}.optional{fill:#fff4d6;stroke:#9b6b00;stroke-width:2}.store{fill:#f3e8ff;stroke:#7b3fa1;stroke-width:2}.head{font:700 17px ui-sans-serif,system-ui,sans-serif;fill:#102a43}.body{font:13px ui-sans-serif,system-ui,sans-serif;fill:#334e68}.light{font:700 18px ui-sans-serif,system-ui,sans-serif;fill:#fff}.ifbody{font:13px ui-sans-serif,system-ui,sans-serif;fill:#d9e2ec}.line{fill:none;stroke:#627d98;stroke-width:3}.dash{stroke-dasharray:8 6}
+      @media (prefers-color-scheme:dark){.bg{fill:#111827}.interface{fill:#315b7d;stroke:#9fb3c8}.core{fill:#213659;stroke:#89aef2}.domain{fill:#163b2a;stroke:#6bc993}.optional{fill:#3b3015;stroke:#e0b84e}.store{fill:#352040;stroke:#c79be2}.head{fill:#f3f4f6}.body{fill:#d1d5db}.ifbody{fill:#f3f4f6}.line{stroke:#9fb3c8}}
+    </style>
+  </defs>
+  <rect class="bg" width="1260" height="720" rx="24"/>
+  <text class="head" x="35" y="38">Interfaces</text>
+  <rect class="interface" x="240" y="55" width="300" height="76" rx="15"/>
+  <text class="light" x="390" y="88" text-anchor="middle">compass-cli</text>
+  <text class="ifbody" x="390" y="112" text-anchor="middle">commands · help · exits · rendering</text>
+  <rect class="interface" x="720" y="55" width="300" height="76" rx="15"/>
+  <text class="light" x="870" y="88" text-anchor="middle">compass-mcp</text>
+  <text class="ifbody" x="870" y="112" text-anchor="middle">tools · resources · stdio / HTTP</text>
+  <path class="line" d="M390 131 V168 H630 M870 131 V168 H630"/>
+  <rect class="core" x="480" y="168" width="300" height="78" rx="15"/>
+  <text class="head" x="630" y="201" text-anchor="middle">compass-core</text>
+  <text class="body" x="630" y="226" text-anchor="middle">build · watch · merge · diagnostics · materialize</text>
+  <path class="line" d="M630 246 V282 H185 M630 282 H1075"/>
+  <text class="head" x="35" y="292">Domain</text>
+  <rect class="domain" x="35" y="310" width="205" height="90" rx="14"/>
+  <text class="head" x="137" y="344" text-anchor="middle">compass-files</text>
+  <text class="body" x="137" y="372" text-anchor="middle">detect · cache · atomic I/O</text>
+  <rect class="domain" x="272" y="310" width="205" height="90" rx="14"/>
+  <text class="head" x="374" y="344" text-anchor="middle">compass-languages</text>
+  <text class="body" x="374" y="372" text-anchor="middle">per-file facts</text>
+  <rect class="domain" x="509" y="310" width="205" height="90" rx="14"/>
+  <text class="head" x="611" y="344" text-anchor="middle">compass-resolve</text>
+  <text class="body" x="611" y="372" text-anchor="middle">cross-file identity</text>
+  <rect class="domain" x="746" y="310" width="205" height="90" rx="14"/>
+  <text class="head" x="848" y="344" text-anchor="middle">compass-graph</text>
+  <text class="body" x="848" y="372" text-anchor="middle">build · cluster · analyze</text>
+  <rect class="domain" x="983" y="310" width="240" height="90" rx="14"/>
+  <text class="head" x="1103" y="344" text-anchor="middle">compass-model</text>
+  <text class="body" x="1103" y="372" text-anchor="middle">document · graph · indexes</text>
+  <path class="line" d="M240 355 H272 M477 355 H509 M714 355 H746 M951 355 H983"/>
+  <rect class="core" x="190" y="450" width="250" height="86" rx="14"/>
+  <text class="head" x="315" y="484" text-anchor="middle">compass-cypher</text>
+  <text class="body" x="315" y="512" text-anchor="middle">CompassQL compiler + plan</text>
+  <rect class="core" x="505" y="450" width="250" height="86" rx="14"/>
+  <text class="head" x="630" y="484" text-anchor="middle">compass-query</text>
+  <text class="body" x="630" y="512" text-anchor="middle">search · traversal · execute</text>
+  <rect class="core" x="820" y="450" width="250" height="86" rx="14"/>
+  <text class="head" x="945" y="484" text-anchor="middle">compass-output</text>
+  <text class="body" x="945" y="512" text-anchor="middle">report · HTML · exports</text>
+  <path class="line" d="M315 450 V428 H630 V450 M848 400 V428 H945 V450 M1103 400 V428 H630"/>
+  <text class="head" x="35" y="582">Optional and durable boundaries</text>
+  <rect class="optional" x="35" y="610" width="360" height="76" rx="14"/>
+  <text class="head" x="215" y="641" text-anchor="middle">Semantic and media</text>
+  <text class="body" x="215" y="667" text-anchor="middle">semantic · media · transcribe · whisper</text>
+  <rect class="store" x="450" y="610" width="360" height="76" rx="14"/>
+  <text class="head" x="630" y="641" text-anchor="middle">compass-history</text>
+  <text class="body" x="630" y="667" text-anchor="middle">immutable realizations · SQLite · Prolly</text>
+  <rect class="optional" x="865" y="610" width="360" height="76" rx="14"/>
+  <text class="head" x="1045" y="641" text-anchor="middle">Focused integrations</text>
+  <text class="body" x="1045" y="667" text-anchor="middle">Cargo · DB · ingest · PRs · global · reflect</text>
+  <path class="line dash" d="M630 536 V585 M215 610 V585 H1045 V610"/>
+</svg>

--- a/docs/concepts/compassql.md
+++ b/docs/concepts/compassql.md
@@ -1,0 +1,360 @@
+# CompassQL concepts
+
+CompassQL is Compass's deterministic, read-only structural query language. It
+uses a documented subset of openCypher to match exact graph patterns without
+copying the graph into another database.
+
+> **Who this page is for:** users deciding between discovery commands and
+> CompassQL, plus integrators preparing stable automated queries.
+>
+> **You will learn:** when CompassQL is appropriate, how Compass data maps into
+> the language, how queries flow through the engine, and how limits protect
+> automation.
+>
+> **Prerequisites:** familiarity with [the graph model](graph-model.md). This is
+> a concept guide; use [CompassQL 1](../COMPASSQL.md) as the canonical syntax
+> and runtime reference.
+>
+> **Reading time:** 8–10 minutes.
+
+## Discovery and structural matching solve different problems
+
+Use natural-language discovery when you do not yet know the exact graph shape:
+
+```bash
+compass query "where is authentication enforced?"
+```
+
+Use CompassQL when you can state the pattern:
+
+```bash
+compass query --cql \
+  "MATCH (caller)-[:CALLS]->(target)
+   WHERE target.label = 'authorize'
+   RETURN caller.id, target.id
+   LIMIT 20"
+```
+
+The modes are explicit. Compass never guesses that text happens to be Cypher.
+
+| Need | Best starting point |
+| --- | --- |
+| Find likely concepts from a phrase | `compass query "..."` |
+| Inspect one node | `compass explain ...` |
+| Connect two known nodes | `compass path ... ...` |
+| Estimate reverse impact | `compass affected ...` |
+| Match an exact pattern | `compass query --cql ...` |
+| Produce typed JSON or JSONL | CompassQL with `--format` |
+| Explain or profile execution | `EXPLAIN` or `PROFILE` CompassQL |
+
+## Data mapping
+
+Each Compass node becomes a Cypher node:
+
+```text
+Compass node
+  id: "src/auth.rs::verify"
+  label: "verify()"
+  file_type: "Function"
+
+CompassQL view
+  (:Function {
+      id: "src/auth.rs::verify",
+      label: "verify()",
+      file_type: "Function",
+      ...
+  })
+```
+
+The single Cypher label is derived from `file_type`. If that value cannot form
+a usable identifier, Compass uses `:Entity`.
+
+Each Compass edge becomes a directed relationship:
+
+```text
+relation: "calls"  ->  [:CALLS]
+```
+
+Missing relation values map to `RELATES_TO`. Stored edge attributes remain
+properties. Parallel relationships remain distinct.
+
+## Stable and snapshot-local identity
+
+Two identity functions look similar but serve different purposes:
+
+```cypher
+RETURN n.id, id(n)
+```
+
+- `n.id` is the stable Compass string ID. Persist this when an integration must
+  refer to the same graph entity.
+- `id(n)` is an integer index for one loaded snapshot. It must not be persisted
+  or compared across snapshots.
+
+The same rule applies to relationship indexes returned by `id(r)`.
+
+## A query is compiled, planned, bounded, and rendered
+
+```text
+query source
+    |
+    v
+lexer and parser
+    |
+    v
+semantic validation and type/scope checks
+    |
+    v
+logical plan and optimizations
+    |
+    v
+bounded execution over graph indexes
+    |
+    v
+table, JSON, JSONL, EXPLAIN, or PROFILE output
+```
+
+Unsupported syntax is rejected. CompassQL does not approximate mutations,
+procedures, unbounded paths, or arbitrary nested subqueries.
+
+This conservative behavior is important for automation: a query either means
+what the documented subset says or produces a diagnostic.
+
+## Parameters
+
+Use parameters when values come from a user, environment, or script:
+
+```bash
+compass query --cql \
+  'MATCH (n) WHERE n.label = $target RETURN n.id' \
+  --param target=authorize
+```
+
+`--param name=value` attempts to parse JSON values such as numbers, booleans,
+lists, maps, and `null`; otherwise it uses a string. A parameters file must be
+a JSON object:
+
+```json
+{
+  "target": "authorize",
+  "relations": ["CALLS", "USES"],
+  "maximumHops": 6
+}
+```
+
+```bash
+compass query --cql --file queries/auth.cypher \
+  --params-file queries/auth-params.json
+```
+
+Parameters separate data from query structure. They also avoid fragile quoting
+and make plan-cache type keys explicit. They are not a license to log secrets:
+Compass diagnostics avoid parameter values, and your surrounding script should
+do the same.
+
+## Bounded paths
+
+CompassQL supports fixed and bounded variable-length patterns:
+
+```cypher
+MATCH p=(entry)-[:CALLS|IMPORTS_FROM*1..6]->(target)
+WHERE target.label = $target
+RETURN entry.id, length(p) AS hops
+ORDER BY hops
+LIMIT 100
+```
+
+Every variable-length relationship requires an explicit upper bound, and the
+language ceiling is 32. This avoids accidental unbounded traversal.
+
+Shortest paths are also bounded:
+
+```cypher
+MATCH p=shortestPath(
+  (entry:Function)-[:CALLS|IMPORTS_FROM*1..8]->(auth:Function)
+)
+WHERE auth.label = $target
+RETURN entry.id, p, length(p) AS hops
+```
+
+A relationship cannot repeat in one matched path.
+
+## Null and optional matching
+
+CompassQL follows three-valued null logic. An `OPTIONAL MATCH` can retain an
+input row even when the optional pattern does not match:
+
+```cypher
+MATCH (service:Class)
+OPTIONAL MATCH (service)-[:CALLS]->(dependency)
+RETURN service.id, dependency.id
+```
+
+The second column can be null. Test for null explicitly and do not assume a
+missing relationship means the source entity is unused; it means that pattern
+did not match in this snapshot.
+
+## Output formats
+
+### Table
+
+Table output is for people:
+
+```bash
+compass query --cql 'MATCH (n) RETURN n.id LIMIT 5'
+```
+
+### JSON
+
+JSON is one complete, versioned result document:
+
+```bash
+compass query --cql 'MATCH (n) RETURN n.id LIMIT 5' --format json
+```
+
+The schema tag is `compass.cql.result/1`.
+
+### JSONL
+
+JSONL emits a versioned header, one object per row, and a summary:
+
+```bash
+compass query --cql 'MATCH (n) RETURN n.id LIMIT 5' --format jsonl
+```
+
+The stream tag is `compass.cql.jsonl/1`.
+
+Consumers must reject unknown major versions rather than guessing.
+
+`--output PATH` writes the completed rendering atomically. A timeout, limit,
+cancellation, or execution failure does not produce a successful partial
+result.
+
+## Limits are part of correctness
+
+Interactive defaults bound:
+
+- deadline;
+- returned rows;
+- path depth;
+- expanded relationships;
+- working memory.
+
+The corresponding flags are:
+
+```text
+--timeout-ms
+--max-rows
+--max-path-depth
+--max-expanded-relationships
+--max-memory-bytes
+```
+
+Use a smaller limit when a caller has a tighter budget. Do not treat a limit
+error as an empty result.
+
+Query files and stdin are also size-limited, and parameter files have a
+separate cap. Consult [CompassQL 1](../COMPASSQL.md) for current numeric values.
+
+## Explain and profile
+
+`EXPLAIN` compiles and shows a plan without running the query:
+
+```cypher
+EXPLAIN
+MATCH (caller)-[:CALLS]->(target)
+WHERE target.label = $target
+RETURN caller.id
+```
+
+Use it to confirm scope, operators, and optimizations.
+
+`PROFILE` executes and adds per-clause measurements such as:
+
+- input and output rows;
+- candidate nodes;
+- expanded relationships;
+- peak working-memory estimate;
+- elapsed time;
+- cancellation checkpoints.
+
+Profiling is diagnostic evidence from one graph and run. Do not treat a small
+fixture's profile as a production capacity guarantee.
+
+## Plan caching
+
+Compiler cache keys include:
+
+- exact query source;
+- CompassQL and planner versions;
+- ordered parameter types;
+- planning limits;
+- graph schema fingerprint.
+
+A cached plan contains no graph values, parameter values, deadline,
+cancellation state, or result rows. Changes that affect type or schema can
+correctly produce a different plan.
+
+## Portability boundary
+
+CompassQL is not full openCypher, Neo4j Cypher, or ISO GQL.
+
+It deliberately rejects:
+
+- mutation (`CREATE`, `MERGE`, `DELETE`, `SET`, `REMOVE`);
+- procedures and `CALL`;
+- `LOAD CSV`;
+- schema and administration commands;
+- dynamic execution;
+- arbitrary nested subqueries;
+- user-defined functions;
+- unbounded paths.
+
+If a query must run in both Compass and another graph system, stay within the
+[checked support matrix](../COMPASSQL_SUPPORT.md) and test both engines. Syntax
+accepted by Neo4j is not automatically a Compass contract.
+
+## Diagnostics and exit categories
+
+Diagnostics include stable family codes and byte spans:
+
+```text
+CQL1xxx  source, syntax, unsupported surface, literal errors
+CQL2xxx  scope, type, function, projection, union, path-shape errors
+CQL3xxx  source, token, nesting, path, row, expansion, memory, time limits
+CQL4xxx  parameter, runtime type, regex, arithmetic, invariant errors
+```
+
+At the CLI boundary:
+
+- exit `2` means source/options/compile failure;
+- exit `3` means graph loading failure;
+- exit `4` means execution, limit, cancellation, or output failure.
+
+These distinctions let automation decide whether to fix input, repair a graph,
+or narrow execution.
+
+## A practical selection rule
+
+```text
+Do I know the exact nodes, relations, and columns?
+  |
+  +-- no --> start with query / explain / path
+  |
+  `-- yes --> do I need repeatable rows or automation?
+                |
+                +-- no --> either surface can help
+                |
+                `-- yes --> use CompassQL + parameters + versioned output
+```
+
+## Related pages
+
+- [CompassQL 1 reference](../COMPASSQL.md)
+- [CompassQL support matrix](../COMPASSQL_SUPPORT.md)
+- [Graph model](graph-model.md)
+- [Integrating Compass](../guides/integrating-compass.md)
+
+**Next step:** try a parameterized query from
+[Integrating Compass](../guides/integrating-compass.md), then use `EXPLAIN` to
+inspect its plan.

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -1,0 +1,353 @@
+# The Compass graph model
+
+Compass stores project knowledge as entities connected by directed,
+attributed relationships. This page develops the model from a small example to
+the node-link JSON and multigraph details used by advanced queries.
+
+> **Who this page is for:** anyone interpreting Compass output or writing
+> CompassQL and graph integrations.
+>
+> **You will learn:** nodes, stable IDs, labels, directed relationships,
+> attributes, parallel edges, hyperedges, communities, snapshots, and common
+> interpretation mistakes.
+>
+> **Prerequisites:** [How Compass works](how-it-works.md) is helpful but not
+> required.
+>
+> **Reading time:** 10–12 minutes.
+
+## Start with two nouns and a verb
+
+The smallest useful graph statement is:
+
+```text
+checkout() --CALLS--> authorize_payment()
+```
+
+`checkout()` and `authorize_payment()` are **nodes**. `CALLS` is the
+**relationship type**. The arrow gives the relationship a direction.
+
+The graph can add evidence:
+
+```text
+checkout() --CALLS [EXTRACTED, app.py:L18]--> authorize_payment()
+```
+
+That evidence is stored as attributes on the node or edge.
+
+## Nodes
+
+A node represents one identifiable project entity. Depending on input and
+extractor, that may be:
+
+- a source file or module;
+- a function, method, class, trait, interface, type, or variable;
+- a configuration key or project manifest item;
+- a database table, column, function, or relation;
+- a document section or semantic concept;
+- an image, media segment, or external integration entity;
+- a structural placeholder that resolution may later connect or replace.
+
+Every serialized node has a stable string `id` within the graph document:
+
+```json
+{
+  "id": "src/payments.py::authorize_payment",
+  "label": "authorize_payment()",
+  "file_type": "Function",
+  "source_file": "src/payments.py",
+  "source_location": "L12"
+}
+```
+
+The exact ID construction is an implementation and compatibility concern.
+Consumers should treat IDs as opaque strings, not parse undocumented segments
+out of them.
+
+### ID versus label
+
+- `id` is the stable graph identity used by edges and exact consumers.
+- `label` is the human-facing display name.
+
+Labels can repeat. Two files may each define `Config`, and several methods may
+be called `run()`. A query interface may accept labels for convenience, but
+automation should return and persist the full string ID when it needs one
+particular node.
+
+CompassQL's `id(n)` is different: it returns a snapshot-local integer index.
+Use `n.id` for a portable stable Compass ID.
+
+## Relationships
+
+A serialized relationship has a source, target, and attributes:
+
+```json
+{
+  "source": "src/checkout.py::checkout",
+  "target": "src/payments.py::authorize_payment",
+  "relation": "calls",
+  "confidence": "EXTRACTED",
+  "context": "call"
+}
+```
+
+Direction is part of the meaning:
+
+```text
+caller --CALLS--> callee
+child  --INHERITS--> parent
+file   --IMPORTS_FROM--> module
+scope  --CONTAINS--> member
+```
+
+When looking for callers, you usually traverse incoming `CALLS` relationships.
+When looking for downstream calls, you traverse outgoing ones.
+
+### Relationship vocabulary
+
+Relation names depend on the extractor and input type. Common families include:
+
+| Family | Examples | Typical meaning |
+| --- | --- | --- |
+| Structure | `contains`, `declares`, `member_of` | Ownership or hierarchy |
+| Dependency | `imports_from`, `uses`, `references` | One entity relies on another |
+| Execution | `calls`, `dispatches` | Potential control transfer |
+| Type | `inherits`, `implements`, `mixes_in` | Type-system relationship |
+| Configuration | `configures`, `depends_on` | Manifest or deployment linkage |
+| Semantic | `relates_to`, source-specific relations | Provider-extracted conceptual linkage |
+
+Do not assume every relation implies runtime execution. `imports_from` and
+`references` express different kinds of dependency from `calls`.
+
+## Attributes
+
+Nodes and edges retain open-ended JSON attributes. Common attributes include:
+
+- `label`;
+- `file_type`;
+- `source_file`;
+- `source_location`;
+- `relation`;
+- `confidence`;
+- `context`;
+- `community`;
+- language or extractor-specific metadata.
+
+Unknown attributes are retained by the graph document loader. This supports
+compatible extensions without forcing every consumer to understand every
+field.
+
+Treat fields in the documented output contract as stable. Treat undocumented
+attributes as extensible data: preserve them when round-tripping and tolerate
+new ones.
+
+## Directed multigraph semantics
+
+The node-link document declares whether it is directed and whether it is a
+multigraph:
+
+```json
+{
+  "directed": true,
+  "multigraph": true,
+  "graph": {},
+  "nodes": [],
+  "links": []
+}
+```
+
+A multigraph can keep more than one relationship between the same two nodes:
+
+```text
+barrel.ts --IMPORTS_FROM--> module.ts
+barrel.ts --RE_EXPORTS----> module.ts
+```
+
+Those edges share endpoints but carry different meanings. A consumer that
+collapses them into a single untyped connection loses information.
+
+Some human renderers list the neighboring node once while preserving the
+parallel-edge contribution to degree. Exact CompassQL patterns and graph JSON
+can inspect distinct relationships.
+
+## Missing endpoints and graph loading
+
+The graph model ensures every edge endpoint can be indexed. When loading a
+compatible document, the implementation can create a minimal endpoint node for
+an edge whose referenced ID is not already in the node list. Validation and
+command-specific loaders still reject malformed or unsafe inputs according to
+their contracts.
+
+Graph loading is guarded by:
+
+- a `.json` extension on normal query paths;
+- a size cap;
+- valid JSON;
+- indexable endpoints;
+- directed/multigraph handling;
+- cache signatures before a binary cache is reused.
+
+This protects query commands from treating arbitrary, oversized, or stale
+cache content as a valid graph.
+
+## Provenance and confidence
+
+Relationships can carry:
+
+- `EXTRACTED` — directly supported by parser/source evidence;
+- `INFERRED` — resolved from evidence across scopes, files, or systems;
+- `AMBIGUOUS` — several plausible interpretations remain.
+
+Provenance qualifies the evidence, not the importance of the relationship. An
+inferred link can be very useful; an extracted link can still describe code
+that is dead or unreachable at runtime.
+
+Read [Provenance and confidence](provenance.md) for a decision framework.
+
+## Communities
+
+Community detection assigns densely connected nodes to groups. A node can
+carry a numeric community identifier, and reports can associate a human-readable
+label with a group.
+
+```text
+Community 2
+├── LoginHandler
+├── SessionStore
+├── verify_token()
+└── AuthMiddleware
+```
+
+Community IDs are properties of a particular graph snapshot and clustering
+result. Do not store business logic that assumes “community 2 always means
+authentication.”
+
+Use communities to:
+
+- choose an entry point for architecture reading;
+- identify subsystem boundaries;
+- find surprising cross-community dependencies;
+- divide a large review into coherent regions.
+
+## God nodes and degree
+
+Degree counts incident relationships. In a directed graph, Compass can consider
+incoming plus outgoing edges for hub analysis.
+
+```text
+low degree                     high degree
+----------                     -----------
+LeafParser --USES--> Token     AppContext
+                                 ^  ^  ^  ^
+                                 |  |  |  |
+                              many dependents
+```
+
+A god node is highly connected relative to the graph. It can reveal a critical
+hub or a design smell, but it can also be a legitimate shared abstraction.
+Compass's report filters some common built-in noise; it does not make a final
+architectural judgment.
+
+## Hyperedges
+
+Some facts involve more than a source and target. For example, a call may bind
+a caller, a target, an argument position, and a type constraint. Compass
+extraction and historical realizations can retain hyperedges for such
+multi-part facts.
+
+The ordinary node-link `links` array remains the main query and visualization
+surface. Do not assume that reconstructing only pairwise edges captures every
+authoritative historical fact; history export preserves the full artifact set
+according to its format contract.
+
+## Graph snapshots
+
+A graph is meaningful only together with the inputs and configuration that
+produced it.
+
+For the working tree:
+
+```text
+snapshot identity ~= files seen + build options + extractor/analyzer versions
+```
+
+For versioned history, Compass makes that explicit:
+
+```text
+realization = exact commit + extraction fingerprint + canonical artifact roots
+```
+
+The same commit can have multiple realizations—for example, a code-only profile
+and a semantic profile. They are not silently treated as equivalent.
+
+## What queries return
+
+Different query surfaces expose different projections:
+
+- `query` returns a focused, budgeted neighborhood;
+- `explain` renders one node's incoming and outgoing neighborhood;
+- `path` returns a shortest known connection;
+- `affected` uses a compact projection with identity, location, and relevant
+  relation fields;
+- CompassQL returns typed tabular values, paths, nodes, relationships, maps, or
+  lists under explicit limits.
+
+A projection is not a second graph truth. It is a task-specific view over a
+saved snapshot.
+
+## Common interpretation mistakes
+
+### “Connected” means “executes”
+
+Not necessarily. An import, reference, containment edge, or semantic relation
+does not imply a runtime call.
+
+### “Extracted” means “correct at runtime”
+
+It means direct static evidence exists. Dead code and conditionally loaded code
+can still be extracted.
+
+### “Inferred” means “made up”
+
+It means a resolver connected structural evidence that was not expressed as
+one direct relation in one file.
+
+### “Shortest path” means “most important path”
+
+It means fewest known hops under the command's traversal semantics. Importance
+and runtime frequency are separate questions.
+
+### “Affected” means “must edit”
+
+It means a node is in the incoming impact neighborhood for configured relation
+families and depth.
+
+### “Community” means “official module”
+
+It is a connectivity-derived cluster and can change with the graph.
+
+## A compact reading checklist
+
+When Compass returns an edge, ask:
+
+```text
+1. What are the exact source and target IDs?
+2. Which direction does the relation point?
+3. What does the relation type claim?
+4. What provenance/confidence is attached?
+5. Which source locations support it?
+6. Is this current-tree or exact-revision data?
+7. Is the result complete or a budgeted projection?
+```
+
+Those seven questions prevent most over-interpretation.
+
+## Related pages
+
+- [How Compass works](how-it-works.md)
+- [Provenance and confidence](provenance.md)
+- [CompassQL concepts](compassql.md)
+- [Output reference](../reference/outputs.md)
+
+**Next step:** read [Provenance and confidence](provenance.md) to learn how to
+weigh graph evidence during investigation and review.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -1,0 +1,394 @@
+# How Compass works
+
+Compass turns a directory of source code and project artifacts into a directed,
+queryable knowledge graph. This page explains the complete flow first in plain
+language, then at the level needed to reason about correctness, performance,
+and extension points.
+
+> **Who this page is for:** evaluators, users who want to interpret results,
+> and contributors building a mental model of the system.
+>
+> **You will learn:** what happens during discovery, extraction, resolution,
+> graph analysis, publication, and querying; which stages are deterministic;
+> and where optional semantic providers enter.
+>
+> **Prerequisites:** none. Familiarity with functions, files, and imports is
+> helpful; graph-database experience is not required.
+>
+> **Reading time:** 12–15 minutes.
+
+![The Compass graph construction and query pipeline](../assets/diagrams/graph-pipeline.svg)
+
+## The short version
+
+Compass does six things:
+
+```text
+1. Discover     choose relevant files and project metadata
+2. Extract      turn each source into entities and local relationships
+3. Resolve      connect facts that cross files, modules, or languages
+4. Analyze      group, rank, and diagnose the resulting graph
+5. Publish      write a coherent compass-out/ artifact set
+6. Query        load indexes and return focused subgraphs or exact matches
+```
+
+For source code, the first five stages are structural and local. Parsers
+identify syntax; language-specific extractors turn that syntax into facts; the
+resolver connects facts across files. No embedding model or vector database is
+needed.
+
+Documents, images, audio/video, and other semantic sources are different. They
+may require the model provider or native media capability you explicitly
+configure. This optional path merges into the same graph rather than creating a
+separate search index.
+
+## A working example
+
+Consider:
+
+```python
+from payments import PaymentGateway
+
+
+def checkout(total):
+    gateway = PaymentGateway()
+    return gateway.charge(total)
+```
+
+A simplified graph might contain:
+
+```text
+app.py
+  |
+  +--CONTAINS-----------> checkout()
+  |
+  `--IMPORTS_FROM-------> payments.py
+
+checkout()
+  |
+  +--USES---------------> PaymentGateway
+  |
+  `--CALLS--------------> PaymentGateway.charge()
+```
+
+The parser supplies facts such as “this node is a call expression” and “this
+identifier occurs in this scope.” A language extractor creates file, function,
+class, import, and call facts. Resolution uses import targets, names, members,
+and scope information to connect the call to the best known definition.
+
+The graph keeps direction. `checkout() --CALLS--> charge()` means something
+different from the reverse. Query and impact commands can therefore choose
+whether to follow outgoing, incoming, or both directions.
+
+## Stage 1: discovery
+
+Discovery decides what enters the build. It:
+
+- walks the requested root;
+- applies supported extensions and project-file detection;
+- respects committed ignore rules by default;
+- applies explicit exclusion patterns;
+- classifies source code, manifests, documents, media, and integration inputs;
+- computes or reuses fingerprints for incremental work.
+
+Discovery is a correctness boundary. A perfect parser cannot represent a file
+that was excluded, ignored, generated after the scan, or outside the requested
+root.
+
+Useful questions when something is missing:
+
+```text
+Was the file under the requested root?
+Was its extension or format recognized?
+Did an ignore or exclude rule remove it?
+Did the build use code-only mode?
+Did an optional integration require explicit configuration?
+```
+
+`--no-gitignore` changes the ignore behavior and should be used deliberately.
+Large generated directories can create noise and cost even when their syntax
+is supported.
+
+## Stage 2: structural extraction
+
+Compass contains a deterministic language registry and a vendored
+tree-sitter language pack. At build time, supported languages use native
+parsers and language-specific extraction rules.
+
+For each file, extraction can produce:
+
+- file and module nodes;
+- definitions such as functions, methods, classes, types, variables, and
+  database objects;
+- containment and declaration edges;
+- import, call, inheritance, use, reference, and configuration relations;
+- source file and source location attributes;
+- language-specific facts needed by the later resolver;
+- hyperedges for facts that naturally involve more than two participants.
+
+Per-file extraction is intentionally separable. Independent files can be
+parsed in parallel, and unchanged file facts can be reused by an incremental
+build.
+
+Structural does not mean simplistic. Language-specific code handles concerns
+such as:
+
+- JavaScript and TypeScript re-exports;
+- member calls and inheritance;
+- namespaces and packages;
+- project manifests;
+- templates and markup;
+- languages whose build metadata changes name resolution.
+
+It does mean that results are based on parseable project evidence, not semantic
+similarity.
+
+## Stage 3: cross-file resolution
+
+A per-file extractor often cannot know the final target of a relation. The
+resolver merges file facts and connects them using project-wide evidence.
+
+For example:
+
+```text
+file A                        file B
+------                        ------
+imports payments             defines module payments
+calls charge()               defines PaymentGateway.charge()
+       \                         /
+        \                       /
+         +---- resolver -------+
+                  |
+                  v
+      checkout --CALLS--> PaymentGateway.charge
+```
+
+Resolution performs targeted language and project operations, including
+canonicalizing import targets, following re-exports, resolving call and member
+facts, disambiguating colliding identifiers, and rewiring unique placeholder
+nodes to known definitions.
+
+This distinction explains provenance:
+
+- a relation directly present in a file can be **EXTRACTED**;
+- a cross-file relation connected by the resolver can be **INFERRED**;
+- a relation with multiple viable targets can remain **AMBIGUOUS**.
+
+“Inferred” in this context is not shorthand for “generated by an LLM.” It means
+Compass derived the link from structural evidence rather than copying one
+explicit syntax relation.
+
+## Stage 4: merge and graph analysis
+
+The merged result is a directed graph document. Analysis derives navigation
+and diagnostic information such as:
+
+- node degree and highly connected “god nodes”;
+- communities of densely related nodes;
+- cross-file or cross-community connections;
+- suggested questions;
+- import cycles and other diagnostics;
+- summary data for `GRAPH_REPORT.md`.
+
+### Communities
+
+A community is a group with stronger internal connectivity than external
+connectivity according to the clustering algorithm. Communities often resemble
+features or subsystems, but they are graph-derived—not hand-maintained
+architecture labels.
+
+Use a community as a starting hypothesis:
+
+```text
+community 4 appears to contain:
+  auth middleware
+  token parsing
+  session storage
+  login handlers
+
+hypothesis:
+  community 4 is the authentication subsystem
+```
+
+Verify the hypothesis by looking at source locations and boundary edges.
+
+### God nodes
+
+A god node has unusually high degree. It may be:
+
+- a true architectural hub;
+- a broad interface or dispatcher;
+- a configuration root;
+- a generic type used everywhere;
+- a noisy or overly broad extraction target.
+
+Degree identifies connectivity, not quality or business importance. Compass
+filters common built-in noise in reports, but interpretation still matters.
+
+## Stage 5: atomic publication
+
+The normal current-tree output lives in `compass-out/`. The public artifacts
+include:
+
+| Artifact | Responsibility |
+| --- | --- |
+| `graph.json` | Complete machine-readable node-link graph |
+| `GRAPH_REPORT.md` | Human-readable orientation and diagnostics |
+| `graph.html` | Optional interactive visualization |
+| `manifest.json` | Incremental build state |
+
+The build pipeline treats output as a set. A failed semantic provider,
+validation error, or incomplete build must not publish a graph as if it were a
+complete successful result. Write paths use temporary or staged artifacts and
+atomic replacement where the contract requires it.
+
+Consumers should still avoid reading files while a writer is replacing an
+artifact set. A long-lived integration can either watch for completion, invoke
+Compass itself, or open a graph snapshot only after the producing command
+returns successfully.
+
+## Stage 6: loading and querying
+
+Read commands load `compass-out/graph.json` by default. The graph layer:
+
+- validates the JSON extension and size guard;
+- decodes the node-link document;
+- preserves directed and multigraph semantics;
+- indexes stable node IDs;
+- builds incoming and outgoing adjacency;
+- builds query indexes and a schema fingerprint;
+- may reuse a local binary cache when it matches the graph signature.
+
+The main read surfaces answer different questions:
+
+| Command | Question |
+| --- | --- |
+| `query` | Which focused neighborhood is relevant to this phrase? |
+| `explain` | What is this node and what connects to it? |
+| `path` | How are these two entities connected? |
+| `affected` | What may depend on this entity through impact relations? |
+| `tree` | What hierarchical structure surrounds this entity? |
+| `query --cql` | Which rows exactly match this structural pattern? |
+
+Natural-language discovery is still deterministic graph search. It tokenizes
+the question, scores candidate nodes, and traverses from relevant anchors under
+a budget. It does not write a prose answer with a model.
+
+CompassQL compiles an explicit structural query into a bounded execution plan.
+It is the right choice when automation needs exact patterns, parameters,
+typed JSON, limits, or profiles.
+
+## Current tree versus exact Git history
+
+`compass update .` describes the working tree at build time. That can include
+uncommitted changes.
+
+Versioned history answers a different question: “What was the complete graph
+for this exact Git commit under this exact extraction profile?”
+
+```text
+working tree                         exact commit
+------------                         ------------
+compass update .                     compass history build REV
+      |                                       |
+      v                                       v
+compass-out/                         immutable realization
+current mutable artifact set        content-addressed Prolly roots in SQLite
+```
+
+Historical materialization resolves a revision, creates a protected offline
+worktree, runs the recorded build profile, validates the result, and publishes
+an immutable realization. Meaning-affecting inputs are captured in an
+extraction fingerprint so a code-only graph is not silently compared with a
+semantic graph.
+
+Read [Versioned graph history](../guides/versioned-history.md) before operating
+the history store.
+
+## Optional semantic path
+
+Some project knowledge is not represented by program syntax:
+
+- design documents;
+- ADRs and RFCs;
+- prose requirements;
+- images and diagrams;
+- office documents;
+- audio or video;
+- remote workspace or database sources.
+
+When enabled, semantic orchestration:
+
+1. classifies supported non-code inputs;
+2. renders or decodes content where needed;
+3. chunks content under configured limits;
+4. sends permitted content to the configured provider or native model path;
+5. validates structured extraction results;
+6. merges semantic nodes and edges with the structural graph;
+7. prevents incomplete provider work from masquerading as a complete build.
+
+Credentials and provider/model selection affect meaning and therefore affect a
+history realization's fingerprint, but secret values are not stored in that
+fingerprint.
+
+Use `--code-only` when you need an explicit fully local structural profile.
+Compass does not silently downgrade a requested semantic history build because
+credentials are missing.
+
+## Determinism and limits
+
+Determinism has practical meanings:
+
+- the same supported inputs and meaning-affecting configuration should produce
+  an equivalent structural graph;
+- output ordering is stable where the public contract requires it;
+- query budgets and resource limits are explicit;
+- unsupported CompassQL syntax is rejected, not approximated;
+- historical realizations are immutable once published.
+
+It does not mean:
+
+- every filesystem state is stable while being scanned;
+- a provider will always return identical semantic content;
+- dynamic runtime behavior can always be recovered from static source;
+- JSON member ordering is a semantic graph property.
+
+Bounded behavior protects interactive and automated use. Graph loading has a
+size cap. CompassQL has row, path-depth, relationship-expansion, memory, and
+deadline limits. File/stdin query sources and parameter documents also have
+caps. Consult the [CompassQL reference](../COMPASSQL.md) for current values.
+
+## Failure model
+
+Compass distinguishes categories so scripts can respond correctly:
+
+```text
+usage or compile mistake
+    -> fix the command/query; retrying unchanged input will not help
+
+graph loading or validation failure
+    -> inspect path, JSON, size, endpoints, or artifact completeness
+
+provider or integration failure
+    -> check credentials/network/source; incomplete builds do not publish
+
+resource limit or cancellation
+    -> narrow the work or lower scope; no successful partial result is emitted
+
+history corruption or profile mismatch
+    -> use explicit inspection/rebuild/profile commands; do not overwrite silently
+```
+
+Exact exit codes differ by command family. Use the
+[command reference](../reference/commands.md) and canonical CompassQL/history
+documents for automation.
+
+## Related pages
+
+- [Graph model](graph-model.md)
+- [Provenance and confidence](provenance.md)
+- [System architecture](../design/architecture.md)
+- [Extraction pipeline](../implementation/extraction-pipeline.md)
+
+**Next step:** read [Graph model](graph-model.md) to interpret the entities,
+relationships, and attributes returned by Compass.

--- a/docs/concepts/provenance.md
+++ b/docs/concepts/provenance.md
@@ -1,0 +1,277 @@
+# Provenance and confidence
+
+Compass keeps evidence quality visible. A graph is more useful when you can
+distinguish a relation copied from direct syntax from one resolved across files
+or left ambiguous.
+
+> **Who this page is for:** users reviewing graph results, integrators ranking
+> evidence, and contributors adding relations or resolvers.
+>
+> **You will learn:** what `EXTRACTED`, `INFERRED`, and `AMBIGUOUS` mean; how
+> they are created; and how to use them without turning provenance into a false
+> probability.
+>
+> **Prerequisites:** basic familiarity with [the graph model](graph-model.md).
+>
+> **Reading time:** 7–9 minutes.
+
+![How Compass classifies relationship provenance](../assets/diagrams/provenance.svg)
+
+## Provenance answers “how do we know?”
+
+Suppose Compass contains:
+
+```text
+CheckoutHandler --CALLS--> authorize_payment()
+```
+
+The relation alone says what connects the nodes. Provenance says how Compass
+arrived at that connection.
+
+```text
+relation type: calls
+provenance:    EXTRACTED
+evidence:      direct call syntax and target identity in the same scope
+```
+
+or:
+
+```text
+relation type: calls
+provenance:    INFERRED
+evidence:      imported name + module target + unique matching definition
+```
+
+or:
+
+```text
+relation type: calls
+provenance:    AMBIGUOUS
+evidence:      more than one viable target remained
+```
+
+## `EXTRACTED`
+
+`EXTRACTED` indicates direct evidence from an extractor or authoritative input.
+Examples can include:
+
+- a function syntactically contained in a file;
+- an explicit import declaration;
+- an inheritance clause naming a base type;
+- a call whose target can be identified directly in the extraction scope;
+- an explicit relation in an ingested structured source.
+
+It is the strongest statement about evidence locality, but it is not a runtime
+guarantee.
+
+```text
+source says:     class Checkout(PaymentFlow)
+graph records:   Checkout --INHERITS [EXTRACTED]--> PaymentFlow
+```
+
+Static evidence can describe unreachable, test-only, platform-specific, or
+dynamically replaced code.
+
+## `INFERRED`
+
+`INFERRED` indicates that Compass derived the connection by resolving multiple
+facts. Typical resolution evidence includes:
+
+- import source plus exported symbol;
+- call name plus scope and unique definition;
+- member name plus receiver type or language-specific call facts;
+- re-export chains;
+- namespace, package, or project metadata;
+- a unique placeholder that can be rewired to a real definition.
+
+```text
+file A: import { charge } from "./payments"
+file A: charge(total)
+file B: export function charge(amount) { ... }
+
+resolver:
+  import target + exported name + call fact
+
+result:
+  checkout() --CALLS [INFERRED]--> payments.charge()
+```
+
+This is structural inference. No semantic model is required for the example.
+
+An inferred edge can be highly reliable when evidence selects one target. The
+tag remains valuable because a contributor can inspect the resolution rules and
+because future changes may alter available evidence.
+
+## `AMBIGUOUS`
+
+`AMBIGUOUS` indicates unresolved alternatives or low-confidence linkage. It
+asks the reader to verify before relying on one interpretation.
+
+Common causes include:
+
+- repeated labels without enough scope information;
+- dynamic dispatch;
+- reflection or dependency injection;
+- incomplete build metadata;
+- generated code not present in the corpus;
+- multiple modules exporting compatible names;
+- semantic extraction that cannot select a unique relation.
+
+```text
+process()
+  |
+  +--possible target--> QueueProcessor.process()
+  `--possible target--> BatchProcessor.process()
+
+graph evidence:
+  AMBIGUOUS until receiver/type evidence selects one
+```
+
+Ambiguity is not a failure to hide. It is useful diagnostic information.
+
+## Provenance is not a numeric probability
+
+Do not assign arbitrary probabilities such as:
+
+```text
+EXTRACTED = 100%
+INFERRED  = 80%
+AMBIGUOUS = 30%
+```
+
+Those numbers have no universal meaning across languages, relation types, or
+repositories. Provenance is a category describing evidence origin and
+resolution status.
+
+If an integration needs ranking, combine:
+
+- provenance;
+- relation type;
+- source location availability;
+- scope or context;
+- uniqueness of the matched identity;
+- repository-specific knowledge;
+- whether independent graph paths support the same conclusion.
+
+Document that ranking as an application policy, not a Compass truth.
+
+## How to review a result
+
+### For code navigation
+
+Use `EXTRACTED` and `INFERRED` relations freely as navigation leads. Verify the
+source before making a consequential edit.
+
+### For change impact
+
+Start with both direct and resolved dependency edges. Give ambiguous edges a
+manual-review bucket rather than dropping them automatically.
+
+### For architecture documentation
+
+Prefer repeated, cross-file evidence over a single surprising edge. Use source
+locations and communities to understand context.
+
+### For automated policy
+
+Use exact CompassQL patterns and explicitly state accepted provenance:
+
+```cypher
+MATCH (entry:Function)-[edge:CALLS]->(target:Function)
+WHERE target.label = $target
+  AND edge.confidence IN ['EXTRACTED', 'INFERRED']
+RETURN entry.id, edge.confidence, target.id
+```
+
+If a policy must act only on direct evidence:
+
+```cypher
+MATCH (source)-[edge]->(target)
+WHERE edge.confidence = 'EXTRACTED'
+RETURN source.id, type(edge), target.id
+```
+
+Remember that attribute presence and naming follow the graph mapping contract.
+The CompassQL mapping supplies missing relationship confidence as `EXTRACTED`
+for compatibility.
+
+## Provenance and semantic extraction
+
+Semantic sources can add relations that are not program syntax. Their
+structured output is validated before merge, but interpretation depends on the
+provider, prompt, mode, and source content.
+
+Do not conflate:
+
+```text
+structural INFERRED
+    derived by deterministic name/scope/project resolution
+
+semantic relation
+    derived through the configured semantic pipeline
+```
+
+Both can live in one graph. Inspect relation attributes and source metadata,
+and keep semantic build profiles distinct in versioned history.
+
+## Provenance through graph operations
+
+Operations that merge, export, diff, or reconstruct graphs should preserve
+relationship attributes and multiplicity. Dropping confidence on export makes
+later review less trustworthy.
+
+For historical export:
+
+- `graph-json` reconstructs the canonical graph JSON;
+- `compass-out` also restores authoritative, non-derivable sidecars and uses
+  recorded renderer versions when regenerating derived outputs.
+
+Semantic equivalence does not require insignificant JSON member ordering, but
+it does require graph structure, attributes, duplicate id-less hyperedges, and
+authoritative bytes to remain correct.
+
+## Troubleshooting unexpected provenance
+
+| Observation | Investigation |
+| --- | --- |
+| Expected `EXTRACTED`, got `INFERRED` | Check whether target identity required cross-file or member resolution |
+| Expected unique target, got `AMBIGUOUS` | Search for duplicate labels, re-exports, missing manifests, or dynamic dispatch |
+| Edge disappeared after update | Check whether source, ignore rules, or resolver evidence changed |
+| Semantic edge appears in code-only build | Confirm which graph path or historical realization was queried |
+| Integration treats missing confidence as unknown | Follow the documented graph/CompassQL compatibility default |
+
+When reporting a suspected extraction bug, include:
+
+- the smallest source fixture that reproduces it;
+- the relevant nodes and edge;
+- expected relation and provenance;
+- actual graph JSON;
+- language and project metadata needed for resolution.
+
+## Contributor rule of thumb
+
+When adding an extractor or resolver:
+
+```text
+Can one input directly justify the exact endpoints?
+    yes -> EXTRACTED may be appropriate
+    no  -> resolution evidence is required
+
+Does the evidence select one stable target?
+    yes -> INFERRED may be appropriate
+    no  -> preserve ambiguity; do not guess
+```
+
+Add a fixture that proves direction, multiplicity, attributes, and provenance
+together. A test that checks only that “some edge exists” is too weak for a
+public graph contract.
+
+## Related pages
+
+- [Graph model](graph-model.md)
+- [How Compass works](how-it-works.md)
+- [Impact-analysis cookbook](../cookbook/impact-analysis.md)
+- [Extending Compass](../implementation/extending-compass.md)
+
+**Next step:** read [CompassQL concepts](compassql.md) to select and filter
+evidence precisely.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -1,0 +1,116 @@
+# Compass cookbook
+
+The cookbook contains short, outcome-focused recipes. Use it when you already
+know the problem and want commands, interpretation guidance, and caveats in one
+place.
+
+> **Who this page is for:** everyday Compass users and integrators.
+>
+> **You will learn:** which recipe fits your task and how cookbook pages differ
+> from full guides and references.
+>
+> **Prerequisites:** [Getting started](../getting-started.md).
+>
+> **Reading time:** 3 minutes.
+
+## Pick a problem
+
+| I need to… | Recipe |
+| --- | --- |
+| estimate the review surface of a symbol or change | [Impact analysis](impact-analysis.md) |
+| map a subsystem or request/data flow | [Architecture discovery](architecture-discovery.md) |
+| generate and query graphs in CI | [CI and automation](ci-and-automation.md) |
+| diagnose install, build, query, provider, or history trouble | [Troubleshooting](troubleshooting.md) |
+
+## Recipe format
+
+Each recipe follows:
+
+```text
+Problem
+  what you are trying to accomplish
+
+Commands
+  the smallest copyable workflow
+
+Interpretation
+  what the result does and does not prove
+
+Variations
+  common changes for nearby tasks
+
+Safety / recovery
+  boundaries, failures, and cleanup
+```
+
+For a complete learning path, use a [guide](../README.md#complete-a-task). For
+exact options and schemas, use the [reference](../README.md#look-up-an-exact-contract).
+
+## Quick recipes
+
+### Find a concept
+
+```bash
+compass query "payment retry and idempotency"
+```
+
+Then explain one concrete result:
+
+```bash
+compass explain RetryPolicy
+```
+
+### Connect two boundaries
+
+```bash
+compass path ApiHandler PaymentRepository
+```
+
+Verify each hop in source.
+
+### List direct callers
+
+```bash
+compass query --cql \
+  "MATCH (caller)-[:CALLS]->(target)
+   WHERE target.label = 'authorize_payment'
+   RETURN caller.id, target.id
+   ORDER BY caller.id
+   LIMIT 100"
+```
+
+### Compare two commits
+
+```bash
+compass diff HEAD~1 HEAD
+```
+
+For scripts:
+
+```bash
+compass diff HEAD~1 HEAD --format json
+```
+
+### Build only structural code knowledge
+
+```bash
+compass extract . --code-only
+```
+
+### Create a reproducible graph for a commit
+
+```bash
+compass history build HEAD --code-only
+compass history export HEAD \
+  --format graph-json \
+  --output target/head-graph.json
+```
+
+## Related pages
+
+- [Explore a codebase guide](../guides/exploring-a-codebase.md)
+- [Command reference](../reference/commands.md)
+- [Graph model](../concepts/graph-model.md)
+
+**Next step:** choose the recipe matching your current task and record the graph
+revision/profile beside any saved result.

--- a/docs/cookbook/architecture-discovery.md
+++ b/docs/cookbook/architecture-discovery.md
@@ -1,0 +1,173 @@
+# Cookbook: architecture discovery
+
+These recipes help map a subsystem, request flow, data flow, or boundary in an
+unfamiliar repository.
+
+> **Who this page is for:** developers onboarding, debugging across modules, or
+> preparing architecture reviews.
+>
+> **You will learn:** community-first, entry-to-side-effect, hub, boundary, and
+> exact-pattern recipes.
+>
+> **Prerequisites:** a fresh `compass-out/`.
+>
+> **Completion time:** 10–30 minutes.
+
+## Recipe 1: map one subsystem
+
+### Problem
+
+You need a compact map of authentication.
+
+### Workflow
+
+```bash
+sed -n '1,220p' compass-out/GRAPH_REPORT.md
+compass query "HTTP authentication token verification and sessions"
+compass explain AuthMiddleware
+```
+
+Write:
+
+```text
+Entry:
+Core services:
+State:
+External boundary:
+Likely community:
+Unverified/ambiguous:
+```
+
+Then verify those source files.
+
+## Recipe 2: trace entry to side effect
+
+### Problem
+
+You need the path from an API handler to a database or external provider.
+
+### Commands
+
+```bash
+compass query "checkout request handling"
+compass query "payment persistence gateway"
+compass path CheckoutHandler PaymentRepository
+```
+
+For each hop:
+
+```text
+node A --relation [provenance]--> node B
+source A:
+source B:
+condition/dynamic caveat:
+```
+
+If the path ends at an abstraction, query its implementers or concrete clients.
+
+## Recipe 3: find cross-subsystem coupling
+
+### Problem
+
+You want edges crossing community boundaries.
+
+### CompassQL
+
+```bash
+compass query --cql \
+  'MATCH (source)-[edge]->(target)
+   WHERE source.community <> target.community
+   RETURN source.community, source.id, type(edge),
+          target.community, target.id, edge.confidence
+   ORDER BY source.community, target.community
+   LIMIT 500' \
+  --format json \
+  --output target/cross-community.json
+```
+
+Interpret repeated cross-community relationships as a boundary worth
+investigating. One edge may be a legitimate adapter.
+
+## Recipe 4: inspect hubs
+
+### Problem
+
+The report identifies a god node.
+
+### Commands
+
+```bash
+compass explain AppContext
+compass affected AppContext --depth 2
+```
+
+Ask:
+
+- Is it a true composition root?
+- Is it a broad interface?
+- Is it a generic built-in/noisy label?
+- Are incoming and outgoing relations balanced?
+- Does it connect many communities?
+- Would changing it create widespread review risk?
+
+High degree is evidence of connectivity, not automatically a design smell.
+
+## Recipe 5: find cycles
+
+Start with `GRAPH_REPORT.md` diagnostics. If import-cycle data is present,
+inspect each edge direction and source.
+
+For an exact bounded pattern, use the relation vocabulary in your graph. Do not
+write an unbounded CompassQL path; set an explicit maximum no greater than 32.
+
+Example shape:
+
+```cypher
+MATCH p=(module)-[:IMPORTS_FROM*2..8]->(module)
+RETURN module.id, p, length(p)
+LIMIT 100
+```
+
+Verify supported path semantics in [CompassQL 1](../COMPASSQL.md).
+
+## Recipe 6: create a shareable subsystem brief
+
+Use:
+
+```text
+Subsystem
+  One sentence describing responsibility.
+
+Entry points
+  Public handlers/commands/jobs.
+
+Core path
+  3–7 graph hops with relation and provenance.
+
+State and integrations
+  Files, DBs, queues, providers, external services.
+
+Internal modules/communities
+  Major graph-derived groups, qualified as hypotheses.
+
+Change hotspots
+  Hubs and incoming impact neighborhoods.
+
+Uncertainty
+  Ambiguous/dynamic/ignored/generated/external behavior.
+
+Evidence
+  Commit/profile, commands, and source files.
+```
+
+This is more useful than attaching an unexplained screenshot of the whole
+graph.
+
+## Related pages
+
+- [Explore a codebase](../guides/exploring-a-codebase.md)
+- [Graph model](../concepts/graph-model.md)
+- [Impact analysis](impact-analysis.md)
+
+**Next step:** produce one subsystem brief and ask a maintainer to verify its
+boundary and uncertainty, not just its terminology.

--- a/docs/cookbook/ci-and-automation.md
+++ b/docs/cookbook/ci-and-automation.md
@@ -1,0 +1,173 @@
+# Cookbook: CI and automation
+
+Use these patterns to generate, query, and publish Compass artifacts in CI
+without depending on human text or hiding failures.
+
+> **Who this page is for:** CI/platform engineers and maintainers adding graph
+> checks to pull requests or scheduled jobs.
+>
+> **You will learn:** deterministic build jobs, exact query policies, artifact
+> retention, cache keys, and historical comparison.
+>
+> **Prerequisites:** Compass installed in the runner and repository checkout.
+>
+> **Completion time:** 15–30 minutes.
+
+## Recipe 1: build and upload a structural graph
+
+```bash
+set -eu
+compass --version
+compass update . --no-viz
+test -s compass-out/graph.json
+test -s compass-out/GRAPH_REPORT.md
+test -s compass-out/manifest.json
+```
+
+Upload the three artifacts plus:
+
+```bash
+git rev-parse HEAD > compass-out/source-revision.txt
+compass --version > compass-out/compass-version.txt
+```
+
+Treat graph artifacts with source-code confidentiality.
+
+## Recipe 2: exact policy query
+
+Create `.compass/no-ambiguous-auth.cypher`:
+
+```cypher
+MATCH (source)-[edge]->(target)
+WHERE edge.confidence = 'AMBIGUOUS'
+  AND (source.label CONTAINS 'Auth' OR target.label CONTAINS 'Auth')
+RETURN source.id, type(edge), target.id
+ORDER BY source.id, target.id
+LIMIT 500
+```
+
+Run:
+
+```bash
+compass query --cql \
+  --file .compass/no-ambiguous-auth.cypher \
+  --format json \
+  --output compass-out/no-ambiguous-auth.json
+```
+
+Decide policy in a separate script that validates
+`compass.cql.result/1` and counts rows. This keeps query execution and
+organization-specific pass/fail rules separate.
+
+## Recipe 3: parameterized reusable query
+
+`.compass/callers.cypher`:
+
+```cypher
+MATCH (caller)-[edge:CALLS]->(target)
+WHERE target.label = $target
+RETURN caller.id, edge.confidence, target.id
+ORDER BY caller.id
+LIMIT 500
+```
+
+Run:
+
+```bash
+compass query --cql \
+  --file .compass/callers.cypher \
+  --param target="$TARGET_LABEL" \
+  --format json \
+  --output compass-out/callers.json
+```
+
+Do not inject `TARGET_LABEL` into source text.
+
+## Recipe 4: compare base and head
+
+```bash
+set -eu
+compass history build "$BASE_SHA" --code-only
+compass history build "$HEAD_SHA" --profile-from "$BASE_SHA"
+compass diff "$BASE_SHA" "$HEAD_SHA" \
+  --topology-only \
+  --format json > compass-out/topology-diff.json
+```
+
+Use full commit SHAs supplied by the CI provider. Avoid fetch-on-demand inside
+historical materialization; make required commits available during checkout.
+
+## Cache strategy
+
+Cache keys should include:
+
+```text
+operating-system / target
+Compass version or binary hash
+Cargo.lock or release artifact identity
+build profile / code-only vs semantic
+relevant parser/extractor version
+repository content key
+```
+
+Do not restore:
+
+- a semantic cache under another model/prompt/profile;
+- query plan cache under an incompatible graph schema;
+- a manifest from another output/root;
+- a live SQLite/WAL history copy assembled from partial files.
+
+History is a live durable store. Prefer supported backup or rebuild workflows
+over naive cache archiving.
+
+## Failure policy
+
+```text
+Compass nonzero
+  -> job fails; retain diagnostic
+
+Query limit
+  -> job fails or reports inconclusive; never "zero matches"
+
+Missing provider key
+  -> fail semantic job or explicitly run code-only
+
+Unknown result major version
+  -> fail closed
+
+Graph policy rows found
+  -> organization policy decides warn/fail
+```
+
+## Security
+
+- Pin or verify downloaded release artifacts.
+- Do not echo provider or database keys.
+- Avoid semantic providers for unapproved repositories.
+- Do not expose `graph.html` publicly by default.
+- Sanitize CI artifacts according to repository classification.
+- Do not execute untrusted checkout build scripts merely to build a graph.
+
+## Suggested artifact bundle
+
+```text
+compass-out/
+├── graph.json
+├── GRAPH_REPORT.md
+├── manifest.json
+├── source-revision.txt
+├── compass-version.txt
+├── policy-result.json
+└── topology-diff.json
+```
+
+HTML is optional and can be omitted for size or security.
+
+## Related pages
+
+- [Integrating Compass](../guides/integrating-compass.md)
+- [Output reference](../reference/outputs.md)
+- [Security and privacy](../design/security-and-privacy.md)
+
+**Next step:** implement the build-only recipe first, inspect its artifacts,
+then add one exact policy query with explicit schema validation.

--- a/docs/cookbook/impact-analysis.md
+++ b/docs/cookbook/impact-analysis.md
@@ -1,0 +1,193 @@
+# Cookbook: impact analysis
+
+Use these recipes to estimate what may depend on a symbol, file, or change.
+
+> **Who this page is for:** implementers and reviewers preparing a change.
+>
+> **You will learn:** reverse-impact traversal, direct-caller queries,
+> historical topology diffs, and how to turn results into a review checklist.
+>
+> **Prerequisites:** a current graph or versioned history.
+>
+> **Completion time:** 5–15 minutes.
+
+## Recipe 1: impact from one symbol
+
+### Problem
+
+You plan to change `TokenVerifier` and want a bounded review scope.
+
+### Commands
+
+```bash
+compass explain TokenVerifier
+compass affected TokenVerifier --depth 3
+```
+
+### Interpret
+
+`explain` shows immediate incoming/outgoing context. `affected` walks incoming
+impact-relevant relations:
+
+```text
+ApiMiddleware --CALLS--> TokenVerifier
+
+change TokenVerifier
+        |
+        `--> review ApiMiddleware
+```
+
+The result is a review queue, not a required edit list.
+
+### Variations
+
+Narrow to one relation:
+
+```bash
+compass affected TokenVerifier --relation calls --depth 2
+```
+
+Use a saved graph:
+
+```bash
+compass affected TokenVerifier --graph target/baseline.json --depth 3
+```
+
+## Recipe 2: exact direct callers
+
+### Problem
+
+You need a deterministic list for automation.
+
+### Command
+
+```bash
+compass query --cql \
+  'MATCH (caller)-[edge:CALLS]->(target)
+   WHERE target.label = $target
+   RETURN caller.id, edge.confidence, target.id
+   ORDER BY caller.id
+   LIMIT 500' \
+  --param target=TokenVerifier \
+  --format json \
+  --output target/token-verifier-callers.json
+```
+
+### Interpret
+
+Review the schema tag, then distinguish direct and resolved evidence by
+`edge.confidence`.
+
+If labels repeat, first discover the stable target ID and query by `target.id`.
+
+## Recipe 3: downstream dependencies
+
+### Problem
+
+You want to know what a service calls or uses.
+
+### Command
+
+```bash
+compass query --cql \
+  'MATCH (source)-[edge:CALLS|USES|IMPORTS_FROM]->(dependency)
+   WHERE source.id = $source
+   RETURN type(edge), dependency.id, edge.confidence
+   ORDER BY type(edge), dependency.id
+   LIMIT 500' \
+  --param source='"src/auth.rs::TokenVerifier"' \
+  --format table
+```
+
+Parameter parsing accepts JSON scalars; quote a string explicitly when shell
+content could be mistaken for another JSON type.
+
+## Recipe 4: compare topology across commits
+
+### Problem
+
+You need to see structural additions/removals without report noise.
+
+### Commands
+
+```bash
+compass history build HEAD~1 --code-only
+compass history build HEAD --profile-from HEAD~1
+compass diff HEAD~1 HEAD --topology-only
+```
+
+For automation:
+
+```bash
+compass diff HEAD~1 HEAD --topology-only --format json \
+  > target/topology-diff.json
+```
+
+### Interpret
+
+The profile-from step makes extraction semantics comparable. Added/removed
+edges show static topology change; they do not prove runtime traffic changed.
+
+## Recipe 5: PR review checklist
+
+### Problem
+
+A PR changes several files and you want graph-informed review.
+
+### Workflow
+
+1. Record changed files:
+
+   ```bash
+   git diff --name-only BASE...HEAD
+   ```
+
+2. Query/explain key changed symbols.
+3. Run `affected` for public or hub symbols.
+4. Compare exact commit graphs if both revisions are available.
+5. Inspect cross-community edges.
+6. Add tests/configuration/consumers to the review list.
+
+Checklist:
+
+```text
+[ ] Direct callers reviewed
+[ ] Importers/consumers reviewed
+[ ] Implementers/inheritors reviewed
+[ ] Tests and fixtures reviewed
+[ ] Configuration/schema dependencies reviewed
+[ ] Ambiguous edges verified manually
+[ ] Dynamic/reflection/external behavior considered
+[ ] Graph profile and revision recorded
+```
+
+## Common false conclusions
+
+| Result | Do not conclude |
+| --- | --- |
+| Node appears in `affected` | It must be edited |
+| Node does not appear | It cannot be affected dynamically |
+| Edge is `EXTRACTED` | It always executes |
+| Edge is `INFERRED` | It is unreliable or model-generated |
+| One shortest path exists | It is the only runtime path |
+| Topology unchanged | Behavior is unchanged |
+
+## Recovery
+
+If results are empty:
+
+- confirm graph freshness and requested revision;
+- explain the seed to confirm identity;
+- query by file/module first;
+- inspect ignore/generated code;
+- confirm relation names;
+- use `--at` for historical rather than a current graph.
+
+## Related pages
+
+- [Explore a codebase](../guides/exploring-a-codebase.md)
+- [Provenance](../concepts/provenance.md)
+- [Versioned history](../guides/versioned-history.md)
+
+**Next step:** convert the impact output into a human review checklist and
+verify the highest-risk relations in source.

--- a/docs/cookbook/troubleshooting.md
+++ b/docs/cookbook/troubleshooting.md
@@ -1,0 +1,191 @@
+# Cookbook: troubleshooting
+
+This page is a symptom-to-diagnosis map. Start with the narrowest category and
+preserve the original diagnostic before deleting or rebuilding anything.
+
+> **Who this page is for:** all Compass users and operators.
+>
+> **You will learn:** how to diagnose installation, build, graph, query,
+> semantic, service, assistant, and history problems safely.
+>
+> **Prerequisites:** access to the failing command, stderr, and working
+> directory.
+>
+> **Completion time:** 5–20 minutes for common failures.
+
+## First five checks
+
+```bash
+pwd
+command -v compass
+compass --version
+git status --short
+df -h .
+```
+
+Then rerun the exact command without suppressing stderr.
+
+Record:
+
+- command with secrets removed;
+- exit code;
+- Compass version;
+- current directory;
+- graph/output path;
+- source revision/profile;
+- first complete diagnostic.
+
+## Installation
+
+| Symptom | Likely cause | Diagnosis | Remedy |
+| --- | --- | --- | --- |
+| command not found | install dir absent from `PATH` | `command -v compass`, inspect `PATH` | add install dir and open new shell |
+| source build uses wrong compiler | rustup override/toolchain | `rustup show` | use pinned `rust-toolchain.toml` |
+| macOS blocks binary | unsigned/not notarized release policy | inspect release and OS message | follow organization policy; build from source if approved |
+| checksum fails | incomplete/tampered/wrong archive | retain installer output | do not run archive; download from official release |
+| build runs out of disk | large Rust dependencies/artifacts | `df -h .`, `du -sh target` | free space or remove only rebuildable Cargo artifacts |
+
+## Build and update
+
+| Symptom | Likely cause | Diagnosis | Remedy |
+| --- | --- | --- | --- |
+| no `compass-out/` | command failed before publication | inspect stderr/exit | fix stage error and rerun |
+| graph stale | update not rerun/watcher failed | compare source times/revision; run manual update | `compass update .` |
+| symbol missing | ignored/unsupported/generated/outside root | inspect report, ignore/exclude, source path | adjust scope/support; rebuild |
+| provider requested unexpectedly | semantic sources present | inspect command and file classes | configure intentionally or use code-only |
+| graph changed on no-op | config/version/input changed | compare manifest/version/options | clean qualification and investigate fingerprint |
+| `graph.html` missing | disabled or graph too large | inspect command/report | query JSON; HTML is optional |
+
+## Query
+
+| Symptom | Likely cause | Diagnosis | Remedy |
+| --- | --- | --- | --- |
+| graph not found | wrong cwd/path | locate `graph.json` | run from root or `--graph PATH` |
+| graph must be JSON | wrong input/export | inspect suffix/content | use canonical graph JSON |
+| node not found | label mismatch/duplicates | broad query by file/domain | use stable ID or more context |
+| path not found | wrong endpoint/direction/missing edge | explain both endpoints | verify graph coverage and relation |
+| too many results | generic phrase/hub | inspect anchors | add behavior/domain terms or CompassQL |
+| limit/timeout | query expansion too broad | run `EXPLAIN`, reduce path/labels | narrow query; approved budget only |
+| JSON consumer breaks | schema mismatch or parsed human text | inspect version tag | consume documented JSON/JSONL and reject unknown major |
+
+## CompassQL
+
+Diagnostic families:
+
+```text
+CQL1xxx  source/syntax/unsupported
+CQL2xxx  scope/type/projection/path shape
+CQL3xxx  source/token/path/row/memory/time limit
+CQL4xxx  parameter/runtime/regex/arithmetic/invariant
+```
+
+Response:
+
+- `CQL1xxx/2xxx`: fix query;
+- `CQL3xxx`: narrow work or limits deliberately;
+- `CQL4xxx`: validate parameters/types and report invariant failures.
+
+No successful partial result is produced on execution failure.
+
+## Semantic providers
+
+| Symptom | Diagnosis | Remedy |
+| --- | --- | --- |
+| missing key | check documented environment variable is present in process, not print value | configure approved secret or code-only |
+| unsafe endpoint | inspect scheme/host warning | use approved HTTPS/loopback endpoint |
+| context exceeded | inspect adaptive-retry diagnostic | reduce source/chunk/mode; do not loop manually |
+| malformed provider output | retain redacted response metadata | retry bounded; provider/model/prompt may be incompatible |
+| partial sources | inspect partial metadata and command policy | rerun failed sources or surface partial status |
+| rate limit | inspect provider status | bounded backoff, lower concurrency |
+
+Never paste secret headers or sensitive corpus content into an issue.
+
+## Watch and hooks
+
+```bash
+compass hook status
+compass update .
+```
+
+If manual update succeeds but watch/hook fails:
+
+- stop duplicate watchers;
+- inspect hook log;
+- confirm installed binary path;
+- check rebase/merge/worktree guards;
+- reinstall managed hooks after binary relocation;
+- uninstall hooks before hand-editing their managed sections.
+
+## Assistant integration
+
+| Symptom | Remedy |
+| --- | --- |
+| skill not discovered | verify platform, scope, generated destination, assistant restart |
+| duplicate managed content | rerun idempotent installer, inspect diff, uninstall/reinstall managed section |
+| strict mode surprises user | `COMPASS_HOOK_STRICT=0`, then review project hook |
+| assistant ignores graph | confirm `compass-out/`, skill discovery, and explicit repository instructions |
+| assistant trusts graph blindly | require source verification and provenance qualification |
+
+## History
+
+| Symptom | Response |
+| --- | --- |
+| profile mismatch | build comparable realization with `--profile-from` |
+| realization missing | build explicitly or allow lazy `--at` materialization |
+| preferred corrupt | inspect with list/show; explicit `rebuild --replace-corrupt` |
+| lease/live work | wait/join/inspect; do not delete live lock |
+| disk file does not shrink after GC | expected; logical reclamation is not `VACUUM` |
+| copied DB will not open coherently | restore SQLite and WAL as a consistent resource |
+| submodule/LFS/filter limitation | follow diagnostic; history refuses unsafe/implicit expansion |
+
+Useful commands:
+
+```bash
+compass history status HEAD
+compass history list HEAD --format json
+compass history show REALIZATION_ID
+compass history gc
+```
+
+## Disk-full recovery
+
+Stop writers first. Identify generated space:
+
+```bash
+df -h .
+du -sh target compass-out 2>/dev/null
+```
+
+Safe categories differ:
+
+- Cargo `target/` is rebuildable but deleting it discards compilation cache;
+- `compass-out/` is rebuildable current output;
+- history SQLite/WAL is durable data and must not be deleted as cache;
+- user source and untracked files are never cleanup targets.
+
+Use explicit, validated paths. Report what was removed.
+
+## When to report a bug
+
+Create a minimal reproduction that includes:
+
+- supported platform and Compass version;
+- exact command/exit;
+- tiny source fixture;
+- expected nodes/edges/output;
+- actual redacted graph fragment/diagnostic;
+- whether cold, incremental, current, or historical;
+- profile/backend name without credentials.
+
+For vulnerabilities, follow [SECURITY.md](../../SECURITY.md), not a public
+issue.
+
+## Related pages
+
+- [Getting started](../getting-started.md)
+- [Operations](../guides/operations.md)
+- [Support](../../SUPPORT.md)
+- [Security policy](../../SECURITY.md)
+
+**Next step:** capture the failing command, first diagnostic, version, path, and
+profile before trying the smallest recovery listed above.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,392 @@
+# Compass system architecture
+
+Compass is a Rust workspace organized around a deterministic graph pipeline,
+bounded query engines, optional integrations, and immutable history.
+
+> **Who this page is for:** contributors and technical evaluators.
+>
+> **You will learn:** architectural layers, dependency direction, primary data
+> flows, public boundaries, and where to look when behavior changes.
+>
+> **Prerequisites:** [Design principles](principles.md) and
+> [How Compass works](../concepts/how-it-works.md).
+>
+> **Reading time:** 15 minutes.
+
+![Compass workspace architecture](../assets/diagrams/workspace-architecture.svg)
+
+## Layered view
+
+```text
+Interfaces
+  compass-cli · compass-mcp
+        |
+        v
+Application services
+  compass-core · history materialization
+        |
+        +--------------------+
+        v                    v
+Graph construction       Query
+  files/languages          model/query/cypher
+  resolve/graph
+        |
+        v
+Optional capabilities
+  semantic/media/transcribe/integrations/exporters
+        |
+        v
+Durability and outputs
+  atomic artifacts · history store · output renderers
+```
+
+The dependency direction aims inward: interfaces coordinate stable domain
+services rather than domain crates reaching up into command parsing.
+
+## Interface layer
+
+### `compass-cli`
+
+Owns:
+
+- command dispatch and argument validation;
+- help and usage text;
+- frontend-specific rendering;
+- command-family exit behavior;
+- provider/install/hook/history/integration orchestration at the CLI boundary;
+- the only shipped `compass` binary.
+
+The binary entry point is intentionally small. It selects specialized runners
+for commands such as `diff`, `watch`, and `serve`, then delegates the rest to
+the library command dispatcher.
+
+The source contains an internal Graphify-compatibility frontend used by
+development parity tests. It is not a second shipped product executable.
+
+### `compass-mcp`
+
+Owns:
+
+- MCP tool and resource definitions;
+- graph-backed request handling;
+- stdio and HTTP transports;
+- authentication and service limits;
+- PR and graph query exposure to compatible clients.
+
+It uses core/model/query functionality; it does not reimplement extraction.
+
+## Application-service layer
+
+### `compass-core`
+
+`compass-core` is the orchestration boundary shared by interfaces. Its public
+services cover:
+
+- graph build pipelines;
+- clustering an existing graph;
+- diagnostics;
+- graph merging;
+- watch mode;
+- historical materialization.
+
+`BuildOptions`, `BuildPurpose`, and `SemanticLayer` carry policy into the build
+without making lower-level crates parse CLI arguments.
+
+The core returns typed results and timings. The CLI decides how to render them.
+
+## Deterministic construction layer
+
+### `compass-files`
+
+Owns filesystem correctness:
+
+- detection and classification;
+- ignore policy and watch filtering;
+- source decoding;
+- file/stat/prompt fingerprints;
+- incremental manifests and caches;
+- file slicing;
+- atomic JSON/text/byte writes;
+- incomplete-build guards.
+
+This layer is used throughout the workspace when a write must be atomic or an
+input must be bounded.
+
+### `compass-languages`
+
+Owns statically linked structural extraction:
+
+- language registry;
+- built-in and language-specific extractors;
+- project/config/manifest extraction;
+- SCIP ingestion;
+- stable ID helpers;
+- per-file `Extraction` facts and raw calls.
+
+The vendored tree-sitter language pack supplies deterministic parser
+definitions and queries.
+
+### `compass-resolve`
+
+Owns cross-file resolution over extraction facts:
+
+- import target canonicalization;
+- JavaScript/TypeScript re-export handling;
+- cross-file calls;
+- language member-call facts;
+- PHP/C#/C-family canonicalization and disambiguation;
+- conservative rewiring of unique stubs;
+- collision handling.
+
+It converts per-file facts into a coherent project-wide extraction without
+making query or rendering decisions.
+
+### `compass-graph`
+
+Owns graph construction and algorithms:
+
+- merge resolved extractions;
+- entity deduplication;
+- node-link document construction;
+- clustering and community scores;
+- stable community remapping;
+- god nodes, surprising connections, suggested questions;
+- import cycles and graph diffs.
+
+## Model and query layer
+
+### `compass-model`
+
+Owns the typed compatibility model:
+
+- `NodeRecord`;
+- `EdgeRecord`;
+- `GraphDocument`;
+- indexed `Graph`;
+- `QueryIndex`;
+- schema fingerprints;
+- validation and graph loading errors.
+
+It preserves unknown attributes, directed/multigraph semantics, stable string
+IDs, and adjacency indexes.
+
+### `compass-query`
+
+Owns:
+
+- text normalization and node scoring;
+- focused BFS/DFS traversal;
+- shortest-path and explanation rendering;
+- affected-impact traversal;
+- query benchmarks;
+- CompassQL execution, limits, profiling, and plan cache.
+
+The query crate operates over loaded graph snapshots. It does not discover
+source files or invoke providers.
+
+### `compass-cypher`
+
+Owns CompassQL language processing:
+
+- lexer and parser;
+- AST and values;
+- diagnostics and spans;
+- semantic/type/scope checks;
+- logical plan;
+- optimizations;
+- support matrix;
+- language and planner versions.
+
+Separating compile/planning from execution keeps unsupported syntax rejection
+and plan-cache contracts explicit.
+
+## Output layer
+
+### `compass-output`
+
+Owns representations derived from graph data:
+
+- JSON;
+- Markdown report;
+- interactive HTML;
+- SVG;
+- GraphML and Cypher;
+- tree and call-flow HTML;
+- Obsidian and wiki exports;
+- canvas-style formats.
+
+Renderers consume graph/analysis data. They should not mutate graph meaning.
+
+## History layer
+
+### `compass-history`
+
+Owns immutable version storage:
+
+- build profiles and extraction fingerprints;
+- commit and realization identities;
+- canonical encoding and typed keys;
+- artifact partitioning and registries;
+- SQLite-backed Prolly storage;
+- publication and preferred pointers;
+- validation;
+- diffs;
+- Git worktree isolation;
+- durable jobs, leases, locks;
+- garbage collection.
+
+`compass-core` adapts the regular build pipeline into the `CompleteGraphBuilder`
+needed for materialization. `compass-cli` exposes operational commands.
+
+## Semantic and media layer
+
+### `compass-semantic`
+
+Owns untrusted semantic fragment handling and provider orchestration:
+
+- prompts and chunk packing;
+- built-in/custom backend selection;
+- API request/response normalization;
+- adaptive retry and context-limit handling;
+- fragment parsing, validation, normalization, and evidence binding;
+- community labeling;
+- partial-result tracking;
+- provider endpoint checks.
+
+### `compass-media`
+
+Extracts bounded text from local files such as PDF, DOCX, and XLSX. Archive
+size and compression-ratio guards defend against decompression abuse.
+
+### `compass-transcribe` and `compass-whisper`
+
+`compass-transcribe` owns bounded orchestration, media acquisition contracts,
+and backend traits. `compass-whisper` owns bounded native CPU inference
+internals. The public CLI does not expose a separate incomplete transcription
+product surface.
+
+## Integration crates
+
+| Crate | Responsibility |
+| --- | --- |
+| `compass-cargo` | Deterministic Cargo workspace dependency introspection |
+| `compass-global` | Persistent cross-project graph registry/management |
+| `compass-google-workspace` | Bounded Google Workspace shortcut export through `gws` |
+| `compass-graphdb` | Native Neo4j Bolt and FalkorDB RESP exporters |
+| `compass-ingest` | Bounded, SSRF-resistant URL ingestion |
+| `compass-postgres` | Read-only PostgreSQL catalog introspection |
+| `compass-prs` | GitHub PR dashboard and graph-impact analysis |
+| `compass-reflect` | Deterministic session-memory aggregation and learning overlay |
+
+Each integration converts external data into graph-compatible facts or consumes
+graph data through a narrow boundary.
+
+## Verification layer
+
+### `compass-parity`
+
+This development-only crate performs differential verification against the
+pinned Python Graphify baseline. It exercises selected data structures,
+pipelines, outputs, and integrations.
+
+Parity evidence establishes the certified compatibility ledger. Native
+features with no Graphify equivalent require their own tests and qualification.
+
+### Tests and scripts
+
+Evidence is distributed intentionally:
+
+- unit tests beside pure logic;
+- crate integration tests for public behavior;
+- CLI subprocess tests for commands, streams, exits, and file trees;
+- openCypher TCK subsets and differential query tests;
+- fuzz targets for untrusted inputs;
+- release, performance, and real-repository qualification scripts.
+
+## Primary data flows
+
+### Current-tree build
+
+```text
+CLI options
+  -> compass-core BuildOptions
+  -> compass-files discovery/incremental state
+  -> compass-languages per-file extractions
+  -> compass-resolve project resolution
+  -> compass-graph build/dedup/cluster/analyze
+  -> optional semantic merge
+  -> compass-output artifacts
+  -> compass-files atomic publication
+```
+
+### Natural-language graph query
+
+```text
+CLI question
+  -> compass-model load/index graph
+  -> compass-query tokenize/score anchors
+  -> bounded traversal
+  -> human-focused text
+```
+
+### CompassQL
+
+```text
+source + parameter types + limits + graph schema fingerprint
+  -> compass-cypher compile/plan
+  -> compass-query bounded execute
+  -> table / versioned JSON / JSONL / profile
+```
+
+### Historical query
+
+```text
+--at REV
+  -> resolve exact commit
+  -> open history store
+  -> validate preferred realization
+  -> lazily materialize if absent
+  -> reconstruct graph document
+  -> normal query engine
+```
+
+## Error ownership
+
+Errors should remain meaningful at their boundary:
+
+| Boundary | Example error |
+| --- | --- |
+| Files | read, decode, outside-root, atomic write |
+| Language | parse/extraction failure |
+| Graph | malformed endpoint, invalid document, dedup failure |
+| Query | not found, compile diagnostic, resource limit |
+| Semantic | provider, response, validation, incomplete fragment |
+| History | Git, fingerprint, corruption, publication, lease |
+| Integration | network protocol, authentication, unsafe URL |
+| CLI | usage, rendering, exit-code mapping |
+
+Avoid converting every error into a generic string too early; structured
+context makes both human diagnostics and automated tests stronger.
+
+## Architectural change checklist
+
+When a change crosses layers:
+
+1. identify the crate that owns the new concept;
+2. keep CLI parsing out of domain crates;
+3. define the data passed across the boundary;
+4. define limits and failure behavior;
+5. preserve provenance and unknown attributes;
+6. decide whether history fingerprints or schemas change;
+7. add the narrowest public test plus integration evidence;
+8. update compatibility/migration when behavior intentionally diverges.
+
+## Related pages
+
+- [Workspace tour](../implementation/workspace-tour.md)
+- [Extraction pipeline](../implementation/extraction-pipeline.md)
+- [Storage and history](storage-and-history.md)
+- [Extending Compass](../implementation/extending-compass.md)
+
+**Next step:** use the [workspace tour](../implementation/workspace-tour.md) to
+locate the exact crate and tests for the subsystem you plan to change.

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -1,0 +1,272 @@
+# Compass design principles
+
+Compass is designed as a native, inspectable knowledge graph engine rather than
+a hidden retrieval service. These principles explain the trade-offs behind its
+public behavior and provide a test for future changes.
+
+> **Who this page is for:** contributors, maintainers, evaluators comparing
+> architectural approaches, and integrators relying on Compass contracts.
+>
+> **You will learn:** the principles governing local execution, determinism,
+> evidence, bounds, publication, compatibility, and independent evolution.
+>
+> **Prerequisites:** [How Compass works](../concepts/how-it-works.md).
+>
+> **Reading time:** 10–12 minutes.
+
+## 1. Local-first structural knowledge
+
+Source-code extraction and graph querying should work without:
+
+- Python at runtime;
+- embeddings;
+- a vector database;
+- runtime grammar downloads;
+- separately installed native libraries;
+- model credentials.
+
+This keeps the default code path fast, inspectable, and suitable for private
+repositories.
+
+“Local-first” does not mean “Compass never supports network features.” Optional
+semantic providers, GitHub workflows, remote ingestion, database
+introspection, and graph exports cross explicit network boundaries. The design
+requirement is that those boundaries are chosen and visible.
+
+## 2. Structure before similarity
+
+Compass records project entities and typed relationships:
+
+```text
+handler --CALLS--> service --USES--> repository
+```
+
+This is different from returning text chunks that are close in embedding space.
+Structural relationships provide:
+
+- direction;
+- relation type;
+- stable identity;
+- source location;
+- provenance;
+- traversable multi-hop context.
+
+Semantic extraction extends the graph for non-code knowledge; it does not
+replace structural facts with similarity scores.
+
+## 3. Evidence stays attached
+
+An edge is more useful when a reader knows how it was established:
+
+```text
+EXTRACTED   direct source/input evidence
+INFERRED    resolved from multiple structural facts
+AMBIGUOUS   multiple viable interpretations remain
+```
+
+Compass should preserve uncertainty instead of turning every candidate into an
+equally certain edge. Export, merge, history, and query operations must not
+silently discard provenance.
+
+## 4. Determinism where the inputs permit it
+
+Structural outputs should be reproducible under equivalent inputs and
+meaning-affecting configuration. That requires:
+
+- deterministic discovery and registries;
+- stable node identity;
+- stable ordering where output contracts require it;
+- bounded, explicit resolution;
+- canonical historical encoding;
+- fixed planner/language versions in cache keys;
+- tests against a pinned behavioral oracle where compatibility applies.
+
+Provider-backed semantics may not be perfectly reproducible. Compass isolates
+that variability in profiles, caches, validation, and completeness metadata.
+
+Determinism is semantic, not cosmetic: insignificant JSON object ordering is
+not graph meaning, while nodes, relationships, attributes, and multiplicity
+are.
+
+## 5. Reject unsupported meaning
+
+CompassQL is read-only and deliberately bounded. Unsupported constructs are
+rejected rather than approximated.
+
+The same rule applies broadly:
+
+- missing semantic credentials do not silently become a code-only historical
+  profile;
+- an unreadable preferred realization is not silently replaced;
+- unsafe checkout filters are rejected for historical materialization;
+- an incomplete semantic build cannot publish as complete;
+- a profile mismatch is surfaced before a normal diff.
+
+Explicit failure is easier to debug and safer to automate than plausible but
+different behavior.
+
+## 6. Bounded work is part of the interface
+
+Parsers, query engines, services, and network clients process potentially
+untrusted or unexpectedly large input.
+
+Compass uses bounds for:
+
+- graph JSON size;
+- semantic fragment nodes, edges, hyperedges, and bytes;
+- provider response size;
+- media and archive expansion;
+- CompassQL source, tokens, nesting, paths, rows, expansions, memory, and time;
+- subprocess output and timeout;
+- URL ingestion and redirects;
+- MCP HTTP requests and result sizes.
+
+These are not afterthoughts. A limit failure is a distinct result that a caller
+must not interpret as “no matches.”
+
+## 7. Publish coherent artifact sets
+
+Generated artifacts must describe one successful build. The pipeline uses
+staging, build guards, validation, and atomic writes so a failure does not
+present incomplete data as complete.
+
+```text
+build temporary facts
+      |
+      v
+validate completeness
+      |
+      +-- fail --> retain prior coherent output / report failure
+      |
+      `-- pass --> atomically publish the new set
+```
+
+Historical publication is stronger: realizations are immutable and preferred
+pointers change only through validated, explicit operations.
+
+## 8. Separate models from orchestration
+
+Crate boundaries keep responsibilities reviewable:
+
+- `compass-model` owns graph data and indexing;
+- `compass-files` owns discovery, fingerprints, caches, and atomic filesystem
+  primitives;
+- `compass-languages` owns per-language extraction;
+- `compass-resolve` owns cross-file resolution;
+- `compass-graph` owns graph construction and algorithms;
+- `compass-query` and `compass-cypher` own query behavior;
+- `compass-core` orchestrates application workflows;
+- `compass-cli` owns command parsing and user-facing outcomes.
+
+Optional integrations have their own crates. A language extractor should not
+need to know how MCP authentication works; a graph renderer should not own Git
+history leases.
+
+## 9. Keep machine contracts explicit
+
+Human-readable output can improve. Machine consumers need version tags,
+documented schemas, stable diagnostics, and exact exit categories.
+
+Examples:
+
+- `compass.cql.result/1`;
+- `compass.cql.jsonl/1`;
+- canonical history encoding and schema versions;
+- typed diagnostics and error families;
+- opaque stable string IDs.
+
+An integration should reject an unknown major version. Compass should not
+encourage parsing prose when a structured format exists.
+
+## 10. Make current and historical truth distinct
+
+The working tree and an exact commit are different sources:
+
+```text
+compass update .            may include uncommitted working-tree state
+compass ... --at REV        exact commit + exact extraction fingerprint
+```
+
+Historical materialization is offline and isolated so local excludes,
+uncommitted files, network fetches, hooks, and checkout filter execution do not
+change the requested revision.
+
+The same commit can have several valid realizations. Compass makes the selected
+profile and preference visible.
+
+## 11. Compatibility is evidence, not identity
+
+Compass was inspired by Graphify and uses a frozen Graphify version as a
+development oracle for certified command families. This provides valuable
+behavioral evidence.
+
+Compass is not permanently constrained to Graphify's surface:
+
+- the shipped executable is `compass`;
+- CompassQL is Compass-native;
+- versioned graph history is Compass-native;
+- native architecture, performance, safety, and product needs can justify
+  divergence;
+- intentional incompatibility requires documentation and migration guidance.
+
+The compatibility ledger defines the current boundary. Marketing language does
+not.
+
+## 12. Developer experience follows correctness
+
+Fast cold builds, very fast unchanged updates, helpful reports, native
+installers, and coding-assistant integration matter because they make correct
+use practical.
+
+Performance changes still must preserve:
+
+- graph parity/equivalence;
+- deterministic ordering contracts;
+- completeness;
+- resource bounds;
+- clear failure.
+
+The [performance qualification](../../PERFORMANCE.md) requires graph
+correctness before speed results are accepted.
+
+## 13. Generated output remains inspectable
+
+Compass produces ordinary files and documented structures:
+
+- JSON graphs;
+- Markdown reports;
+- optional HTML/SVG/export formats;
+- SQLite-backed history with explicit commands;
+- plain-text and structured query output.
+
+Users can inspect, diff, validate, export, and archive the result. Compass does
+not require all value to remain behind a proprietary hosted API.
+
+## Decision checklist for a new feature
+
+Before adding a feature, ask:
+
+```text
+Does structural/local behavior still work without it?
+Where is the network, credential, or execution boundary?
+What evidence and provenance will results carry?
+What are the resource and input bounds?
+How is incomplete work prevented from publishing?
+Which crate owns the responsibility?
+What is the exact machine contract?
+Does it affect historical fingerprints?
+Is it compatible, intentionally divergent, or Compass-native?
+What fixture proves direction, multiplicity, attributes, and failure?
+```
+
+If those questions do not have clear answers, the design is not ready.
+
+## Related pages
+
+- [System architecture](architecture.md)
+- [Security and privacy](security-and-privacy.md)
+- [Compatibility reference](../reference/compatibility.md)
+- [Performance qualification](../../PERFORMANCE.md)
+
+**Next step:** read [System architecture](architecture.md) to see how these
+principles map onto crates and data flows.

--- a/docs/design/security-and-privacy.md
+++ b/docs/design/security-and-privacy.md
@@ -1,0 +1,298 @@
+# Security and privacy design
+
+Compass analyzes source repositories and can optionally contact external
+systems. Its security model begins by separating fully local structural work
+from explicit network, credential, subprocess, and historical-checkout
+boundaries.
+
+> **Who this page is for:** security reviewers, operators, integrators, and
+> contributors changing an input or network boundary.
+>
+> **You will learn:** what stays local, when data can leave the machine, how
+> untrusted input is bounded, and which operational practices remain the
+> deployer's responsibility.
+>
+> **Prerequisites:** [Design principles](principles.md).
+>
+> **Reading time:** 12–15 minutes.
+
+> This page explains architecture. The authoritative vulnerability-reporting
+> and supported-version policy is [SECURITY.md](../../SECURITY.md).
+
+## Trust-boundary map
+
+```text
+Repository files
+     |
+     v
+Local structural pipeline -----------------------+
+  parsers · resolution · graph · local queries   |
+     |                                            |
+     v                                            |
+compass-out/ and local history                    |
+                                                  |
+Explicit optional boundaries                      |
+  +--> semantic provider endpoint                 |
+  +--> GitHub / remote clone / URL ingestion      |
+  +--> PostgreSQL / Google Workspace              |
+  +--> Neo4j / FalkorDB                           |
+  +--> MCP HTTP clients                           |
+  `--> bounded helper subprocesses                |
+```
+
+The default code-only graph path does not need a network or model key.
+
+## Data that remains local by default
+
+For structural source analysis:
+
+- file discovery happens locally;
+- tree-sitter parsing happens locally;
+- language extraction and resolution happen locally;
+- graph construction, clustering, reporting, and querying happen locally;
+- outputs are written to local `compass-out/`;
+- no embedding store is created;
+- Python is not launched by the released executable.
+
+Your operating environment can still copy, back up, index, or monitor these
+files. “Local” describes Compass's data path, not the entire host.
+
+## When data can leave the machine
+
+### Semantic providers
+
+When a semantic backend is configured, supported document/media content or
+derived chunks can be sent to that provider.
+
+Before use:
+
+- approve endpoint and provider;
+- understand retention and training policy;
+- scope the corpus;
+- configure timeouts and concurrency;
+- keep secrets in an approved store/environment;
+- decide how partial results are handled.
+
+An Ollama-compatible URL is local only when it actually points to an approved
+local endpoint. Compass checks URL schemes, warns on non-loopback transfer, and
+rejects link-local/metadata targets in relevant paths.
+
+### Remote ingestion and cloning
+
+`compass add` and `compass clone` fetch remote content. URL ingestion is
+bounded and SSRF-resistant, but fetched content remains untrusted.
+
+Do not automatically execute build scripts from an untrusted clone. Use a
+dedicated directory and sandbox according to your organization.
+
+### External services
+
+GitHub PR workflows, PostgreSQL introspection, Google Workspace export, and
+Neo4j/FalkorDB push all cross explicit service boundaries. Consult command help
+and network policy.
+
+### MCP HTTP
+
+HTTP service mode can expose graph and source-location information. Bind
+narrowly, authenticate, limit requests, and terminate TLS appropriately.
+Prefer stdio for a single local assistant.
+
+## Credentials
+
+Built-in providers use documented environment variables. Custom provider
+metadata stores an environment-variable *name*, not the secret itself.
+
+Rules:
+
+- never pass keys as positional query text;
+- never commit keys in provider config, docs, fixtures, or agent instructions;
+- redact authorization headers and secret URLs from logs;
+- use separate credentials for development and production;
+- rotate credentials after accidental disclosure;
+- do not include secret values in extraction fingerprints.
+
+History fingerprints include provider/model configuration because it affects
+meaning, while excluding credentials because they do not.
+
+## Untrusted source and graph input
+
+Repository content can be adversarial:
+
+- deeply nested syntax;
+- oversized files;
+- malformed JSON/XML/archives;
+- decompression bombs;
+- path traversal attempts;
+- prompt-injection text;
+- malicious URLs;
+- huge query expansions;
+- invalid graph endpoints.
+
+Compass uses:
+
+- raw and decompressed size caps;
+- archive member and compression-ratio limits;
+- parser/JSON depth and record limits;
+- source and output extension checks;
+- canonical/root-bound path handling;
+- URL scheme/host/address validation;
+- query depth/row/expansion/memory/deadline limits;
+- subprocess timeouts and output caps;
+- semantic fragment validation and injection-sentinel neutralization.
+
+Limits should fail explicitly. A caller must not reinterpret a limit failure as
+empty or complete data.
+
+## Historical checkout threats
+
+Checking out an old Git commit can execute code through hooks, filters, LFS,
+submodules, credential helpers, or network fetches if done naively.
+
+Compass historical materialization:
+
+- creates a detached offline worktree;
+- does not run hooks;
+- rejects external-code checkout filters;
+- does not fetch or prompt;
+- does not smudge LFS;
+- does not recurse submodules;
+- reports Gitlinks/LFS pointers as limitations;
+- excludes caller-local and global ignore state.
+
+This reduces both nondeterminism and repository-controlled code execution.
+
+## Output sensitivity
+
+`graph.json` and reports can reveal:
+
+- file paths and source locations;
+- internal type/function names;
+- architecture and dependencies;
+- database/schema names;
+- document concepts;
+- external service relationships;
+- potential high-value hubs.
+
+Treat graph artifacts with the same or higher classification as the source
+corpus. Do not upload them to a public artifact store merely because they
+contain less text than the repository.
+
+HTML and SVG exports must remain self-contained and avoid loading untrusted
+external scripts/fonts/resources.
+
+## Atomicity and integrity
+
+An attacker or concurrent process may try to make a consumer read an incomplete
+artifact.
+
+Compass:
+
+- writes through atomic helpers;
+- validates graph structures;
+- uses build guards;
+- signs binary cache reuse with graph file metadata;
+- validates history realizations before read/export/preference;
+- uses SQLite durability and content-addressed roots.
+
+Consumers should:
+
+- wait for a successful producing process;
+- open files with least privilege;
+- reject unknown structured-output major versions;
+- validate hashes/signatures when transferring artifacts;
+- prevent untrusted users from replacing a graph path.
+
+## Service and query isolation
+
+CompassQL is read-only and rejects mutations, procedures, `LOAD CSV`, dynamic
+execution, and unbounded paths.
+
+That reduces query-driven side effects. It does not replace process isolation:
+a service still reads graph files, uses memory/CPU, and may expose sensitive
+results.
+
+Set per-request budgets and avoid serving multiple trust domains from one
+unpartitioned graph.
+
+## Subprocess boundaries
+
+Some optional workflows use controlled subprocesses such as Git, GitHub CLI,
+or `gws`.
+
+Safe patterns include:
+
+- argument arrays rather than shell concatenation;
+- explicit timeouts;
+- captured-output caps;
+- restricted environment;
+- validated paths/URLs;
+- stable executable discovery;
+- no secrets echoed in diagnostics.
+
+When adding a subprocess, test timeout, nonzero exit, oversized output,
+malformed UTF-8, and missing executable behavior.
+
+## Threat-informed operating checklist
+
+### Fully local code graph
+
+- [ ] Use `--code-only` when non-code inputs should be excluded.
+- [ ] Keep `compass-out/` private like the source.
+- [ ] Exclude unneeded generated/vendor directories.
+- [ ] Run as a non-privileged user.
+
+### Semantic graph
+
+- [ ] Approve endpoint, model, and retention policy.
+- [ ] Store key outside the repository.
+- [ ] Test on non-sensitive content.
+- [ ] Set time/concurrency/size limits.
+- [ ] Surface partial status.
+
+### MCP HTTP
+
+- [ ] Bind to intended interface only.
+- [ ] Configure supported authentication.
+- [ ] Terminate TLS appropriately.
+- [ ] Limit graph/request/result size.
+- [ ] Separate trust domains.
+
+### History
+
+- [ ] Back up SQLite and WAL coherently.
+- [ ] Do not edit preferred pointers or Prolly keys.
+- [ ] Do not copy/delete live resources piecemeal.
+- [ ] Use explicit recovery commands.
+
+### External export
+
+- [ ] Confirm target and write semantics.
+- [ ] Use environment-provided secrets.
+- [ ] Test on disposable target.
+- [ ] Verify counts and known paths.
+
+## Vulnerability reporting
+
+Do not open a public issue for a suspected vulnerability. Follow
+[SECURITY.md](../../SECURITY.md) for the current supported versions and private
+reporting channel.
+
+Include:
+
+- Compass version and platform;
+- minimal reproduction;
+- trust boundary crossed;
+- impact and required preconditions;
+- logs with credentials/source content removed;
+- whether the issue affects current-tree, history, service, provider, or
+  integration paths.
+
+## Related pages
+
+- [Security policy](../../SECURITY.md)
+- [Operations](../guides/operations.md)
+- [Storage and history](storage-and-history.md)
+- [Configuration reference](../reference/configuration.md)
+
+**Next step:** identify which optional boundaries your deployment enables and
+complete the matching checklist before processing a sensitive repository.

--- a/docs/design/storage-and-history.md
+++ b/docs/design/storage-and-history.md
@@ -1,0 +1,297 @@
+# Storage and history design
+
+Compass has two storage models: a mutable current-tree artifact directory and
+an immutable exact-revision history store. They solve different problems and
+have different recovery rules.
+
+> **Who this page is for:** history contributors, maintainers operating large
+> repositories, and integrators requiring reproducible graphs.
+>
+> **You will learn:** current artifact publication, incremental caches,
+> historical fingerprints, Prolly trees, SQLite durability, jobs/leases,
+> validation, export, and garbage collection.
+>
+> **Prerequisites:** [Versioned graph history](../guides/versioned-history.md).
+>
+> **Reading time:** 12–15 minutes.
+
+## Two storage planes
+
+```text
+Current working tree                    Exact Git history
+--------------------                    -----------------
+compass-out/                            <git-common-dir>/compass/
+mutable artifact set                   immutable realizations
+fast incremental rebuild               content-addressed Prolly trees
+can include uncommitted files          exact commit only
+one practical current result           multiple profiles per commit
+```
+
+Do not use one as if it were the other.
+
+## Current-tree artifacts
+
+The normal pipeline writes:
+
+```text
+compass-out/
+├── graph.json
+├── GRAPH_REPORT.md
+├── graph.html
+├── manifest.json
+└── cache/ and optional sidecars
+```
+
+### Manifest and cache
+
+The manifest records the inputs needed to identify unchanged, changed, added,
+renamed, or deleted work. Cached per-file extraction can be reused when its
+fingerprints and parser/extractor inputs remain compatible.
+
+Query loading may build binary caches beside `graph.json`, keyed by graph file
+signature. These caches accelerate repeated reads and are disposable; the JSON
+graph is authoritative.
+
+### Publication
+
+Atomic filesystem helpers write temporary data and replace completed outputs.
+Build guards distinguish a successful complete build from interrupted state.
+
+Consumers should use the producing command's successful exit as the handoff
+point, not poll for the first appearance of a file.
+
+## Historical identity
+
+A history lookup begins with:
+
+```text
+Git revision -> exact commit ID
+```
+
+The storage identity also includes an extraction fingerprint:
+
+```text
+fingerprint inputs:
+  build profile
+  graph and canonical-encoding versions
+  parser/extractor/analyzer versions
+  provider and model configuration
+  meaning-affecting exclusions/options
+```
+
+Excluded:
+
+- credentials;
+- machine-local paths;
+- timings;
+- token counts;
+- operational metadata that does not change graph meaning.
+
+This lets the same commit have multiple immutable realizations without
+silently mixing them.
+
+## Artifact partitioning
+
+A complete realization includes more than nodes and edges:
+
+- graph document;
+- hyperedges;
+- communities and analysis;
+- semantic/inferred data;
+- reconstruction metadata;
+- authoritative sidecars;
+- artifact registry entries and renderer versions;
+- completion evidence.
+
+Large maps are partitioned into typed Prolly trees. Canonical keys encode
+record class and identity so diffs and reconstruction remain deterministic.
+
+## Prolly trees
+
+A Prolly tree is a content-addressed ordered map whose chunk boundaries are
+determined by content. Similar versions can share unchanged nodes:
+
+```text
+version A root ----> branch ----> leaf 1
+                           \----> leaf 2
+
+version B root ----> branch' ---> leaf 1   shared
+                            \---> leaf 2'  changed
+```
+
+This supports:
+
+- structural sharing across nearby commits;
+- deterministic roots;
+- efficient key-range comparison;
+- reconstruction without storing one full duplicate JSON file per revision.
+
+The public contract is the validated realization and export, not the internal
+shape of one SQLite table.
+
+## SQLite durability
+
+`prolly-store-sqlite` is pinned and configured with:
+
+- write-ahead logging;
+- full synchronous durability;
+- a busy timeout.
+
+The live resource set includes:
+
+```text
+history.sqlite
+history.sqlite-wal / shared-memory state as applicable
+jobs
+leases
+locks
+protected worktree records
+other operational files
+```
+
+Copying only `history.sqlite` while writers are active can omit committed WAL
+state. Backup and restore must treat the SQLite resource coherently.
+
+## Publication protocol
+
+Historical publication is staged:
+
+```text
+build complete artifacts
+       |
+       v
+validate sizes, keys, records, references, evidence
+       |
+       v
+prepare content-addressed trees and registry
+       |
+       v
+atomic publication transaction
+       |
+       v
+optional preferred-pointer update
+```
+
+An incomplete, invalid, or provider-failed candidate cannot become preferred.
+Published realization content is immutable.
+
+## Preferred realizations
+
+Preference gives read commands a default when a commit has multiple valid
+profiles.
+
+Rules:
+
+- preference is stored separately from immutable content;
+- selection validates the target realization;
+- an unreadable preferred pointer is not overwritten silently;
+- corrupt replacement requires explicit `rebuild --replace-corrupt`;
+- replacement uses compare-and-swap observation to avoid racing another
+  repair.
+
+## Jobs and leases
+
+Eager hooks enqueue durable work and return quickly. A worker:
+
+1. reads FIFO jobs;
+2. claims or joins through a lease;
+3. heartbeats while materializing;
+4. publishes or records a terminal diagnostic;
+5. continues to later jobs even after one failure.
+
+Leases prevent duplicate workers from casually publishing the same work while
+allowing recovery from expired ownership.
+
+Operational job state is not embedded into immutable graph values; it can age
+out independently.
+
+## Historical checkout isolation
+
+Materialization uses a protected worktree under a restrictive policy:
+
+- exact detached commit;
+- offline;
+- no fetch or credential prompt;
+- no user hooks;
+- no recursive submodules;
+- no LFS smudge;
+- no external-code checkout filters;
+- committed ignore policy only.
+
+This is both reproducibility and security design. A historical query should not
+execute arbitrary repository-controlled checkout behavior.
+
+## Diff model
+
+Diff compares typed records:
+
+- nodes;
+- edges;
+- hyperedges;
+- optional locations;
+- optional analysis;
+- optional metadata.
+
+Topology-only diff avoids reconstructing irrelevant payloads and is qualified
+against the full diff.
+
+Normal comparison checks fingerprint compatibility first. An explicit mismatch
+flag permits inspection, not semantic equivalence.
+
+## Export and reconstruction
+
+`graph-json` reconstructs canonical graph JSON.
+
+`compass-out`:
+
+- restores authoritative sidecars exactly;
+- regenerates derived report/HTML only with recorded renderer versions;
+- validates realization completeness before reconstruction.
+
+Meaning is judged canonically. JSON object ordering can vary; relationship
+multiplicity and authoritative bytes cannot.
+
+## Garbage collection
+
+Default GC preserves all published realizations and removes:
+
+- unreachable content-addressed nodes;
+- expired operational records.
+
+Non-preferred realization pruning is separate, dry-run by default, and requires
+`--yes` to apply.
+
+Logical reclamation does not mean the SQLite file immediately shrinks. GC does
+not promise `VACUUM`.
+
+## Recovery principles
+
+```text
+Disposable current cache corrupt?
+  -> remove/rebuild the disposable cache, retain graph JSON
+
+Current artifact set incomplete?
+  -> rerun update to a known output, inspect build guard/diagnostic
+
+Historical realization invalid?
+  -> list/show/validate, rebuild explicitly
+
+Preferred pointer corrupt?
+  -> use replace-corrupt workflow, not manual SQLite editing
+
+Live database backup inconsistent?
+  -> restore coherent SQLite/WAL backup
+
+Lease appears stuck?
+  -> inspect job/lease state and expiry; do not delete live files blindly
+```
+
+## Related pages
+
+- [Versioned graph history](../guides/versioned-history.md)
+- [History crate tour](../implementation/workspace-tour.md)
+- [Output reference](../reference/outputs.md)
+- [Security and privacy](security-and-privacy.md)
+
+**Next step:** inspect `compass history list HEAD --format json` in a disposable
+repository and identify commit, realization, fingerprint, and preference.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,386 @@
+# Getting started with Compass
+
+This guide takes you from a new installation to a useful answer about a
+codebase. It starts with structural code analysis, which runs locally and does
+not require model credentials.
+
+> **Who this guide is for:** new users and evaluators.
+>
+> **You will learn:** how to install Compass, build a graph, understand its
+> output, ask four kinds of questions, and recognize a successful run.
+>
+> **Prerequisites:** a macOS release target or a Rust 1.97.1+ toolchain for a
+> source build; a source-code repository to inspect.
+>
+> **Completion time:** 10–15 minutes, plus compilation time for a source build.
+
+![From a project directory to the first Compass answer](assets/diagrams/first-graph.svg)
+
+## What you will produce
+
+At the end of this guide, a project directory will contain:
+
+```text
+your-project/
+├── src/
+├── ...
+└── compass-out/
+    ├── graph.json
+    ├── GRAPH_REPORT.md
+    ├── graph.html        when the graph is within the visualization limit
+    └── manifest.json
+```
+
+You will also be able to run:
+
+```bash
+compass query "where is authentication enforced?"
+compass explain AuthenticationService
+compass path LoginHandler AuthenticationService
+compass affected AuthenticationService --depth 3
+```
+
+The exact symbols in your repository will differ. The important outcome is
+that Compass can find and traverse relationships without rereading every source
+file for each question.
+
+## 1. Choose an installation path
+
+### Install a macOS release
+
+The current release workflow publishes Intel and Apple Silicon macOS archives.
+The installer downloads the latest archive, verifies its SHA-256 checksum, and
+installs `compass` into `~/.local/bin` by default:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/crabbuild/compass/releases/latest/download/install.sh |
+  sh
+```
+
+Choose another directory by setting `COMPASS_INSTALL_DIR` for the installer
+process:
+
+```bash
+COMPASS_INSTALL_DIR="$PWD/bin" sh install.sh
+```
+
+The current macOS release is unsigned and not notarized. Read the release notes
+and [security policy](../SECURITY.md) before using an installer in a controlled
+environment.
+
+### Build from source
+
+The repository pins Rust 1.97.1 in `rust-toolchain.toml`:
+
+```bash
+git clone https://github.com/crabbuild/compass.git
+cd compass
+cargo install --locked --path crates/compass-cli --bin compass
+```
+
+`--locked` uses the dependency versions in `Cargo.lock`. The resulting
+executable is native: normal use does not launch Python. Python is used only by
+selected development parity tests.
+
+### Verify the binary
+
+Run:
+
+```bash
+compass --version
+compass --help
+```
+
+A successful installation prints a version and the public command surface. If
+your shell reports `compass: command not found`, first check:
+
+```bash
+command -v compass
+printf '%s\n' "$PATH"
+```
+
+For the default installer location, make sure `~/.local/bin` is on `PATH`, then
+open a new shell.
+
+## 2. Choose a repository
+
+You can use an existing checkout. For a low-risk first run, use a small sample
+repository or create one:
+
+```bash
+mkdir compass-first-project
+cd compass-first-project
+git init
+mkdir src
+```
+
+Create `src/app.py` with a small call chain:
+
+```python
+class PaymentGateway:
+    def charge(self, amount):
+        return {"approved": True, "amount": amount}
+
+
+def authorize_payment(gateway, amount):
+    return gateway.charge(amount)
+
+
+def checkout(total):
+    gateway = PaymentGateway()
+    return authorize_payment(gateway, total)
+```
+
+Compass does not require a Git repository for a normal current-tree build, but
+Git is required for exact-revision history features.
+
+## 3. Build the graph
+
+From the project root, run:
+
+```bash
+compass update .
+```
+
+`update` is the normal “make the saved graph match this working tree” command.
+On the first run, Compass performs a cold build. On later runs it can use the
+manifest and extraction cache to avoid repeating unchanged work.
+
+For source code, Compass:
+
+```text
+discovers files
+      |
+      v
+detects languages and project metadata
+      |
+      v
+parses syntax and extracts entities/relations
+      |
+      v
+resolves cross-file references
+      |
+      v
+analyzes and publishes compass-out/
+```
+
+Structural extraction does not call a model. If a project includes documents,
+images, or other semantic sources, use `--code-only` when you explicitly want
+to skip them:
+
+```bash
+compass extract . --code-only
+```
+
+`extract` exposes detailed build controls. For most first-time codebase use,
+`update` is the simpler entry point.
+
+## 4. Confirm that the build succeeded
+
+Check the expected files:
+
+```bash
+test -f compass-out/graph.json
+test -f compass-out/GRAPH_REPORT.md
+test -f compass-out/manifest.json
+```
+
+Then read the report:
+
+```bash
+sed -n '1,160p' compass-out/GRAPH_REPORT.md
+```
+
+The report is the fastest repository-wide orientation. It summarizes graph
+size and points out highly connected nodes, communities, and diagnostics. A
+large degree does not automatically mean “most important”: generic utilities
+and broad containers may also become highly connected.
+
+If `graph.html` exists, open it with your platform's normal browser command:
+
+```bash
+open compass-out/graph.html       # macOS
+xdg-open compass-out/graph.html  # many Linux desktops
+```
+
+The HTML view is for exploration. `graph.json` remains the machine-readable
+source for query commands and integrations.
+
+## 5. Ask the first four questions
+
+Compass provides several question shapes because no single ranking works for
+every investigation.
+
+### Find a relevant neighborhood
+
+```bash
+compass query "payment authorization"
+```
+
+Natural-language query is local graph discovery, not a model-generated answer.
+Compass scores likely anchors and traverses the saved graph to return a focused
+subgraph.
+
+Use a sentence that names the behavior you care about:
+
+```bash
+compass query "where are failed payments retried?"
+compass query "configuration loading and validation"
+compass query "HTTP request authentication"
+```
+
+### Explain one entity
+
+```bash
+compass explain authorize_payment
+```
+
+`explain` shows the matching node and its incoming and outgoing relationships.
+Use it after a broad query gives you a symbol worth inspecting.
+
+### Trace a path
+
+```bash
+compass path checkout PaymentGateway
+```
+
+`path` finds a known route between two graph entities. A path explains
+connectivity in the extracted graph; it is not necessarily the only runtime
+path or proof that every edge executes in one transaction.
+
+### Estimate change impact
+
+```bash
+compass affected authorize_payment --depth 3
+```
+
+`affected` follows impact-relevant relationships to produce a review scope.
+Treat its output as evidence for investigation, not a guarantee that every
+returned file must change or that every possible dynamic dependency was found.
+
+## 6. Read provenance instead of treating every edge equally
+
+A result may include relationships marked with provenance such as
+`EXTRACTED`, `INFERRED`, or `AMBIGUOUS`:
+
+```text
+checkout
+   |
+   +--CALLS [EXTRACTED]--> authorize_payment
+                                  |
+                                  `--USES [INFERRED]--> PaymentGateway
+```
+
+- **EXTRACTED** means direct source or parser evidence created the relation.
+- **INFERRED** means Compass resolved evidence across scopes or files.
+- **AMBIGUOUS** means more than one interpretation remained.
+
+Inference here is structural resolution; it does not imply an LLM invented the
+edge. See [Provenance and confidence](concepts/provenance.md) for the full
+model.
+
+## 7. Run an exact query when discovery is not enough
+
+CompassQL is a deterministic, read-only subset of openCypher:
+
+```bash
+compass query --cql \
+  "MATCH (caller)-[:CALLS]->(target)
+   WHERE target.label = 'authorize_payment'
+   RETURN caller.id, target.id
+   LIMIT 20"
+```
+
+Use CompassQL when you need an exact graph pattern, parameters, stable
+automation, or JSON/JSONL output. Compass never guesses whether input is
+CompassQL; `--cql` is explicit.
+
+Before building automation, read:
+
+- [CompassQL concepts](concepts/compassql.md)
+- [CompassQL 1 reference](COMPASSQL.md)
+- [CompassQL support matrix](COMPASSQL_SUPPORT.md)
+
+## 8. Install the coding-assistant integration
+
+Compass embeds its assistant skill assets in the binary:
+
+```bash
+compass install
+```
+
+Choose a specific platform or project scope when needed:
+
+```bash
+compass install --platform codex
+compass install --project --platform codex
+```
+
+A global installation is convenient for personal use. A project-scoped
+installation can be reviewed and shared with a repository. Inspect generated
+files before committing them, especially in a repository with existing agent
+instructions.
+
+See [Assistant setup](guides/assistant-setup.md) for platform selection,
+verification, upgrades, and removal.
+
+## 9. Update after a code change
+
+Edit a source file, then run:
+
+```bash
+compass update .
+```
+
+An incremental update should preserve unchanged extraction work and republish a
+coherent artifact set. Do not edit `graph.json` or `manifest.json` by hand and
+expect an update to preserve those edits.
+
+For continuous local changes, `compass watch` can keep the output current. Read
+[Operations](guides/operations.md) before using a long-running process in CI or
+an editor integration.
+
+## Common first-run problems
+
+| Symptom | Likely cause | What to do |
+| --- | --- | --- |
+| `compass` is not found | Install directory is not on `PATH` | Add the directory, open a new shell, rerun `command -v compass` |
+| Rust build selects another toolchain | Local override or old rustup state | Run `rustup show`, then use the pinned toolchain from `rust-toolchain.toml` |
+| Expected files are missing | Command failed or wrote to another output directory | Read stderr, check the exit status, and look for `--out` in the command |
+| Non-code files ask for provider configuration | Semantic sources are present | Configure a provider intentionally or use a code-only build |
+| A symbol is not found | It was ignored, unsupported, generated, or labeled differently | Inspect `GRAPH_REPORT.md`, query by file/module, and read [Troubleshooting](cookbook/troubleshooting.md) |
+| `graph.html` is absent | Visualization was disabled or the graph exceeds its rendering limit | Query `graph.json` through the CLI; HTML is not required |
+| Results feel too broad | Query text names a generic concept or hub | Add domain terms, explain a specific result, or use CompassQL |
+
+## What Compass does not promise
+
+- A static graph is not a complete runtime trace.
+- Dynamic dispatch, generated code, reflection, and unavailable build metadata
+  can limit what structural analysis resolves.
+- An inferred edge is evidence-backed but less direct than an extracted edge.
+- A current-tree graph does not represent an old commit; use
+  [versioned history](guides/versioned-history.md) for exact revisions.
+- A successful local build does not expand the officially supported release
+  platform matrix. Follow [Compatibility](../COMPATIBILITY.md).
+
+## Clean up
+
+The current-tree build is stored under `compass-out/`. Remove that directory
+only when you intend to discard the generated graph and incremental manifest.
+It can be regenerated with `compass update .`.
+
+Versioned history is different: it is stored under the repository's Git common
+directory and may be shared by linked worktrees. Do not delete its SQLite,
+WAL, or operational files while Compass is running. Use history commands
+described in [Versioned graph history](guides/versioned-history.md).
+
+## Related pages
+
+- [Documentation hub](README.md)
+- [How Compass works](concepts/how-it-works.md)
+- [Explore an unfamiliar codebase](guides/exploring-a-codebase.md)
+- [Troubleshooting cookbook](cookbook/troubleshooting.md)
+
+**Next step:** use [Explore an unfamiliar codebase](guides/exploring-a-codebase.md)
+to turn your first graph into a repeatable investigation.

--- a/docs/guides/assistant-setup.md
+++ b/docs/guides/assistant-setup.md
@@ -1,0 +1,274 @@
+# Set up Compass for a coding assistant
+
+Compass embeds assistant integration assets in its native executable. This
+guide explains how to select a platform and scope, inspect what was installed,
+and remove it safely.
+
+> **Who this guide is for:** developers using Compass with coding assistants
+> and maintainers deciding what agent instructions belong in a repository.
+>
+> **You will learn:** global versus project scope, platform selection, strict
+> mode, verification, upgrades, and safe uninstall.
+>
+> **Prerequisites:** the `compass` executable installed.
+>
+> **Completion time:** 5–10 minutes.
+
+## What the integration does
+
+The installed skill teaches an assistant to use the graph before reading a
+large set of raw files:
+
+```text
+architecture question
+      |
+      v
+read compass-out/GRAPH_REPORT.md for broad context
+      |
+      v
+run compass query for a focused subgraph
+      |
+      v
+open only the source files needed to verify the answer
+```
+
+It does not give Compass permission to run arbitrary external actions. It
+provides task instructions and, where the platform supports them, helper
+integration files.
+
+## Global or project scope
+
+### Global installation
+
+```bash
+compass install --platform codex
+```
+
+Use global scope when:
+
+- this is your personal tool configuration;
+- many repositories should use the same skill;
+- you do not want generated assistant files committed per repository.
+
+### Project installation
+
+```bash
+compass install --project --platform codex
+```
+
+Use project scope when:
+
+- the team should review and share the instructions;
+- the repository already defines assistant behavior;
+- a CI or reproducible development environment needs explicit setup.
+
+Project scope writes under the current project. Review `git status` before
+committing generated files:
+
+```bash
+git status --short
+git diff -- . ':!compass-out'
+```
+
+Never overwrite an existing project instruction file without reviewing the
+merged result.
+
+## Select a platform explicitly
+
+Run:
+
+```bash
+compass install --help
+```
+
+The current native installer recognizes the platforms printed by that command,
+including Codex, Claude-family layouts, Agent Skills layouts, Gemini, Cursor,
+and other supported assistants.
+
+Examples:
+
+```bash
+compass install --platform codex
+compass install --platform agents
+compass install --platform gemini
+compass install --platform cursor
+```
+
+`skills` is accepted as an alias for the generic `agents` target. Exact
+destinations differ by platform and scope; use installer output as the source
+of truth instead of copying paths from another tool.
+
+If no platform is passed, the installer uses its documented/default detection
+behavior. Teams should prefer an explicit platform in setup scripts.
+
+## Understand project destinations
+
+Representative project-scoped destinations include:
+
+```text
+Codex       .codex/skills/compass/SKILL.md
+Agents      .agents/skills/compass/SKILL.md
+Claude      .claude/skills/compass/SKILL.md
+Gemini      Gemini-specific skill/config files and GEMINI.md integration
+Cursor      Cursor-specific project integration
+```
+
+The installer can also write companion reference or integration files required
+by the selected platform. Treat the printed file list and `git status` as the
+authoritative result.
+
+## Strict mode
+
+For a supported Claude Code project installation:
+
+```bash
+compass install --project --platform claude --strict
+```
+
+Strict mode blocks the first raw file read in a session until one
+`compass query` runs. It is designed to enforce a graph-first start without
+trapping the entire session.
+
+Runtime control:
+
+```bash
+COMPASS_HOOK_STRICT=0 your-assistant-command
+```
+
+Strict mode:
+
+- requires project scope;
+- applies only where the platform's hook mechanism supports it;
+- is not a security sandbox;
+- should be explained to repository contributors before adoption.
+
+## Verify the installation
+
+### Inspect files
+
+```bash
+git status --short
+```
+
+For a project install, open the installed `SKILL.md` and any referenced files.
+Check:
+
+- commands use `compass`, not a stale product name;
+- output paths use `compass-out/`;
+- repository instructions are preserved;
+- no machine-specific path or credential was written;
+- platform-specific syntax matches the selected assistant.
+
+### Exercise the workflow
+
+In a project with a graph:
+
+1. ask the assistant a broad architecture question;
+2. confirm it reads `compass-out/GRAPH_REPORT.md` or runs a focused query;
+3. ask a narrow implementation question;
+4. confirm it verifies graph results in source;
+5. check that it does not treat inferred/ambiguous edges as unquestionable
+   runtime truth.
+
+### Verify idempotence
+
+Run the same install command again:
+
+```bash
+compass install --project --platform codex
+```
+
+The result should update managed content without duplicating sections
+indefinitely. Review the diff.
+
+## Upgrade
+
+After upgrading the Compass binary, rerun the same installation command:
+
+```bash
+compass install --project --platform codex
+```
+
+This refreshes embedded assets for that version. Review changes like any
+dependency or generated configuration update.
+
+For global installs, record the Compass version in workstation/bootstrap
+automation if reproducibility matters.
+
+## Uninstall
+
+Use the native lifecycle command:
+
+```bash
+compass uninstall --project --platform codex
+```
+
+For global scope, omit `--project`:
+
+```bash
+compass uninstall --platform codex
+```
+
+`--purge` is a stronger removal mode:
+
+```bash
+compass uninstall --project --platform codex --purge
+```
+
+Before using `--purge`, inspect `compass uninstall --help` and the target
+files. Managed-section removal and full-file deletion have different recovery
+implications.
+
+After uninstall:
+
+```bash
+git status --short
+```
+
+Confirm that user-authored instructions remain. Restore only from version
+control or backup when you are certain a removed file was meant to be tracked.
+
+## Repository instructions
+
+A healthy repository-level instruction is small and verifiable:
+
+```text
+This project has a Compass graph at compass-out/.
+
+Before answering architecture questions:
+1. read compass-out/GRAPH_REPORT.md;
+2. run compass query for the focused question;
+3. verify graph claims in source.
+
+After modifying source files, run compass update .
+```
+
+Avoid:
+
+- demanding that every trivial task rebuild the graph;
+- claiming the graph replaces source verification;
+- giving the assistant broad external-write authority;
+- checking secrets or machine-local paths into agent instructions;
+- duplicating a large generated skill in several instruction files.
+
+## Troubleshooting
+
+| Problem | Action |
+| --- | --- |
+| Unknown platform | Use a name printed by `compass install --help` |
+| Project files appear in an unexpected place | Confirm current directory and whether `--project` was passed |
+| Existing instructions changed | Inspect the diff; uninstall managed content and reapply after resolving ownership |
+| Strict mode blocks unexpectedly | Set `COMPASS_HOOK_STRICT=0` for the session, then review the project hook |
+| Assistant ignores the graph | Confirm it discovers the installed skill and that `compass-out/` exists |
+| Assistant over-trusts the graph | Strengthen instructions to verify source and qualify provenance |
+| Upgrade leaves stale content | Rerun install with the same scope/platform and review managed files |
+
+## Related pages
+
+- [Getting started](../getting-started.md)
+- [Explore a codebase](exploring-a-codebase.md)
+- [Security and privacy](../design/security-and-privacy.md)
+- [Troubleshooting cookbook](../cookbook/troubleshooting.md)
+
+**Next step:** ask the configured assistant one architecture question and
+verify that it narrows through Compass before opening source files.

--- a/docs/guides/exploring-a-codebase.md
+++ b/docs/guides/exploring-a-codebase.md
@@ -1,0 +1,383 @@
+# Explore an unfamiliar codebase
+
+This guide gives you a repeatable way to turn a large repository into a small
+set of architectural hypotheses, implementation paths, and review targets.
+
+> **Who this guide is for:** developers onboarding to a repository, reviewers,
+> maintainers, and coding-assistant users.
+>
+> **You will learn:** how to move from a repository-wide report to communities,
+> symbols, paths, impact, source verification, and a concise architecture note.
+>
+> **Prerequisites:** Compass installed and a successful `compass update .`.
+>
+> **Completion time:** 20–45 minutes for an initial survey.
+
+## The investigation loop
+
+Do not try to understand the whole graph at once. Use a narrowing loop:
+
+```text
+broad report
+    |
+    v
+one subsystem or question
+    |
+    v
+focused neighborhood
+    |
+    v
+specific node and path
+    |
+    v
+source verification
+    |
+    `---- refine the question ----+
+```
+
+Compass reduces the reading set; source code remains the final evidence for
+implementation behavior.
+
+## 1. Confirm freshness and scope
+
+From the repository root:
+
+```bash
+compass update .
+```
+
+Confirm the output:
+
+```bash
+test -f compass-out/graph.json
+test -f compass-out/GRAPH_REPORT.md
+```
+
+Before interpreting absence, check:
+
+- the requested root;
+- ignore and explicit exclude patterns;
+- whether the build was code-only;
+- whether generated or external sources exist outside the corpus;
+- whether the language or format is represented in the compatibility ledger.
+
+Record the current revision and dirty state in your investigation notes:
+
+```bash
+git rev-parse --short HEAD
+git status --short
+```
+
+A working-tree graph can include uncommitted changes. If the question is about
+an exact historical revision, use [versioned history](versioned-history.md)
+instead.
+
+## 2. Read the report as a map, not a verdict
+
+Open:
+
+```bash
+sed -n '1,240p' compass-out/GRAPH_REPORT.md
+```
+
+Look for:
+
+1. corpus size and diagnostics;
+2. high-degree nodes;
+3. communities and their representative entities;
+4. cross-file or surprising connections;
+5. suggested questions.
+
+Write three provisional notes:
+
+```text
+Likely entry point:
+Likely subsystem boundary:
+One surprising dependency to verify:
+```
+
+These are hypotheses. A community is a connectivity-derived group; a god node
+is highly connected. Neither is automatically the official architecture.
+
+## 3. Ask a behavior-shaped question
+
+Queries work better when they name a domain behavior than when they name a
+generic programming word.
+
+Good:
+
+```bash
+compass query "HTTP request authentication and session validation"
+compass query "payment retry and idempotency"
+compass query "database migration discovery and execution"
+```
+
+Too broad:
+
+```bash
+compass query "service"
+compass query "manager"
+compass query "data"
+```
+
+If the result is broad, add the boundary or action you care about:
+
+```text
+"authentication"                  broad
+"API authentication middleware"   narrower
+"API token verification failure"  behavior-shaped
+```
+
+Save useful output when comparing questions:
+
+```bash
+compass query "API token verification failure" > /tmp/compass-auth.txt
+```
+
+Do not treat temporary result text as a durable schema. For automation, use
+CompassQL JSON/JSONL.
+
+## 4. Pick and explain an anchor
+
+Choose a concrete result—preferably a function, class, file, or configuration
+entity with a source location:
+
+```bash
+compass explain AuthMiddleware
+```
+
+Read incoming and outgoing relations separately:
+
+```text
+incoming
+  who imports, calls, contains, or depends on this?
+
+outgoing
+  what does this import, call, contain, or depend on?
+```
+
+Check provenance. An `INFERRED` cross-file call can be a strong navigation lead,
+but it should send you to the supporting sources. An `AMBIGUOUS` edge belongs
+in a verification list.
+
+When a label matches several nodes, use the returned stable ID or add context
+such as the file/module name.
+
+## 5. Trace an implementation path
+
+Once you know two boundaries, connect them:
+
+```bash
+compass path HttpHandler TokenVerifier
+```
+
+Useful boundary pairs include:
+
+- endpoint to persistence;
+- command handler to side effect;
+- public API to internal implementation;
+- configuration key to consumer;
+- failing test to production symbol;
+- parser entry to output renderer.
+
+For each hop, record:
+
+| Hop | Relation | Provenance | Source verified? |
+| --- | --- | --- | --- |
+| 1 | calls | extracted | yes/no |
+| 2 | uses | inferred | yes/no |
+
+A shortest path is a compact explanation of known connectivity. It is not
+necessarily the only path, the most frequent path, or one runtime trace.
+
+If no path exists:
+
+1. query each endpoint independently;
+2. confirm the right node IDs;
+3. check direction and relation types;
+4. check ignored/generated/external code;
+5. try a subsystem boundary rather than a leaf symbol;
+6. record the missing link as a graph limitation or extraction issue.
+
+## 6. Understand structure around files and symbols
+
+Generate the tree view:
+
+```bash
+compass tree
+```
+
+The default HTML output is `compass-out/GRAPH_TREE.html`. Use it to move between
+filesystem structure and symbol-level edges. For a large repository, cap
+visible children or outbound edges:
+
+```bash
+compass tree --max-children 100 --top-k-edges 8
+```
+
+Tree view is useful when a graph neighborhood lacks the repository layout
+context a human expects.
+
+## 7. Estimate the review surface
+
+For a symbol you might change:
+
+```bash
+compass affected TokenVerifier --depth 3
+```
+
+Impact traversal typically follows incoming dependency-like relationships:
+
+```text
+caller --CALLS--> target
+
+change target
+    |
+    `--> inspect caller
+```
+
+Use the result to build a review checklist:
+
+- direct callers;
+- importing modules;
+- implementers or inheritors;
+- tests and fixtures;
+- configuration consumers;
+- cross-community dependencies.
+
+Do not convert the result mechanically into “all files that must change.”
+Static graphs can over-include potential dependencies and under-represent
+dynamic ones.
+
+## 8. Use CompassQL for a precise inventory
+
+After discovery tells you the pattern, make it explicit:
+
+```bash
+compass query --cql \
+  "MATCH (caller)-[edge:CALLS]->(target)
+   WHERE target.label = 'TokenVerifier'
+   RETURN caller.id, edge.confidence, target.id
+   ORDER BY caller.id
+   LIMIT 200"
+```
+
+Examples of useful inventories:
+
+### Cross-community calls
+
+```cypher
+MATCH (source)-[edge:CALLS]->(target)
+WHERE source.community <> target.community
+RETURN source.id, target.id, edge.confidence
+LIMIT 200
+```
+
+### Implementers of an interface
+
+```cypher
+MATCH (implementation)-[:IMPLEMENTS]->(contract)
+WHERE contract.label = $contract
+RETURN implementation.id
+ORDER BY implementation.id
+```
+
+### Ambiguous relationships for manual review
+
+```cypher
+MATCH (source)-[edge]->(target)
+WHERE edge.confidence = 'AMBIGUOUS'
+RETURN source.id, type(edge), target.id
+LIMIT 200
+```
+
+Confirm relation names and labels in your graph; extractor vocabularies can
+vary by language and input.
+
+## 9. Verify in source
+
+Compass should shorten source reading, not replace it. For each architectural
+claim:
+
+1. open the source locations from the node/edge;
+2. confirm direction and conditional behavior;
+3. check nearby comments, tests, and configuration;
+4. note dynamic behavior static extraction cannot prove;
+5. revise the graph question if the hypothesis was wrong.
+
+A useful architecture statement includes evidence:
+
+```text
+Token verification enters through AuthMiddleware, which delegates to
+TokenVerifier and reads SessionStore. Evidence: graph path at commit abc123,
+verified in src/http/auth.rs and src/auth/token.rs. Dynamic provider selection
+remains configuration-dependent.
+```
+
+## 10. Write a digestible architecture note
+
+Use this template:
+
+```text
+Question
+  What behavior or boundary did we investigate?
+
+Entry points
+  Which public handlers, commands, or jobs start it?
+
+Core path
+  What are the 3–7 most important hops?
+
+State and side effects
+  Which databases, files, queues, or providers are touched?
+
+Subsystem boundaries
+  Which communities/modules participate?
+
+Change impact
+  Which direct dependents and tests deserve review?
+
+Uncertainty
+  Which ambiguous, dynamic, ignored, or external behavior remains?
+
+Evidence
+  Graph revision/profile, commands, and source files verified.
+```
+
+This keeps the result useful to a teammate who never saw the raw query output.
+
+## Working with a coding assistant
+
+Give the assistant a focused subgraph and an explicit goal:
+
+```text
+Goal: explain token verification failure handling.
+Graph evidence: output of the focused Compass query and path.
+Constraints: verify claims in the cited source files; treat ambiguous edges as
+leads; do not read unrelated directories.
+```
+
+Avoid pasting an entire large `graph.json` into a model. The value of Compass is
+to choose a smaller, structurally coherent context.
+
+## Completion checklist
+
+- [ ] Graph scope and working-tree/revision identity recorded.
+- [ ] Report read and three hypotheses written.
+- [ ] Behavior-shaped query run.
+- [ ] At least one anchor explained.
+- [ ] Core path traced and provenance reviewed.
+- [ ] Impact neighborhood inspected.
+- [ ] Important claims verified in source.
+- [ ] Uncertainty and missing evidence recorded.
+- [ ] Short architecture note written for another reader.
+
+## Related pages
+
+- [How Compass works](../concepts/how-it-works.md)
+- [Architecture-discovery cookbook](../cookbook/architecture-discovery.md)
+- [Impact-analysis cookbook](../cookbook/impact-analysis.md)
+- [Assistant setup](assistant-setup.md)
+
+**Next step:** use the [architecture-discovery cookbook](../cookbook/architecture-discovery.md)
+for shorter recipes you can repeat during reviews.

--- a/docs/guides/integrating-compass.md
+++ b/docs/guides/integrating-compass.md
@@ -1,0 +1,334 @@
+# Integrate Compass with other tools
+
+Compass can be used interactively, as a producer of versioned JSON, through an
+MCP service, or as an exporter to graph systems. This guide focuses on stable
+boundaries and failure-safe consumption.
+
+> **Who this guide is for:** developers building scripts, CI jobs, editor
+> features, internal portals, and graph-analysis integrations.
+>
+> **You will learn:** how to choose an integration surface, consume outputs
+> safely, use CompassQL parameters and versioned results, and avoid coupling to
+> unstable human text.
+>
+> **Prerequisites:** a working graph and familiarity with
+> [CompassQL concepts](../concepts/compassql.md).
+>
+> **Completion time:** 20 minutes for the pattern; implementation time depends
+> on the consumer.
+
+![Compass integration surfaces](../assets/diagrams/integration-surfaces.svg)
+
+## Choose the narrowest stable surface
+
+| Integration need | Recommended surface |
+| --- | --- |
+| Human exploration | CLI text, report, HTML |
+| Scripted exact graph pattern | CompassQL JSON or JSONL |
+| Full graph processing | `compass-out/graph.json` |
+| Historical reproducibility | History `graph-json` or `compass-out` export |
+| Coding-assistant tool calls | `compass serve` / MCP |
+| Cross-repository graph lookup | `compass global` |
+| External graph database | `compass export` and configured target |
+| Compare revisions | `compass diff --format json` |
+
+Human text is optimized for clarity and can evolve. Machine consumers should
+prefer explicitly versioned JSON or documented graph schemas.
+
+## Integration pattern: produce, validate, publish, consume
+
+Treat a graph build as a producer job:
+
+```text
+source checkout
+    |
+    v
+compass update/extract
+    |
+    +-- failure --> keep prior published consumer state
+    |
+    `-- success --> validate expected artifacts
+                         |
+                         v
+                  hand snapshot to consumer
+```
+
+Run the producer to completion before a consumer opens the result:
+
+```bash
+compass update .
+test -s compass-out/graph.json
+```
+
+Do not infer success from a partially written log or the mere existence of an
+old `graph.json`. Check the command exit status.
+
+## Use CompassQL for application-shaped data
+
+A focused query reduces transfer and decouples the consumer from unrelated
+graph attributes:
+
+```bash
+compass query --cql \
+  'MATCH (caller)-[edge:CALLS]->(target)
+   WHERE target.label = $target
+   RETURN caller.id, edge.confidence, target.id
+   ORDER BY caller.id' \
+  --param target=authorize \
+  --format json \
+  --output target/authorize-callers.json
+```
+
+The JSON result uses `compass.cql.result/1`. Validate the major version before
+reading columns or typed values.
+
+### Prefer parameters
+
+Do not build query text by concatenating a label:
+
+```text
+unsafe and fragile:
+  "WHERE n.label = '" + user_value + "'"
+```
+
+Pass it as data:
+
+```bash
+compass query --cql --file queries/find-label.cypher \
+  --param target="$TARGET_LABEL" \
+  --format json
+```
+
+This protects query structure and preserves parameter typing.
+
+### JSON versus JSONL
+
+Use JSON when:
+
+- results are modest;
+- one complete document is convenient;
+- plan/profile metadata belongs beside rows.
+
+Use JSONL when:
+
+- a streaming pipeline consumes rows one at a time;
+- line-oriented tools are convenient;
+- you still validate the `compass.cql.jsonl/1` header and final summary.
+
+An execution error does not represent a valid truncated result.
+
+## Use explicit limits
+
+An integration should set budgets that match its job:
+
+```bash
+compass query --cql --file queries/dependencies.cypher \
+  --format json \
+  --timeout-ms 3000 \
+  --max-rows 5000 \
+  --max-path-depth 8 \
+  --max-expanded-relationships 1000000 \
+  --max-memory-bytes 134217728
+```
+
+On a limit error:
+
+- do not interpret it as zero matches;
+- narrow labels, relation types, or path bounds;
+- partition the query by subsystem or file type;
+- decide deliberately whether a larger resource budget is safe.
+
+## Consume the full graph
+
+`compass-out/graph.json` uses NetworkX-style node-link data:
+
+```json
+{
+  "directed": true,
+  "multigraph": true,
+  "graph": {},
+  "nodes": [
+    {"id": "opaque-id", "label": "display name"}
+  ],
+  "links": [
+    {
+      "source": "opaque-id",
+      "target": "other-id",
+      "relation": "calls",
+      "confidence": "EXTRACTED"
+    }
+  ]
+}
+```
+
+Consumer rules:
+
+1. treat node IDs as opaque strings;
+2. preserve unknown node/edge attributes;
+3. preserve direction;
+4. preserve parallel relationships when `multigraph` is true;
+5. use `links`, while tolerating the documented legacy compatibility boundary
+   only if your application needs it;
+6. do not use JSON member order as graph meaning;
+7. guard size and parsing in your own trust boundary.
+
+Read the [output reference](../reference/outputs.md) before implementing a
+round-trip writer.
+
+## Reproducible historical input
+
+A current `compass-out/` reflects a working tree. For reproducible integration
+tests or audits:
+
+```bash
+compass history build HEAD --code-only
+compass history export HEAD \
+  --format graph-json \
+  --output target/history/head-graph.json
+```
+
+For the complete artifact set:
+
+```bash
+compass history export HEAD \
+  --format compass-out \
+  --output target/history/head-compass-out
+```
+
+Record:
+
+- resolved commit SHA;
+- realization ID;
+- extraction fingerprint;
+- export format;
+- Compass version;
+- query/result schema version.
+
+This lets another run tell whether it is comparing like with like.
+
+## MCP service integration
+
+`compass serve` exposes the native MCP surface over supported transports.
+Before placing it behind an editor or network service:
+
+1. inspect `compass serve --help` for the exact transport and authentication
+   options in your build;
+2. bind to the narrowest appropriate interface;
+3. apply authentication to HTTP exposure;
+4. enforce request and graph limits;
+5. isolate credentials from logs;
+6. test with an official MCP client;
+7. treat graph files and query input as untrusted at the service boundary.
+
+For a local coding assistant, stdio avoids opening a listening socket. Use HTTP
+only when a multi-process or remote integration actually needs it.
+
+## Cross-repository registry
+
+Compass can register graphs in a global index:
+
+```bash
+compass global add path/to/graph.json --as payments
+compass global list
+compass global path
+compass global remove payments
+```
+
+Use stable repository tags. Decide who owns refresh and removal; a global entry
+is a pointer/registry concern, not proof that its graph is fresh.
+
+For multi-repository architecture, record each graph's source revision and
+profile alongside the tag.
+
+## External graph databases
+
+Compass includes native Neo4j and FalkorDB integration code. A typical workflow
+is:
+
+```text
+validated Compass graph
+      |
+      v
+compass export ...
+      |
+      v
+explicit graph database endpoint
+```
+
+Before export:
+
+- confirm the target database and namespace;
+- use environment-provided secrets rather than CLI literals;
+- understand whether the operation appends, replaces, or merges;
+- test on a disposable database;
+- retain the source graph and revision for audit;
+- verify node/edge counts after transfer.
+
+Consult `compass export --help` in the installed version. Provider and database
+flags are exact interfaces and should not be guessed from old examples.
+
+## CI integration
+
+A robust job separates generation from policy:
+
+```bash
+set -eu
+compass update . --no-viz
+test -s compass-out/graph.json
+compass query --cql --file .compass/policy.cypher \
+  --params-file .compass/policy-params.json \
+  --format json \
+  --output compass-out/policy-result.json
+```
+
+Upload:
+
+- `graph.json`;
+- `GRAPH_REPORT.md`;
+- the manifest needed to understand the build;
+- query/policy results;
+- command/version metadata.
+
+Do not cache across incompatible Compass versions or extraction profiles
+without a key that includes those inputs.
+
+See the [CI cookbook](../cookbook/ci-and-automation.md) for complete patterns.
+
+## Exit and retry policy
+
+Classify before retrying:
+
+| Failure | Retry unchanged? | Integration response |
+| --- | --- | --- |
+| CLI usage or CompassQL compile error | No | Fix command/query |
+| Graph missing/corrupt/oversized | Usually no | Rebuild or repair input |
+| Query deadline/resource limit | No | Narrow query or adjust approved budget |
+| Temporary provider/network error | Maybe | Retry with bounded backoff |
+| Missing credentials | No | Configure intentionally or use code-only |
+| History profile mismatch | No | Build/choose comparable realization |
+| Output write error | Maybe after environment fix | Check space, permissions, target path |
+
+Never publish an empty application result merely because Compass returned
+nonzero.
+
+## Security checklist
+
+- [ ] No credentials in query parameters, command history, checked-in files, or
+  captured stdout.
+- [ ] Network endpoints are explicit and expected.
+- [ ] Non-loopback local-model endpoints are treated as remote corpus transfer.
+- [ ] Full graph and source-location data are classified appropriately.
+- [ ] Output paths are not writable by untrusted users.
+- [ ] HTTP service exposure has authentication and resource limits.
+- [ ] Unknown schema major versions fail closed.
+- [ ] Historical exports come from validated realizations.
+
+## Related pages
+
+- [CompassQL concepts](../concepts/compassql.md)
+- [Output reference](../reference/outputs.md)
+- [CI and automation cookbook](../cookbook/ci-and-automation.md)
+- [Security and privacy](../design/security-and-privacy.md)
+
+**Next step:** build one parameterized CompassQL query and validate its schema
+tag before connecting it to a larger application.

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -1,0 +1,371 @@
+# Operate Compass
+
+This guide covers the long-running and optional operational surfaces around the
+core build/query loop: watch mode, MCP serving, hooks, providers, global
+registries, ingestion, PR workflows, and exports.
+
+> **Who this guide is for:** maintainers, platform engineers, editor/assistant
+> integrators, and developers running Compass beyond one-shot local commands.
+>
+> **You will learn:** lifecycle, safety boundaries, observability, and recovery
+> patterns for operational commands.
+>
+> **Prerequisites:** [Getting started](../getting-started.md) and a working
+> `compass update .`.
+>
+> **Reading time:** 15–20 minutes.
+
+## Operational principle: start one-shot, then automate
+
+Before enabling a watcher, hook, service, or provider-backed workflow:
+
+1. run the equivalent one-shot command;
+2. confirm inputs and outputs;
+3. record expected exit behavior;
+4. decide where logs and credentials live;
+5. add lifecycle management and resource limits;
+6. test shutdown and failure recovery.
+
+Automation should reproduce known behavior, not become the first place you
+discover configuration.
+
+## Watch mode
+
+Start:
+
+```bash
+compass watch .
+```
+
+Current options include:
+
+```text
+--debounce SECONDS
+--out DIR
+--no-cluster
+--no-viz
+--no-gitignore
+--exclude PATTERN
+--poll
+```
+
+Watch mode observes relevant changes, debounces bursts, and refreshes the
+output. Choose polling only when native filesystem events are unavailable or
+unreliable.
+
+### Good use cases
+
+- local editor sessions;
+- live architecture exploration;
+- a development container with an explicit process supervisor.
+
+### Avoid
+
+- starting multiple watchers for the same output directory;
+- using watch as an unbounded CI step;
+- watching dependency caches or generated directories;
+- assuming the output is current after the watcher has failed.
+
+### Operate it
+
+Capture logs and stop it through your process supervisor or foreground terminal.
+After a failure, run one manual update:
+
+```bash
+compass update .
+```
+
+That separates watcher/event problems from extraction problems.
+
+## MCP service
+
+Start by inspecting:
+
+```bash
+compass serve --help
+```
+
+Use stdio for a local assistant when possible. It has a smaller exposure
+surface than a listening HTTP service.
+
+For HTTP:
+
+- bind explicitly;
+- require the supported authentication mechanism;
+- limit request and graph sizes;
+- do not expose a source graph to untrusted tenants;
+- keep provider secrets out of service arguments and logs;
+- health-check through a real MCP client;
+- stop accepting requests before replacing or removing graph files.
+
+Compass's MCP implementation is tested against an official client oracle for
+its tools, resources, transports, authentication, and limits. Your deployment
+still owns TLS termination, process isolation, and network access policy.
+
+## Git hooks
+
+Inspect status:
+
+```bash
+compass hook status
+```
+
+Install managed refresh hooks:
+
+```bash
+compass hook install
+```
+
+Remove managed sections:
+
+```bash
+compass hook uninstall
+```
+
+The hook integration:
+
+- launches background refresh work after relevant changes;
+- avoids recursive rebuilds;
+- guards rebases, merges, cherry-picks, and linked-worktree behavior;
+- can enqueue exact history commits where history is enabled;
+- writes logs to its configured/default cache path.
+
+Use `GRAPHIFY_SKIP_HOOK=1` only as the documented compatibility control for a
+specific operation. Do not permanently mask failing hooks without fixing or
+uninstalling them.
+
+When moving or reinstalling the Compass binary, reinstall hooks so embedded
+invocation paths remain valid.
+
+## Semantic providers
+
+Built-in backends and custom OpenAI-compatible providers are configured
+explicitly.
+
+Provider registry lifecycle:
+
+```bash
+compass provider list
+compass provider add NAME \
+  --base-url URL \
+  --default-model MODEL \
+  --env-key ENVIRONMENT_VARIABLE_NAME
+compass provider show NAME
+compass provider remove NAME
+```
+
+The registry stores provider metadata and the *name* of the environment
+variable containing a key—not the secret value itself.
+
+Before sending a corpus:
+
+- identify the exact endpoint;
+- verify TLS and organizational approval;
+- understand retention and training terms;
+- set the key in process environment or an approved secret store;
+- use a small non-sensitive corpus for the first call;
+- set timeouts and concurrency;
+- decide whether partial semantic results are permitted.
+
+An Ollama-compatible endpoint on a non-loopback host is a network transfer even
+if the product is commonly described as local. Compass warns about unexpected
+or metadata-address endpoints; deployment policy should fail closed too.
+
+## Build with a provider
+
+Example shape:
+
+```bash
+compass extract . \
+  --backend openai \
+  --model your-approved-model \
+  --max-concurrency 4 \
+  --api-timeout 60
+```
+
+Use `compass extract --help` for the exact backend and limit surface. Missing
+credentials should cause a clear failure. Use `--code-only` when your intent is
+to skip semantic sources entirely.
+
+`--allow-partial` changes completeness expectations and should never be added
+to automation without deciding how partial status is surfaced to consumers.
+
+## Global graph registry
+
+Register:
+
+```bash
+compass global add path/to/graph.json --as repository-tag
+```
+
+Inspect:
+
+```bash
+compass global list
+compass global path
+```
+
+Remove:
+
+```bash
+compass global remove repository-tag
+```
+
+Operational ownership questions:
+
+- who refreshes the registered graph?
+- how is its source revision recorded?
+- what happens when a repository moves?
+- are tags unique and stable?
+- who removes stale entries?
+
+Treat the registry as an index, not an automatic freshness guarantee.
+
+## Remote ingestion and cloning
+
+Compass exposes native project workflows including:
+
+```bash
+compass clone https://github.com/OWNER/REPOSITORY \
+  --branch BRANCH \
+  --out DIRECTORY
+
+compass add URL --author "Name" --dir ./raw
+```
+
+These commands cause network and filesystem changes. In automation:
+
+- validate the host and URL;
+- use a dedicated output directory;
+- avoid embedding credentials in URLs;
+- set repository size and trust policies externally;
+- scan or sandbox untrusted checkout content;
+- record source URL and revision.
+
+Do not assume cloned content is safe to build or execute.
+
+## Pull-request intelligence
+
+The `prs` command can inspect repository PR context:
+
+```bash
+compass prs --triage --repo OWNER/REPO
+```
+
+Optional modes include worktree, conflict, wrong-base, base-branch, repository,
+and graph controls. Run `compass prs --help` for the current contract.
+
+PR workflows may require GitHub credentials and network access. Keep this
+separate from the fully local structural graph claim.
+
+## Graph database export
+
+Inspect:
+
+```bash
+compass export --help
+```
+
+Before writing to Neo4j or FalkorDB:
+
+- confirm endpoint, database/graph, and write semantics;
+- supply passwords through supported environment variables;
+- test against a disposable target;
+- verify counts and a known path after export;
+- retain source `graph.json` and revision;
+- plan idempotence and rollback.
+
+The existence of a native exporter does not make the remote database local.
+
+## Merge and maintenance commands
+
+Compass exposes lower-level operations such as:
+
+```text
+diagnose multigraph
+merge-graphs
+merge-driver
+merge-chunks
+merge-semantic
+cache-check
+cluster-only
+label
+save-result
+reflect
+check-update
+```
+
+Use them when a guide or command help identifies the correct workflow. Several
+are pipeline/integration surfaces, not everyday first-run commands.
+
+Rules:
+
+- keep original inputs until output validates;
+- write to a new path where the command supports it;
+- inspect multigraph direction and duplicate-edge diagnostics before merging;
+- do not hand-edit incremental caches to recover them;
+- treat semantic merge completeness as a publication boundary.
+
+## Logs and observability
+
+For any long-running operation, record:
+
+```text
+Compass version
+working directory
+resolved source revision
+command with secrets removed
+output directory
+profile/provider name (not key)
+start/end time and exit status
+artifact counts or hashes
+diagnostic codes
+```
+
+Do not log:
+
+- API keys;
+- authorization headers;
+- full secret-bearing URLs;
+- query parameter values that your application classifies as sensitive;
+- source content merely to make debugging easier.
+
+## Recovery ladder
+
+Use the smallest recovery that matches the failure:
+
+```text
+query problem
+  -> rerun exact query with smaller scope / inspect diagnostic
+
+stale current graph
+  -> compass update .
+
+watcher problem
+  -> stop watcher, run one-shot update, restart deliberately
+
+provider problem
+  -> verify endpoint/key/model on a small source; do not publish incomplete result
+
+hook problem
+  -> inspect status/log, uninstall managed hook, verify manual update
+
+history problem
+  -> use history status/list/show/validate/rebuild flows
+
+output corruption
+  -> retain evidence, rebuild to a new location, compare before replacement
+```
+
+Avoid deleting a live SQLite/WAL store, lock, or lease as a first response.
+
+## Related pages
+
+- [Integrating Compass](integrating-compass.md)
+- [Versioned graph history](versioned-history.md)
+- [Security and privacy](../design/security-and-privacy.md)
+- [Troubleshooting cookbook](../cookbook/troubleshooting.md)
+
+**Next step:** choose one operational surface, run its one-shot equivalent, and
+write down lifecycle, credential, log, and recovery ownership before enabling
+automation.

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -1,0 +1,381 @@
+# Use versioned graph history
+
+Compass history stores complete, immutable graph realizations for exact Git
+commits in a SQLite-backed Prolly store outside normal Git history.
+
+> **Who this guide is for:** maintainers comparing revisions, auditors,
+> integrators needing reproducible snapshots, and contributors operating the
+> history subsystem.
+>
+> **You will learn:** profiles, builds, lazy materialization, queries, diffs,
+> exports, preferred realizations, maintenance, failure recovery, and safety
+> boundaries.
+>
+> **Prerequisites:** a Git repository and a working `compass` binary.
+>
+> **Completion time:** 15–30 minutes plus extraction time.
+
+![How Compass materializes and stores an exact Git revision](../assets/diagrams/history-materialization.svg)
+
+## Mental model
+
+```text
+commit SHA + extraction fingerprint
+                |
+                v
+         immutable realization
+                |
+                +-- graph structure
+                +-- semantic/inferred edges
+                +-- hyperedges
+                +-- analysis and communities
+                +-- reconstruction metadata
+                `-- authoritative sidecars
+```
+
+A **realization** is more specific than a commit. The same commit can have a
+code-only realization and one or more semantic realizations with different
+provider/model configuration.
+
+## 1. Inspect the command contract
+
+Run:
+
+```bash
+compass history --help
+compass diff --help
+```
+
+History commands include:
+
+```text
+enable   disable   status   build   rebuild
+list     show      prefer   export  gc
+```
+
+Text output is for people. Commands that support `--format json` expose stable
+machine-readable results.
+
+## 2. Choose a repository-wide profile
+
+### Code-only
+
+For local structural code analysis without model credentials:
+
+```bash
+compass history enable --code-only
+```
+
+The profile includes the relevant build options and installs managed
+`post-commit` and `post-merge` hooks for eager enqueueing.
+
+### Semantic
+
+Select a provider and model explicitly:
+
+```bash
+compass history enable --backend openai --model your-approved-model
+```
+
+Provider credentials come from the supported environment/configuration
+surface. They are not included in the extraction fingerprint; provider/model
+selection and other meaning-affecting options are.
+
+Compass does not silently downgrade a semantic profile to code-only when
+credentials are missing.
+
+### What enable changes
+
+`enable`:
+
+- records the build profile for the repository;
+- enables eager enqueueing;
+- installs managed hooks;
+- does not need to build every historical commit immediately.
+
+Hooks capture the exact resulting commit and enqueue work durably, then return
+without waiting for extraction.
+
+## 3. Build an exact revision
+
+```bash
+compass history build HEAD
+```
+
+Use any locally resolvable Git revision:
+
+```bash
+compass history build v1.2.0
+compass history build HEAD~20
+```
+
+The revision is resolved to a full commit SHA. Materialization runs in a
+detached, protected, offline worktree:
+
+- it does not include the caller's uncommitted files;
+- it honors the committed `.gitignore`;
+- it does not inherit caller-local `.git/info/exclude` or global ignore rules;
+- it does not fetch;
+- it does not prompt for credentials;
+- it does not run hooks or checkout filters that could execute external code;
+- it does not smudge LFS objects or recurse into submodules.
+
+Gitlinks and LFS pointers are reported as limitations instead of being silently
+expanded.
+
+## 4. Inspect realizations
+
+```bash
+compass history status HEAD
+compass history list HEAD
+```
+
+For automation:
+
+```bash
+compass history list HEAD --format json
+```
+
+Inspect one realization:
+
+```bash
+compass history show REALIZATION_ID
+```
+
+Look for:
+
+- exact commit;
+- realization ID;
+- extraction fingerprint;
+- completion and validation status;
+- preferred state;
+- artifact and renderer metadata.
+
+Only a validated, complete realization can become the normal preferred result.
+
+## 5. Query an exact revision
+
+Read commands accept `--at`:
+
+```bash
+compass query "authentication flow" --at HEAD~20
+compass explain TokenVerifier --at v1.2.0
+compass path ApiHandler TokenVerifier --at HEAD~20
+```
+
+`--graph PATH` and `--at REV` are mutually exclusive.
+
+If the preferred realization is missing, the command can synchronously
+materialize it using the configured profile. This lazy behavior works even when
+eager generation is disabled.
+
+For exact CompassQL:
+
+```bash
+compass query --cql \
+  "MATCH (n:Function) RETURN n.id LIMIT 100" \
+  --at HEAD~20 \
+  --format json
+```
+
+Record the resolved commit and realization identity beside saved results.
+
+## 6. Compare revisions
+
+Human-readable summary:
+
+```bash
+compass diff v1.2.0 HEAD
+```
+
+Detailed human output:
+
+```bash
+compass diff v1.2.0 HEAD --detailed
+```
+
+Machine-readable output:
+
+```bash
+compass diff v1.2.0 HEAD --format json
+```
+
+Topology-only comparison:
+
+```bash
+compass diff HEAD~1 HEAD --topology-only
+```
+
+The diff command supports explicit inclusion options for locations, analysis,
+and metadata. Use `compass diff --help` for the exact current surface.
+
+### Profile compatibility
+
+Normal diffs require semantically comparable extraction fingerprints. If they
+differ, Compass explains how to build a comparable realization:
+
+```bash
+compass history build NEW_REV --profile-from OLD_REV_OR_REALIZATION
+```
+
+`--allow-profile-mismatch` is an explicit inspection escape hatch. It does not
+make unlike profiles equivalent.
+
+### Reverse symmetry
+
+A qualified diff should be deterministic and reverse-symmetric: additions from
+A to B correspond to removals from B to A. The real-repository qualification
+script exercises this contract.
+
+## 7. Export a realization
+
+Canonical graph JSON:
+
+```bash
+compass history export HEAD \
+  --format graph-json \
+  --output target/head-graph.json
+```
+
+Full Compass artifact directory:
+
+```bash
+compass history export HEAD \
+  --format compass-out \
+  --output target/head-compass-out
+```
+
+`compass-out` export restores authoritative non-derivable sidecars verbatim.
+Derived reports and HTML are regenerated only with renderer versions recorded
+in the artifact registry.
+
+Export equivalence is semantic and canonical. JSON object or record ordering
+that does not affect meaning is not a contract; graph structure, attributes,
+multiplicity, duplicate id-less hyperedges, and authoritative bytes are.
+
+## 8. Choose a preferred realization
+
+When a commit has multiple valid realizations:
+
+```bash
+compass history prefer REV REALIZATION_ID
+```
+
+Preference is explicit. An unreadable preferred pointer is never silently
+overwritten.
+
+Recover a corrupt preferred realization only with:
+
+```bash
+compass history rebuild REV --replace-corrupt
+```
+
+This operation uses an explicit compare-and-swap observation so a concurrent
+change is not blindly overwritten.
+
+## 9. Understand shared storage
+
+All linked worktrees share:
+
+```bash
+$(git rev-parse --git-common-dir)/compass/history.sqlite
+```
+
+The pinned SQLite adapter uses WAL mode, full synchronous durability, and a
+busy timeout. Operational files—jobs, leases, locks, and protected temporary
+worktrees—live beside the database rather than inside the Prolly values.
+
+Safety rules:
+
+- do not copy only `history.sqlite` while Compass is running;
+- include WAL state in any live-database backup strategy;
+- do not delete operational files to “unlock” a live process;
+- allow Compass to create owner-only resource paths;
+- use commands rather than editing Prolly keys or preferred pointers manually.
+
+## 10. Garbage collection
+
+Normal GC:
+
+```bash
+compass history gc
+```
+
+It retains every published realization and removes unreachable Prolly nodes
+plus expired operational records.
+
+Preview pruning of non-preferred realizations:
+
+```bash
+compass history gc --prune-non-preferred
+```
+
+Apply it explicitly:
+
+```bash
+compass history gc --prune-non-preferred --yes
+```
+
+Reported bytes and node rows are logical reclamation. GC does not promise that
+the SQLite file shrinks and does not run `VACUUM`.
+
+## 11. Disable eager generation
+
+```bash
+compass history disable
+```
+
+Disable is idempotent. It:
+
+- stops eager enqueueing;
+- keeps the database, jobs, and existing realizations;
+- does not disable explicit `build` or `rebuild`;
+- does not disable lazy `--at` or `diff`.
+
+Use it when hooks should stop scheduling work without discarding history.
+
+## Jobs, leases, and failures
+
+The worker uses a durable FIFO queue and leases. A failed job does not prevent
+later jobs from running.
+
+Failure handling:
+
+| Failure | Response |
+| --- | --- |
+| Provider credentials missing | Configure the selected semantic profile or build a code-only realization explicitly |
+| Provider fails mid-build | Fix provider/network and rebuild; incomplete candidate cannot publish |
+| Preferred realization fails validation | Inspect with `show`; use explicit rebuild/recovery path |
+| Profiles differ during diff | Build with `--profile-from` or inspect explicitly with mismatch allowed |
+| Live lease exists | Join/wait according to command behavior; do not delete lock files |
+| Historical checkout limitation | Read the reported Gitlink/LFS/filter limitation and adjust source policy |
+| Store copy is inconsistent | Restore a coherent SQLite/WAL backup; do not guess at Prolly records |
+
+## Qualification
+
+For two commits in a clean real repository:
+
+```bash
+scripts/qualify_history_real_repo.sh /path/to/repository OLD NEW
+```
+
+The harness:
+
+- builds in an isolated shared clone;
+- checks deterministic JSON;
+- checks reverse-symmetric diffs;
+- reopens the SQLite store;
+- verifies topology filtering;
+- requires topology-only diff to be at least twice as fast as full diff.
+
+This is release evidence, not a substitute for application-specific validation.
+
+## Related pages
+
+- [Storage and history design](../design/storage-and-history.md)
+- [History implementation](../implementation/workspace-tour.md)
+- [Output reference](../reference/outputs.md)
+- [Compatibility ledger](../../COMPATIBILITY.md)
+
+**Next step:** enable a code-only profile in a disposable repository, build
+`HEAD`, query it with `--at HEAD`, and inspect the resulting realization.

--- a/docs/implementation/extending-compass.md
+++ b/docs/implementation/extending-compass.md
@@ -1,0 +1,288 @@
+# Extending Compass
+
+This guide turns common extension goals into concrete crate, contract, and
+verification checklists.
+
+> **Who this guide is for:** contributors adding a language, relation,
+> integration, query capability, output, command, or provider.
+>
+> **You will learn:** where an extension belongs, which public contracts it can
+> affect, and what evidence is required before it is complete.
+>
+> **Prerequisites:** [Workspace tour](workspace-tour.md) and
+> [Contributing](../../CONTRIBUTING.md).
+>
+> **Reading time:** 15 minutes.
+
+## Before editing
+
+1. Read the relevant crate `src/lib.rs`.
+2. Find the nearest existing implementation.
+3. Find its unit and CLI/integration tests.
+4. Read [COMPATIBILITY.md](../../COMPATIBILITY.md) for the affected command
+   family.
+5. Decide whether the change is:
+   - compatibility behavior;
+   - intentional divergence with migration impact;
+   - Compass-native behavior.
+6. Define direction, provenance, limits, failure, and output contract.
+
+## Add a language or file format
+
+### Ownership
+
+```text
+classification/extension        compass-files + language registry
+parser/query selection          vendored language pack
+per-file facts                  compass-languages
+cross-file target resolution    compass-resolve
+graph/result verification       compass-graph / CLI fixtures
+```
+
+### Implementation checklist
+
+- add deterministic extension/filename recognition;
+- define parser/language spec;
+- extract file/module and supported entities;
+- emit containment and dependency relations;
+- include source file/location;
+- emit unresolved raw call/member facts when needed;
+- add project/config metadata support if resolution needs it;
+- implement resolver logic conservatively;
+- preserve ambiguous targets;
+- update coverage/support documentation.
+
+### Evidence
+
+- minimal syntax fixture;
+- nested scopes;
+- imports and cross-file calls;
+- duplicate names;
+- inheritance/members;
+- malformed source;
+- ignored/generated paths;
+- stable IDs and ordering;
+- direction, relation, context, provenance;
+- incremental edit/rename/delete;
+- multilingual corpus qualification.
+
+## Add a relation
+
+Define:
+
+```text
+name          normalized persisted string
+direction     what source and target mean
+context       call/import/declaration/etc.
+provenance    direct, resolved, ambiguous
+multiplicity  whether parallel edges are meaningful
+impact        whether affected should traverse it
+CompassQL     normalized relationship type
+```
+
+Do not reuse `uses` when a more precise stable relation is justified, and do
+not introduce a narrowly named relation with no consumer or documentation.
+
+Update:
+
+- extractor/resolver;
+- graph dedup key if appropriate;
+- affected default relations only with impact justification;
+- reports/renderers;
+- query/CompassQL fixtures;
+- output reference.
+
+## Add a CompassQL feature
+
+Work through the full vertical slice:
+
+1. token and span;
+2. AST;
+3. parser with precise diagnostic;
+4. semantic scope/type validation;
+5. logical operator/value;
+6. optimizer rule if beneficial;
+7. bounded executor;
+8. explain/profile representation;
+9. JSON/JSONL typed result;
+10. support matrix and language version decision.
+
+Evidence includes unit syntax cases, negative diagnostics, scope/type cases,
+TCK feature, CLI source modes, limits/cancellation, differential behavior where
+portable, and benchmark regression.
+
+Mutation and unbounded execution remain outside CompassQL's read-only design.
+
+## Add a CLI command
+
+Keep the binary entry small. Add command parsing/rendering in a focused
+`compass-cli` module and put reusable behavior in the owning crate.
+
+Define before implementation:
+
+- usage string and examples;
+- positional/optional argument grammar;
+- mutual exclusions and defaults;
+- stdout versus stderr;
+- text and machine formats;
+- exit codes;
+- filesystem/network side effects;
+- idempotence and cleanup;
+- help visibility and compatibility status.
+
+CLI tests should execute the binary boundary and assert:
+
+- help;
+- success output;
+- usage errors;
+- runtime errors;
+- no partial file on failure;
+- project/global path behavior;
+- JSON schema/version;
+- platform path/encoding where relevant.
+
+## Add an output format
+
+Add to `compass-output` when it is a representation of an already complete
+graph.
+
+Requirements:
+
+- self-contained where possible;
+- safe escaping;
+- no external scripts/fonts by default;
+- direction and parallel-edge preservation;
+- source location and provenance where the format supports them;
+- deterministic ordering;
+- atomic write;
+- size/complexity guard;
+- round-trip or semantic-equivalence test;
+- renderer version if history reconstruction depends on it.
+
+Do not implement topology changes inside a renderer.
+
+## Add a semantic provider
+
+Add a backend only when:
+
+- endpoint and authentication shape are well defined;
+- request/response size and timeout are bounded;
+- secret variables are documented but never stored;
+- response normalization maps into the shared untrusted-fragment validator;
+- context-limit and retry behavior are finite;
+- base URL safety checks apply;
+- model selection enters history fingerprints;
+- code-only paths do not load/call it.
+
+Tests use a local mock server and no real key.
+
+## Add an external integration
+
+Choose or create a focused crate. Define:
+
+```text
+input trust       URL/path/connection/credentials
+network protocol  TLS/auth/redirects/timeouts
+bounds            bytes/rows/process output/duration
+graph mapping     IDs, relations, provenance, multiplicity
+side effects      read-only, append, replace, files written
+recovery          retry/idempotence/rollback
+CLI surface       explicit opt-in and diagnostics
+```
+
+For subprocess integrations, avoid shell concatenation and cap both duration
+and captured output.
+
+For remote write integrations, test against a disposable endpoint and verify
+counts.
+
+## Add history data
+
+History changes are compatibility-sensitive. Determine:
+
+- artifact class;
+- typed key encoding;
+- canonical value encoding;
+- size/count/depth limit;
+- fingerprint input;
+- structural-sharing behavior;
+- diff representation;
+- reconstruction/export;
+- validation;
+- schema/canonical version migration.
+
+Published realizations are immutable. Never “fix” them in place.
+
+Add round-trip, reopen, publication, corruption, diff symmetry, GC reachability,
+and SQLite contract tests.
+
+## Add assistant integration
+
+Generated skill assets live in the native CLI package and must be tested as
+complete file trees.
+
+Requirements:
+
+- use `compass` and `compass-out/`;
+- support global/project scope as appropriate;
+- preserve user-authored instruction content;
+- idempotent install;
+- safe uninstall and explicit purge;
+- no machine paths or secrets;
+- platform-specific discovery layout;
+- actual workflow instructions, not only a command list.
+
+## Compatibility and divergence
+
+If Graphify has equivalent behavior:
+
+- add/update differential evidence;
+- preserve approved normalizations;
+- update the compatibility ledger.
+
+If Compass intentionally differs:
+
+- document why;
+- add native contract tests;
+- update migration guidance;
+- avoid exposing a half-compatible internal frontend behavior as public
+  product identity.
+
+If Compass-native:
+
+- document the new contract independently;
+- do not invent a Graphify command solely for symmetry.
+
+## Verification matrix
+
+| Extension | Required broad evidence |
+| --- | --- |
+| Language | multilingual extraction + incremental + parity where applicable |
+| Relation | direction/provenance/multiplicity + query/impact |
+| Query | compiler + executor + TCK + CLI + limits + benchmark |
+| Command | help/args/streams/exits/files + platform cases |
+| Output | escaping/determinism/semantic equivalence/atomic write |
+| Provider | mock server + endpoint/key/timeout/size/partial/cache |
+| Integration | protocol failure + bounds + mapping + idempotence |
+| History | canonical round trip + reopen + corruption + diff + GC |
+| Assistant | exact generated trees + idempotent install/uninstall |
+
+## Documentation checklist
+
+- concept page if a new idea is introduced;
+- guide or cookbook recipe if users perform a new task;
+- reference update for flags/schema/config;
+- roadmap update if status changes;
+- compatibility/migration/security update where affected;
+- diagram update only when it improves understanding.
+
+## Related pages
+
+- [Contributing](../../CONTRIBUTING.md)
+- [Workspace tour](workspace-tour.md)
+- [Design principles](../design/principles.md)
+- [Compatibility reference](../reference/compatibility.md)
+
+**Next step:** write a one-paragraph extension contract covering ownership,
+inputs, outputs, provenance, bounds, and failure, then map it to the relevant
+checklist above.

--- a/docs/implementation/extraction-pipeline.md
+++ b/docs/implementation/extraction-pipeline.md
@@ -1,0 +1,317 @@
+# Extraction pipeline implementation
+
+The extraction pipeline turns a filesystem snapshot into a coherent graph
+artifact set. This page follows the cold path, incremental path, and failure
+boundaries through the owning crates.
+
+> **Who this page is for:** contributors changing discovery, languages,
+> resolution, graph construction, or output publication.
+>
+> **You will learn:** pipeline stages, core types, incremental invalidation,
+> concurrency, semantic merge, and the tests required for safe changes.
+>
+> **Prerequisites:** [Workspace tour](workspace-tour.md).
+>
+> **Reading time:** 15–20 minutes.
+
+![Cold and incremental Compass update paths](../assets/diagrams/incremental-update.svg)
+
+## Entry points
+
+At the CLI:
+
+```text
+compass update
+compass extract
+compass watch
+```
+
+`compass-cli` parses arguments into `compass-core::BuildOptions` and selects a
+`BuildPurpose`. The core exposes:
+
+```text
+build_local_graph
+build_graph_with_semantic
+build_graph_with_layers
+build_graph_with_layers_and_tiebreaker
+```
+
+The implementation keeps CLI display policy outside the core build transaction.
+
+## Build options
+
+Options cover:
+
+- root and output directory;
+- clustering and visualization;
+- ignore and explicit exclusions;
+- resolution and hub thresholds;
+- force/cold versus incremental work;
+- Cargo/PostgreSQL/Google Workspace inputs;
+- semantic provider, model, mode, budget, concurrency, timeout;
+- partial and deduplication policy;
+- timing.
+
+Not every option affects every stage. Meaning-affecting options must be
+represented in fingerprints or manifest compatibility where reuse could
+otherwise produce a wrong graph.
+
+## Stage 1: detect
+
+`compass-files::detect` walks the requested root under `DetectOptions`.
+
+It returns classified files and incremental information:
+
+```text
+source code
+project/config manifests
+semantic documents/media
+integration shortcuts
+ignored or unsupported paths
+```
+
+Important invariants:
+
+- paths stay within the scan root;
+- file kinds are deterministic;
+- ignore policy is explicit;
+- watch filters use compatible classification;
+- very large or invalid inputs fail at the owning boundary.
+
+## Stage 2: compare with the manifest
+
+The current manifest and stat/content fingerprints divide files into:
+
+```text
+unchanged
+changed
+added
+renamed
+deleted
+```
+
+An unchanged file can reuse cached extraction when:
+
+- content/fingerprint matches;
+- cache format matches;
+- parser/extractor configuration matches;
+- relevant project-wide inputs have not invalidated it.
+
+A file-local cache is only one input. Cross-file resolution and graph analysis
+still operate on a complete logical set.
+
+## Stage 3: parse and extract files
+
+`compass-languages::Registry` maps a file to a `LanguageSpec` and extractor.
+The engine produces an `Extraction`:
+
+```text
+nodes
+edges
+hyperedges
+raw calls / language facts
+```
+
+File work can run in parallel. To keep results deterministic:
+
+- collect facts in stable source order where ordering is contractual;
+- give nodes stable IDs;
+- avoid global mutable parser state;
+- keep errors associated with source paths;
+- separate parsing from project-wide resolution.
+
+### What belongs in an extractor
+
+An extractor should emit evidence available from that file and its explicit
+local/project metadata:
+
+- declarations and containment;
+- imports/re-exports;
+- calls and references with unresolved facts as needed;
+- source locations;
+- relation context and provenance;
+- language-specific identifiers.
+
+It should not pick one arbitrary project-wide target when evidence is
+ambiguous.
+
+## Stage 4: optional integration fragments
+
+Configured sources can add extractions:
+
+- Cargo dependency graph;
+- PostgreSQL schema;
+- Google Workspace shortcuts;
+- SCIP data;
+- documents/media after semantic extraction.
+
+Every integration returns graph-compatible records and remains bounded at its
+I/O boundary.
+
+## Stage 5: resolve
+
+`compass-resolve` merges per-file facts and resolves:
+
+- module/import targets;
+- JavaScript re-exports;
+- cross-file calls;
+- members and receiver types;
+- language-specific call facts;
+- colliding IDs;
+- header/implementation pairs;
+- unique placeholders.
+
+The resolver owns project-wide evidence. It marks derived relations
+appropriately and preserves ambiguity when a unique target cannot be justified.
+
+Peak-memory paths use ownership transfer (`resolve_owned_with_root`) so large
+per-file buffers are appended/dropped rather than cloned.
+
+## Stage 6: graph build and deduplication
+
+`compass-graph` combines resolved extractions into a `GraphDocument`.
+
+It:
+
+- maps facts to node-link records;
+- enforces direction;
+- preserves parallel edges where required;
+- removes only duplicates allowed by the compatibility contract;
+- applies entity deduplication;
+- optionally uses a semantic tiebreaker where explicitly configured;
+- records graph-level metadata.
+
+Deduplication must not merge two same-labeled but distinct entities merely for
+a smaller graph.
+
+## Stage 7: semantic merge
+
+The core can receive a `SemanticLayer`. The semantic pipeline:
+
+1. reads bounded units;
+2. packs chunks;
+3. invokes the selected backend;
+4. parses and validates untrusted JSON fragments;
+5. binds evidence and normalizes IDs;
+6. records partial/completeness status;
+7. merges results with structural facts.
+
+Provider failure or invalid fragments must not publish a complete semantic
+graph. `--allow-partial` is an explicit policy change, not silent recovery.
+
+## Stage 8: cluster and analyze
+
+`compass-graph`:
+
+- clusters nodes into communities;
+- computes community cohesion/signatures;
+- remaps communities stably for incremental output where possible;
+- identifies god nodes and surprising connections;
+- suggests questions;
+- detects import cycles;
+- generates data for reports.
+
+`--no-cluster` can isolate deterministic AST behavior in qualification, but the
+normal user artifact includes analysis when enabled.
+
+## Stage 9: render
+
+`compass-output` converts the graph and analysis to:
+
+- graph JSON;
+- Markdown report;
+- optional HTML;
+- requested export sidecars.
+
+Derived output should not change graph identity. A renderer change can still
+affect historical artifact registries and must be versioned when reproducible
+reconstruction depends on it.
+
+## Stage 10: publish
+
+`compass-files` atomic helpers and build guards publish the new artifact set.
+
+Required behavior:
+
+- no successful marker for incomplete work;
+- no partial JSON replacing a valid graph;
+- diagnostics identify the source/stage;
+- manifest advances only with the graph it describes;
+- disposable cache failure does not redefine graph truth.
+
+## Incremental update correctness
+
+The fast path is correct only if it produces a graph equivalent to a clean
+rebuild for the same inputs.
+
+Cases to test:
+
+| Change | Expected invalidation |
+| --- | --- |
+| edit function body | changed file extraction plus affected resolution/analysis |
+| add file | new extraction and project merge |
+| delete file | remove its nodes/edges and re-resolve dependents |
+| rename file | path/ID/import effects handled |
+| change manifest | project metadata and dependent resolution invalidated |
+| change ignore rule | corpus membership recalculated |
+| parser/extractor version | incompatible caches invalidated |
+| semantic profile change | semantic cache/profile invalidated |
+
+Performance qualification compares cold, warm unchanged, single-file change,
+rename, and delete cases against the frozen oracle.
+
+## Watch mode
+
+`compass-core::watch_local_graph` combines compatible watch filtering,
+debouncing, and the update pipeline.
+
+Watch correctness requires:
+
+- no missed relevant path;
+- no infinite loop on generated `compass-out/`;
+- coalesced bursts;
+- observable failure;
+- clean shutdown;
+- optional polling fallback.
+
+The one-shot update remains the recovery oracle.
+
+## Error propagation
+
+Keep stage context:
+
+```text
+FileError        discovery/read/write/cache
+language error   parse/extract source
+CoreError        orchestration/completeness
+DedupError       graph identity conflict
+semantic error   provider/parse/validation
+output error     rendering/publication
+```
+
+The CLI maps these to useful stderr and exits. Avoid stringifying too early.
+
+## Verification for a pipeline change
+
+At minimum:
+
+1. smallest unit fixture for the new fact or invalidation;
+2. cold build artifact check;
+3. unchanged warm update;
+4. changed/renamed/deleted cases if relevant;
+5. graph equivalence against a clean rebuild;
+6. direction, relation, provenance, attributes, and multiplicity assertions;
+7. malformed/oversized/interrupted input failure;
+8. CLI stdout/stderr/exit/output-tree test;
+9. parity fixture if the behavior is in the compatibility ledger;
+10. performance qualification if the hot/cold pipeline changes.
+
+## Related pages
+
+- [How Compass works](../concepts/how-it-works.md)
+- [Workspace tour](workspace-tour.md)
+- [Semantic pipeline](semantic-pipeline.md)
+- [Performance qualification](../../PERFORMANCE.md)
+
+**Next step:** trace one fixture from detection through its `Extraction`, then
+inspect the resolved edge and final `graph.json` record.

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -1,0 +1,309 @@
+# Query engine implementation
+
+Compass has two complementary query paths: focused discovery/traversal and the
+CompassQL compiler/executor. Both operate over the same indexed graph model.
+
+> **Who this page is for:** contributors changing query ranking, traversal,
+> CompassQL syntax/plans/execution, or machine output.
+>
+> **You will learn:** loading, indexes, discovery scoring, traversal, affected,
+> CompassQL compilation and execution, caching, limits, profiling, and tests.
+>
+> **Prerequisites:** [Graph model](../concepts/graph-model.md) and
+> [Workspace tour](workspace-tour.md).
+>
+> **Reading time:** 15 minutes.
+
+## Load once into the query model
+
+`GraphDocument::load`:
+
+- requires the normal JSON extension;
+- enforces the graph size cap;
+- reuses a binary cache only when its signature matches;
+- retains unknown document fields and attributes.
+
+`Graph::from_document`:
+
+- consolidates duplicate node IDs by extending attributes;
+- ensures edge endpoints can be indexed;
+- preserves parallel edges for multigraph documents;
+- builds ID lookup;
+- builds incoming/outgoing adjacency;
+- builds `QueryIndex` and a schema fingerprint.
+
+Read commands can force stored direction when compatibility documents require
+it.
+
+## Focused discovery path
+
+```text
+question
+  -> query_terms()
+  -> score_nodes()
+  -> choose anchors
+  -> query_graph_text() with BFS/DFS and budget
+  -> focused text subgraph
+```
+
+### Text normalization
+
+`compass-query::text`:
+
+- normalizes labels and questions;
+- removes common question noise;
+- produces search tokens;
+- normalizes context filters.
+
+This is deterministic token matching, not embedding inference.
+
+### Scoring
+
+`score_nodes` uses indexed label/attribute evidence to rank candidates.
+`find_node` and `pick_scored_endpoint` support commands that need one entity.
+
+Ranking changes can alter which subgraph users see even when graph data is
+unchanged. Protect them with realistic query fixtures and stable tie behavior.
+
+### Traversal
+
+`query_graph_text` traverses from anchors using:
+
+- BFS or DFS;
+- depth/working budget;
+- optional relation context filters;
+- hub avoidance/bounds;
+- directed adjacency.
+
+The renderer labels nodes and edges with provenance and source context.
+
+## Explain and path
+
+`render_explanation` separates incoming from outgoing relations and reports
+degree. Human output may list a multigraph neighbor once while retaining
+parallel edge degree.
+
+`render_shortest_path` preserves stored arrow direction:
+
+```text
+A --calls--> B
+```
+
+When queried in reverse, the rendered arrow points backward rather than
+pretending the relation reversed.
+
+Path tests must cover:
+
+- forward/reverse rendering;
+- no path;
+- repeated labels;
+- directed/legacy graphs;
+- parallel edges;
+- tie ordering.
+
+## Affected projection
+
+Impact analysis needs only:
+
+- node ID/label/location;
+- edge endpoints and relation.
+
+`GraphDocument::load_for_affected` can use a compact binary cache and avoids
+retaining irrelevant attributes. `affected_nodes` traverses incoming
+impact-relevant relation families under a depth.
+
+This specialized projection improves cold performance without changing the
+full graph/query model.
+
+## CompassQL compile path
+
+`compass-cypher` compiles:
+
+```text
+bytes
+  -> tokens with spans
+  -> AST
+  -> semantic scope/type checks
+  -> logical operators
+  -> optimizer records
+  -> LogicalPlan
+```
+
+Compile limits bound:
+
+- source bytes;
+- token count;
+- nesting;
+- path depth.
+
+Diagnostics carry stable codes and byte spans. Unsupported read/write syntax
+is rejected during compile/semantic analysis.
+
+## CompassQL execution
+
+`compass-query::cql` executes a logical plan over `Graph`.
+
+Execution supports:
+
+- indexed node candidates;
+- directed expansion and bounded paths;
+- repeated-variable joins;
+- optional matching;
+- correlated one-level existence checks;
+- unwinding;
+- filters and expressions;
+- projection, distinct, union, order, skip, limit;
+- aggregation;
+- shortest-path families;
+- typed values.
+
+Runtime limits track:
+
+- deadline/cancellation;
+- returned rows;
+- expanded relationships;
+- working memory;
+- path depth.
+
+Limit checks occur during work, not only after a huge result is constructed.
+
+## Plan cache
+
+The plan cache key includes:
+
+```text
+exact source
+language/planner versions
+ordered parameter types
+planning limits
+graph schema fingerprint
+```
+
+It excludes:
+
+- parameter values;
+- graph values;
+- result rows;
+- deadline and cancellation state.
+
+This allows safe plan reuse without leaking prior execution data.
+
+## Result model
+
+`QueryResult` contains:
+
+- versioned schema;
+- column metadata;
+- typed rows;
+- optional explain plan;
+- optional profile.
+
+Renderers produce:
+
+- table;
+- `compass.cql.result/1` JSON;
+- `compass.cql.jsonl/1` header/rows/summary.
+
+Output-to-file uses atomic completion. A failed execution must not leave a
+valid-looking partial result.
+
+## Explain and profile
+
+`EXPLAIN` returns logical operators and optimization records without executing.
+
+`PROFILE` adds per-operator/clause:
+
+- input/output rows;
+- candidate nodes;
+- expanded relationships;
+- working-memory estimates;
+- elapsed time;
+- cancellation checkpoints.
+
+Profiles are part of performance diagnosis. They must not include parameter
+values or secrets.
+
+## Historical graph loading
+
+`--at REV` is resolved in the CLI/history service:
+
+1. resolve exact commit;
+2. open history;
+3. find and validate preferred realization;
+4. materialize synchronously if missing;
+5. reconstruct `GraphDocument`;
+6. build the same `LoadedGraph`/query indexes.
+
+The query engine does not need separate semantics for current and historical
+graphs after loading.
+
+## Test map
+
+### `compass-query`
+
+Cover normalization, scoring, traversal, direction, affected, execution,
+limits, caching, profiles, and output values.
+
+### `compass-cypher`
+
+Cover lexer/parser/semantic/plan diagnostics, support records, optimization,
+and language-version behavior.
+
+### CLI tests
+
+`compassql_cli.rs` and read-command tests cover:
+
+- option sources;
+- stdin/file/REPL;
+- parameters;
+- stdout/stderr/exits;
+- output atomicity;
+- `--graph`/`--at`;
+- JSON/JSONL schemas.
+
+### TCK and differential tests
+
+The repository carries an attributed subset of the openCypher TCK and optional
+Neo4j differential evidence. New support should update the matrix and add
+portable feature coverage.
+
+### Benchmarks
+
+`scripts/benchmark_compassql.sh` measures compile/plan, cache hits, fixed
+matches, paths, aggregation, optional matching, cancellation latency,
+expansions, rows, and memory.
+
+## Change checklist
+
+When adding CompassQL syntax:
+
+1. lexer/token/spans;
+2. AST and parser;
+3. semantic scope/type rules;
+4. plan operator;
+5. optimizer effect;
+6. bounded execution;
+7. typed result;
+8. diagnostic code for invalid forms;
+9. support matrix;
+10. TCK/unit/CLI/differential/benchmark evidence.
+
+When changing discovery ranking:
+
+1. realistic question tokens;
+2. multilingual/noise behavior;
+3. stable ties;
+4. hub/context filtering;
+5. result budget;
+6. compatibility snapshots;
+7. cold/warm query performance.
+
+## Related pages
+
+- [CompassQL concepts](../concepts/compassql.md)
+- [CompassQL reference](../COMPASSQL.md)
+- [Graph model](../concepts/graph-model.md)
+- [Performance qualification](../../PERFORMANCE.md)
+
+**Next step:** run a CompassQL query with `EXPLAIN`, then locate each logical
+operator in `compass-cypher` and its executor in `compass-query`.

--- a/docs/implementation/semantic-pipeline.md
+++ b/docs/implementation/semantic-pipeline.md
@@ -1,0 +1,289 @@
+# Semantic pipeline implementation
+
+The semantic pipeline turns untrusted non-code content and provider responses
+into validated graph facts. It is optional and explicitly separate from the
+fully local structural code path.
+
+> **Who this page is for:** contributors adding providers, media formats,
+> semantic relations, validation, or completeness behavior.
+>
+> **You will learn:** source classification, extraction/chunking, backend
+> selection, request safety, response validation, evidence binding, partial
+> results, caching, and test requirements.
+>
+> **Prerequisites:** [Extraction pipeline](extraction-pipeline.md) and
+> [Security and privacy](../design/security-and-privacy.md).
+>
+> **Reading time:** 12–15 minutes.
+
+## Boundary
+
+```text
+code files ----------------> deterministic structural extraction
+
+docs/media/integration text -> semantic orchestration -> validated fragments
+                                                      |
+                                                      v
+                                               shared graph merge
+```
+
+The semantic path must not make code-only builds depend on credentials or
+network availability.
+
+## Source preparation
+
+Input can arrive as:
+
+- plain text/Markdown;
+- PDF;
+- DOCX/XLSX;
+- images and image references;
+- decoded audio/video transcript;
+- Google Workspace export;
+- remote ingested corpus file.
+
+`compass-media` enforces raw and archive-expansion limits before extracting
+text. `compass-transcribe` owns bounded audio/video orchestration.
+
+The semantic layer represents prepared content as bounded units with source
+identity and evidence metadata.
+
+## Chunk packing
+
+Large inputs are sliced under character/token/image budgets:
+
+- per-file character caps;
+- bounded source slices;
+- image byte and per-chunk counts;
+- estimated token cost;
+- deterministic source/evidence ordering.
+
+Chunking should keep enough context for coherent extraction without sending an
+entire repository blindly.
+
+Changes to chunk boundaries can change semantic meaning and cache identity.
+
+## Prompt construction
+
+Compass embeds extraction and deep-mode prompt templates.
+
+Prompt construction:
+
+- identifies the requested structured fragment format;
+- separates instructions from untrusted corpus text;
+- neutralizes injection sentinels;
+- includes source/evidence identity;
+- sets mode-specific requirements;
+- remains bounded.
+
+Repository content is data, not trusted provider instruction.
+
+## Backend selection
+
+Built-in backends include provider families such as:
+
+- Anthropic/Claude;
+- Gemini;
+- OpenAI and compatible endpoints;
+- Azure OpenAI;
+- Ollama-compatible endpoints;
+- Bedrock;
+- other compatibility backends represented in current CLI/source.
+
+A custom provider registry records:
+
+- provider name;
+- base URL;
+- default model;
+- environment-variable name for the key.
+
+Selection combines explicit CLI configuration and documented environment
+fallbacks. History captures provider/model meaning in the extraction profile.
+
+## Endpoint safety
+
+Before a request:
+
+- parse and validate the base URL;
+- require an expected scheme;
+- reject link-local/metadata addresses where required;
+- warn when an allegedly local endpoint is non-loopback;
+- apply timeout and response-byte bounds;
+- keep keys out of diagnostics;
+- avoid uncontrolled redirects or shell execution.
+
+An OpenAI-compatible endpoint can receive the full selected corpus. The
+compatibility label does not make it trustworthy.
+
+## Request/response normalization
+
+Provider APIs have different envelopes. Backend helpers normalize:
+
+- content/messages;
+- image forms;
+- model and temperature rules;
+- authentication headers;
+- completion text;
+- provider errors;
+- context-limit signals;
+- retryable versus permanent failures.
+
+Normalization should preserve enough provider context for diagnostics without
+including secret headers or entire sensitive responses.
+
+## Adaptive retry
+
+When a response indicates context overflow, the pipeline can split or reduce
+work and retry under bounded policy.
+
+It must avoid:
+
+- infinite retries;
+- retrying permanent authentication/usage errors;
+- publishing only the chunks that happened to succeed unless partial policy is
+  explicit;
+- multiplying concurrency after a limit failure.
+
+Callers configure total concurrency and API timeout.
+
+## Parse untrusted fragments
+
+Provider output is untrusted JSON-like content. The semantic crate enforces
+limits such as:
+
+- maximum fragment bytes;
+- maximum nodes;
+- maximum edges;
+- maximum hyperedges;
+- maximum nodes per hyperedge;
+- maximum ID length;
+- maximum provider response bytes.
+
+Parsing/validation checks:
+
+- JSON structure and depth;
+- record shapes;
+- endpoint identity;
+- attribute types and sizes;
+- safe IDs;
+- relation/evidence fields;
+- duplicate and malformed records;
+- prompt-injection residue;
+- fragment completeness.
+
+Malformed output is a provider/extraction failure, not graph data to repair
+silently.
+
+## Evidence binding
+
+Validated nodes and edges are associated with their source evidence. IDs are
+normalized and source references retained so users can trace semantic facts
+back to a document or media segment.
+
+Provenance must distinguish semantic results from deterministic structural
+resolution in the attributes available to consumers.
+
+## Partial builds
+
+The pipeline tracks which semantic sources are partial or missing.
+
+Default:
+
+```text
+one required semantic source fails
+  -> build is incomplete
+  -> no complete semantic publication
+```
+
+Explicit partial policy:
+
+```text
+--allow-partial
+  -> successful fragments may publish
+  -> partial source metadata must remain visible
+```
+
+An integration must not present partial coverage as a complete repository
+graph.
+
+## Cache
+
+Semantic cache identity can include:
+
+- source hash/slice;
+- prompt fingerprint;
+- mode;
+- backend/model;
+- relevant parser/semantic version;
+- image/evidence inputs.
+
+It excludes secret key values.
+
+A cache hit must undergo compatibility/integrity checks. Old unvalidated
+provider content should not bypass new validation solely because it exists.
+
+## Community labeling and deduplication
+
+Semantic providers can optionally help label communities or break genuine
+entity-deduplication ties. These are separate explicit roles:
+
+- community labeling changes display/navigation metadata;
+- semantic extraction adds content facts;
+- a tiebreaker resolves a bounded ambiguity in graph construction.
+
+Do not let a labeling call rewrite structural topology.
+
+## Native media
+
+`compass-whisper` provides bounded CPU inference internals. Device selection
+currently exposes CPU only so released behavior remains portable and
+dependency-free.
+
+`compass-transcribe` keeps model inference behind a trait and owns file/download
+orchestration. No separate public transcription command is exposed merely
+because internals exist.
+
+## Tests for provider work
+
+Use local mock servers. Tests should cover:
+
+- exact request path, method, headers with secrets redacted in assertions;
+- response normalization;
+- non-2xx status;
+- malformed JSON;
+- oversized body;
+- timeout;
+- context-overflow adaptive retry;
+- authentication failure;
+- endpoint scheme/host/link-local checks;
+- model/config precedence;
+- partial/completeness behavior;
+- stable evidence IDs;
+- cache hit/miss/invalidation;
+- no provider call in code-only mode.
+
+Never require a real paid provider or real secret for the normal test suite.
+
+## Tests for new semantic records
+
+Assert:
+
+- node and edge counts;
+- stable IDs;
+- source evidence;
+- direction and relation;
+- provenance;
+- hyperedge participants;
+- size/depth rejection;
+- merge with structural facts;
+- round trip into `graph.json` and history artifacts.
+
+## Related pages
+
+- [Security and privacy](../design/security-and-privacy.md)
+- [Configuration reference](../reference/configuration.md)
+- [Extraction pipeline](extraction-pipeline.md)
+- [Provenance](../concepts/provenance.md)
+
+**Next step:** trace one semantic fixture from a bounded source unit through
+provider normalization, fragment validation, evidence binding, and graph merge.

--- a/docs/implementation/workspace-tour.md
+++ b/docs/implementation/workspace-tour.md
@@ -1,0 +1,375 @@
+# Compass workspace tour
+
+This tour maps each crate to its responsibility, main public interfaces, and
+verification evidence. Use it to decide where a change belongs before opening
+large source files.
+
+> **Who this page is for:** new and returning Compass contributors.
+>
+> **You will learn:** crate ownership, dependency direction, key modules, and
+> the tests that protect each boundary.
+>
+> **Prerequisites:** [System architecture](../design/architecture.md).
+>
+> **Reading time:** 15–20 minutes.
+
+## Start at the workspace manifest
+
+`Cargo.toml` defines one Edition 2024 workspace, Rust 1.97, shared dependency
+versions, and strict lints:
+
+```text
+unsafe_code       forbidden
+clippy::all       denied
+unwrap_used       denied
+expect_used       denied
+panic             denied
+```
+
+The released binary is:
+
+```text
+package: compass-cli
+binary:  compass
+entry:   crates/compass-cli/src/bin/compass.rs
+```
+
+## Core pipeline crates
+
+### `compass-files`
+
+**Purpose:** deterministic filesystem discovery and safe artifacts.
+
+**Key modules:**
+
+```text
+atomic       atomic byte/text/JSON writes
+build_guard  incomplete-build protection
+cache        extraction cache formats
+detect       file classification and ignore policy
+encoding     source decoding
+hash         content/stat/prompt fingerprints
+manifest     incremental build state
+slice        bounded source slicing
+```
+
+**Change here when:** adding detection policy, a cache/manifest contract, or an
+atomic filesystem primitive.
+
+**Evidence:** crate tests plus CLI update/extract/watch tests that exercise
+incremental behavior and output safety.
+
+### `compass-languages`
+
+**Purpose:** statically linked structural extraction.
+
+**Key concepts:**
+
+- `Registry` and `LanguageSpec`;
+- `ExtractorKind`;
+- `Extraction` containing nodes, edges, hyperedges, and raw calls;
+- stable ID helpers;
+- language-specific modules;
+- SCIP and project-manifest ingestion.
+
+**Change here when:** adding syntax support, local facts, node/edge attributes,
+or a new language registry entry.
+
+**Do not:** resolve arbitrary cross-file calls here when the resolver needs
+project-wide facts.
+
+### `compass-resolve`
+
+**Purpose:** deterministic project-wide resolution.
+
+**Public boundary:** merge per-file `Extraction` values and resolve cross-file
+imports, calls, members, re-exports, IDs, and stubs.
+
+**Change here when:** the extractor already emitted enough evidence but the
+final target requires multiple files/scopes.
+
+**Evidence:** language/member-resolution tests and Python-oracle/parity
+fixtures.
+
+### `compass-graph`
+
+**Purpose:** build and analyze the graph.
+
+**Public families:**
+
+- build/deduplication;
+- cluster/community scoring and stable remapping;
+- god-node and surprising-connection analysis;
+- suggested questions;
+- import cycles;
+- graph diff helpers.
+
+**Change here when:** behavior depends on graph topology rather than source
+syntax.
+
+### `compass-core`
+
+**Purpose:** application services.
+
+**Modules:**
+
+```text
+pipeline          current graph builds
+history           complete historical materialization adapter
+cluster_existing  reanalyze a saved graph
+diagnostics       graph diagnostics
+merge             graph merge service
+watch             filesystem watch orchestration
+raw_guard         raw-input safety boundary
+```
+
+**Primary types:** `BuildOptions`, `BuildPurpose`, `BuildResult`,
+`BuildTimings`, `SemanticLayer`, `MaterializeRequest`.
+
+**Change here when:** multiple domain crates must be sequenced into one
+transactional workflow.
+
+## Graph model and query crates
+
+### `compass-model`
+
+**Purpose:** typed node-link graph and indexes.
+
+**Core types:**
+
+```text
+NodeRecord
+EdgeRecord
+GraphDocument
+Graph
+QueryIndex
+SchemaFingerprint
+GraphError
+```
+
+The model retains unknown attributes and preserves directed/multigraph
+semantics. `Graph` builds ID, incoming, outgoing, and query indexes.
+
+**Change here when:** altering the graph document contract or core indexing.
+Such changes require broad compatibility and history review.
+
+### `compass-cypher`
+
+**Purpose:** CompassQL compiler and logical planner.
+
+**Modules:** lexer, tokens, spans, parser, AST, semantic analysis, values,
+logical plan, optimizer, diagnostics, support matrix.
+
+**Versions:** `LANGUAGE_VERSION` and `PLANNER_VERSION` are cache/compatibility
+inputs.
+
+**Change here when:** adding documented query syntax, type rules, or a logical
+operator.
+
+### `compass-query`
+
+**Purpose:** graph query execution.
+
+**Modules:**
+
+```text
+text       normalization and tokens
+score      node scoring/selection
+traversal  focused query, path, explain
+affected   incoming impact traversal
+benchmark  query benchmark support
+cql        CompassQL execution/cache/profile
+```
+
+**Change here when:** implementing execution behavior over the graph. Syntax
+acceptance belongs in `compass-cypher`.
+
+## Interface and output crates
+
+### `compass-cli`
+
+**Purpose:** public command surface.
+
+Command-family modules separate history, query, hooks, install, providers,
+ingestion, PRs, semantic helpers, results, labels, and integrations.
+
+The crate maps domain results to:
+
+- stdout/stderr;
+- human and JSON formats;
+- usage help;
+- exact exit codes;
+- filesystem side effects.
+
+**Change here when:** adding or modifying a public command. Keep reusable
+domain logic in the owning lower crate.
+
+**Evidence:** many subprocess-style integration tests under
+`crates/compass-cli/tests/`.
+
+### `compass-output`
+
+**Purpose:** graph renderers and export documents.
+
+Formats include Markdown report, HTML, JSON, SVG, GraphML, Cypher, tree,
+call-flow, Obsidian, wiki, and canvas outputs.
+
+**Change here when:** the graph meaning is already complete and only its
+representation changes.
+
+### `compass-mcp`
+
+**Purpose:** MCP server over graph and PR services.
+
+Owns MCP schema, resources/tools, stdio/HTTP transport, authentication, and
+request limits.
+
+**Change here when:** adding a service tool or transport behavior. Reuse
+`compass-query` for graph logic.
+
+## History crate
+
+### `compass-history`
+
+**Purpose:** immutable versioned graph storage.
+
+**Module map:**
+
+| Module | Responsibility |
+| --- | --- |
+| `model` | commits, realizations, stored trees, publication model |
+| `fingerprint` | profiles and meaning-affecting identity |
+| `canonical` | canonical encoding |
+| `keys` | typed node/edge/hyperedge keys |
+| `artifacts` | graph partitioning and artifact sets |
+| `store` | SQLite/Prolly read and publication |
+| `validate` | limits and integrity reports |
+| `diff` | typed record streaming |
+| `git` | repository and protected worktree |
+| `jobs` | durable FIFO requests and state |
+| `leases` | claim heartbeat/expiry |
+| `lock` | activity/maintenance coordination |
+| `gc` | reachability and pruning plans |
+| `config` | repository profile and enablement |
+| `durable` | durable file operations |
+
+**Change here when:** altering historical identity, durability, publication,
+validation, diff, or maintenance behavior.
+
+**Evidence:** dedicated tests for canonical encoding, diffs, Git isolation,
+jobs, maintenance, publication, round trips, performance, and SQLite contracts.
+
+## Semantic and media crates
+
+### `compass-semantic`
+
+**Purpose:** validate untrusted semantic fragments and orchestrate providers.
+
+The crate owns hard caps for fragment bytes and record counts, prompt
+construction, response normalization, endpoint checks, adaptive retry, partial
+tracking, evidence binding, and community labels.
+
+**Change here when:** adding a backend, prompt contract, semantic validator, or
+provider safety rule.
+
+### `compass-media`
+
+**Purpose:** bounded text extraction from local documents.
+
+It handles PDF and Office formats with raw, expanded, member, and compression
+ratio limits.
+
+### `compass-transcribe`
+
+**Purpose:** bounded transcription orchestration and download/backend traits.
+
+### `compass-whisper`
+
+**Purpose:** Compass-owned native Whisper inference internals, currently
+portable CPU behavior.
+
+## Integration crates
+
+### `compass-cargo`
+
+Parses Cargo workspaces and dependencies deterministically into graph
+fragments.
+
+### `compass-global`
+
+Maintains a persistent cross-project graph registry and enforces graph/manifest
+size limits.
+
+### `compass-google-workspace`
+
+Exports `.gdoc`, `.gsheet`, and `.gslides` shortcuts through bounded `gws`
+subprocess calls.
+
+### `compass-graphdb`
+
+Implements native Neo4j Bolt and FalkorDB RESP clients and graph-to-operation
+mapping.
+
+### `compass-ingest`
+
+Fetches bounded public URL content with SSRF defenses and writes corpus files
+atomically.
+
+### `compass-postgres`
+
+Performs read-only PostgreSQL catalog introspection for tables, views,
+routines, and constraints.
+
+### `compass-prs`
+
+Uses bounded Git/GitHub subprocesses to build a PR dashboard and connect changed
+files with graph impact.
+
+### `compass-reflect`
+
+Aggregates session memory deterministically and can write a learning overlay
+sidecar.
+
+## Verification-only crate
+
+### `compass-parity`
+
+Development-only differential tests compare selected native behavior with the
+pinned Graphify baseline. It is broad evidence, not a runtime dependency.
+
+## Vendored parser package
+
+`vendor/compass-tree-sitter-language-pack` is a pinned Compass-specific parser
+package with registry, queries, language definitions, download/build policy,
+and extraction helpers.
+
+Changes can affect many languages and release artifacts. Run its registry and
+multilingual qualification, not one language test alone.
+
+## Where should my change go?
+
+```text
+new file extension / ignore behavior?       compass-files
+new syntax entity or local edge?            compass-languages
+cross-file target selection?                compass-resolve
+topology algorithm / communities?           compass-graph
+graph JSON/index behavior?                   compass-model
+query syntax or plan?                        compass-cypher
+query execution?                             compass-query
+pipeline sequencing?                        compass-core
+command/flags/exits?                         compass-cli
+render/export format?                        compass-output
+semantic backend/validation?                 compass-semantic
+immutable revision storage?                  compass-history
+external protocol?                           corresponding integration crate
+```
+
+## Related pages
+
+- [System architecture](../design/architecture.md)
+- [Extraction pipeline](extraction-pipeline.md)
+- [Query engine](query-engine.md)
+- [Extending Compass](extending-compass.md)
+
+**Next step:** locate one feature through this map, then read its crate
+`src/lib.rs`, nearest integration test, and CLI call site in that order.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,580 @@
+# Command reference
+
+This reference groups the public `compass` command surface by responsibility.
+Run `compass <command> --help` for the exact options in the installed version;
+this page explains how the families fit together and which outputs are stable
+for automation.
+
+> **Who this reference is for:** users and integrators looking up a command
+> without reading a tutorial.
+>
+> **You will learn:** public command families, primary inputs/outputs, shared
+> conventions, and where exact subcommand contracts live.
+>
+> **Prerequisites:** Compass installed.
+>
+> **Reading time:** 12–15 minutes as a survey; use the tables for lookup.
+
+## Global entry points
+
+```bash
+compass --help
+compass --version
+compass <command> --help
+```
+
+The shipped product executable is `compass`. Scripts and new documentation
+should not depend on the internal Graphify compatibility frontend.
+
+## Build and analysis
+
+### `update`
+
+Make a saved current-tree graph match the project:
+
+```text
+compass update [PATH]
+  [--out DIR]
+  [--no-cluster]
+  [--force]
+  [--no-viz]
+  [--no-gitignore]
+  [--exclude PATTERN]
+  [--resolution N]
+  [--exclude-hubs N]
+```
+
+Use for normal cold/incremental structural builds.
+
+### `extract`
+
+Expose the full build surface:
+
+```text
+compass extract [PATH]
+  [--code-only]
+  [--cargo]
+  [--google-workspace]
+  [--postgres DSN]
+  [--backend NAME]
+  [--model MODEL]
+  [--mode deep]
+  [--token-budget N]
+  [--max-concurrency N]
+  [--max-workers N]
+  [--api-timeout SECONDS]
+  [--allow-partial]
+  [--dedup-llm]
+  [--timing]
+  [--out DIR]
+  [--no-cluster]
+  [--force]
+  [--no-viz]
+  [--no-gitignore]
+  [--exclude PATTERN]
+  [--resolution N]
+  [--exclude-hubs N]
+```
+
+Use `--code-only` for an explicit fully local structural profile.
+
+### `watch`
+
+```text
+compass watch [PATH]
+  [--debounce SECONDS]
+  [--out DIR]
+  [--no-cluster]
+  [--no-viz]
+  [--no-gitignore]
+  [--exclude PATTERN]
+  [--poll]
+```
+
+Long-running filesystem watcher. Use a manual `update` as its recovery oracle.
+
+### `cluster-only`
+
+Recluster/analyze an existing graph or path:
+
+```text
+compass cluster-only [PATH]
+  [--graph PATH]
+  [--no-viz]
+  [--no-label]
+  [--resolution N]
+  [--exclude-hubs N]
+  [--min-community-size=N]
+```
+
+### `label`
+
+Generate/update semantic community labels:
+
+```text
+compass label [PATH]
+  [--graph PATH]
+  [--backend NAME]
+  [--model NAME]
+  [--missing-only]
+  [--no-viz]
+  [--resolution N]
+  [--exclude-hubs N]
+  [--max-concurrency N]
+  [--batch-size N]
+  [--min-community-size=N]
+  [--timing]
+```
+
+## Read and query
+
+### `query`
+
+Natural-language graph discovery:
+
+```text
+compass query "<question>"
+  [--dfs]
+  [--context VALUE]
+  [--budget N]
+  [--graph PATH | --at REV]
+```
+
+CompassQL:
+
+```text
+compass query --cql QUERY
+  [--param NAME=VALUE]
+  [--format table|json|jsonl]
+  [--graph PATH | --at REV]
+
+compass query --cql --file PATH
+  [--params-file PATH]
+  [--output PATH]
+
+compass query --cql --stdin
+compass query --cql --repl
+```
+
+Limits:
+
+```text
+--timeout-ms N
+--max-rows N
+--max-path-depth N
+--max-expanded-relationships N
+--max-memory-bytes N
+```
+
+Canonical language contract: [CompassQL 1](../COMPASSQL.md).
+
+### `path`
+
+```text
+compass path "<source>" "<target>" [--graph PATH | --at REV]
+```
+
+Renders a shortest known graph path while preserving relationship direction.
+
+### `explain`
+
+```text
+compass explain "<node>" [--graph PATH | --at REV]
+```
+
+Shows one node and incoming/outgoing connections.
+
+### `affected`
+
+```text
+compass affected "<node-or-label>"
+  [--relation R]
+  [--depth N]
+  [--graph PATH]
+```
+
+Traverses incoming impact-relevant relations.
+
+### `tree`
+
+```text
+compass tree
+  [--graph PATH]
+  [--output HTML]
+  [--root PATH]
+  [--max-children N]
+  [--top-k-edges N]
+  [--label NAME]
+```
+
+Defaults:
+
+- graph: `compass-out/graph.json`;
+- output: `compass-out/GRAPH_TREE.html`;
+- max children: 200;
+- top outbound edges: 12.
+
+### `benchmark`
+
+```text
+compass benchmark [GRAPH_JSON]
+```
+
+Runs the native graph-query benchmark surface.
+
+## Versioned history and diffs
+
+### `history`
+
+```text
+compass history enable [build-profile options]
+compass history disable
+compass history status [REV] [--format text|json]
+compass history build REV [build-profile options|--profile-from REV|REALIZATION] [--format text|json]
+compass history rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]
+compass history list [REV] [--format text|json]
+compass history show REALIZATION [--format text|json]
+compass history prefer REV REALIZATION [--format text|json]
+compass history export REV --format graph-json|compass-out --output PATH
+compass history gc [--prune-non-preferred] [--yes] [--format text|json]
+```
+
+Build-profile options include:
+
+```text
+--code-only
+--backend NAME
+--model NAME
+--exclude PATTERN
+--cargo
+```
+
+### `diff`
+
+```text
+compass diff OLD NEW
+  [--detailed]
+  [--format text|json]
+  [--topology-only]
+  [--include-locations]
+  [--include-analysis]
+  [--include-metadata]
+  [--fingerprint SHA]
+  [--allow-profile-mismatch]
+```
+
+`--detailed` is a human format and cannot be combined with JSON.
+
+## Service
+
+### `serve`
+
+```text
+compass serve [GRAPH_PATH]
+  [--graph PATH]
+  [--transport stdio|http]
+  [--host HOST]
+  [--port PORT]
+  [--api-key KEY]
+  [--path PATH]
+  [--json-response]
+  [--stateless]
+  [--session-timeout SECONDS]
+```
+
+Prefer stdio for a single local client. Avoid putting secret values directly in
+shell history; use the deployment's supported secret mechanism.
+
+## Export and visualization
+
+### `export`
+
+Formats include:
+
+```text
+html
+callflow-html
+obsidian
+wiki
+svg
+graphml
+cypher / graph database formats represented by current help
+neo4j
+falkordb
+```
+
+Each format has its own exact flags:
+
+```bash
+compass export --help
+compass export callflow-html --help
+```
+
+Common inputs include `--graph PATH`, labels/report/sections, output directory,
+node/diagram limits, and database connection arguments.
+
+For database credentials, prefer supported environment variables over
+`--password`.
+
+### `tree`
+
+Listed under read/query; produces a filesystem/symbol HTML visualization.
+
+## Graph diagnostics and merge operations
+
+### `diagnose`
+
+The `diagnose` command groups integrity checks for saved graph artifacts. Its
+current public diagnostic is `multigraph`.
+
+#### `diagnose multigraph`
+
+```text
+compass diagnose multigraph
+  [--graph PATH]
+  [--json]
+  [--max-examples N]
+  [--directed | --undirected]
+  [--extract-path PATH]
+```
+
+### `merge-graphs`
+
+```text
+compass merge-graphs graph1.json graph2.json [...]
+  [--out merged.json]
+```
+
+Inputs must have compatible directed/multigraph semantics.
+
+### `merge-driver`
+
+```text
+compass merge-driver BASE CURRENT OTHER
+```
+
+Low-level managed integration surface for graph merge behavior.
+
+### `cache-check`
+
+```text
+compass cache-check FILES_FROM
+  [--root DIR]
+  [--mode M | --deep]
+  [--prompt-file PATH]
+```
+
+Checks whether cached semantic results can be reused for a file list, root,
+mode, and prompt contract.
+
+### `merge-chunks`
+
+```text
+compass merge-chunks CHUNK_FILES... --out PATH
+```
+
+Validates and combines semantic chunk files into one output artifact.
+
+### `merge-semantic`
+
+```text
+compass merge-semantic
+  --cached PATH
+  --new PATH
+  --out PATH
+```
+
+These are pipeline helpers; use them when implementing or diagnosing semantic
+workflows.
+
+## Assistant and hook lifecycle
+
+### `install`
+
+```text
+compass install
+  [--project]
+  [--strict]
+  [--platform P | P]
+```
+
+Run `compass install --help` for the version's platform list. `--strict`
+requires a supported project-scoped hook target.
+
+### `uninstall`
+
+```text
+compass uninstall
+  [--project]
+  [--purge]
+  [--platform P | P]
+```
+
+Review targets before `--purge`.
+
+### `hook`
+
+```text
+compass hook [install|uninstall|status]
+```
+
+### `hook-check`
+
+```text
+compass hook-check
+```
+
+Managed integration probe installed for supported assistants. It is normally
+invoked by generated integration configuration rather than by a person.
+
+### `hook-guard`
+
+```text
+compass hook-guard [search|read [--strict]|gemini]
+```
+
+Managed stdin/stdout adapter used by installed search, read, and Gemini
+integration hooks. Treat its input/output behavior as an internal integration
+contract unless a release explicitly documents it as a public automation API.
+
+## Providers and optional sources
+
+### `provider`
+
+```text
+compass provider list
+compass provider show NAME
+compass provider add NAME
+  --base-url URL
+  --default-model MODEL
+  --env-key KEY_VARIABLE_NAME
+  [--pricing-input N]
+  [--pricing-output N]
+compass provider remove NAME
+```
+
+Built-in provider names cannot be overridden.
+
+### `add`
+
+```text
+compass add URL
+  [--author NAME]
+  [--contributor NAME]
+  [--dir ./raw]
+```
+
+Remote ingestion changes the filesystem and network state.
+
+### `clone`
+
+```text
+compass clone GITHUB_URL
+  [--branch BRANCH]
+  [--out DIR]
+```
+
+Treat cloned content as untrusted.
+
+## Cross-project and collaboration
+
+### `global`
+
+```text
+compass global add graph.json [--as REPO_TAG]
+compass global remove REPO_TAG
+compass global list
+compass global path
+```
+
+### `prs`
+
+```text
+compass prs [NUMBER]
+  [--triage]
+  [--worktrees]
+  [--conflicts]
+  [--wrong-base]
+  [--base BRANCH]
+  [--repo OWNER/REPO]
+  [--graph PATH]
+```
+
+GitHub/network credentials may be required.
+
+## Result memory and reflection
+
+### `save-result`
+
+```text
+compass save-result
+  --question Q
+  (--answer A | --answer-file PATH)
+  [--type T]
+  [--nodes N1 N2 ...]
+  [--outcome useful|dead_end|corrected]
+  [--correction TEXT]
+  [--memory-dir DIR]
+```
+
+### `reflect`
+
+```text
+compass reflect
+  [--memory-dir DIR]
+  [--out PATH]
+  [--graph PATH]
+  [--analysis PATH]
+  [--labels PATH]
+  [--half-life-days N]
+  [--min-corroboration N]
+  [--if-stale]
+```
+
+### `check-update`
+
+```text
+compass check-update PATH
+```
+
+Managed integration/update probe.
+
+## Input selection conventions
+
+- Current read commands default to `compass-out/graph.json`.
+- `--graph PATH` selects a graph JSON.
+- `--at REV` selects an exact historical graph for supported reads.
+- `--graph` and `--at` are mutually exclusive.
+- Build `PATH` defaults are command-specific; run help before scripting.
+- `COMPASS_OUT` can change the default output root for several compatible
+  command families; explicit `--out` is clearer in automation.
+
+## Output and exit conventions
+
+Human text goes to stdout on success. Diagnostics go to stderr.
+
+History:
+
+- success and read-only no-store status/list operations: exit `0`;
+- usage: exit `2`;
+- Git/provider/validation/corruption/storage: exit `1`.
+
+CompassQL:
+
+- source/options/compile: exit `2`;
+- graph loading: exit `3`;
+- execution/limit/cancellation/output: exit `4`.
+
+Other command families preserve documented compatibility-specific codes. Test
+the exact command boundary your automation uses.
+
+## Related pages
+
+- [Configuration reference](configuration.md)
+- [Output reference](outputs.md)
+- [CompassQL 1](../COMPASSQL.md)
+- [Versioned history guide](../guides/versioned-history.md)
+
+**Next step:** run `compass <command> --help` for the command you will automate,
+then pin its input, structured output, and exit expectations in an integration
+test.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,180 @@
+# Compatibility and evolution
+
+Compass was inspired by Graphify and was developed with a frozen Graphify
+baseline as a behavioral oracle. It is a native product with an independently
+evolving feature set.
+
+> **Who this reference is for:** evaluators, migrators, integrators, and
+> contributors deciding whether behavior is compatible or Compass-native.
+>
+> **You will learn:** the frozen baseline, certified command families,
+> intentional normalization, native additions, platform scope, and how
+> divergence is documented.
+>
+> **Prerequisites:** none.
+>
+> **Reading time:** 7–10 minutes.
+
+> The authoritative ledger is [COMPATIBILITY.md](../../COMPATIBILITY.md). This
+> page is a navigational explanation, not a replacement.
+
+## Product relationship
+
+```text
+Graphify
+  ideas + frozen behavioral evidence
+          |
+          v
+Compass native Rust implementation
+  compatible where certified
+  intentionally normalized where documented
+  Compass-native features beyond the baseline
+  future independent evolution
+```
+
+Preferred positioning:
+
+> Compass is a native, local-first knowledge graph engine inspired by Graphify,
+> built in Rust, and evolving beyond it.
+
+Avoid claiming either:
+
+- “Compass has no relationship to Graphify”; or
+- “Compass will always be only a drop-in Rust port.”
+
+## Frozen oracle
+
+The current canonical ledger records:
+
+- Python baseline: Graphify `v0.9.20`;
+- baseline commit: `edec9eabeceeae6aa2375eddb3835efa1a32c0a3`;
+- native root: Compass repository;
+- Python use: development/CI oracle only.
+
+Released Compass binaries do not start Python or load tree-sitter grammars at
+runtime.
+
+## Certified families
+
+The ledger groups evidence for:
+
+- build;
+- query;
+- graph operations;
+- service;
+- project workflows;
+- assistant setup.
+
+Certification can include:
+
+- CLI argument/exit snapshots;
+- graph node/edge equivalence;
+- complete output comparisons;
+- official MCP client tests;
+- native integration tests;
+- release/corpus qualification.
+
+Compatibility is asserted only where evidence exists.
+
+## Approved normalization
+
+The frozen Python query renderer has unstable set-iteration order for
+equal-degree nodes. Compass uses stable node-ID tie ordering.
+
+Differential qualification therefore compares:
+
+- exact headers;
+- complete line multisets for affected query output;
+- order-independent node/edge graph records where Python file walk order is
+  platform-dependent.
+
+Attributes, multiplicity, ranking, traversal membership, and duplicate lines
+remain part of the contract. This is a documented normalization, not permission
+to ignore arbitrary diffs.
+
+## Compass-native capabilities
+
+Examples include:
+
+- `compass query --cql` and the CompassQL compiler/executor;
+- immutable versioned graph history and exact-revision queries/diffs;
+- native product installation and assistant assets;
+- performance/safety improvements that preserve or explicitly evolve
+  contracts.
+
+The frozen Python oracle does not need a matching flag for every native
+feature.
+
+## Command identity
+
+`compass` is the authoritative shipped CLI. New scripts and documentation use:
+
+```bash
+compass update .
+compass query "..."
+compass history build HEAD
+```
+
+The internal compatibility frontend is test infrastructure, not a second
+published product identity.
+
+## Platform matrix
+
+CI currently covers targets listed in the canonical ledger, including Linux,
+macOS, and Windows architectures. Release packaging can be narrower than CI
+compilation/testing.
+
+Do not infer official release support from “it compiled locally.” Follow the
+current [compatibility ledger](../../COMPATIBILITY.md) and release page.
+
+## Assistant platforms
+
+The native installer covers a broad matrix and exact project/global file-tree
+behavior is tested. Use:
+
+```bash
+compass install --help
+```
+
+for the version-specific list.
+
+## Migration
+
+Read [MIGRATION.md](../../MIGRATION.md) for:
+
+- executable and output-path changes;
+- compatibility expectations;
+- behavior intentionally retired or evolved;
+- migration commands.
+
+Do not add a silent incompatible change. Add:
+
+1. compatibility ledger entry;
+2. native and/or differential fixture;
+3. migration note;
+4. documentation/reference change;
+5. release note when user-visible.
+
+## Classifying a change
+
+```text
+Does the frozen baseline have this behavior?
+  |
+  +-- yes --> preserve and add differential evidence,
+  |           or document intentional incompatibility
+  |
+  `-- no  --> define a Compass-native contract and tests
+```
+
+If the behavior is an accidental Python runtime artifact, normalize only with
+explicit approval and evidence.
+
+## Related pages
+
+- [Canonical compatibility ledger](../../COMPATIBILITY.md)
+- [Migration guide](../../MIGRATION.md)
+- [Design principles](../design/principles.md)
+- [Roadmap](../roadmap.md)
+
+**Next step:** before depending on a behavior, find it in the canonical ledger
+or a Compass-native contract and add a fixture if the evidence is missing.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,324 @@
+# Configuration reference
+
+Compass configuration comes from explicit command options, environment
+variables, provider registries, repository history configuration, and generated
+integration files. This page explains ownership and safe use.
+
+> **Who this reference is for:** users, operators, and integrators configuring
+> outputs, providers, history, databases, or assistant integrations.
+>
+> **You will learn:** configuration sources, practical precedence, key
+> environment families, secret handling, and reproducibility rules.
+>
+> **Prerequisites:** none.
+>
+> **Reading time:** 10–12 minutes.
+
+## Precedence rule
+
+For a specific command, use:
+
+```text
+explicit CLI option
+    before
+documented environment fallback
+    before
+stored provider/repository configuration
+    before
+built-in default
+```
+
+Not every option follows one universal resolver. The command's help and source
+remain authoritative. In automation, prefer explicit non-secret options and
+record them.
+
+## Output root
+
+Default:
+
+```text
+compass-out/
+```
+
+Several command families honor:
+
+```bash
+COMPASS_OUT=custom-output compass update .
+```
+
+Where available, `--out DIR` is clearer:
+
+```bash
+compass update . --out custom-output
+```
+
+Do not point two concurrent writers at one output directory.
+
+## Build configuration
+
+Common explicit options:
+
+| Concern | Options |
+| --- | --- |
+| scope | positional `PATH`, `--exclude PATTERN` |
+| ignore | default Git ignore or `--no-gitignore` |
+| rebuild | `--force` |
+| outputs | `--out`, `--no-viz`, `--no-cluster` |
+| analysis | `--resolution`, `--exclude-hubs` |
+| code metadata | `--cargo`, `--postgres`, `--google-workspace` |
+| semantics | `--code-only`, `--backend`, `--model`, `--mode` |
+| resources | `--token-budget`, `--max-workers`, `--max-concurrency`, `--api-timeout` |
+| completeness | `--allow-partial` |
+
+`--code-only` is an explicit semantic choice, not merely a performance flag.
+
+## Provider environment families
+
+Current built-in backend code recognizes families including:
+
+| Backend | Key variables | Endpoint/model examples |
+| --- | --- | --- |
+| Anthropic/Claude | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` |
+| Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `GEMINI_BASE_URL`, `GRAPHIFY_GEMINI_MODEL` |
+| OpenAI | `OPENAI_API_KEY` | `OPENAI_BASE_URL`, `OPENAI_MODEL`, `GRAPHIFY_OPENAI_MODEL` |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY` | `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_DEPLOYMENT` |
+| Ollama-compatible | optional `OLLAMA_API_KEY` | `OLLAMA_BASE_URL`, `OLLAMA_MODEL` |
+| Bedrock | AWS credential chain | `GRAPHIFY_BEDROCK_MODEL` |
+
+Some compatibility variables retain `GRAPHIFY_` names. Their presence does not
+change the public executable name.
+
+Use `compass extract --help` and current provider documentation before
+deployment; backend support and model defaults can evolve.
+
+## Custom provider registry
+
+Add:
+
+```bash
+compass provider add internal \
+  --base-url https://models.example.test/v1 \
+  --default-model approved-model \
+  --env-key INTERNAL_MODEL_API_KEY
+```
+
+The registry stores:
+
+```json
+{
+  "internal": {
+    "base_url": "https://models.example.test/v1",
+    "default_model": "approved-model",
+    "env_key": "INTERNAL_MODEL_API_KEY",
+    "pricing": {"input": 0.0, "output": 0.0},
+    "temperature": 0
+  }
+}
+```
+
+It stores the environment-variable name, not its secret value. The
+compatibility registry path is under the user's Graphify-compatible config
+directory (`~/.graphify/providers.json` on common Unix setups).
+
+Inspect:
+
+```bash
+compass provider list
+compass provider show internal
+```
+
+Remove:
+
+```bash
+compass provider remove internal
+```
+
+Unsafe endpoints are rejected or warned according to endpoint checks.
+
+## Credential rules
+
+```text
+Do:
+  inject secrets through approved environment/secret stores
+  scope keys to the provider and environment
+  redact logs
+  rotate exposed keys
+
+Do not:
+  commit .env files with keys
+  pass keys as query parameters
+  put keys in Git remote/URL strings
+  include keys in history profiles or docs
+  print environment values for diagnosis
+```
+
+History fingerprints include meaning-affecting provider/model configuration but
+exclude credential values.
+
+## Semantic concurrency and timeout
+
+Use explicit bounds:
+
+```bash
+compass extract . \
+  --backend internal \
+  --model approved-model \
+  --max-concurrency 4 \
+  --api-timeout 60 \
+  --token-budget 200000
+```
+
+Lower concurrency when provider rate limits or corpus sensitivity demand it.
+`--allow-partial` changes the completeness contract and should be recorded in
+automation.
+
+Compatibility environment variables for Ollama parallelism/context may exist
+in the current source, including `GRAPHIFY_OLLAMA_PARALLEL`,
+`GRAPHIFY_OLLAMA_NUM_CTX`, and `GRAPHIFY_OLLAMA_KEEP_ALIVE`. Prefer documented
+CLI options when available; treat compatibility variables as exact,
+version-specific interfaces.
+
+## History configuration
+
+```bash
+compass history enable --code-only
+```
+
+or:
+
+```bash
+compass history enable \
+  --backend internal \
+  --model approved-model \
+  --exclude 'vendor/**' \
+  --cargo
+```
+
+The stored repository profile governs eager and lazy historical
+materialization. Disable:
+
+```bash
+compass history disable
+```
+
+This stops eager enqueueing but preserves data and explicit/lazy history
+commands.
+
+Do not edit history configuration or preferred pointers by hand.
+
+## Query configuration
+
+Natural-language discovery:
+
+```text
+--dfs
+--context VALUE
+--budget N
+--graph PATH | --at REV
+```
+
+CompassQL:
+
+```text
+--param NAME=VALUE
+--params-file PATH
+--format table|json|jsonl
+--output PATH
+--timeout-ms N
+--max-rows N
+--max-path-depth N
+--max-expanded-relationships N
+--max-memory-bytes N
+```
+
+Query limits are per invocation and part of the result contract.
+
+## MCP configuration
+
+The current service surface includes:
+
+```text
+--transport stdio|http
+--host HOST
+--port PORT
+--api-key KEY
+--path PATH
+--json-response
+--stateless
+--session-timeout SECONDS
+```
+
+Avoid literal API keys in command history. Bind to loopback for local use and
+use stdio when one local client is sufficient.
+
+## Graph database configuration
+
+Native exporters support Neo4j/FalkorDB connection information. Current code
+recognizes password environment variables including:
+
+```text
+NEO4J_PASSWORD
+FALKORDB_PASSWORD
+```
+
+Use command help for URI/user/database/graph options. Confirm target and write
+semantics before export.
+
+## Hook configuration
+
+Managed hooks recognize compatibility controls such as:
+
+```text
+GRAPHIFY_SKIP_HOOK
+GRAPHIFY_REBUILD_LOG
+```
+
+The output root can be influenced by `COMPASS_OUT`.
+
+Strict assistant hook mode uses:
+
+```text
+COMPASS_HOOK_STRICT
+```
+
+Reinstall hooks after moving/upgrading the binary so embedded invocation paths
+remain correct.
+
+## Assistant configuration
+
+```bash
+compass install --platform codex
+compass install --project --platform codex
+```
+
+Project scope writes reviewable repository files. Global scope writes
+platform-specific user configuration. The platform list and exact destinations
+come from `compass install --help`.
+
+## Reproducibility record
+
+For a reproducible job, record:
+
+```text
+Compass version
+source commit / dirty state
+root and excludes
+code-only or semantic profile
+provider/model name (not key)
+analysis and output options
+query limits and schema version
+history realization/fingerprint where applicable
+```
+
+Environment-only configuration that affects meaning must be captured in your
+job metadata even if Compass's own history fingerprint already includes it.
+
+## Related pages
+
+- [Command reference](commands.md)
+- [Security and privacy](../design/security-and-privacy.md)
+- [Semantic implementation](../implementation/semantic-pipeline.md)
+- [Versioned history](../guides/versioned-history.md)
+
+**Next step:** replace implicit defaults in one automation workflow with
+explicit non-secret options and record the selected profile/version.

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -1,0 +1,313 @@
+# Output reference
+
+Compass outputs range from the current `compass-out/` directory to versioned
+CompassQL results and immutable history exports. This reference describes
+consumer responsibilities and authority.
+
+> **Who this reference is for:** integrators, operators, and contributors
+> changing an output or renderer.
+>
+> **You will learn:** core artifacts, graph JSON, query schemas, derived views,
+> history export, caches, atomicity, and deterministic equivalence.
+>
+> **Prerequisites:** [Graph model](../concepts/graph-model.md).
+>
+> **Reading time:** 10–12 minutes.
+
+## Current output directory
+
+Default:
+
+```text
+compass-out/
+├── graph.json
+├── GRAPH_REPORT.md
+├── graph.html
+├── manifest.json
+├── cache/
+└── optional sidecars and exports
+```
+
+`--out DIR` or compatible `COMPASS_OUT` use can select another root.
+
+## Authority table
+
+| Artifact | Authority | Consumer use |
+| --- | --- | --- |
+| `graph.json` | machine-readable graph snapshot | queries, integrations, export |
+| `GRAPH_REPORT.md` | derived human orientation | architecture survey |
+| `graph.html` | derived optional visualization | interactive exploration |
+| `manifest.json` | incremental build state | next compatible update |
+| binary query caches | disposable acceleration | internal query loading |
+| semantic sidecars | depends on artifact class | completeness/evidence/export |
+
+Do not reconstruct graph truth from HTML when JSON is available.
+
+## `graph.json`
+
+Top-level node-link shape:
+
+```json
+{
+  "directed": true,
+  "multigraph": true,
+  "graph": {},
+  "nodes": [],
+  "links": []
+}
+```
+
+### Node
+
+```json
+{
+  "id": "opaque-stable-string",
+  "label": "authorize_payment()",
+  "file_type": "Function",
+  "source_file": "src/payments.py",
+  "source_location": "L12",
+  "community": 4
+}
+```
+
+Only `id` is structurally required by the typed node record. Attributes are
+extensible.
+
+### Edge
+
+```json
+{
+  "source": "caller-id",
+  "target": "callee-id",
+  "relation": "calls",
+  "confidence": "INFERRED",
+  "context": "call"
+}
+```
+
+Source/target IDs must be indexable. Attributes are extensible.
+
+### Consumer requirements
+
+- preserve unknown attributes;
+- treat IDs as opaque strings;
+- preserve direction;
+- preserve parallel edges when multigraph is true;
+- do not make JSON member order meaningful;
+- use canonical/semantic equivalence for graph comparisons;
+- validate file size and JSON at your trust boundary.
+
+## `GRAPH_REPORT.md`
+
+The report can include:
+
+- corpus and graph summary;
+- freshness/build metadata;
+- god nodes;
+- communities;
+- surprising connections;
+- cycles/diagnostics;
+- suggested questions.
+
+It is intended for people and can evolve in prose/format. Do not parse it when
+structured data or command JSON exists.
+
+## `graph.html`
+
+Optional interactive visualization. It may be absent when:
+
+- `--no-viz` was used;
+- graph size exceeds a rendering limit;
+- a specific build/export omitted it.
+
+It is not required for query commands.
+
+## `manifest.json`
+
+The manifest supports incremental detection and cache compatibility. It
+represents the artifact set it was published with.
+
+Do not:
+
+- edit it manually;
+- copy it between unrelated roots;
+- pair it with another graph version;
+- treat it as a durable historical graph.
+
+A forced/cold build can regenerate current output.
+
+## Query text
+
+`query`, `path`, `explain`, `affected`, and some history commands emit
+human-readable text. It is stable enough for people, not the preferred machine
+contract.
+
+When exact automation is required, use:
+
+- CompassQL JSON/JSONL;
+- history JSON;
+- diff JSON;
+- direct graph JSON.
+
+## CompassQL JSON
+
+Schema:
+
+```text
+compass.cql.result/1
+```
+
+Contains:
+
+- explicit version tag;
+- columns;
+- typed rows;
+- optional plan;
+- optional profile.
+
+Reject an unknown major version.
+
+## CompassQL JSONL
+
+Schema:
+
+```text
+compass.cql.jsonl/1
+```
+
+Order:
+
+```text
+header
+row object
+row object
+...
+summary
+```
+
+Do not treat a truncated stream without a successful command/summary as a
+complete result.
+
+## Atomic query output
+
+`--output PATH` writes a completed rendering atomically. On compile, graph-load,
+execution, limit, cancellation, or output failure, no successful partial result
+should appear at the final path.
+
+Consumers should still check exit status before opening the file.
+
+## History JSON
+
+History commands that accept `--format json` expose stable structured status,
+list, show, build, preference, or GC results. Exact fields are defined by the
+current history schema and tests.
+
+Record:
+
+- commit;
+- realization ID;
+- fingerprint;
+- preferred/validation state;
+- schema/version.
+
+## Diff JSON
+
+```bash
+compass diff OLD NEW --format json
+```
+
+Represents typed additions/removals and summary under selected inclusion
+options. Normal diff requires compatible fingerprints.
+
+Do not combine `--detailed` human output with JSON.
+
+## History export
+
+### `graph-json`
+
+```bash
+compass history export REV \
+  --format graph-json \
+  --output graph.json
+```
+
+Reconstructs canonical graph JSON from a validated realization.
+
+### `compass-out`
+
+```bash
+compass history export REV \
+  --format compass-out \
+  --output directory
+```
+
+Restores:
+
+- authoritative non-derivable sidecars verbatim;
+- graph artifacts;
+- derived reports/HTML only using recorded compatible renderer versions.
+
+## Equivalence
+
+Semantic/canonical equivalence includes:
+
+- same nodes and stable identities;
+- same relationships and direction;
+- same relevant attributes;
+- same multiplicity;
+- same duplicate id-less hyperedges;
+- same authoritative bytes.
+
+It does not require:
+
+- same insignificant JSON object member order;
+- same platform filesystem timestamp;
+- same operational timing/token data;
+- same derived byte order where the renderer contract allows semantic
+  comparison.
+
+## Binary caches
+
+Query caches live under the graph output cache directory with versioned magic
+and graph file signature. They are:
+
+- acceleration only;
+- bounded relative to source graph size;
+- invalidated when signature/format changes;
+- safely rebuildable.
+
+Do not archive them as the only graph copy.
+
+## Other exports
+
+`compass export` can produce:
+
+- HTML and call-flow HTML;
+- SVG;
+- GraphML;
+- Cypher;
+- Obsidian/wiki/canvas-style documents;
+- Neo4j/FalkorDB operations.
+
+Each format has separate escaping, direction, multiplicity, and size concerns.
+Use its command help and retain the source graph.
+
+## Filesystem and concurrency
+
+- Wait for the producing command to succeed.
+- Avoid multiple writers to one output directory.
+- Use distinct output paths for comparisons.
+- Keep old output until new output validates when building critical
+  integrations.
+- Treat disk-full and permission errors as failed publication.
+- Do not copy live history SQLite without its WAL state.
+
+## Related pages
+
+- [Graph model](../concepts/graph-model.md)
+- [Integrating Compass](../guides/integrating-compass.md)
+- [Storage and history](../design/storage-and-history.md)
+- [Command reference](commands.md)
+
+**Next step:** identify the most structured available output for your consumer
+and validate its major version/direction/multiplicity before reading values.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,320 @@
+# Compass roadmap
+
+Compass is inspired by Graphify, implemented natively in Rust, and expected to
+evolve independently. This roadmap separates shipped/current behavior from
+committed design work and longer-term ideas.
+
+> **Who this page is for:** users evaluating project direction, integrators
+> planning adoption, and contributors choosing work.
+>
+> **You will learn:** what exists in the current repository, what has a
+> committed design or implementation plan, and which ideas are explicitly
+> aspirational.
+>
+> **Prerequisites:** none.
+>
+> **Reading time:** 8–10 minutes.
+
+## How to read status
+
+- **Available now** means the behavior exists in the current repository and is
+  backed by source, help, tests, or release evidence. A feature can be available
+  in the repository before every target has a published release artifact.
+- **Planned** means a committed design or implementation plan describes the
+  work. A plan is not proof that implementation is complete.
+- **Aspirational** means the idea is a possible direction, not a commitment.
+  There is no promised release, compatibility guarantee, or delivery date.
+
+The authoritative release surface remains the installed binary's help,
+[compatibility ledger](../COMPATIBILITY.md), and release notes.
+
+## Available now
+
+### Native structural knowledge graphs
+
+Compass discovers, parses, resolves, builds, clusters, analyzes, and publishes
+project graphs natively:
+
+```bash
+compass update .
+compass query "authentication flow"
+compass explain TokenVerifier
+compass path ApiHandler TokenVerifier
+compass affected TokenVerifier --depth 3
+```
+
+The normal code path does not require Python, embeddings, a vector database,
+runtime parser downloads, or model credentials.
+
+Evidence:
+
+- public command registry in `compass-cli`;
+- deterministic pipeline crates and tests;
+- [compatibility ledger](../COMPATIBILITY.md);
+- [performance qualification](../PERFORMANCE.md).
+
+### CompassQL 1
+
+Compass includes a native, deterministic, read-only subset of openCypher with:
+
+- parsing, semantic analysis, planning, optimization, and bounded execution;
+- exact patterns, joins, optional matching, expressions, aggregation, bounded
+  paths, shortest paths, and unions;
+- parameters;
+- table, versioned JSON, and JSONL;
+- explain/profile;
+- time, row, path, expansion, and memory limits;
+- checked TCK/support evidence.
+
+Evidence:
+
+- [CompassQL 1](COMPASSQL.md);
+- [CompassQL support matrix](COMPASSQL_SUPPORT.md);
+- `compass-cypher` and `compass-query`;
+- CLI/TCK/differential tests.
+
+### Immutable versioned graph history
+
+Compass can build, query, compare, export, prefer, and garbage-collect complete
+graph realizations for exact Git commits:
+
+```bash
+compass history enable --code-only
+compass history build HEAD
+compass query "authentication" --at HEAD~20
+compass diff HEAD~1 HEAD --topology-only
+```
+
+The SQLite-backed Prolly store supports immutable realizations, extraction
+fingerprints, structural sharing, protected offline worktrees, durable jobs and
+leases, validation, and canonical reconstruction.
+
+Evidence:
+
+- `compass-history`;
+- history CLI and qualification scripts;
+- [Versioned history guide](guides/versioned-history.md);
+- [storage design](design/storage-and-history.md).
+
+### Native assistant integration
+
+The current repository includes a native `compass install`/`uninstall`
+implementation with global/project scope, platform-specific destinations,
+embedded skill/reference assets, idempotence checks, and managed strict mode
+where supported.
+
+```bash
+compass install --project --platform codex
+```
+
+Evidence:
+
+- `compass-cli` installer source and generated assets;
+- installer filesystem-tree tests;
+- [Assistant setup](guides/assistant-setup.md).
+
+The exact release containing the latest installer asset bundle should be
+confirmed on the releases page.
+
+### Optional semantic and integration surfaces
+
+The current workspace includes native support for:
+
+- provider-backed semantic extraction and community labeling;
+- PDF/Office/media processing and native Whisper internals;
+- Cargo, PostgreSQL, Google Workspace, and SCIP knowledge;
+- MCP stdio/HTTP serving;
+- Neo4j and FalkorDB export;
+- bounded remote ingestion;
+- GitHub PR dashboard/impact workflows;
+- cross-project graph registry;
+- reflection/session-memory overlays;
+- multiple human and machine export formats.
+
+Each surface has its own network, credential, platform, and completeness
+boundary. “Available” does not mean enabled by default.
+
+### Community, licensing, security, and support
+
+Compass is dual-licensed under MIT or Apache-2.0 and includes:
+
+- contribution guidance;
+- Code of Conduct;
+- security policy;
+- support routes;
+- third-party notices;
+- release and distribution workflows.
+
+## Planned
+
+The items below have committed design or implementation-plan evidence in the
+default branch. They are not listed in the current public command surface
+unless explicitly moved to Available now. Ideas that exist only in an
+uncommitted workspace or a separate development branch are intentionally not
+promoted to committed plans here.
+
+### Reusable CompassQL policy and integration surfaces
+
+Goal: reuse one graph loading, compilation, execution, and output implementation
+through CLI/MCP/historical/policy contexts, rather than building parallel
+query engines.
+
+Planned areas include:
+
+- reusable architecture-policy evaluator;
+- exact historical policy queries;
+- “new violation” comparisons;
+- MCP integration for structured CompassQL;
+- stable policy output and limits.
+
+Evidence:
+
+- [`docs/superpowers/plans/2026-07-22-compassql-integrations.md`](superpowers/plans/2026-07-22-compassql-integrations.md)
+- [`docs/superpowers/plans/2026-07-22-compassql-policy.md`](superpowers/plans/2026-07-22-compassql-policy.md)
+
+## Aspirational
+
+These directions have no promised release or compatibility commitment.
+
+### Time-travel architecture explorer
+
+Provide a visual and queryable view that moves across historical realizations:
+
+```text
+commit A ---- commit B ---- commit C
+   |             |             |
+ graph          graph         graph
+   \_____ typed topology and policy changes ____/
+```
+
+Potential value:
+
+- explain when a dependency appeared;
+- watch community boundaries evolve;
+- connect policy violations to the introducing commit;
+- inspect semantic versus topology change.
+
+Open questions include UI scope, large-history performance, and how to preserve
+exact evidence without oversimplifying diffs.
+
+### Multi-repository federation
+
+Build a first-class model for services, shared libraries, schemas, and
+deployment dependencies spanning many repositories.
+
+Possible capabilities:
+
+- repository-qualified stable identities;
+- cross-repository edges with provenance;
+- federated CompassQL;
+- version-aligned release graphs;
+- organization-wide impact analysis.
+
+The current global graph registry is a useful primitive but not a complete
+federation contract.
+
+### Runtime-evidence overlays
+
+Combine static graph structure with optional runtime evidence such as traces,
+coverage, or profiles while keeping the sources distinct:
+
+```text
+static CALLS edge        structural possibility
+runtime observation      observed execution in one environment/run
+```
+
+The key design challenge is avoiding a false claim that one runtime sample
+proves universal behavior.
+
+### Stable extractor/integration SDK
+
+Offer a documented way to extend languages or external systems without
+requiring every integration to live in the core workspace.
+
+Requirements before such an SDK could be stable:
+
+- versioned graph fragment schema;
+- explicit provenance and identity rules;
+- sandbox/process boundary;
+- size/time limits;
+- compatibility negotiation;
+- deterministic test kit;
+- supply-chain policy.
+
+### Rich editor-native views
+
+Provide IDE surfaces for:
+
+- incoming/outgoing relationships at the cursor;
+- exact impact previews;
+- community and path navigation;
+- historical diff annotations;
+- policy witnesses;
+- provenance/source verification.
+
+Any editor integration should call the same native query contracts rather than
+reimplement graph semantics in each extension.
+
+### Broader signed release coverage
+
+Expand reproducible, signed, and platform-native distribution beyond the
+current release packaging while retaining:
+
+- checksum/provenance verification;
+- dependency-free native behavior;
+- exact test matrix;
+- update/uninstall safety;
+- transparent support status.
+
+### Collaborative graph review artifacts
+
+Create reviewable, immutable bundles that combine:
+
+- graph/policy result;
+- exact revision and fingerprint;
+- witness paths;
+- selected source excerpts/locations;
+- human decisions and exemptions;
+- machine-verifiable manifest.
+
+This could support architecture review without requiring a hosted proprietary
+graph store.
+
+## How an item changes status
+
+```text
+Aspirational
+  -> approved design/spec
+  -> Planned
+  -> implementation + contract tests + docs + qualification
+  -> Available now
+  -> published release availability stated separately
+```
+
+A checkbox in a plan is not enough. Moving to Available requires current-state
+evidence across the actual public surface.
+
+## Contributing to the roadmap
+
+For a proposed direction, provide:
+
+- user problem;
+- current limitation/evidence;
+- intended product boundary;
+- local/network/credential impact;
+- graph identity and provenance effect;
+- resource limits and failure behavior;
+- compatibility/divergence classification;
+- smallest independently useful delivery.
+
+Then follow [Contributing](../CONTRIBUTING.md).
+
+## Related pages
+
+- [Documentation hub](README.md)
+- [Compatibility](reference/compatibility.md)
+- [Design principles](design/principles.md)
+- [Contributing](../CONTRIBUTING.md)
+
+**Next step:** verify an Available item against the installed binary or open one
+Planned design and identify the smallest reviewable contribution.

--- a/docs/superpowers/plans/2026-07-22-compass-documentation-system.md
+++ b/docs/superpowers/plans/2026-07-22-compass-documentation-system.md
@@ -1,0 +1,173 @@
+# Compass Documentation System Implementation Plan
+
+> **For agentic workers:** Execute this plan inline, task by task. The user explicitly requested immediate authoring without a TDD approach. Use documentation validation and command verification instead of red-green-refactor steps.
+
+**Goal:** Build a comprehensive, easy-to-digest Markdown documentation system for Compass and align the GitHub repository description with its independently evolving product identity.
+
+**Architecture:** Keep the root README as a concise landing page and make `docs/README.md` the audience-layered navigation hub. Separate concepts, task guides, implementation internals, recipes, and exact references; preserve existing canonical policy and compatibility documents through links. Use inline ASCII for compact visuals and accessible, self-contained SVG files for architecture and pipeline diagrams.
+
+**Tech Stack:** GitHub-flavored Markdown, hand-authored SVG 1.1, shell-based link/XML/content validation, Compass CLI help and Rust source as behavioral evidence.
+
+## Global Constraints
+
+- Serve new evaluators, developers integrating Compass, and Rust contributors.
+- Use plain Markdown; do not add MkDocs, Docusaurus, or another site generator.
+- Make documents comprehensive, clear, scannable, and understandable without prior graph-database knowledge.
+- Use ASCII and SVG diagrams. Do not use Mermaid except for a genuine sequence diagram; the initial document set uses no Mermaid.
+- Label roadmap material as **Available now**, **Planned**, or **Aspirational**.
+- Describe Compass as inspired by Graphify and evolving independently beyond the frozen compatibility baseline.
+- Preserve `COMPATIBILITY.md`, `CONTRIBUTING.md`, `MIGRATION.md`, `PERFORMANCE.md`, `SECURITY.md`, `SUPPORT.md`, `docs/COMPASSQL.md`, and `docs/COMPASSQL_SUPPORT.md` as canonical sources.
+- Preserve all unrelated modified and untracked files in the shared worktree.
+- Do not use a TDD workflow for documentation authoring.
+
+---
+
+### Task 1: Documentation Hub and First Success
+
+**Files:**
+- Create: `docs/README.md`
+- Create: `docs/getting-started.md`
+- Create: `docs/assets/diagrams/reader-journeys.svg`
+- Create: `docs/assets/diagrams/first-graph.svg`
+
+**Produces:** The canonical documentation index and a verified evaluator-to-first-query path used by every later section.
+
+- [ ] Write `docs/README.md` with audience cards, topic index, document-type explanation, current/planned/aspirational legend, and links to all canonical top-level documents.
+- [ ] Write `docs/getting-started.md` with installation choices, first graph, output tour, first queries, assistant setup, success checks, troubleshooting, and next steps.
+- [ ] Create accessible SVGs for reader journeys and the first-graph flow; include `<title>` and `<desc>`.
+- [ ] Verify install and query flags against `compass --help` and command-specific help.
+- [ ] Run `git diff --check` for the four files and parse both SVGs with an XML parser.
+
+### Task 2: Concepts and Product Mechanics
+
+**Files:**
+- Create: `docs/concepts/how-it-works.md`
+- Create: `docs/concepts/graph-model.md`
+- Create: `docs/concepts/provenance.md`
+- Create: `docs/concepts/compassql.md`
+- Create: `docs/assets/diagrams/graph-pipeline.svg`
+- Create: `docs/assets/diagrams/provenance.svg`
+
+**Consumes:** Navigation vocabulary and first-run artifact names from Task 1.
+
+**Produces:** The conceptual vocabulary used by guides, implementation docs, and references.
+
+- [ ] Explain discovery, parsing, extraction, resolution, graph construction, clustering, analysis, publication, and querying from simple model to technical detail.
+- [ ] Define nodes, edges, direction, multiplicity, attributes, provenance, confidence, communities, god nodes, hyperedges, and graph snapshots with examples.
+- [ ] Explain direct, inferred, and ambiguous evidence without implying that inference is an LLM guess.
+- [ ] Introduce CompassQL as a deterministic read-only structural query language and route exact syntax to the canonical CompassQL references.
+- [ ] Create accessible pipeline and provenance SVGs and validate them as XML.
+- [ ] Cross-check terminology against `compass-model`, `compass-core`, `compass-resolve`, `compass-graph`, `compass-query`, and the canonical CompassQL documents.
+
+### Task 3: User and Integration Guides
+
+**Files:**
+- Create: `docs/guides/exploring-a-codebase.md`
+- Create: `docs/guides/integrating-compass.md`
+- Create: `docs/guides/assistant-setup.md`
+- Create: `docs/guides/versioned-history.md`
+- Create: `docs/guides/operations.md`
+- Create: `docs/assets/diagrams/integration-surfaces.svg`
+- Create: `docs/assets/diagrams/history-materialization.svg`
+
+**Consumes:** Commands and concepts from Tasks 1–2.
+
+**Produces:** End-to-end procedures for the principal Compass workflows.
+
+- [ ] Write a repeatable unfamiliar-codebase investigation workflow using report, query, explain, path, tree, and affected.
+- [ ] Document stable machine-readable integration patterns, atomic output use, CompassQL parameters, and service/export boundaries.
+- [ ] Document native assistant installation, project/global scope, verification, and safe removal without duplicating generated asset internals.
+- [ ] Document enabling, building, querying, comparing, exporting, preferring, garbage-collecting, and disabling versioned history, including code-only versus semantic fingerprints.
+- [ ] Document watch, serve, hooks, providers, graph database exports, and operational failure recovery.
+- [ ] Create and validate the integration and history SVGs.
+- [ ] Verify each documented command family against CLI source/help and canonical history contracts.
+
+### Task 4: Design and Implementation Internals
+
+**Files:**
+- Create: `docs/design/principles.md`
+- Create: `docs/design/architecture.md`
+- Create: `docs/design/storage-and-history.md`
+- Create: `docs/design/security-and-privacy.md`
+- Create: `docs/implementation/workspace-tour.md`
+- Create: `docs/implementation/extraction-pipeline.md`
+- Create: `docs/implementation/query-engine.md`
+- Create: `docs/implementation/semantic-pipeline.md`
+- Create: `docs/implementation/extending-compass.md`
+- Create: `docs/assets/diagrams/workspace-architecture.svg`
+- Create: `docs/assets/diagrams/incremental-update.svg`
+
+**Consumes:** Product mechanics and command boundaries from Tasks 1–3.
+
+**Produces:** A source-backed architectural map and contributor onboarding path.
+
+- [ ] Explain local-first boundaries, determinism, inspectability, atomic publication, resource bounds, and compatibility-versus-evolution principles.
+- [ ] Map the CLI, orchestration, model, language, resolution, graph, query, semantic, history, integration, and output crate groups.
+- [ ] Explain SQLite/Prolly history storage, immutable realizations, fingerprints, preferred pointers, jobs, leases, hooks, reconstruction, and garbage collection.
+- [ ] Explain credential, network, file-system, historical-checkout, and generated-output trust boundaries while linking `SECURITY.md` as policy.
+- [ ] Provide a crate-by-crate workspace tour with ownership, dependencies, extension points, and relevant tests.
+- [ ] Explain cold and incremental extraction, query planning/execution, semantic orchestration, and extension workflows.
+- [ ] Create and validate workspace and incremental-update SVGs.
+- [ ] Cross-check all architectural claims against workspace manifests, crate public modules, CLI orchestration, tests, and qualification scripts.
+
+### Task 5: Cookbook and Exact References
+
+**Files:**
+- Create: `docs/cookbook/README.md`
+- Create: `docs/cookbook/impact-analysis.md`
+- Create: `docs/cookbook/architecture-discovery.md`
+- Create: `docs/cookbook/ci-and-automation.md`
+- Create: `docs/cookbook/troubleshooting.md`
+- Create: `docs/reference/commands.md`
+- Create: `docs/reference/configuration.md`
+- Create: `docs/reference/outputs.md`
+- Create: `docs/reference/compatibility.md`
+
+**Consumes:** Verified workflows and concepts from Tasks 1–4.
+
+**Produces:** Copyable recipes and a lookup-oriented public contract index.
+
+- [ ] Write scenario-driven recipes with problem, command, interpretation, variants, safety notes, and next step.
+- [ ] Cover impact review, architecture discovery, CI caching and artifacts, deterministic JSON/JSONL use, and assistant context preparation.
+- [ ] Build a symptom/cause/diagnosis/remedy troubleshooting matrix for install, extraction, query, semantic, history, and output failures.
+- [ ] Inventory the public command families, shared inputs/outputs, format conventions, and exit-status pointers without inventing unsupported flags.
+- [ ] Document configuration precedence and credential-safe examples based on current source.
+- [ ] Document `compass-out/`, graph/result schemas, determinism, atomicity, and consumer guidance.
+- [ ] Explain the frozen Graphify compatibility baseline and Compass-native divergence, linking canonical compatibility and migration ledgers.
+- [ ] Verify commands, configuration names, paths, and schema-version strings against source and tests.
+
+### Task 6: Roadmap, Landing Page, and Cross-Linking
+
+**Files:**
+- Create: `docs/roadmap.md`
+- Modify: `README.md`
+- Modify: all Markdown files created in Tasks 1–5 as needed for final links
+
+**Consumes:** The complete documentation structure and current repository plans/specs.
+
+**Produces:** A coherent landing-to-depth navigation system and explicitly qualified roadmap.
+
+- [ ] Write the roadmap with separate **Available now**, **Planned**, and **Aspirational** sections, evidence links for planned work, and no delivery-date promises.
+- [ ] Carefully merge a concise product-positioning and documentation-navigation section into the current root README without overwriting unrelated concurrent changes.
+- [ ] Add related-page and next-step footers to every substantial new document.
+- [ ] Check that every intended audience has a continuous path from the root README to exact reference or contribution material.
+- [ ] Scan new docs for stale user-facing `graphify` commands, unlabeled speculative behavior, forbidden Mermaid, placeholders, and duplicated volatile claims.
+
+### Task 7: Full Validation and Remote Metadata
+
+**Files:**
+- Validate: all created and modified Markdown and SVG files
+- Remote metadata: `crabbuild/compass` GitHub repository description
+
+**Consumes:** All prior tasks.
+
+**Produces:** Verified, reviewable docs and confirmed GitHub metadata.
+
+- [ ] Run a local relative-link and image checker across the complete Markdown set.
+- [ ] Parse every new SVG as XML and render representative diagrams for visual inspection.
+- [ ] Run `git diff --check`.
+- [ ] Compare documented command names to the CLI command registry and inspect help for high-use commands.
+- [ ] Audit the design specification requirement by requirement against current files and validation evidence.
+- [ ] Update the GitHub description to: `Native, local-first knowledge graph engine for code and project artifacts—inspired by Graphify, built in Rust, and evolving beyond it.`
+- [ ] Read the GitHub repository metadata back and confirm the exact description.
+- [ ] Report the files authored, validation evidence, preserved unrelated changes, and remote metadata result.

--- a/docs/superpowers/specs/2026-07-22-compass-documentation-system-design.md
+++ b/docs/superpowers/specs/2026-07-22-compass-documentation-system-design.md
@@ -1,0 +1,485 @@
+# Compass Documentation System Design
+
+**Date:** 2026-07-22
+**Status:** Approved for implementation planning
+**Repository:** `crabbuild/compass`
+
+## Summary
+
+Compass needs a comprehensive, repository-native documentation system that
+serves three audiences without forcing any of them to read the entire manual:
+
+1. new users evaluating Compass;
+2. developers using or integrating Compass;
+3. contributors extending the Rust implementation.
+
+The documentation will use plain Markdown, inline ASCII diagrams, and
+checked-in SVG diagrams. Mermaid diagrams are prohibited except when a true
+sequence diagram is materially clearer than prose, ASCII, or SVG. The initial
+implementation should not require Mermaid.
+
+Compass will be positioned as an independently evolving, native local-first
+knowledge graph engine. It is inspired by Graphify and informed by compatibility
+work with Graphify, but its current and future product identity is not limited
+to being a port. Compass already contains native features that go beyond the
+frozen Graphify compatibility baseline, and its feature set is expected to
+diverge further.
+
+The GitHub repository description will be:
+
+> Native, local-first knowledge graph engine for code and project
+> artifacts—inspired by Graphify, built in Rust, and evolving beyond it.
+
+## Goals
+
+- Give a new evaluator a clear understanding of Compass within five minutes.
+- Let a new user install Compass, build a graph, and run useful queries without
+  needing to understand the implementation.
+- Give integrators task-oriented guidance for automation, assistant setup,
+  CompassQL, graph output consumption, history, and service integrations.
+- Give contributors a reliable architectural map of the workspace, major
+  pipelines, extension points, invariants, and verification practices.
+- Make long-form documentation easy to scan through progressive disclosure,
+  consistent page openings, cross-links, examples, tables, ASCII diagrams, and
+  SVG diagrams.
+- Preserve existing authoritative documents and remove the need to duplicate
+  contracts across multiple pages.
+- Distinguish current, planned, and aspirational behavior unambiguously.
+- Keep GitHub repository metadata aligned with the documentation's product
+  positioning.
+
+## Non-goals
+
+- Adding a documentation-site generator, generated website, theme, or hosting
+  configuration.
+- Translating the new documentation in the initial implementation.
+- Replacing source code, CLI help, tests, compatibility evidence, or security
+  policy as authoritative contracts.
+- Promising delivery dates for planned or aspirational roadmap items.
+- Re-documenting every internal function or producing API documentation that
+  belongs in Rustdoc.
+- Redesigning Compass behavior or changing public CLI contracts as part of the
+  documentation work.
+- Rewriting unrelated legal, governance, or release-policy documents.
+
+## Audience Model
+
+### Evaluators
+
+Evaluators want to know what Compass does, why it exists, how it differs from
+alternatives, what runs locally, what it produces, how mature it is, and whether
+it fits their workflow. They should start at the root README and move through
+the overview, getting started, how-it-works, privacy, compatibility, and
+performance material.
+
+### Users and integrators
+
+Users and integrators want repeatable procedures and exact contracts. They
+should move from getting started into task guides, cookbook recipes, CompassQL,
+and command/configuration/output references.
+
+### Contributors
+
+Contributors need system boundaries, data flow, crate ownership, extension
+points, invariants, test commands, and contribution policies. They should move
+from design principles into architecture, the workspace tour, implementation
+pipelines, extension guides, and the existing contributing documents.
+
+## Information Architecture
+
+The documentation uses an audience-layered learning hub. The root README is a
+concise product landing page; `docs/README.md` is the full navigation hub.
+
+```text
+README.md
+docs/
+├── README.md
+├── getting-started.md
+├── guides/
+│   ├── exploring-a-codebase.md
+│   ├── integrating-compass.md
+│   ├── assistant-setup.md
+│   ├── versioned-history.md
+│   └── operations.md
+├── concepts/
+│   ├── how-it-works.md
+│   ├── graph-model.md
+│   ├── provenance.md
+│   └── compassql.md
+├── design/
+│   ├── principles.md
+│   ├── architecture.md
+│   ├── storage-and-history.md
+│   └── security-and-privacy.md
+├── implementation/
+│   ├── workspace-tour.md
+│   ├── extraction-pipeline.md
+│   ├── query-engine.md
+│   ├── semantic-pipeline.md
+│   └── extending-compass.md
+├── cookbook/
+│   ├── README.md
+│   ├── impact-analysis.md
+│   ├── architecture-discovery.md
+│   ├── ci-and-automation.md
+│   └── troubleshooting.md
+├── reference/
+│   ├── commands.md
+│   ├── configuration.md
+│   ├── outputs.md
+│   └── compatibility.md
+├── roadmap.md
+└── assets/
+    └── diagrams/
+```
+
+The precise set of files may be consolidated during implementation when two
+planned pages would be too thin to justify separate maintenance. Consolidation
+must preserve the audience journeys and conceptual boundaries.
+
+## Reader Journeys
+
+```text
+Evaluating Compass
+    |
+    +--> Product overview
+    +--> Getting started
+    +--> How it works
+    `--> Compatibility, privacy, and performance
+
+Using or integrating Compass
+    |
+    +--> Task guides
+    +--> Cookbook recipes
+    +--> CompassQL
+    `--> Command, configuration, and output references
+
+Extending Compass
+    |
+    +--> Design principles
+    +--> System architecture
+    +--> Workspace and crate tour
+    +--> Implementation pipelines
+    `--> Contribution workflow
+```
+
+Each substantial page begins with:
+
+- the intended audience;
+- what the reader will learn;
+- prerequisites;
+- an estimated reading or completion time.
+
+Each substantial page ends with:
+
+- related documents;
+- the most useful next step.
+
+## Document Types
+
+The documentation follows four explicit content types:
+
+| Type | Reader question | Required characteristics |
+| --- | --- | --- |
+| Concept | “What is this and why does it work this way?” | Plain-language model, terminology, diagrams, links to exact references |
+| Guide | “How do I complete this task?” | Prerequisites, ordered procedure, verification, failure recovery |
+| Cookbook | “How do I solve this concrete scenario?” | Short problem statement, copyable recipe, variations, caveats |
+| Reference | “What is the exact contract?” | Complete syntax/schema/options, defaults, limits, exits, compatibility notes |
+
+Design and implementation documents may combine concept and reference elements,
+but must state which behavior is a public contract and which is an internal
+implementation detail.
+
+## Root README Design
+
+The root README will become a concise landing page. It will contain:
+
+1. the product name and one-sentence value proposition;
+2. the relationship to Graphify and Compass's independent direction;
+3. a small “source to graph to answers” visual;
+4. an installation path;
+5. one end-to-end example;
+6. a capability summary;
+7. links for evaluators, users/integrators, and contributors;
+8. platform, maturity, licensing, support, and security links.
+
+Long reference material currently in the README will move to or be summarized
+by focused documents. The README must remain useful by itself and must not
+become a bare link directory.
+
+## Content Scope
+
+### Getting started
+
+The getting-started guide covers:
+
+- choosing a supported installation path;
+- verifying the binary;
+- creating a graph in a sample or existing repository;
+- understanding `compass-out/`;
+- running natural-language discovery, `explain`, `path`, and `affected`;
+- opening the HTML graph when available;
+- installing assistant integration;
+- cleaning up or regenerating output;
+- common first-run errors and their remedies.
+
+### Guides
+
+Guides cover:
+
+- exploring an unfamiliar codebase;
+- using Compass in assistant workflows;
+- integrating graph output and JSON into tooling;
+- running CompassQL safely and deterministically;
+- enabling, querying, exporting, and maintaining versioned history;
+- operating watch, serve, hooks, providers, and optional integrations;
+- using Compass in automation and CI.
+
+### Concepts and how it works
+
+Concept pages cover:
+
+- nodes, edges, direction, provenance, confidence, communities, and god nodes;
+- deterministic structural extraction;
+- resolution and inferred relationships;
+- optional semantic extraction;
+- incremental rebuilds and manifests;
+- graph analysis, clustering, and output generation;
+- query, traversal, CompassQL, and result limits;
+- versioned realizations, fingerprints, preferred realizations, and Prolly
+  storage;
+- the boundary between current Graphify compatibility and native Compass
+  evolution.
+
+### Design
+
+Design documents cover:
+
+- local-first operation and explicit semantic-provider boundaries;
+- deterministic and inspectable results;
+- conservative failure behavior and atomic publication;
+- stable machine-readable contracts;
+- bounded resource usage;
+- workspace boundaries;
+- storage/history architecture;
+- security and privacy threat boundaries.
+
+### Implementation
+
+Implementation documents cover:
+
+- the role of each workspace crate;
+- the CLI-to-pipeline data flow;
+- file discovery, language detection, parsing, extraction, resolution, merge,
+  analysis, and rendering;
+- query loading, indexing, planning, execution, and rendering;
+- semantic orchestration and provider boundaries;
+- versioned history storage, materialization, hooks, leases, jobs, and garbage
+  collection;
+- adding a language, relation, extractor, integration, query capability, or
+  output surface;
+- relevant tests and qualification commands for each extension.
+
+### Cookbook
+
+Recipes cover representative tasks:
+
+- finding an authentication or authorization path;
+- mapping a subsystem;
+- finding callers and downstream impact;
+- comparing two commits;
+- producing machine-readable query output;
+- adding Compass to CI;
+- providing focused graph context to a coding assistant;
+- diagnosing missing symbols, unexpected edges, stale output, provider
+  failures, history corruption, and oversized graphs.
+
+### References
+
+References cover:
+
+- the current public command surface and global conventions;
+- configuration sources, precedence, environment variables, and provider
+  settings;
+- `compass-out/` artifacts and graph/result schemas;
+- exits, diagnostics, limits, atomicity, and deterministic ordering;
+- compatibility and migration links;
+- supported platforms, formats, languages, and optional integrations.
+
+### Roadmap
+
+The roadmap has three labeled sections:
+
+1. **Available now** — verified shipped behavior;
+2. **Planned** — work supported by committed specs or implementation plans;
+3. **Aspirational** — ideas that are not commitments and have no promised
+   release or compatibility guarantee.
+
+Every planned item links to repository evidence. Aspirational ideas state the
+problem or opportunity, not a fictional delivery date. The roadmap explains
+that Compass may diverge from Graphify when native design goals, performance,
+correctness, or user needs justify it.
+
+## Existing Canonical Documents
+
+The following remain authoritative and must be linked rather than copied:
+
+- `COMPATIBILITY.md`
+- `CONTRIBUTING.md`
+- `MIGRATION.md`
+- `PERFORMANCE.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `docs/COMPASSQL.md`
+- `docs/COMPASSQL_SUPPORT.md`
+
+New pages may summarize these documents for navigation or teaching, but each
+summary must link to its canonical source and avoid restating volatile numeric
+or compatibility details unless those details are verified during
+implementation.
+
+Approved specs and plans are implementation evidence, not end-user
+documentation. Public docs may derive explanations from them but must not
+expose speculative details as shipped behavior.
+
+## Visual System
+
+### ASCII diagrams
+
+Use inline ASCII for compact relationships, decisions, directory trees, and
+small pipelines. Diagrams must render correctly in monospaced Markdown blocks
+without color.
+
+### SVG diagrams
+
+Use checked-in SVGs for:
+
+- end-to-end graph construction;
+- query and traversal flow;
+- workspace/crate architecture;
+- incremental update pipeline;
+- history storage and materialization;
+- integration surfaces;
+- provenance and confidence;
+- reader journeys when an SVG adds meaningful clarity.
+
+Each SVG must:
+
+- include `<title>` and `<desc>` elements;
+- use semantic group labels;
+- remain readable against GitHub light and dark backgrounds;
+- avoid relying on color as the only carrier of meaning;
+- use legible text at normal GitHub content width;
+- have nearby Markdown prose that communicates the same essential information;
+- avoid external fonts, scripts, images, or network resources.
+
+### Mermaid
+
+Mermaid is not used in the initial documentation set. A future document may use
+Mermaid only for a genuine sequence diagram where time-ordered interactions are
+materially clearer than ASCII, SVG, or prose.
+
+## Technical Accuracy Policy
+
+Every statement about current behavior must be supported by at least one of:
+
+- CLI command definitions or generated `--help`;
+- public Rust interfaces and workspace boundaries;
+- automated tests or qualification scripts;
+- existing canonical release, compatibility, performance, or security
+  evidence.
+
+Claims derived from source rather than a public contract must be labeled as
+implementation details. Claims inferred from repository plans must be labeled
+planned. Uncommitted product ideas must be labeled aspirational.
+
+The docs must use the `compass` executable. References to `graphify` belong
+only in historical, compatibility, migration, or explicit comparison contexts.
+
+## Error Handling in Guides
+
+Task guides must not present only the happy path. Each procedure includes, as
+applicable:
+
+- how the reader confirms success;
+- expected output artifacts;
+- common failure messages or failure categories;
+- whether retrying is safe;
+- cleanup or recovery steps;
+- relevant diagnostic commands;
+- links to deeper troubleshooting or support material.
+
+Security-sensitive examples use placeholders and never encourage putting
+credentials in command history, tracked configuration, screenshots, or example
+output.
+
+## Verification Strategy
+
+### Source and command verification
+
+- Generate or inspect CLI help for documented commands and flags.
+- Run practical quickstart and cookbook commands against a temporary sample
+  repository.
+- Confirm output paths and representative output structure.
+- Cross-check current-feature claims against source and tests.
+- Cross-check planned items against committed specs or plans.
+
+### Documentation integrity
+
+- Check all relative Markdown links.
+- Check every referenced image exists.
+- Parse every SVG as XML.
+- Render and visually inspect SVGs.
+- Scan for `TODO`, `TBD`, placeholders, unsupported claims, accidental Mermaid,
+  and stale end-user `graphify` command examples.
+- Check headings and navigation for duplicate or orphaned topics.
+- Ensure every substantial page declares audience, outcomes, prerequisites,
+  estimated time, related pages, and next step.
+
+### Repository verification
+
+- Run formatting and test commands proportional to documentation-only changes.
+- Preserve the user's existing untracked
+  `docs/superpowers/plans/2026-07-22-compass-native-skill.md`.
+- Run `graphify update .` in the parent Graphify repository if implementation
+  modifies code files, as required by the workspace instructions.
+- Review `git diff --check` and final status before handoff.
+
+### Remote metadata verification
+
+After the final wording exists in the committed documentation:
+
+1. inspect the current `crabbuild/compass` metadata;
+2. update the GitHub description to the approved text;
+3. read the repository metadata back;
+4. report the confirmed description to the user.
+
+## Change Boundaries
+
+- Documentation changes are made in the Compass repository.
+- Existing user changes and untracked files are preserved.
+- The design-spec commit contains only this specification.
+- The later documentation implementation should use focused commits or a
+  clearly reviewable documentation commit, without bundling unrelated code
+  changes.
+- Remote repository metadata is changed only after local documentation and
+  verification are complete.
+
+## Success Criteria
+
+The work is complete when:
+
+- the root README clearly positions Compass and routes all three audiences;
+- the Markdown documentation hub and its primary learning paths exist;
+- getting started, guides, how-it-works, design, implementation, cookbook,
+  reference, and roadmap content are comprehensive and cross-linked;
+- current, planned, and aspirational features are visibly distinct;
+- major architecture and data-flow concepts have accessible ASCII or SVG
+  diagrams;
+- no non-sequence Mermaid diagram is introduced;
+- command examples and internal claims have been verified;
+- all local links and SVGs validate;
+- existing canonical documents remain authoritative and discoverable;
+- no unrelated user file is overwritten;
+- the GitHub repository description matches the approved positioning and is
+  confirmed after update.


### PR DESCRIPTION
## Summary

- add a comprehensive plain-Markdown documentation system with 30 audience-oriented pages for evaluators, integrators, and Rust contributors
- add getting started, concepts, guides, design, implementation, cookbook, reference, and a status-qualified roadmap
- add eight checked-in accessible SVG diagrams plus portable ASCII diagrams; no Mermaid diagrams are used
- clarify that Compass is inspired by Graphify, already adds native capabilities, and is expected to evolve independently
- document all 34 public CLI commands and link existing canonical compatibility, performance, security, support, and CompassQL contracts
- include the approved documentation-system design and implementation plan

## Why

Compass had strong implementation and policy documents but no single progressive path for new users, developers integrating it, or contributors extending the Rust workspace. This change turns the existing evidence into a navigable documentation system while clearly separating available, planned, and aspirational work.

## Impact

Readers can now enter through a role-specific path, complete a first graph build, understand the architecture and data contracts, copy task recipes, and distinguish shipped behavior from committed plans and non-committed ideas.

## Validation

- relative Markdown links checked: 286; missing targets: 0
- local heading anchors checked: missing anchors: 0
- public CLI commands checked: 34; missing reference entries: 0
- SVGs parsed with `xmllint` and rendered with `rsvg-convert`: 8/8; all include `<title>` and `<desc>`
- Mermaid blocks in the new documentation set: 0
- `git diff --check`: passed
- `cargo test --workspace --lib --bins --locked --exclude compass-parity`: 436 passed, 0 failed, 2 ignored

### Known verification limitation

The complete workspace command including `compass-parity` compiles, but the parity crate assumes fixtures are at the parent of the checkout. In the standard `.worktrees/<branch>` layout it resolves them as `.worktrees/tests/fixtures`, causing 95 fixture-not-found failures. The documentation does not modify Rust code or test fixtures; the non-parity workspace suites pass as reported above.
