### PR TITLE
docs: make the Compass README easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,584 +1,295 @@
-# Compass: local knowledge graphs for your codebase
+# Compass
 
-Compass turns source code and project artifacts into a searchable knowledge graph. Use it to find implementation paths, understand dependencies, estimate change impact, give coding assistants focused context, or export the graph to other tools.
+**A fast, local-first knowledge graph for understanding codebases.**
 
-Compass is inspired by [Graphify](https://github.com/Graphify-Labs/graphify),
-built natively in Rust, and evolving independently beyond its original
-compatibility baseline. Structural extraction and graph queries run locally
-without Python, embeddings, a vector database, runtime grammar downloads, or
-separately installed native libraries. Semantic extraction is optional and uses
-only the model provider you configure.
+Compass turns source code and project artifacts into a graph you can search,
+query, visualize, compare across Git history, and share with development tools.
 
-> **Repository description:** Native, local-first knowledge graph engine for
-> code and project artifacts—inspired by Graphify, built in Rust, and evolving
-> beyond it.
+```text
+large codebase
+     |
+     v
+  Compass  ----->  architecture map
+     |           \-> dependency and impact answers
+     |            \-> exact CompassQL results
+     |             \-> historical graph diffs
+     |              \-> focused context for assistants
+     v
+less searching, smaller context, traceable evidence
+```
 
-## Documentation
+[Get started](docs/getting-started.md) ·
+[Read the documentation](docs/README.md) ·
+[Explore the roadmap](docs/roadmap.md) ·
+[View releases](https://github.com/crabbuild/compass/releases)
 
-Start with the path that matches your goal:
+## What Compass gives you
 
-| Reader | Start here |
+| Need | Compass capability |
 | --- | --- |
-| Evaluating Compass | [Getting started](docs/getting-started.md) → [How it works](docs/concepts/how-it-works.md) |
-| Using or integrating Compass | [Guides](docs/README.md#complete-a-task) → [Cookbook](docs/cookbook/README.md) → [Reference](docs/README.md#look-up-an-exact-contract) |
-| Extending the Rust workspace | [Design principles](docs/design/principles.md) → [Architecture](docs/design/architecture.md) → [Workspace tour](docs/implementation/workspace-tour.md) |
+| Understand an unfamiliar repository | Communities, architecture reports, god-node detection, and interactive HTML |
+| Find implementation paths | Natural-language graph discovery, symbol explanations, and directed paths |
+| Estimate change impact | Reverse dependency traversal and version-to-version topology diffs |
+| Automate structural checks | Deterministic, read-only [CompassQL](docs/COMPASSQL.md) with JSON and JSONL output |
+| Ask questions about old revisions | Immutable graph realizations for exact Git commits |
+| Give assistants focused context | Native skills, hooks, MCP serving, and compact graph queries |
+| Connect other tools | Graph JSON, GraphML, SVG, Wiki, Obsidian, Neo4j, FalkorDB, and other exports |
 
-The [documentation hub](docs/README.md) includes comprehensive guides for
-versioned history, CompassQL, assistant setup, security, operations,
-implementation, troubleshooting, and the status-qualified
-[roadmap](docs/roadmap.md). Diagrams use portable ASCII or accessible SVG.
+Structural extraction and graph queries run locally. They do not require
+Python, embeddings, a vector database, model credentials, or runtime parser
+downloads.
 
-## Command surface and graph history
+## How it works
 
-Only completed commands are exposed. `compass` is the authoritative and only
-shipped CLI. It may evolve independently of the Python `graphify` command.
+![Compass graph construction and query pipeline](docs/assets/diagrams/graph-pipeline.svg)
 
-### Current native command surface
-
-```text
-compass update
-compass extract
-compass watch
-compass serve
-compass install
-compass uninstall
-compass cluster-only
-compass query
-compass query --cql
-compass path
-compass explain
-compass diff
-compass history
-compass affected
-compass tree
-compass export
-compass benchmark
-compass diagnose multigraph
-compass merge-graphs
-compass cache-check
-compass merge-chunks
-compass merge-semantic
-compass provider
-compass save-result
-compass reflect
-compass check-update
-compass hook-check
-compass hook-guard
-compass merge-driver
-compass global
-compass clone
-compass add
-compass label
-compass prs
-compass hook
-```
-
-Run `compass --help` to see commands grouped by workflow. Run
-`compass help <command>` or `compass <command> --help` for arguments,
-option descriptions, defaults, examples, and related-command tips. Nested help
-accepts the full path, such as `compass help history build`.
-
-### Versioned graph history
-
-Compass can materialize a complete immutable graph for an exact Git commit and
-keep it in a SQLite-backed Prolly store outside Git history. A realization
-contains the AST graph, semantic and inferred edges, hyperedges, community and
-analysis data, reconstruction metadata, and authoritative sidecars. History is
-opt-in for eager generation; explicit builds and lazy historical queries remain
-available while eager generation is disabled.
-
-```bash
-compass history enable
-compass history build HEAD
-compass query "authentication flow" --at HEAD~20
-compass diff v1.2.0 HEAD --detailed
-compass history export HEAD --format compass-out --output historical-output
-compass history list HEAD --format json
-compass history gc
-compass history disable
-```
-
-For a fully local code graph with no model credentials, select a code-only
-history profile explicitly:
-
-```bash
-compass history enable --code-only
-compass diff HEAD~1 HEAD --topology-only
-```
-
-Code-only and semantic realizations have different extraction fingerprints and
-are never mixed by a normal diff. Compass does not silently downgrade a
-semantic profile when provider credentials are missing.
-
-To qualify history correctness and performance against two commits in a clean
-real repository checkout, run:
-
-```bash
-scripts/qualify_history_real_repo.sh /path/to/repository OLD NEW
-```
-
-The harness builds in an isolated shared clone, checks deterministic and
-reverse-symmetric JSON, reopens the SQLite store, verifies topology filtering,
-and requires topology-only diff to be at least twice as fast as a full diff.
-
-`compass history enable` records a repository-wide build profile and installs
-managed `post-commit` and `post-merge` hooks. The hooks capture the resulting
-commit SHA and durably enqueue work, then return without waiting for extraction.
-The worker uses leases and a FIFO queue; a failed job does not prevent later
-jobs from running. `disable` is idempotent: it stops eager enqueueing but keeps
-the database, jobs, and existing realizations. It does not disable explicit
-`build`/`rebuild`, `--at`, or `diff`.
-
-`query`, `path`, and `explain` accept either `--graph PATH` or `--at REV`.
-`--at` resolves the revision to an exact commit. If its preferred realization
-is missing, Compass synchronously builds it in a detached, offline worktree;
-uncommitted files and caller-local `.git/info/exclude` or global-ignore rules do
-not enter the build. The committed `.gitignore` still applies. Gitlinks and LFS
-pointers are reported as limitations, and checkout filters that could execute
-external code are rejected. Historical materialization does not run hooks,
-smudge LFS objects, prompt for credentials, fetch from the network, or recurse
-into submodules.
-
-Every meaning-affecting input is captured in an extraction fingerprint,
-including the build profile, graph and canonical-encoding versions, parser and
-analyzer versions, and provider/model configuration. Credentials, machine-local
-paths, timings, token counts, and other operational data are excluded. The same
-commit may therefore have multiple immutable realizations; one validated,
-complete realization is the preferred default. Use `history list`, `show`, and
-`prefer` to inspect or select them. An unreadable preferred pointer is never
-silently overwritten: recover it only with an explicit
-`compass history rebuild REV --replace-corrupt`, which uses an exact
-compare-and-swap observation.
-
-All linked worktrees share
-`$(git rev-parse --git-common-dir)/compass/history.sqlite`. The pinned
-`prolly-store-sqlite` adapter runs SQLite in WAL mode with full synchronous
-durability and a busy timeout. The database, WAL, and operational files are
-live resources. Don't copy only `history.sqlite` while Compass is running.
-Compass creates the resource directory and operational records with owner-only
-permissions. Jobs, leases, locks, and protected temporary worktrees are files
-beside the database rather than Prolly values.
-
-`history export --format graph-json` reconstructs the canonical graph JSON.
-`--format compass-out` also restores authoritative, non-derivable sidecars
-verbatim and regenerates reports and HTML only with the renderer versions
-recorded in the artifact registry. Export equivalence is semantic and
-canonical: insignificant JSON member or record ordering is not part of the
-contract, while graph structure, attributes, duplicate id-less hyperedges, and
-authoritative bytes are.
-
-Normal `history gc` retains every published realization and removes only
-unreachable Prolly nodes plus expired operational records. Pruning alternate
-realizations requires `--prune-non-preferred`; it is a dry run until repeated
-with `--yes`. Reported bytes and node rows are logical reclamation. The command
-does not promise that the SQLite file shrinks or run `VACUUM`.
-
-Text output is intended for people; `--format json` emits stable JSON for the
-history commands that support it. Successful queries and no-store read-only
-status/list operations exit `0` and do not create `.git/compass`. CLI usage
-errors exit `2`; Git, provider, validation, corruption, and storage failures
-exit `1`, with diagnostics on stderr. Complete semantic builds require the
-selected provider's credentials when a committed input needs model extraction;
-a provider failure cannot publish or become preferred.
-
-Scripts and new documentation should use `compass`. Versioned history is
-specified, documented, and qualified through `compass`; its commands and help
-do not need a matching Python Graphify surface.
-
-Assistant setup is native and self-contained. The generic
-`compass install --platform <name>` and project-scoped `--project` forms,
-their uninstall counterparts, and their generated file trees are tested in the
-Rust workspace.
-## How Compass works
-
-Compass parses a project into nodes and directed relationships. It then groups related nodes into communities and writes the results to `compass-out/`.
+Compass discovers project files, extracts entities and relationships, resolves
+cross-file references, analyzes the resulting graph, and publishes one
+consistent snapshot.
 
 ```text
- Source code        Project files       Optional semantic sources
- .rs .py .ts ...    Cargo, MCP, etc.    docs, PDFs, Office, images
-      \                  |                         /
-       +-----------------+------------------------+
-                         |
-                         v
-               Parse and resolve locally
-                         |
-                         v
-              +------------------------+
-              |   Compass graph        |
-              |                        |
-              |  nodes --relations-->  |
-              |     \__ communities    |
-              +------------------------+
-                         |
-          +--------------+---------------+
-          |              |               |
-          v              v               v
-       CLI queries   graph.html     assistants / MCP
+function / class / file / document / schema object       node
+CALLS / IMPORTS_FROM / USES / CONTAINS                   relationship
+dense group of related nodes                             community
+direct / resolved / uncertain evidence                   provenance
 ```
 
-Consider a checkout flow. Compass may represent it like this:
+Relationships retain their direction, source location, and provenance:
 
 ```text
- CheckoutHandler
-      |
-      +--CALLS [EXTRACTED]--> authorizePayment()
-      |                              |
-      |                              +--USES--> PaymentGateway
-      |
-      +--CALLS [INFERRED]----> reserveInventory()
+CheckoutHandler
+    |
+    +-- CALLS [EXTRACTED] --> authorizePayment()
+    |                              |
+    |                              +-- USES --> PaymentGateway
+    |
+    +-- CALLS [INFERRED]  --> reserveInventory()
 ```
 
-The graph uses these concepts:
+Read [How Compass works](docs/concepts/how-it-works.md) for the complete
+pipeline and [Graph model](docs/concepts/graph-model.md) for the data model.
 
-- **Node**: a file, function, class, document section, database object, or another project entity
-- **Relationship**: a directed connection such as `CALLS`, `IMPORTS_FROM`, `USES`, or `CONTAINS`
-- **Community**: a densely connected group that usually corresponds to a subsystem or feature
-- **God node**: a highly connected node that may be important, generic, or too broad to help navigation
-- **Provenance**: how Compass determined a relationship: `EXTRACTED` from direct evidence, `INFERRED` from resolution, or `AMBIGUOUS` when more than one interpretation remains
+## Inspired by Graphify, extended by Compass
 
-Compass preserves relationship direction, source locations, and provenance in the graph. You can inspect uncertain relationships instead of treating every connection as equally reliable.
+Compass is inspired by and modeled after
+[Graphify](https://github.com/Graphify-Labs/graphify). Graphify established the
+core workflow: extract a codebase into a knowledge graph, analyze its
+communities, and use focused graph queries to navigate complex projects.
 
-## Install Compass on macOS
+Compass gives explicit credit to that foundation. A frozen Graphify release is
+still used as a behavioral oracle for compatible commands, graph structures,
+and output contracts.
 
-Install the latest release on Apple Silicon or Intel with one command:
+```text
+Graphify ideas and behavior
+           |
+           v
+compatibility fixtures and differential checks
+           |
+           v
+Compass: native Rust engine
+           |
+           +--> preserves proven graph workflows
+           +--> adds Compass-specific capabilities
+           +--> evolves independently where the products diverge
+```
+
+### What Compass adds beyond the frozen Graphify baseline
+
+| Area | Compass extension |
+| --- | --- |
+| Runtime | One native Rust executable; Python is used only by development parity tests |
+| Exact queries | CompassQL, a deterministic and bounded read-only openCypher subset |
+| Versioned graphs | Immutable realizations for exact commits, historical queries, exports, and diffs |
+| Incremental operation | Reuses compatible unchanged extraction work and atomically publishes graph plus manifest |
+| Query safety | Explicit row, path, expansion, memory, and time limits |
+| Native distribution | Linked parsers and native implementations for supported graph, media, database, and service boundaries |
+
+Compatibility is a foundation, not a permanent feature ceiling. Compass may
+diverge when native design, performance, safety, or new workflows benefit from
+a different contract. See [Compatibility](COMPATIBILITY.md) and
+[Migration from Graphify](MIGRATION.md) for exact boundaries.
+
+## Performance improvements over Graphify
+
+Compass is qualified against the frozen Python Graphify oracle on copied
+corpora. Results are accepted only when graph topology and read outputs match
+the oracle.
+
+The current large-corpus baseline contains 850 files, 15,151 nodes, and 38,374
+edges. It was recorded on an Apple M2 Max with 32 GiB RAM using five independent
+corpus copies.
+
+| Large-corpus case | Graphify median | Compass median | Compass speedup |
+| --- | ---: | ---: | ---: |
+| Cold AST build | 10.766 s | 3.774 s | **2.85×** |
+| Unchanged update | 12.180 s | 0.232 s | **52.5×** |
+| One-file change | 12.155 s | 2.112 s | **5.8×** |
+| Query | 0.746 s | 0.132 s | **5.7×** |
+| Path | 0.655 s | 0.107 s | **6.1×** |
+| Explain | 0.609 s | 0.087 s | **7.0×** |
+| Affected analysis | 0.250 s | 0.034 s | **7.4×** |
+
+On the same large corpus, cold-build peak memory fell from 351.3 MiB to
+291.2 MiB. The qualification gate also checks warm updates, edits, renames,
+deletes, query output, and memory use.
+
+These numbers are a reproducible local baseline, not a universal promise for
+every repository or machine. Read [Performance qualification](PERFORMANCE.md)
+for hardware details, raw-evidence rules, regression gates, and benchmark
+commands.
+
+## Quick start
+
+### 1. Install
+
+On macOS (Apple Silicon or Intel):
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/crabbuild/compass/releases/latest/download/install.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/crabbuild/compass/releases/latest/download/install.sh | sh
 ```
 
-The installer verifies the release archive's SHA-256 checksum and installs
-`compass` to `~/.local/bin`. Set `COMPASS_INSTALL_DIR` to choose another
-directory. This first macOS release is unsigned and isn't notarized by Apple.
-
-## Install Compass from source
-
-Building Compass requires Rust 1.97.1 or newer. The repository pins that toolchain in `rust-toolchain.toml`.
+Or build from source with the pinned Rust 1.97.1+ toolchain:
 
 ```bash
 git clone https://github.com/crabbuild/compass.git
 cd compass
 cargo install --locked --path crates/compass-cli --bin compass
-compass --version
 ```
 
-The installed `compass` binary doesn't require Python. The development parity
-suite uses Python only to compare selected behavior with Graphify.
-
-Register the native Compass skill with your coding assistant:
+### 2. Build a local graph
 
 ```bash
-compass install
+cd your-project
+compass update .
 ```
 
-Use a project-scoped skill when the configuration should travel with the
-repository:
+Compass writes:
+
+```text
+compass-out/
+├── graph.json        machine-readable graph
+├── GRAPH_REPORT.md   architecture and community summary
+├── graph.html        interactive visualization when size permits
+└── manifest.json     incremental build state
+```
+
+### 3. Ask useful questions
+
+```bash
+compass query "where is authentication enforced?"
+compass explain TokenVerifier
+compass path ApiHandler TokenVerifier
+compass affected TokenVerifier --depth 3
+```
+
+These commands read the saved graph and do not call a model.
+
+## Compass-specific workflows
+
+### Query exact graph patterns with CompassQL
+
+```bash
+compass query --cql \
+  "MATCH (caller)-[:CALLS]->(target)
+   WHERE target.label = 'authorizePayment()'
+   RETURN caller.id, target.id
+   LIMIT 20" \
+  --format json
+```
+
+CompassQL is deterministic, read-only, parameterized, and resource-bounded.
+See the [language contract](docs/COMPASSQL.md) and
+[support matrix](docs/COMPASSQL_SUPPORT.md).
+
+### Travel through graph history
+
+```bash
+compass history enable --code-only
+compass history build HEAD
+compass query "authentication" --at HEAD~20
+compass diff HEAD~1 HEAD --topology-only
+```
+
+Historical builds use exact Git commits and immutable extraction
+fingerprints. Current and historical graphs can be queried, compared, and
+exported without putting generated graph data into Git.
+
+Read the [versioned history guide](docs/guides/versioned-history.md) and
+[storage design](docs/design/storage-and-history.md).
+
+### Connect a coding assistant
 
 ```bash
 compass install --project --platform codex
 ```
 
-After the crate is published to crates.io, install it with:
-
-```bash
-cargo install --locked compass-cli --bin compass
-```
-
-The release workflow publishes prebuilt Intel and Apple Silicon archives on the
-[Compass releases page](https://github.com/crabbuild/compass/releases).
-
-## Build your first graph
-
-Run `update` from a project directory. This command performs deterministic structural extraction and doesn't call a model.
-
-```bash
-cd your_project_directory
-compass update .
-```
-
-Compass writes the graph and its supporting artifacts to `compass-out/`:
-
-| Artifact | Use it for |
-| --- | --- |
-| `graph.json` | Machine-readable nodes, relationships, attributes, and provenance |
-| `GRAPH_REPORT.md` | Architecture summary, communities, god nodes, and graph diagnostics |
-| `graph.html` | Interactive browser exploration when the graph is within the visualization limit |
-| `manifest.json` | Incremental build state |
-
-Open `compass-out/graph.html` in a browser for a visual tour. Start with `GRAPH_REPORT.md` when you need a repository-wide architecture view.
-
-Ask a focused question when you need a smaller working set:
-
-```bash
-compass query "where is authentication enforced?"
-```
-
-This query searches and traverses the saved graph. It returns relevant nodes and relationships, not a model-generated narrative, and it doesn't access the network.
-
-## Explore the graph with concrete questions
-
-Compass includes focused commands for common code-reading tasks. Each command reads `compass-out/graph.json` by default.
-
-Find the neighborhood related to a concept:
-
-```bash
-compass query "payment retry logic"
-```
-
-Inspect one symbol and its incoming and outgoing relationships:
-
-```bash
-compass explain PaymentGateway
-```
-
-Find the shortest known route between two symbols:
-
-```bash
-compass path CheckoutHandler PaymentGateway
-```
-
-Estimate what may depend on a changed symbol:
-
-```bash
-compass affected authorizePayment --depth 3
-```
-
-`affected` follows impact-related relationships such as calls, imports, and uses. Treat the result as a review scope, not proof that every returned file must change.
-
-### Run exact structural queries with CompassQL
-
-[CompassQL](docs/COMPASSQL.md) is Compass's deterministic, read-only subset of openCypher. Use it when you need an exact graph pattern, stable automation, parameters, or JSON output.
-
-This query finds callers of `authorizePayment()`:
-
-```bash
-compass query --cql \
-  "MATCH (caller)-[:CALLS]->(target) \
-   WHERE target.label = 'authorizePayment()' \
-   RETURN caller.id, target.id \
-   LIMIT 20"
-```
-
-Use parameters when values come from a script:
-
-```bash
-compass query --cql \
-  'MATCH (caller)-[:CALLS]->(target) \
-   WHERE target.label = $target \
-   RETURN caller.id' \
-  --param target='authorizePayment()' \
-  --format json
-```
-
-CompassQL never mutates the graph. See the [CompassQL support matrix](docs/COMPASSQL_SUPPORT.md) for accepted syntax, limits, diagnostics, and unsupported openCypher features.
-
-## Choose structural or semantic extraction
-
-Use `update` for source code and deterministic project structure. Use `extract` when you also need documents, papers, Portable Document Format (PDF) files, Office files, images, or external schemas in the graph.
+The installed Compass skill teaches supported assistants to start from the
+architecture report, request a focused subgraph, and open only the source files
+needed to verify an answer.
 
 ```text
-compass update .
-    local structural graph
-    no model call
-
-compass extract . --code-only --cargo
-    explicit no-model mode
-    includes Cargo workspace dependency edges
-
-compass extract docs --backend openai --model your_model_name
-    adds semantic facts from supported documents
-    sends selected content to the configured provider
+architecture question
+        |
+        v
+read GRAPH_REPORT.md
+        |
+        v
+run a focused Compass query
+        |
+        v
+inspect the smallest useful source set
 ```
 
-`--code-only` guarantees that Compass won't invoke a model. Without that flag, semantic extraction uses the selected built-in or trusted custom provider. Configure provider credentials through the provider's environment variables, then run `compass extract --help` for controls such as token budget, concurrency, timeouts, and partial results.
+See [Assistant setup](docs/guides/assistant-setup.md) for supported platforms,
+scope, strict mode, upgrades, and uninstall.
 
-Native integrations can add other graph layers:
+## Structural and semantic modes
 
-```bash
-# Add workspace-internal Cargo dependencies.
-compass extract . --code-only --cargo
+Choose the smallest mode that answers your question:
 
-# Read a PostgreSQL schema through a read-only connection.
-compass extract . --code-only --postgres 'postgresql://localhost/app_database'
+| Command | Network behavior | Best for |
+| --- | --- | --- |
+| `compass update .` | Local only | Normal source-code graph updates |
+| `compass extract . --code-only` | Local only | Explicit no-model extraction |
+| `compass extract . --code-only --cargo` | Local only | Code plus Cargo dependency edges |
+| `compass extract docs --backend …` | Uses the configured provider | Semantic facts from supported documents and media |
 
-# Export Google Drive shortcuts through the configured gws CLI.
-compass extract . --code-only --google-workspace
-```
+Semantic extraction is optional. Compass contacts a model provider only when
+you select a provider-backed workflow. Read
+[Security and privacy](docs/design/security-and-privacy.md) before processing
+sensitive repositories.
 
-Compass confines image loading to the selected root. PDF, DOCX, and XLSX ingestion also uses bounded native readers.
+## Find the right document
 
-## Keep the graph current
-
-Compass records file state in `manifest.json`, so later updates can reuse unchanged extraction results.
-
-Run an update after a batch of changes:
-
-```bash
-compass update .
-```
-
-Use the watcher during active development:
-
-```bash
-compass watch .
-```
-
-The watcher rebuilds deterministic changes after its debounce interval. When semantic media changes, it writes `compass-out/needs_update` instead of calling a model in the background. Run `compass extract` again when you're ready to refresh that content.
-
-## Connect a coding assistant
-
-Compass can install project-scoped instructions, skills, and hooks for supported coding assistants. For example, install the Codex integration from the project root:
-
-```bash
-compass install --platform codex --project
-```
-
-The integration tells the assistant when to read the architecture report and when to run a focused graph query. It doesn't upload the graph.
-
-Every platform receives the same canonical `compass` skill and progressive
-reference bundle. The core handles graph-first navigation and evidence rules;
-on-demand references cover CompassQL, semantic extraction, immutable history,
-labeling, hooks, exports, MCP serving, multi-repository workflows, reflections,
-diagnostics, and security boundaries. The bundle currently contains 15
-progressive-disclosure references. A native build-time guard checks exact
-reference coverage and reads the public CLI inventory to ensure every command
-has dedicated help and installed skill guidance.
-
-List every supported platform and installation option:
-
-```bash
-compass install --help
-```
-
-Remove one project integration without deleting the graph:
-
-```bash
-compass uninstall --platform codex --project
-```
-
-## Serve the graph over MCP
-
-Compass includes a Model Context Protocol (MCP) server for editors and agents. Standard input and output is the default transport:
-
-```bash
-compass serve compass-out/graph.json
-```
-
-For a network client, start Streamable HTTP and require an API key:
-
-```bash
-export GRAPHIFY_API_KEY='your_access_token_here'
-compass serve --transport http --api-key "$GRAPHIFY_API_KEY"
-```
-
-HTTP mode supports stateful or stateless sessions, bounded request bodies, Domain Name System (DNS) rebinding checks, session expiry, and graceful shutdown. Run `compass serve --help` to configure the host, port, path, and session behavior.
-
-## Export or share the graph
-
-Exports transform the existing graph without rebuilding the project:
-
-```bash
-compass export wiki
-compass export obsidian
-compass export svg
-compass export graphml
-compass export neo4j
-```
-
-Neo4j and FalkorDB exports produce local openCypher by default. Add `--push URI` for bounded live upserts. Compass connects to Neo4j with Bolt and to FalkorDB with Redis Serialization Protocol (RESP), so neither path needs a database software development kit.
-
-Store database passwords in `NEO4J_PASSWORD` or `FALKORDB_PASSWORD`. Compass redacts those values from failures.
-
-## Know when Compass can access the network
-
-The default build and query workflow stays local. Network access occurs only when you select a network-backed feature:
-
-- `compass update`, local queries, CompassQL, traversal, reports, and local exports don't access the network
-- `compass extract --code-only` explicitly disables model calls
-- Semantic extraction may send selected content to your configured model provider
-- `compass export neo4j --push` and `compass export falkordb --push` connect to the target database
-- `compass serve --transport http` listens on the host and port you configure
-- Google Workspace extraction uses your configured `gws` command
-
-All Tree-sitter grammars are linked into the binary. Compass doesn't download parsers while scanning a repository.
-
-## Find the command you need
-
-Compass exposes completed native commands under one interface:
-
-| Task | Commands |
+| You are… | Start here |
 | --- | --- |
-| Build and enrich | `update`, `extract`, `watch`, `cluster-only`, `label` |
-| Explore and assess impact | `query`, `path`, `explain`, `affected`, `tree`, `benchmark` |
-| Inspect versioned graphs | `history`, `diff`, and query commands with `--at` |
-| Export and serve | `export`, `serve` |
-| Manage graph data | `diagnose multigraph`, `merge-graphs`, `merge-chunks`, `merge-semantic`, `cache-check` |
-| Work across projects | `global`, `clone`, `add`, `prs`, `hook`, `merge-driver` |
-| Configure integrations | `install`, `uninstall`, `provider`, `check-update`, `hook-check`, `hook-guard` |
-| Save project knowledge | `save-result`, `reflect` |
+| Evaluating Compass | [Getting started](docs/getting-started.md) → [How it works](docs/concepts/how-it-works.md) |
+| Using or integrating Compass | [Guides](docs/README.md#complete-a-task) → [Cookbook](docs/cookbook/README.md) |
+| Extending the Rust workspace | [Architecture](docs/design/architecture.md) → [Workspace tour](docs/implementation/workspace-tour.md) |
+| Looking up an interface | [Commands](docs/reference/commands.md) → [Outputs](docs/reference/outputs.md) |
+| Tracking future direction | [Available, planned, and aspirational roadmap](docs/roadmap.md) |
 
-Run `compass --help` for the current surface or `compass <command> --help` for command syntax.
+The [documentation hub](docs/README.md) links every concept, guide, design,
+implementation note, recipe, and reference.
 
-## Migrate from Graphify
-
-Compass uses `compass-out/` and doesn't read `graphify-out/` or `GRAPHIFY_OUT`.
-Rebuild a project with `compass update .` after switching from Graphify. Set
-`COMPASS_OUT` when you need a custom output directory.
-
-Use `compass` for new workflows. The release doesn't include compatibility
-executables for the Python Graphify command or its MCP entry point.
-
-```text
-graphify <command>       -> compass <command>
-python -m graphify ...  -> compass ...
-```
-
-See [MIGRATION.md](MIGRATION.md) for side-by-side qualification, cutover, and rollback. See [COMPATIBILITY.md](COMPATIBILITY.md) for the frozen Python baseline and differential evidence.
-
-## Join the Compass community
-
-Use Compass's public community channels to ask questions, report problems, propose improvements, and contribute changes.
+## Community and contributing
 
 | Need | Destination |
 | --- | --- |
-| Usage question or open-ended idea | [GitHub Discussions](https://github.com/crabbuild/compass/discussions) |
-| Reproducible bug or actionable feature request | [GitHub Issue chooser](https://github.com/crabbuild/compass/issues/new/choose) |
-| Security vulnerability | [GitHub private vulnerability reporting](https://github.com/crabbuild/compass/security/advisories/new) |
-| Code or documentation contribution | [GitHub pull requests](https://github.com/crabbuild/compass/pulls) |
+| Usage question or idea | [GitHub Discussions](https://github.com/crabbuild/compass/discussions) |
+| Bug or actionable feature request | [GitHub Issues](https://github.com/crabbuild/compass/issues/new/choose) |
+| Security vulnerability | [Private vulnerability reporting](https://github.com/crabbuild/compass/security/advisories/new) |
+| Code or documentation contribution | [Contributing guide](CONTRIBUTING.md) |
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. All project interactions follow the [Compass code of conduct](CODE_OF_CONDUCT.md). [SUPPORT.md](SUPPORT.md) explains support boundaries, and [SECURITY.md](SECURITY.md) explains private vulnerability reporting.
-
-## Build and verify the workspace
-
-These commands run the checks used for local development:
-
-```bash
-cargo build --release --locked -p compass-cli --bin compass
-cargo fmt --all -- --check
-cargo clippy --workspace --lib --bins --locked -- -D warnings
-cargo test --workspace --lib --bins --locked
-cargo test -p compass-cli --test compass_product --locked
-sh scripts/test_release_scripts.sh
-```
-
-The compatibility suite uses a sibling Graphify checkout as its behavioral oracle. Set `GRAPHIFY_REPO_ROOT` when that checkout lives elsewhere. Set `GRAPHIFY_PYTHON` and `GRAPHIFY_MEDIA_PYTHON` when the test interpreters use non-default paths.
-
-Release qualification also covers native line and region coverage, focused mutation suites, Miri, AddressSanitizer, and fuzz targets for untrusted inputs. Read [PERFORMANCE.md](PERFORMANCE.md) for benchmark methodology and the current baseline.
-
-## Distribution guarantees
-
-Release archives contain `compass`, shell completions, license notices, and a
-SHA-256 checksum. The automated workflow also records build-provenance
-attestations for each archive.
-
-The release workflow currently builds macOS archives for Intel and Apple
-Silicon. Publishing to crates.io uses a separate environment-protected workflow
-that validates the release tag before publishing workspace crates in dependency
-order.
+Development checks, architecture boundaries, and contribution expectations are
+documented in [CONTRIBUTING.md](CONTRIBUTING.md). Support and disclosure
+boundaries live in [SUPPORT.md](SUPPORT.md) and [SECURITY.md](SECURITY.md).
 
 ## License
 
-Compass's original work is available under your choice of the [MIT License](LICENSE-MIT) or [Apache License 2.0](LICENSE-APACHE). The workspace uses the SPDX expression `MIT OR Apache-2.0`.
-
-Third-party components retain their original licenses. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and the license files stored with vendored components.
-
-Unless you explicitly state otherwise, contributions submitted for inclusion in Compass use the same dual license without additional terms or conditions.
+Compass's original work is dual-licensed under
+[MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE).
+Third-party components retain their original licenses; see
+[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).


### PR DESCRIPTION
## Summary

- rewrite the README as a concise Compass product landing page
- remove the quoted repository-description block requested in review
- reduce the README from 3,152 to 1,395 words and replace dense explanations with short sections, tables, one accessible SVG, and three ASCII diagrams
- give Graphify prominent credit as the inspiration, model, and frozen compatibility oracle
- distinguish the Graphify foundation from Compass-specific extensions including the Rust runtime, CompassQL, immutable versioned graphs, incremental publication, and bounded queries
- add an evidence-backed performance comparison using the canonical large-corpus results from `PERFORMANCE.md`
- move deep operational detail behind the comprehensive documentation pages

## Why

The previous README duplicated detailed history, command, integration, and release documentation. That made the repository landing page difficult to scan and obscured the core Compass story, its relationship to Graphify, and the strongest native enhancements.

## Reader impact

A new reader can now understand what Compass does, how it works, how it relates to Graphify, its measured performance, and how to build a first graph without reading long uninterrupted sections.

## Validation

- relative links checked: 33; missing targets: 0
- local anchors checked: missing anchors: 0
- longest prose block: 34 words
- seven performance rows matched against `PERFORMANCE.md`: 0 mismatches
- graph-pipeline SVG parsed with `xmllint` and rendered with `rsvg-convert`
- README rendered successfully with GitHub's GFM Markdown API
- `git diff --check`: passed

This is a README-only change; no Rust source or runtime behavior changed.
