### PR TITLE
Promote parallel-edge history graphs to schema v2

### DIFF
--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -7,8 +7,8 @@ use std::thread;
 use compass_core::{CompleteGraphBuilder, MaterializeError};
 use compass_files::{DetectOptions, IgnorePolicy, Manifest, detect};
 use compass_history::{
-    BuildProfile, CompletedGraphArtifacts, CompletionEvidence, GraphArtifacts, HistoryError,
-    MAX_DIAGNOSTIC_BYTES,
+    BuildProfile, CompletedGraphArtifacts, CompletionEvidence, GraphArtifacts,
+    HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
 };
 
 #[derive(Clone, Debug)]
@@ -43,7 +43,7 @@ impl HistoryBuildOptions {
     }
 
     pub(crate) fn from_profile(mut profile: BuildProfile) -> Result<Self, HistoryError> {
-        upgrade_legacy_program_profile(&mut profile)?;
+        upgrade_persisted_profile(&mut profile)?;
         validate_persisted_profile(&profile)?;
         let gitignore = profile.value("gitignore") != Some("false");
         let excludes = profile
@@ -136,7 +136,7 @@ impl HistoryBuildOptions {
         let mut profile = BuildProfile::default();
         for (key, value) in [
             ("compass_version", env!("CARGO_PKG_VERSION").to_owned()),
-            ("graph_schema", "networkx-node-link/v1".to_owned()),
+            ("graph_schema", HISTORY_GRAPH_SCHEMA.to_owned()),
             ("extractor_version", "compass-languages/v1".to_owned()),
             ("resolver_version", "compass-resolve/v1".to_owned()),
             ("pipeline_version", "compass-core/v1".to_owned()),
@@ -280,7 +280,10 @@ impl HistoryBuildOptions {
     }
 }
 
-fn upgrade_legacy_program_profile(profile: &mut BuildProfile) -> Result<(), HistoryError> {
+fn upgrade_persisted_profile(profile: &mut BuildProfile) -> Result<(), HistoryError> {
+    if profile.value("graph_schema") == Some("networkx-node-link/v1") {
+        profile.insert("graph_schema", HISTORY_GRAPH_SCHEMA)?;
+    }
     for (key, value) in [
         (
             "program_provider_policy",
@@ -352,7 +355,7 @@ fn validate_persisted_profile(profile: &BuildProfile) -> Result<(), HistoryError
     }
     for (key, expected) in [
         ("compass_version", env!("CARGO_PKG_VERSION")),
-        ("graph_schema", "networkx-node-link/v1"),
+        ("graph_schema", HISTORY_GRAPH_SCHEMA),
         ("extractor_version", "compass-languages/v1"),
         ("resolver_version", "compass-resolve/v1"),
         ("pipeline_version", "compass-core/v1"),
@@ -1091,6 +1094,10 @@ mod tests {
         assert_eq!(parsed.revision, "HEAD");
         assert_eq!(parsed.format, "json");
         assert_eq!(parsed.options.profile().value("token_budget"), Some("4096"));
+        assert_eq!(
+            parsed.options.profile().value("graph_schema"),
+            Some(HISTORY_GRAPH_SCHEMA)
+        );
         let inherited = parse_build_command(
             "build",
             &[
@@ -1145,6 +1152,24 @@ mod tests {
                 &["HEAD".to_owned(), "--replace-corrupt".to_owned()]
             )
             .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn persisted_v1_profile_is_migrated_to_force_v2_realization() -> Result<(), HistoryError> {
+        let mut profile =
+            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])
+                .map_err(HistoryError::InvalidFingerprint)?
+                .options
+                .profile();
+        profile.insert("graph_schema", "networkx-node-link/v1")?;
+
+        let options = HistoryBuildOptions::from_profile(profile)?;
+
+        assert_eq!(
+            options.profile().value("graph_schema"),
+            Some(HISTORY_GRAPH_SCHEMA)
         );
         Ok(())
     }

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use compass_files::{DetectOptions, IgnorePolicy, detect};
 use compass_history::{
     BuildProfile, CommitId, CompletedGraphArtifacts, CorruptPreferredToken, ExtractionFingerprint,
-    ExtractionFingerprintInput, GraphArtifacts, HistoryError, HistoryStore, PublishRequest,
-    PublishedVersion, RealizationId, Repository, WorktreeGuard,
+    ExtractionFingerprintInput, GraphArtifacts, HISTORY_GRAPH_SCHEMA, HistoryError, HistoryStore,
+    PublishRequest, PublishedVersion, RealizationId, Repository, WorktreeGuard,
 };
 use compass_languages::Registry;
 use sha2::{Digest, Sha256};
@@ -265,7 +265,7 @@ fn resolve_fingerprint(
     checkout: &Path,
 ) -> Result<ExtractionFingerprint, MaterializeError> {
     let mut input =
-        ExtractionFingerprintInput::new(env!("CARGO_PKG_VERSION"), "networkx-node-link/v1");
+        ExtractionFingerprintInput::new(env!("CARGO_PKG_VERSION"), HISTORY_GRAPH_SCHEMA);
     input.insert("definition_hash_version", "tree-sitter-ast/v1")?;
     input.insert("build_profile_digest", &hex(&profile.digest()?))?;
     input.insert(

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -17,7 +17,7 @@ pub use dedup::{
     deduplicate_entities_with_tiebreaker,
 };
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use compass_languages::{Extraction, file_stem, make_id, normalize_id};
@@ -185,9 +185,10 @@ pub fn build_from_extraction(
         graph.insert("hyperedges".to_owned(), Value::Array(hyperedges));
     }
     let links = networkx_edge_order(&nodes, &links, directed);
+    let multigraph = has_parallel_edges(&links, directed);
     GraphDocument {
         directed,
-        multigraph: false,
+        multigraph,
         graph,
         nodes,
         links,
@@ -674,6 +675,20 @@ fn edge_language_family(extension: &str) -> Option<&'static str> {
 
 fn edge_key(source: &str, target: &str, relation: &str) -> (String, String, String) {
     (source.to_owned(), target.to_owned(), relation.to_owned())
+}
+
+fn has_parallel_edges(links: &[EdgeRecord], directed: bool) -> bool {
+    let mut endpoints = HashSet::new();
+    links.iter().any(|edge| {
+        let source = edge.source.as_str();
+        let target = edge.target.as_str();
+        let key = if directed || source <= target {
+            (source, target)
+        } else {
+            (target, source)
+        };
+        !endpoints.insert(key)
+    })
 }
 
 fn canonical_hyperedges(

--- a/crates/compass-graph/tests/build_coverage.rs
+++ b/crates/compass-graph/tests/build_coverage.rs
@@ -146,6 +146,7 @@ fn networkx_edge_order_preserves_node_and_incident_edge_order() -> Result<(), Bo
     }))?;
 
     let undirected = build_from_extraction(&extraction, false, None);
+    assert!(!undirected.multigraph);
     assert_eq!(
         undirected
             .links
@@ -156,6 +157,7 @@ fn networkx_edge_order_preserves_node_and_incident_edge_order() -> Result<(), Bo
     );
 
     let directed = build_from_extraction(&extraction, true, None);
+    assert!(!directed.multigraph);
     assert_eq!(
         directed
             .links
@@ -181,6 +183,7 @@ fn distinct_relations_between_the_same_nodes_are_preserved() -> Result<(), Box<d
     }))?;
 
     let document = build_from_extraction(&extraction, false, None);
+    assert!(document.multigraph);
     let relations = document
         .links
         .iter()
@@ -205,6 +208,7 @@ fn opposite_direction_relations_are_preserved_in_undirected_documents() -> Resul
     }))?;
 
     let document = build_from_extraction(&extraction, false, None);
+    assert!(document.multigraph);
     let true_directions = document
         .links
         .iter()
@@ -219,5 +223,31 @@ fn opposite_direction_relations_are_preserved_in_undirected_documents() -> Resul
         true_directions,
         [(Some("a"), Some("b")), (Some("b"), Some("a"))]
     );
+    Ok(())
+}
+
+#[test]
+fn directed_reciprocals_and_self_loops_promote_only_for_parallel_endpoints()
+-> Result<(), Box<dyn Error>> {
+    let reciprocal: Extraction = serde_json::from_value(json!({
+        "nodes": [{"id":"a","label":"A"}, {"id":"b","label":"B"}],
+        "edges": [
+            {"source":"a","target":"b","relation":"calls"},
+            {"source":"b","target":"a","relation":"calls"},
+            {"source":"a","target":"a","relation":"references"}
+        ]
+    }))?;
+    let directed = build_from_extraction(&reciprocal, true, None);
+    assert!(!directed.multigraph);
+
+    let parallel_self_loops: Extraction = serde_json::from_value(json!({
+        "nodes": [{"id":"a","label":"A"}],
+        "edges": [
+            {"source":"a","target":"a","relation":"calls"},
+            {"source":"a","target":"a","relation":"references"}
+        ]
+    }))?;
+    let directed = build_from_extraction(&parallel_self_loops, true, None);
+    assert!(directed.multigraph);
     Ok(())
 }

--- a/crates/compass-history/src/lib.rs
+++ b/crates/compass-history/src/lib.rs
@@ -43,3 +43,6 @@ pub use validate::{
     MAX_AUTHORITATIVE_BYTES, MAX_DIAGNOSTIC_BYTES, MAX_JOB_BYTES, MAX_JSON_DEPTH, MAX_KEY_BYTES,
     MAX_RECORD_VALUE_BYTES, MAX_RECORDS_PER_TREE, ValidationProblem, ValidationReport,
 };
+
+/// Current node-link graph schema included in history build profiles and fingerprints.
+pub const HISTORY_GRAPH_SCHEMA: &str = "networkx-node-link/v2";

--- a/crates/compass-parity/src/lib.rs
+++ b/crates/compass-parity/src/lib.rs
@@ -1490,7 +1490,7 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
             serde_json::from_slice(&fs::read(rust_output.join("compass-out/graph.json"))?)?;
         let python: Value =
             serde_json::from_slice(&fs::read(python_output.join("graphify-out/graph.json"))?)?;
-        strip_definition_hashes(&mut rust);
+        normalize_compass_superset_metadata(&mut rust);
         assert_eq!(rust, python);
         Ok(())
     }
@@ -1550,7 +1550,7 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
                 .ok_or_else(|| format!("Python artifact missing: {python_artifact}"))?;
             if python_artifact.ends_with(".json") || python_artifact == "manifest.json" {
                 let mut rust_json = serde_json::from_slice::<Value>(rust_bytes)?;
-                strip_definition_hashes(&mut rust_json);
+                normalize_compass_superset_metadata(&mut rust_json);
                 assert_eq!(
                     rust_json,
                     serde_json::from_slice::<Value>(python_bytes)?,
@@ -1578,11 +1578,13 @@ print(json.dumps({'content': content, 'default': default, 'omitted': omitted}, e
                 .clone(),
         )?;
         for name in ["RAW_NODES", "RAW_EDGES", "LEGEND"] {
-            assert_eq!(
-                embedded_json(&rust_html, name)?,
-                embedded_json(&python_html, name)?,
-                "graph.html {name}"
-            );
+            let mut rust_value = embedded_json(&rust_html, name)?;
+            let mut python_value = embedded_json(&python_html, name)?;
+            if name == "RAW_NODES" {
+                normalize_visualization_superset_metadata(&mut rust_value);
+                normalize_visualization_superset_metadata(&mut python_value);
+            }
+            assert_eq!(rust_value, python_value, "graph.html {name}");
         }
         Ok(())
     }
@@ -3654,11 +3656,13 @@ hydrate();
         );
         let python = fs::read_to_string(&output_path)?;
         for name in ["RAW_NODES", "RAW_EDGES", "LEGEND"] {
-            assert_eq!(
-                embedded_json(&rust, name)?,
-                embedded_json(&python, name)?,
-                "{name}"
-            );
+            let mut rust_value = embedded_json(&rust, name)?;
+            let mut python_value = embedded_json(&python, name)?;
+            if name == "RAW_NODES" {
+                normalize_visualization_superset_metadata(&mut rust_value);
+                normalize_visualization_superset_metadata(&mut python_value);
+            }
+            assert_eq!(rust_value, python_value, "{name}");
         }
         for security_contract in [
             "vis-network@9.1.6/standalone/umd/vis-network.min.js",
@@ -4066,7 +4070,7 @@ hydrate();
     fn compare_graph_build(source: &Path) -> Result<(), Box<dyn Error>> {
         let repo = repository_root();
         let extraction: compass_languages::Extraction = serde_json::from_slice(&fs::read(source)?)?;
-        let rust = serde_json::to_value(build_from_extraction(&extraction, false, None))?;
+        let rust = build_from_extraction(&extraction, false, None);
         let output = Command::new(python_executable(&repo))
             .args([
                 "-c",
@@ -4081,9 +4085,64 @@ hydrate();
             "{}",
             String::from_utf8_lossy(&output.stderr)
         );
-        let python: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-        assert_eq!(rust, python, "graph build: {}", source.display());
+        let python: compass_model::GraphDocument = serde_json::from_slice(&output.stdout)?;
+        assert_eq!(
+            rust.directed,
+            python.directed,
+            "directed: {}",
+            source.display()
+        );
+        assert_eq!(
+            rust.graph,
+            python.graph,
+            "graph metadata: {}",
+            source.display()
+        );
+        assert_eq!(rust.nodes, python.nodes, "nodes: {}", source.display());
+        assert_eq!(rust.extras, python.extras, "extras: {}", source.display());
+        for edge in &python.links {
+            assert!(
+                rust.links.contains(edge),
+                "missing Python edge {edge:?}: {}",
+                source.display()
+            );
+        }
+        assert_eq!(
+            rust.multigraph,
+            has_parallel_endpoint_pairs(&rust),
+            "multigraph metadata: {}",
+            source.display()
+        );
+        if rust.links.len() == python.links.len() {
+            assert_eq!(rust.links, python.links, "links: {}", source.display());
+            assert_eq!(
+                rust.multigraph,
+                python.multigraph,
+                "multigraph: {}",
+                source.display()
+            );
+        } else {
+            assert!(
+                rust.links.len() > python.links.len(),
+                "Compass dropped Python edges: {}",
+                source.display()
+            );
+        }
         Ok(())
+    }
+
+    fn has_parallel_endpoint_pairs(document: &compass_model::GraphDocument) -> bool {
+        let mut pairs = std::collections::BTreeSet::new();
+        document.links.iter().any(|edge| {
+            let source = edge.source.as_str();
+            let target = edge.target.as_str();
+            let pair = if document.directed || source <= target {
+                (source, target)
+            } else {
+                (target, source)
+            };
+            !pairs.insert(pair)
+        })
     }
 
     fn compare_extraction_path(
@@ -4108,19 +4167,54 @@ hydrate();
             String::from_utf8_lossy(&output.stderr)
         );
         let python: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-        strip_definition_hashes(&mut rust);
+        normalize_compass_superset_metadata(&mut rust);
         assert_eq!(rust, python, "fixture: {}", source.display());
         Ok(rust)
     }
 
-    fn strip_definition_hashes(value: &mut Value) {
+    fn normalize_compass_superset_metadata(value: &mut Value) {
+        const COMPASS_ONLY_NODE_FIELDS: &[&str] = &[
+            "implementation_hash",
+            "language",
+            "line_end",
+            "line_start",
+            "signature",
+            "signature_hash",
+            "source_hash",
+            "symbol_kind",
+        ];
         if let Some(nodes) = value.get_mut("nodes").and_then(Value::as_array_mut) {
             for node in nodes {
                 if let Some(attributes) = node.as_object_mut() {
-                    attributes.remove("signature_hash");
-                    attributes.remove("implementation_hash");
-                    attributes.remove("source_hash");
+                    for field in COMPASS_ONLY_NODE_FIELDS {
+                        attributes.remove(*field);
+                    }
                 }
+            }
+        }
+    }
+
+    fn normalize_visualization_superset_metadata(value: &mut Value) {
+        const COMPASS_ONLY_VISUALIZATION_FIELDS: &[&str] = &[
+            "language",
+            "line_end",
+            "line_start",
+            "signature",
+            "source_location",
+            "symbol_kind",
+            "tooltip_html",
+        ];
+        let Some(nodes) = value.as_array_mut() else {
+            return;
+        };
+        for node in nodes {
+            if let Some(attributes) = node.as_object_mut() {
+                for field in COMPASS_ONLY_VISUALIZATION_FIELDS {
+                    attributes.remove(*field);
+                }
+                // Compass replaces Graphify's plain-text hover title with the
+                // structured, escaped `tooltip_html` field above.
+                attributes.remove("title");
             }
         }
     }

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -166,6 +166,11 @@ barrel.ts --RE_EXPORTS----> module.ts
 Those edges share endpoints but carry different meanings. A consumer that
 collapses them into a single untyped connection loses information.
 
+Compass promotes graph JSON to `multigraph: true` automatically whenever the
+emitted links contain repeated endpoint pairs. Direction is part of the pair
+in directed graphs, so reciprocal `A -> B` and `B -> A` links alone do not
+trigger promotion. In undirected graphs they do; repeated self-loops always do.
+
 Some human renderers list the neighboring node once while preserving the
 parallel-edge contribution to degree. Exact CompassQL patterns and graph JSON
 can inspect distinct relationships.

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -37,6 +37,12 @@ A **realization** is more specific than a commit. The same commit can have a
 code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
+History graph schema `networkx-node-link/v2` records automatic multigraph
+promotion. On upgrade, Compass migrates a stored v1 build profile to v2. The
+fingerprint therefore no longer matches a v1 realization, and the next
+requested build rematerializes that commit instead of reusing stale graph
+metadata.
+
 ## 1. Inspect the command contract
 
 Run:

--- a/docs/implementation/extraction-pipeline.md
+++ b/docs/implementation/extraction-pipeline.md
@@ -278,7 +278,10 @@ and edge inclusion, and records five equivalent query samples.
 Parity is set inclusion. Every Graphify node ID, observable shared-node field,
 and `(source, target, relation)` edge must exist in Compass. Compass-only facts,
 including Perl and extensionless executable scripts, are reported but do not
-fail the gate. Derived community assignments are not compared.
+fail the gate. Compass-owned semantic evidence such as symbol kind, language,
+source line bounds, signatures, and definition hashes is excluded from exact
+Python-oracle metadata comparisons; shared attributes and topology remain
+checked. Derived community assignments are not compared.
 
 Extractor semantics use a versioned AST cache namespace. The C declarator and
 positional-document corrections advance that namespace to `v0.9.21`, so the

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -89,6 +89,11 @@ extensible.
 
 Source/target IDs must be indexable. Attributes are extensible.
 
+Compass sets `multigraph` from the emitted links. It is `true` when two links
+share an endpoint pair (ordered for directed graphs, unordered for undirected
+graphs), including repeated self-loops. Consumers do not need to request this
+promotion.
+
 ### Consumer requirements
 
 - preserve unknown attributes;


### PR DESCRIPTION
## Summary

- automatically set `multigraph: true` when emitted links contain repeated endpoint pairs
- cover directed reciprocal edges, single self-loops, parallel self-loops, and undirected reciprocal edges
- bump history graph-schema fingerprints to `networkx-node-link/v2` and migrate persisted v1 profiles so old realizations rematerialize
- document automatic multigraph promotion and the v1-to-v2 history rebuild behavior
- make parity checks accept only named Compass-superset node/visualization metadata and additional preserved Compass edges while still requiring every Python edge and shared field

## Why

Compass preserves semantic relationships that Graphify may collapse, but graph JSON previously reported `multigraph: false`. That metadata was incorrect and allowed stale v1 history realizations to be reused after the contract changed.

## Validation

- `cargo test --workspace --all-targets` — passed; only explicitly ignored network/model/performance acceptance tests were skipped
- `cargo test -p compass-parity` — 100 library tests and 2 graph-subset tests passed
- `cargo test -p compass-graph -p compass-history -p compass-core` — passed
- `cargo test -p compass-cli --lib` — 51 passed
- the macOS CI watch test that flaked passed 20/20 focused local repetitions
- `cargo fmt --all -- --check`
- `git diff --check`
- `graphify update .` — refreshed to 25,450 nodes and 59,849 edges

## CI baseline observed

The current run reproduces failures outside this PR's files and approved scope:

- Clippy: existing `compass-output` `too_many_arguments` errors in `node_tooltip` and `page`
- dependency policy: existing `serde_cbor` advisory plus bans/licenses failures
- Windows x86: existing generated Compass skill frontmatter/line-ending validation
- ARM Linux and ARM Windows: upstream `gemm-common` instructions require `fullfp16`
- x86 macOS: timing-sensitive `watch_rebuilds_code_and_flags_semantic_changes` failure; the exact test passed 20/20 locally

macOS ARM, x86 Linux, and dependency audit pass. The complete local all-target workspace suite and Compass/Graphify parity suite pass.
