### PR TITLE
Make compatibility lineage explicit and preserve directed wiki evidence

### DIFF
--- a/.github/workflows/compass-ci.yml
+++ b/.github/workflows/compass-ci.yml
@@ -24,11 +24,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Verify the compatibility contract
+        run: |
+          python3 -m unittest discover -s scripts/tests -p "test_*.py"
+          python3 scripts/check_compatibility_manifest.py --check
+
       - name: Check out the Graphify compatibility oracle
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: Graphify-Labs/graphify
-          ref: v8
+          ref: de0806be7c95d97aa7ff40371a235da899d6edb0
           path: python-oracle
 
       - name: Install Python oracle

--- a/.github/workflows/compass-hardening.yml
+++ b/.github/workflows/compass-hardening.yml
@@ -16,11 +16,13 @@ jobs:
         working-directory: .
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Verify the compatibility contract
+        run: python3 scripts/check_compatibility_manifest.py --check
       - name: Check out the Graphify compatibility oracle
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: Graphify-Labs/graphify
-          ref: v8
+          ref: de0806be7c95d97aa7ff40371a235da899d6edb0
           path: python-oracle
       - name: Install Python oracle
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -213,7 +215,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: Graphify-Labs/graphify
-          ref: v8
+          ref: de0806be7c95d97aa7ff40371a235da899d6edb0
           path: python-oracle
       - name: Install Python oracle
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -261,7 +263,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: Graphify-Labs/graphify
-          ref: v8
+          ref: de0806be7c95d97aa7ff40371a235da899d6edb0
           path: python-oracle
       - name: Install Python oracle
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,16 +4,43 @@ Compass is a native Rust implementation of Graphify. The Rust workspace uses a
 frozen Python Graphify checkout as a development oracle, but releases ship only
 the `compass` executable.
 
+The machine-readable [`compatibility.toml`](compatibility.toml) manifest is the
+authoritative compatibility identity. This ledger explains that contract for
+humans; `scripts/check_compatibility_manifest.py --check` rejects drift between
+the manifest, this document, and CI.
+
 ## Frozen oracle
 
-- Python baseline: Graphify `v0.9.20`
-- Baseline commit: `edec9eabeceeae6aa2375eddb3835efa1a32c0a3`
+- Python release base: Graphify `v0.9.20` at
+  `edec9eabeceeae6aa2375eddb3835efa1a32c0a3`
+- Qualified oracle checkpoint:
+  `de0806be7c95d97aa7ff40371a235da899d6edb0`
 - Oracle runtime: the repository's pinned Python environment
 - Native implementation root: the Compass repository root
 
-There are no committed changes to `graphify/` between the frozen baseline and
-the current implementation checkpoint. A future Python behavior change must be
-added below before it can be called compatible.
+The qualified checkpoint is one commit after the release base. It adds
+deterministic R extraction and its fixture, which the merged R parity suite
+requires. The exact checkpoint, rather than the mutable `v8` branch, is the
+behavioral oracle. Any future Python behavior change must be added below before
+it can be called compatible.
+
+## Upstream lineages
+
+Graphify `origin/main` is tracked as a capability audit, not as the
+byte-compatible behavioral oracle:
+
+- audited main commit:
+  `91f4d120b630ee35c79bf3c75ccd186870a808f9`;
+- main lineage: Graphify v1, package version `0.1.14`;
+- common ancestor with the v8 lineage:
+  `81a43f028ff1d3fd9a0893318272348a38dad660`.
+
+The main and v8 lines diverged after that ancestor. A main-only capability is
+classified in `compatibility.toml` as `compatible`, `superseded`,
+`intentional-divergence`, or `not-supported`. Main capability coverage does not
+change the frozen oracle's byte, graph, traversal, or CLI contracts. Advancing
+either record requires an immutable commit, an audited delta, fixtures, and
+updated evidence in the same change.
 
 ## Compatibility contract
 
@@ -92,6 +119,7 @@ from workspace builds.
 From the Compass repository root, with Graphify checked out as a sibling:
 
 ```bash
+python3 scripts/check_compatibility_manifest.py --check
 cargo fmt --all -- --check
 cargo clippy --workspace --lib --bins --locked -- -D warnings
 cargo test --workspace --lib --bins --locked
@@ -108,13 +136,15 @@ the pinned mutation matrix and retains each result as release evidence.
 
 ## Post-baseline changes
 
-No Python implementation deltas are pending. Add one row per future delta:
-
 | Python commit | Affected contract | Fixture/evidence | Compass status |
 | --- | --- | --- | --- |
-| _none_ | — | — | — |
+| `de0806be7c95d97aa7ff40371a235da899d6edb0` | deterministic `.r` and `Rscript` extraction | `r_extraction_matches_exactly`, `extensionless_shebang_extraction_matches_exactly` | compatible |
 
 An entry is complete only after the native behavior and a differential
 regression fixture land together. An incompatible or intentionally retired
 behavior requires explicit approval and a migration note; silence is not an
 accepted exception.
+
+Main-line capability dispositions are maintained in `compatibility.toml`.
+They are not duplicated in this post-baseline table because they do not advance
+the frozen v8 behavioral contract.

--- a/compatibility.toml
+++ b/compatibility.toml
@@ -1,0 +1,101 @@
+schema_version = 1
+
+[oracle]
+repository = "Graphify-Labs/graphify"
+release = "v0.9.20"
+release_commit = "edec9eabeceeae6aa2375eddb3835efa1a32c0a3"
+commit = "de0806be7c95d97aa7ff40371a235da899d6edb0"
+lineage = "v8"
+python = "3.12"
+
+[[environment]]
+name = "core"
+extras = ["mcp"]
+
+[[environment]]
+name = "media"
+extras = ["office", "pdf"]
+
+[[normalization]]
+id = "query-equal-degree-order"
+description = "Compare the exact header and complete line multiset; stable node-ID ordering replaces Python hash-set tie ordering."
+
+[[normalization]]
+id = "graph-record-order"
+description = "Compare node and edge records independently of file-walk order while preserving attributes, multiplicity, ranking, and traversal membership."
+
+[[command_family]]
+name = "build"
+entry_points = ["update", "extract", "watch", "cluster-only", "label"]
+evidence = ["compass-parity", "compass-cli/update_cli", "compass-cli/extract_cli", "compass-cli/watch_cli"]
+
+[[command_family]]
+name = "query"
+entry_points = ["query", "path", "explain", "affected", "tree", "benchmark"]
+evidence = ["compass-parity", "compass-query", "compass-cli/compass_product"]
+
+[[command_family]]
+name = "graph-operations"
+entry_points = ["export", "diagnose multigraph", "merge-graphs", "merge-driver", "merge-chunks", "merge-semantic", "cache-check"]
+evidence = ["compass-parity", "compass-output", "compass-cli/compass_product"]
+
+[[command_family]]
+name = "service"
+entry_points = ["serve"]
+evidence = ["compass-parity", "compass-mcp"]
+
+[[command_family]]
+name = "project-workflows"
+entry_points = ["global", "clone", "add", "prs", "hook", "provider", "save-result", "reflect", "check-update", "hook-check", "hook-guard"]
+evidence = ["compass-parity", "compass-cli/integration"]
+
+[[command_family]]
+name = "assistant-setup"
+entry_points = ["install", "uninstall", "platform lifecycle commands"]
+evidence = ["compass-parity", "compass-cli/install"]
+
+[required_evidence]
+test_targets = [
+  "cargo test --workspace --lib --bins --locked",
+  "cargo test -p compass-cli --test compass_product --locked",
+  "cargo test -p compass-parity --locked",
+]
+benchmark_profiles = ["phase1-small", "phase1-medium", "phase1-large"]
+
+[upstream.main]
+repository = "Graphify-Labs/graphify"
+commit = "91f4d120b630ee35c79bf3c75ccd186870a808f9"
+merge_base = "81a43f028ff1d3fd9a0893318272348a38dad660"
+package_version = "0.1.14"
+lineage = "v1"
+role = "capability-audit"
+
+[[capability_audit]]
+key = "confidence-scores"
+status = "compatible"
+evidence = "Compass preserves numeric edge confidence and renders confidence summaries."
+
+[[capability_audit]]
+key = "semantic-similarity"
+status = "compatible"
+evidence = "Compass recognizes and scores semantically_similar_to relationships."
+
+[[capability_audit]]
+key = "hyperedges"
+status = "superseded"
+evidence = "Compass preserves, reports, visualizes, and versions hyperedges."
+
+[[capability_audit]]
+key = "watch-and-hooks"
+status = "superseded"
+evidence = "Compass adds native watch, managed hooks, background refresh, and versioned history."
+
+[[capability_audit]]
+key = "leiden-clustering"
+status = "not-supported"
+evidence = "Compass currently provides deterministic native Louvain clustering."
+
+[[capability_audit]]
+key = "legacy-main-byte-output"
+status = "intentional-divergence"
+evidence = "Graphify main is audited for capabilities and is not the byte-level behavioral oracle."

--- a/crates/compass-output/src/wiki.rs
+++ b/crates/compass-output/src/wiki.rs
@@ -149,6 +149,21 @@ struct WikiGraph<'a> {
     incident: HashMap<&'a str, Vec<&'a EdgeRecord>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EdgeOrientation {
+    Incoming,
+    Outgoing,
+    Undirected,
+    SelfLoop,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Neighbor<'a> {
+    node: &'a str,
+    edge: &'a EdgeRecord,
+    orientation: EdgeOrientation,
+}
+
 impl<'a> WikiGraph<'a> {
     fn new(document: &'a GraphDocument) -> Self {
         let nodes = document
@@ -159,7 +174,7 @@ impl<'a> WikiGraph<'a> {
         let mut incident = HashMap::<&str, Vec<&EdgeRecord>>::new();
         for edge in &document.links {
             incident.entry(edge.source.as_str()).or_default().push(edge);
-            if !document.directed || edge.target != edge.source {
+            if edge.target != edge.source {
                 incident.entry(edge.target.as_str()).or_default().push(edge);
             }
         }
@@ -174,16 +189,38 @@ impl<'a> WikiGraph<'a> {
         self.incident.get(node).map(Vec::len).unwrap_or_default()
     }
 
-    fn neighbors(&self, node: &str) -> Vec<(&'a str, &'a EdgeRecord)> {
+    fn neighbors(&self, node: &str) -> Vec<Neighbor<'a>> {
         self.incident
             .get(node)
             .into_iter()
             .flatten()
             .filter_map(|edge| {
-                if edge.source == node {
-                    Some((edge.target.as_str(), *edge))
-                } else if !self.directed && edge.target == node {
-                    Some((edge.source.as_str(), *edge))
+                if edge.source == node && edge.target == node {
+                    Some(Neighbor {
+                        node: edge.source.as_str(),
+                        edge,
+                        orientation: EdgeOrientation::SelfLoop,
+                    })
+                } else if edge.source == node {
+                    Some(Neighbor {
+                        node: edge.target.as_str(),
+                        edge,
+                        orientation: if self.directed {
+                            EdgeOrientation::Outgoing
+                        } else {
+                            EdgeOrientation::Undirected
+                        },
+                    })
+                } else if edge.target == node {
+                    Some(Neighbor {
+                        node: edge.source.as_str(),
+                        edge,
+                        orientation: if self.directed {
+                            EdgeOrientation::Incoming
+                        } else {
+                            EdgeOrientation::Undirected
+                        },
+                    })
                 } else {
                     None
                 }
@@ -210,9 +247,9 @@ fn community_article(
     let mut cross_order = Vec::<String>::new();
     let mut confidence = HashMap::<String, usize>::new();
     for member in members {
-        for (neighbor, edge) in graph.neighbors(member) {
+        for neighbor in graph.neighbors(member) {
             if let Some(other) = node_community
-                .get(neighbor)
+                .get(neighbor.node)
                 .filter(|other| **other != community)
             {
                 let label = labels
@@ -225,7 +262,7 @@ fn community_article(
                 *cross_counts.entry(label).or_default() += 1;
             }
             *confidence
-                .entry(edge.string("confidence").if_empty("EXTRACTED"))
+                .entry(neighbor.edge.string("confidence").if_empty("EXTRACTED"))
                 .or_default() += 1;
         }
     }
@@ -345,23 +382,29 @@ fn god_node_article(
         ]);
     }
     let mut neighbors = graph.neighbors(&god.id);
-    neighbors.sort_by_key(|(neighbor, _)| std::cmp::Reverse(graph.degree(neighbor)));
+    neighbors.sort_by_key(|neighbor| std::cmp::Reverse(graph.degree(neighbor.node)));
     let mut by_relation = BTreeMap::<String, Vec<String>>::new();
-    for (neighbor, edge) in neighbors {
-        let Some(neighbor_node) = graph.nodes.get(neighbor) else {
+    for neighbor in neighbors {
+        let Some(neighbor_node) = graph.nodes.get(neighbor.node) else {
             continue;
         };
-        let confidence = edge.string("confidence");
+        let confidence = neighbor.edge.string("confidence");
         let suffix = if confidence.is_empty() {
             String::new()
         } else {
             format!(" `{confidence}`")
         };
+        let direction = match neighbor.orientation {
+            EdgeOrientation::Incoming => "← ",
+            EdgeOrientation::Outgoing => "→ ",
+            EdgeOrientation::SelfLoop => "↻ ",
+            EdgeOrientation::Undirected => "",
+        };
         by_relation
-            .entry(edge.string("relation").if_empty("related"))
+            .entry(neighbor.edge.string("relation").if_empty("related"))
             .or_default()
             .push(format!(
-                "{}{suffix}",
+                "{direction}{}{suffix}",
                 markdown_link(neighbor_node.label(), resolver)
             ));
     }

--- a/crates/compass-output/tests/wiki_direction.rs
+++ b/crates/compass-output/tests/wiki_direction.rs
@@ -1,0 +1,127 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fs;
+
+use compass_graph::{Communities, GodNode};
+use compass_model::GraphDocument;
+use compass_output::{WikiOptions, export_wiki};
+use serde_json::json;
+
+#[test]
+fn directed_wiki_preserves_incoming_outgoing_and_self_loop_evidence() -> Result<(), Box<dyn Error>>
+{
+    let document: GraphDocument = serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": true,
+        "graph": {},
+        "nodes": [
+            {"id":"caller","label":"Caller","source_file":"src/caller.rs"},
+            {"id":"external","label":"External","source_file":"src/external.rs"},
+            {"id":"target","label":"Target","source_file":"src/target.rs"},
+            {"id":"dependency","label":"Dependency","source_file":"src/dependency.rs"}
+        ],
+        "links": [
+            {"source":"caller","target":"target","relation":"calls","confidence":"EXTRACTED"},
+            {"source":"caller","target":"target","relation":"calls","confidence":"EXTRACTED"},
+            {"source":"external","target":"target","relation":"calls","confidence":"INFERRED"},
+            {"source":"target","target":"dependency","relation":"uses","confidence":"EXTRACTED"},
+            {"source":"target","target":"target","relation":"recurs","confidence":"EXTRACTED"}
+        ]
+    }))?;
+    let communities = Communities::from([
+        (0, vec!["target".to_owned()]),
+        (1, vec!["caller".to_owned(), "dependency".to_owned()]),
+        (2, vec!["external".to_owned()]),
+    ]);
+    let labels = BTreeMap::from([
+        (0, "Core".to_owned()),
+        (1, "Runtime".to_owned()),
+        (2, "Boundary".to_owned()),
+    ]);
+    let gods = vec![GodNode {
+        id: "target".to_owned(),
+        label: "Target".to_owned(),
+        degree: 5,
+    }];
+    let options = WikiOptions {
+        community_labels: Some(&labels),
+        cohesion: None,
+        god_nodes: Some(&gods),
+    };
+    let first = tempfile::tempdir()?;
+    let second = tempfile::tempdir()?;
+
+    export_wiki(&document, &communities, first.path(), &options)?;
+    export_wiki(&document, &communities, second.path(), &options)?;
+
+    let community = fs::read_to_string(first.path().join("Core.md"))?;
+    assert!(community.contains("[Runtime](Runtime.md) (3 shared connections)"));
+    assert!(community.contains("[Boundary](Boundary.md) (1 shared connections)"));
+    assert!(community.contains("- EXTRACTED: 4 (80%)"));
+    assert!(community.contains("- INFERRED: 1 (20%)"));
+
+    let god = fs::read_to_string(first.path().join("Target.md"))?;
+    assert_eq!(god.matches("- ← Caller `EXTRACTED`").count(), 2);
+    assert!(god.contains("- ← External `INFERRED`"));
+    assert!(god.contains("- → Dependency `EXTRACTED`"));
+    assert!(god.contains("- ↻ [Target](Target.md) `EXTRACTED`"));
+
+    assert_eq!(
+        directory_markdown(first.path())?,
+        directory_markdown(second.path())?
+    );
+    Ok(())
+}
+
+#[test]
+fn undirected_wiki_keeps_directionless_connection_rendering() -> Result<(), Box<dyn Error>> {
+    let document: GraphDocument = serde_json::from_value(json!({
+        "directed": false,
+        "multigraph": false,
+        "graph": {},
+        "nodes": [
+            {"id":"alpha","label":"Alpha","source_file":"alpha.rs"},
+            {"id":"beta","label":"Beta","source_file":"beta.rs"}
+        ],
+        "links": [
+            {"source":"beta","target":"alpha","relation":"related","confidence":"EXTRACTED"}
+        ]
+    }))?;
+    let communities = Communities::from([(0, vec!["alpha".to_owned(), "beta".to_owned()])]);
+    let gods = vec![GodNode {
+        id: "alpha".to_owned(),
+        label: "Alpha".to_owned(),
+        degree: 1,
+    }];
+    let directory = tempfile::tempdir()?;
+
+    export_wiki(
+        &document,
+        &communities,
+        directory.path(),
+        &WikiOptions {
+            community_labels: None,
+            cohesion: None,
+            god_nodes: Some(&gods),
+        },
+    )?;
+
+    let god = fs::read_to_string(directory.path().join("Alpha.md"))?;
+    assert!(god.contains("- Beta `EXTRACTED`"));
+    assert!(!god.contains("← Beta"));
+    assert!(!god.contains("→ Beta"));
+    Ok(())
+}
+
+fn directory_markdown(path: &std::path::Path) -> Result<Vec<(String, String)>, Box<dyn Error>> {
+    let mut files = fs::read_dir(path)?
+        .map(|entry| {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let content = fs::read_to_string(entry.path())?;
+            Ok((name, content))
+        })
+        .collect::<Result<Vec<_>, std::io::Error>>()?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(files)
+}

--- a/scripts/check_compatibility_manifest.py
+++ b/scripts/check_compatibility_manifest.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Validate Compass's machine-readable Graphify compatibility contract."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+import tomllib
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "compatibility.toml"
+WORKFLOWS = (
+    ROOT / ".github" / "workflows" / "compass-ci.yml",
+    ROOT / ".github" / "workflows" / "compass-hardening.yml",
+)
+SHA = re.compile(r"^[0-9a-f]{40}$")
+ALLOWED_DISPOSITIONS = {
+    "compatible",
+    "superseded",
+    "intentional-divergence",
+    "not-supported",
+}
+
+
+def validate_manifest(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if data.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    oracle = data.get("oracle")
+    if not isinstance(oracle, dict):
+        errors.append("oracle must be a table")
+        oracle = {}
+    _validate_sha(errors, oracle.get("commit"), "oracle.commit")
+    _validate_sha(errors, oracle.get("release_commit"), "oracle.release_commit")
+    if oracle.get("repository") != "Graphify-Labs/graphify":
+        errors.append("oracle.repository must be Graphify-Labs/graphify")
+    if not oracle.get("release") or not oracle.get("lineage"):
+        errors.append("oracle.release and oracle.lineage are required")
+    if not oracle.get("python"):
+        errors.append("oracle.python is required")
+
+    upstream = data.get("upstream")
+    main = upstream.get("main") if isinstance(upstream, dict) else None
+    if not isinstance(main, dict):
+        errors.append("upstream.main must be a table")
+        main = {}
+    _validate_sha(errors, main.get("commit"), "upstream.main.commit")
+    _validate_sha(errors, main.get("merge_base"), "upstream.main.merge_base")
+    if main.get("repository") != "Graphify-Labs/graphify":
+        errors.append("upstream.main.repository must be Graphify-Labs/graphify")
+    if main.get("role") != "capability-audit":
+        errors.append("upstream.main.role must be capability-audit")
+    for field in ("package_version", "lineage"):
+        if not main.get(field):
+            errors.append(f"upstream.main.{field} is required")
+
+    _validate_unique_tables(errors, data, "normalization", "id")
+    _validate_unique_tables(errors, data, "command_family", "name")
+    _validate_unique_tables(errors, data, "capability_audit", "key")
+    _validate_table_arrays(errors, data, "command_family", ("entry_points", "evidence"))
+
+    normalizations = data.get("normalization", [])
+    for index, normalization in enumerate(normalizations):
+        if not isinstance(normalization, dict) or not normalization.get("description"):
+            errors.append(f"normalization[{index}].description is required")
+
+    audits = data.get("capability_audit", [])
+    if not isinstance(audits, list) or not audits:
+        errors.append("capability_audit must contain at least one entry")
+    else:
+        for index, audit in enumerate(audits):
+            status = audit.get("status") if isinstance(audit, dict) else None
+            if status not in ALLOWED_DISPOSITIONS:
+                errors.append(
+                    f"capability_audit[{index}].status has unknown disposition {status!r}"
+                )
+            if not isinstance(audit, dict) or not audit.get("evidence"):
+                errors.append(f"capability_audit[{index}].evidence is required")
+
+    required = data.get("required_evidence")
+    if not isinstance(required, dict):
+        errors.append("required_evidence must be a table")
+    else:
+        for field in ("test_targets", "benchmark_profiles"):
+            values = required.get(field)
+            if not isinstance(values, list) or not values:
+                errors.append(f"required_evidence.{field} must be a non-empty array")
+
+    environments = data.get("environment")
+    if not isinstance(environments, list) or not environments:
+        errors.append("environment must contain at least one entry")
+    else:
+        _validate_unique_tables(errors, data, "environment", "name")
+        for index, environment in enumerate(environments):
+            extras = environment.get("extras") if isinstance(environment, dict) else None
+            if not isinstance(extras, list):
+                errors.append(f"environment[{index}].extras must be an array")
+    return errors
+
+
+def validate_checkout_refs(text: str, oracle_commit: str, source: str) -> list[str]:
+    errors: list[str] = []
+    lines = text.splitlines()
+    found = 0
+    for index, line in enumerate(lines):
+        if "repository: Graphify-Labs/graphify" not in line:
+            continue
+        found += 1
+        ref = None
+        for candidate in lines[index + 1 : index + 8]:
+            match = re.match(r"\s*ref:\s*([^\s#]+)", candidate)
+            if match:
+                ref = match.group(1)
+                break
+        if ref is None:
+            errors.append(f"{source}:{index + 1}: Graphify checkout has no nearby ref")
+        elif ref != oracle_commit:
+            errors.append(
+                f"{source}:{index + 1}: Graphify checkout ref {ref!r} "
+                f"does not match oracle.commit {oracle_commit}"
+            )
+    if found == 0:
+        errors.append(f"{source}: no Graphify compatibility checkout found")
+    return errors
+
+
+def validate_repository(root: Path, data: dict[str, Any]) -> list[str]:
+    errors = validate_manifest(data)
+    oracle = data.get("oracle", {})
+    oracle_commit = oracle.get("commit", "") if isinstance(oracle, dict) else ""
+    release_commit = (
+        oracle.get("release_commit", "") if isinstance(oracle, dict) else ""
+    )
+    main = data.get("upstream", {}).get("main", {})
+    main_commit = main.get("commit", "") if isinstance(main, dict) else ""
+
+    for workflow in (
+        root / ".github" / "workflows" / "compass-ci.yml",
+        root / ".github" / "workflows" / "compass-hardening.yml",
+    ):
+        if not workflow.is_file():
+            errors.append(f"missing workflow: {workflow.relative_to(root)}")
+            continue
+        errors.extend(
+            validate_checkout_refs(
+                workflow.read_text(encoding="utf-8"),
+                oracle_commit,
+                str(workflow.relative_to(root)),
+            )
+        )
+
+    ledger_path = root / "COMPATIBILITY.md"
+    if not ledger_path.is_file():
+        errors.append("missing COMPATIBILITY.md")
+    else:
+        ledger = ledger_path.read_text(encoding="utf-8")
+        for token, label in (
+            (oracle_commit, "oracle commit"),
+            (release_commit, "oracle release commit"),
+            (main_commit, "upstream main commit"),
+            ("compatibility.toml", "authoritative manifest"),
+        ):
+            if token not in ledger:
+                errors.append(f"COMPATIBILITY.md is missing {label}: {token!r}")
+    return errors
+
+
+def load_manifest(path: Path = MANIFEST) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_sha(errors: list[str], value: Any, field: str) -> None:
+    if not isinstance(value, str) or SHA.fullmatch(value) is None:
+        errors.append(f"{field} must be a full lowercase 40-character Git SHA")
+
+
+def _validate_unique_tables(
+    errors: list[str], data: dict[str, Any], table: str, key: str
+) -> None:
+    values = data.get(table)
+    if not isinstance(values, list) or not values:
+        errors.append(f"{table} must contain at least one entry")
+        return
+    keys = [entry.get(key) for entry in values if isinstance(entry, dict)]
+    if len(keys) != len(values) or any(not value for value in keys):
+        errors.append(f"{table}.{key} is required for every entry")
+    elif len(keys) != len(set(keys)):
+        errors.append(f"{table}.{key} contains duplicates")
+
+
+def _validate_table_arrays(
+    errors: list[str],
+    data: dict[str, Any],
+    table: str,
+    fields: tuple[str, ...],
+) -> None:
+    values = data.get(table, [])
+    if not isinstance(values, list):
+        return
+    for index, entry in enumerate(values):
+        for field in fields:
+            items = entry.get(field) if isinstance(entry, dict) else None
+            if not isinstance(items, list) or not items:
+                errors.append(f"{table}[{index}].{field} must be a non-empty array")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="validate the Compass compatibility manifest and consumers"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate without modifying files (the only supported mode)",
+    )
+    args = parser.parse_args()
+    if not args.check:
+        parser.error("--check is required")
+
+    try:
+        data = load_manifest()
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        print(f"error: could not load {MANIFEST.relative_to(ROOT)}: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    errors = validate_repository(ROOT, data)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)
+
+    oracle = data["oracle"]
+    main_line = data["upstream"]["main"]
+    print(
+        "Compatibility manifest verified: "
+        f"oracle {oracle['release']}@{oracle['commit']}; "
+        f"main capability audit @{main_line['commit']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_compatibility_manifest.py
+++ b/scripts/tests/test_check_compatibility_manifest.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_compatibility_manifest.py"
+SPEC = importlib.util.spec_from_file_location("check_compatibility_manifest", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class CompatibilityManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.valid = CHECKER.load_manifest()
+
+    def test_real_manifest_shape_is_valid(self) -> None:
+        self.assertEqual(CHECKER.validate_manifest(self.valid), [])
+
+    def test_short_sha_is_rejected(self) -> None:
+        data = copy.deepcopy(self.valid)
+        data["oracle"]["commit"] = "edec9ea"
+        errors = CHECKER.validate_manifest(data)
+        self.assertTrue(any("oracle.commit" in error for error in errors), errors)
+
+    def test_short_release_sha_is_rejected(self) -> None:
+        data = copy.deepcopy(self.valid)
+        data["oracle"]["release_commit"] = "edec9ea"
+        errors = CHECKER.validate_manifest(data)
+        self.assertTrue(
+            any("oracle.release_commit" in error for error in errors),
+            errors,
+        )
+
+    def test_duplicate_capability_is_rejected(self) -> None:
+        data = copy.deepcopy(self.valid)
+        data["capability_audit"].append(copy.deepcopy(data["capability_audit"][0]))
+        errors = CHECKER.validate_manifest(data)
+        self.assertTrue(
+            any("capability_audit.key contains duplicates" in error for error in errors),
+            errors,
+        )
+
+    def test_unknown_disposition_is_rejected(self) -> None:
+        data = copy.deepcopy(self.valid)
+        data["capability_audit"][0]["status"] = "maybe"
+        errors = CHECKER.validate_manifest(data)
+        self.assertTrue(any("unknown disposition" in error for error in errors), errors)
+
+    def test_mutable_workflow_ref_is_rejected(self) -> None:
+        errors = CHECKER.validate_checkout_refs(
+            "repository: Graphify-Labs/graphify\nref: v8\n",
+            self.valid["oracle"]["commit"],
+            "workflow.yml",
+        )
+        self.assertTrue(any("'v8'" in error for error in errors), errors)
+
+    def test_pinned_workflow_ref_is_accepted(self) -> None:
+        commit = self.valid["oracle"]["commit"]
+        errors = CHECKER.validate_checkout_refs(
+            f"repository: Graphify-Labs/graphify\nref: {commit}\n",
+            commit,
+            "workflow.yml",
+        )
+        self.assertEqual(errors, [])
+
+    def test_repository_rejects_drifted_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workflows = root / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            checkout = (
+                "repository: Graphify-Labs/graphify\n"
+                f"ref: {self.valid['oracle']['commit']}\n"
+            )
+            (workflows / "compass-ci.yml").write_text(checkout, encoding="utf-8")
+            (workflows / "compass-hardening.yml").write_text(
+                checkout, encoding="utf-8"
+            )
+            (root / "COMPATIBILITY.md").write_text(
+                (
+                    f"{self.valid['oracle']['commit']}\n"
+                    f"{self.valid['oracle']['release_commit']}\n"
+                    "compatibility.toml is authoritative\n"
+                ),
+                encoding="utf-8",
+            )
+
+            errors = CHECKER.validate_repository(root, self.valid)
+
+        self.assertTrue(
+            any("upstream main commit" in error for error in errors),
+            errors,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a versioned `compatibility.toml` manifest and strict repository checker
- pin all Graphify compatibility checkouts to the immutable R-support oracle checkpoint `de0806be7c95d97aa7ff40371a235da899d6edb0`
- distinguish the v0.9.20 release base, qualified v8 oracle, and divergent Graphify main capability audit
- index both endpoints of directed wiki edges and render incoming, outgoing, and self-loop orientation
- cover directed, undirected, parallel-edge, cross-community, self-loop, and deterministic wiki output behavior

## Why

The compatibility ledger declared an immutable v0.9.20 baseline while CI checked out mutable `v8`, allowing the tested oracle to drift independently of the documented contract. The merged R parity coverage also requires the deterministic R extractor and fixture from the single post-release Graphify checkpoint `de0806b`; the release tag alone cannot run the complete parity suite.

Directed wiki exports separately indexed only source-side evidence. That omitted callers, inbound cross-community bridges, and other target-side relationships even though direction is part of Compass's authoritative graph model.

## Impact

CI now fails early if the manifest, workflows, or human ledger disagree. The complete differential suite runs against an exact reproducible Graphify commit. Directed wiki articles retain both inbound and outbound evidence while undirected rendering remains unchanged.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` — 8 passed
- `python3 scripts/check_compatibility_manifest.py --check`
- `cargo test -p compass-output --locked` — 21 passed
- `cargo clippy -p compass-output --all-targets --locked -- -D warnings`
- `cargo test -p compass-parity --locked` against `de0806be7c95d97aa7ff40371a235da899d6edb0` — 98 passed
- `cargo fmt --all -- --check`
- `git diff --check`
