### PR TITLE
docs: recover Compass planning documents

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,11 +147,27 @@ Compass is dual-licensed under MIT or Apache-2.0 and includes:
 
 ## Planned
 
-The items below have committed design or implementation-plan evidence in the
-default branch. They are not listed in the current public command surface
-unless explicitly moved to Available now. Ideas that exist only in an
-uncommitted workspace or a separate development branch are intentionally not
-promoted to committed plans here.
+The items below have committed design or implementation-plan evidence. They are
+not listed in the current public command surface unless explicitly moved to
+Available now.
+
+### Compass Guard: architecture governance
+
+Goal: build a production CI architecture-governance product on CompassQL and
+versioned graphs. The planned `compass check` surface would:
+
+- evaluate portable read-only CompassQL policies;
+- report witness evidence;
+- support accountable exemptions;
+- compare against baselines so CI can fail only on newly introduced
+  violations;
+- emit stable machine output such as SARIF;
+- integrate with major CI systems.
+
+Evidence:
+
+- [`docs/superpowers/plans/2026-07-22-compass-guard.md`](superpowers/plans/2026-07-22-compass-guard.md)
+- [`docs/superpowers/plans/2026-07-22-compassql-policy.md`](superpowers/plans/2026-07-22-compassql-policy.md)
 
 ### Reusable CompassQL policy and integration surfaces
 
@@ -171,6 +187,43 @@ Evidence:
 
 - [`docs/superpowers/plans/2026-07-22-compassql-integrations.md`](superpowers/plans/2026-07-22-compassql-integrations.md)
 - [`docs/superpowers/plans/2026-07-22-compassql-policy.md`](superpowers/plans/2026-07-22-compassql-policy.md)
+
+### PR Intelligence foundation
+
+Goal: create a trusted, typed, immutable foundation for graph-aware pull-request
+reports.
+
+Planned foundation:
+
+- shared immutable graph snapshots;
+- exact pull-request revision capture;
+- a versioned typed report;
+- immutable evidence manifests;
+- durable report persistence;
+- compatibility-safe CLI and MCP adapters.
+
+Evidence:
+
+- [`docs/superpowers/specs/2026-07-22-pr-intelligence-design.md`](superpowers/specs/2026-07-22-pr-intelligence-design.md)
+- [`docs/superpowers/plans/2026-07-22-pr-intelligence-foundation.md`](superpowers/plans/2026-07-22-pr-intelligence-foundation.md)
+
+### Continued version-history hardening
+
+The core versioned graph surface is available. Committed designs also describe
+continued hardening around:
+
+- resolution-sensitive identity;
+- semantic diff interpretation;
+- gaps discovered by correctness audits;
+- production qualification and compatibility.
+
+Evidence:
+
+- [`docs/superpowers/specs/2026-07-22-versioned-graph-gap-mitigations-design.md`](superpowers/specs/2026-07-22-versioned-graph-gap-mitigations-design.md)
+
+Before treating an individual mitigation as incomplete, inspect current source
+and tests: some planned items may already have landed without the plan file
+being removed.
 
 ## Aspirational
 

--- a/docs/superpowers/plans/2026-07-21-versioned-graph-prolly-tree.md
+++ b/docs/superpowers/plans/2026-07-21-versioned-graph-prolly-tree.md
@@ -1,0 +1,2230 @@
+# Compass Versioned Graph Prolly Tree Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Revised:** 2026-07-22 after the Compass workspace extraction and flat-command rename
+
+**Governing designs:** `docs/superpowers/specs/2026-07-19-compass-native-rust-port-design.md` and `docs/superpowers/specs/2026-07-21-versioned-graph-prolly-tree-design.md`
+
+**Goal:** Persist one complete, immutable Compass realization per Git commit in typed Prolly trees, then support historical query and graph-aware diff with opt-in eager and on-demand lazy materialization through a fully usable Compass-first command surface.
+
+**Architecture:** A new `compass-history` crate converts completed `GraphDocument` artifacts into five immutable Prolly trees and publishes their roots through a content-addressed `GraphVersion` manifest. `prolly-store-sqlite` is the only v1 node/root backend, shared by linked worktrees through the Git common directory. Git revision/worktree orchestration remains above the storage layer, while CLI commands resolve commits, materialize missing versions, and load historical graphs into the existing `compass-query` path.
+
+**Tech Stack:** Rust 2024, Rust 1.97.1 toolchain with workspace MSRV 1.97, `prolly-map = "=0.5.0"`, `prolly-store-sqlite = "=0.3.0"`, Serde/JSON, SHA-256, SQLite WAL, existing Compass graph/core/query crates, and Git CLI.
+
+## Global Constraints
+
+- Implement inside the standalone Compass Git repository at `/Users/haipingfu/graphify/compass`; it is mounted as the Graphify superproject's `compass` submodule, so code commits and worktrees belong to the Compass repository rather than the superproject.
+- File lists use `compass/...` paths relative to the Graphify superproject for unambiguous location. Every shell, Cargo, and Git snippet assumes its working directory is the Compass repository or isolated Compass worktree, so command operands omit the outer `compass/` prefix.
+- Use exactly `prolly-map = "=0.5.0"` and `prolly-store-sqlite = "=0.3.0"`; the library crate names are `prolly` and `prolly_store_sqlite`.
+- Store history below the path returned by `git rev-parse --git-common-dir`, never in the working tree.
+- Store Prolly data at `<git-common-dir>/compass/history.sqlite`; never read or write the adapter's private SQL tables directly.
+- Open SQLite with WAL enabled, `synchronous_normal: false`, and a 10-second busy timeout.
+- Persist and verify `compass/store-format/v1` before accessing application roots.
+- A preferred realization must contain the complete graph, including semantic and inferred relationships; partial semantic results never enter the version catalog.
+- The realization identity excludes timestamps, machine paths, credentials, and runtime-only Prolly cache settings.
+- Preserve every supported `GraphDocument` field and unknown JSON attribute through storage and reconstruction.
+- Schema v1 preserves directed, undirected, simple, and multigraph documents, including exact duplicate parallel edges and exact duplicate id-less hyperedges.
+- Preserve node, edge, and hyperedge order, legacy `edges`, original hyperedge placement, unknown values, and authoritative sidecars.
+- Historical compatibility means canonical semantic equivalence; derived reports and HTML are regenerated rather than stored byte-for-byte.
+- Raw token use, cost, timings, diagnostics, caches, and learning overlays do not enter realization identity.
+- Historical builds apply committed `.gitignore`/`.graphifyignore` files plus explicit profile excludes, never `.git/info/exclude` or global excludes.
+- Temporary worktrees disable hooks, LFS smudging, credential prompts, network fetching, and unsupported external filters.
+- Use one `locks/maintenance.lock`, shared by readers/builders/publication and exclusive to GC/pruning/migration; lock upgrades are forbidden.
+- Replacing a corrupt preferred realization requires explicit `compass history rebuild <rev> --replace-corrupt` recovery.
+- Keep `graph.json` behavior compatible while history is opt-in.
+- Treat `compass` as the sole canonical Rust command surface. A legacy `graphify` binary may remain as a best-effort transition shim, but its command availability and behavior do not constrain Compass or this plan's acceptance gates.
+- Every canonical command begins directly with `compass`; never reintroduce the removed legacy binary or a nested graph-command namespace.
+- Eager history begins only after `compass history enable`; `compass history status`, `compass history list`, and explicit `compass history build`, `compass query`, or `compass diff` commands must not silently enable it. Disabling eager history never deletes stored history.
+- Read-only commands open an existing store without creating the history directory or SQLite database. Explicit enablement or materialization may create it.
+- Use v1 limits of 512 MiB total authoritative input, 1 MiB key, 64 MiB record value, 10,000,000 records per tree, JSON depth 128, 1 MiB job record, and 64 KiB diagnostic.
+- Do not add remote synchronization, per-file roots, or new graph semantics in this implementation.
+- Use Prolly named roots and strict transactions for atomic multi-root publication.
+- Preserve unrelated working-tree changes. Start execution from the Compass repository in an isolated Compass worktree with `superpowers:using-git-worktrees`; never use a Graphify-superproject worktree as a substitute.
+- Follow red-green-refactor for every behavior change and use small commits at the end of each task.
+- Retain established Graphify-compatibility resources exactly as the current Compass code defines them: `graphify-out/`, `graph.json`, `.graphifyignore`, `.graphify_*` sidecars, and `GRAPHIFY_*` environment variables. They are artifact/API compatibility names, not stale workspace branding.
+- Run `compass update .` after the implementation changes are complete so `graphify-out/` matches the resulting Compass code.
+
+The naming boundary is mechanical and testable:
+
+| Concern | Required name |
+|---|---|
+| Repository directory | `compass/` in the Graphify superproject |
+| Crates and Rust modules | `compass-*` and `compass_*` |
+| Canonical executable/command prefix | `compass` with flat subcommands |
+| History directory/database | `<git-common-dir>/compass/history.sqlite` |
+| Prolly store-format and named-root namespace | `compass/store-format/v1` and `compass/v1/...` |
+| Legacy executable | `graphify`, optional best-effort transition shim outside the Compass contract |
+| Compatibility artifacts/configuration | `graphify-out/`, `graph.json`, `.graphifyignore`, `.graphify_*`, and `GRAPHIFY_*`, retained verbatim |
+
+---
+
+## File and crate map
+
+Create `compass/crates/compass-history/` with these responsibilities:
+
+```text
+compass-history/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs          public API and re-exports
+│   ├── error.rs        typed storage, schema, Git, and validation failures
+│   ├── canonical.rs    canonical JSON and schema envelopes
+│   ├── keys.rs         segment-safe typed Prolly and named-root keys
+│   ├── fingerprint.rs  extraction-fingerprint inputs and digest
+│   ├── model.rs        GraphVersion, RealizationId, StoredTree, catalog types
+│   ├── artifacts.rs    graph/sidecar decomposition and reconstruction
+│   ├── store.rs        SQLite adapter, store format, publication, reads, listing
+│   ├── validate.rs     root, count, endpoint, and schema validation
+│   ├── diff.rs         streaming typed-tree graph diffs
+│   ├── git.rs          revision resolution, common-dir discovery, worktree guard
+│   ├── config.rs       opt-in eager-history profile and enablement state
+│   ├── jobs.rs         durable eager-build queue and state transitions
+│   ├── durable.rs      crash-durable owner-only operational-file replacement
+│   ├── leases.rs       generation leases, heartbeat, stale-worker rejection
+│   ├── lock.rs         shared activity and exclusive maintenance guards
+│   └── gc.rs           reachability planning and explicit sweeping
+└── tests/
+    ├── canonical.rs
+    ├── roundtrip.rs
+    ├── publication.rs
+    ├── diff.rs
+    ├── git.rs
+    ├── jobs.rs
+    └── maintenance.rs
+```
+
+Modify existing crates as follows:
+
+- `compass/crates/compass-core/src/history.rs`: materialization orchestration that invokes a supplied complete-graph builder and publishes its artifacts.
+- `compass/crates/compass-core/src/lib.rs`: export history orchestration and construct `LoadedGraph` from a reconstructed document.
+- `compass/crates/compass-cli/src/history_commands.rs`: `history` command family, `diff`, lazy materialization, export, and GC presentation.
+- `compass/crates/compass-cli/src/history_build.rs`: current-executable complete-build adapter used inside detached worktrees.
+- `compass/crates/compass-cli/src/lib.rs`: command dispatch, `--at` parsing, graph-source selection, and help.
+- `compass/crates/compass-cli/src/hook_commands.rs`: enqueue the committed SHA and launch the history worker without blocking the commit.
+- `compass/crates/compass-cli/tests/history_cli.rs`: end-to-end CLI history, query, diff, and lazy-build coverage.
+- `compass/crates/compass-cli/tests/hook_cli.rs`: eager history hook assertions.
+- `compass/crates/compass-output/src/history_bundle.rs`: version-dispatched regeneration of derived history artifacts without a dependency on `compass-history`.
+- `compass/README.md`: Compass-first history command documentation and local-store behavior.
+
+## Shared interfaces
+
+Later tasks use these exact public types:
+
+```rust
+pub struct HistoryStore;
+
+pub struct PublishRequest {
+    pub commit: CommitId,
+    pub parents: Vec<CommitId>,
+    pub fingerprint: ExtractionFingerprint,
+    pub artifacts: GraphArtifacts,
+    pub completion: CompletionEvidence,
+    pub make_preferred: bool,
+}
+
+pub struct PublishedVersion {
+    pub id: RealizationId,
+    pub version: GraphVersion,
+    pub preferred: bool,
+}
+
+pub struct GraphArtifacts {
+    pub document: GraphDocument,
+    pub analysis: Option<serde_json::Value>,
+    pub labels: Option<serde_json::Value>,
+    pub manifest: Option<serde_json::Value>,
+    pub authoritative_sidecars: std::collections::BTreeMap<String, ArtifactContent>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct CompletionEvidence {
+    pub extraction_succeeded: bool,
+    pub allow_partial: bool,
+    pub semantic_files_expected: u64,
+    pub semantic_files_completed: u64,
+    pub failed_chunks: u64,
+}
+
+pub struct CompletedGraphArtifacts {
+    pub artifacts: GraphArtifacts,
+    pub completion: CompletionEvidence,
+}
+
+pub struct MaterializeRequest {
+    pub repository: Repository,
+    pub commit: CommitId,
+    pub profile: BuildProfile,
+    pub rebuild: bool,
+    pub replace_corrupt: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MaterializeStage {
+    Building,
+    Validating,
+    Publishing,
+}
+
+pub trait MaterializeObserver {
+    fn entered(&mut self, stage: MaterializeStage) -> Result<(), MaterializeError>;
+}
+
+pub trait CompleteGraphBuilder {
+    fn build(
+        &self,
+        checkout: &Path,
+        output_root: &Path,
+        seed: Option<&GraphArtifacts>,
+    ) -> Result<CompletedGraphArtifacts, MaterializeError>;
+}
+```
+
+Method signatures remain consistent across tasks: `HistoryStore::preferred` takes
+`&CommitId`; `CommitId` exposes `as_str` and implements `Display`; fingerprints and
+realization IDs expose lowercase hexadecimal text and strict parsing. CLI code never
+reaches into tuple-struct internals.
+
+Store lifecycle is explicit throughout the plan:
+
+```rust
+impl HistoryStore {
+    pub fn create(repository: &Repository) -> Result<Self, HistoryError>;
+    pub fn open_existing(repository: &Repository)
+        -> Result<Option<Self>, HistoryError>;
+}
+```
+
+`create` is reserved for `compass history enable` and explicit/lazy materialization. Read-only
+commands use `open_existing`; absence is a normal state rather than permission to mutate the
+repository. The existence of an SQLite store does not mean eager history is enabled.
+
+## Public CLI and process contract
+
+The commands below are specified only for `compass`. Existing `graphify` forwarding may remain,
+but it is not required to expose the same commands or reproduce Compass help, output, status, or
+side effects. Compass help and errors always use the `compass` spelling.
+
+```text
+compass history enable [build-profile options]
+compass history disable
+compass history status [REV] [--format text|json]
+compass history build REV [build-profile options] [--format text|json]
+compass history rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]
+compass history list [REV] [--format text|json]
+compass history show REALIZATION [--format text|json]
+compass history prefer REV REALIZATION [--format text|json]
+compass history export REV --format graph-json|graphify-out --output PATH
+compass history gc [--prune-non-preferred] [--yes] [--format text|json]
+compass diff OLD NEW [--detailed|--format json] [--topology-only]
+compass query QUERY --at REV
+compass path SOURCE TARGET --at REV
+compass explain SYMBOL --at REV
+```
+
+Exit `0` means success, including idempotent disable, no-store status, and an empty list. Exit
+`2` is reserved for usage errors. Repository, Git, provider, validation, corruption, lock,
+output, and storage errors exit `1`. Results go to stdout; progress and diagnostics go to
+stderr. A JSON mode emits exactly one valid JSON value, including empty results. A broken
+output sink aborts streaming promptly without changing an already valid preferred realization.
+Every parser rejects unknown or repeated singleton options, supports `--flag=value` where the
+existing CLI does, and honors `--` as the end of options so revision and path operands cannot
+be mistaken for flags.
+
+Test-only fixture helpers shown below are local to their named integration-test file.
+Each helper constructs the smallest committed Git repository and/or `GraphArtifacts`
+needed by that test, returns a `tempfile::TempDir`-owning fixture so paths stay alive,
+and never invokes a provider unless the test explicitly covers provider failure.
+`version_one`/`version_two` differ by one node, one edge, and one analysis value;
+`fixture_publish_request` always returns complete cross-checked `CompletionEvidence`. This contract is
+implemented when the first test using each helper is added, rather than as production API.
+
+### Task 1: Scaffold `compass-history` and prove the SQLite Prolly contract
+
+**Files:**
+- Modify: `compass/Cargo.toml`
+- Modify: `compass/Cargo.lock`
+- Create: `compass/crates/compass-history/Cargo.toml`
+- Create: `compass/crates/compass-history/src/lib.rs`
+- Create: `compass/crates/compass-history/src/error.rs`
+- Create: `compass/crates/compass-history/src/git.rs`
+- Create: `compass/crates/compass-history/src/lock.rs`
+- Create: `compass/crates/compass-history/src/store.rs`
+- Create: `compass/crates/compass-history/tests/sqlite_contract.rs`
+
+**Interfaces:**
+- Consumes: `prolly::{Store, ManifestStore, ManifestStoreScan, NodeStoreScan, TransactionalStore}` and `prolly_store_sqlite::{SqliteStore, SqliteStoreConfig}`.
+- Produces: `HistoryStore::{create, open_existing}`, `HistoryStore::database_path`, `ActivityGuard`, and `MaintenanceGuard`.
+
+- [ ] **Step 1: Write the failing storage contract test**
+
+```rust
+use prolly::{ManifestStore, ManifestStoreScan, NodeStoreScan, TransactionalStore};
+use compass_history::HistoryStore;
+
+fn requires_store_contract<T>()
+where
+    T: ManifestStore + ManifestStoreScan + NodeStoreScan + TransactionalStore,
+{
+}
+
+#[test]
+fn sqlite_store_has_every_publication_capability() -> Result<(), Box<dyn std::error::Error>> {
+    requires_store_contract::<prolly_store_sqlite::SqliteStore>();
+    let fixture = committed_repository()?;
+    let repository = Repository::discover(fixture.path())?;
+    assert!(HistoryStore::open_existing(&repository)?.is_none());
+    let history = HistoryStore::create(&repository)?;
+    assert!(HistoryStore::open_existing(&repository)?.is_some());
+    assert_eq!(history.database_path(), repository.common_dir().join("compass/history.sqlite"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify the crate is missing**
+
+Run: `cargo test -p compass-history --test sqlite_contract sqlite_store_has_every_publication_capability`
+
+Expected: FAIL because workspace package `compass-history` does not exist.
+
+- [ ] **Step 3: Add the workspace member and pinned dependency**
+
+Add `"crates/compass-history"` to `[workspace].members` and add both exact pins:
+
+```toml
+[workspace.dependencies]
+prolly-map = "=0.5.0"
+prolly-store-sqlite = "=0.3.0"
+```
+
+Create the crate manifest:
+
+```toml
+[package]
+name = "compass-history"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+description.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+prolly-map.workspace = true
+prolly-store-sqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+compass-files = { path = "../compass-files", version = "0.1.0" }
+compass-model = { path = "../compass-model", version = "0.1.0" }
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 4: Implement the smallest durable store wrapper**
+
+In `git.rs`, implement `Repository::discover` using `git rev-parse --show-toplevel` and
+`git rev-parse --git-common-dir`, resolving relative common-dir output against the top level.
+Task 7 extends this same type with revision and parent operations.
+
+`HistoryStore::create` creates the owner-only directory and `locks/maintenance.lock` before opening SQLite. A new
+database acquires the exclusive maintenance guard through format initialization; an existing
+database acquires the shared guard through format verification. Release the opening guard
+only after the adapter and `compass/store-format/v1` are consistent. `open_existing` first
+checks the validated nonsymlink path and returns `Ok(None)` without creating any path when the
+database is absent; when present it performs the same shared-guard verification.
+
+```rust
+// src/error.rs
+#[derive(Debug, thiserror::Error)]
+pub enum HistoryError {
+    #[error("could not open history store: {0}")]
+    Store(#[from] prolly_store_sqlite::SqliteStoreError),
+    #[error("prolly operation failed: {0}")]
+    Prolly(#[from] prolly::Error),
+}
+```
+
+```rust
+// src/store.rs
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use prolly::{Config, Prolly};
+use prolly_store_sqlite::{SqliteStore, SqliteStoreConfig};
+
+use crate::{HistoryError, Repository};
+
+const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v1";
+
+pub struct HistoryStore {
+    root: PathBuf,
+    database_path: PathBuf,
+    pub(crate) prolly: Prolly<Arc<SqliteStore>>,
+}
+
+impl HistoryStore {
+    pub fn create(repository: &Repository) -> Result<Self, HistoryError> {
+        let root = repository.common_dir().join("compass");
+        create_owner_only_history_dir(&root)?;
+        let database_path = root.join("history.sqlite");
+        let backend = Arc::new(SqliteStore::open_with_config(
+            &database_path,
+            SqliteStoreConfig {
+                busy_timeout_ms: 10_000,
+                enable_wal: true,
+                synchronous_normal: false,
+            },
+        )?);
+        let store = Self {
+            root,
+            database_path,
+            prolly: Prolly::new(backend, Config::default()),
+        };
+        store.initialize_or_verify_store_format(STORE_FORMAT_ROOT)?;
+        Ok(store)
+    }
+
+    pub fn open_existing(repository: &Repository) -> Result<Option<Self>, HistoryError> {
+        let paths = HistoryPaths::existing(repository)?;
+        let Some(paths) = paths else { return Ok(None) };
+        Self::open_verified(paths).map(Some)
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    #[must_use]
+    pub fn database_path(&self) -> &Path {
+        &self.database_path
+    }
+}
+```
+
+```rust
+// src/lib.rs
+mod error;
+mod lock;
+mod git;
+mod store;
+
+pub use error::HistoryError;
+pub use lock::{ActivityGuard, MaintenanceGuard};
+pub use git::Repository;
+pub use store::HistoryStore;
+```
+
+- [ ] **Step 5: Run focused checks**
+
+Before the focused checks, implement `create_owner_only_history_dir` with `0700` Unix directory mode and `0600` database/operational files, using the closest owner-only platform controls elsewhere. Reject symlinks at the `compass` directory, database, lock, configuration, job, lease, and temp targets. Add tests for absent read-only open causing no filesystem changes, concurrent first-open format initialization, unknown store-format rejection, close/reopen, strict rollback, WAL and busy-timeout contention, owner-only Unix permissions, symlink rejection, and reopening a checked-in v1 fixture database. `initialize_or_verify_store_format` must use adapter root CAS rather than private SQL.
+
+Implement `lock.rs` with one `locks/maintenance.lock`: `HistoryStore::activity()` acquires a bounded shared guard and `HistoryStore::maintenance()` acquires a bounded exclusive guard. Use Rust 1.97's `File::try_lock_shared`, `File::try_lock`, and `File::unlock` in an interruptible deadline loop; do not add a locking crate. Guards are RAII, process teardown releases them, acquisition precedes database transactions, and no upgrade API exists. Pass guards into internal operations so they never reacquire or upgrade the same lock.
+
+Run: `cargo test -p compass-history --test sqlite_contract && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+Expected: PASS; Cargo resolves exactly `prolly-map 0.5.0` and `prolly-store-sqlite 0.3.0`.
+
+- [ ] **Step 6: Commit the crate boundary**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-history
+git commit -m "feat(history): add prolly-backed history crate"
+```
+
+### Task 2: Add canonical values, typed keys, and extraction fingerprints
+
+**Files:**
+- Create: `compass/crates/compass-history/src/canonical.rs`
+- Create: `compass/crates/compass-history/src/keys.rs`
+- Create: `compass/crates/compass-history/src/fingerprint.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Create: `compass/crates/compass-history/tests/canonical.rs`
+
+**Interfaces:**
+- Consumes: arbitrary `serde_json::Value`, Compass graph IDs, edge direction, and explicit extraction inputs.
+- Produces: `canonical_json_bytes`, `node_key`, `edge_key`, `hyperedge_key`, `BuildProfile::digest`, and `ExtractionFingerprintInput::digest`.
+
+- [ ] **Step 1: Write failing canonicalization and key tests**
+
+```rust
+use serde_json::json;
+use compass_history::{
+    ExtractionFingerprintInput, canonical_json_bytes, edge_key, hyperedge_key, node_key,
+};
+
+#[test]
+fn object_order_and_separator_bytes_do_not_change_identity() {
+    let left = json!({"z": 1, "a": {"y": 2, "x": 3}});
+    let right = json!({"a": {"x": 3, "y": 2}, "z": 1});
+    assert_eq!(canonical_json_bytes(&left).unwrap(), canonical_json_bytes(&right).unwrap());
+    assert_ne!(node_key("a\0b"), node_key("a"));
+    assert_ne!(edge_key("a", "b\0c", "calls", true, None), edge_key("a\0b", "c", "calls", true, None));
+    let record = canonical_json_bytes(&json!({"members":["a","b"]})).unwrap();
+    assert_ne!(hyperedge_key(&record, Some(0)), hyperedge_key(&record, Some(1)));
+}
+
+#[test]
+fn fingerprint_is_order_independent_and_secret_free() {
+    let mut input = ExtractionFingerprintInput::new("0.1.0", "schema-1");
+    input.insert("model", "claude-sonnet").unwrap();
+    input.insert("prompt_sha256", "abc123").unwrap();
+    let digest = input.digest().unwrap();
+    assert_eq!(digest.as_hex().len(), 64);
+    assert!(input.insert("api_key", "must-not-enter-fingerprint").is_err());
+    assert!(!String::from_utf8(input.canonical_bytes().unwrap()).unwrap().contains("api_key"));
+}
+```
+
+- [ ] **Step 2: Run the tests to verify missing APIs**
+
+Run: `cargo test -p compass-history --test canonical`
+
+Expected: FAIL with unresolved imports from `compass_history`.
+
+- [ ] **Step 3: Implement recursive canonical JSON**
+
+```rust
+// src/canonical.rs
+pub const CANONICAL_ENCODING_VERSION: u32 = 1;
+
+pub fn canonical_json_bytes(value: &serde_json::Value) -> Result<Vec<u8>, HistoryError> {
+    let mut output = Vec::new();
+    write_canonical_value(value, &mut output)?;
+    Ok(output)
+}
+```
+
+`write_canonical_value` recursively sorts object keys by UTF-8 bytes, preserves arrays,
+emits integers as minimal decimal, and emits finite floats with deterministic shortest
+round-trip formatting while preserving float identity (`1.0` is not integer `1` and
+negative zero remains negative zero). It rejects non-finite numbers. Add golden byte
+fixtures for integer boundaries, exponent forms, `1` versus `1.0`, negative zero, Unicode
+escaping, and recursive ordering. The store-format record includes
+`CANONICAL_ENCODING_VERSION`; changing a golden byte requires migration.
+
+Add error variants:
+
+```rust
+#[error("canonical encoding failed: {0}")]
+Canonical(String),
+#[error("invalid typed key: {0}")]
+InvalidKey(String),
+```
+
+- [ ] **Step 4: Implement segment-safe keys using Prolly's key contract**
+
+```rust
+// src/keys.rs
+use prolly::KeyBuilder;
+
+const KEY_SCHEMA_V1: &[u8] = &[1];
+const NODE_KIND: &[u8] = &[1];
+const EDGE_KIND: &[u8] = &[2];
+const HYPEREDGE_KIND: &[u8] = &[3];
+
+pub fn node_key(id: &str) -> Vec<u8> {
+    KeyBuilder::new()
+        .push_segment(KEY_SCHEMA_V1)
+        .push_segment(NODE_KIND)
+        .push_str(id)
+        .finish()
+}
+
+pub fn edge_key(
+    source: &str,
+    target: &str,
+    relation: &str,
+    directed: bool,
+    discriminator: Option<&[u8]>,
+) -> Vec<u8> {
+    let (source, target) = if directed || source <= target {
+        (source, target)
+    } else {
+        (target, source)
+    };
+    let builder = KeyBuilder::new()
+        .push_segment(KEY_SCHEMA_V1)
+        .push_segment(EDGE_KIND)
+        .push_str(source)
+        .push_str(target)
+        .push_str(relation);
+    match discriminator {
+        Some(value) => builder.push_segment(value).finish(),
+        None => builder.finish(),
+    }
+}
+
+pub fn hyperedge_key(identity: &[u8], occurrence: Option<u64>) -> Vec<u8> {
+    let builder = KeyBuilder::new()
+        .push_segment(KEY_SCHEMA_V1)
+        .push_segment(HYPEREDGE_KIND)
+        .push_segment(identity);
+    match occurrence {
+        Some(rank) => builder.push_segment(&rank.to_be_bytes()).finish(),
+        None => builder.finish(),
+    }
+}
+
+pub(crate) fn root_name(parts: &[&[u8]]) -> Vec<u8> {
+    parts
+        .iter()
+        .fold(KeyBuilder::new(), |builder, part| builder.push_segment(part))
+        .finish()
+}
+```
+
+- [ ] **Step 5: Implement explicit fingerprint inputs**
+
+Define `BuildProfile` separately from `ExtractionFingerprintInput`. Queue deduplication uses
+the normalized non-secret profile digest. Only after the exact target worktree exists does
+the worker add target-commit configuration, every applied committed `.gitignore` and
+`.graphifyignore`, explicit excludes, prompt/schema/extractor/resolver/pipeline versions,
+features, direction, multigraph behavior, and clustering settings to the final fingerprint.
+Never include `.git/info/exclude`, global ignores, credentials, absolute paths, time,
+concurrency, timeouts, or diagnostics.
+
+```rust
+// src/fingerprint.rs
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{HistoryError, canonical_json_bytes};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExtractionFingerprint([u8; 32]);
+
+impl ExtractionFingerprint {
+    #[must_use]
+    pub fn as_hex(&self) -> String {
+        self.0.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BuildProfile {
+    values: BTreeMap<String, String>,
+}
+
+impl BuildProfile {
+    pub fn digest(&self) -> Result<[u8; 32], HistoryError> {
+        let bytes = canonical_json_bytes(&serde_json::to_value(&self.values)
+            .map_err(|error| HistoryError::Canonical(error.to_string()))?)?;
+        Ok(Sha256::digest(bytes).into())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExtractionFingerprintInput {
+    values: BTreeMap<String, String>,
+}
+
+impl ExtractionFingerprintInput {
+    pub fn new(compass_version: &str, graph_schema: &str) -> Self {
+        let mut input = Self::default();
+        input.values.insert("compass_version".to_owned(), compass_version.to_owned());
+        input.values.insert("graph_schema".to_owned(), graph_schema.to_owned());
+        input
+    }
+
+    pub fn insert(&mut self, key: &str, value: &str) -> Result<(), HistoryError> {
+        let normalized = key.to_ascii_lowercase();
+        if ["key", "secret", "token", "password", "credential"]
+            .iter()
+            .any(|needle| normalized.contains(needle))
+        {
+            return Err(HistoryError::FingerprintSecretKey(key.to_owned()));
+        }
+        self.values.insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, HistoryError> {
+        canonical_json_bytes(&serde_json::to_value(&self.values)
+            .map_err(|error| HistoryError::Canonical(error.to_string()))?)
+    }
+
+    pub fn digest(&self) -> Result<ExtractionFingerprint, HistoryError> {
+        Ok(ExtractionFingerprint(Sha256::digest(self.canonical_bytes()?).into()))
+    }
+}
+```
+
+Add `HistoryError::FingerprintSecretKey(String)`. Derive Serde traits for
+`ExtractionFingerprint`, implement strict 64-character lowercase-hex parsing, and use
+the same parser when reading manifests and jobs.
+
+- [ ] **Step 6: Export the APIs and run focused tests**
+
+Run: `cargo test -p compass-history --test canonical && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+Expected: PASS, including object-order and separator-byte cases.
+
+- [ ] **Step 7: Commit canonical identity**
+
+```bash
+git add crates/compass-history
+git commit -m "feat(history): define canonical graph identities"
+```
+
+### Task 3: Define version manifests and lossless artifact partitioning
+
+**Files:**
+- Create: `compass/crates/compass-history/src/model.rs`
+- Create: `compass/crates/compass-history/src/artifacts.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Create: `compass/crates/compass-history/tests/roundtrip.rs`
+
+**Interfaces:**
+- Consumes: `GraphDocument`, authoritative analysis/labels/manifest/opaque sidecars, `CompletionEvidence`, and Prolly `Tree` handles.
+- Produces: `GraphArtifacts::{load, partition, reconstruct, write_seed}`, `ArtifactRegistryEntry`, `GraphVersion`, `StoredTree`, and `RealizationId`.
+
+- [ ] **Step 1: Write a failing graph artifact round-trip test**
+
+```rust
+use serde_json::json;
+use compass_history::{CompletionEvidence, GraphArtifacts};
+use compass_model::GraphDocument;
+
+#[test]
+fn complete_graph_and_build_state_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let document: GraphDocument = serde_json::from_value(json!({
+        "directed": false,
+        "multigraph": true,
+        "graph": {"hyperedges": [{"id":"flow","nodes":["a","b"]}]},
+        "nodes": [
+            {"id":"a","label":"A","community":1,"_origin":"ast"},
+            {"id":"b","label":"B","community":1,"_origin":"semantic"}
+        ],
+        "links": [
+            {"source":"a","target":"b","relation":"calls","confidence":"INFERRED"},
+            {"source":"a","target":"b","relation":"calls","confidence":"INFERRED"}
+        ],
+        "hyperedges": [
+            {"nodes":["a","b"]},
+            {"nodes":["a","b"]}
+        ],
+        "built_at_commit": "0123456789abcdef"
+    }))?;
+    let artifacts = GraphArtifacts {
+        document: document.clone(),
+        analysis: Some(json!({"communities":{"1":["a","b"]}})),
+        labels: Some(json!({"1":"Core"})),
+        manifest: Some(json!({"a.py":{"ast_hash":"abc","semantic_hash":"abc","mtime":1.0}})),
+        authoritative_sidecars: Default::default(),
+    };
+    let completion = CompletionEvidence {
+        extraction_succeeded: true,
+        allow_partial: false,
+        semantic_files_expected: 1,
+        semantic_files_completed: 1,
+        failed_chunks: 0,
+    };
+    let partitioned = artifacts.partition(&completion)?;
+    let restored = GraphArtifacts::reconstruct(&partitioned)?;
+    assert_eq!(restored.document, document);
+    assert_eq!(restored.analysis, artifacts.analysis);
+    assert_eq!(restored.labels, artifacts.labels);
+    assert_eq!(restored.manifest, artifacts.manifest);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the round-trip test and verify missing types**
+
+Run: `cargo test -p compass-history --test roundtrip complete_graph_and_build_state_round_trip`
+
+Expected: FAIL with unresolved `GraphArtifacts`.
+
+- [ ] **Step 3: Define content-only tree and realization types**
+
+```rust
+// src/model.rs
+use prolly::{Cid, Config, RuntimeConfig, Tree, TreeFormat};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{HistoryError, canonical_json_bytes};
+
+pub const HISTORY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactClass { Authoritative, Derived, Operational }
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactRegistryEntry {
+    pub registry_version: u32,
+    pub relative_path: String,
+    pub class: ArtifactClass,
+    pub media_type: String,
+    pub schema_version: Option<u32>,
+    pub content_digest: Option<[u8; 32]>,
+    pub storage: Option<Vec<u8>>,
+    pub regeneration_version: Option<String>,
+}
+
+pub type ArtifactContent = Vec<u8>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StoredTree {
+    pub root: Option<[u8; 32]>,
+    pub format: TreeFormat,
+}
+
+impl StoredTree {
+    pub fn from_tree(tree: &Tree) -> Self {
+        Self {
+            root: tree.root.as_ref().map(|cid| cid.0),
+            format: tree.config.format.clone(),
+        }
+    }
+
+    pub fn to_tree(&self) -> Tree {
+        Tree {
+            root: self.root.map(Cid),
+            config: Config {
+                format: self.format.clone(),
+                runtime: RuntimeConfig::default(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GraphVersion {
+    pub schema_version: u32,
+    pub git_commit: String,
+    pub git_parents: Vec<String>,
+    pub extraction_fingerprint: String,
+    pub nodes_root: StoredTree,
+    pub edges_root: StoredTree,
+    pub hyperedges_root: StoredTree,
+    pub analysis_root: StoredTree,
+    pub metadata_root: StoredTree,
+    pub node_count: u64,
+    pub edge_count: u64,
+    pub hyperedge_count: u64,
+    pub analysis_count: u64,
+    pub metadata_count: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RealizationId([u8; 32]);
+
+impl RealizationId {
+    pub fn for_version(version: &GraphVersion) -> Result<Self, HistoryError> {
+        let value = serde_json::to_value(version)
+            .map_err(|error| HistoryError::Canonical(error.to_string()))?;
+        Ok(Self(Sha256::digest(canonical_json_bytes(&value)?).into()))
+    }
+
+    pub fn as_hex(&self) -> String {
+        self.0.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+}
+```
+
+- [ ] **Step 4: Implement artifact loading and typed partition maps**
+
+`GraphArtifacts::load` reads `graph.json`, `.graphify_analysis.json`, `.graphify_labels.json`, `manifest.json`, and every artifact declared authoritative by the versioned registry. It accepts `CompletionEvidence` only through `CompletedGraphArtifacts`; loading files alone is not proof that semantic extraction completed. Raw `.graphify_semantic_marker`, `cost.json`, timings, diagnostics, caches, `.graphify_root`, and learning overlays are operational and remain outside identity. `partition` returns:
+
+```rust
+pub struct PartitionedGraph {
+    pub nodes: Vec<(Vec<u8>, Vec<u8>)>,
+    pub edges: Vec<(Vec<u8>, Vec<u8>)>,
+    pub hyperedges: Vec<(Vec<u8>, Vec<u8>)>,
+    pub analysis: Vec<(Vec<u8>, Vec<u8>)>,
+    pub metadata: Vec<(Vec<u8>, Vec<u8>)>,
+}
+```
+
+For node values, move only `community`, `community_name`, and `norm_label` into an analysis record keyed by node ID. Simple edge keys use direction-aware endpoints and relation. Multigraph keys append the canonical NetworkX `key` when present, otherwise the complete canonical-edge digest plus its zero-based occurrence among byte-identical records. For hyperedges, reject duplicate explicit IDs; id-less records use the complete canonical-record digest plus their zero-based occurrence among byte-identical records.
+
+Metadata records node, edge, and hyperedge input order with fixed-width big-endian rank keys pointing to complete typed record keys, whether the document used `links` or legacy `edges`, original hyperedge placement, unknown graph/top-level values, completion evidence, normalized semantic provenance, graph/export versions, and the artifact registry. Registry entries contain relative path, class (`authoritative`, `derived`, or `operational`), media/schema type, content digest, storage, and regeneration version. Store non-derivable authoritative sidecars verbatim. Mark `GRAPH_REPORT.md`, HTML, visualization output, and label signatures as derived. Unknown files declared authoritative by the current artifact contract may not be silently dropped.
+
+Use one versioned raw envelope for every value:
+
+```rust
+fn encode_record(schema: &str, value: &serde_json::Value) -> Result<Vec<u8>, HistoryError> {
+    let payload = crate::canonical_json_bytes(value)?;
+    prolly::VersionedValue::raw(schema, 1, payload)
+        .to_bytes()
+        .map_err(HistoryError::from)
+}
+```
+
+- [ ] **Step 5: Implement reconstruction and seed export**
+
+`GraphArtifacts::reconstruct` decodes all five record groups, rejoins the three derived node attributes, restores order, legacy spelling, multigraph discriminators, hyperedge placement, unknown values, and authoritative sidecars, then rebuilds `GraphDocument`. `write_seed(output_dir)` writes only compatible authoritative inputs: `graph.json`, analysis, labels, manifest, opaque authoritative sidecars, and a semantic marker generated from completion evidence using `compass_files::{write_bytes_atomic, write_json_atomic}`. It never renders derived files. Task 7 owns report/HTML regeneration through `compass-output` and the recorded renderer version; byte equality is not required, but canonical semantic inputs must match.
+
+The implementation must reject duplicate node keys, duplicate non-multigraph identities,
+duplicate explicit hyperedge IDs, malformed envelopes, invalid occurrence discriminators,
+and analysis/order records that reference missing typed keys. It must preserve parallel
+multigraph edges and exact duplicate id-less hyperedges.
+
+- [ ] **Step 6: Add path, Unicode, unknown-field, and no-sidecar cases**
+
+Extend `roundtrip.rs` with table-driven cases containing NUL bytes in IDs, non-ASCII labels, legacy `edges`, unknown top-level fields, directed/undirected simple and multigraph inputs, exact duplicate edges and id-less hyperedges, absent hyperedges, artifact classes, and absent sidecars. Assert exact `GraphDocument` and authoritative-sidecar equality after reconstruction; assert that changing only raw token/cost/timing provenance does not change partitioned identity.
+
+- [ ] **Step 7: Run crate tests and lint**
+
+Run: `cargo test -p compass-history --test roundtrip && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+Expected: PASS with no lossy-field exceptions.
+
+- [ ] **Step 8: Commit the graph persistence schema**
+
+```bash
+git add crates/compass-history
+git commit -m "feat(history): partition complete graph artifacts"
+```
+
+### Task 4: Build and atomically publish typed Prolly roots
+
+**Files:**
+- Modify: `compass/crates/compass-history/src/store.rs`
+- Modify: `compass/crates/compass-history/src/model.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Modify: `compass/crates/compass-history/tests/publication.rs`
+
+**Interfaces:**
+- Consumes: `PublishRequest` and `PartitionedGraph`.
+- Produces: `HistoryStore::{publish, preferred, compare_and_set_preferred, get, list}`, crate-private `publish_with_activity`, and immutable named roots for all realization components. The exact lookup signature is `preferred(&self, commit: &CommitId)`; the setter takes the commit, expected realization (or `None`), and new realization.
+
+- [ ] **Step 1: Write failing publication, reopen, and conflict tests**
+
+```rust
+#[test]
+fn publication_is_atomic_reopenable_and_content_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = committed_repository()?;
+    let repository = Repository::discover(fixture.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let request = fixture_publish_request("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let first = history.publish(request.clone())?;
+    let second = history.publish(request)?;
+    assert_eq!(first.id, second.id);
+    drop(history);
+
+    let reopened = HistoryStore::open_existing(&repository)?.expect("history store");
+    let commit = first.version.git_commit.parse()?;
+    assert_eq!(reopened.preferred(&commit)?.unwrap().id, first.id);
+    assert_eq!(reopened.get(&first.id)?.version, first.version);
+    assert_eq!(reopened.list(None)?.len(), 1);
+    Ok(())
+}
+```
+
+Add a second test that publishes two different fingerprints for one commit, asserts both remain listed, and asserts only the requested result becomes preferred.
+
+- [ ] **Step 2: Run the publication tests to verify missing APIs**
+
+Run: `cargo test -p compass-history --test publication publication_is_atomic_reopenable_and_content_idempotent`
+
+Expected: FAIL because `PublishRequest` and publication methods do not exist.
+
+- [ ] **Step 3: Add stable commit and publication request types**
+
+```rust
+#[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CommitId(String);
+
+impl std::str::FromStr for CommitId {
+    type Err = HistoryError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let valid_len = matches!(value.len(), 40 | 64);
+        if valid_len && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            Ok(Self(value.to_ascii_lowercase()))
+        } else {
+            Err(HistoryError::InvalidCommit(value.to_owned()))
+        }
+    }
+}
+
+impl CommitId {
+    #[must_use]
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+impl std::fmt::Display for CommitId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Clone)]
+pub struct PublishRequest {
+    pub commit: CommitId,
+    pub parents: Vec<CommitId>,
+    pub fingerprint: ExtractionFingerprint,
+    pub artifacts: GraphArtifacts,
+    pub completion: CompletionEvidence,
+    pub make_preferred: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PublishedVersion {
+    pub id: RealizationId,
+    pub version: GraphVersion,
+    pub preferred: bool,
+}
+```
+
+- [ ] **Step 4: Build each tree with deterministic `BatchBuilder`**
+
+```rust
+fn build_tree(
+    store: std::sync::Arc<prolly_store_sqlite::SqliteStore>,
+    entries: Vec<(Vec<u8>, Vec<u8>)>,
+) -> Result<prolly::Tree, HistoryError> {
+    let mut builder = prolly::BatchBuilder::new(store, prolly::Config::default());
+    for (key, value) in entries {
+        builder.add(key, value);
+    }
+    builder.build().map_err(HistoryError::from)
+}
+```
+
+Expose the backend clone from `HistoryStore` only inside the crate. Public `publish` acquires a shared activity guard; crate-private `publish_with_activity` accepts an existing guard so materialization never nests file locks. Hold the guard across building, validation, catalog publication, reopen verification, and preferred selection so exclusive GC cannot delete unpublished nodes. Build nodes, edges, hyperedges, analysis, and metadata trees; derive `GraphVersion`; then build a one-entry manifest tree containing canonical manifest bytes under `KeyBuilder::new().push_str("manifest").finish()`.
+
+- [ ] **Step 5: Publish the realization and preferred pointer with separate CAS boundaries**
+
+Use named roots with segment-safe names:
+
+```text
+compass/v1/version/<realization-id>/nodes
+compass/v1/version/<realization-id>/edges
+compass/v1/version/<realization-id>/hyperedges
+compass/v1/version/<realization-id>/analysis
+compass/v1/version/<realization-id>/metadata
+compass/v1/version/<realization-id>/manifest
+compass/v1/preferred/<commit>
+```
+
+First publish all six immutable realization roots in one strict transaction. Treat a
+pre-existing identical realization root as idempotent; reject a same-name/different-root
+collision as corruption. This transaction is the version-catalog CAS and makes the
+realization fully addressable before it can be preferred.
+
+Reopen the realization through its six catalog roots and verify its digest and direct roots
+before preferred selection. When `make_preferred` is true, validate the preferred realization
+observed before publication. A corrupt preferred leaves the new realization addressable but
+non-preferred and returns a corruption diagnostic. Otherwise compare-and-swap
+`compass/v1/preferred/<commit>` from the
+value observed at the start of publication to the new manifest tree. A stale preferred
+CAS is not rolled back and does not overwrite the concurrent winner: return the
+published realization with `preferred: false`. Otherwise return `preferred: true`.
+This preserves both distinct concurrent results while readers see only complete roots.
+Expose the same rule through `compare_and_set_preferred` for the explicit CLI command.
+Replacing corrupt preferred state is a separate recovery API requiring its exact observed ID,
+a newly validated candidate, and `--replace-corrupt`; concurrent repair returns conflict.
+
+- [ ] **Step 6: Implement preferred lookup, exact lookup, and listing**
+
+Use `ManifestStoreScan::list_roots`, `prolly::decode_segments`, and the manifest tree's single record. `list(Some(commit))` filters by the exact commit recorded in each manifest rather than trusting a filename alone. Sort results by commit, fingerprint, and realization ID for deterministic CLI output.
+
+- [ ] **Step 7: Run persistence and concurrency tests**
+
+Run: `cargo test -p compass-history --test publication && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+Expected: PASS for reopen, idempotency, multiple realizations, stale preferred CAS, and transaction rollback.
+
+- [ ] **Step 8: Commit atomic publication**
+
+```bash
+git add crates/compass-history
+git commit -m "feat(history): publish immutable graph versions"
+```
+
+### Task 5: Validate published realizations and reject corrupt graphs
+
+**Files:**
+- Create: `compass/crates/compass-history/src/validate.rs`
+- Modify: `compass/crates/compass-history/src/store.rs`
+- Modify: `compass/crates/compass-history/src/error.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Modify: `compass/crates/compass-history/tests/publication.rs`
+
+**Interfaces:**
+- Consumes: `PublishedVersion`, its five trees, and decoded records.
+- Produces: `HistoryStore::validate(&RealizationId) -> Result<ValidationReport, HistoryError>` and pre-publication validation inside `publish`.
+
+- [ ] **Step 1: Write failing validation tests**
+
+```rust
+#[test]
+fn validation_rejects_missing_endpoints_and_count_mismatches() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = committed_repository()?;
+    let repository = Repository::discover(fixture.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let mut request = fixture_publish_request("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    request.artifacts.document.links[0].target = "missing".to_owned();
+    let error = history.publish(request).unwrap_err();
+    assert!(error.to_string().contains("missing edge endpoint"));
+    assert!(history.list(None)?.is_empty());
+    Ok(())
+}
+```
+
+Add tests using a deliberately corrupt prebuilt SQLite fixture or a test-only store wrapper to alter manifest bytes, hide a referenced CID, inject an invalid multigraph discriminator, break an order reference, and inject a missing hyperedge member. Do not mutate adapter-private SQL tables. Each case must return a typed validation error and must not silently select another version.
+
+- [ ] **Step 2: Run the focused test and confirm publication currently accepts the bad edge**
+
+Run: `cargo test -p compass-history --test publication validation_rejects_missing_endpoints_and_count_mismatches`
+
+Expected: FAIL because `publish` does not yet reject the missing endpoint.
+
+- [ ] **Step 3: Add structured validation output**
+
+```rust
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ValidationReport {
+    pub nodes: u64,
+    pub edges: u64,
+    pub hyperedges: u64,
+    pub analysis_records: u64,
+    pub metadata_records: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ValidationProblem {
+    RealizationDigest,
+    MissingRoot(&'static str),
+    Count { kind: &'static str, expected: u64, actual: u64 },
+    KeyMismatch { kind: &'static str, key: Vec<u8> },
+    MissingEdgeEndpoint { edge: Vec<u8>, endpoint: String },
+    MissingHyperedgeMember { hyperedge: Vec<u8>, member: String },
+    MissingAnalysisNode(String),
+    MissingOrderRecord { kind: &'static str, key: Vec<u8> },
+    InvalidMultigraphDiscriminator(Vec<u8>),
+    DuplicateExplicitHyperedgeId(String),
+    ArtifactRegistry(String),
+    IncompleteSemanticState,
+}
+```
+
+Add `HistoryError::InvalidRealization(Vec<ValidationProblem>)` with a concise display summary.
+
+Define these versioned v1 limits in one public policy type rather than scattering literals:
+
+```rust
+pub const MAX_AUTHORITATIVE_BYTES: u64 = 512 * 1024 * 1024;
+pub const MAX_KEY_BYTES: usize = 1024 * 1024;
+pub const MAX_RECORD_VALUE_BYTES: usize = 64 * 1024 * 1024;
+pub const MAX_RECORDS_PER_TREE: u64 = 10_000_000;
+pub const MAX_JSON_DEPTH: usize = 128;
+pub const MAX_JOB_BYTES: usize = 1024 * 1024;
+pub const MAX_DIAGNOSTIC_BYTES: usize = 64 * 1024;
+```
+
+Check lengths before allocation and check nesting while decoding. Tests cross every boundary
+with compact counting readers/builders so they do not allocate hundreds of MiB.
+
+- [ ] **Step 4: Implement streaming validation**
+
+Scan each tree with counters and a bounded decode buffer. Verify endpoint/member/reference
+existence with point lookups into the immutable node/record trees, optionally through a fixed-
+capacity cache; never retain all node IDs or records in memory. Verify:
+
+- recomputed manifest digest equals `RealizationId`;
+- every `StoredTree` root opens;
+- all five record counts, including analysis and metadata, equal the manifest;
+- decoded record identity equals its typed key;
+- multigraph and id-less-hyperedge discriminators are valid and duplicate-safe;
+- every edge endpoint and hyperedge member exists;
+- node-scoped analysis references exist;
+- order records resolve to existing typed keys and the artifact registry is complete;
+- canonical envelopes round-trip within the exact v1 key/value/count/depth limits above;
+- completion evidence says the pipeline succeeded, `allow_partial` was false,
+  expected and completed semantic-file counts match, and failed chunks are zero.
+
+Return every discovered problem in one error so `compass history status` can report a complete diagnosis.
+
+- [ ] **Step 5: Validate before the publication transaction**
+
+Build all trees and the candidate manifest, validate them by their direct immutable roots, and only then enter the named-root transaction. After commit, reopen the realization and run the lightweight digest/root check once more. A failed post-commit check returns corruption without changing preferred to another realization.
+
+- [ ] **Step 6: Run validation and all history tests**
+
+Run: `cargo test -p compass-history && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+Expected: PASS; invalid graphs leave the version catalog unchanged.
+
+- [ ] **Step 7: Commit fail-closed validation**
+
+```bash
+git add crates/compass-history
+git commit -m "feat(history): validate graph realizations before publish"
+```
+
+### Task 6: Stream graph-aware diffs across typed roots
+
+**Files:**
+- Create: `compass/crates/compass-history/src/diff.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Create: `compass/crates/compass-history/tests/diff.rs`
+
+**Interfaces:**
+- Consumes: two `RealizationId` values and Prolly `Diff` entries.
+- Produces: `ChangeSink`, `HistoryStore::diff(old, new, sink)` and stable `GraphChange` records.
+
+- [ ] **Step 1: Write a failing typed diff test**
+
+```rust
+use compass_history::{ChangeKind, ChangeSink, GraphChange, HistoryError, RecordKind};
+
+#[derive(Default)]
+struct VecChangeSink(Vec<GraphChange>);
+
+impl ChangeSink for VecChangeSink {
+    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
+        self.0.push(change);
+        Ok(())
+    }
+}
+
+#[test]
+fn diff_reports_topology_and_attribute_changes() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let history = fixture_history(directory.path())?;
+    let old = history.publish(version_one())?;
+    let new = history.publish(version_two())?;
+    let mut changes = VecChangeSink::default();
+    history.diff(&old.id, &new.id, &mut changes)?;
+    assert!(changes.0.iter().any(|change| change.record == RecordKind::Node && change.change == ChangeKind::Added));
+    assert!(changes.0.iter().any(|change| change.record == RecordKind::Edge && change.change == ChangeKind::Changed));
+    assert!(changes.0.iter().any(|change| change.record == RecordKind::Analysis));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify the diff API is missing**
+
+Run: `cargo test -p compass-history --test diff diff_reports_topology_and_attribute_changes`
+
+Expected: FAIL with unresolved diff types and method.
+
+- [ ] **Step 3: Define stable diff records**
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordKind { Node, Edge, Hyperedge, Analysis, Metadata }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeKind { Added, Removed, Changed }
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+pub struct GraphChange {
+    pub record: RecordKind,
+    pub change: ChangeKind,
+    pub key: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new: Option<serde_json::Value>,
+}
+
+pub trait ChangeSink {
+    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError>;
+}
+```
+
+- [ ] **Step 4: Adapt `prolly::Diff` without buffering both graphs**
+
+For each tree pair, return immediately when `StoredTree` values are equal. Otherwise call `Prolly::stream_diff`, decode `KeyBuilder` segments with `decode_segments`, decode versioned record envelopes, and invoke the sink once per change:
+
+```rust
+pub fn diff(
+    &self,
+    old: &RealizationId,
+    new: &RealizationId,
+    sink: &mut dyn ChangeSink,
+) -> Result<(), HistoryError> {
+    let _activity = self.activity()?;
+    let old = self.get(old)?;
+    let new = self.get(new)?;
+    self.diff_root(RecordKind::Node, &old.version.nodes_root, &new.version.nodes_root, sink)?;
+    self.diff_root(RecordKind::Edge, &old.version.edges_root, &new.version.edges_root, sink)?;
+    self.diff_root(RecordKind::Hyperedge, &old.version.hyperedges_root, &new.version.hyperedges_root, sink)?;
+    self.diff_root(RecordKind::Analysis, &old.version.analysis_root, &new.version.analysis_root, sink)?;
+    self.diff_root(RecordKind::Metadata, &old.version.metadata_root, &new.version.metadata_root, sink)
+}
+```
+
+- [ ] **Step 5: Add relation-change and synthetic-hyperedge expectations**
+
+Test that changing an edge relation yields one removed edge and one added edge. Test that a hyperedge with explicit `id` yields `Changed`, while a synthetic digest key yields removal plus addition. Add exact duplicate multigraph-edge and id-less-hyperedge occurrence tests, and assert a failing sink stops traversal without buffering remaining changes.
+
+- [ ] **Step 6: Prove equal roots perform no record reads**
+
+Wrap the store in a test-only counting adapter, diff a realization against itself, and assert the sink is empty and node-read metrics do not increase. Do not depend on dependency-internal `#[cfg(test)]` APIs, which are unavailable to downstream crates.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run: `cargo test -p compass-history --test diff && cargo clippy -p compass-history --all-targets -- -D warnings`
+
+```bash
+git add crates/compass-history
+git commit -m "feat(history): stream graph-aware version diffs"
+```
+
+### Task 7: Expose explicit history inspection and export commands
+
+**Files:**
+- Modify: `compass/crates/compass-history/src/git.rs`
+- Create: `compass/crates/compass-history/tests/git.rs`
+- Modify: `compass/crates/compass-cli/Cargo.toml`
+- Create: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Create: `compass/crates/compass-cli/tests/history_cli.rs`
+- Create: `compass/crates/compass-output/src/history_bundle.rs`
+- Modify: `compass/crates/compass-output/src/lib.rs`
+- Create: `compass/crates/compass-output/tests/history_bundle.rs`
+
+**Interfaces:**
+- Consumes: `HistoryStore::{open_existing, preferred, get, list, validate}`, `GraphArtifacts::write_seed`, the artifact registry, and versioned `compass-output` renderers.
+- Produces: `Repository::{resolve, parents}` on the existing discovery type, plus canonical `compass history status`, `compass history list`, `compass history show`, `compass history prefer`, and `compass history export` CLI commands.
+
+- [ ] **Step 1: Write failing CLI help and empty-store tests**
+
+```rust
+#[test]
+fn history_help_and_empty_status_are_actionable() -> Result<(), Box<dyn std::error::Error>> {
+    let repository = initialized_repository()?;
+    let help = run_compass(repository.path(), &["history", "--help"])?;
+    assert!(help.status.success());
+    assert!(String::from_utf8_lossy(&help.stdout).contains("history build <rev>"));
+
+    let status = run_compass(repository.path(), &["history", "status", "HEAD"])?;
+    assert!(status.status.success());
+    assert!(String::from_utf8_lossy(&status.stdout).contains("disabled"));
+    assert!(!repository.path().join(".git/compass").exists());
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify `compass history` is unknown**
+
+Run: `cargo test -p compass-cli --test history_cli history_help_and_empty_status_are_actionable`
+
+Expected: FAIL because command dispatch reports an unknown command.
+
+- [ ] **Step 3: Add CLI dependency and command dispatch**
+
+Add `compass-history` to `compass-cli/Cargo.toml`, declare `mod history_commands;`, and dispatch:
+
+```rust
+"history" => history_commands::command_history(frontend, &args),
+"diff" => history_commands::command_diff(frontend, &args),
+```
+
+Add both commands to `compass_help` and `compass_command_help`.
+`history_help(frontend)` must show the complete approved command family even before `build` is
+wired in Task 11. Refactor query/path/explain usage generation so Compass diagnostics always
+render the canonical executable name.
+
+- [ ] **Step 4: Implement repository and revision discovery once**
+
+Add `Repository { root: PathBuf, common_dir: PathBuf }` in `compass/crates/compass-history/src/git.rs`. `Repository::discover(current_dir)` runs:
+
+```text
+git rev-parse --show-toplevel
+git rev-parse --git-common-dir
+```
+
+Resolve relative common-dir output against the repository root and canonicalize it. `resolve(revision)` runs `git rev-parse --verify --end-of-options <revision>^{commit}`, parses a 40- or 64-hex `CommitId`, and rejects stderr/stdout with additional lines. `parents(commit)` runs `git show -s --format=%P <commit>` and parses every parent.
+
+Add tests for a normal repository, a linked worktree, an unknown revision, SHA-1 and SHA-256 repositories, and a revision beginning with `-`. `history_commands::open_existing_repository_history` calls `HistoryStore::open_existing(&repository)` and treats `None` as a normal no-store state; mutating commands introduced later call `HistoryStore::create`. Both target `<repository.common_dir()>/compass/history.sqlite`; no CLI code reimplements Git path or SQLite rules.
+
+- [ ] **Step 5: Implement read-only command output**
+
+- `status [rev] [--format text|json]`: enablement, store presence/compatibility, preferred realization ID, fingerprint, counts, and validation result. An absent store reports `disabled` and `no store`, exits `0`, and creates nothing.
+- `list [rev] [--format text|json]`: deterministic tabular lines or a JSON array for every realization; absent and empty stores are successful empty results.
+- `show <id> [--format text|json]`: text summary or JSON `GraphVersion`.
+- `prefer <rev> <id>`: verify the manifest's commit matches the revision, read the current
+  preferred realization, validate it, then call `compare_and_set_preferred`; report a concurrent
+  change instead of overwriting it. If the current preferred is corrupt, fail and direct the
+  user to `compass history rebuild <rev> --replace-corrupt` rather than bypassing recovery controls.
+- `export <rev> --format graph-json --output <path>`: reconstruct and atomically write canonical `graph.json`; reject directories for this mode.
+- `export <rev> --format graphify-out --output <directory>`: stage a complete bundle beside the destination, write stored authoritative sidecars verbatim, regenerate registered derived reports/HTML using the recorded renderer versions, validate the bundle, then atomically publish it. Fail closed when a required renderer version is unavailable; never silently substitute the current renderer.
+
+Bundle output must not already exist; v1 has no implicit merge or destructive `--force` mode.
+Graph-JSON output atomically replaces only the exact file explicitly named by the user.
+
+In `compass-output/src/history_bundle.rs`, expose a renderer table keyed by the exact
+`regeneration_version` values emitted by Task 3. The API accepts ordinary graph/sidecar values,
+not `compass-history` types, so dependencies remain acyclic. Each supported version renders into
+a staging directory; an unknown version is a typed error. Tests pin canonical-semantic output
+for every registered version and prove the current renderer is never substituted implicitly.
+
+Implement the global exit/output contract: `0` for valid empty/no-store reads, `2` for argument
+errors, and `1` for repository, output, storage, or validation failures. Text/JSON results use
+stdout; diagnostics use stderr. Status renders its report but exits `1` for an incompatible
+store or corrupt selected preferred realization. Test short and broken output writers.
+
+- [ ] **Step 6: Seed CLI tests through the library**
+
+In `history_cli.rs`, publish fixtures directly through `HistoryStore::create` under the test repository's common directory, then assert `list`, `show`, `prefer`, graph-JSON export, and bundle export through `compass`. This keeps CLI presentation tests independent from historical build orchestration and from any legacy executable.
+
+- [ ] **Step 7: Run CLI and coverage-boundary tests**
+
+Run: `cargo test -p compass-cli --test history_cli && cargo test -p compass-cli --test coverage_paths`
+
+Expected: PASS; add invalid `compass history` and `compass diff` argument cases to `coverage_paths.rs`.
+
+- [ ] **Step 8: Commit explicit history inspection**
+
+```bash
+git add crates/compass-history/src/git.rs crates/compass-history/tests/git.rs crates/compass-cli crates/compass-output
+git commit -m "feat(cli): inspect and export graph history"
+```
+
+### Task 8: Add CLI graph diff summaries, details, and JSON streaming
+
+**Files:**
+- Modify: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+- Modify: `compass/crates/compass-cli/tests/coverage_paths.rs`
+
+**Interfaces:**
+- Consumes: two resolved preferred versions and `GraphChange` callbacks.
+- Produces: `compass diff A B`, `--detailed`, `--format json`, and `--topology-only` with the documented Compass process contract.
+
+- [ ] **Step 1: Write failing summary and JSON tests**
+
+```rust
+#[test]
+fn diff_supports_summary_and_machine_readable_output() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = history_fixture_with_two_commits()?;
+    let summary = fixture.run_compass(&["diff", "HEAD~1", "HEAD"])?;
+    assert!(summary.status.success());
+    assert!(String::from_utf8_lossy(&summary.stdout).contains("1 node added"));
+
+    let json = fixture.run_compass(&["diff", "HEAD~1", "HEAD", "--format", "json"])?;
+    let changes: Vec<serde_json::Value> = serde_json::from_slice(&json.stdout)?;
+    assert!(changes.iter().any(|change| change["record"] == "edge"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify `command_diff` is not implemented**
+
+Run: `cargo test -p compass-cli --test history_cli diff_supports_summary_and_machine_readable_output`
+
+Expected: FAIL with the temporary not-implemented history diff response.
+
+- [ ] **Step 3: Parse revisions and mutually exclusive output flags**
+
+Require exactly two revisions. Reject `--detailed` with `--format json`, reject unknown formats, and accept `--topology-only` with either output mode. Resolve both revisions to full commit IDs before store lookup.
+
+- [ ] **Step 4: Implement bounded summary aggregation**
+
+Count changes by `(RecordKind, ChangeKind)` while retaining at most 20 representative labels per category. Render stable singular/plural text. `--topology-only` filters out analysis and metadata before counting.
+
+- [ ] **Step 5: Implement detailed and streaming JSON output**
+
+Detailed mode renders one record at a time. JSON mode writes `[` then each serialized change separated by `,` and finally `]`; it must not collect all changes into a `Vec`. Add a private writer-based function so tests can inject a short-writing or failing sink.
+
+Keep stdout machine-clean while either missing side lazily materializes: stage/progress messages
+go only to stderr. A sink error stops the Prolly traversal and exits `1`.
+
+- [ ] **Step 6: Test relation, confidence, analysis, and empty diffs**
+
+Add fixtures for an edge relation replacement, confidence-only value change, community reassignment, and identical roots. Assert stable output ordering by record-kind order and Prolly key order.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run: `cargo test -p compass-cli --test history_cli && cargo clippy -p compass-cli --all-targets -- -D warnings`
+
+```bash
+git add crates/compass-cli
+git commit -m "feat(cli): diff graph history by commit"
+```
+
+### Task 9: Load already-materialized commits through `--at`
+
+**Files:**
+- Modify: `compass/crates/compass-core/src/lib.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Modify: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+- Modify: `compass/crates/compass-cli/tests/coverage_paths.rs`
+
+**Interfaces:**
+- Consumes: a reconstructed `GraphArtifacts` for a preferred commit.
+- Produces: `LoadedGraph::from_document`, `GraphSelection`, and `--at <rev>` for query, path, and explain.
+
+- [ ] **Step 1: Write a failing historical query test**
+
+```rust
+#[test]
+fn query_path_and_explain_read_the_selected_commit() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = history_fixture_with_two_commits()?;
+    let query = fixture.run_compass(&["query", "legacy service", "--at", "HEAD~1"])?;
+    assert!(query.status.success());
+    assert!(String::from_utf8_lossy(&query.stdout).contains("LegacyService"));
+    assert!(!String::from_utf8_lossy(&query.stdout).contains("ReplacementService"));
+
+    let path = fixture.run_compass(&["path", "LegacyService", "Database", "--at=HEAD~1"])?;
+    assert!(path.status.success());
+    let explain = fixture.run_compass(&["explain", "LegacyService", "--at", "HEAD~1"])?;
+    assert!(explain.status.success());
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify `--at` is ignored or rejected**
+
+Run: `cargo test -p compass-cli --test history_cli query_path_and_explain_read_the_selected_commit`
+
+Expected: FAIL because the current checkout's `graph.json` is loaded.
+
+- [ ] **Step 3: Add an in-memory `LoadedGraph` constructor**
+
+```rust
+impl LoadedGraph {
+    pub fn from_document(document: GraphDocument, force_directed: bool) -> Result<Self, GraphError> {
+        let mut document = document;
+        if force_directed {
+            document.directed = true;
+        }
+        Ok(Self {
+            graph: Graph::from_document(document)?,
+            overlay: HashMap::new(),
+        })
+    }
+}
+```
+
+Historical queries deliberately use an empty learning overlay because the current `.graphify_learning.json` is experiential state, not part of a commit realization.
+
+- [ ] **Step 4: Parse one exclusive graph source**
+
+```rust
+enum GraphSelection {
+    File(PathBuf),
+    Commit(String),
+}
+```
+
+Add a shared parser used by query, path, and explain. Accept `--at REV` and `--at=REV`. Reject `--at` combined with `--graph`, repeated selectors, missing values, or extra positionals. Preserve the existing default graph path when neither selector is present.
+
+Change `command_query`, `command_path`, `command_explain`, and their help/usage helpers so the
+Compass dispatcher, which has removed the mandatory `graph` segment, renders canonical
+`compass ...` usage.
+
+- [ ] **Step 5: Resolve and load materialized history**
+
+For `GraphSelection::Commit`, acquire one shared activity guard spanning preferred lookup,
+validation, reconstruction, and `LoadedGraph::from_document`; discover the repository,
+resolve the revision, load its preferred realization, validate it, reconstruct
+`GraphArtifacts`, and call `LoadedGraph::from_document`. If no preferred version exists, return:
+
+```text
+error: no graph realization for <commit>; run `compass history build <rev>`
+```
+
+Task 11 replaces this missing-version error with lazy materialization.
+
+- [ ] **Step 6: Update help and argument coverage**
+
+Add `[--at REV]` to query, path, and explain help. Extend `coverage_paths.rs` with missing `--at` values and `--graph`/`--at` conflicts for Compass.
+
+- [ ] **Step 7: Run historical query equivalence tests and commit**
+
+Run: `cargo test -p compass-cli --test history_cli && cargo test -p compass-query`
+
+```bash
+git add crates/compass-core/src/lib.rs crates/compass-cli
+git commit -m "feat(query): load graph history by commit"
+```
+
+### Task 10: Add exact-commit worktrees and reusable materialization orchestration
+
+**Files:**
+- Modify: `compass/crates/compass-history/Cargo.toml`
+- Modify: `compass/crates/compass-history/src/git.rs`
+- Modify: `compass/crates/compass-history/tests/git.rs`
+- Modify: `compass/crates/compass-files/src/detect.rs`
+- Modify: `compass/crates/compass-files/tests/contracts.rs`
+- Modify: `compass/crates/compass-core/Cargo.toml`
+- Create: `compass/crates/compass-core/src/history.rs`
+- Modify: `compass/crates/compass-core/src/lib.rs`
+- Create: `compass/crates/compass-core/tests/history_materialize.rs`
+
+**Interfaces:**
+- Consumes: `Repository`, `HistoryStore`, `MaterializeRequest`, and `CompleteGraphBuilder`.
+- Produces: `WorktreeGuard`, `materialize_history`, ancestor seeding, and an injectable build boundary.
+
+- [ ] **Step 1: Write failing Git worktree cleanup tests**
+
+```rust
+#[test]
+fn detached_worktree_is_exact_and_removed_on_drop() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = repository_with_two_commits()?;
+    let repository = Repository::discover(fixture.path())?;
+    let first = repository.resolve("HEAD~1")?;
+    let checkout_path;
+    {
+        let checkout = repository.detached_worktree(&first)?;
+        checkout_path = checkout.path().to_path_buf();
+        assert_eq!(repository.resolve_at(checkout.path(), "HEAD")?, first);
+        assert!(checkout.path().join("old.rs").is_file());
+    }
+    assert!(!checkout_path.exists());
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify worktree APIs are absent**
+
+Run: `cargo test -p compass-history --test git detached_worktree_is_exact_and_removed_on_drop`
+
+Expected: FAIL with missing `detached_worktree`.
+
+- [ ] **Step 3: Implement `WorktreeGuard` without touching the user's checkout**
+
+Add `tempfile.workspace = true` to regular `compass-history` dependencies. Before checkout,
+inventory configured filter drivers and return a typed limitation for unsupported external
+smudge/process drivers. Create the temporary directory below `<common-dir>/compass/tmp/`,
+then run Git with hooks disabled, `GIT_LFS_SKIP_SMUDGE=1`, `GIT_TERMINAL_PROMPT=0`, no
+credential prompting, and no fetch command:
+
+```text
+git -c core.hooksPath=<empty-hooks-dir> -C <repository-root> worktree add --quiet --detach <path> <full-commit>
+```
+
+`WorktreeGuard::drop` runs `git worktree remove --force -- <path>` and then removes the temporary directory. Add an explicit `close(self) -> Result<(), HistoryError>` used by success paths so cleanup failures are reportable; `Drop` remains a best-effort fallback. Verify exact `HEAD`, preserve committed LFS pointer files, report LFS pointers/gitlinks, and fail on missing objects without network access. Add an explicit historical ignore policy to `compass-files` that applies committed `.gitignore`/`.graphifyignore` files and explicit excludes but skips `.git/info/exclude` and global ignores; the history builder selects it without changing current-checkout defaults. Add tests proving checkout hooks do not run and caller-local ignore state does not affect the historical corpus.
+
+Before every worktree remove or recursive cleanup, revalidate that the stored path is a
+nonsymlink descendant of the canonical `<common-dir>/compass/tmp` directory and matches the
+random directory created by this guard. Refuse cleanup on any mismatch. Tests replace path
+components with symlinks and prove no path outside `tmp` is touched.
+
+- [ ] **Step 4: Write a failing fake-builder materialization test**
+
+```rust
+#[test]
+fn materializer_reuses_preferred_ancestor_and_publishes_target() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = materialization_fixture()?;
+    let builder = RecordingBuilder::default();
+    let published = materialize_history(&fixture.store, &builder, fixture.request(false))?;
+    assert_eq!(published.version.git_commit, fixture.target.to_string());
+    assert_eq!(builder.calls(), 1);
+    assert_eq!(builder.seed_commits(), vec![fixture.parent.to_string()]);
+    assert_eq!(fixture.store.preferred(&fixture.target)?.unwrap().id, published.id);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Define the build boundary and request**
+
+```rust
+pub trait CompleteGraphBuilder {
+    fn build(
+        &self,
+        checkout: &Path,
+        output_root: &Path,
+        seed: Option<&GraphArtifacts>,
+    ) -> Result<CompletedGraphArtifacts, MaterializeError>;
+}
+
+pub struct MaterializeRequest {
+    pub repository: Repository,
+    pub commit: CommitId,
+    pub profile: BuildProfile,
+    pub rebuild: bool,
+    pub replace_corrupt: bool,
+}
+```
+
+`MaterializeError` wraps history errors, builder diagnostics, worktree cleanup failure, and incomplete graph state without flattening them into strings.
+
+Provide `materialize_history` with a no-op observer and
+`materialize_history_with_observer` for workers. The latter accepts
+`&mut dyn MaterializeObserver` and reports `Building`, `Validating`, and `Publishing`
+immediately before those phases; an observer failure stops before the next phase.
+
+- [ ] **Step 6: Implement first-parent seed selection**
+
+After creating the exact worktree, compute the final `ExtractionFingerprint` from the profile plus target-commit configuration, committed `.gitignore`/`.graphifyignore` contents, explicit excludes, and all declared meaning-affecting versions/settings. Walk `git rev-list --first-parent <target>` from the target's parent toward the root. Select the first commit with a preferred validated realization whose extraction fingerprint equals that resolved fingerprint. Reconstruct its artifacts and extraction manifest and pass them to the builder. If no compatible ancestor exists, pass `None`.
+
+- [ ] **Step 7: Implement materialization state transitions**
+
+`materialize_history` returns the existing validated preferred version when one exists and `rebuild` is false. Otherwise it acquires the shared activity guard, creates the worktree, resolves the fingerprint, reports/builds, verifies `built_at_commit` equals the requested commit, cross-checks `CompletionEvidence` against the exact-worktree semantic inventory and manifest, reports/validates the complete artifacts, and calls `publish_with_activity` with `make_preferred: true` before closing the worktree and returning `PublishedVersion`. Builder failure or incomplete artifacts never call publication. A corrupt preferred leaves an ordinary build/rebuild candidate non-preferred; only `replace_corrupt: true` invokes the exact-CAS recovery API.
+
+- [ ] **Step 8: Run history/core tests and commit**
+
+Run: `cargo test -p compass-history --test git && cargo test -p compass-core --test history_materialize && cargo clippy -p compass-core -p compass-history --all-targets -- -D warnings`
+
+```bash
+git add crates/compass-history crates/compass-files crates/compass-core
+git commit -m "feat(history): materialize exact Git commits"
+```
+
+### Task 11: Implement `compass history build`, `compass history rebuild`, and lazy query backfill
+
+**Files:**
+- Create: `compass/crates/compass-cli/src/history_build.rs`
+- Modify: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+- Modify: `compass/crates/compass-semantic/src/lib.rs`
+
+**Interfaces:**
+- Consumes: `materialize_history`, current executable, semantic prompt, provider/model flags, and optional ancestor seed.
+- Produces: production `CompleteGraphBuilder`, `compass history build/rebuild`, and automatic materialization for `--at`.
+
+- [ ] **Step 1: Write a failing lazy-backfill integration test**
+
+```rust
+#[test]
+fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = pure_code_repository_with_two_commits()?;
+    let output = fixture.run_compass(&["query", "OldService", "--at", "HEAD~1"])?;
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("OldService"));
+    let status = fixture.run_compass(&["history", "status", "HEAD~1"])?;
+    assert!(status.status.success());
+    Ok(())
+}
+```
+
+The fixture contains only deterministic source files, so a complete graph requires no provider credentials while still exercising the normal complete extraction path.
+
+- [ ] **Step 2: Run the test and verify the missing-version error**
+
+Run: `cargo test -p compass-cli --test history_cli missing_code_only_commit_is_built_on_first_query`
+
+Expected: FAIL with `no graph realization`.
+
+- [ ] **Step 3: Expose the semantic prompt fingerprint**
+
+Add:
+
+```rust
+pub fn extraction_prompt_sha256(deep: bool) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(extraction_prompt(deep).as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+```
+
+Test the shallow and deep digests differ and remain 64 lowercase hex characters.
+
+- [ ] **Step 4: Parse `compass history build` inputs and construct the build profile**
+
+Accept repository-local meaning inputs: `--backend`, `--model`, `--mode`, `--cargo`,
+`--dedup-llm`, `--token-budget`, `--resolution`, `--exclude-hubs`, `--no-gitignore`,
+and repeated `--exclude`. Reject `--allow-partial`, `--code-only`, and `--no-cluster`
+because a history realization must be complete. Reject mutable external-source flags such
+as `--google-workspace` and `--postgres` in this first release. Include normalized
+values, Compass version, graph schema, extractor/resolver/pipeline versions, enabled
+features, prompt digest, direction, and clustering settings in `BuildProfile`. After the
+exact worktree exists, add hashes of target-commit configuration and every applied committed
+`.gitignore`/`.graphifyignore` plus explicit excludes to `ExtractionFingerprintInput`.
+Never read `.git/info/exclude` or global ignores. Record runtime-only
+limits such as concurrency and timeout in job metadata, not in the fingerprint. Never
+include environment credential values.
+
+- [ ] **Step 5: Implement the current-executable builder**
+
+`NativeCompleteGraphBuilder` writes the optional seed to `<output-root>/graphify-out`, then invokes the current executable with `current_dir(checkout)`, `GRAPHIFY_SKIP_HOOK=1`, and the selected build flags:
+
+```rust
+let mut command = std::process::Command::new(&self.executable);
+command
+    .arg("extract")
+    .arg(checkout)
+    .arg("--out")
+    .arg(output_root)
+    .arg("--no-viz")
+    .current_dir(checkout)
+    .env("GRAPHIFY_SKIP_HOOK", "1");
+```
+
+Forward the normalized semantic flags, wait for completion, and retain bounded
+stdout/stderr diagnostics. On exit `0`, return `CompletedGraphArtifacts` by deriving
+`CompletionEvidence` from the build
+result and manifest: count the semantic corpus and completed semantic entries, record
+failed chunks, and assert partial mode was not enabled. Pass that evidence while
+loading `GraphArtifacts`; reject a graph whose `built_at_commit` is not the requested
+full commit. Never infer completeness from `.graphify_semantic_marker`, because that
+file records token use rather than success. Raw marker bytes, `cost.json`, timings, and
+diagnostics stay in bounded attempt provenance and never enter the five identity-bearing trees.
+
+- [ ] **Step 6: Wire synchronous build and rebuild commands**
+
+`compass history build <rev>` resolves the commit and returns an existing preferred version when present. `compass history rebuild <rev>` always runs a new extraction attempt. `compass history rebuild <rev> --replace-corrupt` is the only path that may exact-CAS a validated candidate over a corrupt preferred realization; reject the flag when the preferred realization is not corrupt. Both may create the SQLite store while eager history remains disabled. Both print commit, realization ID, fingerprint, all five counts, and whether the result became preferred; `--format json` emits the same fields as one stable object.
+
+- [ ] **Step 7: Replace missing-version errors with lazy materialization**
+
+Add one `resolve_or_materialize(revision, options)` path used by query/path/explain
+`--at`, both sides of `compass diff`, and `compass history build/rebuild/export`. `compass history status`, `compass history list`, and `compass history show` remain
+inspection-only and never extract. The service invokes the same
+materializer with normalized default extraction settings when no preferred realization
+exists. Display build progress on stderr; preserve command output on stdout. A semantic
+provider error returns exit code `1`; Task 12 adds durable failed-job diagnostics, and
+no failure creates a preferred version.
+
+The service calls `HistoryStore::open_existing` first and `HistoryStore::create` only after it
+has established that materialization is required. It never changes the eager enablement flag.
+
+- [ ] **Step 8: Test ancestor seeding, rebuild, failure, and merge commits**
+
+Add CLI fixtures that assert:
+
+- a second historical build seeds from the compatible first parent;
+- `rebuild` keeps the old realization addressable;
+- provider failure leaves no preferred root;
+- a merge commit graph contains files from the exact merge tree;
+- diffing two previously unseen revisions lazily materializes both before streaming;
+- uncommitted files in the user's checkout never appear in the historical graph.
+- committed ignore files and explicit excludes affect the fingerprint and corpus, while
+  `.git/info/exclude` and global ignores do not;
+- checkout hooks, LFS smudging, credential prompts, network fetching, and unsupported
+  external filters never execute;
+- ordinary rebuild cannot replace corrupt preferred state, while explicit
+  `--replace-corrupt` performs exact-CAS recovery.
+
+- [ ] **Step 9: Run integration tests and commit**
+
+Run: `cargo test -p compass-cli --test history_cli && cargo test -p compass-core --test history_materialize && cargo clippy -p compass-cli -p compass-core -p compass-history --all-targets -- -D warnings`
+
+```bash
+git add crates/compass-cli crates/compass-semantic/src/lib.rs
+git commit -m "feat(history): lazily build complete commit graphs"
+```
+
+### Task 12: Queue eager post-commit builds and persist job state
+
+**Files:**
+- Modify: `compass/Cargo.toml`
+- Modify: `compass/Cargo.lock`
+- Modify: `compass/crates/compass-history/Cargo.toml`
+- Create: `compass/crates/compass-history/src/config.rs`
+- Create: `compass/crates/compass-history/src/durable.rs`
+- Create: `compass/crates/compass-history/src/jobs.rs`
+- Create: `compass/crates/compass-history/src/leases.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Create: `compass/crates/compass-history/tests/jobs.rs`
+- Modify: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/src/hook_commands.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Modify: `compass/crates/compass-cli/tests/hook_cli.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+
+**Interfaces:**
+- Consumes: full commit IDs, normalized materialization options, and the shared history store.
+- Produces: `HistoryConfig::{load, enable, disable}`, `HistoryQueue::{enqueue, claim_or_join, transition, reconcile, list}`, `LeaseGuard`, hidden `compass history-worker`, and opt-in non-blocking eager builds.
+
+- [ ] **Step 1: Write failing durable queue transition tests**
+
+```rust
+#[test]
+fn jobs_follow_the_allowed_state_machine_and_survive_reopen() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let queue = HistoryQueue::open(directory.path())?;
+    let id = queue.enqueue(job_request())?;
+    let claimed = queue.claim_next()?.unwrap();
+    assert_eq!(claimed.id, id);
+    assert_eq!(claimed.state, JobState::Building);
+    queue.transition(&id, JobState::Validating, None)?;
+    queue.transition(&id, JobState::Published, None)?;
+    drop(queue);
+    assert_eq!(HistoryQueue::open(directory.path())?.get(&id)?.unwrap().state, JobState::Published);
+    Ok(())
+}
+```
+
+Add tests rejecting `queued -> published` and `failed -> building`, plus simultaneous join,
+heartbeat, expiration/reclaim, generation increment, late-worker rejection, and reopen.
+Also test absent configuration, enable/disable idempotency, invalid-profile rollback, and that
+read-only status creates neither `config.json` nor the SQLite/operational paths.
+
+- [ ] **Step 2: Run the queue tests and verify the module is missing**
+
+Run: `cargo test -p compass-history --test jobs`
+
+Expected: FAIL with unresolved queue types.
+
+- [ ] **Step 3: Implement explicit job records and transitions**
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobState { Queued, Building, Validating, Published, Failed, Incomplete }
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct JobRecord {
+    pub id: String,
+    pub commit: CommitId,
+    pub profile: BuildProfile,
+    pub profile_digest: String,
+    pub resolved_fingerprint: Option<String>,
+    pub state: JobState,
+    pub attempts: u32,
+    pub diagnostic: Option<String>,
+    pub candidate_realization: Option<RealizationId>,
+    pub observed_preferred: Option<RealizationId>,
+    pub preferred: Option<bool>,
+    pub lease_generation: u64,
+    pub created_at_millis: u64,
+    pub updated_at_millis: u64,
+}
+```
+
+Store one bounded canonical JSON record per attempt under `<common-dir>/compass/jobs` using a
+shared writer from `durable.rs`. It creates an owner-only temporary file in the same directory,
+flushes and `sync_all`s it, atomically replaces the destination, and synchronizes the parent
+directory. Unix uses atomic rename. Windows uses `MoveFileExW` with
+`MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` through an exact-pinned target-specific
+`windows-sys = "=0.61.2"` dependency, or a proven standard-library equivalent if available at
+implementation time. Reject symlink targets and fail closed when this contract is unavailable.
+Never use the existing copy-over fallback in `compass-files::atomic` for job or lease state. Add
+crash/fault-injection tests before and after every sync/replace boundary.
+
+Reject a job before allocation or decoding if it exceeds `MAX_JOB_BYTES`; cap redacted
+diagnostics at `MAX_DIAGNOSTIC_BYTES`. Queue deduplication uses commit plus profile digest
+because the final fingerprint is unavailable before exact checkout. After checkout, persist
+the resolved fingerprint and verify binary/pipeline versions against prior attempts.
+Credentials and credential values never enter any persisted field.
+
+`leases.rs` stores `leases/<commit>-<profile-digest>.lease` with a random owner ID,
+generation, and expiration. A lease lasts 120 seconds and heartbeats every 30 seconds. Claiming
+creates or compare-and-swaps the lease; heartbeat refreshes only the same owner/generation;
+reclaim increments generation after expiration; every job write checks generation so a late
+worker fails. Wall-clock jumps may duplicate extraction work but cannot overwrite a newer
+generation or corrupt the catalog. Lazy and eager requests join the same live lease, while
+explicit rebuild creates a new attempt.
+
+- [ ] **Step 4: Add draining worker execution**
+
+The hidden `compass history-worker` command first reconciles stale attempts, then repeatedly claims the
+oldest queued job and runs `materialize_history_with_observer` until no queued job remains.
+Multiple launched workers join or skip live leases safely. A terminal `Failed` or `Incomplete`
+attempt is recorded and does not prevent later jobs from running. Its observer maps `Building` and `Validating` to
+the durable queue states; `Publishing` is kept as `Validating` because the public state
+machine has no externally observable half-published state. The worker then records
+`Published`, `Failed`, or `Incomplete`. Diagnostics are capped at 64 KiB and redact
+environment values matching credential variable names. Before catalog publication, persist
+the candidate realization ID and observed preferred ID. On startup, `reconcile` checks stale
+jobs against the immutable catalog: if the candidate exists, retry preferred CAS only when
+the observed preferred remains exact; otherwise record `Published { preferred: false }`.
+Test termination before catalog publication, between catalog/preferred CAS, and between
+preferred CAS/terminal persistence. Also test that one launch after several queued commits
+drains all of them in FIFO claim order, including when an earlier job fails.
+
+- [ ] **Step 5: Add explicit enablement and enqueue the exact post-commit SHA**
+
+Implement `compass history enable [build-profile options]` and `compass history disable`. `enable` validates and atomically stores a normalized non-secret eager profile
+in `<common-dir>/compass/config.json`, creates and verifies the SQLite store, and installs or
+updates Compass's managed post-commit hook block through the existing hook installer while
+preserving all user-owned hook content. If hook installation fails, enablement rolls back.
+`disable`
+atomically marks eager history disabled, is idempotent, retains the database/jobs/leases, and
+does not kill an already leased worker. It leaves the inert managed block installed so current
+graph refresh behavior and later re-enablement remain stable. Explicit builds and lazy
+materialization remain usable while disabled. Invalid enable options leave the previous
+configuration unchanged.
+
+Change only the managed post-commit hook block to check the enabled configuration, resolve
+`git rev-parse --verify HEAD^{commit}`, and invoke the current frontend's hidden spawn command:
+
+```text
+compass hook-spawn . --history-commit <full-sha>
+```
+
+When history is disabled or has never been configured, the block performs no history enqueue.
+When enabled, it resolves and enqueues the SHA before refresh-only guards for
+rebase, merge, cherry-pick, changed-file filtering, graph-only commits, or linked worktrees.
+Those guards may suppress rebuilding current `graphify-out`, but they never suppress history
+enqueueing. `compass hook-spawn` launches the frontend-correct `compass history-worker` in the background with the existing
+detached-process policy and independently launches current graph refresh when required. The
+post-checkout hook continues refreshing the current graph but does not create a new commit job.
+
+- [ ] **Step 6: Make `compass history status` include jobs**
+
+Always display eager enablement and the normalized profile digest without secrets. When no
+store exists, report `disabled` and `no store` with exit `0` without creating paths. When no
+preferred realization exists, display the newest job's state, attempt count, and bounded diagnostic. When a preferred version exists, show it first and list any newer failed rebuild attempts separately. Always report store-format compatibility and detected target limitations such as LFS pointers, gitlinks, or unsupported filters.
+
+- [ ] **Step 7: Test hook latency and exact SHA capture**
+
+In `hook_cli.rs`, install the hook and first prove a commit while disabled creates no job. Enable
+history, commit a pure-code change, and assert the commit command completes without waiting for
+the worker. Poll with a bounded test deadline for the job file, then assert its commit equals the
+new full SHA. Disable again and prove stored realizations remain queryable while later commits
+are not queued. Repeat from a linked worktree and for merge/cherry-pick commit state. Use a fake
+executable for provider-failure and launch-failure paths, then launch one later worker and prove
+it drains all queued jobs.
+
+- [ ] **Step 8: Run queue/hook tests and commit**
+
+Run: `cargo test -p compass-history --test jobs && cargo test -p compass-cli --test hook_cli && cargo test -p compass-cli --test history_cli`
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-history crates/compass-cli
+git commit -m "feat(history): enqueue complete graphs after commits"
+```
+
+### Task 13: Add reachability-based garbage collection and retention controls
+
+**Files:**
+- Create: `compass/crates/compass-history/src/gc.rs`
+- Modify: `compass/crates/compass-history/src/store.rs`
+- Modify: `compass/crates/compass-history/src/lib.rs`
+- Modify: `compass/crates/compass-history/tests/publication.rs`
+- Create: `compass/crates/compass-history/tests/maintenance.rs`
+- Modify: `compass/crates/compass-cli/src/history_commands.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+
+**Interfaces:**
+- Consumes: all named roots, preferred realization set, Prolly `NamedRootRetention`, and job retention policy.
+- Produces: `HistoryStore::{plan_gc, sweep_gc}` and `compass history gc [--prune-non-preferred] [--yes]`.
+
+- [ ] **Step 1: Write failing orphan and retention tests**
+
+```rust
+#[test]
+fn gc_keeps_all_published_versions_and_removes_orphans() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let history = fixture_with_preferred_and_nonpreferred(directory.path())?;
+    history.write_unpublished_fixture_tree()?;
+    let plan = history.plan_gc(false)?;
+    assert!(plan.reclaimable_nodes > 0);
+    assert_eq!(plan.prunable_realizations, 0);
+    let sweep = history.sweep_gc(plan)?;
+    assert!(sweep.deleted_nodes > 0);
+    assert_eq!(history.list(None)?.len(), 2);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test and verify GC APIs are missing**
+
+Run: `cargo test -p compass-history --test publication gc_keeps_all_published_versions_and_removes_orphans`
+
+Expected: FAIL with missing `plan_gc`.
+
+- [ ] **Step 3: Plan GC from all retained named roots**
+
+Acquire the exclusive `maintenance.lock` guard before reading any roots and retain it through
+planning, catalog recheck, root removal, node deletion, and cleanup. For normal GC, call:
+
+```rust
+let retention = prolly::NamedRootRetention::all();
+let plan = self.prolly.plan_store_gc_for_retention(&retention)?;
+```
+
+Wrap the Prolly plan with job/temp cleanup counts. Normal GC never removes a published realization root. Add separate-process tests proving an active shared reader or builder blocks/times out maintenance and that GC cannot delete an active builder's unpublished nodes.
+
+- [ ] **Step 4: Plan non-preferred pruning explicitly**
+
+Compute the preferred realization IDs, identify other published IDs, and list the six named roots that would be removed for each. The plan is immutable and includes a digest of the observed catalog state. `sweep_gc` rechecks that digest before deleting roots in a strict transaction, then calls Prolly's store GC against all remaining named roots.
+
+- [ ] **Step 5: Add safe CLI behavior**
+
+- `compass history gc` prints a plan and sweeps abandoned objects plus expired temp/job state.
+- `compass history gc --prune-non-preferred` prints the realization IDs but does not delete them without `--yes`.
+- `compass history gc --prune-non-preferred --yes` applies the checked plan.
+- Never accept a broad filesystem path or glob as a GC target.
+- Report deleted SQLite node rows and reusable bytes/pages when available; never claim the
+  physical `history.sqlite` file shrank.
+- Retain terminal attempt records for 30 days by default. Remove temporary directories only
+  after 24 hours and only when no live lease owns them. Never delete queued or active attempts.
+  Validate every cleanup candidate as a nonsymlink descendant of the canonical common-dir
+  `compass/tmp` or `compass/jobs` directory.
+- `--format json` emits the immutable plan and applied result as stable objects suitable for
+  automation; progress and confirmation prompts remain on stderr.
+
+- [ ] **Step 6: Test stale plans and concurrent preferred changes**
+
+Create a plan, change the preferred version, then assert sweep refuses the stale plan and removes nothing. Add tests for corrupt root listings, interrupted root deletion rollback, shared-reader/builder races, maintenance timeout, 30-day terminal-attempt retention, 24-hour temp retention, live-lease preservation, symlink/path-escape rejection, and the store-format root remaining retained.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run: `cargo test -p compass-history && cargo test -p compass-cli --test history_cli && cargo clippy -p compass-history -p compass-cli --all-targets -- -D warnings`
+
+```bash
+git add crates/compass-history crates/compass-cli
+git commit -m "feat(history): garbage collect unreachable graph objects"
+```
+
+### Task 14: Qualify semantic correctness, coverage, and performance; document the feature
+
+**Files:**
+- Create: `compass/crates/compass-history/tests/performance.rs`
+- Modify: `compass/crates/compass-cli/tests/history_cli.rs`
+- Modify: `compass/README.md`
+- Refresh (generated, normally ignored): `graphify-out/` through `compass update .`
+
+**Interfaces:**
+- Consumes: the complete feature and existing graph/query compatibility oracle.
+- Produces: semantic-equivalence evidence, structural-sharing measurements, user documentation, and a fresh Compass project graph.
+
+- [ ] **Step 1: Add graph export and query semantic-equivalence coverage**
+
+Add a fixture that builds a normal Rust graph, publishes it, reconstructs it, and compares normalized JSON with the original. Run query, path, and explain against both `--graph` and `--at HEAD`; assert identical stdout after excluding only query-stamp side effects.
+
+- [ ] **Step 2: Add an ignored performance evidence test**
+
+```rust
+#[test]
+#[ignore = "performance evidence; run explicitly"]
+fn small_change_reuses_content_addressed_nodes() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = compass_sized_fixture()?;
+    let first = fixture.publish_base()?;
+    let before = fixture.sqlite_node_row_count()?;
+    let second = fixture.publish_one_file_change()?;
+    let after = fixture.sqlite_node_row_count()?;
+    let diff = fixture.structural_diff(&first, &second)?;
+    assert!(diff.shared_nodes > 0);
+    assert!(after - before < diff.second_total_nodes);
+    Ok(())
+}
+```
+
+Obtain logical counts through `NodeStoreScan` or a counting adapter, never adapter-private SQL or filesystem object enumeration. Print cold/seeded publication time, SQLite logical growth and reusable pages, multi-process contention, diff latency and peak buffered records, query latency/memory, and GC planning/sweep. Record evidence without inventing a percentage gate not present in the design.
+
+- [ ] **Step 3: Add malformed and adversarial correctness cases**
+
+Cover legacy `edges`, unknown attributes, multigraph parallel edges, duplicate id-less hyperedges, canonical number fixtures, artifact registry failures, every exact resource-limit boundary without large allocation, Unicode IDs, long relations, corrupt manifests/preferred recovery, missing Git, SHA-1/SHA-256, shallow history, linked worktrees, concurrent SQLite connections, WAL/busy timeout, old fixture reopen, stale leases/late workers, clock jumps, crash reconciliation windows, queue draining after failed jobs, maintenance races, ignored caller-local excludes, LFS/gitlink/filter reporting, symlink/path-escape rejection, no-store read-only behavior, enable/disable behavior, and Compass-specific help and process contracts.
+
+- [ ] **Step 4: Document the command lifecycle**
+
+Update `compass/README.md` with:
+
+```text
+compass history enable
+compass history build HEAD
+compass query "authentication flow" --at HEAD~20
+compass diff v1.2.0 HEAD --detailed
+compass history export HEAD --format graphify-out --output <output-directory>
+compass history list HEAD --format json
+compass history gc
+compass history disable
+```
+
+Do not promise Graphify command compatibility. If the legacy binary is mentioned, label it an
+optional best-effort transition shim outside the Compass versioned-graph contract.
+Explain explicit enable/disable semantics, complete semantic graphs, extraction fingerprints,
+multiple realizations, the live-WAL SQLite store under the Git common directory, owner-only
+permissions, eager queue/lease behavior, lazy backfill, provider requirements,
+canonical-semantic export and versioned derived regeneration, committed-ignore/filter
+limitations, explicit `--replace-corrupt` recovery, exact exit/output behavior, and SQLite GC's
+logical rather than physical reclamation.
+
+- [ ] **Step 5: Run formatting, focused tests, and workspace lint**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p compass-history
+cargo test -p compass-core --test history_materialize
+cargo test -p compass-cli --test history_cli
+cargo test -p compass-cli --test hook_cli
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 6: Run the complete workspace and coverage gates**
+
+Run:
+
+```bash
+cargo test --workspace --all-features --locked
+GRAPHIFY_REPO_ROOT=/Users/haipingfu/graphify GRAPHIFY_PYTHON=/Users/haipingfu/graphify/.venv/bin/python cargo llvm-cov --workspace --all-features --all-targets --locked --exclude compass-tree-sitter-language-pack --lcov --output-path target/compass.lcov
+cargo llvm-cov report --summary-only --fail-under-lines 90 --fail-under-regions 85
+scripts/check_critical_coverage.sh target/compass.lcov 95
+```
+
+Expected: tests pass; workspace line coverage is at least 90%, region coverage at least 85%, and critical-module line coverage at least 95%.
+
+- [ ] **Step 7: Run the explicit structural-sharing evidence test**
+
+Run: `cargo test -p compass-history --test performance small_change_reuses_content_addressed_nodes -- --ignored --nocapture`
+
+Expected: PASS and print the recorded storage/diff measurements.
+
+- [ ] **Step 8: Refresh Compass's project graph**
+
+Run: `compass update .`
+
+Expected: `graphify-out/GRAPH_REPORT.md` records the implementation commit and the graph passes its health checks.
+
+Do not force-add ignored generated outputs. Commit them only if `git ls-files
+graphify-out` shows they were already tracked.
+
+- [ ] **Step 9: Commit qualification and documentation**
+
+```bash
+git add README.md crates/compass-history/tests/performance.rs crates/compass-cli/tests/history_cli.rs
+git commit -m "docs(history): qualify versioned graph maps"
+```
+
+When executing from the Graphify superproject, advance its `compass` submodule pointer only
+after the reviewed Compass branch is pushed. That integration commit is separate from the
+Compass task commits above; a standalone Compass checkout has no parent-pointer step.
+
+## Requirement traceability
+
+| Production requirement | Owning tasks | Required evidence |
+|---|---:|---|
+| Exact pinned SQLite Prolly storage and linked-worktree sharing | 1, 4, 13 | adapter contract, reopen fixture, WAL contention, strict transactions, GC |
+| Stable identity, typed keys, complete lossless graph and artifact registry | 2, 3, 5 | golden bytes, round-trip/property tests, corruption and resource-limit tests |
+| Atomic immutable publication and explicit corrupt recovery | 4, 5, 11, 12 | CAS races, fault windows, `--replace-corrupt` tests |
+| Streaming topology/attribute diff | 6, 8, 11 | differential oracle, equal-root skip, bounded/failing sinks |
+| Compass-first query/path/explain at any commit | 7, 9, 11 | exact-revision semantic-equivalence and lazy-backfill tests |
+| Canonical export plus versioned report/HTML regeneration | 3, 7, 14 | authoritative byte equality and renderer-version compatibility tests |
+| Exact offline Git-tree materialization | 10, 11 | merge/shallow/filter/ignore/LFS/gitlink and cleanup-safety tests |
+| Explicit opt-in eager generation and durable recovery | 12 | enable/disable, hook latency, durable-write fault injection, lease and queue-drain tests |
+| Safe retention and maintenance | 1, 5, 13 | shared/exclusive process races, stale plans, lease-aware retention |
+| Fully usable Compass command surface | 7–14 | Compass help/usage, `--`, JSON, stdout/stderr, and exit-code matrix |
+| Release readiness without default-on regression | 14 | format, full tests, coverage gates, performance evidence, refreshed project graph |
+
+## Final verification checklist
+
+- [ ] Every preferred commit graph contains semantic, inferred, and hyperedge data.
+- [ ] Rebuilding the same commit, parents, fingerprint, persisted formats, and canonical graph content yields the same realization ID regardless of raw token/cost/timing provenance.
+- [ ] Different fingerprints and nondeterministic outputs coexist without overwrite.
+- [ ] `--at` always reads the exact committed tree and ignores uncommitted files.
+- [ ] Graph diffs stream Prolly changes and skip equal roots.
+- [ ] Partial or corrupt output cannot become preferred.
+- [ ] Post-commit work is queued and does not block the commit.
+- [ ] Post-commit enqueue happens only after explicit `compass history enable`; disable is idempotent, retains history, and does not affect explicit/lazy builds.
+- [ ] Linked worktrees share one store through the Git common directory.
+- [ ] The store is `history.sqlite` with exact adapter pins, WAL/full synchronous settings, busy timeout, owner-only protection, and verified `compass/store-format/v1`.
+- [ ] Directed/undirected simple and multigraph structures, exact duplicate id-less hyperedges, order, unknown fields, and authoritative sidecars round-trip.
+- [ ] Historical builds ignore `.git/info/exclude`/global ignores and never execute hooks, LFS smudging, credential prompts, network fetches, or unsupported filters.
+- [ ] Durable generation leases reject late workers and reconcile every catalog/preferred/job crash window.
+- [ ] A worker reconciles and drains all queued jobs, even when an earlier attempt fails.
+- [ ] Operational records use owner-only, symlink-safe, crash-durable atomic replacement; no copy-over fallback can masquerade as atomicity.
+- [ ] One reader-writer maintenance lock prevents GC races with readers, builders, reconstruction, diff, and publication.
+- [ ] Corrupt preferred state is replaced only through explicit `--replace-corrupt` exact-CAS recovery.
+- [ ] Normal GC retains every published realization.
+- [ ] `graph.json` and authoritative sidecars reconstruct with canonical semantic equivalence; reports/HTML regenerate from recorded versions.
+- [ ] No credentials or machine-specific paths appear in fingerprints, manifests, or jobs.
+- [ ] `compass` is the sole canonical command surface and satisfies its documented help and process contracts independently of any legacy Graphify shim.
+- [ ] Read-only no-store commands create nothing; stdout/stderr, JSON shape, and exit codes satisfy the public process contract.
+- [ ] All exact v1 size/count/depth and retention limits have boundary tests.

--- a/docs/superpowers/plans/2026-07-22-compass-guard.md
+++ b/docs/superpowers/plans/2026-07-22-compass-guard.md
@@ -1,0 +1,450 @@
+# Compass Guard Implementation Plan
+
+> **For the implementing agent:** Use `superpowers:executing-plans` and complete the tasks in order. Use test-driven development for every behavioral change. Do not overwrite unrelated changes already present in the Compass worktree.
+
+**Goal:** Turn the implemented CompassQL and versioned-graph foundations into a production CI architecture-governance product that fails only on newly introduced violations, produces reviewable evidence, and works across major CI systems.
+
+**Architecture:** `compass-policy` owns policy and pack schemas, evaluation, fingerprints, exemptions, baselines, differential results, and budgets. `compass-core` owns exact snapshot selection. `compass-output` renders one typed result into terminal, JSON, JSONL, JUnit, and SARIF. `compass-cli` remains the vendor-neutral entry point. The GitHub Action and other CI adapters install a pinned Compass release and consume the same CLI/report contract; they contain no policy logic.
+
+**Technology:** Rust 2024, CompassQL, TOML, JSON Schema-style versioned envelopes, SARIF 2.1.0, JUnit XML, GitHub composite actions, GitLab CI components, Bitbucket Pipelines, Azure Pipelines.
+
+## Scope reconciliation
+
+The approved design and existing implementation plans remain authoritative for CompassQL syntax, zero-row policy semantics, `cmpv1` fingerprints, immutable snapshots, resource limits, exit codes, and the initial schema-1 policy lifecycle:
+
+- `compass/docs/superpowers/specs/2026-07-22-compassql-design.md`
+- `compass/docs/superpowers/plans/2026-07-22-compassql-policy.md`
+- `compass/docs/superpowers/plans/2026-07-22-compassql-integrations.md`
+
+The current repository already has CompassQL execution, `GraphSelection::{File, Commit}`, historical loading through `--at`, native cycle/god-node analysis, and signed release archives with SHA-256 sidecars. It does not yet contain a `compass-policy` crate, `compass check`, differential checks, or a reusable Action.
+
+Compass Guard deliberately adds four contracts beyond the approved schema-1 design:
+
+1. Policy schema 2 adds rationale, compatibility metadata, and accountable exemptions with approver and ticket.
+2. Pack schema 1 adds versioning, dependency-free validation, and fixture-based tests.
+3. JUnit and repeated `--report FORMAT=PATH` sinks let one evaluation feed several CI consumers.
+4. Budget policies are a first-class policy kind; they do not materialize synthetic nodes or pretend every graph metric is portable Cypher.
+
+Schema 1 stays readable and behaviorally unchanged. Official Compass Guard packs use policy schema 2. Unknown fields remain errors within each schema version.
+
+## Product contract
+
+The primary command is:
+
+```bash
+compass check \
+  --against origin/main \
+  --new-only \
+  --policy-root .compass/policies \
+  --fail-on error \
+  --report sarif=compass-guard.sarif \
+  --report json=compass-guard.json \
+  --report junit=compass-guard.xml
+```
+
+The command evaluates base and head with the same policy-pack digest and effective limits. It partitions active violations by `(policy_id, cmpv1 fingerprint)` into `new`, `resolved`, and `unchanged`. Exit 1 means the selected failure threshold was crossed; exits 2–4 remain configuration, graph/execution, and internal failures as defined by the approved design. `--new-only` never turns a failed base/head evaluation or incompatible comparison into a clean result.
+
+## Milestone 1: Complete the approved schema-1 policy engine
+
+### Task 1: Add `compass-policy` and zero-row evaluation
+
+**Files:**
+
+- Modify: `compass/Cargo.toml`
+- Modify: `compass/Cargo.lock`
+- Create: `compass/crates/compass-policy/Cargo.toml`
+- Create: `compass/crates/compass-policy/src/{lib,config,discovery,evaluate,error}.rs`
+- Create: `compass/crates/compass-policy/tests/{support,evaluation,discovery}.rs`
+
+**Steps:**
+
+1. Copy the public `Severity`, `PolicyRequest`, `PolicySuiteResult`, and `Violation` contracts from the approved policy plan. Add the crate to the workspace.
+2. Write failing tests for lexical discovery, duplicate IDs, path escape, symlinks, unknown fields, limits that exceed global limits, zero rows, one row per violation, typed evidence, cancellation, timeout, and query failure.
+3. Implement strict policy schema 1 and execute every discovered policy against one immutable graph snapshot.
+4. Preserve a returned `Path` named `witness` as primary evidence and preserve all remaining returned values as typed evidence.
+5. Run:
+
+   ```bash
+   cd compass
+   cargo test -p compass-policy
+   cargo clippy -p compass-policy --all-targets -- -D warnings
+   ```
+
+6. Commit: `feat(policy): evaluate CompassQL architecture policies`.
+
+### Task 2: Add fingerprints, exemptions, and baselines
+
+**Files:**
+
+- Create: `compass/crates/compass-policy/src/{fingerprint,exemption,baseline}.rs`
+- Create: `compass/crates/compass-policy/tests/{fingerprint,exemption,baseline}.rs`
+- Modify: `compass/crates/compass-policy/src/{lib,config,evaluate}.rs`
+
+**Steps:**
+
+1. Write failing stability tests proving that source-line moves do not change `cmpv1`, while stable node/relationship/path identities do.
+2. Implement the approved length-prefixed canonical encoding and SHA-256 fingerprint.
+3. Write failing exemption tests for exact matches, expiry, duplicates, unknown/stale fingerprints, and invalid dates. Implement schema-1 fields `reason`, `owner`, and `expires` exactly as approved.
+4. Write failing baseline tests for canonical round trips, corruption, path safety, stale entries, and explicit atomic writes.
+5. Implement `--write-baseline PATH --confirm`; never let a baseline suppress configuration, query, timeout, cancellation, or graph failures.
+6. Run `cargo test -p compass-policy && cargo clippy -p compass-policy --all-targets -- -D warnings`.
+7. Commit: `feat(policy): fingerprint and govern policy violations`.
+
+### Task 3: Add source-rich terminal, JSON, JSONL, and SARIF output
+
+**Files:**
+
+- Create: `compass/crates/compass-output/src/{policy,sarif}.rs`
+- Create: `compass/crates/compass-output/tests/{policy,sarif}.rs`
+- Modify: `compass/crates/compass-output/src/lib.rs`
+- Modify: `compass/crates/compass-output/Cargo.toml`
+
+**Evidence contract:**
+
+- Every violation includes policy location, owners, severity, message, fingerprint, exemption/baseline state, and typed evidence.
+- A witness hop includes stable ID, label, `source_file`, `source_location`, relationship direction/type, `confidence`, `confidence_score` when present, and `_origin`/`extractor` when present.
+- SARIF uses the first concrete source location as the primary location, witness hops as related locations, `cmpv1` as a partial fingerprint, policy owners/tags as properties, and execution failures as invocation notifications.
+- Rendering is deterministic and contains no ANSI escapes outside terminal output.
+
+**Steps:**
+
+1. Add failing golden tests for an extracted edge, inferred edge, missing location, multiedge, escaped control characters, exempt violation, and execution failure.
+2. Add an `EvidenceProvenance` view that reads existing graph attributes without changing graph identity or the fingerprint contract.
+3. Implement renderers and validate SARIF against the checked-in SARIF 2.1.0 fixture/schema used by tests.
+4. Run `cargo test -p compass-output && cargo clippy -p compass-output --all-targets -- -D warnings`.
+5. Commit: `feat(output): render Compass Guard evidence and SARIF`.
+
+### Task 4: Expose `compass check`
+
+**Files:**
+
+- Create: `compass/crates/compass-cli/src/check_commands.rs`
+- Create: `compass/crates/compass-cli/tests/check.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Modify: `compass/crates/compass-cli/Cargo.toml`
+- Create: `compass/docs/COMPASSQL_POLICIES.md`
+- Create: `compass/examples/compass-policies/domain-isolation/{policy.toml,query.cypher}`
+
+**Steps:**
+
+1. Write CLI tests for Compass-only exposure, default discovery, explicit roots, every format, fail thresholds, atomic output, Ctrl-C, and exit codes 0–4.
+2. Add `check` dispatch beside `query`; do not expose it through the Graphify compatibility frontend.
+3. Evaluate once per selected snapshot, render only after evaluation completes, and write files atomically.
+4. Run `cargo test -p compass-cli --test check && cargo clippy -p compass-cli --all-targets -- -D warnings`.
+5. Commit: `feat(cli): add Compass architecture policy checks`.
+
+## Milestone 2: Make base-versus-head checks trustworthy
+
+### Task 5: Move graph selection behind a shared snapshot service
+
+**Files:**
+
+- Create: `compass/crates/compass-core/src/query_service.rs`
+- Create: `compass/crates/compass-core/tests/query_service.rs`
+- Modify: `compass/crates/compass-core/src/lib.rs`
+- Modify: `compass/crates/compass-cli/src/{lib,query_commands,check_commands}.rs`
+
+**Steps:**
+
+1. Move the existing CLI-private `GraphSelection` into `compass-core` and add the approved `SnapshotProvider`, `GraphSnapshot`, `SnapshotIdentity`, and `CompassQueryService` interfaces.
+2. Write failing tests proving exact commit resolution, immutable in-flight snapshots, full validation before publication, and no reuse across schema/planner compatibility keys.
+3. Adapt `query` and `check` to the service. Do not introduce a second revision selector or rebuild history behavior in `compass-policy`.
+4. Run `cargo test -p compass-core -p compass-cli && cargo clippy -p compass-core -p compass-cli --all-targets -- -D warnings`.
+5. Commit: `refactor(core): centralize snapshot-aware queries and checks`.
+
+### Task 6: Implement differential policy results
+
+**Files:**
+
+- Create: `compass/crates/compass-policy/src/differential.rs`
+- Create: `compass/crates/compass-policy/tests/differential.rs`
+- Create: `compass/crates/compass-output/src/differential.rs`
+- Create: `compass/crates/compass-cli/tests/check_differential.rs`
+- Modify: `compass/crates/compass-policy/src/lib.rs`
+- Modify: `compass/crates/compass-output/src/lib.rs`
+- Modify: `compass/crates/compass-cli/src/check_commands.rs`
+
+**Steps:**
+
+1. Write failing tests for new/resolved/unchanged partitions, policy-set mismatch, policy digest mismatch, typed parameter mismatch, limit mismatch, fingerprint-version mismatch, corrupt base, corrupt head, and identical snapshots.
+2. Compare only successful suites that share policy IDs, source digests, CompassQL version, typed parameter digests, effective limits, and fingerprint version.
+3. Apply exemptions and baselines independently to each snapshot before comparison. Compare only active `(policy_id, fingerprint)` pairs.
+4. Add `--against REV`; require it for `--new-only`. Preserve current evidence for new/unchanged and base evidence for resolved.
+5. Render all partitions in text/JSON/JSONL/SARIF. With `--new-only`, SARIF includes only new active results while run properties retain counts for resolved and unchanged.
+6. Run:
+
+   ```bash
+   cd compass
+   cargo test -p compass-policy --test differential
+   cargo test -p compass-cli --test check_differential
+   cargo test -p compass-output
+   cargo clippy -p compass-policy -p compass-cli -p compass-output --all-targets -- -D warnings
+   ```
+
+7. Commit: `feat(policy): detect newly introduced architecture violations`.
+
+## Milestone 3: Add the governance and report contracts
+
+### Task 7: Add policy schema 2 without weakening schema 1
+
+**Files:**
+
+- Create: `compass/crates/compass-policy/src/schema_v2.rs`
+- Create: `compass/crates/compass-policy/tests/schema_v2.rs`
+- Modify: `compass/crates/compass-policy/src/{config,exemption,lib}.rs`
+- Modify: `compass/docs/COMPASSQL_POLICIES.md`
+
+**Required schema-2 example:**
+
+```toml
+schema = 2
+id = "architecture.domain-isolation"
+query = "query.cypher"
+severity = "error"
+message = "Domain code must not depend on database implementation"
+rationale = "Keeps business rules independently testable and storage-agnostic."
+owners = ["platform-architecture"]
+tags = ["architecture", "domain"]
+
+[compatibility]
+compass = ">=0.2.0, <0.3.0"
+compassql = 1
+graph_schema = 1
+
+[[exemptions]]
+fingerprint = "cmpv1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+reason = "Legacy adapter is being removed."
+approver = "staff-architect@example.com"
+ticket = "ARCH-241"
+expires = "2026-10-01"
+```
+
+**Steps:**
+
+1. Write failing tests for all required fields, invalid semver ranges, incompatible Compass/CompassQL/graph versions, invalid ticket strings, expired approvals, and schema cross-contamination.
+2. Dispatch deserialization by the numeric schema before applying `deny_unknown_fields` to the selected version.
+3. Keep schema-1 `owner` behavior intact. Require non-empty `approver`, `ticket`, `reason`, and `expires` in schema 2; do not silently translate one schema into the other on disk.
+4. Require a schema-2 variable-length primary witness to be produced by `shortestPath` or `allShortestPaths`; fixed-length path witnesses remain valid. Reject a policy whose primary witness can be non-minimal, and test both accepted forms.
+5. Include rationale and compatibility in JSON, JUnit properties, SARIF rule help/properties, and policy digests used by differential checks.
+6. Run `cargo test -p compass-policy -p compass-output && cargo clippy -p compass-policy -p compass-output --all-targets -- -D warnings`.
+7. Commit: `feat(policy): add accountable governance metadata`.
+
+### Task 8: Add one-evaluation multi-report output and JUnit
+
+**Files:**
+
+- Create: `compass/crates/compass-output/src/junit.rs`
+- Create: `compass/crates/compass-output/tests/junit.rs`
+- Modify: `compass/crates/compass-output/src/{lib,policy,differential}.rs`
+- Modify: `compass/crates/compass-cli/src/check_commands.rs`
+- Modify: `compass/crates/compass-cli/tests/check.rs`
+
+**Contract:**
+
+- `--report FORMAT=PATH` is repeatable for `json`, `jsonl`, `junit`, and `sarif`.
+- The suite is evaluated exactly once per snapshot; all renderers receive the same immutable typed result.
+- JUnit uses one test case per policy, failures for threshold-crossing active violations, skipped cases for fully exempt policies, `<system-out>` for concise witnesses, and properties for snapshots, pack digests, owners, rationale, fingerprints, and counts.
+- Operational/configuration errors remain nonzero CLI failures and also produce JUnit `<error>` elements when a JUnit sink was requested.
+
+**Steps:**
+
+1. Write failing XML escaping, deterministic ordering, new-only, exempt, and operational-error tests.
+2. Implement JUnit without embedding arbitrary source content or terminal control sequences.
+3. Parse and validate every report sink before evaluation; reject duplicate paths and prevent symlink/path escape.
+4. Atomically write all reports. If a write fails, report the failing sink and return the approved output-failure exit without presenting a clean run.
+5. Run `cargo test -p compass-output --test junit && cargo test -p compass-cli --test check`.
+6. Commit: `feat(output): emit JUnit and multiple Guard reports`.
+
+## Milestone 4: Ship the GitHub-first CI product
+
+### Task 9: Publish a checksum-verifying composite Action
+
+**Files:**
+
+- Create: `compass/action.yml`
+- Create: `compass/.github/actions/compass-guard/install.sh`
+- Create: `compass/.github/actions/compass-guard/install.ps1`
+- Create: `compass/.github/actions/compass-guard/run.sh`
+- Create: `compass/.github/actions/compass-guard/run.ps1`
+- Create: `compass/.github/actions/compass-guard/finalize.sh`
+- Create: `compass/.github/actions/compass-guard/finalize.ps1`
+- Create: `compass/.github/workflows/compass-guard-action-ci.yml`
+- Create: `compass/tests/action/{passing,existing-only,new-violation,expired-exemption,invalid-policy}/`
+- Modify: `compass/.github/workflows/compass-release.yml`
+- Modify: `compass/README.md`
+
+**Inputs:** `version`, `base`, `working-directory`, `build`, `graph`, `policy-root`, `fail-on`, `new-only`, `upload-sarif`, and optional `baseline`. `build` defaults to true and runs the local AST graph build; `build=false` requires `graph`.
+
+**Outputs:** `sarif-path`, `json-path`, `junit-path`, `new-count`, `resolved-count`, `unchanged-count`, and `check-exit-code`.
+
+**Steps:**
+
+1. Write fixture workflows that assert pass, newly introduced violation, unchanged legacy violation, expired exemption, invalid policy, missing base ref, and fork-PR behavior.
+2. On Linux/macOS/Windows, map `runner.os` and `runner.arch` to the exact release names already produced by `compass-release.yml`.
+3. Download the requested immutable release and its `.sha256` sidecar, verify the archive before extraction, and refuse `latest` or an unqualified version. Reuse the runner tool cache for the exact version/target tuple.
+4. Resolve the comparison side to an exact commit SHA from `base` or the pull-request event. If it is absent locally, fetch only that SHA into a private Compass ref. Never compare against an unresolved mutable branch name in the Action, and emit a precise shallow-clone diagnostic when the host refuses the fetch.
+5. With `build=true`, run `compass update` in `working-directory` before checking. With `build=false`, validate the supplied graph path. The Action must not invoke semantic/model extraction implicitly.
+6. Run `compass check` once with all three report sinks. Capture its exit long enough to upload artifacts and write `$GITHUB_STEP_SUMMARY`, then return the original exit in the finalizer.
+7. When `upload-sarif=true`, upload the SARIF file through the current major `github/codeql-action/upload-sarif` action pinned to a full commit SHA. Document that the calling job requires `security-events: write`; automatically disable upload for untrusted fork PRs while preserving downloadable artifacts and action failure.
+8. Upload JSON/JUnit/SARIF test artifacts from the Action CI matrix and verify the SARIF appears in an integration repository's code-scanning check before release.
+9. Add release qualification that invokes the packaged Action against `new-violation` using the just-built archive, not a previously published binary.
+10. Commit: `feat(ci): publish Compass Guard GitHub Action`.
+
+## Milestone 5: Versioned, tested policy packs
+
+### Task 10: Add pack schema, validation, and fixture tests
+
+**Files:**
+
+- Create: `compass/crates/compass-policy/src/{pack,pack_test}.rs`
+- Create: `compass/crates/compass-policy/tests/{pack,pack_test}.rs`
+- Create: `compass/crates/compass-cli/src/pack_commands.rs`
+- Create: `compass/crates/compass-cli/tests/pack.rs`
+- Modify: `compass/crates/compass-policy/src/lib.rs`
+- Modify: `compass/crates/compass-cli/src/lib.rs`
+- Create: `compass/docs/POLICY_PACKS.md`
+
+**Pack manifest:**
+
+```toml
+schema = 1
+id = "compass.official.layered"
+version = "1.0.0"
+description = "Dependency-direction rules for layered systems"
+owners = ["compass-maintainers"]
+license = "Apache-2.0 OR MIT"
+policies = ["no-upward-dependencies", "no-storage-from-domain"]
+
+[compatibility]
+compass = ">=0.2.0, <0.3.0"
+compassql = 1
+graph_schema = 1
+```
+
+Each policy directory contains `tests/cases/<case>/graph.json` plus `expected.json`. Expected data records pass/fail and stable evidence IDs, not source line numbers.
+
+**Steps:**
+
+1. Write failing tests for manifest parsing, duplicate IDs, undeclared policy directories, missing policies, incompatible versions, path escape, symlinks, deterministic digest, and fixture mismatch.
+2. Implement `compass pack validate PATH` and `compass pack test PATH`; both are offline and deterministic.
+3. Include manifest bytes, ordered policy digests, and compatibility metadata in a `cmppack1:` SHA-256 digest. Record this digest in every suite/report and require equality in differential checks.
+4. Do not add remote fetching in this milestone. Consumers vendor a pack directory or obtain an immutable release archive through their existing dependency workflow.
+5. Run `cargo test -p compass-policy --test pack --test pack_test && cargo test -p compass-cli --test pack`.
+6. Commit: `feat(policy): validate and test versioned policy packs`.
+
+### Task 11: Ship the first five official packs
+
+**Files:**
+
+- Create: `compass/policy-packs/layered/`
+- Create: `compass/policy-packs/hexagonal/`
+- Create: `compass/policy-packs/domain-isolation/`
+- Create: `compass/policy-packs/data-access/`
+- Create: `compass/policy-packs/public-interface-stability/`
+- Create: `compass/.github/workflows/policy-packs-ci.yml`
+
+**Minimum policies:**
+
+- Layered: presentation cannot reach persistence directly; dependencies point inward.
+- Hexagonal: domain cannot depend on adapters/frameworks; adapters access domain only through ports.
+- Domain isolation: cross-domain calls go through declared public interfaces; no shared persistence models.
+- Data access: application/domain code cannot issue SQL or import concrete database clients; migrations cannot be called by runtime code.
+- Public-interface stability: a differential check reports removal or incompatible movement of nodes tagged as public API.
+
+**Steps:**
+
+1. For every policy, write one allowed fixture, one direct violation, one transitive violation where applicable, and one false-positive regression fixture.
+2. Require schema-2 rationale, owners, tags, compatibility, a minimal witness query, and a README showing customization parameters.
+3. Test packs on Linux/macOS/Windows and against the minimum and current supported Compass versions.
+4. Package each pack independently with manifest, policies, fixtures, digest file, SBOM, and provenance attestation.
+5. Commit: `feat(packs): add official Compass Guard architecture packs`.
+
+## Milestone 6: Architecture budgets
+
+### Task 12: Add first-class budget policies
+
+**Files:**
+
+- Create: `compass/crates/compass-policy/src/{budget,budget_evidence,ownership}.rs`
+- Create: `compass/crates/compass-policy/tests/{budget,ownership}.rs`
+- Modify: `compass/crates/compass-policy/src/{config,evaluate,fingerprint,lib,schema_v2}.rs`
+- Modify: `compass/crates/compass-graph/src/lib.rs`
+- Modify: `compass/crates/compass-query/src/affected.rs`
+- Create: `compass/policy-packs/budgets/`
+
+**Design:** Policy schema 2 requires exactly one of `query` or `[budget]`. A budget evaluator returns deterministic typed evidence, then uses the same violation, fingerprint, exemption, baseline, differential, and output pipeline as query policies.
+
+Supported kinds in the first release:
+
+- `import_cycles`: maximum count, maximum cycle length, and relationship filter; reuse `find_import_cycles`.
+- `god_nodes`: maximum count above a configured degree; reuse `god_nodes` but return stable node evidence.
+- `coupling`: maximum directed cross-scope edges for configured path scopes and relations.
+- `blast_radius`: maximum affected nodes from head-changed files/symbols, with configured relations and depth; valid only with `--against`.
+- `unowned_assets`: maximum source files without an owner after resolving `.compass/owners.toml` and, optionally, repository CODEOWNERS.
+
+**Steps:**
+
+1. Write failing tests for each metric, deterministic ties, multiedges, missing communities, renamed files, changed-only behavior, invalid scope patterns, CODEOWNERS precedence, and empty ownership configuration.
+2. Refactor existing analysis functions only enough to return source-rich stable evidence; keep existing public behavior compatible.
+3. Parse `.compass/owners.toml` as the vendor-neutral source. If CODEOWNERS support is enabled, implement its documented last-match-wins semantics and repository lookup order with conformance fixtures.
+4. For budget overages, emit the smallest deterministic evidence set that proves the threshold was crossed: shortest cycles first, highest-degree nodes first, sorted crossing edges, bounded affected paths, and sorted unowned files.
+5. Fingerprint individual budget evidence items, not the aggregate count, so changed-only reports the newly offending cycle/node/edge/path/file.
+6. Run `cargo test -p compass-policy -p compass-graph -p compass-query && cargo clippy -p compass-policy -p compass-graph -p compass-query --all-targets -- -D warnings`.
+7. Commit: `feat(policy): enforce architecture budgets`.
+
+## Milestone 7: GitLab, Bitbucket, and Azure adapters
+
+### Task 13: Add thin, credential-free CI templates
+
+**Files:**
+
+- Create: `compass/ci/gitlab/compass-guard.yml`
+- Create: `compass/ci/bitbucket/compass-guard.yml`
+- Create: `compass/ci/azure/compass-guard.yml`
+- Create: `compass/ci/scripts/install-compass.sh`
+- Create: `compass/ci/scripts/run-compass-guard.sh`
+- Create: `compass/tests/ci-contracts/`
+- Create: `compass/docs/CI_INTEGRATIONS.md`
+
+**Steps:**
+
+1. Reuse the release checksum verifier and the exact CLI contract from the GitHub Action. Do not duplicate policy evaluation or parse human-readable output.
+2. GitLab: publish `compass-guard.xml` as a JUnit report and JSON/SARIF as artifacts; preserve the Compass exit code.
+3. Bitbucket: publish JUnit through test reporting and JSON/SARIF as artifacts; preserve the Compass exit code.
+4. Azure: use `PublishTestResults@2` for JUnit and publish JSON/SARIF artifacts; preserve the Compass exit code.
+5. Add shell contract tests that run each generated command locally with representative CI variables, a shallow clone, a missing base ref, and an existing-only violation.
+6. Keep provider APIs and long-lived credentials out of this milestone. Native annotations come from SARIF/JUnit capabilities supplied by each platform.
+7. Commit: `feat(ci): add portable Compass Guard pipeline templates`.
+
+## Final qualification gate
+
+Run from `compass/`:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --all-targets --all-features --locked
+cargo test -p compass-policy
+cargo test -p compass-output
+cargo test -p compass-cli --test check --test check_differential --test pack
+scripts/benchmark_compass_policies.sh
+```
+
+Then run the Action matrix and the three CI contract suites. The release is ready only when:
+
+- unchanged debt does not fail `--new-only`;
+- every new violation has a stable fingerprint and source-rich minimal witness;
+- expired exemptions fail closed and every schema-2 exemption has approver, ticket, reason, and expiry;
+- one evaluation produces byte-stable JSON/JUnit/SARIF;
+- official packs validate and pass all fixtures on the supported Compass compatibility range;
+- budget overages produce individual actionable evidence rather than only an aggregate number;
+- release archives, the GitHub Action, and CI installers verify checksums before execution;
+- policy, comparison, report, and pack schemas are versioned and documented.
+
+## Explicit non-goals for the first Guard release
+
+- A hosted policy service, dashboard, SSO/RBAC, or central waiver database.
+- Automatic mutation of baselines or exemptions from CI.
+- Pull-request commenting through provider tokens; SARIF, JUnit, job summaries, and artifacts are the initial review surfaces.
+- Remote pack resolution at evaluation time.
+- AI-authored policies in the enforcement path. AI may propose a policy, but checked-in deterministic policy files remain the authority.

--- a/docs/superpowers/plans/2026-07-22-pr-intelligence-foundation.md
+++ b/docs/superpowers/plans/2026-07-22-pr-intelligence-foundation.md
@@ -1,0 +1,2886 @@
+# Compass PR Intelligence Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the trusted foundation for Compass PR Intelligence: shared immutable graph snapshots, exact pull-request revision capture, a versioned typed report, an immutable evidence manifest, durable report persistence, and typed CLI/MCP adapters.
+
+**Architecture:** `compass-core` owns one shared graph-selection and immutable-snapshot interface consumed by PR Intelligence and CompassQL. `compass-prs` owns exact change-request capture, canonical report identity, foundation orchestration, and durable persistence. CLI and MCP call the same typed operation. The foundation emits no risk, impact, owner, test, overlap, or gate verdict and labels every result `foundation_preview` until the later child designs are approved and implemented.
+
+**Tech Stack:** Rust 2024, Rust 1.97, Serde/JSON, SHA-256, workspace `url`, existing `compass-history` SQLite-backed Prolly realizations, existing `compass-core`/`compass-model` graph types, Git CLI, GitHub CLI, `wait-timeout`, and the current Compass CLI/MCP crates.
+
+## Global Constraints
+
+- Implement in an isolated worktree created from the standalone Compass repository root; preserve all unrelated user changes in the primary worktree.
+- Treat `docs/superpowers/specs/2026-07-22-pr-intelligence-design.md` as the governing umbrella design.
+- This plan implements child 1 only. It must not implement semantic delta, downstream traversal, ownership selection, test selection, overlap analysis, risk bands, policy evaluation, or deterministic gates.
+- PR Intelligence remains preview-only. No foundation result may imply that a pull request is safe, low risk, policy-compliant, or sufficiently tested.
+- This plan owns the shared `GraphSelection`, `SnapshotProvider`, `GraphSnapshot`, and `SnapshotIdentity` interfaces. The CompassQL integration plan must consume these types after this plan lands rather than adding duplicates.
+- Reuse the current implemented `compass-history` crate and `LoadedGraph::from_document`; do not create another historical store or revision resolver.
+- A pull-request analysis captures full object IDs for merge base, pull-request head, target head, and the synthetic merge tree before opening graph snapshots.
+- Never fetch, checkout, or execute code implicitly while capturing pull-request metadata. Missing Git objects fail with an actionable error.
+- Require support for `git merge-tree --write-tree -z --name-only`. An unsupported Git build fails with `PRS2007` and an upgrade diagnostic; do not silently substitute a mutating merge.
+- Graph materialization continues to use the existing offline history worktree protections and complete-realization validation.
+- Policies, CODEOWNERS, risk, owners, tests, overlap, and merge gates are absent from the foundation report rather than represented by invented clean results.
+- Canonical report identity excludes timestamps, machine-specific absolute paths, process IDs, timings, and presentation formatting. It includes the exact semantic file snapshot, including the learning overlay visible to queries.
+- Compass owns the command syntax, MCP tools, schemas, storage paths, environment variables, tests, and deprecation policy introduced by this plan.
+- Keep Compass-specific runtime code, fixtures, schemas, migrations, and release automation inside the Compass repository. Tests assert Compass contracts directly.
+- New JSON schemas reject unknown fields when deserialized by Compass-owned readers.
+- Process output remains bounded at 16 MiB per stream and becomes strict UTF-8; invalid UTF-8 is an error rather than lossy evidence.
+- Report files are limited to 64 MiB, written atomically, owner-only where supported, and never written through symlinks.
+- Every task follows red-green-refactor, ends in an independently reviewable commit, and runs focused tests plus Clippy with warnings denied.
+- Workspace lints remain `unsafe_code = "forbid"`, `unwrap_used = "deny"`, `expect_used = "deny"`, and `panic = "deny"`.
+
+---
+
+## Plan sequence and dependency rule
+
+This plan lands before the snapshot portion of `docs/superpowers/plans/2026-07-22-compassql-integrations.md`. When that plan executes, it uses the `compass-core` snapshot types created here and adds query/check orchestration around them. It must not create a second `GraphSelection`, `SnapshotProvider`, `GraphSnapshot`, or `SnapshotIdentity`.
+
+The already implemented versioned-graph history is a precondition. Verify before Task 1:
+
+```bash
+test -f crates/compass-history/src/lib.rs
+test -f crates/compass-core/src/history.rs
+cargo test -p compass-history
+cargo test -p compass-core --test history_materialize
+```
+
+Expected: all commands exit `0`.
+
+## File and module map
+
+Create or extend these focused modules:
+
+- `crates/compass-core/src/snapshot.rs` owns shared selection, identity, snapshot, and provider types.
+- `crates/compass-core/src/lib.rs` exports the stable snapshot surface.
+- `crates/compass-core/tests/snapshot.rs` verifies file snapshot identity and provider contracts.
+- `crates/compass-prs/src/model.rs` owns reports, revisions, findings, completeness, and gates.
+- `crates/compass-prs/src/canonical.rs` owns canonical bytes and report/evidence SHA-256 identities.
+- `crates/compass-prs/src/source.rs` owns the change-request seam and GitHub CLI adapter.
+- `crates/compass-prs/src/git.rs` owns exact local Git revision, diff, and merge-tree operations.
+- `crates/compass-prs/src/operation.rs` owns foundation orchestration and the repository seam.
+- `crates/compass-prs/src/report_store.rs` owns filesystem persistence.
+- `crates/compass-prs/src/service.rs` owns the object-safe analysis service consumed by adapters.
+- `crates/compass-prs/src/lib.rs` contains the public typed surface.
+- `crates/compass-prs/tests/report_contract.rs` verifies schema, identity, and strict decoding.
+- `crates/compass-prs/tests/change_capture.rs` verifies exact revisions and merge outcomes.
+- `crates/compass-prs/tests/foundation_operation.rs` verifies manifest and snapshot consistency.
+- `crates/compass-prs/tests/report_store.rs` verifies atomic persistence and hostile paths.
+- `crates/compass-prs/tests/service.rs` verifies the adapter-facing analysis service.
+- `crates/compass-cli/src/snapshot_provider.rs` owns file/history production snapshots.
+- `crates/compass-cli/src/prs_commands.rs` owns the foundation preview adapter.
+- `crates/compass-cli/src/lib.rs` consumes the shared selection type and dispatches preview.
+- `crates/compass-cli/tests/prs_cli.rs` verifies existing Compass PR commands remain functional.
+- `crates/compass-cli/tests/prs_intelligence_preview.rs` verifies exact-revision preview end to end.
+- `crates/compass-mcp/src/pr_intelligence.rs` owns the typed `analyze_pr` MCP adapter.
+- `crates/compass-mcp/src/lib.rs` registers the typed adapter.
+- `crates/compass-mcp/tests/pr_intelligence.rs` verifies structured PR Intelligence results.
+- `docs/PR_INTELLIGENCE.md` documents the preview contract, limitations, and troubleshooting.
+- `scripts/benchmark_pr_foundation.sh` measures reproducible cold/warm foundation performance.
+
+Do not add a new crate. `compass-prs` remains the domain module and `compass-core` remains the shared graph snapshot module.
+
+## Shared public interfaces
+
+Tasks use these exact names and shapes.
+
+### Shared snapshots in `compass-core`
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GraphSelection {
+    File(std::path::PathBuf),
+    Commit(String),
+    SyntheticMerge {
+        target_head: String,
+        pull_request_head: String,
+        tree: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SnapshotIdentity {
+    File { sha256: String },
+    Commit { commit: String, realization: String },
+    SyntheticMerge {
+        target_head: String,
+        pull_request_head: String,
+        tree: String,
+        realization: String,
+    },
+}
+
+pub struct GraphSnapshot {
+    pub graph: compass_model::Graph,
+    pub overlay:
+        std::collections::HashMap<String, serde_json::Map<String, serde_json::Value>>,
+    pub schema_fingerprint: compass_model::SchemaFingerprint,
+    pub identity: SnapshotIdentity,
+}
+
+pub trait SnapshotProvider: Send + Sync {
+    fn load(
+        &self,
+        selection: &GraphSelection,
+    ) -> Result<std::sync::Arc<GraphSnapshot>, SnapshotError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("graph snapshot was not found: {0}")]
+    NotFound(String),
+    #[error("graph snapshot is corrupt: {0}")]
+    Corrupt(String),
+    #[error("graph snapshot selection is unsupported by this adapter: {0}")]
+    Unsupported(String),
+    #[error("graph snapshot identity mismatch: expected {expected}, got {actual}")]
+    IdentityMismatch { expected: String, actual: String },
+    #[error("graph snapshot could not be loaded: {0}")]
+    Load(String),
+}
+```
+
+Implement `SnapshotIdentity` deserialization through a private raw enum plus `TryFrom`: file digests and realization IDs must be exactly 64 lowercase hexadecimal characters, and every commit/tree ID must satisfy the same full 40-or-64-character rule as `GitObjectId`. Invalid identities must fail before a provider or report can use them. Child 1 reserves `SyntheticMerge` but providers return `SnapshotError::Unsupported("synthetic_merge")`; child 2 will add non-mutating tree materialization without changing this shared contract.
+
+`SnapshotIdentity::Display` returns:
+
+```text
+file:<64 lowercase hex>
+commit:<full commit oid>:<64 lowercase realization hex>
+merge:<full target oid>:<full PR oid>:<full tree oid>:<64 lowercase realization hex>
+```
+
+The `File.sha256` digest is not merely the raw `graph.json` checksum. It is the SHA-256 of a versioned canonical semantic-snapshot envelope containing the parsed `GraphDocument` and the exact learning overlay returned in `GraphSnapshot`. Recursively sort every JSON object key before serialization. This ensures that a changed overlay produces a changed identity and that the identity always describes the data actually queried.
+
+### Change-request and revision model in `compass-prs`
+
+```rust
+pub const REPORT_SCHEMA: &str = "compass.pr_intelligence.report/1";
+pub const EVIDENCE_MANIFEST_SCHEMA: &str = "compass.pr_intelligence.evidence/1";
+pub const REPORT_ID_SCHEMA: &str = "cmppr-report-v1";
+pub const FINDING_FINGERPRINT_SCHEMA: &str = "cmpprv1";
+
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
+)]
+pub enum ForgeKind {
+    #[serde(rename = "github")]
+    GitHub,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RepositoryIdentityError {
+    #[error("invalid GitHub host: {0}")]
+    Host(String),
+    #[error("invalid GitHub owner: {0}")]
+    Owner(String),
+    #[error("invalid GitHub repository name: {0}")]
+    Name(String),
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryIdentity {
+    forge: ForgeKind,
+    host: String,
+    owner: String,
+    name: String,
+}
+
+impl RepositoryIdentity {
+    pub fn github(
+        host: impl Into<String>,
+        owner: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Result<Self, RepositoryIdentityError> {
+        let host = normalize_github_host(host.into())?;
+        let owner = validate_github_component(owner.into())
+            .map_err(RepositoryIdentityError::Owner)?;
+        let name = validate_github_component(name.into())
+            .map_err(RepositoryIdentityError::Name)?;
+        Ok(Self {
+            forge: ForgeKind::GitHub,
+            host,
+            owner,
+            name,
+        })
+    }
+
+    #[must_use]
+    pub fn slug(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+
+    #[must_use]
+    pub const fn forge(&self) -> ForgeKind {
+        self.forge
+    }
+
+    #[must_use]
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn gh_repo_argument(&self) -> String {
+        if self.host == "github.com" {
+            self.slug()
+        } else {
+            format!("{}/{}", self.host, self.slug())
+        }
+    }
+}
+
+fn normalize_github_host(value: String) -> Result<String, RepositoryIdentityError> {
+    if value.is_empty()
+        || value.chars().any(char::is_control)
+        || value.chars().any(char::is_whitespace)
+        || value
+            .chars()
+            .any(|character| matches!(character, '/' | '@' | '?' | '#'))
+    {
+        return Err(RepositoryIdentityError::Host(value));
+    }
+    let parsed = url::Url::parse(&format!("https://{value}/"))
+        .map_err(|_| RepositoryIdentityError::Host(value.clone()))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| RepositoryIdentityError::Host(value.clone()))?
+        .to_ascii_lowercase();
+    Ok(match parsed.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host,
+    })
+}
+
+fn validate_github_component(value: String) -> Result<String, String> {
+    let valid = !value.is_empty()
+        && value.len() <= 255
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+        });
+    if valid {
+        Ok(value.to_ascii_lowercase())
+    } else {
+        Err(value)
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRepositoryIdentity {
+    forge: ForgeKind,
+    host: String,
+    owner: String,
+    name: String,
+}
+
+impl<'de> serde::Deserialize<'de> for RepositoryIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawRepositoryIdentity::deserialize(deserializer)?;
+        match raw.forge {
+            ForgeKind::GitHub => Self::github(raw.host, raw.owner, raw.name),
+        }
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChangeRequestSelector {
+    pub number: u64,
+    pub repository: Option<RepositoryIdentity>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChangeRequestIdentity {
+    pub repository: RepositoryIdentity,
+    pub number: u64,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(transparent)]
+pub struct GitObjectId(String);
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid full Git object ID: {0}")]
+pub struct GitObjectIdError(String);
+
+impl GitObjectId {
+    pub fn parse(value: impl Into<String>) -> Result<Self, GitObjectIdError> {
+        let value = value.into();
+        let valid_length = matches!(value.len(), 40 | 64);
+        let valid_hex = value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        if valid_length && valid_hex {
+            Ok(Self(value))
+        } else {
+            Err(GitObjectIdError(value))
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "state", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MergeOutcome {
+    Clean { tree: GitObjectId },
+    Conflicted {
+        tree: GitObjectId,
+        paths: Vec<String>,
+        conflict_digest: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevisionSet {
+    pub merge_base: GitObjectId,
+    pub pull_request_head: GitObjectId,
+    pub target_head: GitObjectId,
+    pub merge_outcome: MergeOutcome,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileChangeKind {
+    Added,
+    Modified,
+    Deleted,
+    Renamed,
+    Copied,
+    TypeChanged,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChangedFile {
+    pub kind: FileChangeKind,
+    pub old_path: Option<String>,
+    pub new_path: Option<String>,
+}
+
+impl ChangedFile {
+    #[must_use]
+    pub fn paths_are_repository_relative(&self) -> bool {
+        self.old_path
+            .iter()
+            .chain(self.new_path.iter())
+            .all(|path| is_safe_repository_path(path))
+    }
+}
+
+fn is_safe_repository_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.ends_with('/')
+        && !path.contains('\\')
+        && !path.contains('\0')
+        && !path
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+        && !path
+            .split('/')
+            .next()
+            .is_some_and(|component| component.ends_with(':'))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapturedChangeRequest {
+    pub identity: ChangeRequestIdentity,
+    pub revisions: RevisionSet,
+    pub base_branch: String,
+    pub head_branch: String,
+    pub changed_files: Vec<ChangedFile>,
+    pub changed_files_digest: String,
+}
+
+pub trait ChangeRequestSource: Send + Sync {
+    fn capture(
+        &self,
+        selector: &ChangeRequestSelector,
+    ) -> Result<CapturedChangeRequest, SourceError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SourceError {
+    #[error("[PRS2001] GitHub metadata is unavailable: {message}")]
+    GitHubMetadataUnavailable { message: String },
+    #[error("[PRS2002] GitHub metadata is malformed: {message}")]
+    MalformedGitHubMetadata { message: String },
+    #[error("[PRS2003] repository identity mismatch: expected {expected}, got {actual}")]
+    RepositoryMismatch { expected: String, actual: String },
+    #[error("[PRS2004] required Git object is missing locally: {object}")]
+    MissingGitObject { object: GitObjectId },
+    #[error("[PRS2005] Git revision resolution failed: {message}")]
+    RevisionResolution { message: String },
+    #[error("[PRS2006] changed-file evidence is invalid: {message}")]
+    InvalidChangedFiles { message: String },
+    #[error("[PRS2007] synthetic merge evaluation failed: {message}")]
+    MergeEvaluation { message: String },
+    #[error("[PRS2008] {program} returned non-UTF-8 {stream}")]
+    InvalidUtf8 {
+        program: String,
+        stream: &'static str,
+    },
+}
+
+impl SourceError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::GitHubMetadataUnavailable { .. } => "PRS2001",
+            Self::MalformedGitHubMetadata { .. } => "PRS2002",
+            Self::RepositoryMismatch { .. } => "PRS2003",
+            Self::MissingGitObject { .. } => "PRS2004",
+            Self::RevisionResolution { .. } => "PRS2005",
+            Self::InvalidChangedFiles { .. } => "PRS2006",
+            Self::MergeEvaluation { .. } => "PRS2007",
+            Self::InvalidUtf8 { .. } => "PRS2008",
+        }
+    }
+}
+```
+
+`GitObjectId::parse` accepts only lowercase hexadecimal Git object IDs of exactly 40 or 64 characters. Uppercase, abbreviated, symbolic, empty, or non-hex values fail.
+
+`RepositoryIdentity` has no public field constructor. Its constructor and custom deserializer reject unknown fields, invalid hosts, credentials, paths, whitespace, and invalid components. GitHub host, owner, and repository components normalize to lowercase so equality, hashing, ordering, report identity, CLI input, PR URLs, and local remotes use one canonical identity.
+
+### Foundation report in `compass-prs`
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalysisState {
+    FoundationPreview,
+    Complete,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Completeness {
+    LocalExact,
+    DownstreamComplete,
+    DownstreamPartial,
+    DownstreamUnavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceManifest {
+    pub schema: String,
+    pub request: ChangeRequestIdentity,
+    pub revisions: RevisionSet,
+    pub changed_files_digest: String,
+    pub snapshots: std::collections::BTreeMap<SnapshotRole, SnapshotEvidence>,
+    pub extractor_version: String,
+    pub extractor_config_digest: String,
+    pub policy_pack_digest: Option<String>,
+}
+
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotRole {
+    MergeBase,
+    PullRequestHead,
+    TargetHead,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SnapshotEvidence {
+    pub identity: compass_core::SnapshotIdentity,
+    pub schema_fingerprint: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrIntelligenceReport {
+    pub schema: String,
+    pub report_id: String,
+    pub state: AnalysisState,
+    pub request: ChangeRequestIdentity,
+    pub revisions: RevisionSet,
+    pub evidence_manifest: EvidenceManifest,
+    pub evidence_manifest_digest: String,
+    pub snapshots: std::collections::BTreeMap<SnapshotRole, SnapshotEvidence>,
+    pub completeness: Completeness,
+    pub repository_evidence: Vec<RepositoryEvidence>,
+    pub findings: Vec<Finding>,
+    pub risk: Option<RiskAssessment>,
+    pub gates: Vec<GateResult>,
+    pub failures: Vec<AnalysisFailure>,
+}
+```
+
+Task 2 defines `Finding`, `RiskAssessment`, `GateResult`, and `AnalysisFailure` as strict serializable types even though the foundation creates empty `findings`/`gates`, `risk: None`, and no failures on success. This reserves the approved schema without inventing verdicts.
+
+The strict report validator requires findings sorted uniquely by fingerprint, gates sorted uniquely by `(rule_id, rule_version)`, repository evidence sorted uniquely by `(role, repository)`, risk factors sorted uniquely by kind, and failures sorted by `(code, source, message)`. Every finding fingerprint must be `cmpprv1:<64 lowercase hex>`. `FoundationPreview` requires empty findings/gates, `risk: None`, and exactly one captured local repository record; `Complete` requires a risk assessment and is reserved for later children. These ordering and state rules make canonical report bytes independent of collection insertion order and prevent preview data from masquerading as a verdict.
+
+Reserve completeness detail without claiming downstream coverage:
+
+```rust
+#[derive(
+    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryRole {
+    Local,
+    Downstream,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationOutcome {
+    NotRequired,
+    Allowed,
+    Denied,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceFreshness {
+    Current,
+    Stale,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryEvidenceState {
+    Captured,
+    Complete,
+    Unavailable,
+    Unauthorized,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryEvidence {
+    pub repository: RepositoryIdentity,
+    pub role: RepositoryRole,
+    pub observed_default_head: Option<GitObjectId>,
+    pub graph_revision: Option<GitObjectId>,
+    pub freshness: EvidenceFreshness,
+    pub authorization: AuthorizationOutcome,
+    pub state: RepositoryEvidenceState,
+    pub failure_code: Option<String>,
+}
+```
+
+The foundation constructor emits exactly one `Local` record for the request repository, with target head as both observed default head and graph revision, `Current`, `NotRequired`, `Captured`, and no failure code. `Captured` means revision and snapshot provenance is exact; it does not claim semantic merge analysis is complete. The foundation emits no downstream records.
+
+`EvidenceManifest` is embedded so a report remains independently verifiable after transport or storage. Its custom deserializer requires `schema == EVIDENCE_MANIFEST_SCHEMA`. `PrIntelligenceReport` uses a raw helper plus `TryFrom` during deserialization to require `schema == REPORT_SCHEMA`, validate every digest and ID, verify the duplicated request/revisions/snapshots equal the embedded manifest, recompute the manifest digest, and recompute the report ID.
+
+### Foundation operation and persistence
+
+```rust
+pub trait ReportRepository: Send + Sync {
+    fn save(&self, report: &PrIntelligenceReport) -> Result<StoredReport, ReportStoreError>;
+    fn load(&self, report_id: &str) -> Result<PrIntelligenceReport, ReportStoreError>;
+}
+
+pub struct StoredReport {
+    pub report_id: String,
+    pub path: Option<std::path::PathBuf>,
+}
+
+pub struct FoundationOperation {
+    source: std::sync::Arc<dyn ChangeRequestSource>,
+    snapshots: std::sync::Arc<dyn compass_core::SnapshotProvider>,
+    reports: std::sync::Arc<dyn ReportRepository>,
+    extractor_version: String,
+    extractor_config_digest: String,
+}
+
+impl FoundationOperation {
+    pub fn new(
+        source: std::sync::Arc<dyn ChangeRequestSource>,
+        snapshots: std::sync::Arc<dyn compass_core::SnapshotProvider>,
+        reports: std::sync::Arc<dyn ReportRepository>,
+        extractor_version: String,
+        extractor_config_digest: String,
+    ) -> Result<Self, CanonicalError> {
+        if extractor_version.is_empty()
+            || extractor_version.chars().any(char::is_control)
+        {
+            return Err(CanonicalError::Contract(
+                "extractor version must be nonempty and contain no control characters"
+                    .to_owned(),
+            ));
+        }
+        validate_sha256_digest(&extractor_config_digest)?;
+        Ok(Self {
+            source,
+            snapshots,
+            reports,
+            extractor_version,
+            extractor_config_digest,
+        })
+    }
+
+    pub fn analyze(
+        &self,
+        selector: &ChangeRequestSelector,
+    ) -> Result<PrIntelligenceReport, OperationError>;
+}
+```
+
+The remaining shared errors have these exact contracts:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum CanonicalError {
+    #[error("canonical JSON serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid lowercase SHA-256 digest: {0}")]
+    InvalidDigest(String),
+    #[error("invalid PR Intelligence report ID: {0}")]
+    InvalidReportId(String),
+    #[error("report contract mismatch: {0}")]
+    Contract(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReportStoreError {
+    #[error("invalid report ID: {0}")]
+    InvalidReportId(String),
+    #[error("unsafe report path {path}: {reason}")]
+    UnsafePath { path: std::path::PathBuf, reason: String },
+    #[error("report exceeds the 64 MiB limit: {bytes} bytes")]
+    TooLarge { bytes: u64 },
+    #[error("report identity collision: {0}")]
+    IdentityCollision(String),
+    #[error("report was not found: {0}")]
+    NotFound(String),
+    #[error("report repository state is unavailable: {0}")]
+    State(String),
+    #[error("report contract is invalid: {0}")]
+    Contract(#[from] CanonicalError),
+    #[error("report I/O failed at {path}: {source}")]
+    Io {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OperationError {
+    #[error(transparent)]
+    Source(#[from] SourceError),
+    #[error("snapshot load failed for {role:?}: {source}")]
+    SnapshotLoad {
+        role: SnapshotRole,
+        #[source]
+        source: compass_core::SnapshotError,
+    },
+    #[error("snapshot identity mismatch for {role:?}: expected {expected}, got {actual}")]
+    SnapshotIdentity {
+        role: SnapshotRole,
+        expected: String,
+        actual: String,
+    },
+    #[error(transparent)]
+    Canonical(#[from] CanonicalError),
+    #[error(transparent)]
+    ReportStore(#[from] ReportStoreError),
+}
+
+impl OperationError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Source(source) => source.code(),
+            Self::SnapshotLoad { .. } => "PRS3001",
+            Self::SnapshotIdentity { .. } => "PRS3002",
+            Self::Canonical(_) => "PRS3003",
+            Self::ReportStore(_) => "PRS3004",
+        }
+    }
+}
+```
+
+`ReportStoreError::IdentityCollision` carries the textual `cmppr-report-v1:` ID. Public getters expose validated string forms without exposing mutable inner strings.
+
+## Test fixture contracts
+
+Test helpers are fully specified local support code:
+
+- `fixture_report(order)` constructs one fully valid `foundation_preview` report, inserting its three snapshot roles in the requested order before the production constructor canonicalizes them.
+- `fixture_report_json()` serializes that valid report to a mutable `serde_json::Value` for one-field corruption tests.
+- `fixture_manifest_json()` returns the valid embedded evidence manifest used by `fixture_report_json()`.
+- `FileSnapshotFixture` writes a guarded `graph.json` plus optional `.compass_learning.json` and exposes owned paths without changing process-global environment.
+- `GitFixture::diverged_clean_merge()` creates a temporary repository with a shared merge base, an advanced target, a divergent PR head, one modified `src/lib.rs`, and a stub `ProcessRunner` whose recorded argument vectors are exposed by `saw_arguments`.
+- `captured_fixture()` returns full lowercase OIDs and a canonical changed-file digest; `FakeSource` returns it once; `FakeSnapshots` maps its three commit selections to matching immutable snapshots.
+- `PreviewFixture::new()` creates a temporary repository, three complete history realizations, a fake `gh` executable on a fixture-scoped `PATH`, and helpers for invoking the built Compass binary and resolving a persisted report path.
+- `QualificationFixture` wraps `PreviewFixture`, can replace the captured head/target OID returned by fake `gh`, return one mismatched snapshot identity, create a conflicted merge, remove one preferred history realization, inject one report-store failpoint, create Unicode/control-character paths, generate one-byte-over-limit process/report values, place a symlink at a named store segment, and report the exact persisted files after retry.
+- `FakeAnalyzer` implements `PrIntelligenceAnalyzer`, returns one configured report or error, and exposes an atomic call count. `McpToolResultExt` decodes the typed structured report and exposes the protocol error flag without inspecting display text.
+- Hostile filesystem tests use test-only failpoints in `FilesystemReportRepository`, enabled through a private constructor under `cfg(test)`; production code has no environment-variable failpoints.
+
+## Task 1: Promote graph selection into one immutable snapshot module
+
+**Files:**
+
+- Create: `crates/compass-core/src/snapshot.rs`
+- Modify: `crates/compass-core/src/lib.rs`
+- Modify: `crates/compass-cli/src/lib.rs:3370-3646`
+- Create: `crates/compass-core/tests/snapshot.rs`
+- Modify: `crates/compass-core/Cargo.toml`
+- Modify: `Cargo.lock`
+
+**Interfaces:**
+
+- Consumes: `compass_model::{Graph, GraphDocument, SchemaFingerprint}` and existing `LoadedGraph`.
+- Produces: `GraphSelection`, `SnapshotIdentity`, `GraphSnapshot`, `SnapshotProvider`, `SnapshotError`, and `FileSnapshotProvider`.
+
+- [ ] **Step 1: Write failing snapshot identity and provider tests**
+
+Create `crates/compass-core/tests/snapshot.rs` with the exact fixture contract above and these tests:
+
+```rust
+use std::fs;
+
+use compass_core::{
+    FileSnapshotProvider, GraphSelection, SnapshotIdentity, SnapshotProvider,
+};
+
+#[test]
+fn file_snapshot_identity_is_content_addressed_and_schema_bound()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("graph.json");
+    fs::write(
+        &path,
+        br#"{"directed":true,"multigraph":false,"graph":{},"nodes":[{"id":"a","label":"A"}],"links":[]}"#,
+    )?;
+    let provider = FileSnapshotProvider;
+    let first = provider.load(&GraphSelection::File(path.clone()))?;
+    let second = provider.load(&GraphSelection::File(path.clone()))?;
+    assert_eq!(first.identity, second.identity);
+    assert_eq!(first.schema_fingerprint, first.graph.schema_fingerprint());
+    assert!(matches!(first.identity, SnapshotIdentity::File { .. }));
+
+    fs::write(
+        &path,
+        br#"{"directed":true,"multigraph":false,"graph":{},"nodes":[{"id":"b","label":"B"}],"links":[]}"#,
+    )?;
+    let changed = provider.load(&GraphSelection::File(path))?;
+    assert_ne!(first.identity, changed.identity);
+    Ok(())
+}
+
+#[test]
+fn file_snapshot_identity_includes_the_loaded_learning_overlay()
+-> Result<(), Box<dyn std::error::Error>> {
+    let fixture = FileSnapshotFixture::new()?;
+    let provider = FileSnapshotProvider;
+    let before = provider.load(&GraphSelection::File(fixture.graph_path()))?;
+    fixture.write_learning_overlay("node-a", "owner-a")?;
+    let after = provider.load(&GraphSelection::File(fixture.graph_path()))?;
+    assert_ne!(before.identity, after.identity);
+    assert_ne!(before.overlay, after.overlay);
+    Ok(())
+}
+
+#[test]
+fn file_provider_rejects_commit_selection() {
+    let error = FileSnapshotProvider
+        .load(&GraphSelection::Commit("a".repeat(40)))
+        .err()
+        .map(|error| error.to_string());
+    assert_eq!(
+        error.as_deref(),
+        Some("graph snapshot selection is unsupported by this adapter: commit")
+    );
+    let merge_error = FileSnapshotProvider
+        .load(&GraphSelection::SyntheticMerge {
+            target_head: "a".repeat(40),
+            pull_request_head: "b".repeat(40),
+            tree: "c".repeat(40),
+        })
+        .err()
+        .map(|error| error.to_string());
+    assert_eq!(
+        merge_error.as_deref(),
+        Some(
+            "graph snapshot selection is unsupported by this adapter: synthetic_merge"
+        )
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests and verify the shared interface is absent**
+
+Run:
+
+```bash
+cargo test -p compass-core --test snapshot
+```
+
+Expected: compilation fails because `FileSnapshotProvider`, `GraphSelection`, `SnapshotIdentity`, and `SnapshotProvider` are not exported.
+
+- [ ] **Step 3: Implement the shared snapshot module**
+
+Implement the shared interfaces exactly as declared above. Keep the existing tolerant `load_learning_overlay` unchanged for current query behavior, and add `load_learning_overlay_strict` for snapshot consumers; an absent sidecar means an empty overlay, while an existing unreadable or malformed sidecar is an error. `FileSnapshotProvider::load` performs these actions in order:
+
+1. Reject `GraphSelection::Commit`.
+2. Load one owned `GraphDocument` through the existing size, extension, cache-consistency, and JSON guards.
+3. Load one owned learning overlay through the strict helper.
+4. Recursively sort all JSON object keys in the document and overlay, serialize a `compass.graph_snapshot/1` semantic envelope, and hash those canonical bytes with SHA-256.
+5. Build `LoadedGraph::from_document`, install the already loaded overlay, and capture `graph.schema_fingerprint()`.
+6. Return one `Arc<GraphSnapshot>` containing exactly the semantic data covered by the digest.
+
+The central implementation has this shape:
+
+```rust
+use sha2::Digest as _;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FileSnapshotProvider;
+
+impl SnapshotProvider for FileSnapshotProvider {
+    fn load(
+        &self,
+        selection: &GraphSelection,
+    ) -> Result<std::sync::Arc<GraphSnapshot>, SnapshotError> {
+        let path = match selection {
+            GraphSelection::File(path) => path,
+            GraphSelection::Commit(_) => {
+                return Err(SnapshotError::Unsupported("commit".to_owned()));
+            }
+            GraphSelection::SyntheticMerge { .. } => {
+                return Err(SnapshotError::Unsupported(
+                    "synthetic_merge".to_owned(),
+                ));
+            }
+        };
+        let document = compass_model::GraphDocument::load(path)
+            .map_err(|error| SnapshotError::Corrupt(error.to_string()))?;
+        let overlay = crate::load_learning_overlay_strict(path)
+            .map_err(|error| SnapshotError::Corrupt(error.to_string()))?;
+        let identity_bytes = canonical_snapshot_bytes(&document, &overlay)
+            .map_err(|error| SnapshotError::Corrupt(error.to_string()))?;
+        let digest = sha2::Sha256::digest(&identity_bytes);
+        let mut loaded = crate::LoadedGraph::from_document(document, false)
+            .map_err(|error| SnapshotError::Corrupt(error.to_string()))?;
+        loaded.overlay = overlay;
+        let schema_fingerprint = loaded.graph.schema_fingerprint();
+        Ok(std::sync::Arc::new(GraphSnapshot {
+            graph: loaded.graph,
+            overlay: loaded.overlay,
+            schema_fingerprint,
+            identity: SnapshotIdentity::File {
+                sha256: lower_hex(&digest),
+            },
+        }))
+    }
+}
+```
+
+`canonical_snapshot_bytes` converts every `serde_json::Value::Object` into lexicographic key order recursively before serialization. `lower_hex` writes exactly two lowercase characters per byte without `unwrap`, `expect`, or `unsafe`. Add a regression test proving two semantically identical input documents with different object-key orders have the same file identity.
+
+Use these helper signatures and canonicalization:
+
+```rust
+type LearningOverlay =
+    std::collections::HashMap<String, serde_json::Map<String, serde_json::Value>>;
+
+fn load_learning_overlay_strict(
+    graph_path: &std::path::Path,
+) -> Result<LearningOverlay, SnapshotError>;
+
+fn canonical_snapshot_bytes(
+    document: &compass_model::GraphDocument,
+    overlay: &LearningOverlay,
+) -> Result<Vec<u8>, serde_json::Error> {
+    let mut value = serde_json::json!({
+        "schema": "compass.graph_snapshot/1",
+        "document": document,
+        "overlay": overlay,
+    });
+    sort_json_objects(&mut value);
+    serde_json::to_vec(&value)
+}
+
+fn sort_json_objects(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                sort_json_objects(value);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            let mut entries = std::mem::take(object)
+                .into_iter()
+                .collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            for (key, mut value) in entries {
+                sort_json_objects(&mut value);
+                object.insert(key, value);
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
+    }
+}
+```
+
+Implement `lower_hex(bytes: &[u8]) -> String` with `std::fmt::Write::write_fmt`; ignoring its infallible `String` formatting result is permitted and avoids forbidden `unwrap`/`expect`.
+
+- [ ] **Step 4: Replace the CLI-private selection enum**
+
+Delete the enum at `crates/compass-cli/src/lib.rs:3370-3374`, import `compass_core::GraphSelection`, and preserve the documented parser behavior. Add unit assertions covering `--graph`, `--at`, duplicate selectors, mixed selectors, and `--`.
+
+The production edit is deliberately limited to the type owner:
+
+```rust
+use compass_core::GraphSelection;
+
+// Delete the CLI-local GraphSelection declaration. Existing parser arms
+// continue constructing GraphSelection::File and GraphSelection::Commit.
+```
+
+Add an exhaustive `SyntheticMerge` arm to the existing `load_selected_graph` match that returns `"synthetic merge snapshots are not accepted by this command"`. No existing CLI parser constructs that variant.
+
+- [ ] **Step 5: Run focused behavior and lint checks**
+
+Run:
+
+```bash
+cargo test -p compass-core --test snapshot
+cargo test -p compass-cli --test history_cli
+cargo test -p compass-cli --test coverage_paths
+cargo clippy -p compass-core -p compass-cli --all-targets -- -D warnings
+```
+
+Expected: all commands pass; query/path/explain `--at` behavior and existing help remain unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-core crates/compass-cli/src/lib.rs crates/compass-cli/tests
+git commit -m "refactor(core): share immutable graph snapshots"
+```
+
+## Task 2: Add the strict versioned PR Intelligence report contract
+
+**Files:**
+
+- Create: `crates/compass-prs/src/model.rs`
+- Create: `crates/compass-prs/src/canonical.rs`
+- Modify: `crates/compass-prs/src/lib.rs`
+- Modify: `crates/compass-prs/Cargo.toml`
+- Modify: `Cargo.lock`
+- Create: `crates/compass-prs/tests/report_contract.rs`
+
+**Interfaces:**
+
+- Consumes: `compass_core::SnapshotIdentity`, Serde, and SHA-256.
+- Produces: every report/revision type in Shared public interfaces plus `canonical_report_bytes`, `evidence_manifest_digest`, `report_id`, `validate_report_id`, `validate_sha256_digest`, and `format_sha256_digest`.
+
+Add `compass-core = { path = "../compass-core", version = "0.1.0" }`, `serde.workspace = true`, `sha2.workspace = true`, and `url.workspace = true` to `compass-prs` dependencies.
+
+- [ ] **Step 1: Write failing schema and canonical identity tests**
+
+Create tests covering strict round-trip, unknown fields, stable ordering, and excluded operational data:
+
+```rust
+#[test]
+fn identical_foundation_evidence_has_identical_ids_and_bytes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let first = fixture_report(["head", "base", "target"]);
+    let second = fixture_report(["target", "head", "base"]);
+    assert_eq!(first.report_id, second.report_id);
+    assert_eq!(
+        compass_prs::canonical_report_bytes(&first)?,
+        compass_prs::canonical_report_bytes(&second)?
+    );
+    assert!(first.findings.is_empty());
+    assert!(first.risk.is_none());
+    assert!(first.gates.is_empty());
+    assert_eq!(first.state, AnalysisState::FoundationPreview);
+    Ok(())
+}
+
+#[test]
+fn report_and_manifest_reject_unknown_fields() {
+    let mut report = fixture_report_json();
+    report["unexpected"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<PrIntelligenceReport>(report).is_err());
+
+    let mut manifest = fixture_manifest_json();
+    manifest["unexpected"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<EvidenceManifest>(manifest).is_err());
+}
+
+#[test]
+fn report_rejects_wrong_schema_digest_identity_and_manifest_copies() {
+    let mut wrong_schema = fixture_report_json();
+    wrong_schema["schema"] = serde_json::json!("compass.pr_intelligence.report/2");
+    assert!(serde_json::from_value::<PrIntelligenceReport>(wrong_schema).is_err());
+
+    let mut wrong_digest = fixture_report_json();
+    wrong_digest["evidence_manifest_digest"] = serde_json::json!("c".repeat(64));
+    assert!(serde_json::from_value::<PrIntelligenceReport>(wrong_digest).is_err());
+
+    let mut wrong_id = fixture_report_json();
+    wrong_id["report_id"] =
+        serde_json::json!(format!("cmppr-report-v1:{}", "d".repeat(64)));
+    assert!(serde_json::from_value::<PrIntelligenceReport>(wrong_id).is_err());
+
+    let mut inconsistent_copy = fixture_report_json();
+    inconsistent_copy["request"]["repository"]["name"] =
+        serde_json::json!("different");
+    assert!(
+        serde_json::from_value::<PrIntelligenceReport>(inconsistent_copy).is_err()
+    );
+}
+```
+
+- [ ] **Step 2: Run and verify the report model is absent**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test report_contract
+```
+
+Expected: compilation fails because the report types and canonical functions do not exist.
+
+- [ ] **Step 3: Implement strict foundational types**
+
+Implement the shared types plus these exact supporting types:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingKind {
+    Architecture,
+    Impact,
+    Owner,
+    Test,
+    Overlap,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Exact,
+    Strong,
+    Moderate,
+    Weak,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidencePrecision {
+    Exact,
+    Inferred,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Finding {
+    pub fingerprint: String,
+    pub kind: FindingKind,
+    pub producer_id: String,
+    pub producer_version: String,
+    pub statement: String,
+    pub source_entities: Vec<String>,
+    pub target_entities: Vec<String>,
+    pub evidence: Vec<Evidence>,
+    pub confidence: Confidence,
+    pub completeness: Completeness,
+    pub freshness: EvidenceFreshness,
+    pub remediation: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Evidence {
+    pub source: String,
+    pub source_revision: String,
+    pub source_digest: String,
+    pub precision: EvidencePrecision,
+    pub freshness: EvidenceFreshness,
+    pub witness: Vec<WitnessHop>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WitnessHop {
+    pub source_id: String,
+    pub relation: String,
+    pub target_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskBand {
+    Low,
+    Moderate,
+    High,
+    Critical,
+}
+
+#[derive(
+    Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskFactorKind {
+    ContractSeverity,
+    Propagation,
+    Criticality,
+    VerificationGap,
+    ConcurrentExposure,
+    Uncertainty,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RiskFactor {
+    pub kind: RiskFactorKind,
+    pub severity: RiskBand,
+    pub statement: String,
+    pub evidence: Vec<Evidence>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RiskAssessment {
+    pub band: RiskBand,
+    pub factors: Vec<RiskFactor>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateState {
+    Pass,
+    Fail,
+    Indeterminate,
+    Error,
+    Pending,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GateResult {
+    pub rule_id: String,
+    pub rule_version: String,
+    pub state: GateState,
+    pub finding_fingerprint: Option<String>,
+    pub evidence: Vec<Evidence>,
+    pub explanation: String,
+    pub remediation: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnalysisFailure {
+    pub code: String,
+    pub message: String,
+    pub source: Option<String>,
+}
+```
+
+The foundation constructor is the only public constructor in this child:
+
+```rust
+impl PrIntelligenceReport {
+    pub fn foundation(
+        captured: &CapturedChangeRequest,
+        manifest: &EvidenceManifest,
+    ) -> Result<Self, CanonicalError> {
+        let evidence_manifest_digest = evidence_manifest_digest(manifest)?;
+        let report_id = report_id(
+            &captured.identity,
+            &captured.revisions,
+            &captured.changed_files_digest,
+            &evidence_manifest_digest,
+        )?;
+        Ok(Self {
+            schema: REPORT_SCHEMA.to_owned(),
+            report_id,
+            state: AnalysisState::FoundationPreview,
+            request: captured.identity.clone(),
+            revisions: captured.revisions.clone(),
+            evidence_manifest: manifest.clone(),
+            evidence_manifest_digest,
+            snapshots: manifest.snapshots.clone(),
+            completeness: Completeness::LocalExact,
+            repository_evidence: vec![RepositoryEvidence {
+                repository: captured.identity.repository.clone(),
+                role: RepositoryRole::Local,
+                observed_default_head: Some(
+                    captured.revisions.target_head.clone()
+                ),
+                graph_revision: Some(captured.revisions.target_head.clone()),
+                freshness: EvidenceFreshness::Current,
+                authorization: AuthorizationOutcome::NotRequired,
+                state: RepositoryEvidenceState::Captured,
+                failure_code: None,
+            }],
+            findings: Vec::new(),
+            risk: None,
+            gates: Vec::new(),
+            failures: Vec::new(),
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Implement canonical bytes and versioned identities**
+
+Use only structs, vectors, enums, and `BTreeMap` in identity-bearing data. Serialize with `serde_json::to_vec`; do not serialize `HashMap` or arbitrary object-valued `serde_json::Value` into identity.
+
+```rust
+pub fn canonical_report_bytes(
+    report: &PrIntelligenceReport,
+) -> Result<Vec<u8>, CanonicalError> {
+    serde_json::to_vec(report).map_err(CanonicalError::Json)
+}
+
+pub fn evidence_manifest_digest(
+    manifest: &EvidenceManifest,
+) -> Result<String, CanonicalError> {
+    let bytes = serde_json::to_vec(manifest).map_err(CanonicalError::Json)?;
+    Ok(lower_sha256(&bytes))
+}
+
+pub fn report_id(
+    request: &ChangeRequestIdentity,
+    revisions: &RevisionSet,
+    changed_files_digest: &str,
+    evidence_manifest_digest: &str,
+) -> Result<String, CanonicalError> {
+    #[derive(serde::Serialize)]
+    struct Identity<'a> {
+        schema: &'static str,
+        request: &'a ChangeRequestIdentity,
+        revisions: &'a RevisionSet,
+        changed_files_digest: &'a str,
+        evidence_manifest_digest: &'a str,
+    }
+    let bytes = serde_json::to_vec(&Identity {
+        schema: REPORT_ID_SCHEMA,
+        request,
+        revisions,
+        changed_files_digest,
+        evidence_manifest_digest,
+    })
+    .map_err(CanonicalError::Json)?;
+    Ok(format!("{REPORT_ID_SCHEMA}:{}", lower_sha256(&bytes)))
+}
+
+pub fn validate_report_id(value: &str) -> Result<(), CanonicalError> {
+    let Some(digest) = value.strip_prefix("cmppr-report-v1:") else {
+        return Err(CanonicalError::InvalidReportId(value.to_owned()));
+    };
+    validate_sha256_digest(digest)
+        .map_err(|_| CanonicalError::InvalidReportId(value.to_owned()))
+}
+
+#[must_use]
+pub fn format_sha256_digest(bytes: &[u8; 32]) -> String {
+    lower_hex(bytes)
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(*byte >> 4)]));
+        output.push(char::from(HEX[usize::from(*byte & 0x0f)]));
+    }
+    output
+}
+
+fn lower_sha256(bytes: &[u8]) -> String {
+    use sha2::Digest as _;
+    let digest: [u8; 32] = sha2::Sha256::digest(bytes).into();
+    format_sha256_digest(&digest)
+}
+
+pub fn validate_sha256_digest(value: &str) -> Result<(), CanonicalError> {
+    let valid = value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if valid {
+        Ok(())
+    } else {
+        Err(CanonicalError::InvalidDigest(value.to_owned()))
+    }
+}
+```
+
+`GitObjectId`, every digest field, and the report ID validate length, lowercase hexadecimal encoding, and prefixes at construction and deserialization. Implement shared validators rather than repeating regular expressions. The `TryFrom` report contract validates embedded-manifest consistency and rejects a valid-looking but incorrect `evidence_manifest_digest` or `report_id`.
+
+- [ ] **Step 5: Run tests, schema snapshot, and Clippy**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test report_contract
+cargo test -p compass-prs
+cargo clippy -p compass-prs --all-targets -- -D warnings
+```
+
+Expected: all pass; the checked JSON fixture uses schema `compass.pr_intelligence.report/1`, report IDs use `cmppr-report-v1:`, and the reserved finding fingerprint prefix remains `cmpprv1:`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-prs
+git commit -m "feat(prs): define versioned intelligence reports"
+```
+
+## Task 3: Capture exact GitHub pull-request revisions without mutating Git
+
+**Files:**
+
+- Create: `crates/compass-prs/src/source.rs`
+- Create: `crates/compass-prs/src/git.rs`
+- Modify: `crates/compass-prs/src/lib.rs`
+- Modify: `crates/compass-prs/src/model.rs`
+- Modify: `crates/compass-prs/Cargo.toml`
+- Create: `crates/compass-prs/tests/change_capture.rs`
+- Modify: `crates/compass-prs/tests/coverage_paths.rs`
+
+**Interfaces:**
+
+- Consumes: existing bounded `ProcessRunner`, `gh pr view`, and local Git object database.
+- Produces: `ChangeRequestSource`, `GitHubCliChangeRequestSource`, `CapturedChangeRequest`, strict Git parsing, and `SourceError` codes `PRS2001`–`PRS2008`.
+
+- [ ] **Step 1: Write failing exact-capture tests**
+
+Use a temporary real Git repository plus a stubbed GitHub response. Cover:
+
+- Full base/head OIDs are captured.
+- Merge base differs from an advanced target head.
+- Multiple best merge bases fail explicitly instead of choosing one arbitrarily.
+- Clean merge produces a tree OID.
+- Conflicted merge produces sorted unique paths.
+- Missing local head/base objects fail without invoking `git fetch`.
+- A local checkout whose GitHub remotes do not match the PR repository fails with `PRS2003`.
+- GitHub.com and GitHub Enterprise Server URLs produce distinct canonical repository identities.
+- Repository identity decoding rejects invalid or unknown fields and normalizes host, owner, and repository case.
+- Changed files distinguish add/modify/delete/rename.
+- Abbreviated, uppercase, malformed, or invalid UTF-8 evidence fails.
+
+The main acceptance assertion is:
+
+```rust
+#[test]
+fn capture_freezes_four_revision_identities_and_changed_files()
+-> Result<(), Box<dyn std::error::Error>> {
+    let fixture = GitFixture::diverged_clean_merge()?;
+    let runner = fixture.runner();
+    let source = GitHubCliChangeRequestSource::new(
+        runner,
+        fixture.repository_root().to_path_buf(),
+    );
+    let captured = source.capture(&ChangeRequestSelector {
+        number: 42,
+        repository: Some(RepositoryIdentity::github(
+            "github.com",
+            "acme",
+            "widgets",
+        )?),
+    })?;
+    assert_eq!(captured.identity.repository.slug(), "acme/widgets");
+    assert_eq!(
+        captured.revisions.merge_base,
+        GitObjectId::parse(fixture.merge_base())?
+    );
+    assert_eq!(
+        captured.revisions.pull_request_head,
+        GitObjectId::parse(fixture.head())?
+    );
+    assert_eq!(
+        captured.revisions.target_head,
+        GitObjectId::parse(fixture.target())?
+    );
+    assert!(matches!(
+        captured.revisions.merge_outcome,
+        MergeOutcome::Clean { .. }
+    ));
+    assert_eq!(
+        captured.changed_files,
+        vec![ChangedFile {
+            kind: FileChangeKind::Modified,
+            old_path: Some("src/lib.rs".to_owned()),
+            new_path: Some("src/lib.rs".to_owned()),
+        }]
+    );
+    assert!(!runner.saw_arguments(&["fetch"]));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run and verify exact capture is absent**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test change_capture
+```
+
+Expected: compilation fails because `GitHubCliChangeRequestSource` and exact capture types do not exist.
+
+- [ ] **Step 3: Make bounded process output strict UTF-8**
+
+Replace `String::from_utf8_lossy` in `run_bounded` with strict conversion. Extend `PrsError`:
+
+```rust
+#[error("{program} returned non-UTF-8 {stream}")]
+InvalidUtf8 {
+    program: String,
+    stream: &'static str,
+}
+```
+
+Use:
+
+```rust
+let stdout = String::from_utf8(stdout).map_err(|_| PrsError::InvalidUtf8 {
+    program: program.to_owned(),
+    stream: "stdout",
+})?;
+let stderr = String::from_utf8(stderr).map_err(|_| PrsError::InvalidUtf8 {
+    program: program.to_owned(),
+    stream: "stderr",
+})?;
+```
+
+Update existing tests to prove Unicode PR titles still pass and invalid byte sequences fail instead of being replaced.
+
+- [ ] **Step 4: Implement exact local Git operations**
+
+`git.rs` exposes:
+
+```rust
+pub(crate) fn verify_commit(
+    runner: &dyn ProcessRunner,
+    root: &std::path::Path,
+    object: &GitObjectId,
+) -> Result<(), SourceError>;
+
+pub(crate) fn merge_base(
+    runner: &dyn ProcessRunner,
+    root: &std::path::Path,
+    target: &GitObjectId,
+    head: &GitObjectId,
+) -> Result<GitObjectId, SourceError>;
+
+pub(crate) fn merge_outcome(
+    runner: &dyn ProcessRunner,
+    root: &std::path::Path,
+    target: &GitObjectId,
+    head: &GitObjectId,
+) -> Result<MergeOutcome, SourceError>;
+
+pub(crate) fn changed_files(
+    runner: &dyn ProcessRunner,
+    root: &std::path::Path,
+    base: &GitObjectId,
+    head: &GitObjectId,
+) -> Result<Vec<ChangedFile>, SourceError>;
+```
+
+Every command uses `git -C ROOT`, `--end-of-options` where supported, and exact OIDs. `verify_commit` runs `git cat-file -e <oid>^{commit}`. `merge_base` runs `git merge-base --all TARGET HEAD` and requires exactly one full OID; zero or multiple best bases return `PRS2005` instead of selecting ambiguous intent. `merge_outcome` runs `git merge-tree --write-tree -z --name-only TARGET HEAD` without `--messages`; exit `0` requires exactly one NUL-delimited tree-OID record, while exit `1` parses that tree OID followed only by conflicted path records. The conflicted form retains both the tree OID and a SHA-256 digest of the canonical sorted paths, so the fourth revision always has an immutable identity. Other exits are errors. Detect an unsupported option or subcommand and return `PRS2007` with the required command and installed `git --version`; do not parse localized human prose as conflict evidence.
+
+`changed_files` runs:
+
+```text
+git -C ROOT diff --name-status -z --find-renames --find-copies BASE HEAD --
+```
+
+The parser consumes NUL-separated fields and rejects truncated records, unsupported status letters, path traversal, absolute paths, embedded NUL, and empty paths. Sort by `(new_path, old_path, kind)` before hashing.
+
+Map status records exactly: `A` to `(None, Some(new))`, `D` to `(Some(old), None)`, `M`/`T` to the same path in both fields, and `R0..R100`/`C0..C100` to separate old/new paths. Reject unmerged `U`, combined-diff records, missing or out-of-range similarity scores, and any unexpected extra field.
+
+Hash changed files as the canonical JSON encoding of:
+
+```rust
+#[derive(serde::Serialize)]
+struct ChangedFilesIdentity<'a> {
+    schema: &'static str, // "compass.pr_intelligence.changed_files/1"
+    files: &'a [ChangedFile],
+}
+```
+
+The digest is exactly 64 lowercase hexadecimal characters and covers the sorted, normalized records.
+
+- [ ] **Step 5: Implement the GitHub CLI source adapter**
+
+The adapter runs exactly one metadata request:
+
+```text
+gh pr view NUMBER --json number,baseRefName,headRefName,baseRefOid,headRefOid,url
+```
+
+Append `--repo REPOSITORY_IDENTITY.gh_repo_argument()` only when selected. Derive the canonical repository from the PR URL and require it to equal the explicit selector when present.
+
+The adapter then:
+
+1. Parses full target/head OIDs.
+2. Verifies both objects exist locally.
+3. Computes merge base.
+4. Computes changed files from merge base to head.
+5. Computes the synthetic merge tree from target head and PR head.
+6. Hashes canonical changed-file bytes.
+7. Returns one immutable `CapturedChangeRequest`.
+
+Use this exact response boundary and adapter ownership:
+
+```rust
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GitHubPullRequest {
+    number: u64,
+    base_ref_name: String,
+    head_ref_name: String,
+    base_ref_oid: String,
+    head_ref_oid: String,
+    url: String,
+}
+
+pub struct GitHubCliChangeRequestSource {
+    runner: std::sync::Arc<dyn ProcessRunner + Send + Sync>,
+    repository_root: std::path::PathBuf,
+}
+
+impl GitHubCliChangeRequestSource {
+    pub fn new(
+        runner: std::sync::Arc<dyn ProcessRunner + Send + Sync>,
+        repository_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            runner,
+            repository_root,
+        }
+    }
+}
+```
+
+Private helper contracts are:
+
+```rust
+fn fetch_metadata(
+    runner: &(dyn ProcessRunner + Send + Sync),
+    selector: &ChangeRequestSelector,
+) -> Result<GitHubPullRequest, SourceError>;
+
+fn repository_from_pull_url(
+    url: &str,
+) -> Result<(RepositoryIdentity, u64), SourceError>;
+
+fn require_selected_repository(
+    selected: Option<&RepositoryIdentity>,
+    actual: &RepositoryIdentity,
+) -> Result<(), SourceError>;
+
+fn require_local_repository(
+    runner: &(dyn ProcessRunner + Send + Sync),
+    repository_root: &std::path::Path,
+    actual: &RepositoryIdentity,
+) -> Result<(), SourceError>;
+
+fn changed_files_digest(files: &[ChangedFile]) -> Result<String, SourceError>;
+```
+
+Before this body continues, `fetch_metadata` requires `metadata.number == selector.number`, and `repository_from_pull_url` returns both repository and URL PR number so the URL must agree as well. The implementation body is:
+
+```rust
+fn capture(
+    &self,
+    selector: &ChangeRequestSelector,
+) -> Result<CapturedChangeRequest, SourceError> {
+    let metadata = fetch_metadata(self.runner.as_ref(), selector)?;
+    let (repository, url_number) = repository_from_pull_url(&metadata.url)?;
+    if metadata.number != selector.number || url_number != selector.number {
+        return Err(SourceError::MalformedGitHubMetadata {
+            message: "selected, returned, and URL PR numbers differ".to_owned(),
+        });
+    }
+    require_selected_repository(selector.repository.as_ref(), &repository)?;
+    require_local_repository(
+        self.runner.as_ref(),
+        &self.repository_root,
+        &repository,
+    )?;
+    let target = GitObjectId::parse(&metadata.base_ref_oid).map_err(|error| {
+        SourceError::MalformedGitHubMetadata {
+            message: error.to_string(),
+        }
+    })?;
+    let head = GitObjectId::parse(&metadata.head_ref_oid).map_err(|error| {
+        SourceError::MalformedGitHubMetadata {
+            message: error.to_string(),
+        }
+    })?;
+    verify_commit(self.runner.as_ref(), &self.repository_root, &target)?;
+    verify_commit(self.runner.as_ref(), &self.repository_root, &head)?;
+    let base = merge_base(
+        self.runner.as_ref(),
+        &self.repository_root,
+        &target,
+        &head,
+    )?;
+    let files = changed_files(
+        self.runner.as_ref(),
+        &self.repository_root,
+        &base,
+        &head,
+    )?;
+    let changed_files_digest = changed_files_digest(&files)?;
+    let merge_outcome = merge_outcome(
+        self.runner.as_ref(),
+        &self.repository_root,
+        &target,
+        &head,
+    )?;
+    Ok(CapturedChangeRequest {
+        identity: ChangeRequestIdentity {
+            repository,
+            number: metadata.number,
+        },
+        revisions: RevisionSet {
+            merge_base: base,
+            pull_request_head: head,
+            target_head: target,
+            merge_outcome,
+        },
+        base_branch: metadata.base_ref_name,
+        head_branch: metadata.head_ref_name,
+        changed_files: files,
+        changed_files_digest,
+    })
+}
+```
+
+`repository_from_pull_url` uses workspace `url::Url`, accepts only `https`, no credentials/query/fragment, and exactly the four path components `<owner>/<repository>/pull/<number>`. It canonicalizes the URL hostname and optional port through `RepositoryIdentity::github`. The adapter supports GitHub.com and configured GitHub Enterprise Server hosts. It compares the canonical host/owner/name identity to an explicit selector.
+
+`require_local_repository` runs `git -C ROOT remote`, then
+`git -C ROOT remote get-url --all REMOTE` for each returned name. It parses GitHub HTTPS and SCP-like SSH URLs without invoking a shell, removes one terminal `.git` suffix from the repository path, and requires at least one remote to match the canonical PR hostname, owner, and repository identity. Missing, malformed-only, or nonmatching remotes return `PRS2003`; the diagnostic lists remote names but never credentials or full remote URLs.
+
+Map errors to stable codes:
+
+```text
+PRS2001 GitHub metadata unavailable
+PRS2002 malformed GitHub metadata
+PRS2003 repository identity mismatch
+PRS2004 required Git object missing locally
+PRS2005 Git revision resolution failed
+PRS2006 changed-file evidence invalid
+PRS2007 synthetic merge evaluation failed
+PRS2008 invalid UTF-8 evidence
+```
+
+- [ ] **Step 6: Run focused capture, PR command, and lint tests**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test change_capture
+cargo test -p compass-prs --test coverage_paths
+cargo test -p compass-cli --test prs_cli
+cargo clippy -p compass-prs --all-targets -- -D warnings
+```
+
+Expected: all pass; no test observes an implicit fetch, checkout, ref update, or hook.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-prs
+git commit -m "feat(prs): capture exact pull request revisions"
+```
+
+## Task 4: Build one immutable evidence manifest and foundation operation
+
+**Files:**
+
+- Create: `crates/compass-prs/src/operation.rs`
+- Modify: `crates/compass-prs/src/model.rs`
+- Modify: `crates/compass-prs/src/canonical.rs`
+- Modify: `crates/compass-prs/src/lib.rs`
+- Create: `crates/compass-prs/tests/foundation_operation.rs`
+
+**Interfaces:**
+
+- Consumes: `ChangeRequestSource`, `SnapshotProvider`, the strict report model, and `ReportRepository`.
+- Produces: `FoundationOperation`, `OperationError`, `MemoryReportRepository`, and immutable evidence/report construction.
+
+- [ ] **Step 1: Write failing orchestration tests with real seams**
+
+Create one fake source, one fake snapshot provider, and an in-memory report repository. Assert:
+
+- Capture occurs once.
+- Each of merge base, PR head, and target head loads once.
+- All loads use full commit OIDs from the captured request.
+- Snapshot identities must contain the requested commit.
+- A changed source response after capture cannot affect the in-flight report.
+- Any snapshot failure returns an operation error and persists nothing.
+- Success persists exactly one foundation report with no verdict fields populated.
+
+```rust
+#[test]
+fn operation_captures_once_loads_exact_snapshots_and_persists_no_verdict()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = Arc::new(FakeSource::new(captured_fixture()));
+    let snapshots = Arc::new(FakeSnapshots::for_captured(source.current()));
+    let reports = Arc::new(MemoryReportRepository::default());
+    let operation = FoundationOperation::new(
+        source.clone(),
+        snapshots.clone(),
+        reports.clone(),
+        "0.1.0".to_owned(),
+        "a".repeat(64),
+    )?;
+    let report = operation.analyze(&ChangeRequestSelector {
+        number: 42,
+        repository: Some(RepositoryIdentity::github(
+            "github.com",
+            "acme",
+            "widgets",
+        )?),
+    })?;
+    assert_eq!(source.capture_count(), 1);
+    assert_eq!(
+        snapshots.selections(),
+        vec![
+            GraphSelection::Commit(source.current().revisions.merge_base.to_string()),
+            GraphSelection::Commit(
+                source.current().revisions.pull_request_head.to_string()
+            ),
+            GraphSelection::Commit(source.current().revisions.target_head.to_string()),
+        ]
+    );
+    assert_eq!(report.state, AnalysisState::FoundationPreview);
+    assert!(report.findings.is_empty());
+    assert!(report.risk.is_none());
+    assert!(report.gates.is_empty());
+    assert_eq!(reports.saved_ids()?, vec![report.report_id.clone()]);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run and verify the operation is absent**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test foundation_operation
+```
+
+Expected: compilation fails because `FoundationOperation` and `MemoryReportRepository` do not exist.
+
+- [ ] **Step 3: Define the report repository seam and memory adapter**
+
+Add `ReportRepository`, `StoredReport`, and `ReportStoreError` to `operation.rs` or `report_store.rs`; export them from `lib.rs`. The in-memory adapter stores canonical bytes in a `Mutex<BTreeMap<String, Vec<u8>>>`, rejects duplicate IDs with different bytes, and deserializes through the strict report schema.
+
+The duplicate rule is:
+
+```rust
+match reports.get(&report.report_id) {
+    Some(existing) if existing == &bytes => Ok(existing result),
+    Some(_) => Err(ReportStoreError::IdentityCollision(report.report_id.clone())),
+    None => insert and return,
+}
+```
+
+Implement the in-memory adapter with this storage boundary:
+
+```rust
+#[derive(Default)]
+pub struct MemoryReportRepository {
+    reports: std::sync::Mutex<std::collections::BTreeMap<String, Vec<u8>>>,
+}
+
+impl MemoryReportRepository {
+    pub fn saved_ids(&self) -> Result<Vec<String>, ReportStoreError> {
+        self.reports
+            .lock()
+            .map(|reports| reports.keys().cloned().collect())
+            .map_err(|_| ReportStoreError::State("report lock poisoned".to_owned()))
+    }
+}
+
+impl ReportRepository for MemoryReportRepository {
+    fn save(
+        &self,
+        report: &PrIntelligenceReport,
+    ) -> Result<StoredReport, ReportStoreError> {
+        let bytes = canonical_report_bytes(report)?;
+        let mut reports = self.reports.lock().map_err(|_| {
+            ReportStoreError::State("report lock poisoned".to_owned())
+        })?;
+        match reports.get(&report.report_id) {
+            Some(existing) if existing == &bytes => {}
+            Some(_) => {
+                return Err(ReportStoreError::IdentityCollision(
+                    report.report_id.clone(),
+                ));
+            }
+            None => {
+                reports.insert(report.report_id.clone(), bytes);
+            }
+        }
+        Ok(StoredReport {
+            report_id: report.report_id.clone(),
+            path: None,
+        })
+    }
+
+    fn load(
+        &self,
+        report_id: &str,
+    ) -> Result<PrIntelligenceReport, ReportStoreError> {
+        crate::validate_report_id(report_id)?;
+        let reports = self.reports.lock().map_err(|_| {
+            ReportStoreError::State("report lock poisoned".to_owned())
+        })?;
+        let bytes = reports
+            .get(report_id)
+            .ok_or_else(|| ReportStoreError::NotFound(report_id.to_owned()))?;
+        serde_json::from_slice(bytes)
+            .map_err(CanonicalError::Json)
+            .map_err(ReportStoreError::Contract)
+    }
+}
+```
+
+- [ ] **Step 4: Implement foundation orchestration**
+
+The operation:
+
+1. Calls `source.capture` exactly once.
+2. Constructs three `GraphSelection::Commit` values from the captured OIDs.
+3. Loads snapshots in deterministic role order.
+4. Verifies every `SnapshotIdentity::Commit.commit` equals its requested OID.
+5. Creates an `EvidenceManifest` with an ordered `BTreeMap<SnapshotRole, SnapshotEvidence>` containing each validated identity and `schema_fingerprint.to_hex()`.
+6. Creates `PrIntelligenceReport::foundation`.
+7. Persists the report.
+8. Returns the same report object.
+
+The core helper is:
+
+```rust
+fn require_commit_identity(
+    role: SnapshotRole,
+    expected: &GitObjectId,
+    snapshot: &compass_core::GraphSnapshot,
+) -> Result<(), OperationError> {
+    match &snapshot.identity {
+        compass_core::SnapshotIdentity::Commit { commit, .. }
+            if commit == expected.as_str() =>
+        {
+            Ok(())
+        }
+        actual => Err(OperationError::SnapshotIdentity {
+            role,
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        }),
+    }
+}
+```
+
+Do not load a merge-result graph in this child. Preserve the exact synthetic tree in `RevisionSet`, keep `state: foundation_preview`, and emit no risk or gate.
+
+`FoundationOperation::new` validates `extractor_version` as nonempty UTF-8 without control characters and `extractor_config_digest` as 64 lowercase hexadecimal characters. `analyze` inserts roles in the fixed order `MergeBase`, `PullRequestHead`, `TargetHead`, creates `SnapshotEvidence { identity, schema_fingerprint: snapshot.schema_fingerprint.to_hex() }`, constructs the manifest with `policy_pack_digest: None`, and calls the repository only after all validations succeed.
+
+- [ ] **Step 5: Run orchestration, model, and lint checks**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test foundation_operation
+cargo test -p compass-prs --test report_contract
+cargo clippy -p compass-prs --all-targets -- -D warnings
+```
+
+Expected: all pass; failure tests prove no partial report is persisted.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/compass-prs
+git commit -m "feat(prs): orchestrate foundation evidence"
+```
+
+## Task 5: Persist canonical reports safely below the Git common directory
+
+**Files:**
+
+- Create: `crates/compass-prs/src/report_store.rs`
+- Modify: `crates/compass-prs/src/lib.rs`
+- Modify: `crates/compass-prs/src/operation.rs`
+- Modify: `crates/compass-prs/Cargo.toml`
+- Create: `crates/compass-prs/tests/report_store.rs`
+- Modify: `crates/compass-prs/Cargo.toml` to move workspace `tempfile` from dev-only to production dependencies
+
+**Interfaces:**
+
+- Consumes: `ReportRepository`, `canonical_report_bytes`, and an explicit canonical Git common directory.
+- Produces: `FilesystemReportRepository::{new, save, load, report_path}`.
+
+- [ ] **Step 1: Write failing persistence and hostile-path tests**
+
+Cover:
+
+- Save/load round trip.
+- Idempotent save of identical bytes.
+- Collision rejection for same ID with different bytes.
+- Owner-only directory/file mode on Unix.
+- Symlink rejection at `compass`, `pr-intelligence`, `reports`, destination, and temporary path.
+- Truncated, oversized, corrupt, and unknown-schema reports.
+- An injected failure before no-clobber persistence leaves no visible report; retry creates one complete report.
+- Paths never escape the canonical common directory.
+
+```rust
+#[test]
+fn report_store_is_idempotent_atomic_and_confined()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let common = directory.path().canonicalize()?;
+    let store = FilesystemReportRepository::new(&common)?;
+    let report = fixture_report();
+    let first = store.save(&report)?;
+    let second = store.save(&report)?;
+    assert_eq!(first.report_id, second.report_id);
+    assert_eq!(first.path, second.path);
+    assert_eq!(store.load(&report.report_id)?, report);
+    let path = first.path.ok_or("missing persisted path")?;
+    assert!(path.starts_with(common.join("compass/pr-intelligence/reports")));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run and verify filesystem persistence is absent**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test report_store
+```
+
+Expected: compilation fails because `FilesystemReportRepository` does not exist.
+
+- [ ] **Step 3: Implement confined owner-only storage**
+
+Store each report at
+`<git-common-dir>/compass/pr-intelligence/reports/<cmppr-report-v1-64hex>.json`.
+
+Replace the colon in the filename with a hyphen. The JSON body retains the canonical `cmppr-report-v1:` report ID.
+
+`new` requires the supplied Git common directory to exist, be a directory, be nonsymlinked, and canonicalize to itself. Create descendants one segment at a time, checking each with `symlink_metadata`.
+
+On Unix, create directories with `0700` and files with `0600`. On every platform:
+
+1. Reject symlink destinations.
+2. Serialize before opening the filesystem.
+3. Reject bytes above `64 * 1024 * 1024`.
+4. Write to a `tempfile::NamedTempFile` created inside the validated reports directory.
+5. Flush and `sync_all`.
+6. Call `persist_noclobber` within the same directory so concurrent writers cannot replace an existing immutable report.
+7. Sync the parent directory where supported.
+8. Remove only the exact validated temporary file on failure.
+
+Do not use `compass_files::write_bytes_atomic` here because that helper resolves destination symlinks.
+
+The production store has this shape:
+
+```rust
+const MAX_REPORT_BYTES: u64 = 64 * 1024 * 1024;
+
+pub struct FilesystemReportRepository {
+    common_dir: std::path::PathBuf,
+    reports_dir: std::path::PathBuf,
+}
+
+impl FilesystemReportRepository {
+    pub fn new(common_dir: &std::path::Path) -> Result<Self, ReportStoreError> {
+        reject_existing_symlink(common_dir)?;
+        let canonical = common_dir.canonicalize().map_err(|source| {
+            report_io(common_dir, source)
+        })?;
+        if canonical != common_dir {
+            return Err(ReportStoreError::UnsafePath {
+                path: common_dir.to_path_buf(),
+                reason: "Git common directory must be canonical".to_owned(),
+            });
+        }
+        let compass = canonical.join("compass");
+        let intelligence = compass.join("pr-intelligence");
+        let reports = intelligence.join("reports");
+        for path in [&compass, &intelligence, &reports] {
+            create_owner_directory(path)?;
+        }
+        Ok(Self {
+            common_dir: canonical,
+            reports_dir: reports,
+        })
+    }
+
+    pub fn report_path(
+        &self,
+        report_id: &str,
+    ) -> Result<std::path::PathBuf, ReportStoreError> {
+        crate::validate_report_id(report_id)?;
+        let file_name = format!("{}.json", report_id.replace(':', "-"));
+        let path = self.reports_dir.join(file_name);
+        if !path.starts_with(&self.common_dir) {
+            return Err(ReportStoreError::UnsafePath {
+                path,
+                reason: "report path escaped Git common directory".to_owned(),
+            });
+        }
+        Ok(path)
+    }
+}
+```
+
+Define `reject_existing_symlink`, `create_owner_directory`, `set_owner_file`, `report_io`, and `sync_directory` as private functions in this module. Reuse `crate::validate_report_id` from Task 2. Each filesystem helper accepts the exact path it checks and returns `ReportStoreError`; none resolves or follows a report destination symlink.
+
+- [ ] **Step 4: Implement strict load and collision handling**
+
+`load` validates the report ID before constructing a path, rejects files above 64 MiB, deserializes with `deny_unknown_fields`, reserializes canonically, recomputes `report_id`, and rejects any mismatch.
+
+If `save` finds an existing destination, load and compare canonical bytes. Return success for identical bytes and `IdentityCollision` otherwise. If `persist_noclobber` loses a concurrent race, perform the same comparison against the winner; never replace it.
+
+```rust
+fn compare_existing(
+    store: &FilesystemReportRepository,
+    report: &PrIntelligenceReport,
+    expected: &[u8],
+) -> Result<StoredReport, ReportStoreError> {
+    let actual = store.load(&report.report_id)?;
+    let actual_bytes = canonical_report_bytes(&actual)?;
+    if actual_bytes == expected {
+        Ok(StoredReport {
+            report_id: report.report_id.clone(),
+            path: Some(store.report_path(&report.report_id)?),
+        })
+    } else {
+        Err(ReportStoreError::IdentityCollision(
+            report.report_id.clone(),
+        ))
+    }
+}
+```
+
+The no-clobber write path is:
+
+```rust
+let bytes = canonical_report_bytes(report)?;
+let byte_count = u64::try_from(bytes.len()).map_err(|_| {
+    ReportStoreError::TooLarge { bytes: u64::MAX }
+})?;
+if byte_count > MAX_REPORT_BYTES {
+    return Err(ReportStoreError::TooLarge {
+        bytes: byte_count,
+    });
+}
+let destination = self.report_path(&report.report_id)?;
+if destination.exists() {
+    return compare_existing(self, report, &bytes);
+}
+let mut temporary = tempfile::NamedTempFile::new_in(&self.reports_dir)
+    .map_err(|source| report_io(&self.reports_dir, source))?;
+set_owner_file(temporary.path())?;
+std::io::Write::write_all(&mut temporary, &bytes)
+    .map_err(|source| report_io(temporary.path(), source))?;
+temporary
+    .as_file()
+    .sync_all()
+    .map_err(|source| report_io(temporary.path(), source))?;
+match temporary.persist_noclobber(&destination) {
+    Ok(_) => {
+        sync_directory(&self.reports_dir)?;
+        Ok(StoredReport {
+            report_id: report.report_id.clone(),
+            path: Some(destination),
+        })
+    }
+    Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+        compare_existing(self, report, &bytes)
+    }
+    Err(error) => Err(report_io(&destination, error.error)),
+}
+```
+
+- [ ] **Step 5: Run persistence, Miri, and lint checks**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test report_store
+cargo test -p compass-prs
+cargo clippy -p compass-prs --all-targets -- -D warnings
+```
+
+On a toolchain with Miri installed, additionally run:
+
+```bash
+cargo miri test -p compass-prs --test report_store
+```
+
+Expected: all available commands pass; skipping unavailable Miri is recorded in the task handoff rather than treated as a test failure.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-prs
+git commit -m "feat(prs): persist canonical intelligence reports"
+```
+
+## Task 6: Add the production history snapshot adapter and preview
+
+**Files:**
+
+- Create: `crates/compass-cli/src/snapshot_provider.rs`
+- Modify: `crates/compass-cli/src/history_commands.rs:63-83`
+- Modify: `crates/compass-cli/src/lib.rs`
+- Modify: `crates/compass-cli/src/prs_commands.rs`
+- Modify: `crates/compass-cli/Cargo.toml`
+- Create: `crates/compass-cli/tests/prs_intelligence_preview.rs`
+- Modify: `crates/compass-cli/tests/prs_cli.rs`
+
+**Interfaces:**
+
+- Consumes: `GraphSelection`, `SnapshotProvider`, `HistoryStore`, `FoundationOperation`, `GitHubCliChangeRequestSource`, and `FilesystemReportRepository`.
+- Produces: `CliSnapshotProvider` and `compass prs NUMBER --intelligence-preview --format json`.
+
+- [ ] **Step 1: Write failing end-to-end preview tests**
+
+Create a temporary real Git repository with diverged target/head commits and a fake `gh` executable that returns their full OIDs. Assert:
+
+- The Compass command succeeds and emits one canonical report object.
+- Report state is `foundation_preview`.
+- The three snapshot commit identities match merge base/head/target.
+- Synthetic merge tree is present in revisions.
+- Findings, risk, and gates contain no verdict.
+- The report is persisted below the Git common directory.
+- Preview requires exactly one PR number and `--format json`.
+- Existing Compass PR commands continue to pass their behavior tests.
+
+```rust
+#[test]
+fn compass_preview_emits_exact_foundation_report_without_a_verdict()
+-> Result<(), Box<dyn std::error::Error>> {
+    let fixture = PreviewFixture::new()?;
+    let output = fixture.run_compass(&[
+        "prs",
+        &fixture.pr_number().to_string(),
+        "--intelligence-preview",
+        "--format",
+        "json",
+    ])?;
+    assert_eq!(output.status.code(), Some(0));
+    let report: compass_prs::PrIntelligenceReport =
+        serde_json::from_slice(&output.stdout)?;
+    assert_eq!(report.state, compass_prs::AnalysisState::FoundationPreview);
+    assert!(report.findings.is_empty());
+    assert!(report.risk.is_none());
+    assert!(report.gates.is_empty());
+    assert!(fixture.persisted_report(&report.report_id).is_file());
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run and verify production wiring is absent**
+
+Run:
+
+```bash
+cargo test -p compass-cli --test prs_intelligence_preview
+```
+
+Expected: compilation or assertion failure because the preview flag and production snapshot provider do not exist.
+
+- [ ] **Step 3: Implement `CliSnapshotProvider`**
+
+`File` delegates to `FileSnapshotProvider`. `Commit`:
+
+1. Discovers the current `Repository`.
+2. Resolves the revision to full `CommitId`.
+3. Uses the existing configured history build options.
+4. Resolves or materializes one complete preferred realization.
+5. Holds one history activity guard through validation and reconstruction.
+6. Builds `LoadedGraph::from_document`.
+7. Returns `SnapshotIdentity::Commit { commit, realization }`.
+
+Refactor `history_commands::load_graph_at` to call the same internal loader used by `CliSnapshotProvider`; query/path/explain and PR Intelligence must not maintain two materialization paths.
+
+The returned identity uses `preferred.id.as_hex()` and `preferred.version.git_commit`. It never uses the caller's unresolved revision string.
+
+Use one provider instance bound to one discovered repository and build profile:
+
+```rust
+pub(crate) struct CliSnapshotProvider {
+    repository: compass_history::Repository,
+    options: crate::history_build::HistoryBuildOptions,
+    files: compass_core::FileSnapshotProvider,
+}
+
+impl CliSnapshotProvider {
+    pub(crate) fn new(
+        repository: compass_history::Repository,
+        options: crate::history_build::HistoryBuildOptions,
+    ) -> Self {
+        Self {
+            repository,
+            options,
+            files: compass_core::FileSnapshotProvider,
+        }
+    }
+}
+
+impl compass_core::SnapshotProvider for CliSnapshotProvider {
+    fn load(
+        &self,
+        selection: &compass_core::GraphSelection,
+    ) -> Result<std::sync::Arc<compass_core::GraphSnapshot>, compass_core::SnapshotError> {
+        match selection {
+            compass_core::GraphSelection::File(_) => self.files.load(selection),
+            compass_core::GraphSelection::Commit(revision) => {
+                crate::history_commands::load_snapshot_at(
+                    &self.repository,
+                    revision,
+                    &self.options,
+                    false,
+                )
+                .map(std::sync::Arc::new)
+            }
+            compass_core::GraphSelection::SyntheticMerge { .. } => {
+                Err(compass_core::SnapshotError::Unsupported(
+                    "synthetic_merge".to_owned(),
+                ))
+            }
+        }
+    }
+}
+```
+
+`load_snapshot_at` resolves `revision` to `CommitId`, calls the existing `resolve_or_materialize`, opens one activity guard, validates and reconstructs the preferred realization under that guard, computes the schema fingerprint, and returns an `Arc<GraphSnapshot>` with an empty historical overlay and the full commit/realization identity.
+
+Its shared internal signature is:
+
+```rust
+pub(crate) fn load_snapshot_at(
+    repository: &compass_history::Repository,
+    revision: &str,
+    options: &crate::history_build::HistoryBuildOptions,
+    force_directed: bool,
+) -> Result<compass_core::GraphSnapshot, compass_core::SnapshotError>;
+```
+
+`load_graph_at` passes through its existing `force_directed` value, then moves the owned `graph`/`overlay` data into its existing `LoadedGraph` return without re-resolving or re-materializing the revision.
+
+- [ ] **Step 4: Wire the explicit preview path**
+
+Leave the existing `Arguments` parser unchanged. Add a separate strict parser activated only when `--intelligence-preview` is present:
+
+```rust
+struct PreviewArguments {
+    number: u64,
+    repository: Option<compass_prs::RepositoryIdentity>,
+}
+
+fn parse_preview_arguments(args: &[String]) -> Result<PreviewArguments, String>;
+```
+
+Accept only:
+
+```text
+compass prs NUMBER [--repo [HOST/]OWNER/REPO] --intelligence-preview --format json
+```
+
+The parser accepts `-R` and `--repo=[HOST/]OWNER/REPO` equivalents. It defaults a two-component repository to `github.com` and preserves a three-component enterprise hostname. Reject missing or multiple numbers, duplicate repository/format/preview flags, non-JSON formats, unknown arguments, `--triage`, `--worktrees`, `--conflicts`, `--wrong-base`, `--base`, and `--graph`. The preview always uses exact history snapshots. The strict preview parser is independent from other Compass PR commands.
+
+Construct:
+
+- `GitHubCliChangeRequestSource<SystemRunner>`
+- `CliSnapshotProvider`
+- `FilesystemReportRepository` rooted at `Repository::common_dir()`
+- `FoundationOperation`
+
+Use `env!("CARGO_PKG_VERSION")` for extractor version and the exact configured history `BuildProfile` digest for `extractor_config_digest`.
+
+Serialize with `canonical_report_bytes`, convert the guaranteed JSON UTF-8 with strict `String::from_utf8`, and let `Outcome.stdout_trailing_newline` append one CLI newline. Keep progress on stderr. Operation errors exit `1`; parser errors exit `2`.
+
+The preview dispatch remains an adapter:
+
+```rust
+let preview = parse_preview_arguments(args)?;
+let current = std::env::current_dir().map_err(|error| error.to_string())?;
+let repository = compass_history::Repository::discover(&current)
+    .map_err(|error| error.to_string())?;
+let options = configured_build_options(&repository)?;
+let extractor_config_digest = compass_prs::format_sha256_digest(
+    &options.profile().digest().map_err(|error| error.to_string())?,
+);
+let source = std::sync::Arc::new(
+    compass_prs::GitHubCliChangeRequestSource::new(
+        std::sync::Arc::new(compass_prs::SystemRunner),
+        repository.root().to_path_buf(),
+    ),
+);
+let snapshots = std::sync::Arc::new(CliSnapshotProvider::new(
+    repository.clone(),
+    options,
+));
+let reports = std::sync::Arc::new(
+    compass_prs::FilesystemReportRepository::new(repository.common_dir())?,
+);
+let operation = compass_prs::FoundationOperation::new(
+    source,
+    snapshots,
+    reports,
+    env!("CARGO_PKG_VERSION").to_owned(),
+    extractor_config_digest,
+).map_err(|error| error.to_string())?;
+let report = operation.analyze(&compass_prs::ChangeRequestSelector {
+    number: preview.number,
+    repository: preview.repository.clone(),
+}).map_err(|error| error.to_string())?;
+let output = compass_prs::canonical_report_bytes(&report)
+    .map_err(|error| error.to_string())?;
+let stdout = String::from_utf8(output).map_err(|error| error.to_string())?;
+```
+
+Convert each `?` through the existing `Outcome` boundary so usage errors remain exit `2` and operational errors exit `1`. Return `stdout` with `stdout_trailing_newline: true`; never use a lossy conversion.
+
+- [ ] **Step 5: Run preview, history, PR command, and lint checks**
+
+Run:
+
+```bash
+cargo test -p compass-cli --test prs_intelligence_preview
+cargo test -p compass-cli --test prs_cli
+cargo test -p compass-cli --test history_cli
+cargo test -p compass-prs
+cargo clippy -p compass-cli -p compass-prs -p compass-core --all-targets -- -D warnings
+```
+
+Expected: all pass; existing Compass PR commands keep their documented behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/compass-cli crates/compass-core crates/compass-prs
+git commit -m "feat(cli): expose PR foundation preview"
+```
+
+## Task 7: Expose the typed foundation through MCP
+
+**Files:**
+
+- Create: `crates/compass-prs/src/service.rs`
+- Modify: `crates/compass-prs/src/lib.rs`
+- Create: `crates/compass-prs/tests/service.rs`
+- Create: `crates/compass-mcp/src/pr_intelligence.rs`
+- Modify: `crates/compass-mcp/src/lib.rs`
+- Create: `crates/compass-mcp/tests/pr_intelligence.rs`
+- Modify: `crates/compass-cli/src/lib.rs`
+
+**Interfaces:**
+
+- Consumes: `FoundationOperation`, `ChangeRequestSelector`, and `PrIntelligenceReport`.
+- Produces: object-safe `PrIntelligenceAnalyzer`, typed MCP `analyze_pr`, and CLI injection of the repository-bound analyzer.
+
+- [ ] **Step 1: Write failing service and MCP tests**
+
+Cover:
+
+- The service calls the shared foundation operation once.
+- MCP success returns the exact canonical report as structured content.
+- MCP text states that the result is a foundation preview and contains no verdict.
+- MCP errors include a stable code and set the protocol error flag.
+- GitHub.com and enterprise repository identities round-trip through MCP input.
+- The adapter never opens a graph, invokes GitHub, computes a finding, or persists a second report.
+
+```rust
+#[test]
+fn analyze_pr_returns_the_exact_typed_report()
+-> Result<(), Box<dyn std::error::Error>> {
+    let expected = fixture_report(["base", "head", "target"]);
+    let analyzer = Arc::new(FakeAnalyzer::returning(expected.clone()));
+    let server = PrIntelligenceMcp::new(analyzer.clone());
+    let result = server.analyze_pr(AnalyzePrInput {
+        number: 42,
+        repository: Some(RepositoryIdentity::github(
+            "github.example.com",
+            "acme",
+            "widgets",
+        )?),
+    })?;
+    assert_eq!(result.structured_report()?, expected);
+    assert!(!result.is_error());
+    assert_eq!(analyzer.calls(), 1);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run and verify the typed service is absent**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test service
+cargo test -p compass-mcp --test pr_intelligence
+```
+
+Expected: compilation fails because `PrIntelligenceAnalyzer`, `PrIntelligenceMcp`, and `analyze_pr` do not exist.
+
+- [ ] **Step 3: Implement the adapter-facing service**
+
+```rust
+pub trait PrIntelligenceAnalyzer: Send + Sync {
+    fn analyze(
+        &self,
+        selector: &ChangeRequestSelector,
+    ) -> Result<PrIntelligenceReport, OperationError>;
+}
+
+impl PrIntelligenceAnalyzer for FoundationOperation {
+    fn analyze(
+        &self,
+        selector: &ChangeRequestSelector,
+    ) -> Result<PrIntelligenceReport, OperationError> {
+        FoundationOperation::analyze(self, selector)
+    }
+}
+```
+
+Add `OperationError::code()`. Source errors retain `PRS2001` through `PRS2008`; snapshot load, snapshot identity, canonical report, and report store failures use `PRS3001` through `PRS3004`.
+
+- [ ] **Step 4: Implement the typed MCP adapter**
+
+```rust
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnalyzePrInput {
+    pub number: u64,
+    pub repository: Option<compass_prs::RepositoryIdentity>,
+}
+
+pub struct PrIntelligenceMcp {
+    analyzer: std::sync::Arc<dyn compass_prs::PrIntelligenceAnalyzer>,
+}
+```
+
+Register one `analyze_pr` tool. Run the synchronous analyzer through `tokio::task::spawn_blocking`. On success, serialize the report once and use that value as MCP structured content. Add one short text content item: `Compass PR Intelligence foundation preview; no risk or gate verdict is available yet.` On failure, return structured `{ "code": CODE, "message": MESSAGE }`, set `isError: true`, and do not synthesize an empty report.
+
+- [ ] **Step 5: Inject the same repository runtime into CLI and MCP**
+
+The CLI startup path that serves MCP constructs the same repository, build options, source, snapshot provider, and report repository used by Task 6. It wraps one `FoundationOperation` in `Arc<dyn PrIntelligenceAnalyzer>` and passes it to the MCP server constructor.
+
+Do not let `compass-mcp` depend on `compass-cli`; the CLI remains the composition root. Unit tests inject `FakeAnalyzer` directly.
+
+- [ ] **Step 6: Run typed adapter and lint gates**
+
+Run:
+
+```bash
+cargo test -p compass-prs --test service
+cargo test -p compass-mcp --test pr_intelligence
+cargo test -p compass-cli --test prs_intelligence_preview
+cargo clippy -p compass-prs -p compass-cli -p compass-mcp --all-targets -- -D warnings
+```
+
+Expected: all pass; CLI and MCP return the same report ID and canonical structured report for the same captured evidence.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/compass-prs crates/compass-cli crates/compass-mcp
+git commit -m "feat(mcp): expose typed PR intelligence preview"
+```
+
+## Task 8: Harden, benchmark, document, and qualify the foundation
+
+**Files:**
+
+- Create: `docs/PR_INTELLIGENCE.md`
+- Create: `scripts/benchmark_pr_foundation.sh`
+- Modify: `scripts/check_critical_coverage.sh`
+- Modify: `fuzz/Cargo.toml`
+- Create: `fuzz/fuzz_targets/pr_report.rs`
+- Create: `fuzz/fuzz_targets/pr_changed_files.rs`
+- Modify: `.github/workflows/compass-ci.yml`
+- Modify: `.github/workflows/compass-hardening.yml`
+- Modify: `crates/compass-prs/tests/report_contract.rs`
+- Modify: `crates/compass-prs/tests/change_capture.rs`
+- Modify: `crates/compass-prs/tests/report_store.rs`
+- Modify: `crates/compass-cli/tests/prs_intelligence_preview.rs`
+
+**Interfaces:**
+
+- Consumes: the completed child-1 foundation.
+- Produces: documented preview contract, fuzz/coverage/performance gates, cross-platform CI, and final qualification evidence.
+
+- [ ] **Step 1: Add hostile and invariant test cases**
+
+Add tests for:
+
+- Report ID collision.
+- Snapshot identity mismatch.
+- Force-push capture producing a different report ID.
+- Target-head movement producing a different report ID.
+- Synthetic merge conflict without a false merge snapshot.
+- Missing history realization followed by exact lazy materialization.
+- Report-store interruption and retry.
+- Repository names, branches, and paths containing Unicode and control characters.
+- Maximum bounded process and report output.
+- Symlink attacks at every report-store segment.
+
+Name the tests exactly and make their invariant assertions explicit:
+
+```rust
+#[test]
+fn force_push_or_target_movement_changes_report_identity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut fixture = QualificationFixture::new()?;
+    let original = fixture.analyze()?;
+    fixture.advance_pull_request_head()?;
+    let force_pushed = fixture.analyze()?;
+    assert_ne!(original.report_id, force_pushed.report_id);
+    fixture.advance_target_head()?;
+    let moved_target = fixture.analyze()?;
+    assert_ne!(force_pushed.report_id, moved_target.report_id);
+    Ok(())
+}
+
+#[test]
+fn snapshot_mismatch_and_interrupted_store_never_publish_partial_evidence()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut fixture = QualificationFixture::new()?;
+    fixture.return_wrong_snapshot_once();
+    assert!(fixture.analyze().is_err());
+    assert!(fixture.persisted_reports()?.is_empty());
+    fixture.fail_store_before_persist_once();
+    assert!(fixture.analyze().is_err());
+    assert!(fixture.persisted_reports()?.is_empty());
+    let report = fixture.analyze()?;
+    assert_eq!(fixture.persisted_reports()?, vec![report.report_id]);
+    Ok(())
+}
+
+#[test]
+fn conflict_retains_identity_without_claiming_a_merge_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let fixture = QualificationFixture::conflicted_merge()?;
+    let report = fixture.analyze()?;
+    assert!(matches!(
+        report.revisions.merge_outcome,
+        MergeOutcome::Conflicted { .. }
+    ));
+    assert_eq!(report.snapshots.len(), 3);
+    assert!(report.risk.is_none());
+    assert!(report.gates.is_empty());
+    Ok(())
+}
+```
+
+Complete the matrix with these assertions:
+
+```rust
+#[test]
+fn missing_realization_materializes_exact_commit()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut fixture = QualificationFixture::new()?;
+    let expected = fixture.pull_request_head().to_owned();
+    fixture.remove_head_realization()?;
+    let report = fixture.analyze()?;
+    let head = &report.snapshots[&SnapshotRole::PullRequestHead].identity;
+    assert!(matches!(
+        head,
+        SnapshotIdentity::Commit { commit, .. } if commit == &expected
+    ));
+    Ok(())
+}
+
+#[test]
+fn unicode_and_control_characters_round_trip_without_terminal_injection()
+-> Result<(), Box<dyn std::error::Error>> {
+    let report = QualificationFixture::unicode_paths()?.analyze()?;
+    let bytes = canonical_report_bytes(&report)?;
+    assert!(!bytes.contains(&0x1b));
+    assert_eq!(serde_json::from_slice::<PrIntelligenceReport>(&bytes)?, report);
+    Ok(())
+}
+
+#[test]
+fn bounded_process_and_report_limits_are_enforced() {
+    assert!(matches!(
+        QualificationFixture::oversized_process_output(),
+        Err(PrsError::OutputTooLarge { .. })
+    ));
+    assert!(matches!(
+        QualificationFixture::oversized_report(),
+        Err(ReportStoreError::TooLarge { .. })
+    ));
+}
+
+#[test]
+fn every_report_store_segment_rejects_symlinks()
+-> Result<(), Box<dyn std::error::Error>> {
+    for segment in ["compass", "pr-intelligence", "reports", "destination"] {
+        let fixture = QualificationFixture::symlink_at(segment)?;
+        assert!(matches!(
+            fixture.save_report(),
+            Err(ReportStoreError::UnsafePath { .. })
+        ));
+    }
+    Ok(())
+}
+```
+
+Run:
+
+```bash
+cargo test -p compass-prs
+cargo test -p compass-cli --test prs_intelligence_preview
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Add fuzz targets**
+
+`pr_report` feeds arbitrary bytes to strict `PrIntelligenceReport` deserialization and, on success, asserts canonical round-trip and stable report ID verification.
+
+`pr_changed_files` feeds arbitrary UTF-8/NUL-delimited bytes to the internal changed-file parser and asserts no panic, no absolute path, no parent traversal, deterministic sorting, and bounded output.
+
+Add a non-default `fuzzing` feature to `compass-prs` that exposes only the parser shim. The target bodies are:
+
+```toml
+# crates/compass-prs/Cargo.toml
+[features]
+fuzzing = []
+
+# fuzz/Cargo.toml dependency and targets
+compass-prs = { path = "../crates/compass-prs", features = ["fuzzing"] }
+
+[[bin]]
+name = "pr_report"
+path = "fuzz_targets/pr_report.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "pr_changed_files"
+path = "fuzz_targets/pr_changed_files.rs"
+test = false
+doc = false
+bench = false
+```
+
+```rust
+// crates/compass-prs/src/lib.rs
+#[cfg(feature = "fuzzing")]
+pub fn fuzz_parse_changed_files(input: &str) -> Result<Vec<ChangedFile>, SourceError> {
+    git::parse_changed_files(input)
+}
+```
+
+```rust
+// fuzz/fuzz_targets/pr_report.rs
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|bytes: &[u8]| {
+    if let Ok(report) =
+        serde_json::from_slice::<compass_prs::PrIntelligenceReport>(bytes)
+        && let Ok(canonical) = compass_prs::canonical_report_bytes(&report)
+        && let Ok(round_trip) =
+            serde_json::from_slice::<compass_prs::PrIntelligenceReport>(&canonical)
+    {
+        assert_eq!(report, round_trip);
+        assert_eq!(
+            compass_prs::canonical_report_bytes(&round_trip).ok(),
+            Some(canonical)
+        );
+    }
+});
+```
+
+```rust
+// fuzz/fuzz_targets/pr_changed_files.rs
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|bytes: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(bytes)
+        && let Ok(first) = compass_prs::fuzz_parse_changed_files(text)
+    {
+        let second = compass_prs::fuzz_parse_changed_files(text);
+        assert_eq!(second.as_ref().ok(), Some(&first));
+        assert!(first.iter().all(|file| file.paths_are_repository_relative()));
+    }
+});
+```
+
+Run bounded smoke fuzzing:
+
+```bash
+cargo fuzz run pr_report -- -max_total_time=30
+cargo fuzz run pr_changed_files -- -max_total_time=30
+```
+
+Expected: both complete without crashes, timeouts, or corpus-triggered assertion failures.
+
+- [ ] **Step 3: Add critical coverage and CI gates**
+
+Add `compass-core/src/snapshot.rs`, `compass-prs/src/{model,canonical,source,git,operation,report_store}.rs`, and the Compass preview adapter to critical coverage. Require at least 95% line coverage for identity validation, evidence-manifest construction, snapshot mismatch, report persistence, and parser error branches.
+
+CI runs focused tests on Linux, macOS, and Windows. Hardening runs fuzz smoke tests, report-store hostile-path tests, and the small benchmark smoke tier on Linux. Full medium/large performance gates run only on the declared self-hosted reference runner so shared-runner variance cannot create meaningless regressions.
+
+Add these workflow commands to the existing matrices rather than creating a parallel workflow:
+
+```yaml
+- name: PR Intelligence foundation
+  run: |
+    cargo test -p compass-core --test snapshot
+    cargo test -p compass-prs
+    cargo test -p compass-cli --test prs_intelligence_preview
+    cargo test -p compass-mcp --test pr_intelligence
+```
+
+On Linux hardening:
+
+```yaml
+- run: cargo fuzz run pr_report -- -max_total_time=30
+- run: cargo fuzz run pr_changed_files -- -max_total_time=30
+- run: COMPASS_BENCH_TIER=small bash scripts/benchmark_pr_foundation.sh
+```
+
+Extend `scripts/check_critical_coverage.sh`'s checked-source array with the exact files named in this step and fail if any named file is absent, uncovered, or below 95%.
+
+- [ ] **Step 4: Add the reproducible benchmark**
+
+`benchmark_pr_foundation.sh` creates Git repositories and prebuilt graph history for:
+
+```text
+small:  10,000 graph nodes, 20,000 relationships
+medium: 250,000 graph nodes, 750,000 relationships
+large:  1,000,000 graph nodes, 3,000,000 relationships
+```
+
+`COMPASS_BENCH_TIER=small|medium|large|all` selects fixture size; the default is `small`. Reuse checked benchmark fixture manifests between runs rather than rebuilding million-node histories inside the timed interval. For cold and warm runs, record:
+
+- Capture time.
+- Three snapshot load times.
+- Peak RSS.
+- Canonical serialization time.
+- Persistence time.
+- Total wall time.
+- Report bytes.
+
+On the declared reference host, the script exits nonzero when warm p95 exceeds 5 seconds for small, 30 seconds for medium, or 90 seconds for large; when foundation memory exceeds the three loaded snapshots plus 20%; or when report persistence exceeds two seconds. On an undeclared host, it records metrics and enforces only correctness and the two-second persistence ceiling. The umbrella five-minute SLA remains reserved for completed stages 1–5.
+
+The script accepts only these environment inputs:
+
+```bash
+COMPASS_BENCH_TIER="${COMPASS_BENCH_TIER:-small}"
+COMPASS_BENCH_RUNS="${COMPASS_BENCH_RUNS:-20}"
+COMPASS_BENCH_REFERENCE_HOST="${COMPASS_BENCH_REFERENCE_HOST:-}"
+```
+
+Validate the tier against `small|medium|large|all`, validate runs as an integer from 5 through 100, create all temporary repositories with `mktemp -d`, install one exit trap that removes only that exact directory, and write newline-delimited JSON measurements to stdout. Timing starts after fixture/history construction and ends after report persistence.
+
+- [ ] **Step 5: Document exact behavior and limitations**
+
+`docs/PR_INTELLIGENCE.md` documents:
+
+- `foundation_preview` is provenance infrastructure, not a safety verdict.
+- Exact four-revision meanings.
+- Why only three commit snapshots load in child 1.
+- Report and evidence schema names.
+- Report storage path and permissions.
+- Git/GitHub prerequisites.
+- Missing-object remediation without implicit fetching.
+- Preview CLI syntax and exit codes.
+- No findings, risk, or gates until the relevant child designs are approved and implemented.
+- Relationship to versioned graphs and CompassQL shared snapshots.
+- Redaction and authorization are not implemented in the local-only foundation.
+
+Do not add marketing copy to the README until stages 1–5 are complete.
+
+- [ ] **Step 6: Run the full qualification matrix**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+bash scripts/check_critical_coverage.sh
+COMPASS_BENCH_TIER=small bash scripts/benchmark_pr_foundation.sh
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 7: Review the final diff and commit**
+
+Verify:
+
+```bash
+git status --short
+git diff --check
+git log --oneline --max-count=8
+```
+
+Expected: only child-1 files are modified; no primary-worktree user files appear.
+
+Commit:
+
+```bash
+git add .github crates/compass-core crates/compass-prs crates/compass-cli crates/compass-mcp docs/PR_INTELLIGENCE.md scripts fuzz
+git commit -m "test(prs): qualify intelligence foundation"
+```
+
+## Acceptance checklist
+
+- [ ] `GraphSelection`, `SnapshotProvider`, `GraphSnapshot`, and `SnapshotIdentity` exist exactly once in `compass-core`.
+- [ ] Existing query/path/explain `--at` behavior remains green.
+- [ ] Pull-request capture records merge base, PR head, target head, and synthetic merge tree as full object IDs.
+- [ ] Capture performs no implicit fetch, checkout, ref mutation, hook, or code execution.
+- [ ] The evidence manifest contains only immutable, identity-bearing inputs.
+- [ ] Foundation reports use `compass.pr_intelligence.report/1` and `cmppr-report-v1:` report identities; future finding fingerprints retain `cmpprv1:`.
+- [ ] Foundation reports contain no risk, gate, impact, owner, test, or overlap verdict.
+- [ ] Snapshot identity mismatch prevents persistence.
+- [ ] Reports persist atomically below the Git common directory and reject symlink traversal.
+- [ ] The Compass preview emits canonical JSON and labels itself `foundation_preview`.
+- [ ] CLI and MCP consume the same typed analyzer and return the same canonical report.
+- [ ] Repository identity distinguishes GitHub.com and GitHub Enterprise Server hosts.
+- [ ] Fuzz, critical coverage, cross-platform, and performance gates pass.

--- a/docs/superpowers/specs/2026-07-21-versioned-graph-prolly-tree-design.md
+++ b/docs/superpowers/specs/2026-07-21-versioned-graph-prolly-tree-design.md
@@ -1,0 +1,876 @@
+# How Compass stores versioned graphs with SQLite-backed Prolly trees
+
+**Date:** 2026-07-21
+
+**Revised:** 2026-07-22 after the Compass workspace extraction and command flattening
+
+**Status:** Approved architecture, revised after storage, correctness, and Compass-rename audits
+
+**Implementation root:** `/Users/haipingfu/graphify/compass` (the `crabbuild/compass` Git submodule and standalone repository)
+
+**Pinned dependencies:** `prolly-map = "=0.5.0"` and `prolly-store-sqlite = "=0.3.0"`
+
+## Purpose and scope
+
+This design defines a local versioned graph map for Compass, the standalone native Rust code-intelligence system extracted from Graphify. It stores one complete immutable graph realization for each materialized Git commit, supports historical query, and streams graph-aware differences between realizations. `compass` is the sole canonical command surface. A legacy `graphify` executable may remain as a best-effort transition shim, but its command availability, help, output, exit status, and side effects do not constrain Compass or this feature's acceptance criteria.
+
+A complete realization includes Abstract Syntax Tree (AST) facts, semantic nodes and edges, inferred relationships, hyperedges, community assignments, analysis, and the metadata required to reconstruct Compass's Graphify-compatible outputs. Git remains the source of source-code history. SQLite-backed Prolly trees store graph history without placing generated data in Git commits.
+
+## Approved decisions
+
+- Every preferred realization represents a complete Compass build, including semantic and inferred relationships
+- History is explicitly enabled and disabled with `compass history enable|disable`; merely inspecting status or running an explicit historical command never silently enables eager work
+- Once enabled, new commits enqueue eager materialization after `git commit` without blocking the commit on extraction
+- Build, query, path, explain, export, and diff synchronously materialize missing commits from their exact Git trees; inspection-only status/list/show never trigger extraction
+- One Git commit may have multiple immutable realizations
+- Each realization records an extraction fingerprint for every meaning-affecting input
+- One realization per commit is preferred without deleting other realizations
+- One realization contains separate Prolly trees for nodes, edges, hyperedges, analysis, and metadata
+- `prolly-store-sqlite` is the only v1 Prolly backend
+- Implementation lives in the standalone Compass workspace (`compass/` in the Graphify superproject); crates and Rust modules use `compass-*` and `compass_*` names
+- All linked worktrees share one SQLite database below the Git common directory
+- New history-owned filesystem and Prolly namespaces use `compass`, including `<git-common-dir>/compass/`, `compass/store-format/v1`, and `compass/v1/...`
+- Operational jobs, leases, locks, and temporary worktrees remain files beside the database
+- `graph.json` remains a compatibility export
+- Historical compatibility means canonical semantic equivalence, not byte-for-byte output reproduction
+- A versioned artifact registry classifies authoritative, derived, and operational outputs
+- Non-derivable authoritative sidecars are stored verbatim; reports and HTML are regenerated
+- Historical ignores come only from the target commit and explicit build-profile excludes
+- Temporary historical checkouts disable hooks, network fetching, and LFS smudging
+- One cross-process reader-writer lock coordinates activity and maintenance
+- Raw token usage, costs, timings, and diagnostics remain operational attempt provenance outside realization identity
+- Replacing a corrupt preferred realization requires explicit `--replace-corrupt` recovery
+- History remains opt-in until semantic-correctness, durability, and performance gates pass
+- Compass command contracts are specified and tested independently; no Graphify CLI compatibility or alias-parity gate applies
+- Every canonical user command begins directly with `compass`; there is no legacy binary or nested graph-command namespace
+- Established Graphify-compatibility resources remain unchanged: `graphify-out/`, `graph.json`, `.graphifyignore`, `.graphify_*` sidecars, and `GRAPHIFY_*` environment variables
+
+## Naming and resource boundary
+
+The Compass extraction changes implementation ownership and the canonical command surface. It does not rename established Graphify-compatible artifact and configuration contracts.
+
+| Concern | V1 canonical name | Treatment |
+|---|---|---|
+| Standalone repository and superproject path | `crabbuild/compass`, `compass/` | All implementation work and commits occur in the Compass repository |
+| Workspace packages and Rust modules | `compass-*`, `compass_*` | New history code follows Compass naming |
+| Executable and command prefix | `compass` | Commands are flat, such as `compass query` and `compass history build`; never `compass graph ...` |
+| History-owned local directory and database | `<git-common-dir>/compass/history.sqlite` | New Compass resource; shared by linked worktrees |
+| History-owned Prolly names | `compass/store-format/v1`, `compass/v1/...` | New Compass namespace |
+| Legacy executable | `graphify` | Optional best-effort transition shim; it is outside the versioned-graph public contract and may diverge or be removed |
+| Compatibility artifacts and configuration | `graphify-out/`, `graph.json`, `.graphifyignore`, `.graphify_*`, `GRAPHIFY_*` | Retained verbatim so existing consumers and repositories continue to work |
+
+## Goals
+
+1. Query, traverse, and explain the complete graph at any materialized commit.
+2. Materialize a missing historical commit from its exact Git tree.
+3. Generate new commit graphs without blocking `git commit` on extraction.
+4. Diff graph topology and attributes through shared Prolly subtrees.
+5. Preserve provenance and distinguish different extraction environments.
+6. Reconstruct Compass's graph and sidecar outputs without semantic or structural loss.
+7. Prevent incomplete, corrupt, or unsupported graphs from becoming preferred.
+8. Recover deterministically from process termination, write contention, and stale jobs.
+9. Keep realization identity independent from operational cost and timing variation.
+10. Regenerate supported presentation artifacts from versioned semantic state.
+
+## Non-goals and explicit limits
+
+- This design does not replace Git branches, commits, merges, or synchronization.
+- This design does not store the SQLite database in ordinary Git commits.
+- V1 does not synchronize graph history between machines.
+- V1 does not offer a runtime storage-backend selector.
+- V1 does not make semantic extraction deterministic.
+- V1 does not introduce per-file Prolly roots.
+- V1 does not automatically delete realizations after Git history rewrites.
+- V1 rejects mutable external sources such as live Google Workspace and PostgreSQL inputs. A later design must snapshot those inputs before they can represent a Git commit.
+- V1 materializes committed superproject files. It does not fetch Git submodules or Git Large File Storage (LFS) objects. Status output reports detected gitlinks or LFS pointers.
+- V1 applies committed `.gitignore` and `.graphifyignore` files plus explicit normalized build-profile excludes. It does not apply `.git/info/exclude` or global Git ignore configuration.
+- SQLite garbage collection makes deleted pages reusable. It does not promise that the database file immediately shrinks.
+
+## Existing Compass boundaries
+
+Compass already separates the relevant responsibilities:
+
+- `compass-model` owns `GraphDocument`, `NodeRecord`, and `EdgeRecord`
+- `compass-core` produces the resolved, inferred, clustered, and validated graph
+- `compass-output` writes NetworkX-compatible `graph.json` and sidecar artifacts
+- `compass-query` consumes an immutable query-oriented `Graph`
+- `compass-files` owns manifests, hashes, atomic file writes, and incremental detection
+- `compass-graph` defines current graph-aware identity and analysis behavior
+
+The history layer consumes completed artifacts. It does not parse code, prompt a model, resolve symbols, deduplicate entities, cluster nodes, or infer relationships.
+
+## Component architecture
+
+Add a `compass-history` workspace crate. It depends on `compass-model`, `compass-files`, `prolly-map`, and `prolly-store-sqlite`. It does not depend on CLI presentation or semantic-provider crates.
+
+`compass-history` owns:
+
+- canonical graph-record encoding
+- typed Prolly key construction
+- extraction-fingerprint calculation
+- immutable realization manifests
+- SQLite-backed Prolly roots and catalogs
+- lossless artifact decomposition and reconstruction
+- streaming graph-aware diffs
+- realization validation and garbage collection
+- repository discovery, revision resolution, jobs, leases, and maintenance locks
+
+`compass-core` owns reusable materialization orchestration behind an injected complete-graph builder. `compass-cli` supplies the production builder, handles commands, starts workers, and renders progress and diagnostics.
+`compass-output` owns the version-dispatched derived-artifact renderers. Its history bundle API
+accepts model/JSON inputs rather than `compass-history` types, avoiding a dependency cycle;
+`compass-cli` joins reconstructed artifacts and registry entries to that API.
+
+## SQLite storage boundary
+
+### Local layout
+
+Resolve the shared directory with `git rev-parse --git-common-dir`. Never assume `.git` is a directory because linked worktrees use a `.git` file.
+
+```text
+<git-common-dir>/compass/
+├── history.sqlite
+├── history.sqlite-wal
+├── history.sqlite-shm
+├── config.json
+├── jobs/
+├── leases/
+├── locks/
+└── tmp/
+```
+
+SQLite creates the `-wal` and `-shm` files while Write-Ahead Logging (WAL) is active. Callers must not treat the main file alone as a consistent live backup. Compass exports realizations through its history commands instead of recommending raw database copies.
+
+On Unix, Compass creates the `compass` directory with mode `0700` and the database and operational files with mode `0600`. Other platforms use their closest owner-only controls. Opening rejects a symlink at the `compass` directory, database, lock, configuration, job, lease, or temporary-worktree target; cleanup only removes validated descendants of the canonical `tmp` directory. The store never contains credentials, but it can contain proprietary source-derived graph data.
+
+### Adapter configuration
+
+The concrete store is `prolly_store_sqlite::SqliteStore`. `HistoryStore` constructs it with `SqliteStore::open_with_config` and wraps it in `prolly::Prolly`:
+
+```rust
+pub struct HistoryStore {
+    root: PathBuf,
+    engine: Prolly<Arc<SqliteStore>>,
+}
+```
+
+V1 uses these settings:
+
+- `enable_wal: true`
+- `synchronous_normal: false`, which retains SQLite's full synchronous default
+- a 10-second busy timeout
+
+The adapter owns the SQLite schema. Compass does not read or write `prolly_nodes`, `prolly_hints`, or `prolly_roots` through direct SQL. This prevents Compass from coupling to private adapter details.
+
+`SqliteStore` implements `Store`, `NodeStoreScan`, `ManifestStore`, `ManifestStoreScan`, and `TransactionalStore`. These contracts support content-addressed nodes, root listing, compare-and-swap, strict multi-root transactions, and Prolly garbage collection.
+
+The adapter audit used the published `prolly-store-sqlite 0.3.0` source, which depends on `prolly-map 0.5.0`. Its 18 unit and integration tests plus two documentation tests passed locally, including strict transaction rollback and file-backed reopen coverage. The [adapter manifest](https://github.com/crabbuild/prolly/blob/main/stores/prolly-store-sqlite/Cargo.toml) and [SQLite adapter documentation](https://github.com/crabbuild/prolly/blob/main/stores/prolly-store-sqlite/README.md) remain the primary upstream references.
+
+### Project-owned API
+
+Business logic depends on `HistoryStore`, not on `SqliteStore` or raw Prolly types. The public boundary uses project types:
+
+```rust
+impl HistoryStore {
+    pub fn create(repository: &Repository) -> Result<Self, HistoryError>;
+    pub fn open_existing(repository: &Repository)
+        -> Result<Option<Self>, HistoryError>;
+    pub fn publish(&self, request: PublishRequest)
+        -> Result<PublishedVersion, HistoryError>;
+    pub fn preferred(&self, commit: &CommitId)
+        -> Result<Option<PublishedVersion>, HistoryError>;
+    pub fn get(&self, id: &RealizationId)
+        -> Result<PublishedVersion, HistoryError>;
+    pub fn diff(&self, old: &RealizationId, new: &RealizationId,
+        sink: &mut dyn ChangeSink) -> Result<(), HistoryError>;
+}
+```
+
+`create` is used only by enabling history or by an explicit build/materialization operation. `open_existing` never creates the history directory or database, so read-only status and list operations cannot enable history or mutate an untouched repository. Store existence and eager-history enablement are independent: disabling eager history retains all realizations and still permits explicit build, query, diff, export, validation, and garbage collection.
+
+The wrapper persists each tree root as its Content Identifier (CID) plus its persisted `TreeFormat`. It never includes runtime cache settings in stored identity.
+
+### Store format compatibility
+
+The database contains a reserved named root with this logical name:
+
+```text
+compass/store-format/v1
+```
+
+Its canonical value records the Compass history schema, canonical encoding version, typed-key version, and expected adapter family. Opening an existing database verifies this record before reading application roots. Unknown or incompatible versions fail with a migration-required error.
+
+Dependency versions are exact pins. Upgrading either Prolly crate requires contract tests, reopen tests against an old fixture database, and an explicit migration decision.
+
+### Contention and failures
+
+Each process opens its own `SqliteStore`; the adapter serializes calls within that process. WAL and the busy timeout coordinate multiple processes. A store error never triggers an unbounded blind retry.
+
+Interactive commands report a bounded diagnostic and preserve the prior preferred realization. Background jobs remain retryable with an incremented attempt count. Strict transaction conflicts follow the catalog rules below rather than being treated as database corruption.
+
+## Version and identity model
+
+### Completion evidence
+
+A file's existence does not prove a complete build. `.graphify_semantic_marker` records token use and cannot serve as a success marker.
+
+Every publication supplies content-addressed completion evidence:
+
+```rust
+struct CompletionEvidence {
+    extraction_succeeded: bool,
+    allow_partial: bool,
+    semantic_files_expected: u64,
+    semantic_files_completed: u64,
+    failed_chunks: u64,
+}
+```
+
+Completion evidence is authoritative realization content. Raw token usage, provider cost,
+timings, captured diagnostics, and the original `.graphify_semantic_marker` are operational
+attempt provenance and do not enter any identity-bearing tree. A compatibility export may
+generate a semantic marker from normalized completion evidence. Operational attempt records
+remain subject to job-retention policy and are not permanent graph-history artifacts.
+
+Publication requires a successful extraction, `allow_partial == false`, equal expected and completed semantic-file counts, and zero failed chunks. A repository with no semantic-source files has equal zero counts and remains complete.
+
+Publication cross-checks these counts against the extraction manifest and semantic-source inventory produced from the exact worktree. `PublishRequest` is an internal materialization boundary, not a command that accepts caller-supplied completion claims.
+
+History builds reject `--allow-partial`, `--code-only`, and `--no-cluster`. They also reject unsnapshotted external-source flags. The normal pipeline still supports those flags outside history mode.
+
+### Graph realization manifest
+
+A published realization has this immutable manifest:
+
+```rust
+struct GraphVersion {
+    schema_version: u32,
+    git_commit: String,
+    git_parents: Vec<String>,
+    extraction_fingerprint: String,
+    nodes_root: TreeRoot,
+    edges_root: TreeRoot,
+    hyperedges_root: TreeRoot,
+    analysis_root: TreeRoot,
+    metadata_root: TreeRoot,
+    node_count: u64,
+    edge_count: u64,
+    hyperedge_count: u64,
+    analysis_count: u64,
+    metadata_count: u64,
+}
+```
+
+`RealizationId` is the SHA-256 digest of canonical manifest bytes. Operational values such as time, machine path, process ID, job ID, and duration do not enter the manifest.
+
+An identical rebuild returns the same realization ID only when the commit, parents, fingerprint, persisted tree formats, and graph content are identical. Identical graph content at different Git commits produces different IDs because commit provenance is part of the manifest.
+
+The manifest records Git parent commit IDs, not parent realization IDs. Compass can therefore materialize a child before its parent without rewriting the child's immutable manifest.
+
+### Extraction fingerprint
+
+The extraction fingerprint hashes normalized inputs that can change graph meaning:
+
+- Compass, graph-schema, extractor, resolver, semantic-pipeline, and analysis versions
+- semantic prompt digest
+- provider and model identifiers
+- extraction mode and meaning-affecting flags
+- directed or undirected mode
+- multigraph behavior
+- clustering algorithm and configuration
+- repository-local Compass/Graphify-compatible configuration and ignore-file contents from the target commit
+- enabled optional extractors and compile-time features
+
+The fingerprint excludes credentials, credential environment-variable values, absolute paths, timestamps, machine names, concurrency, timeouts, and logging options. The job record may contain non-secret runtime limits.
+
+The commit identifies source content while the fingerprint identifies the extraction environment. Two runs with the same commit and fingerprint may still produce different semantic content. Both realization IDs remain addressable.
+
+## Catalog and publication model
+
+### Named roots
+
+All logical catalog entries are binary, segment-safe named roots inside SQLite's `prolly_roots` table. Human-readable forms below describe their meaning:
+
+```text
+compass/v1/version/<realization-id>/nodes
+compass/v1/version/<realization-id>/edges
+compass/v1/version/<realization-id>/hyperedges
+compass/v1/version/<realization-id>/analysis
+compass/v1/version/<realization-id>/metadata
+compass/v1/version/<realization-id>/manifest
+compass/v1/preferred/<commit>
+```
+
+The preferred root points to the selected realization's manifest tree. The manifest records the commit and fingerprint, so listing code validates catalog names against content instead of trusting root names.
+
+### Publication sequence
+
+Only complete and validated content enters the version catalog:
+
+1. Build the five typed trees and manifest tree.
+2. Validate direct immutable roots, counts, endpoints, schema, and completion evidence.
+3. Publish the six realization roots in one strict SQLite transaction.
+4. Reopen the realization through its catalog roots and verify its digest and roots.
+5. Compare-and-swap `preferred/<commit>` from the value observed before publication.
+6. Record the job as published, including whether this realization became preferred.
+
+Prolly builders may write content-addressed nodes before step 3. Those nodes remain unreachable if validation or publication fails and normal garbage collection can remove them.
+
+The realization-root transaction and preferred compare-and-swap are separate by design. If two different realizations publish concurrently, both remain addressable. A stale preferred compare-and-swap does not overwrite the winner and returns `preferred: false` for the losing publication.
+
+Before attempting step 5, publication validates the observed preferred realization when one exists. A corrupt preferred root prevents automatic replacement, leaves the new realization addressable but non-preferred, and returns a corruption diagnostic. Only `compass history rebuild <revision> --replace-corrupt` may replace a corrupt preferred root; ordinary `compass history prefer` fails closed on corrupt current state.
+
+An explicit `compass history prefer` command reads the current preferred ID and performs the same compare-and-swap. A concurrent change produces a conflict instead of an implicit overwrite.
+
+Readers resolve only named realization roots or preferred roots. They never infer published state from unreferenced content-addressed nodes.
+
+## Typed graph maps
+
+Every key starts with a schema-version byte and record-kind byte. Remaining components use Prolly's length-prefixed `KeyBuilder` segments. Arbitrary Unicode, NUL bytes, separators, and common prefixes cannot collide.
+
+### Node map
+
+```text
+key:   schema / node / canonical node ID
+value: complete canonical NodeRecord excluding separately stored analysis fields
+```
+
+Node IDs remain case-sensitive strings. Unknown attributes remain in the value. Duplicate node IDs fail validation.
+
+### Edge map
+
+For `multigraph: false`, the key is:
+
+```text
+schema / edge / direction-aware source / target / relation
+```
+
+Directed keys retain endpoint order. Undirected keys sort endpoints for identity while the value retains the producer's source and target. Duplicate non-multigraph identities fail validation.
+
+For `multigraph: true`, append a discriminator:
+
+```text
+schema / edge / direction-aware source / target / relation / discriminator
+```
+
+Use a canonical NetworkX `key` attribute when present. Otherwise, use the SHA-256 digest of the complete canonical edge followed by its zero-based occurrence among byte-identical records. This rule preserves parallel edges and exact duplicates. An attribute change on a digest-keyed parallel edge appears as removal plus addition.
+
+### Hyperedge map
+
+```text
+key:   schema / hyperedge / explicit ID or canonical-record digest
+value: complete canonical hyperedge record
+```
+
+Use a valid explicit `id` when present. Duplicate explicit IDs fail validation. Otherwise,
+append the zero-based occurrence among byte-identical id-less records to the complete
+canonical-record digest:
+
+```text
+schema / hyperedge / canonical-record-digest / occurrence
+```
+
+This preserves exact duplicate array entries. Preserve member-array order and unknown
+attributes in the value. Validation recognizes Compass's supported `nodes` and `members`
+forms and verifies every referenced node.
+
+### Analysis map
+
+The analysis tree stores every graph-derived field and analysis sidecar record needed for reconstruction and architectural diff:
+
+```text
+community/<node-id>
+community-label/<community-id>
+cohesion/<community-id>
+god-node/<rank>
+surprise/<rank>
+question/<rank>
+sidecar/<typed-path>
+```
+
+Known records receive stable logical keys. Unknown analysis fields receive versioned typed paths and retain their complete canonical JSON values. No analysis needed for compatibility remains only in an unversioned worktree file.
+
+### Metadata map
+
+The metadata tree stores:
+
+- `directed` and `multigraph`
+- unknown `graph` members and unknown top-level fields
+- whether the document used `links` or legacy `edges`
+- node, edge, and hyperedge input-order records
+- original hyperedge placement
+- labels, extraction manifest, normalized semantic provenance, and completion evidence
+- graph and export schema versions
+- values required to reproduce Compass's supported outputs
+
+Order records use lexicographically ordered numeric ranks and reference typed record keys, including multigraph discriminators. This keeps values bounded while preserving exact array ordering. Unknown arrays retain their original order.
+
+### Versioned artifact registry
+
+The metadata tree contains one registry record for every supported realization artifact:
+
+```text
+artifact/<relative-path> -> {
+  registry_version,
+  class,
+  media_type,
+  schema_version,
+  content_digest,
+  storage,
+  regeneration_version
+}
+```
+
+`class` is one of `authoritative`, `derived`, or `operational`:
+
+- Authoritative graph state includes the decomposed `graph.json`, analysis, labels,
+  extraction manifest, completion evidence, and any non-derivable semantic sidecar. Its
+  canonical content or verbatim bytes are stored in the five realization trees and affect
+  the realization ID.
+- Derived artifacts include `GRAPH_REPORT.md`, HTML, visualization output, label signatures,
+  and other deterministic presentations. The registry records their regeneration version;
+  their generated bytes do not affect realization identity.
+- Operational artifacts include `.graphify_root`, learning overlays, query logs, caches,
+  incomplete markers, chunk temporaries, raw semantic markers, `cost.json`, timings, and
+  diagnostics. They are excluded from realization content. Attempt provenance may retain a
+  bounded subset outside the Prolly catalog.
+
+Historical export guarantees canonical semantic equivalence. It does not guarantee that a
+regenerated report or HTML file is byte-identical to the original run. Unknown future
+sidecars must be classified explicitly; the loader never silently drops an unclassified
+file that the current artifact contract declares authoritative.
+
+## Canonical encoding
+
+Prolly values use a versioned binary envelope around canonical JSON bytes. The canonical encoder:
+
+1. Sorts object keys by UTF-8 byte order recursively.
+2. Emits integers as minimal base-10 text without leading zeroes.
+3. Emits finite floating-point values with deterministic shortest round-trip formatting,
+   while retaining floating-point identity (`1.0` does not canonicalize to integer `1`).
+4. Retains negative zero as floating-point negative zero when accepted by the parser.
+5. Preserves array order unless a declared Compass field has set semantics.
+6. Rejects non-finite numeric input before serialization.
+7. Emits UTF-8 without insignificant whitespace.
+8. Tags every record with its schema name and version.
+
+Canonicalization applies to content identity, not to user-facing formatting. Reconstruction uses the stored order and placement metadata.
+
+Golden byte fixtures cover integer boundaries, exponent forms, `1` versus `1.0`, negative
+zero, Unicode escaping, and recursive object ordering. The canonical-encoding version is
+part of `compass/store-format/v1`; changing any golden byte requires an explicit migration
+decision.
+
+## Exact-commit materialization
+
+### Repository and revision rules
+
+Repository discovery resolves the top level and Git common directory through Git commands. Revision resolution accepts a user revision, passes `--end-of-options`, resolves it to one full commit ID, and stores lowercase SHA-1 or SHA-256 text.
+
+The builder creates a detached temporary worktree below `<git-common-dir>/compass/tmp`. It verifies that the worktree `HEAD` equals the requested full commit before extraction. It never modifies or reads uncommitted files from the caller's checkout.
+
+Before checkout, Compass inventories configured filter drivers. It rejects unsupported
+external smudge/process drivers with a typed limitation instead of executing them. The
+worktree is then created with checkout hooks disabled, `GIT_LFS_SKIP_SMUDGE=1`, credential
+prompts disabled, and no command that fetches missing objects. Compass preserves committed
+LFS pointer files and reports LFS pointers and gitlinks. Missing local Git objects fail
+materialization.
+
+Historical detection applies `.gitignore` and `.graphifyignore` files present in the target
+tree plus explicit normalized profile excludes. It deliberately ignores `.git/info/exclude`,
+global excludes, and caller-worktree ignore state. Every applied committed ignore file and
+explicit exclude enters the extraction fingerprint.
+
+V1 does not fetch submodules or LFS objects. It extracts the committed superproject representation and reports detected gitlinks and LFS pointers. Network-dependent recursive materialization requires a separate opt-in design.
+
+### Ancestor seeding
+
+Ancestor reuse is an optimization. Walk the target's first-parent history and select the nearest validated preferred realization with the same extraction fingerprint. Reconstruct its graph and extraction manifest into the isolated output directory before running incremental extraction.
+
+If no compatible ancestor exists, perform a full build. The target commit's checked-out tree remains authoritative for linear, branch, and merge commits.
+
+### Complete builder boundary
+
+The reusable materializer accepts an injected builder:
+
+```rust
+trait CompleteGraphBuilder {
+    fn build(&self, checkout: &Path, output: &Path,
+        seed: Option<&GraphArtifacts>)
+        -> Result<CompletedGraphArtifacts, MaterializeError>;
+}
+```
+
+`CompletedGraphArtifacts` contains `GraphArtifacts` and `CompletionEvidence`. The production CLI builder runs the normal Compass pipeline with partial mode disabled, verifies `built_at_commit`, and derives semantic counts from the completed build and manifest. It never infers success from token counts.
+
+## Eager and lazy lifecycle
+
+### Eager post-commit generation
+
+`compass history enable` stores a normalized, non-secret eager build profile in
+`config.json`, creates/verifies the store, and installs or updates the existing managed
+post-commit hook block while preserving user-owned hook content. Enablement rolls back if the
+managed block cannot be installed. `disable` clears that enabled state without
+deleting the database, realizations, jobs, or leases and without terminating a worker that
+already owns a live lease; the now-inert managed block remains installed. Explicit historical commands continue to work while eager history
+is disabled. Re-enabling replaces the stored profile only after validating all requested
+options.
+
+When history is enabled, the managed post-commit hook resolves the new full commit ID, atomically enqueues it, starts
+a detached queue-draining worker, and returns. History enqueueing occurs before refresh-only guards
+for rebase, merge, cherry-pick, changed-file filtering, or linked worktrees. Those guards may
+suppress rebuilding the current `graphify-out`, but they never suppress commit-history
+enqueueing. A launch failure leaves the queued job for the next worker launch; an explicit
+build/query of that same commit may also claim and complete its durable attempt synchronously.
+
+The worker reconciles stale attempts and drains every queued job in FIFO order before exiting.
+Multiple workers safely join or skip leases, and one terminally failed job does not prevent
+later queued jobs from running. For each claimed job it:
+
+1. Claims or joins the job lease.
+2. Creates an exact detached worktree.
+3. Selects a compatible first-parent seed.
+4. Runs complete extraction, inference, clustering, and analysis.
+5. Builds and validates the typed roots.
+6. Publishes the realization and attempts the preferred compare-and-swap.
+7. Removes the worktree and records the terminal job result.
+
+The hook captures the commit before returning. Later branch movement, amend, rebase, or checkout operations do not change the job target.
+
+### Lazy historical generation
+
+Query, path, explain, and both sides of diff use one `resolve_or_materialize` service. When a commit has no preferred realization, the command joins an existing compatible job or runs the build synchronously and reports stages on stderr.
+
+Lazy commands preserve machine-readable stdout. A provider, Git, validation, or store error returns a nonzero exit status and leaves the previous catalog unchanged.
+
+## Jobs, leases, and crash recovery
+
+Operational state remains outside the immutable Prolly store:
+
+```text
+jobs/<job-id>.json
+leases/<commit>-<profile-digest>.lease
+locks/maintenance.lock
+```
+
+Job files use bounded canonical JSON and crash-durable same-directory replacement: write a new owner-only temporary file, flush and synchronize it, atomically replace the destination, and synchronize the parent directory. Unix uses atomic `rename`; Windows uses a replace-existing, write-through primitive. Unsupported filesystems fail closed rather than claiming durability. They contain the commit, normalized non-secret build profile, profile digest, optional resolved fingerprint, state, attempt count, diagnostic, realization ID, preferred result, timestamps, and lease generation. A job file is limited to 1 MiB and its redacted diagnostic to 64 KiB.
+
+The state machine is:
+
+```text
+queued -> building -> validating -> published
+                 \-> failed
+                 \-> incomplete
+```
+
+`published` records `preferred: true` or `preferred: false`. `incomplete` never records a cataloged realization.
+
+A queued job cannot claim a final extraction fingerprint before Compass reads configuration and ignore inputs from the exact target commit. The queue therefore deduplicates by commit and normalized build-profile digest. After creating the detached worktree, the worker resolves the full fingerprint, stores it in the job, and validates that its binary and pipeline versions match any previous attempt.
+
+A worker claim creates or compare-and-swaps a lease containing a random owner ID, generation, and expiration. Leases last 120 seconds and refresh every 30 seconds during long extraction stages. A new worker may reclaim an expired lease by incrementing its generation. Every state transition and terminal write checks the generation, so late writes from an old generation fail. Wall-clock jumps can cause redundant work, but cannot corrupt the catalog or overwrite a newer job generation.
+
+Before catalog publication, the worker persists the candidate realization ID and the preferred ID it observed. Recovery reconciles stale jobs against the immutable catalog. If the realization exists, recovery retries the preferred compare-and-swap only when the observed preferred ID still matches; otherwise it records a published non-preferred result. This covers termination between catalog publication, preferred selection, and terminal job persistence.
+
+Lazy and eager requests for the same commit and build profile join one live lease. Explicit `compass history rebuild` creates a new attempt and may produce a distinct realization. Credentials and credential values never enter jobs, leases, diagnostics, fingerprints, or manifests.
+
+## Activity and maintenance locking
+
+SQLite protects database transactions, but it cannot protect a Prolly builder's
+not-yet-published nodes from concurrent garbage collection. Compass therefore uses one
+cross-process reader-writer lock file, `locks/maintenance.lock`:
+
+- query, diff, reconstruction, publication, and active builders hold a shared activity lock
+- garbage collection, non-preferred pruning, database replacement, and future migrations hold the exclusive maintenance lock
+
+The lock spans the complete multi-read or multi-write operation. This prevents garbage collection from deleting nodes used by an active reader or builder. SQLite root compare-and-swap still resolves ordinary publication contention; the maintenance lock is not a global writer lock.
+
+The implementation uses Rust's standard `File::{try_lock_shared,try_lock,unlock}` APIs and a
+bounded deadline loop; it does not add a second locking crate. Acquisition is bounded and interruptible. Guards release locks through RAII and operating-system
+process teardown. Lock upgrades are forbidden: a command must release a shared guard before
+requesting exclusive maintenance, then revalidate all observed state. Every command acquires
+the maintenance lock before opening a database transaction, preventing lock-order deadlocks.
+There is no separate `activity.lock`; two independent lock files would not provide mutual
+exclusion.
+
+## Query and reconstruction
+
+Graph-reading commands accept one exclusive source selector:
+
+```text
+compass query "authentication flow" --at <revision>
+compass path <source> <target> --at <revision>
+compass explain <symbol> --at <revision>
+```
+
+The loader resolves or materializes the preferred realization, validates it, reconstructs a `GraphDocument` in memory, and creates the existing immutable query graph. It does not write temporary `graph.json`.
+
+Historical queries use an empty learning overlay. The current checkout's `.graphify_learning.json` is experiential state, not committed realization data.
+
+Compatibility export remains explicit:
+
+```text
+compass history export <revision> --format graph-json --output <path>
+compass history export <revision> --format graphify-out --output <directory>
+```
+
+The bundle export writes stored authoritative files verbatim and regenerates every registered
+derived artifact with the renderer version recorded by the realization. It fails before
+publishing the destination when a required renderer version is unavailable; it never silently
+uses the current renderer and claims historical equivalence. The bundle destination must not
+already exist; v1 performs no implicit merge or destructive force-replacement.
+
+Reconstruction restores node and edge order, legacy `edges` spelling, hyperedge placement, unknown fields, multigraph discriminators, analysis, labels, manifest data, and semantic metadata. Tests compare parsed `GraphDocument` and sidecars, then verify stable serialized output.
+
+## Streaming graph-aware diff
+
+```text
+compass diff <old-revision> <new-revision>
+```
+
+Both revisions resolve or lazily materialize preferred realizations. Equal tree CIDs skip a record kind. Prolly's streaming diff skips equal subtrees and emits ordered changes without reconstructing both graphs.
+
+Compass projects records into:
+
+- added, removed, and changed nodes
+- added, removed, and changed edges
+- added, removed, and changed hyperedges with stable IDs
+- removal and addition for synthetic-key record changes
+- community, label, score, and ranked-analysis changes
+- graph metadata and extraction-configuration changes
+
+Output modes remain:
+
+```text
+compass diff A B
+compass diff A B --detailed
+compass diff A B --format json
+compass diff A B --topology-only
+```
+
+Summary mode retains bounded examples. Detailed mode and JSON mode write one change at a time. A failing output sink stops traversal and returns an error.
+
+## Validation and corruption handling
+
+Publication and explicit audit validate:
+
+- store-format compatibility
+- every named root and persisted tree format
+- recomputed manifest digest and realization ID
+- all five tree counts against manifest counts
+- typed-key schema and decoded record identity
+- unique node IDs and valid multigraph discriminators
+- edge endpoints and hyperedge members
+- analysis references and metadata order records
+- commit and fingerprint against catalog location
+- canonical envelope round-trip
+- completion evidence with no partial or failed semantic work
+- the v1 resource limits: 512 MiB total authoritative input, 1 MiB encoded key, 64 MiB encoded record value, 10,000,000 records per tree, JSON nesting depth 128, 1 MiB job record, and 64 KiB redacted diagnostic
+
+Unknown schema versions fail with a compatibility error. Corrupt preferred realizations never
+trigger automatic fallback or ordinary replacement. A normal eager build, lazy build, or
+rebuild may publish a valid candidate, but it remains non-preferred while the corrupt preferred
+root exists. Replacement requires:
+
+```text
+compass history rebuild <revision> --replace-corrupt
+```
+
+Recovery validates the candidate, records the corrupt preferred ID in attempt history, and
+compare-and-swaps from that exact preferred value. Concurrent repair or preferred selection
+produces a conflict instead of overwriting the winner.
+
+## Garbage collection and retention
+
+Normal retention keeps every published realization, including non-preferred ones. Git history rewriting does not automatically remove graph history.
+
+Under the exclusive maintenance lock, normal garbage collection:
+
+1. Snapshots all retained named roots.
+2. Uses Prolly retention planning to trace reachable CIDs.
+3. Rechecks the catalog digest before deletion.
+4. Deletes only unreachable node rows.
+5. Removes terminal attempt records older than 30 days and temporary directories older than
+   24 hours only when neither has a live lease. Queued or active attempts are never removed.
+
+`--prune-non-preferred` first lists candidate realization IDs and requires explicit confirmation. Pruning removes their six named roots in a strict transaction, recomputes reachability, and then deletes unreachable nodes. A preferred change or catalog digest mismatch invalidates the plan without deleting anything.
+
+SQLite may keep freed pages inside `history.sqlite`; later writes reuse them. V1 reports reclaimed rows and reusable bytes when available, but it does not claim physical file shrinkage.
+
+## Commands
+
+V1 exposes this canonical Compass surface:
+
+```text
+compass history enable [build-profile options]
+compass history disable
+compass history status [<revision>] [--format text|json]
+compass history build <revision> [build-profile options] [--format text|json]
+compass history rebuild <revision> [build-profile options] [--replace-corrupt] [--format text|json]
+compass history list [<revision>] [--format text|json]
+compass history show <realization-id> [--format text|json]
+compass history prefer <revision> <realization-id> [--format text|json]
+compass history export <revision> --format graph-json|graphify-out --output <path>
+compass history gc [--prune-non-preferred] [--yes] [--format text|json]
+compass diff <old-revision> <new-revision> [--detailed|--format json] [--topology-only]
+```
+
+Only the `compass` forms above are part of the versioned-graph public contract. Existing legacy
+`graphify` forwarding may continue on a best-effort basis, but missing commands or differences in
+help, stdout, stderr, exit status, and side effects are not Compass regressions. Compass help and
+diagnostics always use the `compass` spelling.
+
+`compass history status` reports enablement, preferred validation, queued or active jobs, failed
+attempts, gitlink or LFS limitations, and store compatibility. On a repository that has never
+created history it reports `disabled`/`no store` and exits successfully without creating files.
+`disable` is idempotent. `list` on an absent or empty store is an empty success. Explicit
+build/rebuild and lazy `--at` materialization are permitted while eager history is disabled.
+Status still renders its report but exits `1` when an existing selected preferred realization
+is corrupt or the store format is incompatible; an absent store is not an error.
+
+Exit code `0` means success, including empty read-only results; `2` means command-line usage
+error; `1` means repository, Git, provider, validation, corruption, lock, output, or store
+failure. Progress and human diagnostics go to stderr. Text or JSON results go to stdout, and
+JSON output is a single valid value even for empty results. Broken output pipes stop work and
+return failure without corrupting store state. Parsers reject unknown/repeated singleton
+options and honor `--` as the end of options for revision and path operands.
+
+## Testing strategy
+
+### Canonical and schema tests
+
+- Object insertion order produces identical canonical bytes and tree roots
+- Typed keys remain collision-free for Unicode, NUL bytes, and separators
+- Directed, undirected, simple, and multigraph edge identities match the declared rules
+- Exact duplicate multigraph edges survive reconstruction
+- Exact duplicate id-less hyperedges survive reconstruction
+- Node, edge, hyperedge, unknown-field, sidecar, and order data round-trip
+- Canonical number golden fixtures remain byte-stable across reopen and dependency checks
+- Artifact registry classification rejects undeclared authoritative sidecars
+- Derived reports regenerate with canonical semantic equivalence
+- Raw token, cost, timing, and diagnostic variation does not change realization identity
+- Fingerprints include every declared meaning input and exclude secrets and runtime-only data
+- Manifest identity excludes operational values
+
+### SQLite adapter and durability tests
+
+- Compile-time assertions cover every required Prolly store trait
+- In-memory and file-backed databases pass publication tests
+- Named roots and trees survive close and reopen
+- Strict multi-root transactions commit or roll back together
+- Concurrent connections exercise WAL, busy timeout, and preferred conflicts
+- Abrupt worker termination leaves the previous preferred realization readable
+- Store-format mismatch and corrupt root data fail closed
+- Unix permission tests verify owner-only defaults
+- operational-file fault injection proves temp sync, atomic replacement, parent sync, and symlink rejection
+- Old fixture databases reopen under the exact pinned dependencies
+
+### Property and differential tests
+
+- Random insertion order yields identical roots
+- Random graph edits reconstruct with exact supported structure and ordering
+- Streaming Prolly diff equals full in-memory graph comparison
+- Historical query, path, and explain equal `graph.json` behavior with an empty overlay
+- SQLite-backed and in-memory test stores produce identical logical roots
+
+### Git, job, and maintenance scenarios
+
+- linear history, branches, merge commits, renames, and deletions
+- SHA-1 and SHA-256 repositories
+- shallow history and missing Git objects
+- linked worktrees sharing one database
+- uncommitted caller files excluded from historical builds
+- `.git/info/exclude` and global ignores do not affect historical fingerprints or corpora
+- checkout hooks, LFS smudging, credential prompts, and network fetching remain disabled
+- detected gitlinks and LFS pointers reported without network access
+- eager queueing, lazy joining, stale-lease recovery, and late-worker rejection
+- disabled hooks enqueue nothing; enable installs the managed block; disable retains queryable history
+- one worker drains all queued attempts in FIFO claim order and continues after terminal failures
+- no-store status/list create no files and Compass process contracts remain stable
+- provider failure, partial output, retry, and recovery
+- same-fingerprint nondeterministic realizations and preferred contention
+- garbage collection racing an active reader or builder
+- shared and exclusive operations contend on the same maintenance lock file
+- stale prune plans and interrupted maintenance
+- corrupt preferred replacement requires `--replace-corrupt` and an exact compare-and-swap
+
+### Performance qualification
+
+Benchmarks record:
+
+- cold and seeded materialization time
+- database growth and reusable pages
+- publication contention across processes
+- diff latency and peak buffered records
+- query latency and peak memory
+- garbage-collection planning and sweep time
+
+Default enablement requires measurable subtree reuse and diff benefit without a material query regression. The design does not invent a percentage threshold before measurements exist.
+
+## Rollout
+
+### Phase 1: immutable SQLite storage
+
+- Add `compass-history` and exact Prolly dependency pins
+- Implement SQLite opening, format verification, canonical encoding, typed keys, manifests, publication, validation, reconstruction, and streaming diff
+- Add adapter, schema, property, corruption, and reopen tests
+
+### Phase 2: explicit history commands
+
+- Add the Compass build, rebuild, list, show, prefer, export, diff, and garbage-collection commands
+- Keep current graph persistence as the default
+
+### Phase 3: historical query and lazy materialization
+
+- Add `--at` to query, path, and explain
+- Add exact detached worktrees, compatible ancestor seeding, and synchronous lazy builds
+
+### Phase 4: eager generation and recovery
+
+- Add explicit enable/disable lifecycle and extend the managed post-commit hook
+- Add durable jobs, leases, worker recovery, retries, and diagnostics
+- Qualify linked-worktree and concurrent-process behavior
+
+### Phase 5: default-persistence evaluation
+
+- Run semantic-correctness, durability, and performance qualification
+- Make history the default only when every gate passes
+- Keep `graph.json` as a compatibility export
+- Design remote synchronization and mutable-source snapshots separately
+
+## Acceptance criteria
+
+The feature is complete when:
+
+1. Rust commands materialize and query any available Git commit from its exact superproject tree.
+2. Every preferred realization contains complete AST, semantic, inferred, hyperedge, clustering, and analysis data.
+3. SQLite transactions and catalog compare-and-swap preserve all published concurrent realizations.
+4. Reconstruction preserves Compass's supported simple and multigraph structure, order, sidecars, and unknown attributes.
+5. Cross-version diff streams Prolly changes without loading both complete graphs.
+6. Post-commit work is durable and does not block on extraction.
+7. Lazy backfill shares the same complete materializer and joins compatible active work.
+8. Interrupted, incomplete, corrupt, and unsupported builds cannot become preferred.
+9. Linked worktrees share one owner-protected SQLite store safely.
+10. Garbage collection cannot race active readers, builders, or publication.
+11. Existing commands behave as before when history is disabled.
+12. Exact pinned adapter versions pass reopen, transaction, concurrency, and migration fixtures.
+13. Artifact export preserves canonical semantic equivalence while keeping operational attempt data outside realization identity.
+14. Historical materialization is independent of caller-local ignore files, checkout hooks, and network-dependent filters.
+15. Read-only no-store commands create nothing, and eager enqueue occurs only while explicitly enabled.
+16. Compass is the sole canonical frontend; its help, parsing, output, exit status, and side effects pass the documented process contracts without depending on Graphify alias behavior.
+17. Durable job writes, generation leases, worker draining, retention, and path validation pass fault and concurrency tests.
+
+## Audit conclusions and residual risks
+
+This revision resolves the original design's storage-layout mismatch, ambiguous publication atomicity, unproven completeness marker, multigraph contradiction, ordering ambiguity, job-recovery gap, garbage-collection races, accidental eager opt-in, frontend ambiguity, non-durable operational writes, unbounded validation policy, and unspecified retention.
+
+No design can guarantee defect-free implementation. These risks remain measurable rather than hidden:
+
+- SQLite permits one writer at a time, so publication contention must pass workload benchmarks
+- semantic providers can return nondeterministic complete results, so multiple realizations remain necessary
+- bundled SQLite increases binary size and requires platform qualification
+- submodule and LFS contents remain outside v1's exact superproject snapshot
+- deleted SQLite pages may remain allocated until later reuse
+- future Prolly or adapter upgrades require explicit format and reopen qualification
+- old derived artifacts can be regenerated only while their recorded renderer version remains supported
+- wall-clock jumps may duplicate leased work, although generation checks prevent stale catalog/job writes
+
+The implementation plan must preserve these invariants and attach a failing test to every acceptance criterion before changing production behavior.

--- a/docs/superpowers/specs/2026-07-22-pr-intelligence-design.md
+++ b/docs/superpowers/specs/2026-07-22-pr-intelligence-design.md
@@ -1,0 +1,550 @@
+# Compass PR Intelligence Design
+
+**Status:** Approved design
+
+**Date:** 2026-07-22
+
+**Initial forge:** GitHub.com and GitHub Enterprise Server
+
+**Analysis SLA:** Five minutes at the declared scale tier
+
+## Goal
+
+Compass PR Intelligence gives a reviewer one reproducible answer to:
+
+- What changed architecturally?
+- What can break locally and in registered downstream repositories?
+- Which owners should review the change, and why?
+- Which tests are required, recommended, or missing?
+- Which concurrent pull requests interact with this change?
+- Why is the change risky?
+- Which findings are deterministic enough to block merging?
+
+The initial product is reviewer-first. Advisory intelligence never blocks merging. A separate selective gate blocks only deterministic architecture-policy violations, proven contract breaks, or explicitly required tests that did not run successfully.
+
+The analysis does not require an organization graph for the pull request repository. Local analysis requires the referenced Git objects and a valid Compass extraction configuration; Compass never fetches objects implicitly. When registered downstream graphs are available, the same report includes cross-repository consumers with explicit freshness and completeness. Compass waits for local, downstream, ownership, and test-impact analysis before publishing one completed report. Required tests may continue running after analysis; their gate remains pending until results bound to the exact merge revision arrive.
+
+## Non-goals
+
+The initial release does not:
+
+- Modify source code.
+- Automatically request reviewers.
+- Reorder a merge queue.
+- Execute arbitrary code from a pull request.
+- Use an opaque machine-learning score as a gate.
+- Treat inferred relationships as deterministic evidence.
+- Rebuild an entire organization during each pull request.
+- Claim organization-wide completeness when downstream evidence is unavailable.
+
+## Product decisions
+
+1. The core is an evidence-first semantic change engine.
+2. CompassQL supplies organization-specific policies and risk definitions.
+3. Historical and statistical signals are later advisory enrichments.
+4. Advisory risk and deterministic gates are separate outputs.
+5. The first release analyzes the local repository plus registered downstream consumers.
+6. The analysis SLA is five minutes; test execution has its own CI lifetime.
+7. CLI, MCP, CI, and forge delivery consume one typed result.
+8. GitHub is the first forge, but forge details do not leak into analysis semantics.
+
+## Standalone product boundary
+
+Compass owns every PR Intelligence contract: repository identity, report schemas, command syntax, Model Context Protocol (MCP) tools, storage paths, configuration, release cadence, and deprecation policy.
+
+PR Intelligence tests assert Compass behavior directly. Compass-specific runtime code, fixtures, schemas, migrations, and release automation live in the Compass repository. Standard interchange formats such as Git, SARIF, JUnit, LCOV, Cobertura, JaCoCo, and MCP remain product-neutral inputs and outputs.
+
+Compass versions its public schemas and migrations independently. A breaking command, tool, or report change follows Compass's own deprecation and schema-version policy.
+
+## Report contract
+
+The primary output is `compass.pr_intelligence.report/1`. Its identity includes the repository and pull request identities; the merge-base, pull request head, target head, and synthetic merge-result identities; the graph schema version; the extractor version and configuration digest; the policy-pack digest; and the evidence-manifest digest.
+
+Identical inputs produce byte-equivalent canonical findings. Presentation metadata such as timestamps and durations is kept outside the canonical finding set.
+
+The report contains:
+
+1. **Architecture delta:** changed entities, relationships, contracts, schemas, configuration, and architecture structure.
+2. **Impact:** direct and transitive consumers with witness paths.
+3. **Review routing:** direct, contract, downstream, and policy owners.
+4. **Verification plan:** required, recommended, and suggested tests plus coverage gaps.
+5. **Concurrent overlap:** interactions with open or queued pull requests.
+6. **Advisory risk:** an explainable risk band and independent factors.
+7. **Deterministic gates:** pass, fail, indeterminate, or error for gate-enabled rules.
+8. **Provenance and completeness:** revisions, evidence sources, freshness, graph coverage, and failures.
+
+Every claim carries its type and stable fingerprint, a human-readable statement, source and target entity identities, an optional witness path, the source revision, the evidence source and digest, confidence, completeness, freshness, and remediation.
+
+Finding fingerprints use `cmpprv1:<lowercase-sha256>`. The digest covers the fingerprint schema, finding type, rule or classifier version, stable entity identities, ordered relationship identities in the witness, and canonical scalar evidence. It excludes source line numbers, timestamps, display formatting, and transient graph indexes.
+
+### Completeness
+
+The top-level report and every cross-repository finding use these states:
+
+- `local_exact`
+- `downstream_complete`
+- `downstream_partial`
+- `downstream_unavailable`
+
+Completeness also lists every registered repository considered, its graph revision, freshness, authorization outcome, and failure state. An unavailable or unauthorized graph is not interpreted as proof that it has no affected consumers.
+
+Downstream evidence is fresh only when its graph revision matches the registered default-branch head observed in the immutable evidence manifest. A graph behind that head may still produce advisory findings, but it cannot satisfy a deterministic rule that requires complete downstream evidence. Installations may impose a stricter maximum graph age; they may not relax the exact-head requirement for deterministic downstream gates.
+
+## Revision semantics
+
+One pull request analysis captures four immutable revision identities. Comparing the merge base with the pull request head explains the author's change intent. Comparing the target head with the synthetic merge evaluates the actual candidate merge after the target branch has advanced.
+
+The change-request source resolves full commit object IDs before analysis begins. The evidence manifest is then immutable. A force push or target-branch update creates a new analysis identity; it cannot mutate an in-flight report.
+
+If Git cannot construct the synthetic merge because of a textual conflict, Compass reports that conflict, omits merge-result graph conclusions, and marks merge-result-dependent gates indeterminate. It does not analyze the pull request head as though it were the merge result.
+
+Merge queues are first-class analysis targets. A `merge_group` event is analyzed against the exact temporary group revision, including pull requests ahead of the current item.
+
+## Architecture
+
+The shared PR Intelligence operation is the external seam. CLI, MCP, CI, and forge delivery are adapters. They may parse transport input and render the typed report, but they may not calculate findings, risk, or gates.
+
+### Change-request source module
+
+This deep module owns repository identity, pull request identity, exact revisions, diff hunks, file status and renames, review state, checks, pagination, rate limits, and forge error semantics.
+
+The initial adapters are:
+
+- GitHub App or Actions event input for CI.
+- GitHub CLI for local interactive use.
+- Local Git for explicit revision analysis.
+
+GitHub adapters support GitHub.com and configured GitHub Enterprise Server hostnames. Repository identity includes forge kind, hostname, owner, and repository name. GitLab and Bitbucket justify the seam later as additional adapters. The low-level process runner remains an internal implementation detail rather than the forge interface.
+
+### Snapshot module
+
+This module reuses the graph-selection and immutable snapshot model shared with CompassQL and versioned graphs. It loads or builds graph snapshots keyed by repository, commit, extractor version, extractor configuration, and graph schema.
+
+The module supplies exact snapshots for merge base, pull request head, target head, synthetic merge result, and registered downstream revisions. It retains each history activity guard through artifact validation and reconstruction. The operation then owns the reconstructed snapshots and verifies their identities again before report persistence.
+
+### Semantic delta module
+
+This module maps changed hunks to graph entities and classifies entity and relationship changes. It owns cross-revision identity alignment, rename and move inference, contract classifiers, and architecture-delta normalization.
+
+### Relation semantics module
+
+This module gives graph relationships typed impact behavior. It owns traversal direction, contract significance, permitted depth, confidence treatment, and witness rendering for calls, imports, inheritance, events, schemas, configuration, data, packages, and deployment relationships.
+
+Raw relation strings and traversal assumptions do not leak into PR callers. The module earns depth by concentrating behavior currently repeated in affected traversal, graph analysis, policies, and PR logic.
+
+### Impact module
+
+This module accepts a semantic change set and returns local and downstream impacts with bounded witness paths. It composes relation semantics, registered consumer indexes, criticality, and graph confidence.
+
+### Ownership and test-evidence modules
+
+Ownership and test evidence vary independently and therefore have real seams with multiple adapters.
+
+Ownership adapters include graph or catalog ownership, target-branch CODEOWNERS, repository metadata, policy ownership, and historical contribution evidence.
+
+Test adapters include per-test runtime coverage, static graph relationships, build-target relationships, configured test rules, CI check results, and advisory historical evidence.
+
+### Overlap module
+
+This module builds compact pull request footprints, finds candidate interactions through inverted indexes, and performs exact combined-snapshot analysis for selected pairs or merge groups.
+
+### Decision module
+
+This module evaluates CompassQL policies, compatibility classifiers, required-test rules, advisory risk factors, evidence sufficiency, and gate eligibility. It is the only module that assigns risk bands or gate states.
+
+### Report module
+
+This module constructs the canonical typed report, stable fingerprints, human explanations, and delivery projections. Text, JSON, JSONL, SARIF, MCP structured content, and forge checks are generated from the same report.
+
+## Analysis flow
+
+1. Resolve the pull request and full revisions.
+2. Capture the immutable evidence manifest.
+3. Load or build local and downstream snapshots.
+4. Map changed hunks to entities.
+5. Compute semantic intent and merge-result deltas.
+6. Run impact, ownership, test, overlap, and policy analyses concurrently.
+7. Derive advisory risk and deterministic gate states.
+8. Persist the canonical report.
+9. Publish delivery projections.
+
+No adapter may reopen a graph or fetch mutable pull request state after the evidence manifest is captured.
+
+## Semantic architecture delta
+
+Compass begins with changed hunks instead of changed filenames. Each hunk maps to the smallest enclosing entities in the base and result snapshots.
+
+Entity alignment proceeds conservatively:
+
+1. Exact stable Compass identity.
+2. Exact language-native identity such as a fully qualified or SCIP symbol.
+3. Container and structural fingerprints for a probable move or rename.
+4. Otherwise, separate deletion and addition.
+
+Only the first two classes are exact. Probable matches are labeled and remain advisory.
+
+The semantic delta classifies:
+
+- Entity added, removed, modified, renamed, or moved.
+- Relationship added or removed.
+- Public signature, visibility, or contract shape changed.
+- Dependency direction changed.
+- Cross-community or cross-owner dependency introduced.
+- Cycle introduced or resolved.
+- Critical abstraction gained or lost dependants.
+- Contract producer and consumer changed compatibly or incompatibly.
+
+Initial contract classifiers cover:
+
+- Language-level public types, functions, methods, and traits.
+- HTTP routes and request or response shapes when present in the graph.
+- RPC operations and messages when present.
+- Events, topics, and schema-registry subjects.
+- Database tables, columns, views, routines, and migrations.
+- Configuration keys and environment variables.
+- Package coordinates and version constraints.
+- Infrastructure resources and externally referenced outputs.
+
+A classifier that cannot prove compatibility returns `possible_break`, never `proven_break`.
+
+## Impact analysis
+
+Traversal follows relation semantics rather than one universal direction:
+
+- Changed functions affect callers.
+- Changed interfaces affect implementations and consumers.
+- Changed events affect publishers and subscribers.
+- Changed tables affect queries, jobs, interfaces, and reports.
+- Changed configuration affects readers and deployments.
+- Changed packages affect importers and downstream repositories.
+
+Each finding retains the shortest useful witness. The implementation removes duplicate and subsumed paths, but never removes the only witness for a distinct owner, repository, contract, or gate.
+
+Path confidence is the weakest relationship confidence on the retained witness. Any inferred or ambiguous hop makes the path advisory.
+
+Cross-repository traversal uses stable external identities such as package coordinates, route operations, event subjects, database objects, and schema subjects. Display labels are not cross-repository identity.
+
+A deterministic downstream contract-break gate requires:
+
+- An exact changed contract identity.
+- A classifier-proven incompatible change.
+- A registered consumer using the exact affected element.
+- Fresh and complete evidence for that consumer.
+- An exact merge-result snapshot.
+
+## Ownership
+
+Compass distinguishes:
+
+- **Direct owners:** own changed files or entities.
+- **Contract owners:** own changed public contracts.
+- **Affected owners:** own proven downstream consumers.
+- **Policy owners:** own triggered architecture rules.
+- **Suggested specialists:** have advisory historical familiarity.
+
+Evidence precedence is:
+
+1. Explicit graph or catalog ownership.
+2. Target-branch CODEOWNERS.
+3. Repository and team metadata.
+4. Policy ownership.
+5. Historical contribution evidence.
+
+Target-branch CODEOWNERS is authoritative because proposed ownership changes in the pull request must not weaken review routing.
+
+Compass recommends the smallest team-oriented reviewer set that covers material ownership domains. It returns the uncovered domains when no such set exists. Historical activity never overrides declared ownership and never gates merging.
+
+## Test impact
+
+Test evidence tiers are:
+
+1. Per-test runtime coverage bound to a source revision.
+2. Static test relationships in the graph.
+3. Build-target relationships.
+4. Configured test rules.
+5. Naming, co-change, or historical failure association.
+
+Results are grouped as:
+
+- **Required:** demanded by a versioned rule.
+- **Recommended:** supported by exact coverage, static, or build evidence.
+- **Suggested:** supported only by heuristic or historical evidence.
+- **Coverage gap:** affected critical behavior has no known covering test.
+
+Aggregate coverage formats cannot prove which individual test covers a line. Compass records aggregate coverage as verification evidence but does not manufacture per-test identity.
+
+For large suites, Compass recommends a minimal set through weighted set coverage over affected entities. Contract and critical-path coverage receive priority. The report states the proportion of exact and inferred affected evidence covered by the recommendation.
+
+A missing-required-tests gate is valid only when:
+
+- A versioned target-branch rule explicitly requires a suite or target.
+- Compass can resolve that requirement to a stable CI check or test identity.
+- The execution result belongs to the exact merge revision.
+- The result is successful.
+
+Pending, skipped, cancelled, stale, or unavailable execution is not passing. The gate remains pending, indeterminate, or error according to the rule's evidence policy.
+
+Initial evidence formats are JUnit execution results, LCOV, Cobertura, JaCoCo, build-system test targets, and forge check results.
+
+## Pull request overlap
+
+Community intersection remains a weak candidate signal, not a merge-safety conclusion.
+
+Compass classifies:
+
+- `text_conflict`
+- `entity_collision`
+- `contract_consumer_interaction`
+- `dependency_intersection`
+- `deletion_reference_interaction`
+- `emergent_policy_violation`
+- `verification_overlap`
+
+Every interaction includes both pull request identities, shared entities or witness paths, directionality, confidence, completeness, and a coordination recommendation.
+
+The overlap implementation:
+
+1. Builds one compact footprint per pull request.
+2. Indexes entities, contracts, owners, policies, and critical paths.
+3. Selects candidate pairs through index intersection.
+4. Runs exact combined-snapshot analysis only for candidate pairs, explicitly requested sets, and merge groups.
+5. Caches results by target revision and ordered pull request heads.
+
+Pairwise predictions are advisory. Emergent policy or contract findings become gate-eligible only on the exact merge-group revision.
+
+## Advisory risk
+
+Risk is an explanation derived from independent factors:
+
+- **Contract severity:** internal, compatible public, possible break, or proven break.
+- **Propagation:** crossed entity, ownership, repository, and runtime domains.
+- **Criticality:** explicit catalog tier, policy tags, sensitivity, and production evidence.
+- **Verification gap:** missing or weak coverage of affected behavior.
+- **Concurrent exposure:** exact and semantic interactions with other changes.
+- **Uncertainty:** ambiguous identities, inferred paths, stale graphs, and extraction gaps.
+
+Propagation is not raw node count. Crossing a repository, ownership, deployment, or data-sensitivity domain is more material than touching many private helpers in one module.
+
+The default risk bands are:
+
+- **Critical:** proven breaking change to a critical contract, or a high-criticality path with no effective verification.
+- **High:** material public change, multi-repository propagation, or strong semantic overlap.
+- **Moderate:** bounded internal impact with identifiable owners and verification.
+- **Low:** isolated, well-verified change with complete evidence.
+
+Organization policy may raise a factor or band but may not relabel inferred evidence as exact. Uncertainty may raise risk or lower confidence; it may not lower risk.
+
+Every high or critical factor has an explanation tree with concrete evidence. LLMs may summarize the typed report but cannot create factors, change severity, or decide gates.
+
+## Deterministic gates
+
+Advisory intelligence and deterministic gates are separate forge checks.
+
+A finding is gate-eligible only when it has:
+
+- A gate-enabled, versioned rule.
+- Exact local and merge-result snapshots.
+- A stable fingerprint.
+- Exact evidence and a retained witness.
+- Sufficient freshness and completeness for that rule.
+- A reproducible remediation message.
+
+Gate states are:
+
+- `pass`
+- `fail`
+- `indeterminate`
+- `error`
+- `pending`, used only while an exact required check is still executing
+
+Missing evidence never becomes `pass`. The default treatment of `indeterminate` is advisory. Regulated installations may configure individual rules to fail closed. That decision is versioned with the policy and appears in the report.
+
+Initial deterministic rule families are:
+
+- New CompassQL architecture-policy violation.
+- Proven incompatible contract change with an exact registered consumer.
+- Explicit required test or check missing or unsuccessful on the merge revision.
+
+## Reviewer experience
+
+The forge publishes:
+
+- **Compass / PR Intelligence:** the completed advisory report.
+- **Compass / Deterministic Gates:** gate state only.
+
+The summary order is:
+
+1. Risk, gate state, and completeness.
+2. Architecture changes.
+3. Affected local and downstream systems.
+4. Recommended owners.
+5. Required and recommended tests.
+6. Coverage gaps.
+7. Overlapping pull requests.
+8. Gate findings.
+
+Source annotations are reserved for actionable findings. Full evidence is expandable and includes witness paths, confidence, freshness, and remediation.
+
+Publishing is idempotent. A rerun updates the same check and managed comment. Stable fingerprints divide findings into new, resolved, and unchanged.
+
+The initial CLI extends the existing namespace:
+
+```bash
+compass prs 123 --format text
+compass prs 123 --format json
+compass prs --overlap
+compass prs 123 --explain <finding-fingerprint>
+```
+
+MCP exposes typed `analyze_pr`, `list_pr_overlaps`, and `explain_pr_finding` operations. Each operation returns structured content derived from the canonical report.
+
+The canonical report is persisted before forge publishing. Failed delivery retries reuse the persisted report and do not rerun analysis.
+
+## Five-minute execution model
+
+The SLA applies to completed analysis, including test selection, not to the runtime of required tests.
+
+The implementation uses:
+
+- Content-addressed graph snapshots.
+- Versioned-graph subtree hashes to skip unchanged data.
+- Precomputed registered downstream contract-consumer indexes.
+- Pre-ingested ownership, coverage, build-target, and test evidence.
+- Concurrent analyses over one immutable evidence manifest.
+- Candidate filtering before combined pull request analysis.
+- Bounded traversal, memory, concurrency, and stage deadlines.
+
+The scale tier records repository count, total graph nodes and relationships, open pull request count, registered downstream count, cache state, and hardware. Compass does not advertise a five-minute SLA without that envelope.
+
+At the deadline, outstanding optional evidence is cancelled. Compass may publish with explicit downstream incompleteness only when local semantic and merge-result analysis is exact. If exact local analysis is unavailable, it publishes an operation error without a risk band.
+
+## Failure model
+
+Failures are classified as:
+
+- **Operation error:** exact local analysis cannot be trusted.
+- **Incomplete evidence:** optional downstream, ownership, or test evidence is unavailable.
+- **Indeterminate gate:** a rule requires unavailable evidence.
+- **Publishing error:** a persisted report could not be delivered.
+
+Snapshot mismatch, graph corruption, extractor mismatch, and mixed revisions are operation errors. A single optional downstream timeout is incomplete evidence. A required downstream graph timeout is also an indeterminate gate for rules that require it.
+
+All errors use stable codes, causal messages, affected evidence sources, and remediation. Execution failures never become empty successful results.
+
+## Security and authorization
+
+Pull request content is untrusted.
+
+- Policies and CODEOWNERS come from the target revision.
+- Analyzers never execute repository code.
+- Executable plugins or provider configuration introduced by the pull request are ignored.
+- Parsers use strict size, recursion, memory, and time limits.
+- Forge credentials are unavailable to source analyzers.
+- Imported graphs and evidence are schema-validated before composition.
+- Caches are tenant-scoped and content-addressed.
+- Cross-repository paths, owners, and source locations are filtered through repository authorization.
+- A reviewer without downstream access sees a redacted affected-repository fact, not protected source details.
+
+The report records redaction and authorization outcomes as completeness evidence.
+
+## Observability
+
+Operational metadata includes:
+
+- Stage duration and cancellation.
+- Cache hit, miss, and eviction.
+- Snapshot identities.
+- Evidence freshness.
+- Extraction coverage and unresolved references.
+- Registered downstream success and failure.
+- Exact versus inferred finding counts.
+- Test-impact coverage.
+- Publisher retries.
+
+Operational metadata never changes a risk band invisibly. Any signal used by the decision module appears as report evidence.
+
+## Verification
+
+The report interface is the primary test surface.
+
+### Semantic delta
+
+Fixtures cover signature changes, moves, renames, deletion and addition, relationship changes, public visibility, ambiguous matches, and stable fingerprints across supported language families.
+
+### Revision integrity
+
+Tests force target movement, pull request force-pushes, simultaneous reloads, cache reuse, and synthetic merge failures. No report may contain findings from mixed revisions.
+
+### Impact
+
+Tests cover relation direction, shortest useful witnesses, cycles, bounded traversal, confidence propagation, path subsumption, and stable cross-repository identities.
+
+### Ownership
+
+Tests cover target-branch CODEOWNERS precedence, catalog ownership, contract and downstream owners, authorization redaction, minimal team selection, and uncovered domains.
+
+### Test evidence
+
+Tests distinguish per-test and aggregate coverage, stale evidence, build targets, explicit required suites, pending and skipped checks, and unverified critical paths.
+
+### Overlap
+
+Fixtures cover every interaction class, candidate filtering, exact combined snapshots, merge groups, and policies that fail only after composition.
+
+### Risk and gates
+
+Property and mutation tests enforce:
+
+- Uncertainty never lowers risk.
+- Inferred evidence never gates.
+- Incomplete evidence never passes a rule that requires it.
+- Unrelated low-risk factors cannot hide a critical factor.
+- Identical canonical evidence produces identical fingerprints.
+
+### Security and resilience
+
+Fuzzing covers hostile diffs, malformed graphs, oversized coverage, symlinks, invalid Unicode, cyclic evidence, decompression limits, timeouts, and malicious pull request configuration.
+
+### End-to-end
+
+Tests cover GitHub pull requests, forks, force pushes, target updates, check retries, idempotent comments, required checks, and `merge_group` events.
+
+### Performance
+
+Cold and warm benchmarks cover declared small, medium, large, and organization scale tiers. The release gate measures p50 and p95 wall time, peak memory, graph cache reuse, downstream fan-out, open-pull-request overlap count, cancellation latency, and report size.
+
+## Rollout
+
+This document is the umbrella design. It is intentionally not implemented through one monolithic plan. Delivery is decomposed into child design and implementation cycles:
+
+1. **PR Intelligence foundation:** typed report, exact revision capture, evidence manifest, snapshot use, shared operation module, persistence, and typed CLI/MCP adapters.
+2. **Semantic delta and local impact:** hunk mapping, identity alignment, relation semantics, contract classification, and witnesses.
+3. **Ownership, tests, and decisions:** evidence adapters, reviewer routing, test planning, risk explanations, and deterministic rules.
+4. **Downstream federation:** registered consumer indexes, authorization, freshness, completeness, and cross-repository witnesses.
+5. **Overlap and merge groups:** footprints, candidate pairing, combined snapshots, and exact merge-queue evaluation.
+6. **Historical calibration:** separately labeled advisory outcome evidence.
+
+Each child receives its own approved specification and implementation plan. Child 1 is first because every later child consumes its report, revision, evidence, and operation interfaces. The interfaces are allowed to grow only through versioned additions proven necessary by a later child; child 1 must not prebuild speculative historical or multi-forge implementation.
+
+PR Intelligence remains preview-only until stages 1 through 5 operate together. Preview commands and MCP tools use the versioned typed report from their first release.
+
+Production rollout begins in shadow mode:
+
+1. Publish advisory reports without gates.
+2. Compare owners and tests with reviewer choices and runtime evidence.
+3. Measure false positives, missed impacts, stale evidence, and latency.
+4. Enable deterministic gates one rule at a time after rule-specific validation.
+5. Retain a versioned per-rule emergency disable and full audit history.
+
+## Success criteria
+
+- p95 analysis completes within five minutes for the documented scale tier.
+- Identical inputs produce byte-equivalent canonical findings.
+- No deterministic gate uses inferred or incomplete evidence.
+- Every high or critical factor has a human-readable witness.
+- Every downstream conclusion reports completeness and freshness.
+- Test recommendations report exact and inferred coverage separately.
+- Force pushes replace stale findings without comment duplication.
+- Reviewers can explain every recommended owner and test.
+- Gate false positives are measured per rule before enforcement.
+- The analysis result can be reproduced from its persisted evidence manifest.

--- a/docs/superpowers/specs/2026-07-22-versioned-graph-gap-mitigations-design.md
+++ b/docs/superpowers/specs/2026-07-22-versioned-graph-gap-mitigations-design.md
@@ -1,0 +1,332 @@
+# Versioned Graph Resolution and Semantic Diff Mitigations
+
+**Date:** 2026-07-22
+
+**Status:** Approved
+
+**Implementation root:** `/Users/haipingfu/graphify/compass`
+
+**Amends:** `docs/superpowers/plans/2026-07-21-versioned-graph-prolly-tree.md`
+
+## Purpose
+
+This design closes correctness and usability gaps found while verifying Compass versioned graphs end to end against LevelDB. It preserves the approved SQLite-backed Prolly architecture while making lazy materialization use the intended build profile, preventing read operations from leaving unnecessary jobs, requiring comparable realizations for normal diffs, and distinguishing meaningful graph changes from source-location churn.
+
+The verification established that raw Prolly diffs are deterministic and correct relative to exported graph records. The remaining problems are resolution policy and presentation:
+
+- Lazy `query --at`, `path --at`, `explain --at`, export, and `diff` use default build options rather than the enabled repository profile.
+- Resolution enqueues a job before checking whether a valid preferred realization already exists.
+- Function-body changes are not represented directly when topology is unchanged.
+- A one-line insertion can surface as many changed nodes and edges because `source_location` is treated like any other attribute.
+- Analysis and metadata churn can obscure the architectural changes a person is trying to understand.
+
+## Approved decisions
+
+- One centralized resolver governs historical query, path, explain, export, and diff.
+- Valid existing realizations are resolved and validated before any durable mutation.
+- A normal diff requires matching extraction fingerprints.
+- Cross-profile comparison requires explicit `--allow-profile-mismatch`.
+- Missing history is materialized using a comparable stored profile when possible.
+- Every realization stores its canonical non-secret build profile, not only a fingerprint.
+- Code symbols record stable signature, implementation, and source hashes without changing their identity keys.
+- Diff records are classified as semantic, textual, location, analysis, or metadata changes.
+- Default text output shows semantic changes first and collapses location, analysis, and metadata churn into separate sections.
+- `--topology-only` means literal topology: node and edge identity additions and removals only.
+- JSON uses a versioned comparison envelope and retains every streamed record with its category.
+- The versioned graph feature has not shipped, so the development v1 realization format may be amended without migration support.
+- Compass is the canonical command surface; Graphify compatibility does not constrain this design.
+
+## Goals
+
+1. Make eager and lazy materialization use the same normalized profile semantics.
+2. Ensure a successful historical read is operationally read-only when its realization already exists.
+3. Prevent extraction-environment differences from masquerading as code-architecture differences.
+4. Report implementation changes even when node and edge topology is unchanged.
+5. Preserve complete exact diffs while presenting meaningful changes before positional and derived churn.
+6. Retain streaming, bounded-memory behavior and Prolly subtree reuse.
+7. Produce actionable, deterministic diagnostics for missing, corrupt, or incomparable history.
+
+## Non-goals
+
+- Inferring semantic equivalence between two different extraction fingerprints.
+- Automatically replacing a corrupt preferred realization.
+- Mutating preferred pointers merely to satisfy one diff invocation.
+- Storing source text or secrets in realization manifests.
+- Adding a second semantic-only Prolly tree in this version.
+- Maintaining the current development-only JSON diff shape.
+
+## Central history resolver
+
+Introduce one resolver service used by every commit-aware read command. It owns repository discovery, revision resolution, store access, profile selection, job creation, waiting, validation, and reconstruction boundaries.
+
+The resolver exposes three conceptual operations:
+
+- `resolve_existing`: locate and validate an existing realization without creating a store, job, lease, hook, or temporary worktree.
+- `resolve_or_materialize`: return a valid realization or materialize exactly one missing commit with a selected profile.
+- `resolve_comparable_pair`: resolve two commits, enforce the requested fingerprint policy, and return validated realizations ready for Prolly diffing.
+
+### Existing-realization fast path
+
+The resolver must perform these steps in order:
+
+1. Resolve the revision to an exact Git object ID.
+2. Open an existing history store without creating operational state.
+3. Look up the selected or preferred realization.
+4. Validate the realization and all required roots.
+5. Return immediately when it is valid.
+
+Only after this fast path fails may the resolver create the history store, allocate a job, acquire a lease, or create an exact-tree worktree. Tests must assert that the job count, SQLite modification time, and operational directories do not change on the fast path.
+
+A corrupt preferred realization fails closed. It is not silently skipped, replaced, or rebuilt. The diagnostic directs the user to `compass history rebuild REV --replace-corrupt`.
+
+### Profile selection
+
+When materialization is required, choose a profile in this order:
+
+1. An explicit `--profile-from REV|REALIZATION` request.
+2. The stored profile of the already-resolved counterpart in a comparable diff.
+3. The enabled repository-wide `HistoryConfig.profile`.
+4. Deterministic Compass defaults when no repository profile exists.
+
+Explicit `compass history build REV` options continue to define their own normalized profile. Eager jobs capture the enabled profile at enqueue time; later configuration changes do not rewrite legitimate queued jobs.
+
+The selected profile is canonicalized before the job ID is derived. Concurrent requests for the same commit and profile join the same non-terminal job.
+
+## Comparable realization selection
+
+`compass diff OLD NEW` first resolves both preferred realizations without writes.
+
+| OLD | NEW | Behavior |
+|---|---|---|
+| Present, same fingerprint | Present, same fingerprint | Validate both and stream the diff. |
+| Present | Missing | Materialize NEW with OLD's stored profile. |
+| Missing | Present | Materialize OLD with NEW's stored profile. |
+| Missing | Missing | Materialize both with the enabled profile, or deterministic defaults if history is not configured. |
+| Present, different fingerprints | Present, different fingerprints | Fail before scanning Prolly trees. |
+| Corrupt | Any | Fail closed with explicit recovery instructions. |
+
+The normal mismatch error includes both commits, realization IDs, fingerprints, and concise remediation:
+
+```text
+error: realizations are not semantically comparable
+
+OLD fingerprint: abc…
+NEW fingerprint: def…
+
+Build a comparable realization:
+  compass history build NEW --profile-from OLD
+
+Or inspect intentionally:
+  compass diff OLD NEW --allow-profile-mismatch
+```
+
+`--fingerprint SHA` selects existing valid realizations with that fingerprint on both commits without changing preferred pointers. A missing or ambiguous selection is an error. `--profile-from` is the explicit mechanism for creating a missing comparable realization.
+
+`--allow-profile-mismatch` bypasses only the comparability check. It never changes profile data or preferred pointers. Text mode writes a prominent warning to stderr. JSON records `profile_mismatch: true` in the comparison metadata.
+
+## Immutable profile provenance
+
+Each realization manifest stores:
+
+- The normalized non-secret `BuildProfile`.
+- Its profile digest.
+- The extraction fingerprint derived from all meaning-affecting inputs.
+- Canonicalization, definition-hash, graph-schema, extractor, resolver, and analysis versions.
+
+Publication validates that the stored profile digest matches the canonical profile bytes and agrees with the fingerprint inputs. Profiles must not contain API keys, bearer tokens, authorization headers, environment values, or credential-bearing endpoints.
+
+Operational job files may be cleaned without losing the ability to reproduce a realization. Reproduction depends only on immutable realization provenance and available source/tool artifacts.
+
+## Stable symbol change evidence
+
+Code-symbol records gain three optional versioned attributes:
+
+- `signature_hash`: a hash of the normalized declaration or public interface.
+- `implementation_hash`: a hash of the normalized implementation AST.
+- `source_hash`: a hash of the exact definition slice after line-ending normalization.
+
+These attributes do not participate in node identity. A symbol moved within or between files retains its identity under the existing canonical ID rules.
+
+The implementation hash excludes absolute positions, whitespace, and comment nodes. Its input is a deterministic representation of node kinds, operators, identifiers, literals, and ordered named children. The algorithm version is part of the realization fingerprint. When a supported parser cannot provide a trustworthy definition boundary, Compass omits the hash and records the limitation instead of fabricating one.
+
+The source hash detects formatting and comment-only edits that do not alter the normalized implementation. Compass stores only digests, never source slices.
+
+## Diff classification
+
+The existing typed Prolly diff remains the source of raw changes. A bounded classifier processes each `GraphChange` independently.
+
+Classification first uses the named root that produced the record. Every analysis-tree record is **analysis**, and every metadata-tree record is **metadata**, including additions and removals. Records from the node, edge, and hyperedge trees then use this precedence:
+
+1. **Semantic:** record identity added or removed; signature, implementation, topology, relation, confidence, or another meaning-bearing attribute changed.
+2. **Textual:** only the exact source hash changed while normalized signature and implementation hashes remained equal.
+3. **Location:** old and new records become equal after removing position, span, line, and column fields.
+
+Community assignments, normalized labels, questions, cycles, surprises, and other analysis outputs belong to the analysis category. Artifact-registry, manifest, provenance, build-state, and other metadata outputs belong to the metadata category.
+
+Node and edge keys remain unchanged. Location fields remain stored so historical explanation and navigation preserve exact coordinates.
+
+## Command behavior
+
+The command surface becomes:
+
+```text
+compass diff OLD NEW
+  [--detailed]
+  [--format text|json]
+  [--topology-only]
+  [--include-locations]
+  [--include-analysis]
+  [--include-metadata]
+  [--fingerprint SHA]
+  [--allow-profile-mismatch]
+
+compass history build REV [build-profile options]
+  [--profile-from REV|REALIZATION]
+```
+
+`--profile-from` conflicts with direct build-profile options. `--fingerprint` conflicts with `--allow-profile-mismatch` because the former requests comparability and the latter waives it.
+
+### Text output
+
+Default text output orders sections by usefulness:
+
+```text
+Semantic graph changes
+  5 nodes added
+  8 edges added
+  1 implementation changed
+
+Textual changes
+  2 definitions changed without semantic AST changes
+
+Analysis changes
+  27 community assignments changed (collapsed)
+
+Location changes
+  161 records moved across 1 file (collapsed)
+
+Metadata changes
+  3 records changed (collapsed)
+```
+
+`--detailed` expands semantic and textual changes but leaves the other sections collapsed. The corresponding `--include-*` option expands a collapsed category. Examples remain bounded.
+
+`--topology-only` emits only node and edge identity additions and removals. Attribute, implementation, textual, location, analysis, and metadata changes are excluded. A function-body-only commit therefore reports an implementation change normally and `no topology changes` under `--topology-only`.
+
+### JSON output
+
+JSON uses a versioned envelope:
+
+```json
+{
+  "schema_version": 2,
+  "comparison": {
+    "old_commit": "...",
+    "new_commit": "...",
+    "old_realization": "...",
+    "new_realization": "...",
+    "old_fingerprint": "...",
+    "new_fingerprint": "...",
+    "profile_mismatch": false
+  },
+  "changes": [
+    {
+      "category": "semantic",
+      "record": "node",
+      "change": "changed",
+      "key": ["..."],
+      "old": {},
+      "new": {}
+    }
+  ],
+  "summary": {
+    "semantic": 12,
+    "textual": 2,
+    "location": 161,
+    "analysis": 27,
+    "metadata": 3
+  }
+}
+```
+
+The writer emits comparison metadata, streams the `changes` array, and appends the bounded summary. A broken or short writer aborts the Prolly scan promptly. JSON ordering is deterministic for identical roots and options.
+
+## Error and recovery behavior
+
+- Unknown revisions fail before opening or creating history storage.
+- Missing provider credentials or unsupported historical inputs fail without publishing a candidate.
+- Fingerprint mismatches fail before reading changed Prolly subtrees.
+- Corrupt preferred state requires explicit rebuild recovery.
+- A failed materialization remains diagnostic operational state and never becomes preferred.
+- A valid existing realization returns without creating or joining a job.
+- An explicit mismatched comparison remains read-only and clearly marks the mismatch.
+- Temporary exact-tree worktrees are removed after success, failure, cancellation, or process recovery.
+
+## Performance and boundedness
+
+The classifier does not materialize complete graphs. It retains category counts, bounded examples, and renderer state. Raw JSON changes continue streaming directly to the output writer.
+
+Equal stored roots return without node reads. Different roots continue using `Prolly::stream_diff`, preserving shared-subtree skipping. Adding hashes changes only the symbol records whose definitions are affected; unchanged records and subtrees remain content-addressed and reusable.
+
+No second semantic-view tree is introduced until measurements show classification itself is a bottleneck.
+
+## Verification requirements
+
+### Resolver and job lifecycle
+
+- Enabled profile exclusions are honored by lazy diff, query, path, explain, and export.
+- A valid preferred realization creates no store, job, lease, hook, or temporary worktree.
+- One missing diff side inherits the other side's stored profile.
+- Two missing sides use one identical enabled or default profile.
+- Concurrent requests join one commit/profile job.
+- Corrupt preferred state fails without automatic replacement.
+- Legitimate queued jobs retain the profile captured when they were enqueued.
+
+### Comparability
+
+- Matching fingerprints stream normally.
+- Mismatched fingerprints fail before Prolly node reads.
+- `--allow-profile-mismatch` warns and marks JSON metadata.
+- `--fingerprint` selects deterministic non-preferred realizations without changing preferred roots.
+- `--profile-from` recreates the stored non-secret profile exactly.
+
+### Diff meaning
+
+- A function-body-only edit produces an implementation change.
+- A signature edit produces a signature change.
+- A formatting-only edit is textual, not semantic.
+- A line insertion produces a collapsed location section.
+- A new function and call produce node and edge additions.
+- Community churn is classified as analysis.
+- Manifest and artifact-registry churn is classified as metadata.
+- `--topology-only` excludes implementation, attribute, location, analysis, and metadata changes.
+
+### Determinism and durability
+
+- Forward and reverse diffs swap old/new values and added/removed kinds symmetrically.
+- Repeated JSON output is byte-identical.
+- Identical roots produce an empty change array without additional node reads.
+- Broken output streams stop scanning promptly.
+- Publication and preferred selection remain atomic across injected failures.
+- Reopening SQLite validates all named roots and stored profile provenance.
+
+### End-to-end replay
+
+Keep synthetic repositories in mandatory CI for deterministic coverage. Provide an optional real-repository replay script that reproduces the LevelDB scenarios:
+
+- `78a352f..4a0c572`: body-only deadlock fix and location separation.
+- `bfae97f..1d6e8d6`: Zstd symbols and call edges added.
+
+The replay verifies independent graph exports against Prolly node and edge counts, JSON determinism, reverse symmetry, topology filtering, historical query selection, and a clean original checkout.
+
+## Acceptance criteria
+
+The mitigation is complete when:
+
+1. Lazy and eager paths select profiles through the same resolver.
+2. Reading a valid preferred realization leaves durable operational state unchanged.
+3. Normal diff cannot compare unequal fingerprints.
+4. Body-only changes are visible without treating line shifts as semantic changes.
+5. Default output presents semantic changes first and collapses location, analysis, and metadata churn.
+6. JSON remains complete, deterministic, streamable, and explicitly versioned.
+7. All resolver, durability, classification, CLI, and real-replay verification gates pass.


### PR DESCRIPTION
## Summary

- restore the recovered versioned-graph implementation plan, design, and gap-mitigation design
- restore the Compass Guard implementation plan
- restore the latest recovered PR Intelligence design and foundation plan
- update the roadmap so these committed plans are discoverable

## Why

These documents were displaced as untracked material when the former local `main` was synchronized with `origin/main`. The source and generated material in that recovery snapshot was audited separately; this PR preserves only the seven unique planning documents.

## Impact

Documentation only. This adds no runtime or build changes.

## Validation

- `git diff main...HEAD --check`
- verified every committed file is byte-identical to its recovery copy
- verified relative Markdown links in all seven files resolve
- confirmed generated `graphify-out/` material was not staged