### PR TITLE
Support Perl executables in Compass graphs

### DIFF
--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -342,6 +342,7 @@ fn build_graph_inner(
         .into_iter()
         .flatten()
         .map(PathBuf::from)
+        .filter(|path| Registry::resolve(path).is_some())
         .collect::<Vec<_>>();
     sources.extend(
         detection
@@ -2293,6 +2294,38 @@ mod tests {
         assert!(
             code_positions.iter().max() < document_positions.iter().min(),
             "Python compatibility requires every code extraction to precede deterministic document extraction"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_extensionless_shebang_is_skipped() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        fs::write(
+            directory.path().join("main.py"),
+            "def supported_symbol():\n    return 1\n",
+        )?;
+        fs::write(
+            directory.path().join("vendor-treadmill"),
+            "#!/usr/bin/fish\nfunction unsupported_symbol; echo 1; end\n",
+        )?;
+        let mut options = BuildOptions::new(directory.path());
+        options.no_cluster = true;
+        options.no_viz = true;
+
+        let result = build_local_graph(&options)?;
+        let graph = GraphDocument::load(&result.output_dir.join("graph.json"))?;
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .any(|node| node.label() == "supported_symbol()")
+        );
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .all(|node| node.string("source_file") != "vendor-treadmill")
         );
         Ok(())
     }

--- a/crates/compass-files/src/detect.rs
+++ b/crates/compass-files/src/detect.rs
@@ -17,9 +17,9 @@ const CODE_EXTENSIONS: &[&str] = &[
     "groovy", "gradle", "cpp", "cc", "cxx", "c", "h", "hpp", "cu", "cuh", "metal", "rb", "rake",
     "swift", "kt", "kts", "cs", "scala", "php", "lua", "luau", "toc", "zig", "ps1", "psm1", "psd1",
     "ex", "exs", "m", "mm", "jl", "vue", "svelte", "astro", "dart", "v", "sv", "svh", "sql", "r",
-    "f", "f90", "f95", "f03", "f08", "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk",
-    "sh", "bash", "json", "tf", "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx",
-    "csproj", "fsproj", "vbproj", "xaml", "razor", "cshtml", "cls", "trigger",
+    "pl", "pm", "f", "f90", "f95", "f03", "f08", "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm",
+    "lfm", "lpk", "sh", "bash", "json", "tf", "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf",
+    "sln", "slnx", "csproj", "fsproj", "vbproj", "xaml", "razor", "cshtml", "cls", "trigger",
 ];
 const DOCUMENT_EXTENSIONS: &[&str] = &[
     "md", "mdx", "qmd", "skill", "txt", "rst", "html", "yaml", "yml", "docx", "xlsx", "gdoc",
@@ -76,6 +76,7 @@ const SKIP_DIRS: &[&str] = &[
     ".nox",
     ".eggs",
     "compass-out",
+    "graphify-out",
     "coverage",
     "lcov-report",
     "visual-tests",
@@ -249,6 +250,7 @@ impl WatchPathFilter {
             || relative.components().any(|component| {
                 let value = component.as_os_str().to_string_lossy();
                 value.starts_with('.')
+                    || SKIP_DIRS.contains(&value.as_ref())
                     || value == self.output_name
                     || Path::new(&self.output_name)
                         .file_name()
@@ -583,6 +585,8 @@ fn shebang_is_code(path: &Path) -> bool {
                 | "python2"
                 | "ruby"
                 | "perl"
+                | "perl5"
+                | "perl6"
                 | "node"
                 | "nodejs"
                 | "bash"

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -108,7 +108,23 @@ fn watcher_filter_reuses_ignore_and_output_boundaries() -> Result<(), Box<dyn Er
     assert!(!filter.allows(&root.join("model.generated.rs")));
     assert!(!filter.allows(&root.join(".hidden/main.rs")));
     assert!(!filter.allows(&root.join("compass-out/graph.json")));
+    assert!(!filter.allows(&root.join("graphify-out/graph.json")));
     assert!(!filter.allows(&root.join("README.unknown")));
+    Ok(())
+}
+
+#[test]
+fn detection_ignores_graphify_generated_output() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    fs::write(root.join("main.rs"), "fn main() {}\n")?;
+    fs::create_dir(root.join("graphify-out"))?;
+    fs::write(root.join("graphify-out/graph.json"), "{}\n")?;
+    fs::write(root.join("graphify-out/.graphify_labels.json"), "{}\n")?;
+
+    let detection = compass_files::detect(root, &DetectOptions::default())?;
+    assert_eq!(detection.files["code"].len(), 1);
+    assert!(detection.files["code"][0].ends_with("main.rs"));
     Ok(())
 }
 
@@ -148,6 +164,8 @@ fn classification_exercises_manifests_shebangs_media_papers_and_asset_exclusions
         ("pyproject.toml", "[project]\n", Some(FileType::Code)),
         ("view.blade.php", "<div />\n", Some(FileType::Code)),
         ("main.rs", "fn main() {}\n", Some(FileType::Code)),
+        ("script.pl", "sub main {}\n", Some(FileType::Code)),
+        ("Module.pm", "package Module;\n", Some(FileType::Code)),
         ("photo.PNG", "image", Some(FileType::Image)),
         ("clip.MP4", "video", Some(FileType::Video)),
         ("notes.md", "ordinary notes", Some(FileType::Document)),
@@ -204,7 +222,7 @@ fn detector_covers_nested_ignores_memory_sensitive_files_and_large_corpus_warnin
     fs::write(root.join(".env.local"), "TOKEN=nope\n")?;
     fs::write(root.join("song.mp3"), b"audio")?;
 
-    let memory = root.join("graphify-out/memory/nested");
+    let memory = root.join("compass-out/memory/nested");
     fs::create_dir_all(&memory)?;
     fs::write(memory.join("remember.md"), "# Durable memory\n")?;
 

--- a/crates/compass-languages/src/config.rs
+++ b/crates/compass-languages/src/config.rs
@@ -145,6 +145,20 @@ pub(crate) fn generic_config(spec: LanguageSpec) -> GenericConfig {
             "object",
             &["name"],
         ),
+        "perl" => config(
+            &[],
+            &["subroutine_declaration_statement"],
+            &["use_statement", "require_expression"],
+            &[
+                "function_call_expression",
+                "ambiguous_function_call_expression",
+            ],
+            "function",
+            &[],
+            "",
+            "",
+            &["bareword", "function", "package"],
+        ),
         "lua" => config(
             &[],
             &["function_declaration"],

--- a/crates/compass-languages/src/registry.rs
+++ b/crates/compass-languages/src/registry.rs
@@ -82,6 +82,7 @@ impl Registry {
             "kt" | "kts" => spec("kotlin", "kotlin", ExtractorKind::Generic),
             "scala" => spec("scala", "scala", ExtractorKind::Generic),
             "php" => spec("php", "php", ExtractorKind::Generic),
+            "pl" | "pm" => spec("perl", "perl", ExtractorKind::Generic),
             "swift" => spec("swift", "swift", ExtractorKind::Generic),
             "lua" | "luau" | "toc" => spec("lua", "lua", ExtractorKind::Generic),
             "zig" => spec("zig", "zig", ExtractorKind::Generic),
@@ -152,8 +153,8 @@ impl Registry {
         &[
             "py", "ts", "tsx", "js", "go", "rs", "java", "c", "cpp", "rb", "cs", "kt", "scala",
             "php", "swift", "lua", "zig", "ps1", "ex", "m", "jl", "f90", "vue", "svelte", "astro",
-            "dart", "v", "sql", "md", "pas", "dfm", "sh", "json", "tf", "dm", "sln", "csproj",
-            "xaml", "razor", "cls",
+            "dart", "v", "sql", "pl", "pm", "md", "pas", "dfm", "sh", "json", "tf", "dm", "sln",
+            "csproj", "xaml", "razor", "cls",
         ]
     }
 }
@@ -179,6 +180,7 @@ fn shebang_spec(path: &Path) -> Option<LanguageSpec> {
         }
         "node" | "nodejs" => Some(spec("javascript", "javascript", ExtractorKind::Generic)),
         "ruby" => Some(spec("ruby", "ruby", ExtractorKind::Generic)),
+        "perl" | "perl5" | "perl6" => Some(spec("perl", "perl", ExtractorKind::Generic)),
         "lua" => Some(spec("lua", "lua", ExtractorKind::Generic)),
         "php" => Some(spec("php", "php", ExtractorKind::Generic)),
         "julia" => Some(spec("julia", "julia", ExtractorKind::Generic)),

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::fs;
 
-use compass_languages::{Engine, ExtractError, make_id};
+use compass_languages::{Engine, ExtractError, Registry, make_id};
 
 #[test]
 fn caller_supplied_source_matches_file_based_generic_extraction() -> Result<(), Box<dyn Error>> {
@@ -13,6 +13,55 @@ fn caller_supplied_source_matches_file_based_generic_extraction() -> Result<(), 
     let from_file = Engine::default().extract(&path)?;
     let from_memory = Engine::default().extract_source(&path, source)?;
     assert_eq!(from_memory, from_file);
+    Ok(())
+}
+
+#[test]
+fn extensionless_perl_shebang_extracts_subroutines_and_calls() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("buildah-vendor-treadmill");
+    fs::write(
+        &path,
+        r#"#!/usr/bin/perl
+use strict;
+use warnings;
+
+sub helper {
+    return 1;
+}
+
+sub run {
+    helper();
+}
+
+run();
+"#,
+    )?;
+
+    assert_eq!(Registry::resolve(&path).map(|spec| spec.name), Some("perl"));
+    let extraction = Engine::default().extract(&path)?;
+    assert!(
+        extraction
+            .nodes
+            .iter()
+            .any(|node| node.label() == "helper()"),
+        "nodes={:?}",
+        extraction.nodes
+    );
+    assert!(
+        extraction.nodes.iter().any(|node| node.label() == "run()"),
+        "nodes={:?}",
+        extraction.nodes
+    );
+    let helper_id = make_id(&[&path.to_string_lossy(), "helper"]);
+    let run_id = make_id(&[&path.to_string_lossy(), "run"]);
+    assert!(
+        extraction.edges.iter().any(|edge| {
+            edge.source == run_id && edge.target == helper_id && edge.string("relation") == "calls"
+        }),
+        "edges={:?}",
+        extraction.edges
+    );
     Ok(())
 }
 

--- a/crates/compass-languages/tests/registry.rs
+++ b/crates/compass-languages/tests/registry.rs
@@ -15,7 +15,7 @@ fn registry_covers_every_python_dispatch_extension() -> Result<(), Box<dyn Error
         "svelte", "astro", "dart", "v", "sv", "svh", "sql", "md", "mdx", "qmd", "skill", "pas",
         "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk", "sh", "bash", "json", "tf",
         "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx", "csproj", "fsproj",
-        "vbproj", "xaml", "razor", "cshtml", "cls", "trigger",
+        "vbproj", "xaml", "razor", "cshtml", "cls", "trigger", "pl", "pm",
     ];
     for extension in ordinary {
         let path = directory.path().join(format!("sample.{extension}"));
@@ -58,6 +58,7 @@ fn every_declared_grammar_is_statically_available() {
         "lua",
         "objc",
         "pascal",
+        "perl",
         "php",
         "powershell",
         "python",

--- a/vendor/compass-tree-sitter-language-pack/build.rs
+++ b/vendor/compass-tree-sitter-language-pack/build.rs
@@ -75,6 +75,7 @@ const COMPASS_STATIC_LANGUAGES: &[&str] = &[
     "lua",
     "objc",
     "pascal",
+    "perl",
     "php",
     "powershell",
     "python",


### PR DESCRIPTION
## Summary

- statically link the pinned `tree-sitter-perl` grammar
- recognize `.pl`, `.pm`, and extensionless `perl` / `perl5` / `perl6` shebang sources
- extract Perl subroutines, imports, and function calls through the generic AST engine
- skip detected sources that do not have a registered extractor instead of aborting the entire graph build
- exclude legacy `graphify-out/` artifacts from scans and filesystem watch events

## Root cause

Compass source detection recognized the extensionless `hack/buildah-vendor-treadmill` Perl executable as code, but the language registry did not resolve Perl and the bundled Perl grammar was not in the statically linked parser set. The pipeline therefore sent the path to the extraction engine and failed the whole update with `unsupported deterministic source format`.

After that failure was removed, Podman's existing `graphify-out/.graphify_labels.json` was also scanned because the legacy output directory was missing from Compass's skip list.

## Impact

`compass update .` now completes on Podman and produces real graph facts for its extensionless Perl executable. Other shebangs that detection recognizes but Compass does not yet parse, such as Fish, are skipped without making the output directory empty or aborting supported extraction.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-files -p compass-languages -p compass-core`
- forced Podman build: 8,191 files, 116,336 nodes, 237,600 edges, 8,383 communities in 35.64s
- warm Podman build: 0 extracted / 8,191 cached in 11.29s
- CompassQL query: 24 symbols from `hack/buildah-vendor-treadmill` in 1.10s
- verified 87 incident relationships for the Perl executable, including resolved internal call edges
