### PR TITLE
Harden extraction parity, HTML exploration, and history workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+- Correct C function identities by resolving the callable declarator before
+  generic declaration names, including macro-heavy SQLite declarations.
+- Preserve repeated Markdown sections and rationale entries as distinct
+  positional graph nodes.
+- Advance the AST extraction cache namespace to `v0.9.21`. The first update
+  after upgrading refreshes deterministic AST facts, then unchanged updates
+  reuse the new cache normally.
+- Add a development-only Graphify superset comparator and guarded Podman
+  qualification script for node, edge, cold, warm, and query measurements.

--- a/advisor-plans/000-origin-main-audit.md
+++ b/advisor-plans/000-origin-main-audit.md
@@ -1,0 +1,176 @@
+# Graphify origin/main → Compass deep audit
+
+## Executive result
+
+Compass already surpasses the fetched Graphify `origin/main` snapshot in the
+areas that define its architecture: native typed Modules, deterministic graph
+construction, bounded CompassQL, immutable versioned realizations, Program IR,
+resource limits, and evidence-preserving history.
+
+The fetched branch still revealed one user-visible correctness gap and four
+high-leverage architectural gaps:
+
+1. Compass wiki exports omit incoming relationships for directed graphs.
+2. Compatibility identity is prose spread across files while CI checks out a
+   mutable, different upstream line.
+3. Query and MCP text drops numeric confidence and relationship provenance.
+4. Current-tree artifacts are individually atomic but not published as one
+   observable generation.
+5. Pull-request and release workflows do not enforce all-target and
+   production-path qualification promised by the documentation.
+
+## Snapshot and lineage
+
+| Repository/ref | Commit | Date | Identity |
+|---|---|---|---|
+| Compass `main` | `3837b411197771351b387cff935e4ae1e0eb8750` | 2026-07-23 | Native Rust workspace |
+| Graphify `origin/main` | `91f4d120b630ee35c79bf3c75ccd186870a808f9` | 2026-05-14 | v1 line; package `0.1.14` |
+| Compass frozen Graphify oracle | `edec9eabeceeae6aa2375eddb3835efa1a32c0a3` | frozen ledger | Graphify `v0.9.20` on v8 lineage |
+
+`origin/main` and the frozen v8 oracle diverge after
+`81a43f028ff1d3fd9a0893318272348a38dad660`. At audit time, Git reported 36
+commits unique to main and 1,235 commits unique to `origin/v8`. Therefore
+“latest origin/main” means the tip of a legacy-divergent product line, not the
+latest behavior on Compass's current oracle lineage.
+
+The audit worktree is:
+
+```text
+/private/tmp/graphify-origin-main-audit.kd6DCD/worktree
+```
+
+The user's dirty Graphify `v8` checkout and R-support changes were not merged,
+rebased, stashed, or modified.
+
+## Main-only capability disposition
+
+| Graphify main capability | Compass status | Evidence summary |
+|---|---|---|
+| Scored `INFERRED` edges | Present, but not fully surfaced | Numeric scores survive graph/output paths; surprise/query text drops part of the evidence |
+| Semantic-similarity edges | Present | Native analysis recognizes `semantically_similar_to` |
+| Hyperedges | Surpassed in storage/history; query gap remains | Preserved, reported, shaded in HTML, and versioned |
+| Wiki export | Present with a directed-graph correctness gap | Outgoing evidence is rendered; incoming evidence is omitted |
+| Code-only watch rebuild | Surpassed | Native watcher also tracks program artifacts and SCIP companions |
+| Git hook/worktree fixes | Surpassed in implementation depth | Managed hooks, custom hook paths, background refresh, merge integration, and history |
+| Rationale-node prohibition | Defensive cleanup exists; prompt contract drifts | Cleanup converts/removes pseudo-nodes, but embedded prompt still advertises `rationale|concept` |
+| Worked mixed-corpus examples | Product/evidence gap | Compass has benchmark machinery but not an equivalent public frozen mixed-corpus walkthrough |
+| Leiden clustering | Not parity | Compass ships deterministic Louvain only |
+
+## Verification performed
+
+### Graphify origin/main
+
+Command:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 \
+  /Users/haipingfu/graphify/.venv/bin/python \
+  -m pytest -q -p no:cacheprovider
+```
+
+Result: 253 passed and 40 failed. Every displayed failure was blocked by the
+audit environment lacking `graspologic`; the dependency is mandatory on this
+Graphify line. No install was performed because the audit was source-read-only.
+
+### Compass against the exact main snapshot
+
+Command:
+
+```bash
+GRAPHIFY_REPO_ROOT=/private/tmp/graphify-origin-main-audit.kd6DCD/worktree \
+GRAPHIFY_PYTHON=/Users/haipingfu/graphify/.venv/bin/python \
+PYTHONDONTWRITEBYTECODE=1 \
+cargo test -p compass-parity --locked -- --test-threads=1
+```
+
+Result: 24 passed and 74 failed. This is evidence that the current differential
+suite is bound to the v8 lineage, not evidence of 74 Compass regressions.
+Failures included v8-only commands, modules, fixtures, and extraction contracts
+that do not exist on main, plus real behavior differences such as legacy node
+IDs and call confidence.
+
+### Focused Compass feature checks
+
+The following passed:
+
+- `cargo test -p compass-output --locked`: 19 tests.
+- `cargo test -p compass-core watch_ --locked`: 2 watcher tests.
+- `cargo test -p compass-cli --test hook_cli --locked`: 7 hook tests.
+- `cargo test -p compass-semantic cleanup_attaches_only_explicit_rationale_and_repairs_hyperedges --locked`: 1 semantic cleanup test.
+
+No source files were changed by these checks.
+
+## Vetted findings
+
+| # | Finding | Category | Impact | Effort | Fix risk | Confidence |
+|---|---|---|---|---|---|---|
+| 1 | Directed wiki omits incoming caller/dependent evidence | Correctness | HIGH | S | LOW | HIGH |
+| 2 | Compatibility lineage and evidence can drift | Dependencies/docs | HIGH | M | MED | HIGH |
+| 3 | Path/discovery/MCP drop confidence and provenance | Direction/architecture | HIGH | M | MED | HIGH |
+| 4 | Current outputs are not one observable generation | Correctness/architecture | HIGH | L | HIGH | HIGH |
+| 5 | PR/release gates do not match qualification claims | Tests/performance | HIGH | M | LOW | HIGH |
+| 6 | Natural-query traversal is directionally incomplete in MCP | Correctness | HIGH | M | MED | HIGH |
+| 7 | Ghost merging uses basename plus label | Correctness | HIGH | M | MED | HIGH |
+| 8 | Edge assembly can collapse distinct relations/evidence sites | Correctness | HIGH | L | HIGH | HIGH |
+| 9 | Changed-file updates still redo corpus-sized downstream work | Performance | MED/HIGH at scale | L | HIGH | HIGH |
+| 10 | Natural-query scoring scans every node twice | Performance | MED/HIGH at scale | M | MED | HIGH |
+| 11 | MCP multi-project graph cache is unbounded | Performance | MED | M | LOW | HIGH |
+| 12 | Linux/Windows are tested but not packaged | Distribution | HIGH for adoption | L | MED | HIGH |
+
+### Evidence highlights
+
+- Graphify main uses an undirected `nx.Graph` at
+  `graphify/build.py:14-27`; its wiki sees both endpoint directions.
+- Compass's `WikiGraph` only records target-side incidence when
+  `document.directed` is false at `crates/compass-output/src/wiki.rs:146-189`.
+- `COMPATIBILITY.md:7-16` names an immutable v0.9.20 oracle, while
+  `.github/workflows/compass-ci.yml:27-41` and
+  `.github/workflows/compass-hardening.yml:260-272` check out mutable `v8`.
+- `crates/compass-graph/src/analyze.rs:87-98` does not carry numeric confidence
+  or relationship source evidence into `SurpriseConnection`.
+- `crates/compass-core/src/pipeline.rs:836-960` replaces current artifacts
+  sequentially. `BuildGuard::ensure_complete` exists at
+  `crates/compass-files/src/build_guard.rs:19-25`, but native readers do not
+  consult it.
+- PR CI limits workspace tests to `--lib --bins` at
+  `.github/workflows/compass-ci.yml:71-91`; all-target execution is scheduled
+  hardening, and `.github/workflows/compass-release.yml:28-95` does not depend
+  on qualification for the tagged commit.
+
+## Architecture assessment
+
+### Modules where Compass has greater Depth
+
+- `compass-history` hides immutable Prolly-tree realization, validation,
+  publication, leases, and garbage collection behind a cohesive Interface.
+- `compass-cypher` plus `compass-query` provides a bounded read-only query
+  engine Graphify main does not have.
+- `compass-program`, `compass-ir`, and `compass-analysis` establish a typed
+  evidence Seam that can deepen without changing graph consumers.
+- Native semantic and media Modules enforce size, retry, concurrency, and
+  untrusted-input boundaries missing from Graphify main's skill orchestration.
+
+### Seams that need deeper Implementations
+
+- Compatibility needs one machine-readable Module instead of prose/workflow
+  duplication.
+- Wiki/navigation needs a directional evidence Interface shared by human and
+  agent-facing Adapters.
+- Current output publication should reuse the staging-and-rename pattern that
+  already gives history bundles strong Locality and consistency.
+- Qualification should be a release Interface, not a scheduled side workflow.
+
+## Direction options
+
+These are not ranked as bugs and were not promoted into this five-plan batch:
+
+- Add first-class bounded hyperedge read/query APIs before attempting new
+  CompassQL syntax.
+- Ship a named versioned mixed-corpus profile over existing document, image,
+  media, watch, semantic-cache, and history primitives.
+- Add a token/trigram natural-query index with cached document frequencies.
+- Add a byte-weighted LRU for MCP's multi-project graph cache.
+- Evaluate a native Leiden-quality clustering Adapter using deterministic
+  quality and stability gates.
+- Preserve relation and evidence-site multiplicity in the authoritative graph,
+  with a legacy simple-graph compatibility projection.

--- a/advisor-plans/001-machine-checkable-compatibility-lineage.md
+++ b/advisor-plans/001-machine-checkable-compatibility-lineage.md
@@ -1,0 +1,177 @@
+# Plan 001: Make upstream compatibility lineage machine-checkable
+
+> **Executor instructions:** Follow every step and verification gate. Do not
+> push or open a pull request. Update this plan's status in
+> `advisor-plans/README.md` when done. Stop on any STOP condition.
+>
+> **Drift check:** Run
+> `git diff --stat 3837b411..HEAD -- COMPATIBILITY.md compatibility.toml scripts/check_compatibility_manifest.py .github/workflows/compass-ci.yml .github/workflows/compass-hardening.yml`
+> before editing. If an in-scope file has changed, compare it with the current
+> state below and stop when the contract no longer matches.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** MED
+- **Depends on:** none
+- **Category:** dependencies, tests, docs
+- **Planned at:** `3837b411`, 2026-07-23
+
+## Why this matters
+
+Compass declares Graphify v0.9.20 at an immutable commit as its oracle, while
+CI checks out mutable `v8`. Graphify `origin/main` is a separate v1 lineage with
+36 unique commits, not a newer commit on the oracle's ancestry. A single
+machine-readable compatibility Module should own lineage identity,
+normalizations, feature disposition, and required evidence so prose, CI, and
+benchmarks cannot silently disagree.
+
+## Current state
+
+- `COMPATIBILITY.md:7-16` declares:
+
+  ```text
+  Python baseline: Graphify v0.9.20
+  Baseline commit: edec9eabeceeae6aa2375eddb3835efa1a32c0a3
+  ```
+
+- `.github/workflows/compass-ci.yml:27-41` checks out `ref: v8`.
+- `.github/workflows/compass-hardening.yml:260-272` also checks out `ref: v8`.
+- Graphify `origin/main` is
+  `91f4d120b630ee35c79bf3c75ccd186870a808f9`, package version `0.1.14`, and
+  diverges from the v8 line after `81a43f028ff1d3fd9a0893318272348a38dad660`.
+- The parity suite is intentionally coupled to v8-only fixtures and commands:
+  running it against main produced 24 passes and 74 failures.
+
+Use the repository's existing convention of pinned action SHAs and Python
+checkers under `scripts/`.
+
+## Commands
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Manifest check | `python3 scripts/check_compatibility_manifest.py --check` | exit 0 and prints exact oracle SHA |
+| Workflow refs | `rg -n "ref: (v8|main)$" .github/workflows` | no mutable Graphify oracle refs |
+| Parity | `cargo test -p compass-parity --locked` with manifest-declared oracle env | all tests pass |
+
+## Scope
+
+**In scope:**
+
+- Create `compatibility.toml`.
+- Create `scripts/check_compatibility_manifest.py`.
+- Update `COMPATIBILITY.md`.
+- Update `.github/workflows/compass-ci.yml`.
+- Update `.github/workflows/compass-hardening.yml`.
+- Add checker tests under `scripts/tests/` if that directory is established;
+  otherwise test through a temporary manifest in the checker itself.
+
+**Out of scope:**
+
+- Changing native runtime behavior.
+- Advancing the frozen v8 oracle.
+- Claiming byte parity with Graphify `origin/main`.
+- Installing Graphify at Compass runtime.
+
+## Git workflow
+
+- Branch: `advisor/001-compatibility-lineage`
+- Commit style: imperative summary, for example
+  `Make Graphify compatibility lineage machine-checkable`.
+- Do not push or open a PR.
+
+## Steps
+
+### Step 1: Define one compatibility manifest
+
+Create `compatibility.toml` with a versioned schema and these required fields:
+
+- repository and immutable oracle commit;
+- upstream lineage/ref label and merge-base metadata;
+- Python version and enabled extras;
+- allowed ordering normalizations;
+- certified command families;
+- required test and benchmark evidence targets;
+- a separate capability-audit entry for Graphify main at `91f4d120...` with
+  dispositions `compatible`, `superseded`, `intentional-divergence`, or
+  `not-supported`.
+
+Do not put executable shell fragments in the manifest. Keep it declarative.
+
+**Verify:** parse it with Python's `tomllib`; expected result is exit 0 and the
+exact 40-character frozen SHA.
+
+### Step 2: Add a strict checker
+
+Create `scripts/check_compatibility_manifest.py`. It must:
+
+1. validate schema and full immutable SHAs;
+2. reject mutable oracle refs in the two workflows;
+3. verify the workflow checkout SHA equals the manifest oracle;
+4. verify `COMPATIBILITY.md` contains the same oracle identity;
+5. reject duplicate capability keys or unknown dispositions;
+6. print a concise summary and return nonzero on drift.
+
+Add negative tests for a shortened SHA, mutable `v8`, mismatched docs, duplicate
+capabilities, and unknown disposition.
+
+**Verify:** `python3 scripts/check_compatibility_manifest.py --check` exits 0;
+each negative fixture exits nonzero with the expected field name.
+
+### Step 3: Pin CI and hardening to the immutable oracle
+
+Replace `ref: v8` only for compatibility-oracle checkouts with the manifest's
+immutable SHA. Do not alter unrelated Git refs.
+
+Add the manifest checker before environment installation so identity drift
+fails quickly.
+
+**Verify:** `rg -n "repository: Graphify-Labs/graphify|ref:" .github/workflows`
+shows each compatibility checkout followed by the exact immutable SHA.
+
+### Step 4: Reconcile the human ledger
+
+Update `COMPATIBILITY.md` to explain:
+
+- frozen v8 behavioral oracle;
+- Graphify main legacy-line capability audit;
+- why main parity is not byte parity;
+- how to advance either record;
+- which file is authoritative.
+
+Do not claim the main capability audit is a release oracle.
+
+**Verify:** checker exits 0 and Markdown links resolve locally.
+
+## Test plan
+
+- Unit-test all manifest validation branches.
+- Run the checker on the real repository.
+- Run the existing parity crate against the manifest-declared checkout.
+- In a temporary copy, change the workflow ref to `v8` and confirm the checker
+  fails before tests start.
+
+## Done criteria
+
+- [ ] `compatibility.toml` owns exact immutable lineage identity.
+- [ ] CI and hardening use the declared full SHA.
+- [ ] `COMPATIBILITY.md` distinguishes v8 oracle and main capability audit.
+- [ ] Checker positive and negative tests pass.
+- [ ] `cargo fmt --all -- --check` exits 0.
+- [ ] No runtime source file changed.
+
+## STOP conditions
+
+- The maintainer wants Graphify main to replace, rather than supplement, the
+  v8 oracle.
+- The pinned v8 commit cannot reproduce the declared test environment.
+- A workflow depends on a branch-only file not present at the frozen SHA.
+- Implementing the checker requires changing runtime Rust behavior.
+
+## Maintenance notes
+
+Any future Graphify change must update the manifest, fixtures, evidence, and
+human ledger together. Reviewers should reject mutable compatibility refs even
+when a branch name appears stable.

--- a/advisor-plans/002-directed-wiki-evidence.md
+++ b/advisor-plans/002-directed-wiki-evidence.md
@@ -1,0 +1,152 @@
+# Plan 002: Restore incoming evidence in directed wiki exports
+
+> **Executor instructions:** Follow every step and verification gate. Do not
+> push or open a pull request. Update `advisor-plans/README.md` when complete.
+>
+> **Drift check:** Run
+> `git diff --stat 3837b411..HEAD -- crates/compass-output/src/wiki.rs crates/compass-output/tests`
+> and stop if the wiki incidence model has materially changed.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** S
+- **Risk:** LOW
+- **Depends on:** plan 001
+- **Category:** bug
+- **Planned at:** `3837b411`, 2026-07-23
+
+## Why this matters
+
+Normal Compass graphs are directed, but the wiki's incident-edge index includes
+target-side edges only for undirected graphs. Wiki-only navigation can therefore
+omit callers, dependents, inbound community bridges, and half of a god node's
+useful neighborhood. Graphify main uses an undirected NetworkX graph and does
+not lose that evidence.
+
+## Current state
+
+`crates/compass-output/src/wiki.rs:158-164` currently contains:
+
+```rust
+incident.entry(edge.source.as_str()).or_default().push(edge);
+if !document.directed || edge.target != edge.source {
+    incident.entry(edge.target.as_str()).or_default().push(edge);
+}
+```
+
+`WikiGraph::neighbors` at `wiki.rs:177-191` returns the target endpoint for an
+outgoing edge, but only returns the source endpoint for an incoming edge when
+the entire document is undirected.
+
+Direction is a public graph invariant; `docs/concepts/graph-model.md:94-104`
+explains that incoming `CALLS` traversal is how callers are found.
+
+## Commands
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Target tests | `cargo test -p compass-output wiki --locked` | all wiki tests pass |
+| Full crate | `cargo test -p compass-output --locked` | all tests pass |
+| Lint | `cargo clippy -p compass-output --all-targets --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+
+## Scope
+
+**In scope:**
+
+- `crates/compass-output/src/wiki.rs`
+- Create `crates/compass-output/tests/wiki_direction.rs` or add equivalent
+  focused tests to an established wiki test module.
+
+**Out of scope:**
+
+- Changing graph direction or edge identity.
+- Changing natural-query traversal.
+- Reproducing Graphify's undirected graph globally.
+- Changing Obsidian, HTML, GraphML, or history semantics.
+
+## Git workflow
+
+- Branch: `advisor/002-directed-wiki-evidence`
+- Commit: `Preserve incoming evidence in directed wiki exports`
+- Do not push or open a PR.
+
+## Steps
+
+### Step 1: Add failing directed fixtures
+
+Create a directed graph with:
+
+- `caller -> target` using `CALLS`;
+- `external -> target` crossing communities;
+- `target -> dependency`;
+- a self-loop.
+
+Export a wiki where `target` is both a community member and a god node. Assert
+that:
+
+- incoming caller and external evidence is present;
+- outgoing dependency evidence is present;
+- the inbound cross-community count is included;
+- self-loops are emitted once;
+- deterministic output is unchanged across two runs.
+
+**Verify:** the new test fails on current code specifically because incoming
+target-side evidence is absent.
+
+### Step 2: Make incidence direction-complete
+
+Index every non-self-loop edge under both endpoints regardless of graph
+direction. Return a small typed neighbor record containing:
+
+- other node ID;
+- edge;
+- orientation (`Incoming`, `Outgoing`, or `SelfLoop`).
+
+Do not infer direction from relation names. Use stored source and target.
+
+**Verify:** the new directed fixtures pass.
+
+### Step 3: Render direction without losing compatibility
+
+In relationship sections, expose direction using stable arrows or explicit
+incoming/outgoing labels. Keep headings, filenames, escaping, truncation, and
+audit-trail behavior unchanged.
+
+If an exact Graphify-compatible wiki projection is required, make it an
+explicit option; do not make the authoritative Compass wiki lossy.
+
+**Verify:** full `compass-output` tests and clippy pass.
+
+## Test plan
+
+- Directed incoming, outgoing, cross-community, and self-loop cases.
+- Undirected regression fixture.
+- Duplicate parallel-edge behavior.
+- Hostile label/path escaping.
+- Byte-determinism across repeat exports.
+
+Model tests after `crates/compass-output/tests/coverage_paths.rs` and the private
+wiki helpers in `crates/compass-output/src/wiki.rs`.
+
+## Done criteria
+
+- [ ] Directed wiki articles include incoming and outgoing evidence.
+- [ ] Orientation is visible and source/target semantics remain exact.
+- [ ] Self-loops are not duplicated.
+- [ ] Full `compass-output` tests, clippy, and format checks pass.
+- [ ] No files outside the scope changed.
+
+## STOP conditions
+
+- Wiki output is a documented byte-compatibility contract with Graphify main.
+- Fixing the bug requires changing authoritative graph direction.
+- Parallel-edge behavior cannot be represented without resolving plan 003 or
+  the deferred edge-multiplicity design.
+
+## Maintenance notes
+
+Reviewers should check that inbound evidence affects both article content and
+cross-community counts. Future relation renderers must use stored orientation,
+not English relation-name heuristics.

--- a/advisor-plans/003-structured-query-provenance.md
+++ b/advisor-plans/003-structured-query-provenance.md
@@ -1,0 +1,191 @@
+# Plan 003: Return structured provenance from path and discovery queries
+
+> **Executor instructions:** Follow each verification gate. Keep compatibility
+> text rendering as an Adapter over a new structured result; do not duplicate
+> query semantics. Do not push or open a pull request.
+>
+> **Drift check:** Run
+> `git diff --stat 3837b411..HEAD -- crates/compass-query/src/traversal.rs crates/compass-graph/src/analyze.rs crates/compass-output/src/report.rs crates/compass-mcp/src/lib.rs crates/compass-cli/src`
+> and stop if another structured query-result contract has landed.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** MED
+- **Depends on:** plan 001
+- **Category:** architecture, direction
+- **Planned at:** `3837b411`, 2026-07-23
+
+## Why this matters
+
+Compass preserves confidence and provenance in graph records but drops much of
+it on the assistant-facing path, natural-query, surprise-report, and MCP
+surfaces. Users can see `INFERRED` without knowing the numeric score, evidence
+site, origin, or extractor. CLI and MCP also implement path presentation in
+different Modules. One structured evidence Interface should preserve facts;
+text and transport Adapters should decide presentation and limits.
+
+## Current state
+
+- `crates/compass-graph/src/analyze.rs:87-98` defines
+  `SurpriseConnection` without `confidence_score`, source location, origin, or
+  provider identity.
+- `crates/compass-output/src/report.rs:218-236` renders only the confidence
+  category for each surprise.
+- `crates/compass-query/src/traversal.rs:77-155` resolves and renders paths.
+- `crates/compass-mcp/src/lib.rs:757-852` repeats endpoint resolution,
+  traversal, edge direction, confidence, and text rendering.
+- Graphify main renders numeric inferred confidence in
+  `graphify/report.py:27-29,63-71`.
+- `docs/concepts/provenance.md:132-156` requires provenance to remain
+  interpretable and warns against treating source-specific scores as calibrated
+  truth.
+
+Use `compass-model` records as the authoritative source. Do not parse rendered
+text to recover evidence.
+
+## Commands
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Query tests | `cargo test -p compass-query --all-targets --locked` | all pass |
+| Graph tests | `cargo test -p compass-graph --all-targets --locked` | all pass |
+| MCP tests | `cargo test -p compass-mcp --all-targets --locked` | all pass |
+| CLI contract | `cargo test -p compass-cli --test compass_product --locked` | all pass |
+| Lint | `cargo clippy -p compass-query -p compass-graph -p compass-output -p compass-mcp -p compass-cli --all-targets --locked -- -D warnings` | exit 0 |
+
+## Scope
+
+**In scope:**
+
+- `crates/compass-query/src/traversal.rs` and query exports.
+- `crates/compass-graph/src/analyze.rs`.
+- `crates/compass-output/src/report.rs`.
+- `crates/compass-mcp/src/lib.rs`.
+- Thin CLI Adapter changes under `crates/compass-cli/src/`.
+- Focused tests in those crates.
+
+**Out of scope:**
+
+- New CompassQL syntax.
+- Hyperedge query semantics.
+- Changing extraction confidence calculations.
+- Calibrating scores across providers.
+- Changing authoritative edge multiplicity.
+
+## Git workflow
+
+- Branch: `advisor/003-structured-query-provenance`
+- Prefer one commit for the typed result and one for Adapters/tests.
+- Example: `Centralize structured path evidence`.
+- Do not push or open a PR.
+
+## Steps
+
+### Step 1: Characterize current CLI and MCP behavior
+
+Add fixtures for:
+
+- exact path;
+- ambiguous endpoint candidates;
+- missing endpoint;
+- reversed stored edge;
+- inferred edge with `confidence_score`, `source_file`,
+  `source_location`, `_origin`, and provider/extractor attributes;
+- absent optional attributes.
+
+Capture current compatibility text separately from the future structured
+payload.
+
+**Verify:** characterization tests pass before refactoring.
+
+### Step 2: Introduce a typed evidence result
+
+In `compass-query`, define a versioned result that includes:
+
+- resolved endpoints and alternative candidates;
+- ordered nodes;
+- ordered edge evidence with stored source/target;
+- relation, confidence category, optional numeric score;
+- source file/location, origin, and provider/extractor when present;
+- warnings and typed failure kind;
+- truncation/budget metadata.
+
+Keep transport-neutral data types. This is the deep Module Interface; it must
+not contain terminal strings or MCP response objects.
+
+**Verify:** unit tests serialize a stable versioned JSON shape and preserve
+missing optional values without invention.
+
+### Step 3: Make CLI and MCP thin Adapters
+
+Have CLI text rendering consume the structured result. Have MCP return:
+
+- the compatibility text where existing tools require it;
+- a versioned structured payload through an additive tool/result surface.
+
+Remove independent MCP traversal/presentation logic once parity tests prove the
+Adapter preserves intentional transport differences such as maximum depth.
+
+**Verify:** query, MCP, and product-contract tests pass; repository search shows
+one implementation of endpoint/path evidence selection.
+
+### Step 4: Carry evidence into surprising connections
+
+Extend `SurpriseConnection` with optional evidence fields. Populate them from
+the selected edge and render numeric confidence plus source evidence when
+available.
+
+Label scores as source-specific evidence. Never call them probabilities unless
+the provider contract explicitly does.
+
+**Verify:** add a report fixture requiring `INFERRED 0.82` plus source location,
+and a fixture proving absent scores do not render fabricated defaults.
+
+### Step 5: Document the contract
+
+Update the query/MCP/provenance reference pages with:
+
+- schema versioning;
+- optionality;
+- stored direction;
+- score interpretation;
+- compatibility text versus structured evidence.
+
+**Verify:** all referenced commands and paths exist; plan 005's docs checker
+should later enforce this.
+
+## Test plan
+
+- Exact and ambiguous endpoints.
+- Incoming/outgoing/reversed edges.
+- Every optional provenance field present/absent.
+- Stable JSON ordering and schema version.
+- CLI compatibility text snapshots.
+- MCP size and depth limits.
+- No secret/config values copied from unrelated attributes.
+
+## Done criteria
+
+- [ ] One structured path-evidence Interface owns query semantics.
+- [ ] CLI and MCP are presentation/transport Adapters.
+- [ ] Numeric confidence and evidence sites reach report and structured query
+  results.
+- [ ] Existing compatibility text remains covered.
+- [ ] All target tests, clippy, and format checks pass.
+
+## STOP conditions
+
+- Existing MCP protocol cannot add a versioned payload without a breaking
+  transport change.
+- Provider identity has no stable stored attribute contract.
+- Exact compatibility requires MCP and CLI to keep different traversal
+  membership, not just different limits/presentation.
+- The work expands into hyperedge or edge-multiplicity redesign.
+
+## Maintenance notes
+
+New query consumers should depend on the structured result, never scrape text.
+Reviewers must verify numeric scores are presented as evidence metadata rather
+than universal probability.

--- a/advisor-plans/004-atomic-current-generation.md
+++ b/advisor-plans/004-atomic-current-generation.md
@@ -1,0 +1,190 @@
+# Plan 004: Publish current outputs as one observable generation
+
+> **Executor instructions:** This is a high-risk storage/output change. Add
+> crash and concurrent-reader characterization before implementation. Do not
+> remove legacy direct files until a compatibility migration is approved. Do
+> not push or open a pull request.
+>
+> **Drift check:** Run
+> `git diff --stat 3837b411..HEAD -- crates/compass-core/src/pipeline.rs crates/compass-files/src/build_guard.rs crates/compass-model/src/document.rs crates/compass-mcp/src/lib.rs crates/compass-output/src/history_bundle.rs docs/reference/outputs.md`
+> and stop if current-generation publication already exists.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** L
+- **Risk:** HIGH
+- **Depends on:** plan 001
+- **Category:** correctness, architecture
+- **Planned at:** `3837b411`, 2026-07-23
+
+## Why this matters
+
+Compass atomically replaces individual files, but readers can observe a new
+graph with old labels, report, manifest, semantic marker, or Program IR.
+`BuildGuard` leaves an incomplete marker after a crash, yet production readers
+do not consult it. History bundles already demonstrate the stronger
+Implementation: build a staging directory, validate it, then rename it.
+
+## Current state
+
+- `crates/compass-core/src/pipeline.rs:836-960` writes `graph.json`, root,
+  analysis/labels, report, HTML, semantic marker, manifest, and `program.json`
+  sequentially before `guard.commit()`.
+- `crates/compass-files/src/build_guard.rs:13-32` exposes
+  `ensure_complete`, but native graph/MCP readers do not call it.
+- `crates/compass-model/src/document.rs:70-98` loads `graph.json` directly.
+- `crates/compass-mcp/src/lib.rs:136-167` hot-reloads and caches the direct file.
+- `crates/compass-output/src/history_bundle.rs:38-61` builds and validates a
+  staging directory, then renames it to the destination.
+
+Use the history-bundle pattern as the exemplar Module. Preserve output
+compatibility through an explicit Adapter.
+
+## Commands
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Core | `cargo test -p compass-core --all-targets --locked` | all pass |
+| Files/model | `cargo test -p compass-files -p compass-model --all-targets --locked` | all pass |
+| Output | `cargo test -p compass-output --all-targets --locked` | all pass |
+| MCP | `cargo test -p compass-mcp --all-targets --locked` | all pass |
+| Product | `cargo test -p compass-cli --test compass_product --locked` | all pass |
+| Format/lint | workspace format and scoped all-target clippy | exit 0 |
+
+## Scope
+
+**In scope:**
+
+- A versioned current-generation layout and pointer contract.
+- Pipeline staging, validation, publication, and recovery.
+- Native reader resolution.
+- Compatibility materialization for direct legacy paths.
+- Crash/concurrency tests and output documentation.
+
+**Out of scope:**
+
+- Changing graph schema or semantic content.
+- Changing immutable history identity.
+- Removing legacy files in the first migration.
+- Rewriting every exporter.
+- Network/distributed storage.
+
+## Git workflow
+
+- Branch: `advisor/004-atomic-current-generation`
+- Use small commits: contract/tests, publisher, readers, compatibility Adapter,
+  documentation.
+- Do not push or open a PR.
+
+## Steps
+
+### Step 1: Specify generation identity and layout
+
+Define a private versioned layout, for example:
+
+```text
+compass-out/
+  generations/<content-id>/
+    graph.json
+    manifest.json
+    program.json
+    ...
+  current
+  graph.json                compatibility materialization
+```
+
+The generation ID must bind all authoritative artifacts and renderer/profile
+versions. Specify same-filesystem rename requirements and Windows behavior.
+
+**Verify:** contract tests reject missing/mismatched artifacts, path traversal,
+duplicate generation IDs, and unsupported schema versions.
+
+### Step 2: Add pre-implementation crash tests
+
+Introduce a test-only failpoint at each existing publication boundary. Assert
+that a reader sees either the old complete generation or the new complete
+generation, never a mixture.
+
+Add concurrent MCP reload tests where publication pauses before pointer swap.
+
+**Verify:** at least one test fails on current sequential publication by
+observing mixed metadata or ignored incomplete state.
+
+### Step 3: Build and validate a staging generation
+
+Extract publication from `build_graph_inner` behind a narrow Interface. Write
+all artifacts to an adjacent staging directory, fsync where the repository's
+durability contract requires it, validate digests/schema/references, then rename
+to the immutable generation path.
+
+Do not make callers reassemble artifact order.
+
+**Verify:** injected failure before rename leaves the last-good generation
+readable and cleans or safely quarantines staging.
+
+### Step 4: Atomically switch readers
+
+Switch a small pointer/descriptor only after validation. Update native graph,
+query, MCP, export, and watch readers to resolve the current generation once per
+request and retain it for that request.
+
+Readers must not fall through to partially written compatibility files.
+
+**Verify:** concurrent-reader tests pass under repeated publication loops.
+
+### Step 5: Preserve legacy direct paths through an Adapter
+
+Materialize or atomically link/copy legacy direct files after generation
+publication. Document which files are authoritative and which are compatibility
+views. A failure in compatibility materialization must not corrupt the current
+pointer.
+
+**Verify:** existing CLI/product/parity tests using `compass-out/graph.json`
+continue to pass.
+
+### Step 6: Recovery and cleanup
+
+On startup/update:
+
+- ignore incomplete staging;
+- validate current pointer;
+- retain last-good generation;
+- bound obsolete-generation cleanup;
+- never delete a generation held by an active reader.
+
+**Verify:** tests cover crash windows, corrupt pointer, missing generation,
+Windows rename semantics where CI supports them, and active-reader retention.
+
+## Test plan
+
+- Failpoint at every artifact write and before/after pointer swap.
+- Concurrent MCP and CLI readers.
+- Cross-device/same-filesystem validation.
+- Corrupt/missing pointer recovery.
+- Compatibility materialization failure.
+- Watch rebuild and history materialization regression.
+- No mixed `graph.json`/manifest/program/report generation.
+
+## Done criteria
+
+- [ ] One validated generation becomes visible with one atomic switch.
+- [ ] Native readers retain one generation per request.
+- [ ] Last-good output survives every injected crash window.
+- [ ] Legacy direct paths remain compatible.
+- [ ] All scoped tests, clippy, and format checks pass.
+
+## STOP conditions
+
+- Output roots cannot guarantee same-filesystem rename.
+- Windows requires a materially different pointer contract not covered by CI.
+- A legacy consumer requires observing files while a build is in progress.
+- Generation identity conflicts with immutable history identity.
+- The change requires silently deleting user-owned output files.
+
+## Maintenance notes
+
+The pointer, generation schema, and compatibility projection are public
+operational contracts even if their directory names are private. Reviewers
+should scrutinize durability assumptions, reader lifetime, Windows behavior,
+and cleanup races.

--- a/advisor-plans/005-production-qualification-gate.md
+++ b/advisor-plans/005-production-qualification-gate.md
@@ -1,0 +1,200 @@
+# Plan 005: Gate pull requests and releases on production qualification
+
+> **Executor instructions:** Keep external/provider-dependent tests explicitly
+> classified. Do not make required CI depend on credentials or live services.
+> Do not push or open a pull request.
+>
+> **Drift check:** Run
+> `git diff --stat 3837b411..HEAD -- .github/workflows/compass-ci.yml .github/workflows/compass-hardening.yml .github/workflows/compass-release.yml Makefile PERFORMANCE.md scripts`
+> and stop if a tagged-SHA qualification gate already exists.
+
+## Status
+
+- **Priority:** P1
+- **Effort:** M
+- **Risk:** LOW
+- **Depends on:** plan 001
+- **Category:** tests, performance, DX, docs
+- **Planned at:** `3837b411`, 2026-07-23
+
+## Why this matters
+
+Graphify main runs its complete 293-test suite on each pull request. Compass has
+far more and deeper integration tests, but normal CI uses `--lib --bins` and
+weekly hardening owns all-target coverage. Release builds do not require
+qualification evidence for the tagged commit, despite `PERFORMANCE.md` saying
+they do. The performance matrix also excludes clustering and does not exercise
+hot in-process MCP/query paths.
+
+## Current state
+
+- `.github/workflows/compass-ci.yml:71-91` runs workspace `--lib --bins`, one
+  CLI integration target, and selected TCKs.
+- The workspace contains 87 integration-test files; 29 are under
+  `crates/compass-cli/tests/`.
+- `.github/workflows/compass-hardening.yml:47-62` owns all-target execution.
+- `.github/workflows/compass-hardening.yml:252-310` owns performance evidence.
+- `.github/workflows/compass-release.yml:28-95` depends on metadata and builds,
+  not hardening evidence for the tag SHA.
+- `scripts/qualify_phase1.sh:78-83` and `PERFORMANCE.md:43-46` deliberately use
+  `--no-cluster`.
+- `PERFORMANCE.md:8-18` documents nonexistent `rust/scripts/...` paths.
+
+Use action SHA pinning and retained artifacts exactly as current workflows do.
+Consume the compatibility manifest from plan 001.
+
+## Commands
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Test inventory | `cargo metadata --no-deps --format-version 1` plus classifier | every integration target has one class |
+| Native PR suite | `cargo nextest run --workspace --all-targets --locked` with committed filters | all self-contained tests pass |
+| Qualification | `scripts/qualify_phase1_matrix.sh` | raw evidence and pass/fail summary |
+| Docs check | `python3 scripts/check_docs.py --check` | exit 0 |
+| Workflow syntax | existing shell/Python syntax checks | exit 0 |
+
+## Scope
+
+**In scope:**
+
+- Test classification and native all-target PR job.
+- Exact-SHA reusable qualification workflow.
+- Release dependency on approved qualification evidence.
+- Clustered and hot in-process benchmark cases.
+- Documentation command/link checker.
+- `Makefile`, `PERFORMANCE.md`, and relevant scripts/workflows.
+
+**Out of scope:**
+
+- Live model/provider calls in required CI.
+- Changing benchmark thresholds without recorded baseline evidence.
+- Publishing Linux/Windows artifacts.
+- Replacing correctness parity with performance metrics.
+
+## Git workflow
+
+- Branch: `advisor/005-production-qualification-gate`
+- Commit separately: test classification, qualification workflow, release gate,
+  docs validation.
+- Do not push or open a PR.
+
+## Steps
+
+### Step 1: Classify integration targets
+
+Create a committed inventory with exactly three classes:
+
+- `native-self-contained`;
+- `oracle-dependent`;
+- `external-or-scheduled`.
+
+Fail CI when a newly discovered integration target is unclassified. Keep
+network, credentials, large media, mutation, and fuzz suites out of the native
+self-contained class unless hermetic fixtures prove otherwise.
+
+**Verify:** the inventory command reports zero unclassified and zero duplicate
+targets.
+
+### Step 2: Run self-contained all-target tests on pull requests
+
+Add a PR job using nextest filters generated from or checked against the
+inventory. Add `make test-native-all` with the same contract.
+
+Keep oracle-dependent differential tests in a separate job pinned through plan
+001.
+
+**Verify:** both commands run from a clean checkout without Python, model
+credentials, databases, or network services after dependency fetch.
+
+### Step 3: Create a reusable exact-SHA qualification workflow
+
+Refactor hardening qualification into a callable workflow that records:
+
+- Compass commit;
+- Graphify oracle commit and environment digest;
+- Rust/Python/tool versions;
+- target and runner identity;
+- corpus digest;
+- profile/features;
+- raw samples and thresholds.
+
+Include existing compatibility-isolating `--no-cluster` cases plus:
+
+- clustered end-to-end update;
+- hot same-process natural query;
+- hot MCP reload/query;
+- cancellation and budget behavior;
+- history materialization;
+- memory residency after multiple project loads.
+
+**Verify:** every artifact contains the exact tested Compass SHA and manifest
+identity.
+
+### Step 4: Require qualification for release
+
+Before release publication, resolve a successful qualification run for the
+exact tag SHA and verify its artifact signature/digests. Do not accept a branch
+head, cache key alone, or prior commit.
+
+Keep per-target packaging smoke tests.
+
+**Verify:** a dry-run release with no matching evidence fails before build
+publication; a run with valid exact-SHA evidence proceeds.
+
+### Step 5: Add executable documentation validation
+
+Create `scripts/check_docs.py --check` to validate:
+
+- relative links;
+- referenced local files;
+- documented script paths;
+- selected non-mutating `--help` examples;
+- stale `rust/scripts/` prefixes.
+
+Fix `PERFORMANCE.md` to use `scripts/qualify_phase1.sh` and
+`scripts/qualify_phase1_matrix.sh`.
+
+**Verify:** checker passes, and changing one path to a missing file makes it
+fail with file and line.
+
+### Step 6: Retain reviewable evidence
+
+Upload raw samples, summaries, compatibility manifest, and logs even on
+qualification failure. Use bounded retention and avoid secrets/environment
+values.
+
+**Verify:** a deliberately failed threshold still uploads a complete,
+secret-free evidence bundle.
+
+## Test plan
+
+- Inventory positive/negative tests.
+- Clean native all-target run.
+- Oracle-dependent job with immutable SHA.
+- Release dry run with missing, wrong-SHA, corrupt, and valid evidence.
+- Benchmark smoke mode for PRs and full mode for qualification.
+- Documentation checker broken-link/path fixtures.
+
+## Done criteria
+
+- [ ] Every integration target is classified.
+- [ ] Self-contained all-target tests run on every PR.
+- [ ] Qualification binds exact Compass and Graphify commits.
+- [ ] Release publication requires exact-tag qualification evidence.
+- [ ] Production clustered/hot paths have baselines.
+- [ ] Canonical docs commands are mechanically checked.
+- [ ] No required job depends on live credentials/services.
+
+## STOP conditions
+
+- The repository cannot distinguish hermetic and external integration tests.
+- Qualification evidence cannot be bound to an exact tag SHA.
+- Required benchmark runners are too noisy to sustain existing thresholds;
+  collect data and request threshold approval instead.
+- A release platform cannot consume the reusable workflow's evidence safely.
+
+## Maintenance notes
+
+Adding a test target requires classifying it. Adding a release path requires
+declaring its qualification evidence. Benchmark thresholds should move only
+with retained before/after raw data and an explicit rationale.

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -1,0 +1,70 @@
+# Compass enhancement advisor plans
+
+Generated from a deep comparison on 2026-07-23.
+
+Upstream snapshots:
+
+- Compass: `3837b411197771351b387cff935e4ae1e0eb8750`
+- Graphify `origin/main`: `91f4d120b630ee35c79bf3c75ccd186870a808f9`
+- Graphify v0.9.20 release base: `edec9eabeceeae6aa2375eddb3835efa1a32c0a3`
+- Graphify qualified R-support oracle: `de0806be7c95d97aa7ff40371a235da899d6edb0`
+
+Graphify `origin/main` is a divergent v1 product line, not a newer commit on
+the frozen v8 oracle's ancestry. Read
+[`000-origin-main-audit.md`](000-origin-main-audit.md) before executing a plan.
+
+## Execution order and status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|---|---|---:|---:|---|---|
+| 001 | Make upstream compatibility lineage machine-checkable | P1 | M | — | DONE |
+| 002 | Restore incoming evidence in directed wiki exports | P1 | S | 001 | DONE |
+| 003 | Return structured provenance from path and discovery queries | P1 | M | 001 | TODO |
+| 004 | Publish current outputs as one observable generation | P1 | L | 001 | TODO |
+| 005 | Gate pull requests and releases on production qualification | P1 | M | 001 | TODO |
+
+Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
+
+## Dependency notes
+
+- Plan 001 establishes the exact upstream line and evidence vocabulary used by
+  all later compatibility decisions.
+- Plan 002 is deliberately small and should land before the broader structured
+  evidence work in plan 003.
+- Plans 003 and 004 are independent after plan 001.
+- Plan 005 should consume the manifest and evidence targets introduced by plan
+  001 rather than introducing another compatibility configuration.
+
+## Direction options not promoted to implementation plans
+
+- **First-class hyperedge queries:** high architectural adjacency, but the
+  identity, role, history, and CompassQL semantics need an approved design
+  before implementation.
+- **Versioned mixed-corpus workspace profile:** Graphify main leads with this
+  workflow and Compass already has most primitives. Product priority and
+  provider/cost defaults need maintainer approval.
+- **Natural-query token/trigram index:** high-confidence performance
+  opportunity, but benchmark scale curves should establish priority after the
+  release qualification gate is trustworthy.
+- **Pluggable Leiden-quality community engine:** feature parity is incomplete,
+  but expected user value must be proven with modularity, connectivity,
+  stability, latency, and memory measurements.
+- **Linux and Windows release artifacts:** clear distribution gap; deferred
+  only to keep this first plan set at five items.
+
+## Findings considered and rejected
+
+- Reimplement Graphify main's Python pipeline architecture: rejected because
+  Compass's typed native workspace, deterministic indexes, bounded CompassQL,
+  immutable history, and safety limits are deeper Modules with stronger
+  Interfaces.
+- Treat all 74 failures from running `compass-parity` against Graphify main as
+  Compass regressions: rejected. The suite is designed for the v8 lineage and
+  many failures are missing v8 fixtures, commands, or modules on the divergent
+  main branch.
+- Duplicate Graphify main's hyperedge storage and shaded HTML: rejected because
+  Compass already preserves, reports, visualizes, and versions hyperedges.
+- Replace Compass watch and hook implementations with Graphify main's versions:
+  rejected because focused Compass tests pass and the native implementation
+  already handles custom hook paths, safe managed blocks, background refresh,
+  history, and external SCIP changes.

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -27,6 +27,7 @@ pub(crate) struct ParsedBuildCommand {
     pub(crate) format: String,
     pub(crate) replace_corrupt: bool,
     pub(crate) profile_from: Option<String>,
+    pub(crate) use_repository_profile: bool,
     pub(crate) options: HistoryBuildOptions,
 }
 
@@ -723,6 +724,7 @@ pub(crate) fn parse_build_command(
         format,
         replace_corrupt,
         profile_from,
+        use_repository_profile: !direct_profile_option,
         options,
     })
 }

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -170,9 +170,7 @@ fn resolve_or_materialize(
 
 fn configured_build_options(repository: &Repository) -> Result<HistoryBuildOptions, String> {
     let config = HistoryConfig::load(repository).map_err(|error| error.to_string())?;
-    if config.enabled
-        && let Some(profile) = config.profile
-    {
+    if let Some(profile) = config.profile {
         return HistoryBuildOptions::from_profile(profile).map_err(|error| error.to_string());
     }
     HistoryBuildOptions::defaults().map_err(|error| error.to_string())
@@ -1735,6 +1733,8 @@ fn execute_build(
     let options = if let Some(source) = &parsed.profile_from {
         HistoryBuildOptions::from_profile(stored_profile(repository, source).map_err(runtime)?)
             .map_err(runtime)?
+    } else if parsed.use_repository_profile {
+        configured_build_options(repository).map_err(runtime)?
     } else {
         parsed.options
     };

--- a/crates/compass-cli/tests/extract_cli.rs
+++ b/crates/compass-cli/tests/extract_cli.rs
@@ -105,14 +105,23 @@ fn native_artifact(root: &Path, name: &str) -> Result<Vec<u8>, Box<dyn Error>> {
     artifact(root, &name.replace(".graphify_", ".compass_"))
 }
 
-fn graph_without_definition_hashes(bytes: &[u8]) -> Result<Value, Box<dyn Error>> {
+fn graph_without_native_metadata(bytes: &[u8]) -> Result<Value, Box<dyn Error>> {
     let mut graph: Value = serde_json::from_slice(bytes)?;
     if let Some(nodes) = graph.get_mut("nodes").and_then(Value::as_array_mut) {
         for node in nodes {
             if let Some(attributes) = node.as_object_mut() {
-                attributes.remove("signature_hash");
-                attributes.remove("implementation_hash");
-                attributes.remove("source_hash");
+                for key in [
+                    "signature_hash",
+                    "implementation_hash",
+                    "source_hash",
+                    "symbol_kind",
+                    "language",
+                    "line_start",
+                    "line_end",
+                    "signature",
+                ] {
+                    attributes.remove(key);
+                }
             }
         }
     }
@@ -186,9 +195,9 @@ fn cold_force_and_raw_extract_match_python() -> Result<(), Box<dyn Error>> {
             let actual = native_artifact(directory.path(), name)?;
             if name == "graph.json" {
                 assert_eq!(
-                    graph_without_definition_hashes(&actual)?,
-                    graph_without_definition_hashes(&expected)?,
-                    "{name} mismatch outside definition hashes"
+                    graph_without_native_metadata(&actual)?,
+                    graph_without_native_metadata(&expected)?,
+                    "{name} mismatch outside native metadata"
                 );
             } else {
                 assert_eq!(actual, expected, "{name} mismatch");
@@ -213,7 +222,7 @@ fn warm_clustered_and_raw_extract_match_python() -> Result<(), Box<dyn Error>> {
         assert!(run_python(&arguments, home.path())?.status.success());
         let expected = run_python(&arguments, home.path())?;
         let expected_graph =
-            graph_without_definition_hashes(&artifact(directory.path(), "graph.json")?)?;
+            graph_without_native_metadata(&artifact(directory.path(), "graph.json")?)?;
         let expected_manifest = artifact(directory.path(), "manifest.json")?;
         remove_output(directory.path())?;
 
@@ -221,7 +230,7 @@ fn warm_clustered_and_raw_extract_match_python() -> Result<(), Box<dyn Error>> {
         let actual = run_rust(&arguments, home.path())?;
         assert_same_output(&expected, &actual);
         let actual_graph =
-            graph_without_definition_hashes(&artifact(directory.path(), "graph.json")?)?;
+            graph_without_native_metadata(&artifact(directory.path(), "graph.json")?)?;
         assert_eq!(actual_graph, expected_graph);
         assert_eq!(
             artifact(directory.path(), "manifest.json")?,

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -137,6 +137,120 @@ fn enable_disable_are_explicit_idempotent_and_invalid_profiles_roll_back()
 }
 
 #[test]
+fn explicit_build_uses_the_enabled_repository_profile_when_no_profile_options_are_given()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(
+        directory.path().join("service.rs"),
+        "pub struct ProfiledService;\n",
+    )?;
+    std::fs::write(
+        directory.path().join("README.md"),
+        "A semantic document that requires code-only profile reuse.\n",
+    )?;
+    git(directory.path(), &["add", "service.rs", "README.md"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "fixture"])?;
+
+    let compass = env!("CARGO_BIN_EXE_compass");
+    assert!(
+        run(
+            compass,
+            directory.path(),
+            &["history", "enable", "--code-only"],
+        )?
+        .status
+        .success()
+    );
+    let built = run(
+        compass,
+        directory.path(),
+        &["history", "build", "HEAD", "--format=json"],
+    )?;
+    assert!(
+        built.status.success(),
+        "{}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    let preferred = history
+        .preferred(&repository.resolve("HEAD")?)?
+        .ok_or("missing preferred realization")?;
+    assert_eq!(
+        preferred.version.build_profile.value("code_only"),
+        Some("true")
+    );
+    Ok(())
+}
+
+#[test]
+fn lazy_materialization_uses_the_retained_profile_after_eager_history_is_disabled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(
+        directory.path().join("service.rs"),
+        "pub struct DisabledProfileService;\n",
+    )?;
+    std::fs::write(
+        directory.path().join("README.md"),
+        "A semantic document that requires the retained code-only profile.\n",
+    )?;
+    git(directory.path(), &["add", "service.rs", "README.md"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "fixture"])?;
+
+    let compass = env!("CARGO_BIN_EXE_compass");
+    assert!(
+        run(
+            compass,
+            directory.path(),
+            &["history", "enable", "--code-only"],
+        )?
+        .status
+        .success()
+    );
+    assert!(
+        run(compass, directory.path(), &["history", "disable"])?
+            .status
+            .success()
+    );
+    let query = run(
+        compass,
+        directory.path(),
+        &["query", "DisabledProfileService", "--at", "HEAD"],
+    )?;
+    assert!(
+        query.status.success(),
+        "{}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+    assert!(String::from_utf8_lossy(&query.stdout).contains("DisabledProfileService"));
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    let preferred = history
+        .preferred(&repository.resolve("HEAD")?)?
+        .ok_or("missing preferred realization")?;
+    assert_eq!(
+        preferred.version.build_profile.value("code_only"),
+        Some("true")
+    );
+    Ok(())
+}
+
+#[test]
 fn worker_drains_fifo_after_an_earlier_job_fails() -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     git(directory.path(), &["init", "--quiet"])?;

--- a/crates/compass-cli/tests/update_cli.rs
+++ b/crates/compass-cli/tests/update_cli.rs
@@ -178,6 +178,7 @@ fn output_files(root: &Path) -> Result<Vec<PathBuf>, Box<dyn Error>> {
                     .replace(".compass_", ".graphify_"),
             )
         })
+        .filter(|path| path != Path::new(".graphify_output_stats.json"))
         .collect::<Vec<_>>();
     files.sort();
     Ok(files)
@@ -197,6 +198,11 @@ fn normalize_json(value: &mut serde_json::Value, fixture: &Fixture) {
             object.remove("signature_hash");
             object.remove("implementation_hash");
             object.remove("source_hash");
+            object.remove("symbol_kind");
+            object.remove("language");
+            object.remove("line_start");
+            object.remove("line_end");
+            object.remove("signature");
             for value in object.values_mut() {
                 normalize_json(value, fixture);
             }

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -20,7 +20,7 @@ use compass_output::{
 };
 use compass_resolve::{merge_decl_def_classes, resolve_owned_with_root};
 use rayon::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::program::{ProgramBuild, build_program, load_current_program, write_program};
@@ -62,6 +62,17 @@ pub enum BuildPurpose {
     #[default]
     Update,
     Extract,
+}
+
+const OUTPUT_STATS_FILE: &str = ".compass_output_stats.json";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OutputStats {
+    graph_bytes: u64,
+    nodes: usize,
+    edges: usize,
+    communities: usize,
+    clustered: bool,
 }
 
 impl BuildOptions {
@@ -373,18 +384,12 @@ fn build_graph_inner(
         && supplemental.is_empty()
         && manifest_unchanged
         && (!options.program_analysis || unchanged_program.is_some())
-        && let Some(document) = unchanged_output_document(options, &output_dir)
+        && let Some(stats) = unchanged_output_stats(options, &output_dir)
     {
         if options.no_viz {
             remove_if_exists(&output_dir.join("graph.html"))?;
         }
         remove_if_exists(&output_dir.join("needs_update"))?;
-        let communities = document
-            .nodes
-            .iter()
-            .filter_map(|node| node.attributes.get("community")?.as_u64())
-            .collect::<HashSet<_>>()
-            .len();
         guard.commit()?;
         return Ok(BuildResult {
             root,
@@ -394,9 +399,9 @@ fn build_graph_inner(
             files_extracted: 0,
             files_cached: sources.len(),
             empty_files: Vec::new(),
-            nodes: document.nodes.len(),
-            edges: document.links.len(),
-            communities,
+            nodes: stats.nodes,
+            edges: stats.edges,
+            communities: stats.communities,
             html_written: output_dir.join("graph.html").is_file(),
             outputs_changed: false,
             program_modules: program_modules(unchanged_program.as_ref()),
@@ -675,6 +680,7 @@ fn build_graph_inner(
             options.purpose,
             tokens,
         )?;
+        save_output_stats(&output_dir, nodes.len(), edges.len(), 0, false)?;
         write_semantic_marker(&output_dir, semantic)?;
         if options.purpose == BuildPurpose::Update {
             write_text_atomic(
@@ -957,6 +963,13 @@ fn build_graph_inner(
     )?;
     timings.export = stage_started.elapsed();
     write_program_output(&output_dir, program.as_ref())?;
+    save_output_stats(
+        &output_dir,
+        document.nodes.len(),
+        document.links.len(),
+        communities.len(),
+        true,
+    )?;
     guard.commit()?;
     Ok(BuildResult {
         root,
@@ -1311,7 +1324,7 @@ fn collect_ast_id_remap(
         {
             continue;
         }
-        if node.id == make_id(&[source]) || node.id == old_prefix {
+        if node.id == make_id(&[source]) {
             id_remap.insert(node.id.clone(), new_prefix);
         } else if let Some(suffix) = node.id.strip_prefix(&format!("{old_prefix}_")) {
             id_remap.insert(node.id.clone(), format!("{new_prefix}_{suffix}"));
@@ -1848,17 +1861,44 @@ fn update_artifacts_complete(output_dir: &Path) -> bool {
     .all(|name| output_dir.join(name).is_file())
 }
 
-fn unchanged_output_document(options: &BuildOptions, output_dir: &Path) -> Option<GraphDocument> {
+fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<OutputStats> {
     let graph_path = output_dir.join("graph.json");
+    let graph_bytes = fs::metadata(&graph_path).ok()?.len();
+    let saved = fs::read(output_dir.join(OUTPUT_STATS_FILE))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<OutputStats>(&bytes).ok());
+    if let Some(stats) = saved.filter(|stats| stats.graph_bytes == graph_bytes) {
+        if options.no_cluster == stats.clustered
+            || !output_dir.join(".compass_root").is_file()
+            || (!options.no_cluster
+                && (options.resolution != 1.0
+                    || options.exclude_hubs.is_some()
+                    || !update_artifacts_complete(output_dir)))
+            || (!options.no_viz && !output_dir.join("graph.html").is_file() && stats.nodes <= 5_000)
+        {
+            return None;
+        }
+        return Some(stats);
+    }
+
     let bytes = fs::read(&graph_path).ok()?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    let is_clustered = value.get("directed").is_some() && value.get("multigraph").is_some();
+    let header = &bytes[..bytes.len().min(512)];
+    let has_key = |key: &[u8]| header.windows(key.len()).any(|window| window == key);
+    let is_clustered = has_key(b"\"directed\"") && has_key(b"\"multigraph\"");
     if options.no_cluster == is_clustered || !output_dir.join(".compass_root").is_file() {
         return None;
     }
-    let document: GraphDocument = serde_json::from_value(value).ok()?;
+    let document: GraphDocument = serde_json::from_slice(&bytes).ok()?;
     if options.no_cluster {
-        return Some(document);
+        let stats = OutputStats {
+            graph_bytes,
+            nodes: document.nodes.len(),
+            edges: document.links.len(),
+            communities: 0,
+            clustered: false,
+        };
+        let _ = write_json_atomic(output_dir.join(OUTPUT_STATS_FILE), &stats, true);
+        return Some(stats);
     }
     if options.resolution != 1.0
         || options.exclude_hubs.is_some()
@@ -1870,7 +1910,47 @@ fn unchanged_output_document(options: &BuildOptions, output_dir: &Path) -> Optio
     {
         return None;
     }
-    Some(document)
+    let stats = OutputStats {
+        graph_bytes,
+        nodes: document.nodes.len(),
+        edges: document.links.len(),
+        communities: document
+            .nodes
+            .iter()
+            .filter_map(|node| node.attributes.get("community")?.as_u64())
+            .collect::<HashSet<_>>()
+            .len(),
+        clustered: true,
+    };
+    let _ = write_json_atomic(output_dir.join(OUTPUT_STATS_FILE), &stats, true);
+    Some(stats)
+}
+
+fn save_output_stats(
+    output_dir: &Path,
+    nodes: usize,
+    edges: usize,
+    communities: usize,
+    clustered: bool,
+) -> Result<(), CoreError> {
+    let graph_bytes = fs::metadata(output_dir.join("graph.json"))
+        .map_err(|source| compass_files::FileError::Io {
+            path: output_dir.join("graph.json"),
+            source,
+        })?
+        .len();
+    write_json_atomic(
+        output_dir.join(OUTPUT_STATS_FILE),
+        &OutputStats {
+            graph_bytes,
+            nodes,
+            edges,
+            communities,
+            clustered,
+        },
+        true,
+    )?;
+    Ok(())
 }
 
 fn canonical_node(node: &NodeRecord) -> String {
@@ -1993,6 +2073,51 @@ mod tests {
     use serde_json::{Map, Value};
 
     use super::*;
+
+    #[test]
+    fn ast_id_remap_does_not_conflate_prefix_named_symbol_with_file() -> Result<(), Box<dyn Error>>
+    {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path();
+        let source = root.join("internal/timeformattype_string.go");
+        fs::create_dir_all(source.parent().ok_or("source path has no parent")?)?;
+        fs::write(&source, "package internal\n\nfunc _() {}\n")?;
+        let source_text = source.to_string_lossy().into_owned();
+        let file_id = make_id(&[&source_text]);
+        let prefix_symbol_id = make_id(&[&file_stem(&source)]);
+        let mut extraction = Extraction {
+            nodes: vec![
+                NodeRecord {
+                    id: file_id,
+                    attributes: Map::from_iter([(
+                        "source_file".to_owned(),
+                        Value::String(source_text.clone()),
+                    )]),
+                },
+                NodeRecord {
+                    id: prefix_symbol_id.clone(),
+                    attributes: Map::from_iter([(
+                        "source_file".to_owned(),
+                        Value::String(source_text),
+                    )]),
+                },
+            ],
+            ..Extraction::default()
+        };
+        let (live_id_remap, live_sources) =
+            ast_source_identity_maps(std::slice::from_ref(&source), root);
+        let id_remap = collect_ast_id_remap(
+            std::slice::from_ref(&extraction),
+            root,
+            &live_id_remap,
+            &live_sources,
+        );
+        apply_ast_id_remap(&mut extraction, &id_remap);
+
+        assert_eq!(extraction.nodes[0].id, "internal_timeformattype_string");
+        assert_eq!(extraction.nodes[1].id, prefix_symbol_id);
+        Ok(())
+    }
 
     #[test]
     fn out_of_root_ast_sources_get_portable_ext_ids() -> Result<(), Box<dyn Error>> {

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -10,6 +10,8 @@ use sha2::{Digest, Sha256};
 
 use crate::{FileError, StatHashIndex, io_error, write_json_atomic};
 
+const AST_EXTRACTOR_VERSION: &str = "0.9.21";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CacheKind {
     Ast,
@@ -88,7 +90,7 @@ impl Cache {
             root,
             cache_root,
             output_name,
-            extractor_version: "0.9.20".to_owned(),
+            extractor_version: AST_EXTRACTOR_VERSION.to_owned(),
             hashes,
             session_hashes: HashMap::new(),
         };

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -478,6 +478,11 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     let root = directory.path().join("root");
     let cache_root = directory.path().join("cache-root");
     fs::create_dir_all(&root)?;
+    fs::create_dir_all(cache_root.join("compass-out/cache/ast/v0.9.20"))?;
+    fs::write(
+        cache_root.join("compass-out/cache/ast/v0.9.20/stale.json"),
+        "{}",
+    )?;
     fs::create_dir_all(cache_root.join("compass-out/cache/ast/vold"))?;
     fs::write(
         cache_root.join("compass-out/cache/ast/vold/stale.json"),
@@ -495,6 +500,14 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     )?;
     let source = root.join("main.md");
     fs::write(&source, "---\ntitle: ignored\n---\nbody\n")?;
+
+    let default_cache = Cache::new(&root, Some(&cache_root))?;
+    assert!(
+        default_cache
+            .directory(&CacheKind::Ast, None)
+            .ends_with("ast/v0.9.21")
+    );
+    assert!(!cache_root.join("compass-out/cache/ast/v0.9.20").exists());
 
     let mut cache = Cache::new(&root, Some(&cache_root))?.with_extractor_version("current");
     assert!(

--- a/crates/compass-graph/src/dedup.rs
+++ b/crates/compass-graph/src/dedup.rs
@@ -91,7 +91,7 @@ pub fn deduplicate_entities_with_tiebreaker(
     let mut exact_merges = 0;
     let mut by_norm = HashMap::<String, Vec<&NodeRecord>>::new();
     for node in &unique_nodes {
-        if is_code(node) {
+        if !is_entity_merge_candidate(node) {
             continue;
         }
         let key = normalize_label(node.label());
@@ -119,7 +119,7 @@ pub fn deduplicate_entities_with_tiebreaker(
     let mut candidates = Vec::<&NodeRecord>::new();
     let mut seen_norms = HashSet::new();
     for node in &unique_nodes {
-        if is_code(node) {
+        if !is_entity_merge_candidate(node) {
             continue;
         }
         let key = normalize_label(node.label());
@@ -554,6 +554,17 @@ fn is_code(node: &NodeRecord) -> bool {
     string_attribute(node, "file_type").as_deref() == Some("code")
 }
 
+fn is_positional(node: &NodeRecord) -> bool {
+    matches!(
+        string_attribute(node, "file_type").as_deref(),
+        Some("document" | "rationale")
+    )
+}
+
+fn is_entity_merge_candidate(node: &NodeRecord) -> bool {
+    !is_code(node) && !is_positional(node)
+}
+
 fn source_file(node: &NodeRecord) -> String {
     string_attribute(node, "source_file").unwrap_or_default()
 }
@@ -745,6 +756,21 @@ mod tests {
         }
     }
 
+    fn positional_node(
+        id: &str,
+        label: &str,
+        source_file: &str,
+        source_location: &str,
+        file_type: &str,
+    ) -> NodeRecord {
+        let mut node = node(id, label, source_file);
+        node.attributes
+            .insert("source_location".to_owned(), json!(source_location));
+        node.attributes
+            .insert("file_type".to_owned(), json!(file_type));
+        node
+    }
+
     #[test]
     fn exact_and_fuzzy_merges_rewire_edges() -> Result<(), DedupError> {
         let nodes = vec![
@@ -794,6 +820,62 @@ mod tests {
         ];
         let result = deduplicate_entities(&nodes, &[], &HashMap::new())?;
         assert_eq!(result.nodes.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn repeated_positional_nodes_in_one_file_remain_distinct() -> Result<(), DedupError> {
+        let nodes = vec![
+            positional_node(
+                "release_notes_heading_l10",
+                "Fixed",
+                "RELEASE_NOTES.md",
+                "L10",
+                "document",
+            ),
+            positional_node(
+                "release_notes_heading_l40",
+                "Fixed",
+                "RELEASE_NOTES.md",
+                "L40",
+                "document",
+            ),
+            positional_node(
+                "decision_l12",
+                "Preserve compatibility",
+                "ADR.md",
+                "L12",
+                "rationale",
+            ),
+            positional_node(
+                "decision_l60",
+                "Preserve compatibility",
+                "ADR.md",
+                "L60",
+                "rationale",
+            ),
+        ];
+
+        let result = deduplicate_entities(&nodes, &[], &HashMap::new())?;
+
+        assert_eq!(result.nodes.len(), 4);
+        assert_eq!(result.stats.removed, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn literal_positional_id_collisions_still_collapse() -> Result<(), DedupError> {
+        let node = positional_node(
+            "release_notes_heading_l10",
+            "Fixed",
+            "RELEASE_NOTES.md",
+            "L10",
+            "document",
+        );
+
+        let result = deduplicate_entities(&[node.clone(), node], &[], &HashMap::new())?;
+
+        assert_eq!(result.nodes.len(), 1);
         Ok(())
     }
 

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -143,7 +143,7 @@ pub fn build_from_extraction(
         ))
     });
     let mut links = Vec::<EdgeRecord>::new();
-    let mut edge_positions = HashMap::<(String, String), usize>::new();
+    let mut edge_positions = HashMap::<(String, String, String), usize>::new();
     for mut edge in source_edges {
         if edge.attributes.remove("_drop") == Some(Value::Bool(true)) {
             continue;
@@ -169,18 +169,9 @@ pub fn build_from_extraction(
         edge.attributes
             .insert("_tgt".to_owned(), Value::String(edge.target.clone()));
 
-        let key = edge_key(&edge.source, &edge.target, directed);
+        let key = edge_key(&edge.source, &edge.target, relation(&edge));
         if let Some(&position) = edge_positions.get(&key) {
-            let existing = &links[position];
-            let reverse_duplicate = !directed
-                && relation(existing) == relation(&edge)
-                && existing.attributes.get("_src").and_then(Value::as_str)
-                    == Some(edge.target.as_str())
-                && existing.attributes.get("_tgt").and_then(Value::as_str)
-                    == Some(edge.source.as_str());
-            if !reverse_duplicate {
-                links[position].attributes.extend(edge.attributes);
-            }
+            links[position].attributes.extend(edge.attributes);
         } else {
             edge_positions.insert(key, links.len());
             links.push(edge);
@@ -681,12 +672,8 @@ fn edge_language_family(extension: &str) -> Option<&'static str> {
     }
 }
 
-fn edge_key(source: &str, target: &str, directed: bool) -> (String, String) {
-    if directed || source <= target {
-        (source.to_owned(), target.to_owned())
-    } else {
-        (target.to_owned(), source.to_owned())
-    }
+fn edge_key(source: &str, target: &str, relation: &str) -> (String, String, String) {
+    (source.to_owned(), target.to_owned(), relation.to_owned())
 }
 
 fn canonical_hyperedges(

--- a/crates/compass-graph/tests/build_coverage.rs
+++ b/crates/compass-graph/tests/build_coverage.rs
@@ -166,3 +166,58 @@ fn networkx_edge_order_preserves_node_and_incident_edge_order() -> Result<(), Bo
     );
     Ok(())
 }
+
+#[test]
+fn distinct_relations_between_the_same_nodes_are_preserved() -> Result<(), Box<dyn Error>> {
+    let extraction: Extraction = serde_json::from_value(json!({
+        "nodes": [
+            {"id":"caller","label":"caller()","file_type":"code","source_file":"main.c"},
+            {"id":"target","label":"Target","file_type":"code","source_file":"main.c"}
+        ],
+        "edges": [
+            {"source":"caller","target":"target","relation":"calls"},
+            {"source":"caller","target":"target","relation":"references"}
+        ]
+    }))?;
+
+    let document = build_from_extraction(&extraction, false, None);
+    let relations = document
+        .links
+        .iter()
+        .map(|edge| edge.string("relation"))
+        .collect::<Vec<_>>();
+    assert_eq!(relations, ["calls", "references"]);
+    Ok(())
+}
+
+#[test]
+fn opposite_direction_relations_are_preserved_in_undirected_documents() -> Result<(), Box<dyn Error>>
+{
+    let extraction: Extraction = serde_json::from_value(json!({
+        "nodes": [
+            {"id":"a","label":"A","file_type":"code","source_file":"main.go"},
+            {"id":"b","label":"B","file_type":"code","source_file":"main.go"}
+        ],
+        "edges": [
+            {"source":"a","target":"b","relation":"calls"},
+            {"source":"b","target":"a","relation":"calls"}
+        ]
+    }))?;
+
+    let document = build_from_extraction(&extraction, false, None);
+    let true_directions = document
+        .links
+        .iter()
+        .map(|edge| {
+            (
+                edge.attributes.get("_src").and_then(|value| value.as_str()),
+                edge.attributes.get("_tgt").and_then(|value| value.as_str()),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        true_directions,
+        [(Some("a"), Some("b")), (Some("b"), Some("a"))]
+    );
+    Ok(())
+}

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -1225,12 +1225,25 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
     }
 
     fn function_name(&self, node: Node<'tree>) -> Option<String> {
+        if self.language == "c" {
+            return self
+                .c_function_name(node)
+                .or_else(|| self.declaration_name(node));
+        }
         self.declaration_name(node).or_else(|| {
             node.child_by_field_name("declarator")
                 .and_then(first_identifier)
                 .and_then(|name| self.node_text(name))
                 .map(clean_name)
         })
+    }
+
+    fn c_function_name(&self, node: Node<'tree>) -> Option<String> {
+        let declarator = node.child_by_field_name("declarator")?;
+        let name = c_declarator_name(declarator)?;
+        self.node_text(name)
+            .map(clean_name)
+            .filter(|name| !name.is_empty())
     }
 
     fn call_name(&self, node: Node<'tree>) -> Option<CallName> {
@@ -2733,6 +2746,22 @@ fn first_identifier(node: Node<'_>) -> Option<Node<'_>> {
     .find_map(|kind| first_descendant(node, kind))
 }
 
+fn c_declarator_name(node: Node<'_>) -> Option<Node<'_>> {
+    if node.kind() == "identifier" {
+        return Some(node);
+    }
+    if let Some(declarator) = node.child_by_field_name("declarator") {
+        return c_declarator_name(declarator);
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if let Some(name) = c_declarator_name(child) {
+            return Some(name);
+        }
+    }
+    None
+}
+
 fn last_identifier(node: Node<'_>) -> Option<Node<'_>> {
     let mut result = None;
     let mut cursor = node.walk();
@@ -3032,6 +3061,33 @@ fn resolve_js_import_path(path: &Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod rationale_tests {
     use super::*;
+
+    #[test]
+    fn c_function_declarators_prefer_callable_names_over_types()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("declarators.c");
+        fs::write(
+            &source,
+            "SQLITE_PRIVATE char *sqlite3CompileOptions(void) { return 0; }\n\
+             SQLITE_PRIVATE sqlite3_int64 sqlite3StatusValue(int op) { return op; }\n",
+        )?;
+
+        let extraction = Engine::default().extract(&source)?;
+        let labels = extraction
+            .nodes
+            .iter()
+            .map(NodeRecord::label)
+            .collect::<HashSet<_>>();
+
+        for expected in ["sqlite3CompileOptions()", "sqlite3StatusValue()"] {
+            assert!(labels.contains(expected), "missing {expected}");
+        }
+        for invalid in ["char()", "sqlite3_int64()"] {
+            assert!(!labels.contains(invalid), "unexpected {invalid}");
+        }
+        Ok(())
+    }
 
     #[test]
     fn definition_hashes_separate_signature_implementation_and_source_changes()

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -1544,6 +1544,25 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             self.add_js_import(node);
             return;
         }
+        if self.language == "c"
+            && let Some(path) = node.child_by_field_name("path")
+            && path.kind() != "system_lib_string"
+            && let Some(raw) = self.node_text(path)
+            && let clean = raw.trim_matches(['<', '>', '\'', '"', ' '])
+            && !clean.is_empty()
+            && let Some(parent) = Path::new(&self.source_file).parent()
+            && let Ok(resolved) = fs::canonicalize(parent.join(clean))
+            && resolved.is_file()
+        {
+            self.add_edge(
+                &self.file_id.clone(),
+                &make_id(&[&resolved.to_string_lossy()]),
+                "imports",
+                line(node),
+                Some("import"),
+            );
+            return;
+        }
         let target = quoted_value(&text)
             .or_else(|| angle_value(&text))
             .or_else(|| {
@@ -2305,13 +2324,30 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             collect_c_type_names(return_type, self.source, &mut names);
             self.add_c_type_references(function_id, &names, "return_type", line(node));
         }
-        let mut parameters = Vec::new();
-        collect_nodes_of_kind(node, "parameter_declaration", &mut parameters);
-        for parameter in parameters {
-            if let Some(type_node) = parameter.child_by_field_name("type") {
-                let mut names = Vec::new();
-                collect_c_type_names(type_node, self.source, &mut names);
-                self.add_c_type_references(function_id, &names, "parameter_type", line(node));
+        let mut declarator = node.child_by_field_name("declarator");
+        while declarator.is_some_and(|candidate| {
+            matches!(
+                candidate.kind(),
+                "pointer_declarator" | "reference_declarator"
+            )
+        }) {
+            declarator =
+                declarator.and_then(|candidate| candidate.child_by_field_name("declarator"));
+        }
+        if let Some(parameters) = declarator
+            .filter(|candidate| candidate.kind() == "function_declarator")
+            .and_then(|candidate| candidate.child_by_field_name("parameters"))
+        {
+            let mut cursor = parameters.walk();
+            for parameter in parameters
+                .children(&mut cursor)
+                .filter(|candidate| candidate.kind() == "parameter_declaration")
+            {
+                if let Some(type_node) = parameter.child_by_field_name("type") {
+                    let mut names = Vec::new();
+                    collect_c_type_names(type_node, self.source, &mut names);
+                    self.add_c_type_references(function_id, &names, "parameter_type", line(node));
+                }
             }
         }
     }
@@ -3250,7 +3286,9 @@ mod rationale_tests {
         fs::write(
             &source,
             "SQLITE_PRIVATE char *sqlite3CompileOptions(void) { return 0; }\n\
-             SQLITE_PRIVATE sqlite3_int64 sqlite3StatusValue(int op) { return op; }\n",
+             SQLITE_PRIVATE sqlite3_int64 sqlite3StatusValue(int op) { return op; }\n\
+             int valueFromExpr(void) { int (*callback)(op *); return callback != 0; }\n\
+             int acceptsOp(Op *value) { return value != 0; }\n",
         )?;
 
         let extraction = Engine::default().extract(&source)?;
@@ -3266,6 +3304,29 @@ mod rationale_tests {
         for invalid in ["char()", "sqlite3_int64()"] {
             assert!(!labels.contains(invalid), "unexpected {invalid}");
         }
+        assert!(labels.contains("Op"));
+        assert!(!labels.contains("op"));
+        Ok(())
+    }
+
+    #[test]
+    fn c_quoted_include_targets_the_existing_header_file() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let directory = tempfile::tempdir()?;
+        let header = directory.path().join("shm_lock.h");
+        let source = directory.path().join("shm_lock.c");
+        fs::write(&header, "int lock(void);\n")?;
+        fs::write(
+            &source,
+            "#include \"shm_lock.h\"\nint main(void) { return lock(); }\n",
+        )?;
+
+        let extraction = Engine::default().extract(&source)?;
+        let expected = make_id(&[&fs::canonicalize(header)?.to_string_lossy()]);
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.target == expected
+                && edge.attributes.get("relation").and_then(Value::as_str) == Some("imports")
+        }));
         Ok(())
     }
 

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -81,15 +81,16 @@ impl Engine {
             &generic_config(spec),
             language,
         );
-        attach_definition_hashes(
+        if language == "python" {
+            add_python_rationale(path, source, tree.root_node(), &mut extraction);
+        }
+        attach_definition_metadata(
             &mut extraction,
             source,
             tree.root_node(),
             &generic_config(spec),
+            language,
         );
-        if language == "python" {
-            add_python_rationale(path, source, tree.root_node(), &mut extraction);
-        }
         Ok(extraction)
     }
 
@@ -112,21 +113,27 @@ impl Engine {
         source: &[u8],
     ) -> Result<Extraction, ExtractError> {
         if spec.name == "groovy" {
-            return Ok(crate::groovy::extract(path, source));
+            let mut extraction = crate::groovy::extract(path, source);
+            attach_basic_symbol_metadata(&mut extraction, source, spec.name);
+            return Ok(extraction);
         }
         // These extractors are intentionally source-driven and do not consume a
         // tree-sitter root. Avoid initializing and touching their large static
         // grammar tables only to discard the tree; this materially lowers cold
         // multilingual startup RSS and latency while preserving identical facts.
-        match spec.name {
-            "zig" => return Ok(crate::zig::extract(path, source)),
-            "verilog" => return Ok(crate::verilog::extract(path, source)),
-            "sql" => return Ok(crate::sql::extract(path, source)),
-            "r" => return Ok(crate::r::extract(path, source)),
-            "pascal" => return Ok(crate::pascal::extract(path, source)),
-            "apex" => return Ok(crate::apex::extract(path, source)),
-            "dart" => return Ok(crate::dart::extract(path, source)),
-            _ => {}
+        let source_driven = match spec.name {
+            "zig" => Some(crate::zig::extract(path, source)),
+            "verilog" => Some(crate::verilog::extract(path, source)),
+            "sql" => Some(crate::sql::extract(path, source)),
+            "r" => Some(crate::r::extract(path, source)),
+            "pascal" => Some(crate::pascal::extract(path, source)),
+            "apex" => Some(crate::apex::extract(path, source)),
+            "dart" => Some(crate::dart::extract(path, source)),
+            _ => None,
+        };
+        if let Some(mut extraction) = source_driven {
+            attach_basic_symbol_metadata(&mut extraction, source, spec.name);
+            return Ok(extraction);
         }
         let mut masked = Vec::new();
         let source = if spec.name == "objc" {
@@ -154,10 +161,10 @@ impl Engine {
             "fortran" => crate::fortran::extract(path, source, root),
             _ => extract_tree(path, source, root, &config, spec.name),
         };
-        attach_definition_hashes(&mut extraction, source, root, &config);
         if spec.name == "python" {
             add_python_rationale(path, source, root, &mut extraction);
         }
+        attach_definition_metadata(&mut extraction, source, root, &config, spec.name);
         Ok(extraction)
     }
 
@@ -352,15 +359,17 @@ fn extract_tree(
     state.extraction
 }
 
-fn attach_definition_hashes(
+fn attach_definition_metadata(
     extraction: &mut Extraction,
     source: &[u8],
     root: Node<'_>,
     config: &GenericConfig,
+    language: &str,
 ) {
+    attach_basic_symbol_metadata(extraction, source, language);
     let mut candidates = HashMap::<usize, Vec<usize>>::new();
     for (index, node) in extraction.nodes.iter().enumerate() {
-        if node.attributes.get("_callable").and_then(Value::as_bool) != Some(true) {
+        if node.string("file_type") != "code" || node.string("source_file").is_empty() {
             continue;
         }
         let Some(line) = node
@@ -380,24 +389,52 @@ fn attach_definition_hashes(
         let Some(indices) = candidates.get_mut(&at_line) else {
             continue;
         };
-        let Some(index) = indices.first().copied() else {
-            continue;
-        };
-        indices.remove(0);
-        let body = definition.child_by_field_name("body").or_else(|| {
-            let mut cursor = definition.walk();
-            definition.children(&mut cursor).find(|child| {
-                matches!(
-                    child.kind(),
-                    "body" | "block" | "compound_statement" | "class_body" | "declaration_list"
-                )
+        let name = definition_name(definition, source);
+        let matched = name.as_deref().and_then(|name| {
+            indices.iter().position(|index| {
+                normalize_symbol_label(extraction.nodes[*index].label())
+                    == clean_name(name.to_owned())
             })
         });
+        let fallback = indices.iter().position(|index| {
+            extraction.nodes[*index]
+                .attributes
+                .get("_callable")
+                .and_then(Value::as_bool)
+                == Some(true)
+        });
+        let Some(position) = matched.or(fallback).or((indices.len() == 1).then_some(0)) else {
+            continue;
+        };
+        let index = indices.remove(position);
+        let body = definition_body(definition);
         let signature_hash = ast_hash(definition, source, body.map(|body| body.id()));
         let source_hash = source
             .get(definition.start_byte()..definition.end_byte())
             .map(normalized_source_hash);
+        let is_nested = extraction.nodes[index].label().starts_with('.');
+        let symbol_kind = symbol_kind(
+            definition.kind(),
+            config.class_types.contains(&definition.kind()),
+            is_nested,
+        );
         let attributes = &mut extraction.nodes[index].attributes;
+        attributes.insert(
+            "symbol_kind".to_owned(),
+            Value::String(symbol_kind.to_owned()),
+        );
+        attributes.insert("language".to_owned(), Value::String(language.to_owned()));
+        attributes.insert(
+            "line_start".to_owned(),
+            Value::from(definition.start_position().row + 1),
+        );
+        attributes.insert(
+            "line_end".to_owned(),
+            Value::from(definition.end_position().row + 1),
+        );
+        if let Some(signature) = readable_signature(definition, body, source) {
+            attributes.insert("signature".to_owned(), Value::String(signature));
+        }
         attributes.insert("signature_hash".to_owned(), Value::String(signature_hash));
         if let Some(body) = body {
             attributes.insert(
@@ -409,6 +446,149 @@ fn attach_definition_hashes(
             attributes.insert("source_hash".to_owned(), Value::String(source_hash));
         }
     }
+}
+
+fn attach_basic_symbol_metadata(extraction: &mut Extraction, source: &[u8], language: &str) {
+    let source_lines = source.iter().filter(|byte| **byte == b'\n').count() + 1;
+    for node in &mut extraction.nodes {
+        let source_file = node.string("source_file");
+        if source_file.is_empty() {
+            continue;
+        }
+        let line_start = node
+            .attributes
+            .get("source_location")
+            .and_then(Value::as_str)
+            .and_then(source_line)
+            .unwrap_or(1);
+        let file_name = Path::new(&source_file)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        let is_file = node.label() == file_name;
+        let fallback_kind = if is_file {
+            "file".to_owned()
+        } else if node.label().ends_with("()") {
+            if node.label().starts_with('.') {
+                "method".to_owned()
+            } else {
+                "function".to_owned()
+            }
+        } else {
+            node.attributes
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("symbol")
+                .to_owned()
+        };
+        node.attributes
+            .entry("symbol_kind".to_owned())
+            .or_insert_with(|| Value::String(fallback_kind));
+        node.attributes
+            .entry("language".to_owned())
+            .or_insert_with(|| Value::String(language.to_owned()));
+        node.attributes
+            .entry("line_start".to_owned())
+            .or_insert_with(|| Value::from(line_start));
+        node.attributes
+            .entry("line_end".to_owned())
+            .or_insert_with(|| Value::from(if is_file { source_lines } else { line_start }));
+    }
+}
+
+fn definition_body(node: Node<'_>) -> Option<Node<'_>> {
+    node.child_by_field_name("body").or_else(|| {
+        let mut cursor = node.walk();
+        node.children(&mut cursor).find(|child| {
+            matches!(
+                child.kind(),
+                "body" | "block" | "compound_statement" | "class_body" | "declaration_list"
+            )
+        })
+    })
+}
+
+fn definition_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    if let Some(name) = node.child_by_field_name("name") {
+        return Some(source_node_text(name, source));
+    }
+    let mut declarator = node.child_by_field_name("declarator");
+    while let Some(candidate) = declarator {
+        if matches!(
+            candidate.kind(),
+            "identifier" | "field_identifier" | "type_identifier" | "operator_name"
+        ) {
+            return Some(source_node_text(candidate, source));
+        }
+        declarator = candidate
+            .child_by_field_name("declarator")
+            .or_else(|| candidate.child_by_field_name("name"));
+    }
+    None
+}
+
+fn normalize_symbol_label(label: &str) -> String {
+    clean_name(
+        label
+            .trim_start_matches('.')
+            .trim_end_matches("()")
+            .trim()
+            .to_owned(),
+    )
+}
+
+fn symbol_kind(kind: &str, is_class: bool, is_nested: bool) -> &'static str {
+    if is_class {
+        if kind.contains("interface") {
+            "interface"
+        } else if kind.contains("enum") {
+            "enum"
+        } else if kind.contains("struct") {
+            "struct"
+        } else if kind.contains("record") {
+            "record"
+        } else if kind.contains("protocol") {
+            "protocol"
+        } else if kind.contains("module") || kind.contains("object") {
+            "module"
+        } else if kind.contains("type_alias") {
+            "type"
+        } else {
+            "class"
+        }
+    } else if kind.contains("constructor") || kind.contains("init_declaration") {
+        "constructor"
+    } else if kind.contains("deinit") {
+        "destructor"
+    } else if kind.contains("method") || is_nested {
+        "method"
+    } else {
+        "function"
+    }
+}
+
+fn readable_signature(node: Node<'_>, body: Option<Node<'_>>, source: &[u8]) -> Option<String> {
+    let end = body.map_or(node.end_byte(), |body| body.start_byte());
+    let raw = source.get(node.start_byte()..end)?;
+    let compact = String::from_utf8_lossy(raw)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let compact = compact
+        .trim()
+        .trim_end_matches(['{', ':', ';'])
+        .trim()
+        .to_owned();
+    if compact.is_empty() {
+        return None;
+    }
+    let mut chars = compact.chars();
+    let signature = chars.by_ref().take(500).collect::<String>();
+    Some(if chars.next().is_some() {
+        format!("{signature}…")
+    } else {
+        signature
+    })
 }
 
 fn source_line(location: &str) -> Option<usize> {
@@ -3086,6 +3266,35 @@ mod rationale_tests {
         for invalid in ["char()", "sqlite3_int64()"] {
             assert!(!labels.contains(invalid), "unexpected {invalid}");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn definitions_include_display_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("fixture.py");
+        fs::write(
+            &source,
+            "def reveal(t, hold_val=\"1\", start_val=\"0\"):\n\
+             \x20   value = t + hold_val\n\
+             \x20   return value + start_val\n",
+        )?;
+
+        let extraction = Engine::default().extract(&source)?;
+        let node = extraction
+            .nodes
+            .iter()
+            .find(|node| node.label() == "reveal()")
+            .ok_or("missing reveal function")?;
+
+        assert_eq!(node.string("symbol_kind"), "function");
+        assert_eq!(node.string("language"), "python");
+        assert_eq!(node.attributes.get("line_start"), Some(&Value::from(1)));
+        assert_eq!(node.attributes.get("line_end"), Some(&Value::from(3)));
+        assert_eq!(
+            node.string("signature"),
+            "def reveal(t, hold_val=\"1\", start_val=\"0\")"
+        );
         Ok(())
     }
 

--- a/crates/compass-output/src/html.rs
+++ b/crates/compass-output/src/html.rs
@@ -62,6 +62,7 @@ pub fn html_document(
                 node_limit: None,
                 learning_overlay: options.learning_overlay,
             },
+            Some((document, communities)),
         );
         return Ok(Some(HtmlRender {
             nodes: meta.nodes.len(),
@@ -71,7 +72,7 @@ pub fn html_document(
         }));
     }
     Ok(Some(HtmlRender {
-        html: render(document, communities, output_path.as_ref(), options),
+        html: render(document, communities, output_path.as_ref(), options, None),
         aggregated: false,
         nodes: document.nodes.len(),
         edges: document.links.len(),
@@ -109,7 +110,76 @@ fn render(
     communities: &Communities,
     output_path: &Path,
     options: &HtmlOptions<'_>,
+    drilldown: Option<(&GraphDocument, &Communities)>,
 ) -> String {
+    let nodes = node_values(document, communities, options);
+    let edges = document.links.iter().map(edge_value).collect::<Vec<_>>();
+    let mut legend = Vec::new();
+    if let Some(labels) = options.community_labels {
+        for community in labels.keys() {
+            let count = options.member_counts.map_or_else(
+                || communities.get(community).map(Vec::len).unwrap_or_default(),
+                |counts| {
+                    counts.get(community).copied().unwrap_or_else(|| {
+                        communities.get(community).map(Vec::len).unwrap_or_default()
+                    })
+                },
+            );
+            let mut item = Map::new();
+            item.insert("cid".into(), Value::from(*community));
+            item.insert(
+                "color".into(),
+                Value::String(COMMUNITY_COLORS[community % COMMUNITY_COLORS.len()].into()),
+            );
+            item.insert(
+                "label".into(),
+                Value::String(html_escape(&sanitize_label(&community_name(
+                    *community,
+                    options.community_labels,
+                )))),
+            );
+            item.insert("count".into(), Value::from(count));
+            legend.push(Value::Object(item));
+        }
+    }
+    let hyperedges = document
+        .graph
+        .get("hyperedges")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let details = drilldown.map_or_else(
+        || Value::Object(Map::new()),
+        |(source, source_communities)| community_details(source, source_communities, options),
+    );
+    let nodes_json = js_safe(&python_json_compact(&Value::Array(nodes)));
+    let edges_json = js_safe(&python_json_compact(&Value::Array(edges)));
+    let legend_json = js_safe(&python_json_compact(&Value::Array(legend)));
+    let hyperedges_json = js_safe(&python_json_compact(&hyperedges));
+    let details_json = js_safe(&python_json_compact(&details));
+    let title = html_escape(&sanitize_label(&output_path.to_string_lossy()));
+    let stats = format!(
+        "{} nodes &middot; {} edges &middot; {} communities",
+        document.nodes.len(),
+        document.links.len(),
+        communities.len()
+    );
+    page(
+        &title,
+        &stats,
+        &nodes_json,
+        &edges_json,
+        &legend_json,
+        &hyperedges_json,
+        &details_json,
+        drilldown.is_some(),
+    )
+}
+
+fn node_values(
+    document: &GraphDocument,
+    communities: &Communities,
+    options: &HtmlOptions<'_>,
+) -> Vec<Value> {
     let node_community = communities
         .iter()
         .flat_map(|(community, members)| {
@@ -153,7 +223,6 @@ fn render(
             "font".into(),
             serde_json::json!({"size": font_size, "color": "#ffffff"}),
         );
-        output.insert("title".into(), Value::String(html_escape(&label)));
         output.insert("community".into(), Value::from(community));
         output.insert(
             "community_name".into(),
@@ -173,6 +242,61 @@ fn render(
                 .cloned()
                 .unwrap_or_else(|| Value::String(String::new())),
         );
+        let source_location = sanitize_label(&node.string("source_location"));
+        let symbol_kind = sanitize_label(&node.string("symbol_kind"));
+        let language = sanitize_label(&node.string("language"));
+        let signature = sanitize_metadata(&node.string("signature"), 500);
+        let (location_start, location_end) = source_line_range(&source_location);
+        let line_start = node
+            .attributes
+            .get("line_start")
+            .and_then(Value::as_u64)
+            .or(location_start);
+        let line_end = node
+            .attributes
+            .get("line_end")
+            .and_then(Value::as_u64)
+            .or(location_end)
+            .or(line_start);
+        let display_kind = if symbol_kind.is_empty() {
+            sanitize_label(&node.string("file_type"))
+        } else {
+            symbol_kind
+        };
+        output.insert(
+            "source_location".into(),
+            Value::String(source_location.clone()),
+        );
+        output.insert("symbol_kind".into(), Value::String(display_kind.clone()));
+        output.insert("language".into(), Value::String(language.clone()));
+        output.insert(
+            "line_start".into(),
+            line_start.map_or(Value::Null, Value::from),
+        );
+        output.insert("line_end".into(), line_end.map_or(Value::Null, Value::from));
+        output.insert("signature".into(), Value::String(signature.clone()));
+        if let Some(counts) = options.member_counts {
+            output.insert("is_community".into(), Value::Bool(true));
+            output.insert(
+                "member_count".into(),
+                Value::from(counts.get(&community).copied().unwrap_or_default()),
+            );
+        }
+        output.insert(
+            "tooltip_html".into(),
+            Value::String(node_tooltip(
+                &label,
+                &display_kind,
+                &language,
+                &node.string("source_file"),
+                line_start,
+                line_end,
+                &signature,
+                options
+                    .member_counts
+                    .and_then(|counts| counts.get(&community).copied()),
+            )),
+        );
         output.insert("degree".into(), Value::from(degree));
         if let Some(entry) = options
             .learning_overlay
@@ -182,61 +306,131 @@ fn render(
         {
             add_learning_fields(&mut output, entry, &label, color);
         }
+        output.remove("title");
         nodes.push(Value::Object(output));
     }
+    nodes
+}
 
-    let edges = document.links.iter().map(edge_value).collect::<Vec<_>>();
-    let mut legend = Vec::new();
-    if let Some(labels) = options.community_labels {
-        for community in labels.keys() {
-            let count = options.member_counts.map_or_else(
-                || communities.get(community).map(Vec::len).unwrap_or_default(),
-                |counts| {
-                    counts.get(community).copied().unwrap_or_else(|| {
-                        communities.get(community).map(Vec::len).unwrap_or_default()
-                    })
-                },
-            );
-            let mut item = Map::new();
-            item.insert("cid".into(), Value::from(*community));
-            item.insert(
-                "color".into(),
-                Value::String(COMMUNITY_COLORS[community % COMMUNITY_COLORS.len()].into()),
-            );
-            item.insert(
-                "label".into(),
-                Value::String(html_escape(&sanitize_label(&community_name(
-                    *community,
-                    options.community_labels,
-                )))),
-            );
-            item.insert("count".into(), Value::from(count));
-            legend.push(Value::Object(item));
+fn community_details(
+    document: &GraphDocument,
+    communities: &Communities,
+    options: &HtmlOptions<'_>,
+) -> Value {
+    let detail_options = HtmlOptions {
+        community_labels: options.community_labels,
+        member_counts: None,
+        node_limit: None,
+        learning_overlay: options.learning_overlay,
+    };
+    let mut grouped_nodes = BTreeMap::<usize, Vec<Value>>::new();
+    for node in node_values(document, communities, &detail_options) {
+        let community = node
+            .get("community")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as usize;
+        grouped_nodes.entry(community).or_default().push(node);
+    }
+    let node_community = communities
+        .iter()
+        .flat_map(|(community, members)| {
+            members
+                .iter()
+                .map(move |member| (member.as_str(), *community))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut grouped_edges = BTreeMap::<usize, Vec<Value>>::new();
+    for edge in &document.links {
+        let (Some(source), Some(target)) = (
+            node_community.get(edge.source.as_str()),
+            node_community.get(edge.target.as_str()),
+        ) else {
+            continue;
+        };
+        if source == target {
+            grouped_edges
+                .entry(*source)
+                .or_default()
+                .push(edge_value(edge));
         }
     }
-    let hyperedges = document
-        .graph
-        .get("hyperedges")
-        .cloned()
-        .unwrap_or_else(|| Value::Array(Vec::new()));
-    let nodes_json = js_safe(&python_json_compact(&Value::Array(nodes)));
-    let edges_json = js_safe(&python_json_compact(&Value::Array(edges)));
-    let legend_json = js_safe(&python_json_compact(&Value::Array(legend)));
-    let hyperedges_json = js_safe(&python_json_compact(&hyperedges));
-    let title = html_escape(&sanitize_label(&output_path.to_string_lossy()));
-    let stats = format!(
-        "{} nodes &middot; {} edges &middot; {} communities",
-        document.nodes.len(),
-        document.links.len(),
-        communities.len()
-    );
-    page(
-        &title,
-        &stats,
-        &nodes_json,
-        &edges_json,
-        &legend_json,
-        &hyperedges_json,
+    Value::Object(
+        grouped_nodes
+            .into_iter()
+            .map(|(community, nodes)| {
+                let edges = grouped_edges.remove(&community).unwrap_or_default();
+                (
+                    community.to_string(),
+                    serde_json::json!({
+                        "community": community,
+                        "name": community_name(community, options.community_labels),
+                        "nodes": nodes,
+                        "edges": edges,
+                    }),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn source_line_range(location: &str) -> (Option<u64>, Option<u64>) {
+    let Some(location) = location.strip_prefix('L') else {
+        return (None, None);
+    };
+    let (start, end) = location
+        .split_once('-')
+        .map_or((location, None), |(start, end)| (start, Some(end)));
+    (start.parse().ok(), end.and_then(|end| end.parse().ok()))
+}
+
+fn node_tooltip(
+    label: &str,
+    symbol_kind: &str,
+    language: &str,
+    source_file: &str,
+    line_start: Option<u64>,
+    line_end: Option<u64>,
+    signature: &str,
+    member_count: Option<usize>,
+) -> String {
+    let kind = if symbol_kind.is_empty() {
+        "symbol"
+    } else {
+        symbol_kind
+    };
+    let mut rows = Vec::new();
+    if let Some(count) = member_count {
+        rows.push(format!(
+            "<span>{count} symbols · double-click to explore</span>"
+        ));
+    } else {
+        if !language.is_empty() {
+            rows.push(format!("<span>Language: {}</span>", html_escape(language)));
+        }
+        if !source_file.is_empty() {
+            rows.push(format!(
+                "<span class=\"hover-source\">{}</span>",
+                html_escape(&sanitize_metadata(source_file, 320))
+            ));
+        }
+        if let Some(start) = line_start {
+            let range = line_end
+                .filter(|end| *end != start)
+                .map_or_else(|| start.to_string(), |end| format!("{start}–{end}"));
+            rows.push(format!("<span>Lines: {range}</span>"));
+        }
+        if !signature.is_empty() {
+            rows.push(format!(
+                "<code>{}</code>",
+                html_escape(&sanitize_metadata(signature, 320))
+            ));
+        }
+    }
+    format!(
+        "<div class=\"node-hover-card\"><div><strong>{}</strong><b>{}</b></div>{}</div>",
+        html_escape(label),
+        html_escape(&kind.to_uppercase()),
+        rows.join("")
     )
 }
 
@@ -342,10 +536,13 @@ fn aggregate(
         .keys()
         .map(|community| NodeRecord {
             id: community.to_string(),
-            attributes: Map::from_iter([(
-                "label".into(),
-                Value::String(community_name(*community, options.community_labels)),
-            )]),
+            attributes: Map::from_iter([
+                (
+                    "label".into(),
+                    Value::String(community_name(*community, options.community_labels)),
+                ),
+                ("symbol_kind".into(), Value::String("community".to_owned())),
+            ]),
         })
         .collect::<Vec<_>>();
     let mut counts = Vec::<((usize, usize), usize)>::new();
@@ -496,10 +693,13 @@ fn community_name(community: usize, labels: Option<&BTreeMap<usize, String>>) ->
         .unwrap_or_else(|| format!("Community {community}"))
 }
 fn sanitize_label(value: &str) -> String {
+    sanitize_metadata(value, 256)
+}
+fn sanitize_metadata(value: &str, limit: usize) -> String {
     value
         .chars()
         .filter(|character| !((*character as u32) < 0x20 || *character == '\u{7f}'))
-        .take(256)
+        .take(limit)
         .collect()
 }
 fn html_escape(value: &str) -> String {
@@ -625,6 +825,8 @@ fn page(
     edges: &str,
     legend: &str,
     hyperedges: &str,
+    details: &str,
+    aggregated: bool,
 ) -> String {
     format!(
         r##"<!DOCTYPE html>
@@ -781,6 +983,70 @@ button {{ min-height: 40px; }}
   color: var(--text);
   background: var(--focus-soft);
   border-color: var(--line);
+}}
+.tool-button[hidden] {{ display: none; }}
+#node-tooltip,
+.vis-tooltip {{
+  max-width: 430px !important;
+  padding: 0 !important;
+  overflow: hidden;
+  border: 1px solid var(--line-strong) !important;
+  border-radius: 12px !important;
+  background: #111c2a !important;
+  color: var(--muted) !important;
+  box-shadow: 0 18px 42px rgba(0, 0, 0, .42) !important;
+  font-family: inherit !important;
+}}
+#node-tooltip {{
+  position: absolute;
+  z-index: 7;
+  pointer-events: none;
+}}
+#node-tooltip[hidden] {{ display: none; }}
+.node-hover-card {{
+  display: grid;
+  gap: 7px;
+  padding: 13px 15px;
+  font-size: 12px;
+  line-height: 1.35;
+}}
+.node-hover-card > div {{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}}
+.node-hover-card strong {{
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  text-overflow: ellipsis;
+}}
+.node-hover-card b,
+.symbol-badge {{
+  display: inline-flex;
+  width: max-content;
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: rgba(89, 161, 79, .2);
+  color: #8de384;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: .07em;
+}}
+.node-hover-card span,
+.node-hover-card code {{
+  display: block;
+}}
+.node-hover-card .hover-source {{
+  color: var(--focus);
+}}
+.node-hover-card code {{
+  max-width: 395px;
+  overflow: hidden;
+  color: #cbd8e8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }}
 #sidebar {{
   position: relative;
@@ -975,6 +1241,32 @@ button {{ min-height: 40px; }}
   text-overflow: ellipsis;
   white-space: nowrap;
 }}
+.signature-block {{
+  margin-bottom: 15px;
+  padding: 10px;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(5, 11, 20, .42);
+  color: #cad8e9;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}}
+.inspector-actions {{
+  display: flex;
+  gap: 7px;
+  margin-bottom: 14px;
+}}
+.inspector-action {{
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--focus-soft);
+  color: var(--text);
+  cursor: pointer;
+}}
+.inspector-action:hover {{ border-color: var(--line-strong); }}
 .neighbors-heading {{
   justify-content: space-between;
   margin: 3px 0 7px;
@@ -1128,12 +1420,17 @@ button {{ min-height: 40px; }}
 <body>
 <main id="workspace">
   <div id="graph" role="region" aria-label="Interactive Compass knowledge graph"></div>
+  <div id="node-tooltip" role="tooltip" hidden></div>
   <div id="graph-toolbar" class="glass-panel" role="toolbar" aria-label="Graph controls">
     <div id="viewer-status" data-state="running" role="status" aria-live="polite">
       <span class="status-dot" aria-hidden="true"></span>
       <span id="viewer-status-text">Layout settling</span>
     </div>
     <div class="toolbar-actions">
+      <button id="back-overview" class="tool-button" type="button" aria-label="Back to community overview" hidden>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m15 18-6-6 6-6"/></svg>
+        <span class="button-label">Communities</span>
+      </button>
       <button id="physics-toggle" class="tool-button is-active" type="button" aria-label="Pause layout" aria-pressed="true">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14M16 5v14"/></svg>
         <span class="button-label">Pause layout</span>
@@ -1167,7 +1464,7 @@ button {{ min-height: 40px; }}
     <div id="search-results" role="listbox" aria-label="Matching nodes"></div>
   </div>
   <section id="info-panel" aria-labelledby="info-title">
-    <div class="section-heading"><h2 id="info-title">Inspector</h2><span>Node details</span></div>
+    <div class="section-heading"><h2 id="info-title">Inspector</h2><span id="info-mode">Node details</span></div>
     <div id="info-content"><span class="empty">Select a node to inspect its relationships</span></div>
   </section>
   <section id="legend-wrap" aria-labelledby="communities-title">
@@ -1181,6 +1478,16 @@ button {{ min-height: 40px; }}
 const RAW_NODES = {nodes};
 const RAW_EDGES = {edges};
 const LEGEND = {legend};
+const COMMUNITY_DETAILS = {details};
+const IS_AGGREGATED = {aggregated};
+const SEARCH_NODES = IS_AGGREGATED
+  ? [
+      ...RAW_NODES,
+      ...Object.values(COMMUNITY_DETAILS).flatMap(detail => detail.nodes),
+    ]
+  : RAW_NODES;
+let ACTIVE_NODES = RAW_NODES;
+let ACTIVE_EDGES = RAW_EDGES;
 function esc(value) {{
   return String(value)
     .replace(/&/g, '&amp;')
@@ -1190,7 +1497,8 @@ function esc(value) {{
     .replace(/'/g, '&#39;');
 }}
 
-const nodesDS = new vis.DataSet(RAW_NODES.map(node => ({{
+function decorateNode(node) {{
+  return {{
   ...node,
   _baseColor: node.color,
   _baseFont: node.font,
@@ -1198,10 +1506,22 @@ const nodesDS = new vis.DataSet(RAW_NODES.map(node => ({{
   _community: node.community,
   _community_name: node.community_name,
   _source_file: node.source_file,
+  _source_location: node.source_location,
   _file_type: node.file_type,
+  _symbol_kind: node.symbol_kind,
+  _language: node.language,
+  _line_start: node.line_start,
+  _line_end: node.line_end,
+  _signature: node.signature,
+  _is_community: node.is_community,
+  _member_count: node.member_count,
+  _tooltip_html: node.tooltip_html,
   _degree: node.degree,
-}})));
-const edgesDS = new vis.DataSet(RAW_EDGES.map((edge, index) => ({{
+  }};
+}}
+
+function decorateEdge(edge, index) {{
+  return {{
   id: index,
   from: edge.from,
   to: edge.to,
@@ -1213,7 +1533,11 @@ const edgesDS = new vis.DataSet(RAW_EDGES.map((edge, index) => ({{
   _baseColor: edge.color,
   _baseWidth: edge.width,
   arrows: {{ to: {{ enabled: true, scaleFactor: .5 }} }},
-}})));
+  }};
+}}
+
+const nodesDS = new vis.DataSet(RAW_NODES.map(decorateNode));
+const edgesDS = new vis.DataSet(RAW_EDGES.map(decorateEdge));
 const container = document.getElementById('graph');
 const network = new vis.Network(container, {{ nodes: nodesDS, edges: edgesDS }}, {{
   physics: {{
@@ -1246,14 +1570,45 @@ const viewerState = {{
   focusedNodeId: null,
   forceLabels: false,
   initialView: null,
+  activeCommunity: null,
 }};
 const physicsToggle = document.getElementById('physics-toggle');
 const labelsToggle = document.getElementById('labels-toggle');
 const viewerStatus = document.getElementById('viewer-status');
 const viewerStatusText = document.getElementById('viewer-status-text');
+const backOverview = document.getElementById('back-overview');
+const statsEl = document.getElementById('stats');
+const overviewStats = statsEl.innerHTML;
+const nodeTooltip = document.getElementById('node-tooltip');
 
 function setViewerStatus(text) {{
   viewerStatusText.textContent = text;
+}}
+
+function hideNodeTooltip() {{
+  nodeTooltip.hidden = true;
+  nodeTooltip.replaceChildren();
+}}
+
+function showNodeTooltip(id) {{
+  const node = nodesDS.get(id);
+  const position = network.getPositions([id])[id];
+  if (!node?._tooltip_html || !position) return;
+  const point = network.canvasToDOM(position);
+  nodeTooltip.innerHTML = node._tooltip_html;
+  nodeTooltip.hidden = false;
+  requestAnimationFrame(() => {{
+    const left = Math.min(
+      container.clientWidth - nodeTooltip.offsetWidth - 12,
+      Math.max(12, point.x + 18)
+    );
+    const top = Math.min(
+      container.clientHeight - nodeTooltip.offsetHeight - 12,
+      Math.max(88, point.y - nodeTooltip.offsetHeight / 2)
+    );
+    nodeTooltip.style.left = `${{left}}px`;
+    nodeTooltip.style.top = `${{top}}px`;
+  }});
 }}
 
 function setPhysicsRunning(running) {{
@@ -1307,8 +1662,16 @@ function clearFocus() {{
   }})));
   document.getElementById('info-content').innerHTML =
     '<span class="empty">Select a node to inspect its relationships</span>';
+  document.getElementById('info-mode').textContent = 'Node details';
   viewerStatus.dataset.state = viewerState.physicsRunning ? 'running' : 'paused';
   setViewerStatus(viewerState.physicsRunning ? 'Layout settling' : 'Layout paused');
+}}
+
+function sourceRange(node) {{
+  if (!node._line_start) return node._source_location || '';
+  return node._line_end && node._line_end !== node._line_start
+    ? `${{node._line_start}}–${{node._line_end}}`
+    : String(node._line_start);
 }}
 
 function showInfo(id) {{
@@ -1320,20 +1683,38 @@ function showInfo(id) {{
     const color = neighbor ? neighbor._baseColor.background : '#334155';
     return `<button class="neighbor-link" type="button" style="border-left-color:${{esc(color)}}" data-nid="${{esc(nid)}}">${{esc(neighbor ? neighbor.label : nid)}}</button>`;
   }}).join('');
+  const kind = node._symbol_kind || node._file_type || 'symbol';
+  const range = sourceRange(node);
+  const location = node._source_file
+    ? `${{node._source_file}}${{range ? `:${{range}}` : ''}}`
+    : '';
+  const signature = node._signature
+    ? `<div class="signature-block">${{esc(node._signature)}}</div>`
+    : '';
+  const actions = node._is_community
+    ? `<div class="inspector-actions"><button class="inspector-action explore-community" type="button" data-community="${{esc(node._community)}}">Explore ${{node._member_count || 0}} symbols</button></div>`
+    : location
+      ? `<div class="inspector-actions"><button class="inspector-action copy-location" type="button" data-location="${{esc(location)}}">Copy file location</button></div>`
+      : '';
   document.getElementById('info-content').innerHTML = `
     <div class="node-identity">
       <span class="node-swatch" style="--node-color:${{esc(node._baseColor.background)}}"></span>
-      <div><strong>${{esc(node.label)}}</strong><span>${{esc(node._file_type || 'Unknown type')}}</span></div>
+      <div><strong>${{esc(node.label)}}</strong><span class="symbol-badge">${{esc(kind.toUpperCase())}}</span></div>
     </div>
     <dl class="metadata-grid">
       <div><dt>Community</dt><dd>${{esc(node._community_name)}}</dd></div>
       <div><dt>Degree</dt><dd>${{node._degree}}</dd></div>
+      ${{node._language ? `<div><dt>Language</dt><dd>${{esc(node._language)}}</dd></div>` : ''}}
+      ${{range ? `<div><dt>Lines</dt><dd>${{esc(range)}}</dd></div>` : ''}}
       <div class="metadata-wide"><dt>Source</dt><dd title="${{esc(node._source_file || 'Not recorded')}}">${{esc(node._source_file || 'Not recorded')}}</dd></div>
     </dl>
+    ${{signature}}
+    ${{actions}}
     ${{neighborIds.length
       ? `<div class="neighbors-heading"><span>Connected nodes</span><strong>${{neighborIds.length}}</strong></div><div id="neighbors-list">${{neighborItems}}</div>`
       : '<span class="empty">No connected nodes</span>'}}
   `;
+  document.getElementById('info-mode').textContent = 'Pinned';
 }}
 
 function focusNode(id) {{
@@ -1352,9 +1733,71 @@ function focusNode(id) {{
   setViewerStatus(`Inspecting ${{node.label}}`);
 }}
 
+function replaceGraph(nodes, edges) {{
+  clearFocus();
+  ACTIVE_NODES = nodes;
+  ACTIVE_EDGES = edges;
+  nodesDS.clear();
+  edgesDS.clear();
+  nodesDS.add(nodes.map(decorateNode));
+  edgesDS.add(edges.map(decorateEdge));
+  if (viewerState.forceLabels) {{
+    nodesDS.update(nodes.map(node => ({{
+      id: node.id,
+      font: {{ ...node.font, size: 12 }},
+    }})));
+  }}
+  setPhysicsRunning(true);
+  network.once('stabilizationIterationsDone', () => {{
+    setPhysicsRunning(false);
+    network.fit({{ animation: false }});
+  }});
+  network.stabilize(180);
+}}
+
+function enterCommunity(community, focusId = null) {{
+  const key = String(community);
+  const detail = COMMUNITY_DETAILS[key];
+  if (!detail) return;
+  viewerState.activeCommunity = Number(community);
+  backOverview.hidden = false;
+  document.getElementById('communities-title').textContent = detail.name;
+  statsEl.textContent = `${{detail.nodes.length}} symbols · ${{detail.edges.length}} internal edges`;
+  replaceGraph(detail.nodes, detail.edges);
+  setViewerStatus(`Exploring ${{detail.name}}`);
+  if (focusId !== null) requestAnimationFrame(() => focusNode(focusId));
+}}
+
+function exitCommunity() {{
+  if (viewerState.activeCommunity === null) return;
+  viewerState.activeCommunity = null;
+  backOverview.hidden = true;
+  document.getElementById('communities-title').textContent = 'Communities';
+  statsEl.innerHTML = overviewStats;
+  replaceGraph(RAW_NODES, RAW_EDGES);
+  setViewerStatus('Community overview');
+}}
+
+async function copyText(value) {{
+  if (navigator.clipboard?.writeText) {{
+    await navigator.clipboard.writeText(value);
+    return;
+  }}
+  const field = document.createElement('textarea');
+  field.value = value;
+  field.setAttribute('readonly', '');
+  field.style.position = 'fixed';
+  field.style.opacity = '0';
+  document.body.appendChild(field);
+  field.select();
+  document.execCommand('copy');
+  field.remove();
+}}
+
 physicsToggle.addEventListener('click', () => {{
   setPhysicsRunning(!viewerState.physicsRunning);
 }});
+backOverview.addEventListener('click', exitCommunity);
 document.getElementById('fit-graph').addEventListener('click', () => {{
   network.fit({{
     animation: reduceMotion ? false : {{ duration: 280, easingFunction: 'easeInOutQuad' }},
@@ -1377,7 +1820,7 @@ labelsToggle.addEventListener('click', () => {{
   labelsToggle.setAttribute('aria-pressed', String(viewerState.forceLabels));
   labelsToggle.querySelector('.button-label').textContent =
     viewerState.forceLabels ? 'Hide labels' : 'Show labels';
-  nodesDS.update(RAW_NODES.map(node => ({{
+  nodesDS.update(ACTIVE_NODES.map(node => ({{
     id: node.id,
     font: {{ ...node.font, size: viewerState.forceLabels ? 12 : node.font.size }},
   }})));
@@ -1391,12 +1834,33 @@ network.once('stabilizationIterationsDone', () => {{
   }};
 }});
 network.on('click', params => {{
+  hideNodeTooltip();
   if (params.nodes.length) focusNode(params.nodes[0]);
   else clearFocus();
 }});
-document.addEventListener('click', event => {{
+network.on('hoverNode', params => showNodeTooltip(params.node));
+network.on('blurNode', hideNodeTooltip);
+network.on('dragStart', hideNodeTooltip);
+network.on('zoom', hideNodeTooltip);
+network.on('doubleClick', params => {{
+  if (!IS_AGGREGATED || !params.nodes.length) return;
+  const node = nodesDS.get(params.nodes[0]);
+  if (node?._is_community) enterCommunity(node._community);
+}});
+document.addEventListener('click', async event => {{
   const link = event.target.closest('.neighbor-link');
   if (link && link.dataset.nid !== undefined) focusNode(link.dataset.nid);
+  const explore = event.target.closest('.explore-community');
+  if (explore?.dataset.community !== undefined) enterCommunity(explore.dataset.community);
+  const copy = event.target.closest('.copy-location');
+  if (copy?.dataset.location) {{
+    try {{
+      await copyText(copy.dataset.location);
+      copy.textContent = 'Copied';
+    }} catch {{
+      copy.textContent = 'Copy failed';
+    }}
+  }}
 }});
 
 const results = document.getElementById('search-results');
@@ -1413,7 +1877,12 @@ function closeSearchResults() {{
 }}
 
 function chooseSearchResult(node) {{
-  focusNode(node.id);
+  if (IS_AGGREGATED && !node.is_community
+      && viewerState.activeCommunity !== Number(node.community)) {{
+    enterCommunity(node.community, node.id);
+  }} else {{
+    focusNode(node.id);
+  }}
   search.value = '';
   closeSearchResults();
   search.focus();
@@ -1427,7 +1896,9 @@ function renderSearchResults() {{
     option.className = 'search-item';
     option.setAttribute('role', 'option');
     option.setAttribute('aria-selected', String(index === activeSearchIndex));
-    option.textContent = node.label;
+    option.textContent = node.source_file
+      ? `${{node.label}} — ${{node.source_file}}`
+      : node.label;
     option.style.borderLeftColor = node.color.background;
     option.addEventListener('click', () => chooseSearchResult(node));
     results.appendChild(option);
@@ -1447,7 +1918,11 @@ function renderSearchResults() {{
 search.addEventListener('input', () => {{
   const query = search.value.toLowerCase().trim();
   searchMatches = query
-    ? RAW_NODES.filter(node => node.label.toLowerCase().includes(query)).slice(0, 20)
+    ? SEARCH_NODES.filter(node =>
+        `${{node.label}} ${{node.source_file || ''}} ${{node.signature || ''}}`
+          .toLowerCase()
+          .includes(query)
+      ).slice(0, 20)
     : [];
   activeSearchIndex = searchMatches.length ? 0 : -1;
   renderSearchResults();
@@ -1484,7 +1959,7 @@ const hiddenCommunities = new Set();
 const selectAll = document.getElementById('select-all-cb');
 
 function updateVisibility() {{
-  nodesDS.update(RAW_NODES.map(node => ({{
+  nodesDS.update(ACTIVE_NODES.map(node => ({{
     id: node.id,
     hidden: hiddenCommunities.has(node.community),
   }})));
@@ -1547,6 +2022,7 @@ LEGEND.forEach(community => {{
 <script>
 const hyperedges = {hyperedges};
 network.on('afterDrawing', ctx => {{
+  if (viewerState.activeCommunity !== null) return;
   hyperedges.forEach(hyperedge => {{
     const positions = hyperedge.nodes
       .map(id => network.getPositions([id])[id])
@@ -1682,7 +2158,13 @@ mod tests {
     fn explicit_limit_builds_community_meta_graph() -> Result<(), Box<dyn Error>> {
         let graph: GraphDocument = serde_json::from_value(json!({
             "nodes":[
-                {"id":"a","label":"A"},{"id":"b","label":"B"},
+                {
+                    "id":"a","label":"A()","source_file":"src/a.py",
+                    "source_location":"L4","line_start":4,"line_end":8,
+                    "symbol_kind":"function","language":"python",
+                    "signature":"def A(value)"
+                },
+                {"id":"b","label":"B"},
                 {"id":"c","label":"C"},{"id":"d","label":"D"}
             ],
             "links":[
@@ -1708,6 +2190,20 @@ mod tests {
         assert!(rendered.aggregated);
         assert_eq!((rendered.nodes, rendered.edges), (2, 1));
         assert!(rendered.html.contains("2 cross-community edges"));
+        for marker in [
+            "const COMMUNITY_DETAILS =",
+            "const IS_AGGREGATED = true",
+            "function enterCommunity(community, focusId = null)",
+            "id=\"back-overview\"",
+            "\"symbol_kind\": \"function\"",
+            "\"language\": \"python\"",
+            "\"line_start\": 4",
+            "\"line_end\": 8",
+            "\"signature\": \"def A(value)\"",
+            "class=\\\"node-hover-card\\\"",
+        ] {
+            assert!(rendered.html.contains(marker), "missing {marker}");
+        }
         Ok(())
     }
 

--- a/crates/compass-parity/Cargo.toml
+++ b/crates/compass-parity/Cargo.toml
@@ -12,8 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 publish = false
 
-[dev-dependencies]
+[dependencies]
 serde_json.workspace = true
+
+[dev-dependencies]
 tempfile.workspace = true
 time.workspace = true
 compass-cli = { version = "0.1.2", path = "../compass-cli" }

--- a/crates/compass-parity/src/bin/compare-graphs.rs
+++ b/crates/compass-parity/src/bin/compare-graphs.rs
@@ -228,7 +228,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn graphify_subset_with_compass_extras_passes() {
+    fn graphify_subset_with_compass_extras_passes() -> Result<(), String> {
         let graphify = json!({
             "nodes": [
                 {
@@ -260,14 +260,15 @@ mod tests {
             "links": []
         });
 
-        let report = compare(&compass, &graphify).expect("valid graphs");
+        let report = compare(&compass, &graphify)?;
 
         assert!(report.compatible());
         assert_eq!(report.compass_only_nodes, ["perl_extra"]);
+        Ok(())
     }
 
     #[test]
-    fn missing_node_field_and_edge_fail() {
+    fn missing_node_field_and_edge_fail() -> Result<(), String> {
         let graphify = json!({
             "nodes": [
                 {
@@ -300,11 +301,12 @@ mod tests {
             "links": []
         });
 
-        let report = compare(&compass, &graphify).expect("valid graphs");
+        let report = compare(&compass, &graphify)?;
 
         assert!(!report.compatible());
         assert_eq!(report.missing_nodes, ["b"]);
         assert_eq!(report.mismatched_nodes.len(), 1);
         assert_eq!(report.missing_edges.len(), 1);
+        Ok(())
     }
 }

--- a/crates/compass-parity/src/bin/compare-graphs.rs
+++ b/crates/compass-parity/src/bin/compare-graphs.rs
@@ -1,0 +1,310 @@
+//! Compare Compass graph output against Graphify's required shared facts.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::ExitCode;
+
+use serde_json::Value;
+
+const OBSERVABLE_NODE_FIELDS: &[&str] = &["label", "file_type", "source_file", "source_location"];
+const MAX_EXAMPLES: usize = 50;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct EdgeKey {
+    source: String,
+    target: String,
+    relation: String,
+}
+
+#[derive(Debug, Default)]
+struct Report {
+    graphify_nodes: usize,
+    compass_nodes: usize,
+    graphify_edges: usize,
+    compass_edges: usize,
+    missing_nodes: Vec<String>,
+    mismatched_nodes: Vec<String>,
+    missing_edges: Vec<EdgeKey>,
+    compass_only_nodes: Vec<String>,
+    compass_only_edges: Vec<EdgeKey>,
+}
+
+impl Report {
+    fn compatible(&self) -> bool {
+        self.missing_nodes.is_empty()
+            && self.mismatched_nodes.is_empty()
+            && self.missing_edges.is_empty()
+    }
+}
+
+fn main() -> ExitCode {
+    let mut arguments = env::args_os();
+    let program = arguments
+        .next()
+        .and_then(|value| Path::new(&value).file_name().map(|name| name.to_owned()))
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| "compare-graphs".to_owned());
+    let Some(compass_path) = arguments.next() else {
+        eprintln!("usage: {program} <compass-graph.json> <graphify-graph.json>");
+        return ExitCode::from(2);
+    };
+    let Some(graphify_path) = arguments.next() else {
+        eprintln!("usage: {program} <compass-graph.json> <graphify-graph.json>");
+        return ExitCode::from(2);
+    };
+    if arguments.next().is_some() {
+        eprintln!("usage: {program} <compass-graph.json> <graphify-graph.json>");
+        return ExitCode::from(2);
+    }
+
+    let result = read_graph(Path::new(&compass_path))
+        .and_then(|compass| {
+            read_graph(Path::new(&graphify_path)).map(|graphify| (compass, graphify))
+        })
+        .and_then(|(compass, graphify)| compare(&compass, &graphify));
+    match result {
+        Ok(report) => {
+            print_report(&report);
+            if report.compatible() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn read_graph(path: &Path) -> Result<Value, String> {
+    let bytes = fs::read(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_slice(&bytes).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn compare(compass: &Value, graphify: &Value) -> Result<Report, String> {
+    let compass_nodes = node_map(compass, "Compass")?;
+    let graphify_nodes = node_map(graphify, "Graphify")?;
+    let compass_edges = edge_set(compass, "Compass")?;
+    let graphify_edges = edge_set(graphify, "Graphify")?;
+
+    let mut report = Report {
+        graphify_nodes: graphify_nodes.len(),
+        compass_nodes: compass_nodes.len(),
+        graphify_edges: graphify_edges.len(),
+        compass_edges: compass_edges.len(),
+        ..Report::default()
+    };
+
+    for (id, expected) in &graphify_nodes {
+        let Some(actual) = compass_nodes.get(id) else {
+            report.missing_nodes.push(id.clone());
+            continue;
+        };
+        for field in OBSERVABLE_NODE_FIELDS {
+            let Some(expected_value) = comparable_field(expected, field) else {
+                continue;
+            };
+            let actual_value = comparable_field(actual, field).unwrap_or("<missing>");
+            if actual_value != expected_value {
+                report.mismatched_nodes.push(format!(
+                    "{id}: {field} expected {expected_value:?}, got {actual_value:?}"
+                ));
+            }
+        }
+    }
+
+    report.compass_only_nodes = compass_nodes
+        .keys()
+        .filter(|id| !graphify_nodes.contains_key(*id))
+        .cloned()
+        .collect();
+    report.missing_edges = graphify_edges.difference(&compass_edges).cloned().collect();
+    report.compass_only_edges = compass_edges.difference(&graphify_edges).cloned().collect();
+    Ok(report)
+}
+
+fn node_map<'a>(graph: &'a Value, tool: &str) -> Result<BTreeMap<String, &'a Value>, String> {
+    let values = graph
+        .get("nodes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{tool} graph has no nodes array"))?;
+    let mut nodes = BTreeMap::new();
+    for (index, node) in values.iter().enumerate() {
+        let id = node
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| format!("{tool} node {index} has no canonical id"))?;
+        nodes.entry(id.to_owned()).or_insert(node);
+    }
+    Ok(nodes)
+}
+
+fn edge_set(graph: &Value, tool: &str) -> Result<BTreeSet<EdgeKey>, String> {
+    let values = graph
+        .get("links")
+        .or_else(|| graph.get("edges"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("{tool} graph has no links or edges array"))?;
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, edge)| {
+            let source = edge
+                .get("source")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| format!("{tool} edge {index} has no source"))?;
+            let target = edge
+                .get("target")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| format!("{tool} edge {index} has no target"))?;
+            let relation = edge
+                .get("relation")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            Ok(EdgeKey {
+                source: source.to_owned(),
+                target: target.to_owned(),
+                relation: relation.to_owned(),
+            })
+        })
+        .collect()
+}
+
+fn comparable_field<'a>(node: &'a Value, field: &str) -> Option<&'a str> {
+    node.get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+fn print_report(report: &Report) {
+    println!(
+        "nodes: Graphify={} Compass={}",
+        report.graphify_nodes, report.compass_nodes
+    );
+    println!(
+        "edges: Graphify={} Compass={}",
+        report.graphify_edges, report.compass_edges
+    );
+    println!("missing Graphify nodes: {}", report.missing_nodes.len());
+    println!("mismatched shared nodes: {}", report.mismatched_nodes.len());
+    println!("missing Graphify edges: {}", report.missing_edges.len());
+    println!("Compass-only nodes: {}", report.compass_only_nodes.len());
+    println!("Compass-only edges: {}", report.compass_only_edges.len());
+
+    print_examples("missing nodes", &report.missing_nodes);
+    print_examples("field mismatches", &report.mismatched_nodes);
+    let missing_edges = report
+        .missing_edges
+        .iter()
+        .map(|edge| format!("{} --{}--> {}", edge.source, edge.relation, edge.target))
+        .collect::<Vec<_>>();
+    print_examples("missing edges", &missing_edges);
+}
+
+fn print_examples(title: &str, examples: &[String]) {
+    if examples.is_empty() {
+        return;
+    }
+    println!("{title}:");
+    for example in examples.iter().take(MAX_EXAMPLES) {
+        println!("  {example}");
+    }
+    if examples.len() > MAX_EXAMPLES {
+        println!("  ... {} more", examples.len() - MAX_EXAMPLES);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn graphify_subset_with_compass_extras_passes() {
+        let graphify = json!({
+            "nodes": [
+                {
+                    "id": "a",
+                    "label": "a()",
+                    "file_type": "code",
+                    "source_file": "a.c",
+                    "source_location": "L1"
+                }
+            ],
+            "links": []
+        });
+        let compass = json!({
+            "nodes": [
+                {
+                    "id": "a",
+                    "label": "a()",
+                    "file_type": "code",
+                    "source_file": "a.c",
+                    "source_location": "L1"
+                },
+                {
+                    "id": "perl_extra",
+                    "label": "run()",
+                    "file_type": "code",
+                    "source_file": "tool"
+                }
+            ],
+            "links": []
+        });
+
+        let report = compare(&compass, &graphify).expect("valid graphs");
+
+        assert!(report.compatible());
+        assert_eq!(report.compass_only_nodes, ["perl_extra"]);
+    }
+
+    #[test]
+    fn missing_node_field_and_edge_fail() {
+        let graphify = json!({
+            "nodes": [
+                {
+                    "id": "a",
+                    "label": "a()",
+                    "file_type": "code",
+                    "source_file": "a.c",
+                    "source_location": "L1"
+                },
+                {
+                    "id": "b",
+                    "label": "b()",
+                    "file_type": "code",
+                    "source_file": "a.c",
+                    "source_location": "L2"
+                }
+            ],
+            "links": [{"source": "a", "target": "b", "relation": "calls"}]
+        });
+        let compass = json!({
+            "nodes": [
+                {
+                    "id": "a",
+                    "label": "wrong()",
+                    "file_type": "code",
+                    "source_file": "a.c",
+                    "source_location": "L1"
+                }
+            ],
+            "links": []
+        });
+
+        let report = compare(&compass, &graphify).expect("valid graphs");
+
+        assert!(!report.compatible());
+        assert_eq!(report.missing_nodes, ["b"]);
+        assert_eq!(report.mismatched_nodes.len(), 1);
+        assert_eq!(report.missing_edges.len(), 1);
+    }
+}

--- a/crates/compass-parity/src/lib.rs
+++ b/crates/compass-parity/src/lib.rs
@@ -2315,6 +2315,19 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
     }
 
     #[test]
+    fn macro_heavy_c_declarators_match_graphify() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("declarators.c");
+        fs::write(
+            &source,
+            "SQLITE_PRIVATE char *sqlite3CompileOptions(void) { return 0; }\n\
+             SQLITE_PRIVATE sqlite3_int64 sqlite3StatusValue(int op) { return op; }\n",
+        )?;
+        compare_extraction_path(&source, "extract_c")?;
+        Ok(())
+    }
+
+    #[test]
     fn ruby_ast_extraction_matches_exactly() -> Result<(), Box<dyn Error>> {
         compare_extraction("sample.rb", "extract_ruby")
     }
@@ -2500,6 +2513,20 @@ output "instance_id" { value = aws_instance.web.id }
         ] {
             compare_extraction_path(&repo.join("tests/fixtures").join(fixture), "extract_cpp")?;
         }
+        Ok(())
+    }
+
+    #[test]
+    fn nested_cpp_declarators_match_graphify() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("declarators.cpp");
+        fs::write(
+            &source,
+            "int DBImpl::Compact() { return 1; }\n\
+             DBImpl::~DBImpl() {}\n\
+             bool DBImpl::operator==(const DBImpl&) const { return true; }\n",
+        )?;
+        compare_extraction_path(&source, "extract_cpp")?;
         Ok(())
     }
 

--- a/crates/compass-parity/src/lib.rs
+++ b/crates/compass-parity/src/lib.rs
@@ -1867,7 +1867,7 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
             "nodes": [{"id": "compass", "source_file": source_string}],
             "edges": []
         });
-        let mut cache = Cache::new(&root, None)?;
+        let mut cache = Cache::new(&root, None)?.with_extractor_version("0.9.20");
         cache.save(&source, &cached, &CacheKind::Ast, None)?;
         cache.flush()?;
         let output = Command::new(python_executable(&repo))

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -1074,6 +1074,15 @@ fn resolve_python_import_guided_with_calls(
             .or_default()
             .push((source, node.id.clone()));
     }
+    let normalized_sources = sources
+        .iter()
+        .map(|(source_file, source)| {
+            (
+                normalize_path(source_file),
+                (source_file.as_str(), source.as_str()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
     let mut known = extraction
         .edges
         .iter()
@@ -1112,12 +1121,13 @@ fn resolve_python_import_guided_with_calls(
                 None,
                 &normalized_file_nodes,
             );
-            let candidates = python_definition_candidates(
+            let candidates = python_resolved_definition_candidates(
                 Path::new(source_file),
                 root,
                 &imported.module,
                 &imported.imported,
                 &definitions,
+                &normalized_sources,
                 false,
             );
             if candidates.len() == 1 {
@@ -1193,12 +1203,13 @@ fn resolve_python_import_guided_with_calls(
         let Some((module, imported)) = aliases.get(&raw.callee) else {
             continue;
         };
-        let candidates = python_definition_candidates(
+        let candidates = python_resolved_definition_candidates(
             Path::new(&raw.source_file),
             root,
             module,
             imported,
             &definitions,
+            &normalized_sources,
             false,
         );
         if candidates.len() != 1 {
@@ -1319,6 +1330,15 @@ fn resolve_python_class_uses(
                 .push(node.id.clone());
         }
     }
+    let normalized_sources = sources
+        .iter()
+        .map(|(source_file, source)| {
+            (
+                normalize_path(source_file),
+                (source_file.as_str(), source.as_str()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
     let mut known = extraction
         .edges
         .iter()
@@ -1338,12 +1358,13 @@ fn resolve_python_class_uses(
             continue;
         };
         for imported in python_symbol_imports(source) {
-            let candidates = python_definition_candidates(
+            let candidates = python_resolved_definition_candidates(
                 Path::new(source_file),
                 root,
                 &imported.module,
                 &imported.imported,
                 &definitions,
+                &normalized_sources,
                 true,
             );
             if candidates.len() != 1 {
@@ -1537,6 +1558,102 @@ fn python_definition_candidates(
         }
     }
     output
+}
+
+fn python_resolved_definition_candidates(
+    caller: &Path,
+    root: &Path,
+    module: &str,
+    imported: &str,
+    definitions: &HashMap<String, Vec<(String, String)>>,
+    sources: &HashMap<String, (&str, &str)>,
+    allow_module_tail: bool,
+) -> Vec<String> {
+    let mut caller = caller.to_path_buf();
+    let mut module = module.to_owned();
+    let mut imported = imported.to_owned();
+    let mut seen = HashSet::new();
+    for _ in 0..16 {
+        let direct = python_definition_candidates(
+            &caller,
+            root,
+            &module,
+            &imported,
+            definitions,
+            allow_module_tail,
+        );
+        if !direct.is_empty() {
+            return direct;
+        }
+        let Some((target_source, target_text)) =
+            python_module_source(&caller, root, &module, sources)
+        else {
+            break;
+        };
+        let target_key = normalize_path(target_source);
+        let in_module = definitions
+            .get(&imported)
+            .into_iter()
+            .flatten()
+            .filter(|(source_file, _)| normalize_path(source_file) == target_key)
+            .map(|(_, id)| id.clone())
+            .collect::<Vec<_>>();
+        if !in_module.is_empty() {
+            return in_module;
+        }
+        if Path::new(target_source)
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some("__init__.py")
+            || !seen.insert((target_source.to_owned(), imported.clone()))
+        {
+            break;
+        }
+        let Some(reexport) = python_symbol_imports(target_text)
+            .into_iter()
+            .find(|candidate| candidate.local == imported)
+        else {
+            break;
+        };
+        caller = Path::new(target_source).to_path_buf();
+        module = reexport.module;
+        imported = reexport.imported;
+    }
+    Vec::new()
+}
+
+fn python_module_source<'a>(
+    caller: &Path,
+    root: &Path,
+    module: &str,
+    sources: &'a HashMap<String, (&'a str, &'a str)>,
+) -> Option<(&'a str, &'a str)> {
+    let depth = module
+        .len()
+        .saturating_sub(module.trim_start_matches('.').len());
+    let bare = module.trim_start_matches('.');
+    let mut base = if depth == 0 {
+        root.to_path_buf()
+    } else {
+        let mut base = caller
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        for _ in 1..depth {
+            base = base.parent().unwrap_or(&base).to_path_buf();
+        }
+        base
+    };
+    if !bare.is_empty() {
+        base.push(bare.replace('.', "/"));
+    }
+    [base.with_extension("py"), base.join("__init__.py")]
+        .iter()
+        .find_map(|candidate| {
+            sources
+                .get(&normalize_path(&candidate.to_string_lossy()))
+                .copied()
+        })
 }
 
 fn candidate_calls(
@@ -2103,10 +2220,12 @@ mod tests {
     #[test]
     fn python_package_initializers_reexport_imported_symbols() {
         let root = Path::new("/repo");
+        let caller = "/repo/caller.py";
         let init = "/repo/pkg/__init__.py";
         let module = "/repo/pkg/mod.py";
         let mut extraction = Extraction {
             nodes: vec![
+                node("caller", "caller.py", caller, "module"),
                 node("pkg_init", "__init__.py", init, "module"),
                 node("pkg_mod", "mod.py", module, "module"),
                 node("pkg_mod_fn", "fn()", module, "function"),
@@ -2114,6 +2233,7 @@ mod tests {
             ..Extraction::default()
         };
         let sources = HashMap::from([
+            (caller.to_owned(), "from pkg import fn\n".to_owned()),
             (init.to_owned(), "from .mod import fn\n".to_owned()),
             (module.to_owned(), "def fn():\n    return 1\n".to_owned()),
         ]);
@@ -2125,6 +2245,12 @@ mod tests {
                 && edge.target == "pkg_mod"
                 && relation(edge) == "re_exports"
                 && edge.string("context") == "export"
+        }));
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.source == "caller"
+                && edge.target == "pkg_mod_fn"
+                && relation(edge) == "imports"
+                && edge.string("context") == "import"
         }));
     }
 

--- a/docs/implementation/extraction-pipeline.md
+++ b/docs/implementation/extraction-pipeline.md
@@ -260,6 +260,31 @@ Cases to test:
 Performance qualification compares cold, warm unchanged, single-file change,
 rename, and delete cases against the frozen oracle.
 
+### Graphify superset qualification
+
+Use the large Podman checkout to verify Graphify compatibility and release
+performance together:
+
+```bash
+PODMAN_ROOT=/Volumes/Workspace/Github/podman \
+  bash scripts/qualify_graphify_superset.sh
+```
+
+The script validates the checkout before deleting anything. It removes only
+`$PODMAN_ROOT/compass-out` and `$PODMAN_ROOT/graphify-out`, builds release
+Compass, records three cold and warm builds for each tool, checks Graphify node
+and edge inclusion, and records five equivalent query samples.
+
+Parity is set inclusion. Every Graphify node ID, observable shared-node field,
+and `(source, target, relation)` edge must exist in Compass. Compass-only facts,
+including Perl and extensionless executable scripts, are reported but do not
+fail the gate. Derived community assignments are not compared.
+
+Extractor semantics use a versioned AST cache namespace. The C declarator and
+positional-document corrections advance that namespace to `v0.9.21`, so the
+first update after upgrading refreshes AST facts. Later unchanged updates return
+to the normal warm path.
+
 ## Watch mode
 
 `compass-core::watch_local_graph` combines compatible watch filtering,

--- a/docs/superpowers/plans/2026-07-23-extraction-superset-parity.md
+++ b/docs/superpowers/plans/2026-07-23-extraction-superset-parity.md
@@ -1,0 +1,635 @@
+# Extraction Superset Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Compass a correctness-preserving superset of Graphify on shared Podman inputs while keeping release medians at or below 32 seconds cold and 10 seconds warm.
+
+**Architecture:** Correct C-family names at the syntax-tree boundary, prevent entity deduplication from merging positional document facts, and version the AST cache when extraction semantics change. Add development-only graph comparison and qualification tools so Podman parity and timing remain reproducible without adding Graphify or Python to the Compass runtime.
+
+**Tech Stack:** Rust 2024, tree-sitter, serde_json, Cargo tests, POSIX shell, Compass CLI, Graphify Python CLI
+
+## Global Constraints
+
+- Graphify shared nodes must be a subset of Compass nodes.
+- Graphify shared edges must be a subset of Compass edges.
+- Valid Compass-only Perl and extensionless-script facts must remain present.
+- Shared node IDs, labels, types, source paths, and available locations must agree.
+- Derived community assignments are outside the parity contract.
+- Podman release medians must remain at or below 32 seconds cold and 10 seconds warm across three runs each.
+- Correctness takes priority over timing.
+- Production Compass must not depend on Graphify, Python, or the network.
+- The user explicitly waived test-first development. Add and run focused regression tests immediately after each production change.
+- Preserve the unrelated working-tree change in `crates/compass-output/src/html.rs` and the untracked `advisor-plans/`, `codegraph/`, and `graphify-out/` paths.
+
+---
+
+## File structure
+
+- Modify `crates/compass-languages/src/engine.rs`: resolve C and C++ function names from declarators before generic declaration fallback.
+- Modify `crates/compass-parity/src/lib.rs`: add exact Graphify oracle coverage for macro-heavy C and nested C++ declarators.
+- Modify `crates/compass-graph/src/dedup.rs`: classify positional nodes and exclude them from label-based entity merging.
+- Modify `crates/compass-files/src/cache.rs`: advance and name the AST extraction cache version.
+- Modify `crates/compass-files/tests/contracts.rs`: verify the new namespace and stale-cache cleanup.
+- Modify `crates/compass-parity/Cargo.toml`: expose serde_json to the development-only comparison binary.
+- Create `crates/compass-parity/src/bin/compare_graphs.rs`: compare Graphify nodes and edges as required subsets and report Compass-only facts.
+- Create `scripts/qualify_graphify_superset.sh`: reset explicit output directories, build release Compass, run cold/warm/query samples, and invoke the comparator.
+- Modify `docs/implementation/extraction-pipeline.md`: document the compatibility gate, cache rebuild, and qualification command.
+- Create `CHANGELOG.md`: establish an Unreleased section that describes corrected C-family names, preserved positional nodes, and the one-time AST cache refresh.
+
+### Task 1: Resolve C and C++ callable declarators
+
+**Files:**
+
+- Modify: `crates/compass-languages/src/engine.rs:1227`
+- Modify: `crates/compass-parity/src/lib.rs:2313`
+
+**Interfaces:**
+
+- Consumes: tree-sitter `Node`, `ExtractState::node_text`, and the current `function_name` dispatch.
+- Produces: `ExtractState::c_family_function_name(Node) -> Option<String>` and `c_family_declarator_name(Node) -> Option<Node>`.
+
+- [ ] **Step 1: Add declarator-first production resolution**
+
+Add a C-family branch before the generic declaration-name path:
+
+```rust
+fn function_name(&self, node: Node<'tree>) -> Option<String> {
+    if matches!(self.language, "c" | "cpp") {
+        return self
+            .c_family_function_name(node)
+            .or_else(|| self.declaration_name(node));
+    }
+    self.declaration_name(node).or_else(|| {
+        node.child_by_field_name("declarator")
+            .and_then(first_identifier)
+            .and_then(|name| self.node_text(name))
+            .map(clean_name)
+    })
+}
+
+fn c_family_function_name(&self, node: Node<'tree>) -> Option<String> {
+    let declarator = node.child_by_field_name("declarator")?;
+    let name = c_family_declarator_name(declarator)?;
+    self.node_text(name)
+        .map(clean_name)
+        .filter(|name| !name.is_empty())
+}
+```
+
+Add a bounded resolver beside the identifier helpers. It follows named declarator fields first and accepts callable terminal forms without scanning the declaration prefix:
+
+```rust
+fn c_family_declarator_name(node: Node<'_>) -> Option<Node<'_>> {
+    if matches!(
+        node.kind(),
+        "identifier"
+            | "field_identifier"
+            | "qualified_identifier"
+            | "destructor_name"
+            | "operator_name"
+    ) {
+        return Some(node);
+    }
+    if let Some(inner) = node.child_by_field_name("declarator") {
+        return c_family_declarator_name(inner);
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if let Some(name) = c_family_declarator_name(child) {
+            return Some(name);
+        }
+    }
+    None
+}
+```
+
+Keep the traversal inside the function's declarator subtree. Do not call `first_identifier` on the full declaration.
+
+- [ ] **Step 2: Format and compile the language crate**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p compass-languages
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 3: Add post-change regression coverage**
+
+Add temporary-file parity cases to `crates/compass-parity/src/lib.rs`:
+
+```rust
+#[test]
+fn macro_heavy_c_declarators_match_graphify() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let source = directory.path().join("declarators.c");
+    fs::write(
+        &source,
+        "SQLITE_PRIVATE char *sqlite3CompileOptions(void) { return 0; }\n\
+         static struct Stat *sqlite3StatType(int value) { return 0; }\n\
+         SQLITE_API sqlite3_int64 sqlite3StatusValue(void) { return 0; }\n",
+    )?;
+    compare_extraction_path(&source, "extract_c")?;
+    Ok(())
+}
+
+#[test]
+fn nested_cpp_declarators_match_graphify() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let source = directory.path().join("declarators.cpp");
+    fs::write(
+        &source,
+        "int DBImpl::Compact() { return 1; }\n\
+         DBImpl::~DBImpl() {}\n\
+         bool DBImpl::operator==(const DBImpl&) const { return true; }\n",
+    )?;
+    compare_extraction_path(&source, "extract_cpp")?;
+    Ok(())
+}
+```
+
+Also add a direct engine test that asserts the three C labels are `sqlite3CompileOptions()`, `sqlite3StatType()`, and `sqlite3StatusValue()`, and that `char()`, `struct()`, and `sqlite3_int64()` are absent.
+
+- [ ] **Step 4: Run focused and existing extraction parity tests**
+
+Run:
+
+```bash
+cargo test -p compass-languages
+cargo test -p compass-parity tests::macro_heavy_c_declarators_match_graphify -- --exact
+cargo test -p compass-parity tests::nested_cpp_declarators_match_graphify -- --exact
+cargo test -p compass-parity tests::c_ast_extraction_matches_exactly -- --exact
+cargo test -p compass-parity tests::cpp_ast_extraction_matches_exactly -- --exact
+```
+
+Expected: every command exits successfully and exact extraction matches the Graphify oracle.
+
+- [ ] **Step 5: Commit the callable-name correction**
+
+```bash
+git add crates/compass-languages/src/engine.rs crates/compass-parity/src/lib.rs
+git commit -m "fix: resolve C family callable declarators"
+```
+
+### Task 2: Preserve positional document and rationale nodes
+
+**Files:**
+
+- Modify: `crates/compass-graph/src/dedup.rs:84`
+
+**Interfaces:**
+
+- Consumes: `NodeRecord.attributes["file_type"]`.
+- Produces: `is_entity_merge_candidate(&NodeRecord) -> bool`, used by exact and fuzzy label merging.
+
+- [ ] **Step 1: Exclude positional facts from entity merging**
+
+Add:
+
+```rust
+fn is_positional(node: &NodeRecord) -> bool {
+    matches!(
+        string_attribute(node, "file_type").as_deref(),
+        Some("document" | "rationale")
+    )
+}
+
+fn is_entity_merge_candidate(node: &NodeRecord) -> bool {
+    !is_code(node) && !is_positional(node)
+}
+```
+
+Replace both `if is_code(node) { continue; }` guards in exact and fuzzy candidate construction with:
+
+```rust
+if !is_entity_merge_candidate(node) {
+    continue;
+}
+```
+
+Keep `collapse_id_collisions` unchanged so literal duplicate records with the same canonical ID still collapse.
+
+- [ ] **Step 2: Add post-change positional identity tests**
+
+Add a helper that assigns `file_type`, `source_location`, and a line-qualified ID. Add these cases:
+
+```rust
+#[test]
+fn repeated_positional_nodes_in_one_file_remain_distinct() -> Result<(), DedupError> {
+    let nodes = vec![
+        positional_node("release_notes_heading_l10", "Fixed", "RELEASE_NOTES.md", "L10", "document"),
+        positional_node("release_notes_heading_l40", "Fixed", "RELEASE_NOTES.md", "L40", "document"),
+        positional_node("decision_l12", "Preserve compatibility", "ADR.md", "L12", "rationale"),
+        positional_node("decision_l60", "Preserve compatibility", "ADR.md", "L60", "rationale"),
+    ];
+    let result = deduplicate_entities(&nodes, &[], &HashMap::new())?;
+    assert_eq!(result.nodes.len(), 4);
+    assert_eq!(result.stats.removed, 0);
+    Ok(())
+}
+
+#[test]
+fn literal_positional_id_collisions_still_collapse() -> Result<(), DedupError> {
+    let node = positional_node(
+        "release_notes_heading_l10",
+        "Fixed",
+        "RELEASE_NOTES.md",
+        "L10",
+        "document",
+    );
+    let result = deduplicate_entities(&[node.clone(), node], &[], &HashMap::new())?;
+    assert_eq!(result.nodes.len(), 1);
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Run focused and graph tests**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p compass-graph dedup
+cargo test -p compass-graph
+cargo test -p compass-parity tests::deterministic_entity_dedup_matches_python -- --exact
+```
+
+Expected: positional repeats survive, ID collisions collapse, existing concept dedup remains unchanged, and the existing cross-file Graphify oracle case still passes.
+
+- [ ] **Step 4: Commit positional identity preservation**
+
+```bash
+git add crates/compass-graph/src/dedup.rs
+git commit -m "fix: preserve positional document identities"
+```
+
+### Task 3: Invalidate stale AST extraction entries once
+
+**Files:**
+
+- Modify: `crates/compass-files/src/cache.rs:62`
+- Modify: `crates/compass-files/tests/contracts.rs:480`
+
+**Interfaces:**
+
+- Produces: `const AST_EXTRACTOR_VERSION: &str = "0.9.21"` as the default AST namespace.
+- Preserves: `Cache::with_extractor_version` for isolated compatibility tests.
+
+- [ ] **Step 1: Name and advance the default AST version**
+
+Add the named constant and use it in `Cache::new`:
+
+```rust
+const AST_EXTRACTOR_VERSION: &str = "0.9.21";
+
+let cache = Self {
+    root,
+    cache_root,
+    output_name,
+    extractor_version: AST_EXTRACTOR_VERSION.to_owned(),
+    hashes,
+    session_hashes: HashMap::new(),
+};
+```
+
+This changes only the AST directory from `cache/ast/v0.9.20` to `cache/ast/v0.9.21`. Existing semantic caches remain eligible.
+
+- [ ] **Step 2: Extend the cache contract test**
+
+Before the custom-version assertions, instantiate a default cache in an isolated cache root and assert:
+
+```rust
+let default_cache = Cache::new(&root, Some(&cache_root))?;
+assert!(
+    default_cache
+        .directory(&CacheKind::Ast, None)
+        .ends_with("ast/v0.9.21")
+);
+assert!(!cache_root.join("compass-out/cache/ast/v0.9.20").exists());
+```
+
+Create `v0.9.20/stale.json` in the fixture setup so the cleanup assertion proves a semantic version change invalidates the old AST namespace.
+
+- [ ] **Step 3: Run cache and incremental pipeline verification**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p compass-files cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total -- --exact
+cargo test -p compass-files
+cargo test -p compass-core update
+```
+
+Expected: the old AST namespace is removed, the new namespace is selected, and incremental update tests pass.
+
+- [ ] **Step 4: Commit cache invalidation**
+
+```bash
+git add crates/compass-files/src/cache.rs crates/compass-files/tests/contracts.rs
+git commit -m "fix: invalidate stale extraction cache"
+```
+
+### Task 4: Add a deterministic superset comparator
+
+**Files:**
+
+- Modify: `crates/compass-parity/Cargo.toml`
+- Create: `crates/compass-parity/src/bin/compare_graphs.rs`
+
+**Interfaces:**
+
+- CLI: `cargo run -p compass-parity --bin compare-graphs -- <compass-graph.json> <graphify-graph.json>`
+- Produces exit code `0` only when every Graphify node, observable node field, and edge key exists in Compass.
+- Edge key: `(source, target, relation)`.
+- Observable node fields: `label`, `file_type`, `source_file`, and non-empty `source_location`.
+
+- [ ] **Step 1: Add the development-only binary dependency**
+
+Move `serde_json.workspace = true` into regular dependencies while keeping runtime Compass crates unchanged:
+
+```toml
+[dependencies]
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+```
+
+- [ ] **Step 2: Implement graph normalization and comparison**
+
+Create a binary with these concrete records:
+
+```rust
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct EdgeKey {
+    source: String,
+    target: String,
+    relation: String,
+}
+
+#[derive(Debug, Default)]
+struct Report {
+    missing_nodes: Vec<String>,
+    mismatched_nodes: Vec<String>,
+    missing_edges: Vec<EdgeKey>,
+    compass_only_nodes: Vec<String>,
+    compass_only_edges: Vec<EdgeKey>,
+}
+
+impl Report {
+    fn compatible(&self) -> bool {
+        self.missing_nodes.is_empty()
+            && self.mismatched_nodes.is_empty()
+            && self.missing_edges.is_empty()
+    }
+}
+```
+
+Load `nodes` by canonical `id`. Load edges from `links`, falling back to `edges`. Compare every Graphify node against the Compass map. For each shared ID, compare `label`, `file_type`, and `source_file`; compare `source_location` only when Graphify provides a non-empty value. Normalize edges into `BTreeSet<EdgeKey>` and compute `graphify_edges.difference(&compass_edges)`.
+
+Print totals and at most 50 representative failures grouped under `missing nodes`, `field mismatches`, and `missing edges`. Print Compass-only counts as informational. Return exit code 1 for an incompatible report and 2 for invalid arguments or unreadable JSON.
+
+- [ ] **Step 3: Add post-change comparator tests**
+
+Use inline JSON fixtures to verify:
+
+```rust
+#[test]
+fn graphify_subset_with_compass_extras_passes() {
+    let graphify = json!({
+        "nodes": [{"id":"a","label":"a()","file_type":"code","source_file":"a.c","source_location":"L1"}],
+        "links": []
+    });
+    let compass = json!({
+        "nodes": [
+            {"id":"a","label":"a()","file_type":"code","source_file":"a.c","source_location":"L1"},
+            {"id":"perl_extra","label":"run()","file_type":"code","source_file":"tool"}
+        ],
+        "links": []
+    });
+    assert!(compare(&compass, &graphify).unwrap().compatible());
+}
+
+#[test]
+fn missing_node_field_and_edge_fail() {
+    let graphify = json!({
+        "nodes": [
+            {"id":"a","label":"a()","file_type":"code","source_file":"a.c","source_location":"L1"},
+            {"id":"b","label":"b()","file_type":"code","source_file":"a.c","source_location":"L2"}
+        ],
+        "links": [{"source":"a","target":"b","relation":"calls"}]
+    });
+    let compass = json!({
+        "nodes": [{"id":"a","label":"wrong()","file_type":"code","source_file":"a.c","source_location":"L1"}],
+        "links": []
+    });
+    let report = compare(&compass, &graphify).unwrap();
+    assert_eq!(report.missing_nodes, ["b"]);
+    assert_eq!(report.mismatched_nodes.len(), 1);
+    assert_eq!(report.missing_edges.len(), 1);
+}
+```
+
+- [ ] **Step 4: Run comparator verification**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p compass-parity --bin compare-graphs
+cargo clippy -p compass-parity --bin compare-graphs -- -D warnings
+```
+
+Expected: tests pass and Clippy reports no warnings.
+
+- [ ] **Step 5: Commit the comparator**
+
+```bash
+git add crates/compass-parity/Cargo.toml crates/compass-parity/src/bin/compare_graphs.rs Cargo.lock
+git commit -m "feat: add graph superset parity checker"
+```
+
+### Task 5: Add reproducible Podman qualification and documentation
+
+**Files:**
+
+- Create: `scripts/qualify_graphify_superset.sh`
+- Modify: `docs/implementation/extraction-pipeline.md:260`
+- Create: `CHANGELOG.md`
+
+**Interfaces:**
+
+- Environment:
+  - `PODMAN_ROOT`, default `/Volumes/Workspace/Github/podman`
+  - `COMPASS_BIN`, default `target/release/compass` resolved from the Compass repository root
+  - `GRAPHIFY_PYTHON`, default `/Users/haipingfu/graphify/.venv/bin/python`
+  - `PARITY_SAMPLES`, default `3`
+  - `QUERY_SAMPLES`, default `5`
+- Outputs: timing TSV and summary under a new temporary directory printed by the script.
+
+- [ ] **Step 1: Implement guarded output reset and release build**
+
+The script must use `set -euo pipefail`, resolve absolute paths, and reject a Podman root that is empty, `/`, the home directory, or lacks `.git`. Set explicit output paths:
+
+```bash
+compass_output="$PODMAN_ROOT/compass-out"
+graphify_output="$PODMAN_ROOT/graphify-out"
+```
+
+Before each destructive reset, verify the target equals one of those two exact paths and its parent equals the validated Podman root. Remove only the validated output directory.
+
+Build:
+
+```bash
+cargo build --release -p compass-cli
+```
+
+- [ ] **Step 2: Record three cold and warm samples for both tools**
+
+Use `/usr/bin/time -p` around:
+
+```bash
+(cd "$PODMAN_ROOT" && COMPASS_OUT=compass-out "$COMPASS_BIN" update .)
+(cd "$PODMAN_ROOT" && "$GRAPHIFY_PYTHON" -m graphify update .)
+```
+
+For cold samples, reset only the corresponding output directory first. For warm samples, preserve a completed output and run an unchanged update. Record tool, operation, sample, seconds, commit IDs, node count, and edge count as TSV. Sort each three-sample series numerically and select the middle value as the median.
+
+Exit unsuccessfully when Compass cold median exceeds 32 seconds or Compass warm median exceeds 10 seconds.
+
+- [ ] **Step 3: Run parity and query qualification**
+
+After the final complete outputs, invoke:
+
+```bash
+cargo run --release -p compass-parity --bin compare-graphs -- \
+  "$compass_output/graph.json" \
+  "$graphify_output/graph.json"
+```
+
+Run each query five times and record medians:
+
+```bash
+"$COMPASS_BIN" query "update" --graph "$compass_output/graph.json"
+"$GRAPHIFY_PYTHON" -m graphify query "update" --graph "$graphify_output/graph.json"
+```
+
+Capture query output outside the timed result. Before reporting latency, normalize the `NODE` and `EDGE` result rows and fail if the Graphify rows are not a subset of the Compass rows.
+
+- [ ] **Step 4: Document the gate and cache change**
+
+Add a `Graphify superset qualification` subsection to `docs/implementation/extraction-pipeline.md` with:
+
+```bash
+PODMAN_ROOT=/Volumes/Workspace/Github/podman \
+  bash scripts/qualify_graphify_superset.sh
+```
+
+Explain that the command deletes only `$PODMAN_ROOT/compass-out` and `$PODMAN_ROOT/graphify-out`, runs both tools from clean outputs, checks shared node and edge inclusion, and records medians. State that Compass-only language facts are informational.
+
+Add a changelog entry explaining that corrected C/C++ declarator semantics use AST cache namespace `v0.9.21`, causing one extraction refresh followed by normal warm reuse.
+
+- [ ] **Step 5: Run local script validation**
+
+Run:
+
+```bash
+bash -n scripts/qualify_graphify_superset.sh
+git diff --check
+```
+
+Expected: shell syntax and whitespace checks pass.
+
+- [ ] **Step 6: Commit qualification tooling and documentation**
+
+```bash
+git add scripts/qualify_graphify_superset.sh docs/implementation/extraction-pipeline.md CHANGELOG.md
+git commit -m "docs: add Graphify superset qualification"
+```
+
+### Task 6: Complete repository and Podman verification
+
+**Files:**
+
+- Modify only if failures reveal a scoped correctness defect in the files named by Tasks 1 through 5.
+- Refresh generated graph output with `graphify update .` after all code changes.
+
+**Interfaces:**
+
+- Consumes: the release Compass binary, Graphify environment, Podman checkout, parity comparator, and qualification script.
+- Produces: passing workspace checks, zero Graphify-missing nodes and edges, and benchmark evidence.
+
+- [ ] **Step 1: Run repository checks**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+git diff --check
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 2: Refresh the required repository graph**
+
+Run from `/Users/haipingfu/graphify`:
+
+```bash
+graphify update .
+```
+
+Expected: the graph update exits successfully. Do not stage generated `graphify-out/` files unless they are already tracked and intentionally changed by repository policy.
+
+- [ ] **Step 3: Run full Podman qualification**
+
+Run:
+
+```bash
+PODMAN_ROOT=/Volumes/Workspace/Github/podman \
+  COMPASS_BIN=/Users/haipingfu/graphify/compass/target/release/compass \
+  GRAPHIFY_PYTHON=/Users/haipingfu/graphify/.venv/bin/python \
+  bash scripts/qualify_graphify_superset.sh
+```
+
+Expected:
+
+- Missing Graphify nodes: 0
+- Mismatched shared nodes: 0
+- Missing Graphify edges: 0
+- Compass cold median: at most 32 seconds
+- Compass warm median: at most 10 seconds
+- Query result inclusion: pass
+- Compass-only Perl and extensionless-script facts: reported and retained
+
+- [ ] **Step 4: Inspect the final change set**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate origin/main..HEAD
+git diff --stat origin/main...HEAD
+```
+
+Confirm that `crates/compass-output/src/html.rs`, `advisor-plans/`, `codegraph/`, and generated output directories were not included in any task commit.
+
+- [ ] **Step 5: Commit any verification-driven scoped correction**
+
+If Step 3 exposes a defect, return to the task that owns the affected interface, apply its verification commands, and stage only the exact files listed by that task. Use `git commit -m "fix: close remaining graph parity gap"` after the scoped verification passes. If Step 3 passes without a correction, do not create an empty commit.
+
+## Completion evidence
+
+Record in the final handoff:
+
+- Branch and commit list
+- Focused and workspace verification commands
+- Compass and Graphify node and edge totals
+- Missing shared node, field, and edge counts
+- All cold, warm, and query samples plus medians
+- Compass-only facts retained
+- Any unrelated working-tree changes left untouched

--- a/docs/superpowers/plans/2026-07-23-versioned-history-html-export.md
+++ b/docs/superpowers/plans/2026-07-23-versioned-history-html-export.md
@@ -1,0 +1,650 @@
+# Versioned History HTML Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Export every preferred materialized Compass realization as one offline HTML file where selecting a Git commit displays that commit’s complete code graph.
+
+**Architecture:** The immutable history store stays authoritative. The CLI selects validated preferred realizations, derives topology-aware timeline metadata and parent diffs, and streams them into a no-clobber staged export. The HTML contains a small manifest plus one independently compressed payload per commit, so the browser can validate and decode only the selected graph, isolate corruption, and retain at most a small LRU of decoded snapshots. The viewer reuses the current Compass graph canvas behavior instead of creating a second divergent renderer.
+
+**Tech Stack:** Rust (`compass-files`, `compass-cli`, `compass-history`, `compass-output`), `serde_json`, SHA-256, `flate2`, `base64`, static HTML/CSS/JavaScript, vendored `vis-network` 9.1.6 and a pinned MIT-licensed DEFLATE decoder.
+
+## Global Constraints
+
+- `compass history export --output PATH` defaults to HTML only with no revision; `--format html` is equivalent.
+- Existing `history export REV --format graph-json|compass-out --output PATH` behavior is unchanged.
+- Export only preferred, validated materializations. Do not build absent commits or expose alternates.
+- The HTML embeds data and renderer; it makes no network request.
+- An existing output fails. `--force` confirms only output over 256 MiB and never overwrites.
+- Writes use a staged, atomic, no-clobber publish primitive and leave no partial destination.
+- Default view is a selected commit’s full graph; parent comparison is opt-in and merge parents are explicit.
+- Full SHA and realization IDs are embedded. `#commit=<full-sha>` and browser history restore selection.
+- Timeline order follows the embedded parent DAG, not lexicographic SHA order. Select materialized `HEAD` by default; otherwise select the nearest materialized first-parent ancestor, then the newest topological leaf.
+- Missing Git objects after a history rewrite do not make export fail. Stored SHA/parents/graph data remain authoritative and missing subject/author/date use explicit “unavailable” presentation.
+- Never embed the absolute repository path. Use a sanitized repository basename unless the user supplies `--title`.
+- Keep the full exact graph payload for every commit. Above the current 5,000-node rendering limit, open in community overview mode and allow search/drill-down without discarding exact data.
+- Parent comparison uses Compass `diff_records` semantics and is disabled with an explanatory warning when the parent is absent or build profiles are not comparable.
+- The archive verifies each compressed payload before decoding it. A broken payload disables only that commit.
+- Commit rail, graph controls, and inspector meet WCAG 2.2 AA, remain usable at 320 CSS px, use 44×44 px touch targets, and respect reduced motion.
+- Use CSS custom-property tokens for canvas, panels, text, focus, additions, removals, and changed records. Honor system light/dark preference and provide a keyboard-accessible in-session theme toggle; both themes meet AA contrast.
+- Treat the parent-DAG rail as the visual signature: crisp topology lanes and commit strata, not generic nested cards, glass blur, gradient text, or decorative metric tiles.
+- Switching commits preserves positions for stable node IDs, keeps a surviving node selection, destroys old network listeners, and maintains an LRU of at most three decoded graphs.
+- A strict Content Security Policy enforces the offline boundary; string searches for `https://` are not a security test.
+- Treat commit metadata and every graph attribute as untrusted. Validate structural IDs, use `textContent`/DOM construction for labels, and never interpolate payload strings into HTML, CSS, selectors, or event-handler source.
+- Manifest corruption is a page-level fatal error with recovery guidance; payload corruption remains commit-local.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/compass-files/src/atomic.rs`, `src/lib.rs`, `tests/atomic_contract.rs` | Staged no-clobber publication used by single-file history export. |
+| `crates/compass-history/src/git.rs`, `src/lib.rs`, `tests/git_contract.rs` | Optional presentation metadata and topology/default-selection contracts. |
+| `crates/compass-output/assets/vis-network-9.1.6.min.js`, `assets/fflate-0.8.2.min.js` | Pinned offline graph and payload-decompression libraries. |
+| `crates/compass-output/src/html.rs`, `src/history_html.rs`, `src/lib.rs`, `tests/history_html.rs` | Shared graph canvas, streamed archive, lazy viewer, and renderer contracts. |
+| `crates/compass-cli/src/history_commands.rs`, `tests/history_cli.rs` | New no-revision syntax and validated snapshot collection. |
+| `crates/compass-cli/src/help.rs`, `tests/coverage_paths.rs`, `docs/reference/commands.md`, `docs/reference/outputs.md`, `docs/guides/versioned-history.md`, `crates/compass-cli/assets/compass-skill/references/history.md` | Command documentation and assertions. |
+| `tests/history-html/package.json`, `tests/history-html/time-travel.spec.mjs`, `.github/workflows/compass-ci.yml` | Real Chromium `file://` acceptance coverage. |
+| `THIRD_PARTY_NOTICES.md` | `vis-network` and DEFLATE decoder source/version/license notices. |
+
+## Canonical Terms
+
+- **Materialized commit:** a Git commit with at least one published Compass realization.
+- **Preferred realization:** the single realization selected by the history store for a materialized commit.
+- **Timeline entry:** exported metadata for one preferred realization, whether or not its Git object still exists.
+- **Graph payload:** the independently compressed, digested exact `GraphDocument` for one timeline entry.
+- **Comparable parent:** an embedded parent realization whose normalized build profile is semantically comparable to the selected realization.
+- **Overview mode:** a derived community meta-graph used only for rendering large graphs; the exact payload remains embedded and searchable.
+
+## Task 0: Add staged atomic no-clobber file publication
+
+**Files:**
+- Modify: `crates/compass-files/src/atomic.rs`
+- Modify: `crates/compass-files/src/lib.rs`
+- Create: `crates/compass-files/tests/atomic_contract.rs`
+
+**Interfaces:** Produces `PreparedFile::new`, `PreparedFile::writer`, `PreparedFile::len`, and `PreparedFile::publish_noclobber`. Task 2 streams the HTML into it; Task 3 decides whether to publish after seeing the exact size.
+
+- [ ] **Step 1: Write failing no-clobber and cleanup tests**
+
+```rust
+#[test]
+fn prepared_file_publishes_without_overwriting() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("history.html");
+    std::fs::write(&destination, "existing")?;
+    let mut prepared = PreparedFile::new(&destination)?;
+    prepared.writer().write_all(b"replacement")?;
+    assert!(matches!(prepared.publish_noclobber(), Err(FileError::DestinationExists(_))));
+    assert_eq!(std::fs::read_to_string(destination)?, "existing");
+    Ok(())
+}
+
+#[test]
+fn dropping_unpublished_prepared_file_removes_staging() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let destination = directory.path().join("history.html");
+    { let mut prepared = PreparedFile::new(&destination)?; prepared.writer().write_all(b"partial")?; }
+    assert!(!destination.exists());
+    assert_eq!(std::fs::read_dir(directory.path())?.count(), 0);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `cargo test -p compass-files --test atomic_contract prepared_file`
+
+Expected: compilation fails because `PreparedFile` is not defined.
+
+- [ ] **Step 3: Implement the staged writer**
+
+Create the temporary file in the destination directory with owner-only permissions. `publish_noclobber` must flush and `sync_all`, atomically link/persist without replacing an existing destination, sync the parent directory, and delete the staging name. `Drop` removes unpublished staging. Keep the platform-specific no-clobber operation behind one private helper and exercise it on the existing Linux, macOS, and Windows CI matrix.
+
+```rust
+#[error("destination already exists: {0}")]
+DestinationExists(PathBuf),
+pub struct PreparedFile { destination: PathBuf, staging: PathBuf, file: Option<File>, bytes: u64 }
+pub struct PreparedWriter<'a> { file: &'a mut File, bytes: &'a mut u64 }
+impl Write for PreparedWriter<'_> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize>;
+    fn flush(&mut self) -> std::io::Result<()>;
+}
+impl PreparedFile {
+    pub fn new(destination: &Path) -> Result<Self, FileError>;
+    pub fn writer(&mut self) -> PreparedWriter<'_>;
+    pub fn len(&self) -> u64;
+    pub fn publish_noclobber(mut self) -> Result<(), FileError>;
+}
+```
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cargo fmt --check && cargo test -p compass-files --test atomic_contract`
+
+Expected: all atomic contract tests pass on the host platform.
+
+Run: `git add crates/compass-files/src/atomic.rs crates/compass-files/src/lib.rs crates/compass-files/tests/atomic_contract.rs && git commit -m "feat(files): add atomic no-clobber publication"`
+
+## Task 1: Add safe Git presentation metadata
+
+**Files:**
+- Modify: `crates/compass-history/src/git.rs`
+- Modify: `crates/compass-history/src/lib.rs`
+- Create: `crates/compass-history/tests/git_contract.rs`
+
+**Interfaces:** Produces `CommitPresentation` and `Repository::presentation(&CommitId) -> Result<Option<CommitPresentation>, HistoryError>`; Task 3 consumes both. `None` means the immutable realization exists but Git no longer has the commit object.
+
+- [ ] **Step 1: Write the failing contract test**
+
+```rust
+#[test]
+fn presentation_returns_safe_commit_display_fields() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Historian"])?;
+    git(directory.path(), &["config", "user.email", "history@example.invalid"])?;
+    std::fs::write(directory.path().join("lib.rs"), "pub fn v1() {}\n")?;
+    git(directory.path(), &["add", "lib.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "feat: add history view"])?;
+    let repository = Repository::discover(directory.path())?;
+    let presentation = repository.presentation(&repository.resolve("HEAD")?)?.ok_or("metadata")?;
+    assert_eq!(presentation.subject, "feat: add history view");
+    assert_eq!(presentation.author, "Compass Historian");
+    assert!(presentation.authored_at.contains('T'));
+    let missing = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?;
+    assert_eq!(repository.presentation(&missing)?, None);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p compass-history --test git_contract presentation_returns_safe_commit_display_fields`
+
+Expected: compilation fails because optional `Repository::presentation` does not exist.
+
+- [ ] **Step 3: Implement NUL-delimited Git parsing**
+
+Add the type and method below. Use `git_output`, not `git_line`, since the format includes NUL delimiters. Require exactly five split fields, an empty trailing field, and the requested SHA. Reject non-UTF-8 or multiline display fields with `HistoryError::Git`.
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitPresentation { pub subject: String, pub author: String, pub authored_at: String }
+
+pub fn presentation(&self, commit: &CommitId) -> Result<Option<CommitPresentation>, HistoryError> {
+    if !self.has_commit_object(commit)? { return Ok(None); }
+    let output = git_output(&self.root, &["show", "-s", "--format=%H%x00%s%x00%an%x00%aI%x00", "--end-of-options", commit.as_str()])?;
+    let fields = output.split(|byte| *byte == 0).collect::<Vec<_>>();
+    let [actual, subject, author, authored_at, trailing] = fields.as_slice() else {
+        return Err(HistoryError::Git("Git returned malformed commit presentation".to_owned()));
+    };
+    if !trailing.is_empty() || std::str::from_utf8(actual).ok() != Some(commit.as_str()) {
+        return Err(HistoryError::Git("Git returned an unexpected commit presentation".to_owned()));
+    }
+    let field = |bytes: &[u8], name: &str| -> Result<String, HistoryError> {
+        let value = std::str::from_utf8(bytes).map_err(|error| HistoryError::Git(format!("Git returned non-UTF-8 {name}: {error}")))?;
+        if value.contains(['\r', '\n']) { return Err(HistoryError::Git(format!("Git returned multiline {name}"))); }
+        Ok(value.to_owned())
+    };
+    Ok(Some(CommitPresentation { subject: field(subject, "subject")?, author: field(author, "author")?, authored_at: field(authored_at, "timestamp")? }))
+}
+```
+
+Implement `has_commit_object` with `git cat-file --batch-check=%(objectname) %(objecttype)` and pass `<sha>^{commit}\n` on stdin through a new private `git_output_with_input` helper. Treat the machine-readable `<expression> missing` response as `false`, accept only `<full-sha> commit` as `true`, and reject every other response as `HistoryError::Git`; do not infer absence from process exit codes or localized stderr. Re-export with `pub use git::{CommitPresentation, GitTargetLimitation, Repository, WorktreeGuard};`.
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `cargo fmt --check && cargo test -p compass-history --test git_contract presentation_returns_safe_commit_display_fields`
+
+Expected: both commands pass.
+
+Run: `git add crates/compass-history/src/git.rs crates/compass-history/src/lib.rs crates/compass-history/tests/git_contract.rs && git commit -m "feat(history): expose commit presentation metadata"`
+
+## Task 2: Implement the self-contained history renderer
+
+**Files:**
+- Create: `crates/compass-output/assets/vis-network-9.1.6.min.js`
+- Create: `crates/compass-output/assets/fflate-0.8.2.min.js`
+- Modify: `THIRD_PARTY_NOTICES.md`
+- Modify: `Cargo.toml`
+- Modify: `crates/compass-output/Cargo.toml`
+- Modify: `crates/compass-output/src/html.rs`
+- Create: `crates/compass-output/src/history_html.rs`
+- Modify: `crates/compass-output/src/lib.rs`
+- Create: `crates/compass-output/tests/history_html.rs`
+
+**Interfaces:** Produces shared `GraphViewModel`, `HistoryTimelineEntry`, `HistorySnapshot`, `HistoryArchiveBuilder`, and `PreparedHistoryHtml`; Task 3 consumes them. `PreparedHistoryHtml::len` exposes exact staged size and `publish_noclobber` delegates to Task 0.
+
+- [ ] **Step 1: Vendor the pinned library and record its license**
+
+Run: `curl --fail --location --silent --show-error https://unpkg.com/vis-network@9.1.6/standalone/umd/vis-network.min.js --output crates/compass-output/assets/vis-network-9.1.6.min.js && curl --fail --location --silent --show-error https://unpkg.com/fflate@0.8.2/umd/index.js --output crates/compass-output/assets/fflate-0.8.2.min.js && shasum -a 256 crates/compass-output/assets/vis-network-9.1.6.min.js crates/compass-output/assets/fflate-0.8.2.min.js`
+
+Expected SHA-256 digests:
+
+```text
+576bb887733eb01bb52ee75b90ef46d818454de5fddb5b616fb8a298d307ca12  crates/compass-output/assets/vis-network-9.1.6.min.js
+c3b34f2e9f5e74d4d7d64e01cac7a0c01954c6c406414d42185c7b53d6875ddf  crates/compass-output/assets/fflate-0.8.2.min.js
+```
+
+Add both MIT licenses, versions, and source URLs to `THIRD_PARTY_NOTICES.md`; retain source headers. Add workspace `flate2 = "1.1.9"` and `base64 = "0.22.1"` dependencies to `compass-output`.
+
+- [ ] **Step 2: Write the failing renderer contracts**
+
+```rust
+#[test]
+fn history_html_is_offline_deterministic_and_embeds_all_commits() -> Result<(), Box<dyn std::error::Error>> {
+    let rendered = render_fixture(vec![entry("b".repeat(40), "Second"), entry("a".repeat(40), "First")])?;
+    let html = rendered.text();
+    assert!(html.contains("default-src 'none'"));
+    assert!(!html.contains("<script src="));
+    assert!(html.contains("vis.Network"));
+    assert!(html.contains("compass-history-manifest/v1"));
+    assert_eq!(html.matches("data-compass-payload=").count(), 2);
+    assert!(html.contains("function decodeSelectedPayload"));
+    Ok(())
+}
+
+#[test]
+fn history_html_escapes_script_terminators() -> Result<(), Box<dyn std::error::Error>> {
+    let rendered = render_fixture(vec![entry_with_label("</script><img src=x>")])?;
+    let html = rendered.text();
+    assert!(!html.contains("</script><img"));
+    assert_eq!(decode_fixture_payload(html)?.nodes[0].label(), "</script><img src=x>");
+    Ok(())
+}
+
+#[test]
+fn corrupt_payload_is_isolated_from_other_commits() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rendered = render_fixture(two_entries())?;
+    rendered.corrupt_payload(FIRST_COMMIT);
+    assert!(rendered.manifest().entry(FIRST_COMMIT).is_err());
+    assert!(rendered.manifest().entry(SECOND_COMMIT).is_ok());
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add typed payload rendering and safe serialization**
+
+```rust
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryArchiveHeader {
+    pub title: String, pub exported_at: String, pub default_commit: String,
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryDiffCounts {
+    pub nodes_added: u64, pub nodes_removed: u64, pub nodes_changed: u64,
+    pub edges_added: u64, pub edges_removed: u64, pub edges_changed: u64,
+    pub hyperedges_added: u64, pub hyperedges_removed: u64, pub hyperedges_changed: u64,
+}
+#[derive(Clone, Debug, Serialize)]
+pub enum HistoryRecordKind { Node, Edge, Hyperedge }
+#[derive(Clone, Debug, Serialize)]
+pub enum HistoryChangeKind { Added, Removed, Changed }
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryChangedRecord {
+    pub record: HistoryRecordKind, pub change: HistoryChangeKind, pub key: Vec<String>,
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryParentDiff {
+    pub parent: String, pub comparable: bool, pub unavailable_reason: Option<String>,
+    pub counts: HistoryDiffCounts, pub changed: Vec<HistoryChangedRecord>, pub truncated: bool,
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryTimelineEntry {
+    pub commit: String, pub parents: Vec<String>, pub realization: String,
+    pub profile_digest: String, pub fingerprint: String,
+    pub subject: Option<String>, pub author: Option<String>, pub authored_at: Option<String>,
+    pub lane: usize, pub node_count: u64, pub edge_count: u64, pub overview: bool,
+    pub parent_diffs: Vec<HistoryParentDiff>,
+}
+#[derive(Clone, Debug, Serialize)]
+pub struct GraphViewModel {
+    pub nodes: Vec<Value>, pub edges: Vec<Value>, pub legend: Vec<Value>,
+    pub hyperedges: Value, pub source_nodes: usize, pub source_edges: usize,
+}
+#[derive(Clone, Debug, Serialize)]
+struct HistoryPayloadManifest {
+    timeline: HistoryTimelineEntry, element_id: String, sha256: String,
+    compressed_bytes: u64, uncompressed_bytes: u64,
+}
+pub struct HistorySnapshot {
+    pub timeline: HistoryTimelineEntry,
+    pub document: GraphDocument,
+    pub overview: Option<GraphViewModel>,
+}
+pub struct HistoryArchiveBuilder {
+    prepared: PreparedFile, header: HistoryArchiveHeader,
+    entries: Vec<HistoryPayloadManifest>, seen: BTreeSet<String>,
+}
+pub struct PreparedHistoryHtml { prepared: PreparedFile, entries: usize }
+impl HistoryArchiveBuilder {
+    pub fn new(destination: &Path, header: HistoryArchiveHeader) -> Result<Self, OutputError>;
+    pub fn append(&mut self, snapshot: HistorySnapshot) -> Result<(), OutputError>;
+    pub fn finish(self) -> Result<PreparedHistoryHtml, OutputError>;
+}
+impl PreparedHistoryHtml {
+    pub fn len(&self) -> u64;
+    pub fn publish_noclobber(self) -> Result<(), OutputError>;
+}
+```
+
+Extract the current node/edge/community transformation and graph-control script from `html.rs` into a reusable `GraphViewModel`/shared template section; keep existing static HTML output byte-compatible where its parity tests require it. For graphs above 5,000 nodes, compute the same community overview model during export and store it beside the exact document. Each `append` canonicalizes one payload envelope containing the exact document plus optional overview, computes SHA-256 over the uncompressed bytes, compresses it with `flate2::write::ZlibEncoder` at the default level, base64-encodes it, writes an inert per-commit payload element, records compressed/uncompressed sizes, and drops the document before the next snapshot. The browser must use fflate's `unzlibSync` for the matching zlib wrapper. `finish` writes the small `compass-history-manifest/v1` separately from payloads. Escape `<`, `>`, `&`, U+2028, and U+2029 in the manifest. Duplicate commits fail. Inline both pinned assets and a CSP with `default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; worker-src blob:`.
+
+- [ ] **Step 4: Implement browser-side behavior**
+
+```javascript
+async function selectCommit(commit, { updateHistory = true } = {}) {
+  const entry = entriesByCommit.get(commit) || entriesByCommit.get(manifest.defaultCommit);
+  setViewerBusy(true, `Loading ${shortSha(entry.commit)}`);
+  const previousPositions = captureStableNodePositions();
+  const graphDocument = await decodeSelectedPayload(entry);
+  selectedCommit = entry.commit;
+  renderCommitRail(entry.commit);
+  replaceGraph(graphDocument, { previousPositions, selectedNodeId });
+  renderInspector(entry);
+  document.title = `Compass history — ${entry.commit.slice(0, 12)}`;
+  if (updateHistory) history.pushState({ commit: entry.commit }, "", `#commit=${entry.commit}`);
+  setViewerBusy(false, `Showing ${shortSha(entry.commit)}`);
+}
+function restoreCommitFromLocation() {
+  const requested = new URLSearchParams(location.hash.slice(1)).get("commit");
+  const commit = entriesByCommit.has(requested) ? requested : manifest.defaultCommit;
+  selectCommit(commit, { updateHistory: false });
+}
+function compareWithParent(parentCommit) {
+  const diff = entriesByCommit.get(selectedCommit).parentDiffs.find(value => value.parent === parentCommit);
+  if (!diff || !diff.comparable) return showComparisonUnavailable(diff);
+  applyEmbeddedDiff(diff); renderComparisonSummary(diff);
+}
+```
+
+`decodeSelectedPayload` locates only the selected payload element, base64-decodes and inflates it, checks exact uncompressed length and SHA-256 before parsing, then inserts it into a three-entry LRU. Digest verification may use Web Crypto when available but must include a local fallback that works from `file://`. Decode/inflate in a Blob Worker for payloads over 5 MiB so the commit rail remains responsive.
+
+Implement a virtualized searchable commit rail (SHA, subject, author, unavailable-metadata fallback), full graph canvas, and inspector. Use a real listbox or button list with `aria-current`, Up/Down/Home/End navigation, visible focus, an `aria-live` load/error status, and a canvas text alternative summarizing node/edge counts and selected node relationships. At 760 px collapse the inspector into a drawer; at 520 px collapse the rail into a modal sheet. Touch targets are at least 44×44 px. Stop physics under `prefers-reduced-motion`. Drive light/dark/highlight colors through named CSS variables, initialize from `prefers-color-scheme`, and update both DOM and `vis-network` colors from an accessible theme toggle without using storage APIs.
+
+`replaceGraph` must destroy the old `vis.Network` and its listeners, reuse positions for IDs present in both commits, seed new nodes near connected surviving nodes, keep a selected node when its ID survives, and show “node not present in this commit” otherwise. Embedded Compass diffs highlight added/changed current records and list removed records in the inspector. Missing or incomparable parents render disabled controls with reasons. Register `popstate` and `hashchange` to restore fragments without duplicate history entries.
+
+- [ ] **Step 5: Verify and commit renderer work**
+
+Add duplicate-SHA, independent-payload, digest, compressed round-trip, CSP, named-viewer-hook, stable-layout, fragment, accessibility-marker, theme-token, responsive-breakpoint, external-reference, and escaping tests. Test 0, 1, 5,001, and 50,000-node snapshots; the latter two must retain exact payloads while selecting overview rendering. Run: `cargo test -p compass-output --test history_html && cargo test -p compass-output`
+
+Expected: both commands pass.
+
+Run: `git add Cargo.toml THIRD_PARTY_NOTICES.md crates/compass-output/Cargo.toml crates/compass-output/assets/vis-network-9.1.6.min.js crates/compass-output/assets/fflate-0.8.2.min.js crates/compass-output/src/html.rs crates/compass-output/src/history_html.rs crates/compass-output/src/lib.rs crates/compass-output/tests/history_html.rs && git commit -m "feat(output): render scalable offline history viewer"`
+
+## Task 3: Wire preferred history to `compass history export`
+
+**Files:**
+- Modify: `crates/compass-cli/src/history_commands.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+
+**Interfaces:** Consumes Tasks 0–2 plus `HistoryStore::{list,validate,artifacts,diff_records}`. Produces `compass history export --output PATH [--format html] [--title NAME] [--force]`.
+
+- [ ] **Step 1: Write failing CLI coverage**
+
+Extend `history_commands_inspect_prefer_and_export_published_realizations` with a second committed/preferred graph, then add:
+
+```rust
+let output = directory.path().join("history.html");
+let result = run(compass, directory.path(), &["history", "export", "--output", output.to_str().unwrap()])?;
+assert!(result.status.success());
+let html = std::fs::read_to_string(&output)?;
+assert!(html.contains("compass-history-manifest/v1"));
+assert!(html.contains(first_commit.as_str()) && html.contains(second_commit.as_str()));
+assert!(html.contains("default-src 'none'"));
+assert!(!html.contains("<script src="));
+assert_eq!(run(compass, directory.path(), &["history", "export", "HEAD", "--format", "html", "--output", "bad.html"])?.status.code(), Some(2));
+assert_eq!(run(compass, directory.path(), &["history", "export", "--format", "graph-json", "--output", "bad.json"])?.status.code(), Some(2));
+```
+
+Add fixtures for a two-parent merge, an unmaterialized parent, different build profiles, and a stored commit whose Git object was deleted. Assert the export keeps all preferred entries, chooses materialized HEAD as `default_commit`, uses DAG order rather than SHA order, embeds a disabled reason for missing/incomparable parents, falls back to unavailable Git metadata, omits the absolute temporary directory, and leaves output absent for empty history.
+
+- [ ] **Step 2: Verify the focused test fails**
+
+Run: `cargo test -p compass-cli --test history_cli history_commands_inspect_prefer_and_export_published_realizations`
+
+Expected: failure because the current handler requires `REV`.
+
+- [ ] **Step 3: Make parsing format-aware**
+
+Replace the parser tuple with `HistoryOptions { positionals, format: Option<String>, output: Option<PathBuf>, title: Option<String>, force: bool }`; only the no-revision HTML export accepts `title` and `force`. Reject duplicates and empty/over-200-scalar titles. Use this exact decision function while retaining `text` as the default for all non-export commands:
+
+```rust
+fn export_format(options: &HistoryOptions) -> Result<&str, CommandFailure> {
+    match (options.positionals.is_empty(), options.format.as_deref()) {
+        (true, None | Some("html")) => Ok("html"),
+        (true, Some(_)) => Err(usage("history export without REV only supports --format html")),
+        (false, Some("graph-json" | "compass-out")) => Ok(options.format.as_deref().unwrap()),
+        (false, Some("html")) => Err(usage("history export --format html accepts no REV")),
+        (false, None) => Err(usage("history export REV requires --format graph-json or compass-out")),
+    }
+}
+```
+
+- [ ] **Step 4: Implement collection and size-gated atomic export**
+
+Add `const HISTORY_HTML_CONFIRM_BYTES: u64 = 256 * 1024 * 1024;`. The `export_history_html` helper collects `history.list(None)` entries with `preferred == true`, validates every ID, and builds an index by commit. Compute the default commit as: embedded `HEAD`; otherwise nearest embedded first-parent ancestor of `HEAD`; otherwise a parent-DAG leaf ordered by available authored timestamp and full SHA. Topologically order the rail newest-first while preserving merge lanes; use SHA only as a deterministic tie-breaker. Never call `resolve_or_materialize`.
+
+Fail fast when `output.exists()`, then still rely on Task 0's atomic no-clobber publication to close the race where another process creates the destination during export.
+
+```rust
+struct ExportCandidate {
+    published: PublishedVersion,
+    commit: CommitId,
+    presentation: Option<CommitPresentation>,
+}
+struct OrderedCommit { commit: String, lane: usize }
+fn choose_default_commit(repository: &Repository, entries: &BTreeMap<String, ExportCandidate>) -> Result<String, CommandFailure>;
+fn order_timeline(entries: &BTreeMap<String, ExportCandidate>, default: &str) -> Result<Vec<OrderedCommit>, CommandFailure>;
+fn collect_parent_diffs(history: &HistoryStore, selected: &PublishedVersion, entries: &BTreeMap<String, ExportCandidate>) -> Result<Vec<HistoryParentDiff>, CommandFailure>;
+fn timeline_entry(selected: &PublishedVersion, lane: usize, presentation: Option<CommitPresentation>, parent_diffs: Vec<HistoryParentDiff>) -> HistoryTimelineEntry;
+fn build_history_overview(document: &GraphDocument, node_limit: usize) -> Result<Option<GraphViewModel>, OutputError>;
+```
+
+`order_timeline` uses reverse Kahn sorting: start with commits that have no embedded children, emit the default commit’s component first, and release a parent only after all embedded children were considered. Order other leaf components by authored timestamp and SHA. Detect and fail on an impossible cycle rather than silently dropping entries. Assign deterministic lane numbers in a second pass so merges and disconnected/rewrite-retained histories are visually distinguishable.
+
+```rust
+let header = HistoryArchiveHeader {
+    title: title.unwrap_or_else(|| repository.root().file_name().and_then(OsStr::to_str).unwrap_or("Compass history").to_owned()),
+    exported_at: OffsetDateTime::now_utc().format(&Rfc3339).map_err(runtime)?,
+    default_commit: default_commit.clone(),
+};
+let entry_count = ordered.len();
+let mut archive = HistoryArchiveBuilder::new(output, header).map_err(runtime)?;
+for ordered_commit in ordered {
+    let candidate = preferred_by_commit.get(&ordered_commit.commit).ok_or_else(|| runtime("ordered commit disappeared"))?;
+    let published = &candidate.published;
+    history.validate(&published.id).map_err(runtime)?;
+    let parent_diffs = collect_parent_diffs(&history, published, &preferred_by_commit)?;
+    let document = history.artifacts(&published.id).map_err(runtime)?.artifacts.document;
+    archive.append(HistorySnapshot {
+        timeline: timeline_entry(published, ordered_commit.lane, candidate.presentation.clone(), parent_diffs),
+        overview: build_history_overview(&document, 5_000).map_err(runtime)?,
+        document,
+    }).map_err(runtime)?;
+}
+let prepared = archive.finish().map_err(runtime)?;
+if prepared.len() > HISTORY_HTML_CONFIRM_BYTES && !force {
+    return Err(runtime(format!("history HTML is {} bytes; rerun with --force for exports larger than 256 MiB", prepared.len())));
+}
+let bytes = prepared.len();
+prepared.publish_noclobber().map_err(runtime)?;
+Ok(format!("exported {entry_count} preferred history realizations to {} ({bytes} bytes)", output.display()))
+```
+
+`collect_parent_diffs` calls `normalized_profile_for_comparison` for each embedded parent. For comparable pairs, stream only `Node`, `Edge`, and `Hyperedge` changes through `diff_records` into bounded summary/detail records; cap detailed changed IDs at 5,000 per parent while retaining exact counts and a `truncated` flag. Missing or incompatible parents get a reason and no misleading diff. Refuse an empty entry set with `no preferred materialized realizations to export`. Dropping an over-threshold unforced `PreparedHistoryHtml` removes staging.
+
+- [ ] **Step 5: Verify and commit CLI work**
+
+Add explicit HTML, `--title`, legacy format, non-export `--force`, existing target with `--force`, exact threshold, staging cleanup, rewritten-history metadata fallback, DAG ordering, HEAD fallback, missing parent, merge parents, comparable diff, profile mismatch, and diff-truncation tests. Run: `cargo test -p compass-cli --test history_cli && cargo test -p compass-cli history_commands::tests`
+
+Expected: both commands pass; existing `graph-json` and `compass-out` contracts stay green.
+
+Run: `git add crates/compass-cli/src/history_commands.rs crates/compass-cli/tests/history_cli.rs && git commit -m "feat(history): export offline time-travel HTML"`
+
+## Task 4: Update public help and documentation
+
+**Files:**
+- Modify: `crates/compass-cli/src/help.rs`
+- Modify: `crates/compass-cli/tests/coverage_paths.rs`
+- Modify: `docs/reference/commands.md`
+- Modify: `docs/reference/outputs.md`
+- Modify: `docs/guides/versioned-history.md`
+- Modify: `crates/compass-cli/assets/compass-skill/references/history.md`
+
+- [ ] **Step 1: Write the failing help assertion**
+
+```rust
+let help = invoke(Frontend::Compass, &["help", "history", "export"]);
+assert_eq!(help.code, 0);
+assert!(help.stdout.contains("history export [--format html] --output <PATH> [--title <NAME>] [--force]"));
+assert!(help.stdout.contains("default: html"));
+assert!(help.stdout.contains("256 MiB"));
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `cargo test -p compass-cli --test coverage_paths history_export_help_describes_offline_time_travel`
+
+Expected: failure because current help requires `REV`.
+
+- [ ] **Step 3: Document exact usage and safety rules**
+
+Use these examples in all five surfaces:
+
+```text
+compass history export --output history.html
+compass history export --format html --output history.html
+compass history export --output history.html --title "Payments architecture"
+compass history export --output history.html --force
+```
+
+Explain that the bundle includes all preferred materialized commits, including entries retained after Git rewrites; missing Git presentation fields are labeled unavailable. It opens offline, defaults to the exact full graph when a row is clicked, enters overview mode above 5,000 rendered nodes without dropping exact payload data, and offers optional parent comparison only when an embedded parent is semantically comparable. Document topology ordering, HEAD fallback, `--title`, payload compression/lazy decoding, the three-snapshot LRU, CSP, the 256 MiB confirmation, no absolute local path, and the no-overwrite rule. Retain separate revision-specific examples.
+
+- [ ] **Step 4: Verify and commit docs**
+
+Run: `cargo test -p compass-cli --test coverage_paths history_export_help_describes_offline_time_travel && rg -n "history export \[--format html\] --output|256 MiB|offline|overview mode|Git rewrite|--title" crates/compass-cli/src/help.rs docs crates/compass-cli/assets/compass-skill/references/history.md`
+
+Expected: test passes and `rg` returns each documentation surface.
+
+Run: `git add crates/compass-cli/src/help.rs crates/compass-cli/tests/coverage_paths.rs docs/reference/commands.md docs/reference/outputs.md docs/guides/versioned-history.md crates/compass-cli/assets/compass-skill/references/history.md && git commit -m "docs(history): explain offline HTML time travel"`
+
+## Task 5: Add real-browser accessibility and time-travel acceptance coverage
+
+**Files:**
+- Create: `crates/compass-output/examples/history_html_fixture.rs`
+- Create: `tests/history-html/package.json`
+- Create: `tests/history-html/package-lock.json`
+- Create: `tests/history-html/time-travel.spec.mjs`
+- Modify: `.github/workflows/compass-ci.yml`
+
+**Interfaces:** Consumes the exported file exactly as a user does through `file://`; verifies behavior that Rust string-marker tests cannot prove.
+
+- [ ] **Step 1: Create deterministic browser fixtures**
+
+The Rust example writes three standalone files to a required output directory: `linear.html` (three comparable commits and one persistent node), `merge.html` (two materialized parents), and `corrupt.html` (one deliberately damaged payload plus one valid payload). It uses fixed SHAs/timestamps and 5,001 nodes in one commit to exercise overview mode.
+
+Run: `cargo run -p compass-output --example history_html_fixture -- tests/history-html/generated`
+
+Expected: all three files exist, and rerunning produces byte-identical files.
+
+- [ ] **Step 2: Add pinned Playwright and axe dependencies**
+
+```json
+{
+  "name": "compass-history-html-tests",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "playwright test" },
+  "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
+    "@playwright/test": "1.61.1"
+  }
+}
+```
+
+Run: `npm install --prefix tests/history-html --package-lock-only`
+
+Expected: `package-lock.json` pins every transitive dependency and `npm ci --prefix tests/history-html` succeeds.
+
+- [ ] **Step 3: Write failing `file://` acceptance tests**
+
+```javascript
+test("selects exact commits, restores history, and never requests network", async ({ page }) => {
+  const requests = [];
+  page.on("request", request => requests.push(request.url()));
+  await page.goto(pathToFileURL(resolve("generated/linear.html")).href);
+  await page.getByRole("button", { name: /second commit/i }).click();
+  await expect(page).toHaveURL(/#commit=[0-9a-f]{40}$/);
+  await expect(page.getByRole("status")).toContainText("Showing");
+  await page.goBack();
+  await expect(page.getByRole("button", { name: /newest commit/i })).toHaveAttribute("aria-current", "true");
+  expect(requests.filter(url => /^https?:/.test(url))).toEqual([]);
+});
+
+test("is keyboard, responsive, reduced-motion, and WCAG AA usable", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.setViewportSize({ width: 320, height: 720 });
+  await page.goto(pathToFileURL(resolve("generated/linear.html")).href);
+  await page.getByRole("button", { name: /open commit history/i }).click();
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Enter");
+  expect((await new AxeBuilder({ page }).analyze()).violations).toEqual([]);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  await expect(page.getByTestId("physics-state")).toHaveText("paused");
+});
+```
+
+Add tests for lazy decode (`window.__COMPASS_DEBUG__.decodedCommits <= 1` after load), three-entry LRU after four selections, position reuse for a stable node, merge-parent choice, overview mode retaining exact search, light/dark theme contrast and toggle state, profile-mismatch disabled state, invalid fragment fallback with notice, corrupt-payload isolation, fatal manifest corruption guidance, and hostile commit/node labels that must render as text without executing or creating injected elements.
+
+- [ ] **Step 4: Run the browser suite and verify it fails before viewer completion**
+
+Run: `cargo run -p compass-output --example history_html_fixture -- tests/history-html/generated && npm ci --prefix tests/history-html && npm exec --prefix tests/history-html -- playwright install chromium && npm test --prefix tests/history-html`
+
+Expected before Tasks 2–3 are complete: tests fail on missing time-travel controls. Expected afterward: all Chromium tests pass.
+
+- [ ] **Step 5: Add a pinned CI browser-smoke step and commit**
+
+In `quality-and-parity`, after Rust tests, run the fixture generator, `npm ci --prefix tests/history-html`, `npm exec --prefix tests/history-html -- playwright install --with-deps chromium`, and `npm test --prefix tests/history-html`. Keep generated HTML ignored and regenerated in CI.
+
+Run: `git add crates/compass-output/examples/history_html_fixture.rs tests/history-html/package.json tests/history-html/package-lock.json tests/history-html/time-travel.spec.mjs .github/workflows/compass-ci.yml .gitignore && git commit -m "test(history): exercise HTML time travel in Chromium"`
+
+## Task 6: Complete verification
+
+**Files:** Modify only files where verification exposes a defect.
+
+- [ ] **Step 1: Run test and formatting gates**
+
+Run: `cargo fmt --check && cargo clippy --workspace --lib --bins --locked -- -D warnings && cargo test -p compass-files && cargo test -p compass-history && cargo test -p compass-output && cargo test -p compass-cli && npm test --prefix tests/history-html`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Audit a generated artifact offline**
+
+Run: `rg -n "<script[^>]+src=|<link[^>]+href=|fetch\(|XMLHttpRequest|WebSocket" history.html; rg -n "Content-Security-Policy|compass-history-manifest/v1|data-compass-payload|#commit=|Compare with parent" history.html`
+
+Expected: no result from the first search; the second finds CSP, manifest, independent payloads, deep-link, and comparison markers. The Task 5 browser suite supplies the required `file://` interaction evidence.
+
+- [ ] **Step 3: Refresh Graphify after source changes**
+
+Run: `graphify update .`
+
+Expected: graph update completes successfully.
+
+## Plan Self-Review
+
+- **Spec coverage:** Task 0 guarantees staged no-clobber publication. Tasks 1 and 3 select validated preferred history, tolerate rewritten Git history, order the parent DAG, and embed comparable Compass diffs. Task 2 makes independent compressed payloads, lazy verification/decoding, shared graph controls, stable layout, overview mode, responsive accessibility, and CSP. Task 4 documents the exact contract. Task 5 proves `file://` behavior in Chromium. Task 6 runs project gates and refreshes Graphify.
+- **Placeholder scan:** Each task contains exact paths, interfaces, test assertions, commands, expected results, and a commit boundary.
+- **Type consistency:** `CommitPresentation` originates in `compass-history`; `PreparedFile` originates in `compass-files`; `HistoryTimelineEntry`, `HistorySnapshot`, `HistoryArchiveBuilder`, and `PreparedHistoryHtml` originate in `compass-output`; `history_commands.rs` is the adapter and never materializes during export.
+
+## Deferred Time-Travel Opportunities
+
+These are valuable follow-ups, deliberately excluded from the first release so the archive and parent-time-travel contract can stabilize:
+
+1. **Pin any commit as comparison baseline.** Compute an on-demand browser topology comparison between two already decoded exact payloads, with a strong warning when profiles differ. Do not precompute all pairs.
+2. **Follow a node through time.** Add a compact export-time index of commits where a stable node ID was added, changed, or removed, then let the inspector jump among those commits.
+3. **Architecture growth track.** Plot node/edge/community counts along the commit rail and mark discontinuities caused by extraction-profile changes separately from code growth.
+4. **Playback controls.** Add Previous/Next and optional autoplay while keeping the commit rail primary; respect reduced motion and pause when the tab is hidden.
+5. **Signed exports.** Add an optional detached or embedded signature over manifest and payload digests for authenticity. The v1 SHA-256 fields detect corruption, not malicious replacement.
+6. **Range exports.** If real repositories regularly exceed practical browser/file limits even after compression, add an explicit revision-range filter while keeping all materialized commits as the default.

--- a/docs/superpowers/reviews/2026-07-23-versioned-history-html-export-plan-audit.md
+++ b/docs/superpowers/reviews/2026-07-23-versioned-history-html-export-plan-audit.md
@@ -1,0 +1,148 @@
+# Versioned History HTML Export Plan Audit
+
+## Outcome
+
+The original plan had a sound product direction but was not implementation-ready. It contained three release-blocking contradictions and omitted important performance, history-rewrite, comparison, accessibility, privacy, and browser-verification contracts. The implementation plan and design spec have been revised to close those gaps.
+
+This audit scores plan coverage, not a shipped UI. Implementation quality must be re-audited after the viewer exists.
+
+## Audit Health Score
+
+| Dimension | Original | Revised plan | Key correction |
+| --- | ---: | ---: | --- |
+| Accessibility | 1/4 | 4/4 | Keyboard model, live state, canvas alternative, touch targets, WCAG browser test |
+| Performance | 1/4 | 3/4 | Streamed archive, per-commit compression, lazy decode, worker, bounded LRU, overview mode |
+| Responsive design | 1/4 | 4/4 | Explicit 760/520 px adaptations and 320 px acceptance test |
+| Theming | 1/4 | 3/4 | Shared tokens, light/dark behavior, contrast tests |
+| Anti-patterns | 3/4 | 4/4 | DAG rail becomes the signature; generic glass/card styling is prohibited |
+| **Total** | **7/20 — Poor** | **18/20 — Excellent plan coverage** | **Implementation evidence still required** |
+
+## Anti-Patterns Verdict
+
+**Pass with corrections.** The commit rail and graph canvas are specific to Compass and do not inherently read as generic AI UI. The original plan did risk a generic three-pane dashboard and a second copy of the existing graph viewer. The revised plan makes the parent-DAG rail the visual signature, reuses Compass graph behavior, and explicitly rejects decorative glass blur, nested cards, gradient text, and metric-tile filler.
+
+## Executive Summary
+
+- Original issues: **3 P0, 9 P1, 3 P2**
+- Release blockers: monolithic payload architecture, unsafe no-clobber semantics, incorrect SHA-based timeline/default selection
+- Major risks: rewritten Git history, non-Compass diff logic, renderer divergence, large graphs, layout instability, privacy/XSS/CSP, and missing real-browser evidence
+- The revised plan now has six implementation tasks plus an atomic-file prerequisite and a deferred enhancement backlog
+
+## Detailed Findings
+
+### P0 — One monolithic raw JSON archive contradicted corruption isolation and scalability
+
+- **Location:** Original Task 2 renderer architecture
+- **Impact:** One malformed record would prevent parsing the entire archive. Loading every full graph at startup would multiply memory use and freeze or crash large histories.
+- **Recommendation applied:** Separate manifest from independently compressed/digested payloads; stream export; lazy-decode one commit; keep a three-entry LRU; isolate payload errors.
+
+### P0 — Check-then-write did not guarantee no overwrite
+
+- **Location:** Original `write_history_html`/CLI publication steps
+- **Impact:** A concurrent process could create the target between `exists()` and atomic replacement, causing data loss despite the documented no-overwrite promise.
+- **Recommendation applied:** Add `PreparedFile` with staged owner-only output and an atomic no-clobber publish primitive tested on Linux, macOS, and Windows.
+
+### P0 — SHA sorting could not produce a timeline or identify the newest commit
+
+- **Location:** Original deterministic-order test and `newestEntry` client fallback
+- **Impact:** Lexicographic object IDs are unrelated to time or ancestry. The rail could be scrambled and invalid fragments could open an arbitrary graph.
+- **Recommendation applied:** Reverse topological ordering over stored parent edges, deterministic lane assignment, materialized `HEAD` default, first-parent fallback, then deterministic leaf fallback.
+
+### P1 — Rewritten Git history could make a valid immutable export fail
+
+- **Location:** Original required `Repository::presentation` lookup
+- **Impact:** Compass deliberately retains realizations after history rewrites, but the plan required Git subject/author/date to exist.
+- **Recommendation applied:** Use machine-readable `git cat-file --batch-check`; missing objects produce optional presentation fields while stored SHA/parents/graph remain exportable.
+
+### P1 — Browser-side ID comparison bypassed Compass diff comparability
+
+- **Location:** Original `compareWithParent`
+- **Impact:** It missed changed records and hyperedges and could present profile-induced differences as code changes.
+- **Recommendation applied:** Precompute bounded Node/Edge/Hyperedge diffs through `HistoryStore::diff_records`; disable absent/incompatible parent comparisons with reasons.
+
+### P1 — A second graph renderer would regress existing Compass behavior
+
+- **Location:** Original new `history_html.rs` viewer
+- **Impact:** Search, aggregation, accessibility, physics controls, node inspection, and parity behavior would drift from `html.rs`.
+- **Recommendation applied:** Extract and reuse a shared `GraphViewModel` and canvas/control template while preserving existing static export parity.
+
+### P1 — Large graphs had no rendering contract
+
+- **Location:** Original full-snapshot viewer
+- **Impact:** Current Compass HTML aggregates above 5,000 nodes; directly sending 50,000 nodes to `vis-network` is not usable.
+- **Recommendation applied:** Embed the exact graph but precompute/open a community overview above 5,000 nodes; retain exact search and drill-down.
+
+### P1 — Commit changes would visually “teleport”
+
+- **Location:** Original `renderGraph` replacement
+- **Impact:** Fresh physics layouts destroy a user’s spatial memory, undermining time travel.
+- **Recommendation applied:** Preserve positions for stable node IDs, seed new nodes near surviving neighbors, retain surviving node selection, and destroy old network/listener state.
+
+### P1 — Offline intent lacked an enforceable security boundary
+
+- **Location:** Original “no `https://`” string assertion
+- **Impact:** String checks can false-positive on license text and miss dynamic requests. Untrusted commit/node labels could become DOM injection.
+- **Recommendation applied:** Strict CSP, inert compressed payload elements, structural ID validation, text-only DOM insertion, hostile-label browser tests, and request interception.
+
+### P1 — The shareable file could leak an absolute local path
+
+- **Location:** Original `repository.root().display().to_string()`
+- **Impact:** Exporting and sharing the HTML disclosed the exporter’s filesystem/user path.
+- **Recommendation applied:** Use repository basename or explicit `--title`; test that the temporary root never appears.
+
+### P1 — Accessibility and responsive behavior were unplanned
+
+- **Location:** Original three-pane viewer task
+- **Impact:** No keyboard rail model, canvas alternative, mobile collapse, touch-target, live-status, reduced-motion, or contrast contract existed.
+- **Standard:** WCAG 2.2 AA
+- **Recommendation applied:** Explicit semantics and breakpoints plus Playwright/axe coverage at 320 px and reduced motion.
+
+### P1 — Marker tests could not prove `file://` behavior
+
+- **Location:** Original final verification
+- **Impact:** Deep links, Back/Forward, CSP, workers, payload decode, and accessibility can fail in a browser while Rust substring tests pass.
+- **Recommendation applied:** Add pinned Chromium acceptance tests over generated deterministic fixtures and run them in CI.
+
+### P2 — Payload digest semantics were incomplete
+
+- **Location:** Original manifest contract
+- **Impact:** A stored digest provided no value unless the browser checked exact bytes before parsing.
+- **Recommendation applied:** Verify uncompressed length and SHA-256 before JSON parsing with a local `file://` fallback. Clarify that v1 integrity is not authenticity.
+
+### P2 — Manifest failure and payload failure were not distinguished
+
+- **Location:** Original runtime error behavior
+- **Impact:** “Other commits stay selectable” is possible for a payload error but not for an unreadable manifest.
+- **Recommendation applied:** Manifest corruption is page-fatal with recovery guidance; payload corruption is commit-local.
+
+### P2 — Visual language and theme behavior were underspecified
+
+- **Location:** Original UI plan
+- **Impact:** It could regress contrast or become a generic dashboard disconnected from Compass.
+- **Recommendation applied:** Shared tokens, accessible light/dark themes, topology-lane visual identity, and anti-pattern constraints.
+
+## Systemic Issues Corrected
+
+- The original plan treated a small export and a repository-wide historical archive as the same rendering problem.
+- It relied on current Git state even though Compass history is intentionally more durable than Git reachability.
+- It specified offline behavior as content inspection rather than a browser-enforced/runtime-tested contract.
+- It treated time travel as data replacement, without spatial continuity or semantic comparability.
+
+## Positive Findings Preserved
+
+- The CLI remains backward-compatible with revision-specific `graph-json` and `compass-out` exports.
+- Preferred realizations are validated and alternate realizations stay out of v1.
+- Full graph is the default; comparison remains opt-in.
+- Merge parents are explicit.
+- The export is a single portable HTML artifact.
+- The plan retains TDD steps, focused contracts, frequent commit boundaries, and a final `graphify update .`.
+
+## Recommended Execution Order
+
+1. **P0 `/harden`** — Implement staged no-clobber publication, CSP, payload isolation, and rewritten-history fallback.
+2. **P0 `/optimize`** — Implement streaming compression, lazy worker decode, bounded LRU, virtualization, and overview mode.
+3. **P1 `/normalize`** — Extract and reuse the current graph view model/controls instead of duplicating them.
+4. **P1 `/adapt`** — Complete keyboard, responsive, reduced-motion, theme, and canvas-alternative behavior.
+5. **P2 `/polish`** — Validate layout continuity, copy, empty/error states, and the DAG rail’s visual clarity.
+
+Re-run `/audit` after implementation to replace plan-coverage scores with measured UI evidence.

--- a/docs/superpowers/specs/2026-07-23-extraction-superset-parity-design.md
+++ b/docs/superpowers/specs/2026-07-23-extraction-superset-parity-design.md
@@ -1,0 +1,230 @@
+# Achieve Graphify superset parity without slowing Compass
+
+This design corrects Compass extraction gaps found on Podman, makes parity with Graphify measurable, and protects Compass's release-build performance. Compass will preserve its broader language support while matching Graphify's canonical nodes and edges for inputs both tools support.
+
+## Goal and audience
+
+The goal is to make Compass an interpretation-compatible superset of Graphify on shared supported source files. For every Graphify node and edge in that scope, Compass must emit the same canonical identity and topology. Compass may also emit valid facts that Graphify does not, including Perl and extensionless executable scripts.
+
+The audience includes Compass maintainers, contributors who add language extractors, and users evaluating Compass as a faster Graphify replacement on large repositories.
+
+## Requirements
+
+The implementation must:
+
+- Correct C and C++ symbol names so return types, storage classes, and macros do not replace function identifiers
+- Preserve positional Markdown sections and rationale entries as distinct graph nodes
+- Match every Graphify node and edge for shared supported Podman inputs
+- Preserve valid Compass-only nodes and edges
+- Invalidate stale extraction cache entries when extractor semantics change
+- Keep the Podman release-build median at or below 32 seconds for cold indexing and 10 seconds for warm updates
+- Avoid a Graphify, Python, or network dependency in production Compass execution
+
+Correctness has priority over the performance thresholds. The implementation may optimize work, caching, and allocation, but it must not omit correct facts to meet a timing target.
+
+## Parity contract
+
+Parity is set inclusion rather than equal aggregate counts.
+
+Let `G` be Graphify output for source files and languages supported by both tools. Let `C` be Compass output for the same repository. Acceptance requires:
+
+```text
+Graphify shared nodes ⊆ Compass nodes
+Graphify shared edges ⊆ Compass edges
+```
+
+A shared node matches when its canonical ID is equal and its observable extraction fields agree. These fields include label, node type, source path, and source location when Graphify supplies them.
+
+A shared edge matches when its source ID, target ID, and relation are equal. Edge comparison will include deterministic metadata that participates in graph meaning, but it will ignore storage order.
+
+The parity gate will exclude derived clustering and community-analysis output because those results depend on the complete graph. Valid Compass-only facts can change those derived results even when the shared extracted graph is compatible.
+
+The shared-input filter will compare files Graphify successfully supports. It will not treat Perl files or extensionless executable scripts as parity failures when Graphify emits no facts for them.
+
+## Current Podman baseline
+
+The baseline comparison produced these totals:
+
+| Metric | Compass | Graphify |
+| --- | ---: | ---: |
+| Nodes | 116,336 | 119,191 |
+| Edges | 237,600 | 258,417 |
+| Code nodes | 110,221 | 111,619 |
+| Document nodes | 6,028 | 7,484 |
+| Rationale nodes | 49 | 50 |
+| Concept nodes | 38 | 38 |
+
+The outputs share 116,132 nodes. Graphify has 3,059 unmatched nodes and Compass has 204 unmatched nodes. The Graphify-only set contains 1,602 code nodes, 1,456 document nodes, and one rationale node.
+
+Two causes explain almost all of the node difference:
+
+1. `vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c` accounts for 1,539 Graphify-only nodes. Compass also emits 62 unmatched SQLite nodes with incorrect generic names such as `char()`, `struct()`, `int()`, and `void()`. The net SQLite gap is 1,477 nodes.
+2. Positional document merging accounts for a net gap of 1,456 document nodes. In `RELEASE_NOTES.md`, Compass retains 141 nodes while Graphify retains 533. Repeated headings created with distinct line-based IDs are later merged by generic entity deduplication.
+
+Compass covers all 8,173 source files represented by Graphify plus eight extensionless scripts. It also emits 24 nodes from the Perl `hack/buildah-vendor-treadmill` executable, where Graphify emits none. These additions demonstrate why total-count equality would be the wrong contract.
+
+The observed Compass release timings are 30.11 seconds for the latest cold run, 28.96 seconds for an earlier cold run, and 8.80 seconds for a warm run. The formal acceptance protocol below replaces individual observations with medians.
+
+## C and C++ declarator resolution
+
+Compass currently asks a generic declaration-name helper for a name before it resolves the function declarator. In macro-heavy C, the generic traversal can select a return type, storage class, or macro identifier before it reaches the function identifier.
+
+The extractor will introduce an explicit declarator resolver and call it before any generic fallback. The resolver will:
+
+1. Start from the declaration's `declarator` field.
+2. Recursively unwrap pointer, reference, parenthesized, array, function, and attributed declarator nodes.
+3. Select C identifiers from the resolved declarator rather than from the declaration prefix.
+4. Preserve C++ qualified identifiers, field identifiers, destructors, and operator names.
+5. Return no name when the declarator does not contain a supported callable identifier.
+6. Use the existing generic fallback only for syntax shapes outside the explicit resolver's contract.
+
+The resolver will not scan arbitrary descendants for the first identifier. This prevents a type or macro in the declaration prefix from becoming the canonical function name.
+
+Focused fixtures will cover:
+
+- Macro-decorated C declarations
+- Pointer and function-pointer declarators
+- Nested and qualified C++ methods
+- Constructors and destructors
+- Operator overloads
+- Malformed declarations that must fail safely
+
+The SQLite binding file will serve as the large regression corpus. The comparison must confirm canonical names such as `sqlite3CompileOptions()`, `sqlite3StatType()`, and `sqlite3StatusValue()` at the locations where Compass currently emits generic type names.
+
+## Positional document and rationale identity
+
+Markdown headings and rationale entries describe positions in a document, not global entities. Two headings with the same text can represent different sections and must remain distinct.
+
+The extraction stage already creates line-qualified identities for repeated Markdown headings. Generic graph deduplication later merges non-code nodes with the same normalized label and source path. The deduplication policy will distinguish positional content from entity content:
+
+- `document` and `rationale` nodes keep their extractor-assigned positional IDs
+- Exact or fuzzy label-based entity merging will not combine positional nodes
+- Literal duplicate records with the same canonical ID may still collapse
+- Parent-child section edges will continue to reference the preserved positional IDs
+- Concept and entity nodes will retain their existing deduplication behavior
+
+Positional nodes do not benefit from normalization sketches used for fuzzy entity matching. Skipping that work protects both identity and performance.
+
+Fixtures will include repeated headings at different lines, repeated rationale text, nested heading hierarchies, and literal duplicate records. The tests must prove that positional repeats survive while byte-identical records with one canonical ID do not multiply.
+
+## Cache invalidation
+
+Corrected extraction logic must not reuse graph fragments produced by older semantics. The implementation will advance the deterministic extraction fingerprint or cache namespace used by the manifest and AST cache.
+
+The cache test will:
+
+1. Build an index with the old fixture result represented in cache.
+2. Run an update using the new extractor version.
+3. Confirm that affected files are re-extracted.
+4. Run another update without changes.
+5. Confirm that the second update uses the warm path.
+
+The implementation plan will identify the concrete cache-version field after tracing the current manifest and cache-key flow.
+
+## Differential parity gate
+
+A deterministic comparison harness will normalize Compass and Graphify exports into comparable records. Graphify remains a test oracle and benchmark participant only. It will not become a runtime dependency.
+
+The harness will report:
+
+- Missing Graphify node IDs
+- Missing Graphify edges grouped by relation
+- Field mismatches for shared node IDs
+- Counts by source path, language, and node type
+- Compass-only nodes and edges as informational additions
+- The largest source-level gaps first
+
+Reports must include representative records, not only totals. This keeps failures actionable when aggregate counts happen to balance.
+
+The Podman parity workflow will run in stages:
+
+1. Execute focused unit and integration fixtures.
+2. Build fresh Compass and Graphify outputs from the same Podman commit.
+3. Apply the shared-input filter.
+4. Compare nodes and then edges.
+5. Group remaining failures by extractor and source file.
+6. Add a focused failing fixture before correcting each new extraction class.
+7. Repeat until both Graphify-missing sets are empty.
+
+The checked-in test suite should use compact fixtures and deterministic snapshots. The full Podman and Graphify comparison may remain an explicit release-validation command if its runtime is unsuitable for routine continuous integration.
+
+## Performance design
+
+Performance work will preserve the current incremental architecture and keep expensive compatibility logic outside the production indexing path.
+
+The main safeguards are:
+
+- Resolve declarators with bounded syntax-tree traversal
+- Skip entity-normalization and fuzzy-dedup work for positional nodes
+- Reuse parsed output for unchanged files after the one-time cache-version change
+- Stream or index parity records in the external comparison harness instead of adding runtime graph passes
+- Measure release binaries only
+
+The benchmark procedure will use one fixed Compass commit, one fixed Graphify commit, and one fixed Podman commit. It will record tool versions, commands, machine details, output counts, and elapsed wall time.
+
+For each tool:
+
+1. Remove only that tool's output directory.
+2. Run three cold builds.
+3. Recreate the same warm starting state for each warm sample.
+4. Run three no-source-change updates.
+5. Record every sample and compare medians.
+
+Compass passes when its median cold time is at most 32 seconds and its median warm time is at most 10 seconds. Query benchmarks will use the same completed indexes and identical semantic queries. Query results must first satisfy correctness checks, then report median latency over repeated runs.
+
+Graphify timing provides the comparison baseline. It does not relax the absolute Compass thresholds.
+
+## Error handling and diagnostics
+
+Unsupported or malformed files must not abort a repository-wide update. The extractor will attach the source path and parser context to recoverable diagnostics, skip only the unsupported construct, and continue processing the file when safe.
+
+The parity harness will exit unsuccessfully when Graphify nodes, Graphify edges, or shared-node fields are missing. Compass-only additions will not fail the run. Performance threshold failures will be reported separately from parity failures so a speed regression cannot hide a correctness result.
+
+## Test strategy
+
+Implementation will follow a red-green-refactor sequence:
+
+1. Add a focused failing test for one diagnosed behavior.
+2. Confirm that the failure reflects the intended contract.
+3. Make the smallest production change that passes it.
+4. Run the relevant crate tests.
+5. Refactor while keeping the focused test green.
+6. Run workspace checks and the Podman differential gate.
+
+Required verification includes:
+
+- C and C++ declarator unit tests
+- Markdown and rationale deduplication tests
+- Cache invalidation and warm-update tests
+- Deterministic parity-harness tests with known missing and extra records
+- Existing language extraction and graph tests
+- Workspace formatting, linting, and test commands
+- Fresh Podman Compass and Graphify output comparison
+- Three-sample cold, warm, and query benchmarks
+
+After code changes, `graphify update .` will refresh the repository knowledge graph as required by the project instructions.
+
+## Acceptance criteria
+
+The work is complete when all of these conditions hold:
+
+1. No Graphify node in the shared Podman input set is missing from Compass.
+2. No Graphify edge in the shared Podman input set is missing from Compass.
+3. Shared node IDs, labels, types, source paths, and available locations agree.
+4. Valid Compass-only Perl and extensionless-script facts remain present.
+5. SQLite C functions use callable identifiers rather than return types or macros.
+6. Repeated positional Markdown sections and rationale entries remain distinct.
+7. A semantic extractor change invalidates stale cache entries once, then returns to the warm path.
+8. The Compass release median is at most 32 seconds cold and 10 seconds warm across three runs each.
+9. Query comparisons return equivalent shared facts before latency is evaluated.
+10. Focused tests, workspace verification, and the refreshed Graphify knowledge graph complete successfully.
+
+## Out of scope
+
+This work will not force equal total node or edge counts, remove valid Compass-only language support, match derived community assignments, add Graphify to Compass runtime dependencies, or trade away correct extraction to reach a benchmark threshold.
+
+## Documentation plan
+
+The implementation will update contributor-facing extraction documentation with the parity contract, the local differential command, and the benchmark protocol. Release notes will describe corrected C and C++ names, preserved positional document sections, and any cache rebuild users should expect after upgrading.
+
+There are no unresolved product questions. Concrete module boundaries and command names will be finalized in the implementation plan after the written design is approved.

--- a/docs/superpowers/specs/2026-07-23-history-build-all-design.md
+++ b/docs/superpowers/specs/2026-07-23-history-build-all-design.md
@@ -1,0 +1,404 @@
+# Full-Ref Versioned History Build Design
+
+**Date:** 2026-07-23  
+**Status:** Approved for implementation planning
+
+## Summary
+
+Compass currently materializes one immutable graph realization per
+`compass history build` invocation. Users who want complete versioned graph
+history for a branch or tag must combine Compass with a shell loop over
+`git rev-list`.
+
+This feature makes that workflow a first-class Compass operation:
+
+```bash
+compass history build main --all
+```
+
+The command resolves the ref once, enumerates every reachable commit, and
+materializes a comparable graph history oldest-first. It resumes safely by
+skipping matching validated realizations, continues after individual commit
+failures, prints a final summary, and exits nonzero when any commit failed.
+
+## Goals
+
+- Build every commit reachable from a branch, tag, or commit ref with one
+  discoverable Compass command.
+- Include merged-branch commits by default.
+- Offer first-parent-only traversal for users who want the mainline.
+- Use one normalized build profile across the entire operation so adjacent
+  realizations remain comparable.
+- Process oldest-first to maximize compatible ancestor reuse.
+- Resume safely after interruption or failure.
+- Continue past per-commit failures and report every failure at the end.
+- Preserve Compass history's existing offline Git, validation, publication,
+  queue, lease, and storage guarantees.
+- Provide stable human-readable and JSON results.
+
+## Non-goals
+
+- Parallel materialization or a `--jobs` option.
+- Remote fetching or automatic shallow-history deepening.
+- Date, count, or path filters such as `--since` or `--max-count`.
+- Bulk `history rebuild`.
+- Background/detached bulk execution.
+- A new SQLite schema or realization format.
+- Changing the semantics of existing single-commit history builds.
+
+## CLI contract
+
+### Canonical forms
+
+```text
+compass history build <REF> --all [BUILD_PROFILE_OPTIONS] [OPTIONS]
+compass history build <REF> --all --first-parent [BUILD_PROFILE_OPTIONS] [OPTIONS]
+```
+
+Examples:
+
+```bash
+compass history build main --all
+compass history build v2.0.0 --all --first-parent
+compass history build release/2026.07 --all --code-only
+compass history build main --all --profile-from v2.0.0
+compass history build main --all --format=json
+```
+
+`--all` is valid only for `history build`. `--first-parent` requires `--all`.
+Both flags are singleton boolean options and reject inline values. Existing
+option ordering and `--` end-of-options behavior remain unchanged.
+
+All existing build-profile options apply to the complete batch. A user may
+select the profile with direct profile options or `--profile-from`, subject to
+the existing conflicts between those forms. When neither is present, Compass
+uses the stored repository profile when configured and otherwise resolves its
+normal default profile once.
+
+### Scope
+
+The default scope is every commit reachable from the resolved ref, including
+commits introduced through merges:
+
+```text
+git rev-list --reverse --topo-order <resolved-tip-sha>
+```
+
+`--first-parent` selects only the ref's first-parent lineage:
+
+```text
+git rev-list --reverse --topo-order --first-parent <resolved-tip-sha>
+```
+
+These commands describe ordering semantics; Compass invokes Git through its
+existing repository abstraction rather than a shell.
+
+The ref is resolved to a full commit ID before enumeration. Later movement of
+the branch or tag does not change the selected tip or commit set. Compass does
+not fetch missing history. A shallow repository therefore builds only commits
+available and reachable in that local repository.
+
+## Execution model
+
+### Preflight
+
+Before materializing any commit, Compass:
+
+1. discovers the repository;
+2. parses and validates all options;
+3. resolves the supplied ref to one immutable tip commit;
+4. resolves and validates one normalized build profile;
+5. enumerates the complete ordered commit set.
+
+An invalid ref, invalid profile, unsupported option combination, or enumeration
+failure exits `1` or `2` according to the existing Compass error taxonomy
+before any build is enqueued.
+
+### Sequential materialization
+
+Compass processes commits sequentially in the enumerated oldest-first order.
+For each commit:
+
+1. Open the existing history store and inspect its preferred realization.
+2. If the preferred realization validates and its stored normalized build
+   profile digest equals the batch profile digest, record the commit as
+   `skipped`.
+3. If no preferred realization exists, use the existing
+   `resolve_or_materialize` path and record a successful publication as
+   `built`.
+4. If a valid preferred realization exists with a different build profile,
+   run a new materialization with the batch profile and record a successful
+   publication as `rebuilt`.
+5. If inspection, materialization, validation, or publication fails, record
+   the commit as `failed` and continue to the next commit.
+
+The selected profile is immutable for the duration of the batch. Environment
+changes or repository configuration edits during execution do not alter later
+commits.
+
+Single-commit builds continue to use their current path. Batch orchestration
+must delegate each actual build to the same queue, lease, exact detached
+worktree, materializer, validator, and publisher used by single-commit builds.
+
+### Resume and interruption
+
+Every successful realization is published atomically before Compass proceeds
+to the next commit. An interrupted process leaves all prior publications
+valid. Re-running the same command selects the same profile and skips those
+matching validated realizations.
+
+If another Compass process is already materializing the same commit and
+profile, batch mode uses the existing join/lease behavior. It does not create
+a parallel materialization path.
+
+On an interrupt, Compass stops scheduling new commits, preserves all completed
+work, and exits with the platform-appropriate interrupted status. It does not
+emit a misleading successful summary.
+
+## Results and exit status
+
+### Text mode
+
+Progress is written to stderr so stdout remains suitable for the final result:
+
+```text
+Building 1,981 commits reachable from main (71f9cc9d)
+[1/1981] 0a41bc12 built
+[2/1981] 91c062f0 skipped
+[3/1981] af7300de failed: unsupported Git filter
+```
+
+The final stdout summary is:
+
+```text
+ref: main
+tip: 71f9cc9dc693080310181a2d011fb737420f7907
+scope: reachable
+profile: 52e0ef243c20b2a78e41bb36059dac1d61963b0b792d6c79a7ff0c12fd9b91b8
+total: 1981
+built: 320
+rebuilt: 4
+skipped: 1656
+failed: 1
+```
+
+When failures exist, deterministic commit/diagnostic lines follow the counts.
+Diagnostics use the existing bounded and redacted history diagnostic policy.
+
+### JSON mode
+
+`--format=json` writes progress to stderr and exactly one JSON object to
+stdout:
+
+```json
+{
+  "schema_version": 1,
+  "ref": "main",
+  "tip": "71f9cc9dc693080310181a2d011fb737420f7907",
+  "scope": "reachable",
+  "profile_digest": "52e0ef243c20b2a78e41bb36059dac1d61963b0b792d6c79a7ff0c12fd9b91b8",
+  "counts": {
+    "total": 1981,
+    "built": 320,
+    "rebuilt": 4,
+    "skipped": 1656,
+    "failed": 1
+  },
+  "results": [
+    {
+      "commit": "0a41bc12...",
+      "status": "built",
+      "realization": "..."
+    },
+    {
+      "commit": "91c062f0...",
+      "status": "skipped",
+      "realization": "..."
+    },
+    {
+      "commit": "af7300de...",
+      "status": "failed",
+      "diagnostic": "unsupported Git filter"
+    }
+  ]
+}
+```
+
+Results retain the same oldest-first commit order used for execution.
+Successful `built`, `rebuilt`, and `skipped` results contain the validated
+realization ID. Failed results contain a bounded diagnostic and no realization
+field.
+
+The command exits:
+
+- `0` when every commit is built, rebuilt, or skipped;
+- `1` when one or more individual commits fail or a runtime/preflight error
+  occurs;
+- `2` for command-line usage errors.
+
+A final stdout write failure returns `1`. Realizations already published
+before that failure remain valid.
+
+## Architecture
+
+### `compass-history`
+
+`Repository` gains an offline commit-enumeration method that accepts a resolved
+tip and a first-parent boolean. It invokes Git without a shell, rejects
+malformed output, accepts the repository's configured SHA-1 or SHA-256 object
+format, and returns `Vec<CommitId>` in parent-before-child order.
+
+This method owns Git traversal semantics so the CLI does not duplicate
+repository discovery, object-format, environment, or error-handling rules.
+
+### `compass-cli/history_build.rs`
+
+`ParsedBuildCommand` gains:
+
+```rust
+all: bool,
+first_parent: bool,
+```
+
+The parser enforces command and option conflicts. Existing profile resolution
+continues to produce one `HistoryBuildOptions`; batch execution reuses that
+resolved value rather than parsing or inspecting provider environment for each
+commit.
+
+### `compass-cli/history_batch.rs`
+
+A new focused module owns bulk orchestration and rendering. Its internal model
+is equivalent to:
+
+```rust
+struct BatchBuildResult {
+    reference: String,
+    tip: CommitId,
+    scope: BatchScope,
+    profile_digest: String,
+    results: Vec<CommitBuildResult>,
+}
+
+enum CommitBuildStatus {
+    Built,
+    Rebuilt,
+    Skipped,
+    Failed,
+}
+```
+
+The module receives the resolved repository, tip, ordered commits, and build
+options. It does not implement Git checkout, extraction, storage, or
+publication itself.
+
+### `compass-cli/history_commands.rs`
+
+`execute_build` dispatches to batch orchestration only when `parsed.all` is
+true. Existing single-commit behavior remains the default. Small shared
+helpers may become `pub(crate)` so both paths use identical profile lookup,
+materialization, and validation logic.
+
+### Help and documentation
+
+Update:
+
+- canonical CLI help and shell completions;
+- `docs/reference/commands.md`;
+- `docs/guides/versioned-history.md`;
+- the embedded Compass skill history reference;
+- the real-repository qualification documentation.
+
+The primary guide example becomes:
+
+```bash
+compass history build main --all --code-only
+```
+
+## Safety and consistency
+
+- Enumeration and materialization remain offline and never fetch.
+- Exact historical worktrees keep hooks, credentials, filters, LFS smudging,
+  and submodule recursion disabled under existing policy.
+- The command never enables eager history implicitly.
+- The batch profile contains no secrets and is resolved once.
+- Each publication remains atomic and independently valid.
+- A failed commit cannot publish an incomplete realization.
+- A profile-mismatched existing realization is never counted as resumable
+  success.
+- Concurrent preference changes use existing compare-and-swap behavior and
+  become per-commit failures rather than silent overwrites.
+- Bulk mode introduces no new database transaction spanning multiple commits;
+  that preserves resumability and avoids long-lived global locks.
+
+## Testing strategy
+
+### Repository traversal tests
+
+- A linear SHA-1 repository returns root-to-tip order.
+- A merge DAG includes merged-branch commits by default.
+- The same merge DAG excludes side-branch commits with `first_parent`.
+- SHA-256 repositories work when supported by installed Git.
+- Unknown commits, malformed Git output, and unavailable Git objects fail
+  without fetching.
+- A resolved tip remains stable if the named ref moves afterward.
+
+### Parser and help tests
+
+- `build main --all` and `build main --all --first-parent` parse.
+- `--first-parent` without `--all` is a usage error.
+- `rebuild main --all` is a usage error.
+- Duplicate or valued boolean flags are rejected.
+- Direct profile options and `--profile-from` retain existing conflicts.
+- A revision beginning with `-` works after `--`.
+- Help, completions, and examples expose the canonical command.
+
+### Batch integration tests
+
+- A linear repository builds every commit oldest-first.
+- A second identical run skips every commit.
+- Explicit and stored profiles apply uniformly to every realization.
+- Disabling eager history retains the profile for bulk builds.
+- A mismatched preferred profile causes a new comparable realization.
+- A middle commit that requires unavailable semantic credentials fails while
+  earlier and later code-only-corpus commits complete.
+- Per-commit failure produces a complete final summary and exit code `1`.
+- All-success and all-skipped runs exit `0`.
+- Text progress stays on stderr.
+- JSON stdout is one stable object with ordered results and exact counts.
+- Interrupt/restart leaves published commits resumable.
+- Existing single-commit build and rebuild tests remain unchanged and green.
+
+### Real-repository qualification
+
+Create a shallow disposable clone of
+`/Volumes/Workspace/Github/cocoindex` containing a small number of commits.
+Run:
+
+```bash
+compass history build HEAD --all --code-only --format=json
+```
+
+Verify:
+
+- every locally reachable commit has one matching validated preferred
+  realization;
+- a second run reports every commit as skipped;
+- reported totals match `git rev-list --count HEAD`;
+- adjacent diffs remain profile-compatible;
+- the original checkout is unchanged.
+
+## Acceptance criteria
+
+The feature is complete when:
+
+1. `compass history build <REF> --all` materializes every locally reachable
+   commit, including merge-side history.
+2. `--first-parent` restricts the set to the first-parent lineage.
+3. All commits use one selected normalized profile.
+4. Matching validated realizations are skipped on rerun.
+5. A per-commit failure does not stop later commits.
+6. Any per-commit failure makes the final exit code `1`.
+7. Text and JSON summaries report exact, internally consistent counts.
+8. Existing single-commit history behavior and storage formats do not change.
+9. Unit, integration, resume, merge-DAG, profile, output, and real-repository
+   qualification tests pass.

--- a/docs/superpowers/specs/2026-07-23-versioned-history-html-export-design.md
+++ b/docs/superpowers/specs/2026-07-23-versioned-history-html-export-design.md
@@ -1,0 +1,134 @@
+# Compass versioned-history HTML export
+
+## Purpose
+
+Compass will export an offline, self-contained time-travel viewer for every
+materialized commit in its immutable history store. A user opens one HTML file,
+selects a commit in a Git-style rail, and sees the complete code graph from that
+exact commit. The viewer requires neither the source repository nor a server.
+
+## Scope and command line
+
+Add an all-history export form:
+
+```text
+compass history export [--format html] --output PATH [--force]
+```
+
+`html` is the default format for this no-revision form. It exports one preferred,
+validated realization for every materialized commit. No revision positional is
+accepted in this form; the output is inherently a history-wide viewer.
+
+Retain the existing revision-specific forms without changing their meanings:
+
+```text
+compass history export REV --format graph-json --output PATH
+compass history export REV --format compass-out --output PATH
+```
+
+The CLI must report a clear usage error for ambiguous combinations, such as a
+revision with `--format html`, or no revision with a non-HTML format.
+
+## Export source and manifest
+
+The history store remains authoritative. The exporter enumerates all commits
+with a preferred materialized realization, validates each realization before
+reading its artifacts, then reconstructs its exact `GraphDocument`.
+
+Each commit appears once. If a commit has alternate realizations, the current
+preferred realization is exported; users can make a deliberate selection before
+exporting with `compass history prefer`. The initial release does not expose
+alternates in the viewer.
+
+Embed a versioned manifest containing:
+
+- repository display identity and export time;
+- exporter/viewer schema and renderer versions;
+- one entry per commit: full SHA, parent SHAs, subject, author, timestamp,
+  preferred realization ID, extraction fingerprint, and node/edge counts;
+- the embedded graph payload associated with each manifest entry; and
+- an integrity digest for each payload.
+
+Git metadata is display and navigation data. The embedded graph document is the
+only graph source used by the viewer. The exported document must preserve the
+full SHA and realization ID so its displayed selection is auditable.
+
+## Self-contained HTML
+
+The output is a single HTML file. It contains the viewer CSS and JavaScript,
+the commit manifest, all graph payloads, and the graph-rendering dependency.
+It makes no runtime HTTP requests. In particular, the current `vis-network`
+CDN dependency must be bundled inline or replaced by an equivalent local,
+licensed asset in the generated document.
+
+The exporter may use deterministic payload deduplication and compression, but
+only when the generated viewer can decode it without a network dependency. A
+browser that cannot decode the selected payload must show a clear local error;
+it must not load a different revision or fetch a substitute.
+
+Writes are staged beside the target and atomically published only after the
+entire document is generated. The output path must not already exist; `--force`
+only confirms a large export and never authorizes overwriting a prior bundle.
+
+## Viewer interaction
+
+The viewer is a three-pane layout:
+
+1. **Commit rail.** A searchable, filterable Git-style list shows commit SHA,
+   subject, author/date, merge-parent count, and concise graph-change counts.
+   The initial selection is the newest exported commit.
+2. **Graph canvas.** Selecting a commit replaces the canvas with that commit's
+   complete graph. Graph search, zoom, layout, filters, and node inspection are
+   local viewer state and stay usable after a commit selection where possible.
+3. **Inspector.** It shows the selected commit's exact identity, realization
+   identity, parents, metadata, graph statistics, and an optional graph-change
+   summary.
+
+The primary view is always the complete graph at the selected commit. A
+secondary `Compare with parent` control opens comparison with a user-chosen
+parent for merge commits; it never replaces the full-graph default.
+
+Commit selection updates the document title and URL fragment to
+`#commit=<full-sha>`. Opening that fragment, and browser back/forward, restores
+the corresponding commit selection. Invalid or unavailable fragments fall back
+to the newest exported commit and surface a non-blocking message.
+
+## Size, failures, and privacy
+
+Before writing, Compass calculates and reports the estimated output size. When
+it exceeds a documented safety threshold, the command requires `--force` to
+continue. This check protects users from unexpectedly creating very large
+history bundles without preventing intentional exports.
+
+The command fails before publishing if history is unavailable, no preferred
+realizations exist, a selected realization cannot be validated, Git metadata
+cannot be resolved, the output path is unsafe, or the output cannot be written.
+No partial destination may remain after failure.
+
+At runtime, a corrupted embedded record results in a clear commit-local viewer
+error. Other valid commits stay selectable. The viewer does not contact the
+network, send telemetry, or infer data from the local checkout.
+
+## Verification
+
+Tests must cover:
+
+- command parsing, including the HTML default and compatibility of the existing
+  revision-specific formats;
+- inclusion of every and only preferred materialized commit, in deterministic
+  order, with exact SHA and realization provenance;
+- validation failure and atomic cleanup before publication;
+- self-contained output with no external script, stylesheet, data, or network
+  reference;
+- selection of a commit rendering its exact embedded graph;
+- fragment selection and browser history restoration;
+- optional comparison behavior for ordinary and merge commits;
+- corrupt payload isolation in the viewer; and
+- size warning/`--force` behavior.
+
+## Non-goals
+
+- Exporting alternate realizations in the first viewer release.
+- Materializing Git commits during export.
+- Replacing the existing `graph-json` or `compass-out` revision export forms.
+- Hosting the viewer or introducing a server/API requirement.

--- a/docs/superpowers/specs/2026-07-23-versioned-history-html-export-design.md
+++ b/docs/superpowers/specs/2026-07-23-versioned-history-html-export-design.md
@@ -12,12 +12,13 @@ exact commit. The viewer requires neither the source repository nor a server.
 Add an all-history export form:
 
 ```text
-compass history export [--format html] --output PATH [--force]
+compass history export [--format html] --output PATH [--title NAME] [--force]
 ```
 
 `html` is the default format for this no-revision form. It exports one preferred,
 validated realization for every materialized commit. No revision positional is
-accepted in this form; the output is inherently a history-wide viewer.
+accepted in this form; the output is inherently a history-wide viewer. `--title`
+sets the shareable display title without exposing the absolute local path.
 
 Retain the existing revision-specific forms without changing their meanings:
 
@@ -52,19 +53,28 @@ Embed a versioned manifest containing:
 Git metadata is display and navigation data. The embedded graph document is the
 only graph source used by the viewer. The exported document must preserve the
 full SHA and realization ID so its displayed selection is auditable.
+History may retain a realization after Git history is rewritten and its commit
+object becomes unavailable. That entry must still export using stored SHA,
+parents, realization metadata, and graph data; subject, author, and timestamp
+are explicitly labeled unavailable rather than failing the whole export.
+Timeline ordering follows the stored parent DAG, not SHA order. Materialized
+`HEAD` is the default; otherwise use its nearest materialized first-parent
+ancestor, then a deterministic newest leaf.
 
 ## Self-contained HTML
 
 The output is a single HTML file. It contains the viewer CSS and JavaScript,
-the commit manifest, all graph payloads, and the graph-rendering dependency.
+the commit manifest, independently compressed per-commit graph payloads, and
+the graph-rendering/decompression dependencies.
 It makes no runtime HTTP requests. In particular, the current `vis-network`
 CDN dependency must be bundled inline or replaced by an equivalent local,
 licensed asset in the generated document.
 
-The exporter may use deterministic payload deduplication and compression, but
-only when the generated viewer can decode it without a network dependency. A
-browser that cannot decode the selected payload must show a clear local error;
-it must not load a different revision or fetch a substitute.
+The viewer lazily verifies, decompresses, and parses only the selected payload,
+then retains at most three decoded graphs. A browser that cannot decode the
+selected payload must show a clear commit-local error; it must not load a
+different revision or fetch a substitute. A strict Content Security Policy
+enforces the offline boundary.
 
 Writes are staged beside the target and atomically published only after the
 entire document is generated. The output path must not already exist; `--force`
@@ -76,38 +86,52 @@ The viewer is a three-pane layout:
 
 1. **Commit rail.** A searchable, filterable Git-style list shows commit SHA,
    subject, author/date, merge-parent count, and concise graph-change counts.
-   The initial selection is the newest exported commit.
+   It visualizes parent/merge lanes and retained disconnected histories. The
+   initial selection follows the `HEAD` fallback rule above.
 2. **Graph canvas.** Selecting a commit replaces the canvas with that commit's
    complete graph. Graph search, zoom, layout, filters, and node inspection are
    local viewer state and stay usable after a commit selection where possible.
+   Shared node IDs retain positions and selection across commits. Graphs above
+   5,000 nodes open in community overview mode while keeping the exact graph
+   embedded and searchable.
 3. **Inspector.** It shows the selected commit's exact identity, realization
    identity, parents, metadata, graph statistics, and an optional graph-change
    summary.
 
 The primary view is always the complete graph at the selected commit. A
 secondary `Compare with parent` control opens comparison with a user-chosen
-parent for merge commits; it never replaces the full-graph default.
+parent for merge commits; it never replaces the full-graph default. Comparison
+uses Compass topology diff semantics and is disabled with an explanation when
+the parent is absent or extraction profiles are not comparable.
 
 Commit selection updates the document title and URL fragment to
 `#commit=<full-sha>`. Opening that fragment, and browser back/forward, restores
 the corresponding commit selection. Invalid or unavailable fragments fall back
-to the newest exported commit and surface a non-blocking message.
+to the manifest's default commit and surface a non-blocking message.
 
 ## Size, failures, and privacy
 
-Before writing, Compass calculates and reports the estimated output size. When
-it exceeds a documented safety threshold, the command requires `--force` to
-continue. This check protects users from unexpectedly creating very large
-history bundles without preventing intentional exports.
+Compass streams into a staged file so it never retains every graph or a second
+copy of the full HTML in memory. When exact staged size exceeds 256 MiB, the
+command requires `--force` to publish. Dropping an unconfirmed stage removes it.
+Publication is atomic and no-clobber even if another process creates the target
+during export.
 
 The command fails before publishing if history is unavailable, no preferred
-realizations exist, a selected realization cannot be validated, Git metadata
-cannot be resolved, the output path is unsafe, or the output cannot be written.
+realizations exist, a selected realization cannot be validated, the output
+path is unsafe, or the output cannot be written. Missing optional Git
+presentation metadata is not a failure.
 No partial destination may remain after failure.
 
 At runtime, a corrupted embedded record results in a clear commit-local viewer
 error. Other valid commits stay selectable. The viewer does not contact the
-network, send telemetry, or infer data from the local checkout.
+network, send telemetry, infer data from the local checkout, or embed the
+absolute local repository path.
+
+The commit rail, graph controls, and inspector meet WCAG 2.2 AA, work at
+320 CSS pixels, expose keyboard navigation and live loading/error status, use
+44-by-44-pixel touch targets, honor reduced-motion preferences, use shared
+design tokens, and support accessible light/dark themes without a network font.
 
 ## Verification
 
@@ -117,14 +141,20 @@ Tests must cover:
   revision-specific formats;
 - inclusion of every and only preferred materialized commit, in deterministic
   order, with exact SHA and realization provenance;
+- parent-DAG ordering, merge lanes, `HEAD` fallback, and rewritten-history
+  metadata fallback;
 - validation failure and atomic cleanup before publication;
 - self-contained output with no external script, stylesheet, data, or network
-  reference;
+  reference, enforced by CSP;
+- independent compressed payload round-trips, lazy decode, integrity checks,
+  corrupt-commit isolation, and the three-snapshot cache bound;
 - selection of a commit rendering its exact embedded graph;
+- stable node layout/selection across adjacent commits and large-graph overview;
 - fragment selection and browser history restoration;
-- optional comparison behavior for ordinary and merge commits;
-- corrupt payload isolation in the viewer; and
-- size warning/`--force` behavior.
+- optional comparison behavior for ordinary, merge, absent-parent, and
+  profile-incompatible commits;
+- keyboard, responsive, reduced-motion, and WCAG AA behavior in a real browser;
+- exact size warning/`--force`, no-clobber race, and staging cleanup behavior.
 
 ## Non-goals
 

--- a/scripts/qualify_graphify_superset.sh
+++ b/scripts/qualify_graphify_superset.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+compass_repo=$(cd "$script_dir/.." && pwd -P)
+podman_input=${PODMAN_ROOT:-/Volumes/Workspace/Github/podman}
+if [[ ! -d "$podman_input" ]]; then
+  echo "error: Podman root does not exist: $podman_input" >&2
+  exit 2
+fi
+podman_root=$(cd "$podman_input" && pwd -P)
+user_home=$(cd && pwd -P)
+if [[ -z "$podman_root" || "$podman_root" == "/" || "$podman_root" == "$user_home" ]]; then
+  echo "error: unsafe Podman root: $podman_root" >&2
+  exit 2
+fi
+if [[ ! -d "$podman_root/.git" ]]; then
+  echo "error: Podman root is not a Git checkout: $podman_root" >&2
+  exit 2
+fi
+
+compass_bin=${COMPASS_BIN:-"$compass_repo/target/release/compass"}
+graphify_python=${GRAPHIFY_PYTHON:-/Users/haipingfu/graphify/.venv/bin/python}
+parity_samples=${PARITY_SAMPLES:-3}
+query_samples=${QUERY_SAMPLES:-5}
+query_text=${PARITY_QUERY:-update}
+compass_output="$podman_root/compass-out"
+graphify_output="$podman_root/graphify-out"
+results_dir=$(mktemp -d "${TMPDIR:-/tmp}/compass-graphify-parity.XXXXXX")
+timings="$results_dir/timings.tsv"
+
+for count in "$parity_samples" "$query_samples"; do
+  if [[ ! "$count" =~ ^[1-9][0-9]*$ ]] || ((count % 2 == 0)); then
+    echo "error: sample counts must be positive odd integers" >&2
+    exit 2
+  fi
+done
+if [[ ! -x "$graphify_python" ]]; then
+  echo "error: Graphify Python is not executable: $graphify_python" >&2
+  exit 2
+fi
+
+reset_output() {
+  local target=$1
+  if [[ "$target" != "$compass_output" && "$target" != "$graphify_output" ]]; then
+    echo "error: refusing to reset unexpected output: $target" >&2
+    exit 2
+  fi
+  if [[ "$(dirname "$target")" != "$podman_root" ]]; then
+    echo "error: refusing to reset output outside Podman: $target" >&2
+    exit 2
+  fi
+  if [[ -e "$target" ]]; then
+    rm -rf -- "$target"
+  fi
+}
+
+graph_counts() {
+  local graph=$1
+  "$graphify_python" - "$graph" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(f"{len(data.get('nodes', []))}\t{len(data.get('links', data.get('edges', [])))}")
+PY
+}
+
+measure() {
+  local tool=$1
+  local operation=$2
+  local sample=$3
+  local graph=$4
+  shift 4
+  local label="${tool}-${operation}-${sample}"
+  local stdout_file="$results_dir/$label.stdout"
+  local stderr_file="$results_dir/$label.stderr"
+
+  if ! (
+    cd "$podman_root"
+    /usr/bin/time -p "$@"
+  ) >"$stdout_file" 2>"$stderr_file"; then
+    cat "$stderr_file" >&2
+    echo "error: $tool $operation sample $sample failed" >&2
+    exit 1
+  fi
+  local seconds
+  seconds=$(awk '$1 == "real" { value=$2 } END { print value }' "$stderr_file")
+  if [[ -z "$seconds" ]]; then
+    echo "error: no elapsed time recorded for $label" >&2
+    exit 1
+  fi
+  local nodes edges
+  IFS=$'\t' read -r nodes edges < <(graph_counts "$graph")
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$tool" "$operation" "$sample" "$seconds" "$nodes" "$edges" >>"$timings"
+  echo "$tool $operation $sample: ${seconds}s, $nodes nodes, $edges edges"
+}
+
+median() {
+  local tool=$1
+  local operation=$2
+  local count=$3
+  local middle=$((count / 2 + 1))
+  awk -F $'\t' -v tool="$tool" -v operation="$operation" \
+    '$1 == tool && $2 == operation { print $4 }' "$timings" |
+    LC_ALL=C sort -n |
+    sed -n "${middle}p"
+}
+
+assert_at_most() {
+  local label=$1
+  local value=$2
+  local maximum=$3
+  if ! awk -v value="$value" -v maximum="$maximum" \
+    'BEGIN { exit(value <= maximum ? 0 : 1) }'; then
+    echo "error: $label median ${value}s exceeds ${maximum}s" >&2
+    exit 1
+  fi
+}
+
+normalize_query() {
+  local input=$1
+  local output=$2
+  awk '/^(NODE|EDGE) / { print }' "$input" | LC_ALL=C sort -u >"$output"
+}
+
+printf 'tool\toperation\tsample\tseconds\tnodes\tedges\n' >"$timings"
+
+echo "Building release Compass and parity comparator"
+(cd "$compass_repo" && cargo build --release -p compass-cli)
+(cd "$compass_repo" && cargo build --release -p compass-parity --bin compare-graphs)
+if [[ ! -x "$compass_bin" ]]; then
+  echo "error: Compass binary is not executable: $compass_bin" >&2
+  exit 2
+fi
+comparator="$compass_repo/target/release/compare-graphs"
+
+for sample in $(seq 1 "$parity_samples"); do
+  reset_output "$compass_output"
+  measure compass cold "$sample" "$compass_output/graph.json" \
+    env COMPASS_OUT=compass-out "$compass_bin" update .
+done
+for sample in $(seq 1 "$parity_samples"); do
+  measure compass warm "$sample" "$compass_output/graph.json" \
+    env COMPASS_OUT=compass-out "$compass_bin" update .
+done
+
+for sample in $(seq 1 "$parity_samples"); do
+  reset_output "$graphify_output"
+  measure graphify cold "$sample" "$graphify_output/graph.json" \
+    env GRAPHIFY_OUT=graphify-out "$graphify_python" -m graphify update .
+done
+for sample in $(seq 1 "$parity_samples"); do
+  measure graphify warm "$sample" "$graphify_output/graph.json" \
+    env GRAPHIFY_OUT=graphify-out "$graphify_python" -m graphify update .
+done
+
+echo "Checking graph superset parity"
+"$comparator" "$compass_output/graph.json" "$graphify_output/graph.json" |
+  tee "$results_dir/parity.txt"
+
+for sample in $(seq 1 "$query_samples"); do
+  measure compass query "$sample" "$compass_output/graph.json" \
+    "$compass_bin" query "$query_text" --graph "$compass_output/graph.json"
+  measure graphify query "$sample" "$graphify_output/graph.json" \
+    "$graphify_python" -m graphify query "$query_text" --graph "$graphify_output/graph.json"
+done
+
+normalize_query "$results_dir/compass-query-${query_samples}.stdout" \
+  "$results_dir/compass-query.normalized"
+normalize_query "$results_dir/graphify-query-${query_samples}.stdout" \
+  "$results_dir/graphify-query.normalized"
+comm -23 \
+  "$results_dir/graphify-query.normalized" \
+  "$results_dir/compass-query.normalized" >"$results_dir/query-missing.txt"
+if [[ -s "$results_dir/query-missing.txt" ]]; then
+  echo "error: Compass query is missing Graphify result rows" >&2
+  sed -n '1,50p' "$results_dir/query-missing.txt" >&2
+  exit 1
+fi
+
+compass_cold=$(median compass cold "$parity_samples")
+compass_warm=$(median compass warm "$parity_samples")
+graphify_cold=$(median graphify cold "$parity_samples")
+graphify_warm=$(median graphify warm "$parity_samples")
+compass_query=$(median compass query "$query_samples")
+graphify_query=$(median graphify query "$query_samples")
+
+assert_at_most "Compass cold" "$compass_cold" 32
+assert_at_most "Compass warm" "$compass_warm" 10
+
+{
+  echo "Compass cold median: ${compass_cold}s"
+  echo "Compass warm median: ${compass_warm}s"
+  echo "Graphify cold median: ${graphify_cold}s"
+  echo "Graphify warm median: ${graphify_warm}s"
+  echo "Compass query median: ${compass_query}s"
+  echo "Graphify query median: ${graphify_query}s"
+  echo "Query result inclusion: pass"
+} | tee "$results_dir/summary.txt"
+
+echo "Qualification evidence: $results_dir"

--- a/scripts/qualify_graphify_superset.sh
+++ b/scripts/qualify_graphify_superset.sh
@@ -55,6 +55,12 @@ reset_output() {
   fi
 }
 
+prepare_graphify_output() {
+  mkdir -p "$graphify_output"
+  printf '%s\n' '{"excludes":["/compass-out/"]}' \
+    >"$graphify_output/.graphify_build.json"
+}
+
 graph_counts() {
   local graph=$1
   "$graphify_python" - "$graph" <<'PY'
@@ -123,7 +129,12 @@ assert_at_most() {
 normalize_query() {
   local input=$1
   local output=$2
-  awk '/^(NODE|EDGE) / { print }' "$input" | LC_ALL=C sort -u >"$output"
+  # Community labels may differ when Compass adds superset-only topology, and
+  # edge rows compete for the shared token budget after all result nodes are
+  # printed. Compare stable node identity here; the full graph comparator above
+  # already proves exact Graphify node attributes and edge inclusion.
+  sed -n 's/^NODE \(.*\) community=[^]]*]$/NODE \1]/p' "$input" |
+    LC_ALL=C sort -u >"$output"
 }
 
 printf 'tool\toperation\tsample\tseconds\tnodes\tedges\n' >"$timings"
@@ -149,6 +160,7 @@ done
 
 for sample in $(seq 1 "$parity_samples"); do
   reset_output "$graphify_output"
+  prepare_graphify_output
   measure graphify cold "$sample" "$graphify_output/graph.json" \
     env GRAPHIFY_OUT=graphify-out "$graphify_python" -m graphify update .
 done
@@ -198,7 +210,7 @@ assert_at_most "Compass warm" "$compass_warm" 10
   echo "Graphify warm median: ${graphify_warm}s"
   echo "Compass query median: ${compass_query}s"
   echo "Graphify query median: ${graphify_query}s"
-  echo "Query result inclusion: pass"
+  echo "Query node inclusion: pass"
 } | tee "$results_dir/summary.txt"
 
 echo "Qualification evidence: $results_dir"


### PR DESCRIPTION
## Summary

- Preserve distinct extraction identities, edge relations, and directions while improving cross-file and language-specific resolution.
- Add a machine-checkable Graphify-superset comparator and production qualification workflow.
- Enrich the Compass-only offline HTML explorer with stable layout controls, rich symbol hover/pinned inspection, readable signatures and source locations, named communities, and community-to-symbol drill-down.
- Retain repository history build profiles during explicit and lazy materialization, add incremental output-stat caching, and document the full-ref history/export design and audit findings.

## Why

Compass needs to remain a strict Graphify extraction superset while making large offline graphs practical to inspect. Previously, some identities and parallel/opposite-direction relations could collapse, Python parity fixtures treated Compass-only metadata as mismatches, and large community views exposed numeric placeholders instead of useful navigation context.

## User impact

Users can inspect symbol kind, language, file, line range, parameters/signature, and named communities directly in Compass HTML exports. Large graphs remain navigable through pinned inspection and community drill-down without changing the Graphify HTML export experience.

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/qualify_graphify_superset.sh`
- `cargo test -p compass-cli -p compass-core -p compass-graph -p compass-languages -p compass-resolve`
- Post-rebase smoke checks: Compass extract/update parity suites plus all `compass-languages` and `compass-output` tests
- `graphify update .`
- Release-build verification against the CocoIndex repository: 17,814 nodes, 40,432 edges, 844 named communities, and 9,615 signatures in a 24 MB offline HTML export; search, drill-down, pinned inspection, and browser console were verified without errors

## Scope note

The richer visualization is intentionally limited to Compass export HTML. Generated graph/runtime directories are not included in this PR.