### PR TITLE
chore(release): bump Compass to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-ir",
  "serde",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-model",
  "glob",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-analysis",
  "compass-files",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-model",
  "regex",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "md-5 0.10.6",
  "rayon",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "compass-core",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-cypher",
  "compass-files",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "compass-parity"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-cli",
  "compass-core",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-model",
  "regex",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -28,28 +28,28 @@ serde_json.workspace = true
 tempfile.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.3" }
-compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
-compass-ir = { path = "../compass-ir", version = "0.1.3" }
-compass-program = { path = "../compass-program", version = "0.1.3" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
-compass-cargo = { path = "../compass-cargo", version = "0.1.3" }
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-graph = { path = "../compass-graph", version = "0.1.3" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.3" }
-compass-global = { path = "../compass-global", version = "0.1.3" }
-compass-history = { path = "../compass-history", version = "0.1.3" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.3" }
-compass-ingest = { path = "../compass-ingest", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
-compass-mcp = { path = "../compass-mcp", version = "0.1.3" }
-compass-output = { path = "../compass-output", version = "0.1.3" }
-compass-postgres = { path = "../compass-postgres", version = "0.1.3" }
-compass-prs = { path = "../compass-prs", version = "0.1.3" }
-compass-query = { path = "../compass-query", version = "0.1.3" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.3" }
-compass-semantic = { path = "../compass-semantic", version = "0.1.3" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.1.3" }
+compass-core = { path = "../compass-core", version = "0.1.4" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.4" }
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
+compass-program = { path = "../compass-program", version = "0.1.4" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.4" }
+compass-cargo = { path = "../compass-cargo", version = "0.1.4" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-graph = { path = "../compass-graph", version = "0.1.4" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.4" }
+compass-global = { path = "../compass-global", version = "0.1.4" }
+compass-history = { path = "../compass-history", version = "0.1.4" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.4" }
+compass-ingest = { path = "../compass-ingest", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
+compass-mcp = { path = "../compass-mcp", version = "0.1.4" }
+compass-output = { path = "../compass-output", version = "0.1.4" }
+compass-postgres = { path = "../compass-postgres", version = "0.1.4" }
+compass-prs = { path = "../compass-prs", version = "0.1.4" }
+compass-query = { path = "../compass-query", version = "0.1.4" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.4" }
+compass-semantic = { path = "../compass-semantic", version = "0.1.4" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.1.4" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
-compass-ir = { path = "../compass-ir", version = "0.1.3" }
-compass-program = { path = "../compass-program", version = "0.1.3" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.4" }
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
+compass-program = { path = "../compass-program", version = "0.1.4" }
 rayon.workspace = true
 notify.workspace = true
 num_cpus.workspace = true
@@ -23,15 +23,15 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.3" }
-compass-languages = { path = "../compass-languages", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
-compass-graph = { path = "../compass-graph", version = "0.1.3" }
-compass-history = { path = "../compass-history", version = "0.1.3" }
-compass-output = { path = "../compass-output", version = "0.1.3" }
-compass-reflect = { path = "../compass-reflect", version = "0.1.3" }
-compass-resolve = { path = "../compass-resolve", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.1.4" }
+compass-languages = { path = "../compass-languages", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
+compass-graph = { path = "../compass-graph", version = "0.1.4" }
+compass-history = { path = "../compass-history", version = "0.1.4" }
+compass-output = { path = "../compass-output", version = "0.1.4" }
+compass-reflect = { path = "../compass-reflect", version = "0.1.4" }
+compass-resolve = { path = "../compass-resolve", version = "0.1.4" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.1.3" }
+compass-media = { path = "../compass-media", version = "0.1.4" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -18,8 +18,8 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-languages = { path = "../compass-languages", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -20,10 +20,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
-compass-ir = { path = "../compass-ir", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.4" }
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-transcribe = { path = "../compass-transcribe", version = "0.1.3", default-features = false }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-transcribe = { path = "../compass-transcribe", version = "0.1.4", default-features = false }
 ureq.workspace = true
 url.workspace = true
 

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.1.3" }
-compass-program = { path = "../compass-program", version = "0.1.3" }
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
+compass-program = { path = "../compass-program", version = "0.1.4" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -24,8 +24,8 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-language-pack.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,11 +19,11 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.1.3" }
-compass-graph = { path = "../compass-graph", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
-compass-prs = { path = "../compass-prs", version = "0.1.3" }
-compass-query = { path = "../compass-query", version = "0.1.3" }
+compass-core = { path = "../compass-core", version = "0.1.4" }
+compass-graph = { path = "../compass-graph", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
+compass-prs = { path = "../compass-prs", version = "0.1.4" }
+compass-query = { path = "../compass-query", version = "0.1.4" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -18,11 +18,11 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
-compass-graph = { path = "../compass-graph", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
-compass-query = { path = "../compass-query", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.4" }
+compass-graph = { path = "../compass-graph", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
+compass-query = { path = "../compass-query", version = "0.1.4" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-parity/Cargo.toml
+++ b/crates/compass-parity/Cargo.toml
@@ -18,20 +18,20 @@ serde_json.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 time.workspace = true
-compass-cli = { version = "0.1.3", path = "../compass-cli" }
-compass-core = { version = "0.1.3", path = "../compass-core" }
-compass-files = { version = "0.1.3", path = "../compass-files" }
-compass-graph = { version = "0.1.3", path = "../compass-graph" }
-compass-languages = { version = "0.1.3", path = "../compass-languages" }
-compass-media = { version = "0.1.3", path = "../compass-media" }
-compass-mcp = { version = "0.1.3", path = "../compass-mcp" }
-compass-model = { version = "0.1.3", path = "../compass-model" }
-compass-output = { version = "0.1.3", path = "../compass-output" }
-compass-query = { version = "0.1.3", path = "../compass-query" }
-compass-reflect = { version = "0.1.3", path = "../compass-reflect" }
-compass-resolve = { version = "0.1.3", path = "../compass-resolve" }
-compass-semantic = { version = "0.1.3", path = "../compass-semantic" }
-compass-transcribe = { version = "0.1.3", path = "../compass-transcribe" }
+compass-cli = { version = "0.1.4", path = "../compass-cli" }
+compass-core = { version = "0.1.4", path = "../compass-core" }
+compass-files = { version = "0.1.4", path = "../compass-files" }
+compass-graph = { version = "0.1.4", path = "../compass-graph" }
+compass-languages = { version = "0.1.4", path = "../compass-languages" }
+compass-media = { version = "0.1.4", path = "../compass-media" }
+compass-mcp = { version = "0.1.4", path = "../compass-mcp" }
+compass-model = { version = "0.1.4", path = "../compass-model" }
+compass-output = { version = "0.1.4", path = "../compass-output" }
+compass-query = { version = "0.1.4", path = "../compass-query" }
+compass-reflect = { version = "0.1.4", path = "../compass-reflect" }
+compass-resolve = { version = "0.1.4", path = "../compass-resolve" }
+compass-semantic = { version = "0.1.4", path = "../compass-semantic" }
+compass-transcribe = { version = "0.1.4", path = "../compass-transcribe" }
 
 [lints]
 workspace = true

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.3" }
+compass-languages = { path = "../compass-languages", version = "0.1.4" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,7 +16,7 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -16,12 +16,12 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-cypher = { path = "../compass-cypher", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.1.3" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.1.4" }
 
 [lints]
 workspace = true

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -16,8 +16,8 @@ rayon.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-languages = { path = "../compass-languages", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.1.3" }
-compass-history = { path = "../compass-history", version = "0.1.3" }
-compass-ir = { path = "../compass-ir", version = "0.1.3" }
-compass-model = { path = "../compass-model", version = "0.1.3" }
+compass-analysis = { path = "../compass-analysis", version = "0.1.4" }
+compass-history = { path = "../compass-history", version = "0.1.4" }
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
+compass-model = { path = "../compass-model", version = "0.1.4" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.1.3" }
-compass-program = { path = "../compass-program", version = "0.1.3" }
+compass-languages = { path = "../compass-languages", version = "0.1.4" }
+compass-program = { path = "../compass-program", version = "0.1.4" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.1.3" }
-compass-media = { path = "../compass-media", version = "0.1.3" }
+compass-files = { path = "../compass-files", version = "0.1.4" }
+compass-media = { path = "../compass-media", version = "0.1.4" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -27,7 +27,7 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-whisper = { version = "0.1.3", path = "../compass-whisper", optional = true }
+compass-whisper = { version = "0.1.4", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- bump the Compass workspace and internal path dependencies to 0.1.4
- refresh Cargo.lock for the patch release
- prepare macOS arm64 and x86_64 release artifacts

## Validation
- `cargo check -p compass-cli --bin compass`
- `sh scripts/test_release_scripts.sh`
- `cargo test --locked -p compass-cli --test compass_product`
- release builds for `aarch64-apple-darwin` and `x86_64-apple-darwin`
- both packaged binaries report `compass 0.1.4`, pass `query --help`, and have valid checksums

## Existing baseline issues
The clean `origin/main` baseline already has clustering parity failures against Graphify `v8`. Its latest main CI run also has pre-existing quality/dependency and non-macOS failures, while both macOS matrix jobs pass. This version-only change does not modify those behaviors.