### PR TITLE
chore(release): bump Compass to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-ir",
  "serde",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-model",
  "glob",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-analysis",
  "compass-files",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-model",
  "regex",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "md-5 0.10.6",
  "rayon",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "axum",
  "compass-core",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-cypher",
  "compass-files",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "compass-parity"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-cli",
  "compass-core",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-model",
  "regex",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -27,27 +27,27 @@ serde_json.workspace = true
 tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.2" }
-compass-analysis = { path = "../compass-analysis", version = "0.1.2" }
-compass-ir = { path = "../compass-ir", version = "0.1.2" }
-compass-program = { path = "../compass-program", version = "0.1.2" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.2" }
-compass-cargo = { path = "../compass-cargo", version = "0.1.2" }
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-graph = { path = "../compass-graph", version = "0.1.2" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.2" }
-compass-global = { path = "../compass-global", version = "0.1.2" }
-compass-history = { path = "../compass-history", version = "0.1.2" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.2" }
-compass-ingest = { path = "../compass-ingest", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
-compass-mcp = { path = "../compass-mcp", version = "0.1.2" }
-compass-output = { path = "../compass-output", version = "0.1.2" }
-compass-postgres = { path = "../compass-postgres", version = "0.1.2" }
-compass-prs = { path = "../compass-prs", version = "0.1.2" }
-compass-query = { path = "../compass-query", version = "0.1.2" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.2" }
-compass-semantic = { path = "../compass-semantic", version = "0.1.2" }
+compass-core = { path = "../compass-core", version = "0.1.3" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
+compass-ir = { path = "../compass-ir", version = "0.1.3" }
+compass-program = { path = "../compass-program", version = "0.1.3" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
+compass-cargo = { path = "../compass-cargo", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-graph = { path = "../compass-graph", version = "0.1.3" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.3" }
+compass-global = { path = "../compass-global", version = "0.1.3" }
+compass-history = { path = "../compass-history", version = "0.1.3" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.3" }
+compass-ingest = { path = "../compass-ingest", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-mcp = { path = "../compass-mcp", version = "0.1.3" }
+compass-output = { path = "../compass-output", version = "0.1.3" }
+compass-postgres = { path = "../compass-postgres", version = "0.1.3" }
+compass-prs = { path = "../compass-prs", version = "0.1.3" }
+compass-query = { path = "../compass-query", version = "0.1.3" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.3" }
+compass-semantic = { path = "../compass-semantic", version = "0.1.3" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.1.2" }
-compass-ir = { path = "../compass-ir", version = "0.1.2" }
-compass-program = { path = "../compass-program", version = "0.1.2" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
+compass-ir = { path = "../compass-ir", version = "0.1.3" }
+compass-program = { path = "../compass-program", version = "0.1.3" }
 rayon.workspace = true
 notify.workspace = true
 num_cpus.workspace = true
@@ -23,15 +23,15 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.2" }
-compass-languages = { path = "../compass-languages", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
-compass-graph = { path = "../compass-graph", version = "0.1.2" }
-compass-history = { path = "../compass-history", version = "0.1.2" }
-compass-output = { path = "../compass-output", version = "0.1.2" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.2" }
-compass-resolve = { path = "../compass-resolve", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.3" }
+compass-languages = { path = "../compass-languages", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-graph = { path = "../compass-graph", version = "0.1.3" }
+compass-history = { path = "../compass-history", version = "0.1.3" }
+compass-output = { path = "../compass-output", version = "0.1.3" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.3" }
+compass-resolve = { path = "../compass-resolve", version = "0.1.3" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.1.2" }
+compass-media = { path = "../compass-media", version = "0.1.3" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -18,8 +18,8 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-languages = { path = "../compass-languages", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -20,10 +20,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-analysis = { path = "../compass-analysis", version = "0.1.2" }
-compass-ir = { path = "../compass-ir", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
+compass-ir = { path = "../compass-ir", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-transcribe = { path = "../compass-transcribe", version = "0.1.2", default-features = false }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-transcribe = { path = "../compass-transcribe", version = "0.1.3", default-features = false }
 ureq.workspace = true
 url.workspace = true
 

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.1.2" }
-compass-program = { path = "../compass-program", version = "0.1.2" }
+compass-ir = { path = "../compass-ir", version = "0.1.3" }
+compass-program = { path = "../compass-program", version = "0.1.3" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -24,8 +24,8 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-language-pack.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,11 +19,11 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.2" }
-compass-graph = { path = "../compass-graph", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
-compass-prs = { path = "../compass-prs", version = "0.1.2" }
-compass-query = { path = "../compass-query", version = "0.1.2" }
+compass-core = { path = "../compass-core", version = "0.1.3" }
+compass-graph = { path = "../compass-graph", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-prs = { path = "../compass-prs", version = "0.1.3" }
+compass-query = { path = "../compass-query", version = "0.1.3" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -18,11 +18,11 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.2" }
-compass-graph = { path = "../compass-graph", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
-compass-query = { path = "../compass-query", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
+compass-graph = { path = "../compass-graph", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-query = { path = "../compass-query", version = "0.1.3" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-parity/Cargo.toml
+++ b/crates/compass-parity/Cargo.toml
@@ -18,20 +18,20 @@ serde_json.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 time.workspace = true
-compass-cli = { version = "0.1.2", path = "../compass-cli" }
-compass-core = { version = "0.1.2", path = "../compass-core" }
-compass-files = { version = "0.1.2", path = "../compass-files" }
-compass-graph = { version = "0.1.2", path = "../compass-graph" }
-compass-languages = { version = "0.1.2", path = "../compass-languages" }
-compass-media = { version = "0.1.2", path = "../compass-media" }
-compass-mcp = { version = "0.1.2", path = "../compass-mcp" }
-compass-model = { version = "0.1.2", path = "../compass-model" }
-compass-output = { version = "0.1.2", path = "../compass-output" }
-compass-query = { version = "0.1.2", path = "../compass-query" }
-compass-reflect = { version = "0.1.2", path = "../compass-reflect" }
-compass-resolve = { version = "0.1.2", path = "../compass-resolve" }
-compass-semantic = { version = "0.1.2", path = "../compass-semantic" }
-compass-transcribe = { version = "0.1.2", path = "../compass-transcribe" }
+compass-cli = { version = "0.1.3", path = "../compass-cli" }
+compass-core = { version = "0.1.3", path = "../compass-core" }
+compass-files = { version = "0.1.3", path = "../compass-files" }
+compass-graph = { version = "0.1.3", path = "../compass-graph" }
+compass-languages = { version = "0.1.3", path = "../compass-languages" }
+compass-media = { version = "0.1.3", path = "../compass-media" }
+compass-mcp = { version = "0.1.3", path = "../compass-mcp" }
+compass-model = { version = "0.1.3", path = "../compass-model" }
+compass-output = { version = "0.1.3", path = "../compass-output" }
+compass-query = { version = "0.1.3", path = "../compass-query" }
+compass-reflect = { version = "0.1.3", path = "../compass-reflect" }
+compass-resolve = { version = "0.1.3", path = "../compass-resolve" }
+compass-semantic = { version = "0.1.3", path = "../compass-semantic" }
+compass-transcribe = { version = "0.1.3", path = "../compass-transcribe" }
 
 [lints]
 workspace = true

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.2" }
+compass-languages = { path = "../compass-languages", version = "0.1.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,7 +16,7 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -16,12 +16,12 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.2" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.3" }
 
 [lints]
 workspace = true

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -16,8 +16,8 @@ rayon.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.2" }
-compass-model = { path = "../compass-model", version = "0.1.2" }
+compass-languages = { path = "../compass-languages", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.3" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.2" }
-compass-media = { path = "../compass-media", version = "0.1.2" }
+compass-files = { path = "../compass-files", version = "0.1.3" }
+compass-media = { path = "../compass-media", version = "0.1.3" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -27,7 +27,7 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-whisper = { version = "0.1.2", path = "../compass-whisper", optional = true }
+compass-whisper = { version = "0.1.3", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- bump the Compass workspace and internal path dependencies to 0.1.3
- refresh Cargo.lock for the patch release
- prepare macOS arm64 and x86_64 release artifacts

## Validation
- `cargo check -p compass-cli --bin compass`
- `sh scripts/test_release_scripts.sh`
- `cargo test --locked -p compass-cli --test compass_product`
- release builds for `aarch64-apple-darwin` and `x86_64-apple-darwin`
- both binaries report `compass 0.1.3`; both checksums verify

## Existing baseline issue
The parity suite already fails on `origin/main` against the CI-pinned Graphify `v8` oracle because Compass emits newer node metadata fields. This version-only change does not modify that behavior.