### PR TITLE
chore: prepare Compass 0.1.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-model",
  "glob",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-cargo",
  "compass-core",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-files",
  "compass-google-workspace",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "md-5 0.10.6",
  "rayon",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atomicwrites",
  "compass-files",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "compass-core",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-cypher",
  "compass-files",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "compass-parity"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-cli",
  "compass-core",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -27,24 +27,24 @@ serde_json.workspace = true
 tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.0" }
-compass-cargo = { path = "../compass-cargo", version = "0.1.0" }
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-graph = { path = "../compass-graph", version = "0.1.0" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.0" }
-compass-global = { path = "../compass-global", version = "0.1.0" }
-compass-history = { path = "../compass-history", version = "0.1.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.0" }
-compass-ingest = { path = "../compass-ingest", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
-compass-mcp = { path = "../compass-mcp", version = "0.1.0" }
-compass-output = { path = "../compass-output", version = "0.1.0" }
-compass-postgres = { path = "../compass-postgres", version = "0.1.0" }
-compass-prs = { path = "../compass-prs", version = "0.1.0" }
-compass-query = { path = "../compass-query", version = "0.1.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.0" }
-compass-semantic = { path = "../compass-semantic", version = "0.1.0" }
+compass-core = { path = "../compass-core", version = "0.1.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.1" }
+compass-cargo = { path = "../compass-cargo", version = "0.1.1" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-graph = { path = "../compass-graph", version = "0.1.1" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.1" }
+compass-global = { path = "../compass-global", version = "0.1.1" }
+compass-history = { path = "../compass-history", version = "0.1.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.1" }
+compass-ingest = { path = "../compass-ingest", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
+compass-mcp = { path = "../compass-mcp", version = "0.1.1" }
+compass-output = { path = "../compass-output", version = "0.1.1" }
+compass-postgres = { path = "../compass-postgres", version = "0.1.1" }
+compass-prs = { path = "../compass-prs", version = "0.1.1" }
+compass-query = { path = "../compass-query", version = "0.1.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.1" }
+compass-semantic = { path = "../compass-semantic", version = "0.1.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -20,15 +20,15 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.0" }
-compass-languages = { path = "../compass-languages", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
-compass-graph = { path = "../compass-graph", version = "0.1.0" }
-compass-history = { path = "../compass-history", version = "0.1.0" }
-compass-output = { path = "../compass-output", version = "0.1.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.0" }
-compass-resolve = { path = "../compass-resolve", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.1" }
+compass-languages = { path = "../compass-languages", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
+compass-graph = { path = "../compass-graph", version = "0.1.1" }
+compass-history = { path = "../compass-history", version = "0.1.1" }
+compass-output = { path = "../compass-output", version = "0.1.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.1" }
+compass-resolve = { path = "../compass-resolve", version = "0.1.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.1.0" }
+compass-media = { path = "../compass-media", version = "0.1.1" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -18,8 +18,8 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-languages = { path = "../compass-languages", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -20,8 +20,8 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-transcribe = { path = "../compass-transcribe", version = "0.1.0", default-features = false }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-transcribe = { path = "../compass-transcribe", version = "0.1.1", default-features = false }
 ureq.workspace = true
 url.workspace = true
 

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -22,8 +22,8 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-language-pack.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,11 +19,11 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.0" }
-compass-graph = { path = "../compass-graph", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
-compass-prs = { path = "../compass-prs", version = "0.1.0" }
-compass-query = { path = "../compass-query", version = "0.1.0" }
+compass-core = { path = "../compass-core", version = "0.1.1" }
+compass-graph = { path = "../compass-graph", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
+compass-prs = { path = "../compass-prs", version = "0.1.1" }
+compass-query = { path = "../compass-query", version = "0.1.1" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -18,11 +18,11 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.0" }
-compass-graph = { path = "../compass-graph", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
-compass-query = { path = "../compass-query", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.1" }
+compass-graph = { path = "../compass-graph", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
+compass-query = { path = "../compass-query", version = "0.1.1" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-parity/Cargo.toml
+++ b/crates/compass-parity/Cargo.toml
@@ -16,20 +16,20 @@ publish = false
 serde_json.workspace = true
 tempfile.workspace = true
 time.workspace = true
-compass-cli = { version = "0.1.0", path = "../compass-cli" }
-compass-core = { version = "0.1.0", path = "../compass-core" }
-compass-files = { version = "0.1.0", path = "../compass-files" }
-compass-graph = { version = "0.1.0", path = "../compass-graph" }
-compass-languages = { version = "0.1.0", path = "../compass-languages" }
-compass-media = { version = "0.1.0", path = "../compass-media" }
-compass-mcp = { version = "0.1.0", path = "../compass-mcp" }
-compass-model = { version = "0.1.0", path = "../compass-model" }
-compass-output = { version = "0.1.0", path = "../compass-output" }
-compass-query = { version = "0.1.0", path = "../compass-query" }
-compass-reflect = { version = "0.1.0", path = "../compass-reflect" }
-compass-resolve = { version = "0.1.0", path = "../compass-resolve" }
-compass-semantic = { version = "0.1.0", path = "../compass-semantic" }
-compass-transcribe = { version = "0.1.0", path = "../compass-transcribe" }
+compass-cli = { version = "0.1.1", path = "../compass-cli" }
+compass-core = { version = "0.1.1", path = "../compass-core" }
+compass-files = { version = "0.1.1", path = "../compass-files" }
+compass-graph = { version = "0.1.1", path = "../compass-graph" }
+compass-languages = { version = "0.1.1", path = "../compass-languages" }
+compass-media = { version = "0.1.1", path = "../compass-media" }
+compass-mcp = { version = "0.1.1", path = "../compass-mcp" }
+compass-model = { version = "0.1.1", path = "../compass-model" }
+compass-output = { version = "0.1.1", path = "../compass-output" }
+compass-query = { version = "0.1.1", path = "../compass-query" }
+compass-reflect = { version = "0.1.1", path = "../compass-reflect" }
+compass-resolve = { version = "0.1.1", path = "../compass-resolve" }
+compass-semantic = { version = "0.1.1", path = "../compass-semantic" }
+compass-transcribe = { version = "0.1.1", path = "../compass-transcribe" }
 
 [lints]
 workspace = true

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.0" }
+compass-languages = { path = "../compass-languages", version = "0.1.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,7 +16,7 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -16,12 +16,12 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.0" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -16,8 +16,8 @@ rayon.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.0" }
-compass-model = { path = "../compass-model", version = "0.1.0" }
+compass-languages = { path = "../compass-languages", version = "0.1.1" }
+compass-model = { path = "../compass-model", version = "0.1.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.0" }
-compass-media = { path = "../compass-media", version = "0.1.0" }
+compass-files = { path = "../compass-files", version = "0.1.1" }
+compass-media = { path = "../compass-media", version = "0.1.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -27,7 +27,7 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-whisper = { version = "0.1.0", path = "../compass-whisper", optional = true }
+compass-whisper = { version = "0.1.1", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## What

- bump every publishable Compass workspace package from `0.1.0` to `0.1.1`
- update all internal Compass dependency constraints to `0.1.1`
- refresh the lockfile package versions without changing third-party dependencies

## Why

The native Compass skill installer is merged into `main`. The macOS release workflow requires the `compass-v<version>` tag to exactly match every publishable workspace package, so a new version is required before building and publishing updated artifacts.

## Release qualification

- `cargo metadata --locked --no-deps --format-version 1` reports only `0.1.1` for publishable Compass packages
- `cargo fmt --all -- --check`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/test_release_scripts.sh`
- optimized local builds for:
  - `aarch64-apple-darwin`
  - `x86_64-apple-darwin`
- packaged both targets with `scripts/package_macos.sh`
- verified Mach-O architectures, `compass 0.1.1`, query help, licenses, notices, completions, archive extraction, and SHA-256 checksums
