### PR TITLE
feat: add adaptive filesystem watch

### DIFF
--- a/crates/compass-cli/src/bin/compass.rs
+++ b/crates/compass-cli/src/bin/compass.rs
@@ -41,10 +41,12 @@ fn main() -> ExitCode {
                 &mut io::stderr(),
             ));
         }
-        return ExitCode::from(compass_cli::run_watch(
+        let output_is_terminal = io::stdout().is_terminal();
+        return ExitCode::from(compass_cli::run_watch_with_terminal(
             &arguments[1..],
             &mut io::stdout(),
             &mut io::stderr(),
+            output_is_terminal,
         ));
     }
     if arguments.first().and_then(|value| value.to_str()) == Some("serve") {

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -157,7 +157,7 @@ const PAGES: &[Page] = &[
         "watch",
         "Rebuild the graph automatically when project files change",
         ["compass watch [PATH] [OPTIONS]"],
-        "Arguments:\n  [PATH]                       Project directory to watch [default: .]\n\nOptions:\n  --program-artifact <PATH>    Add an offline program-evidence artifact; repeatable\n  --debounce <SECONDS>         Wait after changes before rebuilding [default: 3]\n  --out <DIR>                  Output directory\n  --no-cluster                 Skip community detection\n  --no-viz                     Skip graph.html generation\n  --no-gitignore               Ignore .gitignore rules\n  --exclude <PATTERN>          Exclude a glob pattern; repeatable\n  --poll                       Poll instead of using filesystem notifications\n\nExamples:\n  compass watch\n  compass watch ./services/api --program-artifact index.scip --poll"
+        "Arguments:\n  [PATH]                       Project directory to watch [default: .]\n\nOptions:\n  --program-artifact <PATH>    Add an offline program-evidence artifact; repeatable\n  --debounce <SECONDS>         Adaptive quiet window [default: 0.15]\n  --out <DIR>                  Output directory\n  --no-cluster                 Skip community detection\n  --no-viz                     Skip graph.html generation\n  --no-gitignore               Ignore .gitignore rules\n  --exclude <PATTERN>          Exclude a glob pattern; repeatable\n  --poll                       Force content-aware polling\n\nExamples:\n  compass watch\n  compass watch ./services/api --program-artifact index.scip --poll\n\nNotes:\n  Watch synchronizes once at startup, then uses native filesystem events with adaptive coalescing. Continuous edits cannot delay a build beyond five debounce windows. If native watching is unavailable, Compass falls back to polling automatically."
     ),
     page!(
         "cluster-only",
@@ -978,7 +978,7 @@ mod tests {
     #[test]
     fn catalog_has_unique_complete_public_roots() {
         let roots = root_commands();
-        assert_eq!(roots.len(), 35);
+        assert_eq!(roots.len(), 36);
         for root in roots {
             let matches = PAGES.iter().filter(|page| page.path == root).count();
             assert_eq!(matches, 1, "{root}");

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -31,10 +31,10 @@ use std::time::{Duration, Instant};
 
 use compass_core::{
     BuildOptions, BuildPurpose, BuildResult, BuildTimings, ClusterExistingOptions, ExportInputs,
-    LoadedGraph, SemanticLayer, WatchOptions, WatchStatus, build_graph_with_layers,
-    build_graph_with_layers_and_tiebreaker, cluster_existing_graph, default_graph_path,
-    diagnose_graph_file, format_diagnostic_json, format_diagnostic_report, merge_graphs,
-    watch_local_graph,
+    LoadedGraph, SemanticLayer, WatchBackend, WatchBuildReason, WatchOptions, WatchStatus,
+    build_graph_with_layers, build_graph_with_layers_and_tiebreaker, cluster_existing_graph,
+    default_graph_path, diagnose_graph_file, format_diagnostic_json, format_diagnostic_report,
+    merge_graphs, watch_local_graph,
 };
 use compass_files::{
     BuildScope, DetectOptions, Manifest, ManifestKind, ProjectConfig, detect, write_bytes_atomic,
@@ -456,7 +456,23 @@ fn mcp_help(frontend: McpFrontend) -> String {
 /// Signal registration lives at this process boundary rather than in
 /// `compass-core`, so embedders can provide their own cancellation mechanism.
 pub fn run_watch(arguments: &[OsString], stdout: &mut impl Write, stderr: &mut impl Write) -> u8 {
-    run_watch_with_frontend(Frontend::Compass, arguments, stdout, stderr)
+    run_watch_with_frontend(Frontend::Compass, arguments, stdout, stderr, true)
+}
+
+/// Run Compass's watcher with terminal-aware status rendering.
+pub fn run_watch_with_terminal(
+    arguments: &[OsString],
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+    output_is_terminal: bool,
+) -> u8 {
+    run_watch_with_frontend(
+        Frontend::Compass,
+        arguments,
+        stdout,
+        stderr,
+        output_is_terminal,
+    )
 }
 
 /// Run the frozen Graphify watch frontend without requiring Python or watchdog.
@@ -465,7 +481,7 @@ pub fn run_graphify_watch(
     stdout: &mut impl Write,
     stderr: &mut impl Write,
 ) -> u8 {
-    run_watch_with_frontend(Frontend::Graphify, arguments, stdout, stderr)
+    run_watch_with_frontend(Frontend::Graphify, arguments, stdout, stderr, true)
 }
 
 fn run_watch_with_frontend(
@@ -473,6 +489,7 @@ fn run_watch_with_frontend(
     arguments: &[OsString],
     stdout: &mut impl Write,
     stderr: &mut impl Write,
+    output_is_terminal: bool,
 ) -> u8 {
     let args = arguments
         .iter()
@@ -497,7 +514,7 @@ fn run_watch_with_frontend(
         }
     };
     let result = watch_local_graph(&options, stop, |status| {
-        write_watch_status(frontend, status, stdout, stderr);
+        write_watch_status_mode(frontend, status, stdout, stderr, output_is_terminal);
     });
     match result {
         Ok(()) => 0,
@@ -508,13 +525,89 @@ fn run_watch_with_frontend(
     }
 }
 
+#[cfg(test)]
 fn write_watch_status(
     frontend: Frontend,
     status: WatchStatus,
     stdout: &mut impl Write,
     stderr: &mut impl Write,
 ) {
+    write_watch_status_mode(frontend, status, stdout, stderr, true);
+}
+
+fn write_watch_status_mode(
+    frontend: Frontend,
+    status: WatchStatus,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+    output_is_terminal: bool,
+) {
+    let timestamp = (!output_is_terminal && frontend == Frontend::Compass)
+        .then(watch_timestamp)
+        .flatten();
+    macro_rules! native_line {
+        ($writer:expr, $($argument:tt)*) => {
+            if let Some(timestamp) = timestamp.as_deref() {
+                writeln!($writer, "[{timestamp}] {}", format_args!($($argument)*))
+            } else {
+                writeln!($writer, $($argument)*)
+            }
+        };
+    }
     match status {
+        WatchStatus::Starting {
+            root,
+            includes,
+            excludes,
+            output,
+        } => {
+            if frontend == Frontend::Compass {
+                let scope = if includes == 0 {
+                    format!("all eligible files, {excludes} exclude")
+                } else {
+                    format!("{includes} include, {excludes} exclude")
+                };
+                let _result = native_line!(
+                    stdout,
+                    "[compass watch] Starting {} (scope: {scope}; output: {})",
+                    root.display(),
+                    output.display()
+                );
+                let _result = stdout.flush();
+            }
+        }
+        WatchStatus::Backend {
+            backend,
+            fallback_error,
+            poll_interval,
+        } => {
+            if frontend == Frontend::Compass {
+                match (backend, fallback_error) {
+                    (WatchBackend::Native, _) => {
+                        let _result = native_line!(
+                            stdout,
+                            "[compass watch] Native filesystem events active."
+                        );
+                    }
+                    (WatchBackend::Polling, Some(error)) => {
+                        let _result = native_line!(
+                            stderr,
+                            "[compass watch] Native watcher unavailable; polling every {}s: {error}",
+                            poll_interval.as_secs_f64()
+                        );
+                    }
+                    (WatchBackend::Polling, None) => {
+                        let _result = native_line!(
+                            stdout,
+                            "[compass watch] Polling every {}s.",
+                            poll_interval.as_secs_f64()
+                        );
+                    }
+                }
+                let _result = stdout.flush();
+                let _result = stderr.flush();
+            }
+        }
         WatchStatus::Watching { root, debounce } => {
             if frontend == Frontend::Graphify {
                 let _result = writeln!(
@@ -534,21 +627,52 @@ fn write_watch_status(
                 let _result = stdout.flush();
                 return;
             }
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] Watching {} - press Ctrl+C to stop",
                 root.display()
             );
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] Deterministic changes rebuild locally; semantic media changes set needs_update."
             );
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
-                "[compass watch] Debounce: {}s",
+                "[compass watch] Adaptive debounce: {}s",
                 debounce.as_secs_f64()
             );
             let _result = stdout.flush();
+        }
+        WatchStatus::Synchronizing => {
+            if frontend == Frontend::Compass {
+                let _result = native_line!(stdout, "[compass watch] Synchronizing current graph…");
+                let _result = stdout.flush();
+            }
+        }
+        WatchStatus::Settling {
+            paths,
+            quiet_window,
+            maximum_window,
+        } => {
+            if frontend == Frontend::Compass {
+                let _result = native_line!(
+                    stdout,
+                    "[compass watch] {paths} path(s) changed; settling for {}s (maximum {}s)…",
+                    quiet_window.as_secs_f64(),
+                    maximum_window.as_secs_f64()
+                );
+                let _result = stdout.flush();
+            }
+        }
+        WatchStatus::Building { reason } => {
+            if frontend == Frontend::Compass {
+                let _result = native_line!(
+                    stdout,
+                    "[compass watch] Building ({})…",
+                    watch_reason(reason)
+                );
+                let _result = stdout.flush();
+            }
         }
         WatchStatus::Batch {
             paths,
@@ -561,9 +685,9 @@ fn write_watch_status(
                 let _result = stdout.flush();
                 return;
             }
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
-                "\n[compass watch] {} file(s) changed ({deterministic} deterministic, {semantic} semantic)",
+                "[compass watch] {} file(s) changed ({deterministic} deterministic, {semantic} semantic)",
                 paths.len()
             );
             let _result = stdout.flush();
@@ -595,7 +719,7 @@ fn write_watch_status(
                 let _result = stdout.flush();
                 return;
             }
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] Rebuilt: {} nodes, {} edges, {} communities ({} extracted, {} cached)",
                 result.nodes,
@@ -604,17 +728,55 @@ fn write_watch_status(
                 result.files_extracted,
                 result.files_cached
             );
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] {}",
                 format_program_analysis(&result)
             );
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] graph artifacts updated in {}",
                 result.output_dir.display()
             );
             let _result = stdout.flush();
+        }
+        WatchStatus::UpToDate { reason } => {
+            if frontend == Frontend::Compass {
+                let _result = native_line!(
+                    stdout,
+                    "[compass watch] Up to date after {}.",
+                    watch_reason(reason)
+                );
+                let _result = stdout.flush();
+            }
+        }
+        WatchStatus::FollowUpQueued { paths } => {
+            if frontend == Frontend::Compass {
+                let _result = native_line!(
+                    stdout,
+                    "[compass watch] {paths} path(s) arrived during build; one follow-up queued."
+                );
+                let _result = stdout.flush();
+            }
+        }
+        WatchStatus::RetryScheduled {
+            delay,
+            error,
+            repeated,
+        } => {
+            if frontend == Frontend::Compass {
+                let suffix = if repeated > 1 {
+                    format!(" (same failure {repeated} times)")
+                } else {
+                    String::new()
+                };
+                let _result = native_line!(
+                    stderr,
+                    "[compass watch] Build failed; retrying in {}s: {error}{suffix}",
+                    delay.as_secs_f64()
+                );
+                let _result = stderr.flush();
+            }
         }
         WatchStatus::SemanticUpdateRequired { flag } => {
             if frontend == Frontend::Graphify {
@@ -643,7 +805,7 @@ fn write_watch_status(
                 let _result = stdout.flush();
                 return;
             }
-            let _result = writeln!(
+            let _result = native_line!(
                 stdout,
                 "[compass watch] Semantic media changed; update required. Flag written to {}",
                 flag.display()
@@ -656,7 +818,7 @@ fn write_watch_status(
                 let _result = stdout.flush();
                 return;
             }
-            let _result = writeln!(stderr, "[compass watch] Filesystem event error: {error}");
+            let _result = native_line!(stderr, "[compass watch] Filesystem event error: {error}");
             let _result = stderr.flush();
         }
         WatchStatus::RebuildError(error) => {
@@ -664,8 +826,15 @@ fn write_watch_status(
                 let _result = writeln!(stdout, "[graphify watch] Rebuild failed: {error}");
                 let _result = stdout.flush();
             } else {
-                let _result = writeln!(stderr, "[compass watch] Rebuild failed: {error}");
+                let _result = native_line!(stderr, "[compass watch] Rebuild failed: {error}");
                 let _result = stderr.flush();
+            }
+        }
+        WatchStatus::Finishing => {
+            if frontend == Frontend::Compass {
+                let _result =
+                    native_line!(stdout, "[compass watch] Finishing the active atomic build…");
+                let _result = stdout.flush();
             }
         }
         WatchStatus::Stopped => {
@@ -674,10 +843,29 @@ fn write_watch_status(
             } else {
                 "compass watch"
             };
-            let _result = writeln!(stdout, "\n[{label}] Stopped.");
+            let _result = if frontend == Frontend::Compass {
+                native_line!(stdout, "[{label}] Stopped.")
+            } else {
+                writeln!(stdout, "\n[{label}] Stopped.")
+            };
             let _result = stdout.flush();
         }
     }
+}
+
+fn watch_reason(reason: WatchBuildReason) -> &'static str {
+    match reason {
+        WatchBuildReason::Initial => "initial synchronization",
+        WatchBuildReason::Changes => "filesystem changes",
+        WatchBuildReason::Retry => "retry",
+        WatchBuildReason::Reconciliation => "periodic reconciliation",
+    }
+}
+
+fn watch_timestamp() -> Option<String> {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .ok()
 }
 
 fn parse_watch_options(
@@ -701,12 +889,14 @@ fn parse_watch_options(
         }
         let mut options = WatchOptions::new(root);
         options.graphify_compatibility = true;
+        options.adaptive = false;
+        options.debounce = Duration::from_secs(3);
         options.force_polling = cfg!(target_os = "macos");
         return Ok(Some(options));
     }
     let mut root = None;
     let mut output_root = None;
-    let mut debounce = Duration::from_secs(3);
+    let mut debounce = Duration::from_millis(150);
     let mut no_cluster = false;
     let mut no_viz = false;
     let mut gitignore = true;
@@ -3903,9 +4093,54 @@ mod mcp_option_tests {
         let mut stderr = Vec::new();
         write_watch_status(
             Frontend::Compass,
+            WatchStatus::Starting {
+                root: PathBuf::from("project"),
+                includes: 1,
+                excludes: 2,
+                output: PathBuf::from("project/compass-out"),
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::Backend {
+                backend: WatchBackend::Native,
+                fallback_error: None,
+                poll_interval: Duration::from_millis(500),
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::Synchronizing,
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
             WatchStatus::Watching {
                 root: PathBuf::from("project"),
                 debounce: Duration::from_millis(1500),
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::Settling {
+                paths: 2,
+                quiet_window: Duration::from_millis(150),
+                maximum_window: Duration::from_millis(750),
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::Building {
+                reason: WatchBuildReason::Changes,
             },
             &mut stdout,
             &mut stderr,
@@ -3917,6 +4152,36 @@ mod mcp_option_tests {
                 deterministic: 1,
                 semantic: 1,
             },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::UpToDate {
+                reason: WatchBuildReason::Reconciliation,
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::FollowUpQueued { paths: 1 },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::RetryScheduled {
+                delay: Duration::from_secs(2),
+                error: "temporarily blocked".to_owned(),
+                repeated: 1,
+            },
+            &mut stdout,
+            &mut stderr,
+        );
+        write_watch_status(
+            Frontend::Compass,
+            WatchStatus::Finishing,
             &mut stdout,
             &mut stderr,
         );
@@ -3955,13 +4220,33 @@ mod mcp_option_tests {
 
         let stdout = String::from_utf8(stdout)?;
         let stderr = String::from_utf8(stderr)?;
+        assert!(stdout.contains("Starting project (scope: 1 include, 2 exclude"));
+        assert!(stdout.contains("Native filesystem events active"));
+        assert!(stdout.contains("Synchronizing current graph"));
         assert!(stdout.contains("[compass watch] Watching project"));
+        assert!(stdout.contains("settling for 0.15s (maximum 0.75s)"));
+        assert!(stdout.contains("Building (filesystem changes)"));
         assert!(stdout.contains("2 file(s) changed (1 deterministic, 1 semantic)"));
         assert!(stdout.contains("3 nodes, 2 edges, 1 communities (1 extracted, 1 cached)"));
+        assert!(stdout.contains("Up to date after periodic reconciliation"));
+        assert!(stdout.contains("one follow-up queued"));
+        assert!(stdout.contains("Finishing the active atomic build"));
         assert!(stdout.contains("Flag written to project/compass-out/needs_update"));
         assert!(stdout.contains("[compass watch] Stopped."));
         assert!(stderr.contains("Filesystem event error: event failed"));
         assert!(stderr.contains("Rebuild failed: build failed"));
+        assert!(stderr.contains("retrying in 2s: temporarily blocked"));
+
+        let mut logged = Vec::new();
+        write_watch_status_mode(
+            Frontend::Compass,
+            WatchStatus::Synchronizing,
+            &mut logged,
+            &mut Vec::new(),
+            false,
+        );
+        let logged = String::from_utf8(logged)?;
+        assert!(logged.contains("Z] [compass watch] Synchronizing current graph"));
         Ok(())
     }
 
@@ -4217,6 +4502,14 @@ mod mcp_option_tests {
         assert_eq!(watch.build.output_root, Some(PathBuf::from("artifacts")));
         assert_eq!(watch.build.extra_excludes, ["target"]);
         assert!(watch.force_polling);
+        assert!(watch.adaptive);
+
+        let defaults = parse_watch_options(Frontend::Compass, &[])?.ok_or("unexpected help")?;
+        assert_eq!(defaults.debounce, Duration::from_millis(150));
+        assert!(defaults.adaptive);
+        let graphify = parse_watch_options(Frontend::Graphify, &[])?.ok_or("unexpected help")?;
+        assert_eq!(graphify.debounce, Duration::from_secs(3));
+        assert!(!graphify.adaptive);
 
         assert_eq!(
             command_cluster_only(Frontend::Compass, &["--help".to_owned()]).code,

--- a/crates/compass-cli/tests/watch_cli.rs
+++ b/crates/compass-cli/tests/watch_cli.rs
@@ -127,3 +127,45 @@ fn watch_startup_and_interrupt_match_python() -> Result<(), Box<dyn Error>> {
     assert_same(&expected, &actual);
     Ok(())
 }
+
+#[cfg(unix)]
+#[test]
+fn native_watch_synchronizes_before_reporting_ready() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    std::fs::write(
+        directory.path().join("main.rs"),
+        "fn synchronized_on_start() {}\n",
+    )?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["watch", ".", "--poll", "--no-cluster", "--no-viz"])
+        .current_dir(directory.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().ok_or("missing stdout pipe")?;
+    let mut stdout = BufReader::new(stdout);
+    let mut output = String::new();
+    for _ in 0..20 {
+        let mut line = String::new();
+        if stdout.read_line(&mut line)? == 0 {
+            break;
+        }
+        output.push_str(&line);
+        if line.contains("Watching for changes") || line.contains("Watching ") {
+            break;
+        }
+    }
+    let pid = child.id().to_string();
+    let status = Command::new("kill").args(["-INT", pid.as_str()]).status()?;
+    if !status.success() {
+        return Err("could not interrupt native watch child".into());
+    }
+    stdout.read_to_string(&mut output)?;
+    let status = child.wait()?;
+    assert!(status.success(), "watch output: {output}");
+    assert!(output.contains("Starting"));
+    assert!(output.contains("Synchronizing current graph"));
+    assert!(output.contains("Watching"));
+    assert!(directory.path().join("compass-out/graph.json").is_file());
+    Ok(())
+}

--- a/crates/compass-core/src/lib.rs
+++ b/crates/compass-core/src/lib.rs
@@ -8,6 +8,7 @@ mod pipeline;
 mod program;
 mod raw_guard;
 mod watch;
+mod watch_scheduler;
 
 pub use cluster_existing::{
     ClusterExistingOptions, ClusterExistingResult, ClusterExistingTimings, ClusterLabelContext,
@@ -24,7 +25,9 @@ pub use pipeline::{
     build_graph_with_layers, build_graph_with_layers_and_tiebreaker, build_graph_with_semantic,
     build_local_graph,
 };
-pub use watch::{WatchError, WatchOptions, WatchStatus, watch_local_graph};
+pub use watch::{
+    WatchBackend, WatchBuildReason, WatchError, WatchOptions, WatchStatus, watch_local_graph,
+};
 
 use std::collections::HashMap;
 use std::fs;

--- a/crates/compass-core/src/watch.rs
+++ b/crates/compass-core/src/watch.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use compass_files::{DetectOptions, FileType, WatchPathFilter, classify_file, write_text_atomic};
@@ -10,7 +11,10 @@ use compass_languages::Registry;
 use notify::event::EventKind;
 use notify::{Config, Event, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 
+use crate::watch_scheduler::{WatchScheduler, retry_delay};
 use crate::{BuildOptions, BuildResult, CoreError, build_local_graph};
+
+const DEFAULT_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone, Debug)]
 pub struct WatchOptions {
@@ -19,6 +23,8 @@ pub struct WatchOptions {
     pub poll_interval: Duration,
     pub force_polling: bool,
     pub graphify_compatibility: bool,
+    pub adaptive: bool,
+    pub reconciliation_interval: Duration,
 }
 
 impl WatchOptions {
@@ -26,19 +32,55 @@ impl WatchOptions {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self {
             build: BuildOptions::new(root),
-            debounce: Duration::from_secs(3),
+            debounce: Duration::from_millis(150),
             poll_interval: Duration::from_millis(500),
             force_polling: false,
             graphify_compatibility: false,
+            adaptive: true,
+            reconciliation_interval: DEFAULT_RECONCILIATION_INTERVAL,
         }
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WatchBackend {
+    Native,
+    Polling,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WatchBuildReason {
+    Initial,
+    Changes,
+    Retry,
+    Reconciliation,
+}
+
 #[derive(Clone, Debug)]
 pub enum WatchStatus {
+    Starting {
+        root: PathBuf,
+        includes: usize,
+        excludes: usize,
+        output: PathBuf,
+    },
+    Backend {
+        backend: WatchBackend,
+        fallback_error: Option<String>,
+        poll_interval: Duration,
+    },
     Watching {
         root: PathBuf,
         debounce: Duration,
+    },
+    Synchronizing,
+    Settling {
+        paths: usize,
+        quiet_window: Duration,
+        maximum_window: Duration,
+    },
+    Building {
+        reason: WatchBuildReason,
     },
     Batch {
         paths: Vec<PathBuf>,
@@ -46,11 +88,23 @@ pub enum WatchStatus {
         semantic: usize,
     },
     Rebuilt(Box<BuildResult>),
+    UpToDate {
+        reason: WatchBuildReason,
+    },
+    FollowUpQueued {
+        paths: usize,
+    },
+    RetryScheduled {
+        delay: Duration,
+        error: String,
+        repeated: u32,
+    },
     SemanticUpdateRequired {
         flag: PathBuf,
     },
     EventError(String),
     RebuildError(String),
+    Finishing,
     Stopped,
 }
 
@@ -76,8 +130,18 @@ pub enum WatchError {
 pub fn watch_local_graph(
     options: &WatchOptions,
     stop: &AtomicBool,
-    mut emit: impl FnMut(WatchStatus),
+    emit: impl FnMut(WatchStatus),
 ) -> Result<(), WatchError> {
+    if options.adaptive && !options.graphify_compatibility {
+        watch_adaptive(options, stop, emit)
+    } else {
+        watch_legacy(options, stop, emit)
+    }
+}
+
+fn watch_context(
+    options: &WatchOptions,
+) -> Result<(PathBuf, WatchPathFilter, BTreeSet<PathBuf>), WatchError> {
     if !options.build.root.exists() {
         return Err(CoreError::MissingRoot(options.build.root.clone()).into());
     }
@@ -97,6 +161,16 @@ pub fn watch_local_graph(
             ..DetectOptions::default()
         },
     )?;
+    let program_paths = program_watch_paths(&root, &options.build);
+    Ok((root, filter, program_paths))
+}
+
+fn watch_legacy(
+    options: &WatchOptions,
+    stop: &AtomicBool,
+    mut emit: impl FnMut(WatchStatus),
+) -> Result<(), WatchError> {
+    let (root, filter, program_paths) = watch_context(options)?;
     let (sender, receiver) = mpsc::channel();
     let handler = move |event| {
         let _result = sender.send(event);
@@ -133,20 +207,7 @@ pub fn watch_local_graph(
             path: root.clone(),
             source,
         })?;
-    let program_paths = program_watch_paths(&root, &options.build);
-    for parent in program_paths
-        .iter()
-        .filter(|path| !path.starts_with(&root))
-        .filter_map(|path| path.parent())
-        .collect::<BTreeSet<_>>()
-    {
-        watcher
-            .watch(parent, RecursiveMode::NonRecursive)
-            .map_err(|source| WatchError::Start {
-                path: parent.to_path_buf(),
-                source,
-            })?;
-    }
+    attach_external_paths(&mut *watcher, &root, &program_paths)?;
     emit(WatchStatus::Watching {
         root: root.clone(),
         debounce: options.debounce,
@@ -155,7 +216,7 @@ pub fn watch_local_graph(
     let mut pending = BTreeSet::new();
     let mut last_change = None;
     while !stop.load(Ordering::Acquire) {
-        let timeout = next_timeout(last_change, options.debounce, options.poll_interval);
+        let timeout = legacy_next_timeout(last_change, options.debounce, options.poll_interval);
         match receiver.recv_timeout(timeout) {
             Ok(Ok(event)) => {
                 if collect_event(&event, &filter, &program_paths, &mut pending) {
@@ -179,7 +240,515 @@ pub fn watch_local_graph(
     Ok(())
 }
 
-fn next_timeout(last: Option<Instant>, debounce: Duration, poll: Duration) -> Duration {
+type EventMessage = Result<Event, notify::Error>;
+
+struct EventSource {
+    _watcher: Box<dyn Watcher>,
+    receiver: Receiver<EventMessage>,
+    backend: WatchBackend,
+    fallback_error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+enum AdaptiveWork {
+    Initial,
+    Changes(Vec<PathBuf>),
+    Reconciliation,
+}
+
+struct RetryState {
+    work: AdaptiveWork,
+    failures: u32,
+    at: Instant,
+    error: String,
+    repeated: u32,
+}
+
+enum AdaptiveOutcome {
+    Succeeded(Option<Box<BuildResult>>),
+    Failed(String),
+}
+
+fn watch_adaptive(
+    options: &WatchOptions,
+    stop: &AtomicBool,
+    mut emit: impl FnMut(WatchStatus),
+) -> Result<(), WatchError> {
+    let (root, filter, program_paths) = watch_context(options)?;
+    let output_name = std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned());
+    let output = options
+        .build
+        .output_root
+        .as_deref()
+        .unwrap_or(&root)
+        .join(output_name);
+    emit(WatchStatus::Starting {
+        root: root.clone(),
+        includes: options.build.scope.include.len(),
+        excludes: options.build.scope.exclude.len(),
+        output,
+    });
+    let mut source = start_adaptive_event_source(options, &root, &program_paths)?;
+    emit(WatchStatus::Backend {
+        backend: source.backend,
+        fallback_error: source.fallback_error.take(),
+        poll_interval: options.poll_interval,
+    });
+
+    let mut scheduler = WatchScheduler::new(
+        Instant::now(),
+        options.debounce,
+        options.reconciliation_interval,
+    );
+    let mut initial = true;
+    let mut retry: Option<RetryState> = None;
+    let mut event_errors = RepeatedError::default();
+    let mut watching = false;
+
+    loop {
+        if stop.load(Ordering::Acquire) {
+            emit(WatchStatus::Stopped);
+            return Ok(());
+        }
+
+        let now = Instant::now();
+        let selected = if initial {
+            initial = false;
+            Some((AdaptiveWork::Initial, 0, None, 0))
+        } else if retry.as_ref().is_some_and(|state| now >= state.at) {
+            retry.take().map(|state| {
+                (
+                    state.work,
+                    state.failures,
+                    Some(state.error),
+                    state.repeated,
+                )
+            })
+        } else if retry.is_none() && scheduler.is_batch_ready(now) {
+            Some((AdaptiveWork::Changes(scheduler.take_batch()), 0, None, 0))
+        } else if retry.is_none() && scheduler.reconciliation_due(now) {
+            Some((AdaptiveWork::Reconciliation, 0, None, 0))
+        } else {
+            None
+        };
+
+        if let Some((mut work, failures, previous_error, previous_repeated)) = selected {
+            if let AdaptiveWork::Changes(paths) = &mut work {
+                paths.extend(scheduler.take_batch());
+                paths.sort();
+                paths.dedup();
+            } else {
+                // A full build observes every change already present before it
+                // starts. Only events arriving during the build need a
+                // follow-up.
+                scheduler.take_batch();
+            }
+            let reason = if failures > 0 {
+                WatchBuildReason::Retry
+            } else {
+                match work {
+                    AdaptiveWork::Initial => WatchBuildReason::Initial,
+                    AdaptiveWork::Changes(_) => WatchBuildReason::Changes,
+                    AdaptiveWork::Reconciliation => WatchBuildReason::Reconciliation,
+                }
+            };
+            if matches!(work, AdaptiveWork::Initial) {
+                emit(WatchStatus::Synchronizing);
+            }
+            emit(WatchStatus::Building { reason });
+            let outcome = run_adaptive_work_observed(
+                options,
+                &root,
+                &program_paths,
+                &work,
+                stop,
+                &mut source,
+                &filter,
+                &mut scheduler,
+                &mut event_errors,
+                &mut emit,
+            )?;
+            match outcome {
+                AdaptiveOutcome::Succeeded(result) => {
+                    scheduler.mark_build_succeeded(Instant::now());
+                    event_errors.clear();
+                    if let Some(result) = result {
+                        if result.outputs_changed {
+                            emit(WatchStatus::Rebuilt(result));
+                        } else {
+                            emit(WatchStatus::UpToDate { reason });
+                        }
+                    }
+                    if matches!(work, AdaptiveWork::Initial) && !watching {
+                        emit(WatchStatus::Watching {
+                            root: root.clone(),
+                            debounce: options.debounce,
+                        });
+                        watching = true;
+                    }
+                    if scheduler.pending_len() > 0 {
+                        emit(WatchStatus::FollowUpQueued {
+                            paths: scheduler.pending_len(),
+                        });
+                    }
+                    retry = None;
+                }
+                AdaptiveOutcome::Failed(error) => {
+                    if stop.load(Ordering::Acquire) {
+                        emit(WatchStatus::RebuildError(error));
+                        continue;
+                    }
+                    if let AdaptiveWork::Changes(paths) = &mut work {
+                        paths.extend(scheduler.take_batch());
+                        paths.sort();
+                        paths.dedup();
+                    }
+                    let failures = failures.saturating_add(1);
+                    let repeated = if previous_error.as_deref() == Some(error.as_str()) {
+                        previous_repeated.saturating_add(1)
+                    } else {
+                        1
+                    };
+                    let delay = retry_delay(failures);
+                    emit(WatchStatus::RetryScheduled {
+                        delay,
+                        error: error.clone(),
+                        repeated,
+                    });
+                    retry = Some(RetryState {
+                        work,
+                        failures,
+                        at: Instant::now() + delay,
+                        error,
+                        repeated,
+                    });
+                }
+            }
+            continue;
+        }
+
+        let retry_at = retry.as_ref().map(|state| state.at);
+        let timeout = scheduler.next_timeout(now, options.poll_interval, retry_at);
+        match source.receiver.recv_timeout(timeout) {
+            Ok(Ok(event)) => {
+                let was_empty = scheduler.pending_len() == 0;
+                record_adaptive_event(
+                    &event,
+                    &filter,
+                    &program_paths,
+                    &mut scheduler,
+                    Instant::now(),
+                );
+                if was_empty && scheduler.pending_len() > 0 {
+                    emit(WatchStatus::Settling {
+                        paths: scheduler.pending_len(),
+                        quiet_window: options.debounce,
+                        maximum_window: scheduler.maximum_window(),
+                    });
+                }
+            }
+            Ok(Err(error)) => {
+                if let Some(message) = event_errors.observe(error.to_string()) {
+                    emit(WatchStatus::EventError(message));
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) if source.backend == WatchBackend::Native => {
+                source = start_single_event_source(
+                    options,
+                    &root,
+                    &program_paths,
+                    WatchBackend::Polling,
+                )?;
+                emit(WatchStatus::Backend {
+                    backend: WatchBackend::Polling,
+                    fallback_error: Some("native filesystem event channel disconnected".to_owned()),
+                    poll_interval: options.poll_interval,
+                });
+            }
+            Err(RecvTimeoutError::Disconnected) => return Err(WatchError::Disconnected),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_adaptive_work_observed(
+    options: &WatchOptions,
+    root: &Path,
+    program_paths: &BTreeSet<PathBuf>,
+    work: &AdaptiveWork,
+    stop: &AtomicBool,
+    source: &mut EventSource,
+    filter: &WatchPathFilter,
+    scheduler: &mut WatchScheduler,
+    event_errors: &mut RepeatedError,
+    emit: &mut impl FnMut(WatchStatus),
+) -> Result<AdaptiveOutcome, WatchError> {
+    let worker_options = options.clone();
+    let worker_root = root.to_path_buf();
+    let worker_program_paths = program_paths.clone();
+    let worker_work = work.clone();
+    let (outcome_sender, outcome_receiver) = mpsc::channel();
+    let (status_sender, status_receiver) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        let outcome = run_adaptive_work(
+            &worker_options,
+            &worker_root,
+            &worker_program_paths,
+            &worker_work,
+            &mut |status| {
+                let _result = status_sender.send(status);
+            },
+        );
+        let _result = outcome_sender.send(outcome);
+    });
+    let mut finishing = false;
+    let mut disconnected_backend = None;
+    let outcome = loop {
+        while let Ok(status) = status_receiver.try_recv() {
+            emit(status);
+        }
+        match outcome_receiver.try_recv() {
+            Ok(outcome) => break outcome,
+            Err(TryRecvError::Disconnected) => {
+                break AdaptiveOutcome::Failed(
+                    "adaptive watch build worker stopped unexpectedly".to_owned(),
+                );
+            }
+            Err(TryRecvError::Empty) => {}
+        }
+        if stop.load(Ordering::Acquire) && !finishing {
+            emit(WatchStatus::Finishing);
+            finishing = true;
+        }
+        if disconnected_backend.is_some() {
+            thread::sleep(Duration::from_millis(25));
+            continue;
+        }
+        match source.receiver.recv_timeout(Duration::from_millis(25)) {
+            Ok(Ok(event)) => {
+                record_adaptive_event(&event, filter, program_paths, scheduler, Instant::now())
+            }
+            Ok(Err(error)) => {
+                if let Some(message) = event_errors.observe(error.to_string()) {
+                    emit(WatchStatus::EventError(message));
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                disconnected_backend = Some(source.backend);
+            }
+        }
+    };
+    while let Ok(status) = status_receiver.try_recv() {
+        emit(status);
+    }
+    if worker.join().is_err() {
+        return Ok(AdaptiveOutcome::Failed(
+            "adaptive watch build worker panicked".to_owned(),
+        ));
+    }
+    match disconnected_backend {
+        Some(WatchBackend::Native) => {
+            *source =
+                start_single_event_source(options, root, program_paths, WatchBackend::Polling)?;
+            emit(WatchStatus::Backend {
+                backend: WatchBackend::Polling,
+                fallback_error: Some("native filesystem event channel disconnected".to_owned()),
+                poll_interval: options.poll_interval,
+            });
+        }
+        Some(WatchBackend::Polling) => return Err(WatchError::Disconnected),
+        None => {}
+    }
+    Ok(outcome)
+}
+
+fn run_adaptive_work(
+    options: &WatchOptions,
+    root: &Path,
+    program_paths: &BTreeSet<PathBuf>,
+    work: &AdaptiveWork,
+    emit: &mut impl FnMut(WatchStatus),
+) -> AdaptiveOutcome {
+    match work {
+        AdaptiveWork::Initial | AdaptiveWork::Reconciliation => {
+            match build_local_graph(&options.build) {
+                Ok(result) => AdaptiveOutcome::Succeeded(Some(Box::new(result))),
+                Err(error) => AdaptiveOutcome::Failed(error.to_string()),
+            }
+        }
+        AdaptiveWork::Changes(paths) => {
+            let deterministic = paths
+                .iter()
+                .filter(|path| {
+                    is_deterministic(path, options.graphify_compatibility, program_paths)
+                })
+                .count();
+            let semantic = paths.len().saturating_sub(deterministic);
+            emit(WatchStatus::Batch {
+                paths: paths.clone(),
+                deterministic,
+                semantic,
+            });
+            if semantic > 0 {
+                let output_root = options.build.output_root.as_deref().unwrap_or(root);
+                let output_name =
+                    std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned());
+                let flag = output_root.join(output_name).join("needs_update");
+                if let Err(error) = write_text_atomic(&flag, "1") {
+                    return AdaptiveOutcome::Failed(error.to_string());
+                }
+                emit(WatchStatus::SemanticUpdateRequired { flag });
+            }
+            if deterministic == 0 {
+                AdaptiveOutcome::Succeeded(None)
+            } else {
+                match build_local_graph(&options.build) {
+                    Ok(result) => AdaptiveOutcome::Succeeded(Some(Box::new(result))),
+                    Err(error) => AdaptiveOutcome::Failed(error.to_string()),
+                }
+            }
+        }
+    }
+}
+
+fn start_adaptive_event_source(
+    options: &WatchOptions,
+    root: &Path,
+    program_paths: &BTreeSet<PathBuf>,
+) -> Result<EventSource, WatchError> {
+    if options.force_polling {
+        return start_single_event_source(options, root, program_paths, WatchBackend::Polling);
+    }
+    match start_single_event_source(options, root, program_paths, WatchBackend::Native) {
+        Ok(source) => Ok(source),
+        Err(native_error) => {
+            let mut source =
+                start_single_event_source(options, root, program_paths, WatchBackend::Polling)?;
+            source.fallback_error = Some(native_error.to_string());
+            Ok(source)
+        }
+    }
+}
+
+fn start_single_event_source(
+    options: &WatchOptions,
+    root: &Path,
+    program_paths: &BTreeSet<PathBuf>,
+    backend: WatchBackend,
+) -> Result<EventSource, WatchError> {
+    let (sender, receiver) = mpsc::channel();
+    let mut watcher: Box<dyn Watcher> = match backend {
+        WatchBackend::Native => Box::new(
+            RecommendedWatcher::new(event_handler(sender), Config::default()).map_err(
+                |source| WatchError::Start {
+                    path: root.to_path_buf(),
+                    source,
+                },
+            )?,
+        ),
+        WatchBackend::Polling => Box::new(
+            PollWatcher::new(
+                event_handler(sender),
+                Config::default()
+                    .with_poll_interval(options.poll_interval)
+                    .with_compare_contents(true),
+            )
+            .map_err(|source| WatchError::Start {
+                path: root.to_path_buf(),
+                source,
+            })?,
+        ),
+    };
+    watcher
+        .watch(root, RecursiveMode::Recursive)
+        .map_err(|source| WatchError::Start {
+            path: root.to_path_buf(),
+            source,
+        })?;
+    attach_external_paths(&mut *watcher, root, program_paths)?;
+    Ok(EventSource {
+        _watcher: watcher,
+        receiver,
+        backend,
+        fallback_error: None,
+    })
+}
+
+fn event_handler(sender: Sender<EventMessage>) -> impl FnMut(EventMessage) + Send + 'static {
+    move |event| {
+        let _result = sender.send(event);
+    }
+}
+
+fn attach_external_paths(
+    watcher: &mut dyn Watcher,
+    root: &Path,
+    program_paths: &BTreeSet<PathBuf>,
+) -> Result<(), WatchError> {
+    for parent in program_paths
+        .iter()
+        .filter(|path| !path.starts_with(root))
+        .filter_map(|path| path.parent())
+        .collect::<BTreeSet<_>>()
+    {
+        watcher
+            .watch(parent, RecursiveMode::NonRecursive)
+            .map_err(|source| WatchError::Start {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+    }
+    Ok(())
+}
+
+fn record_adaptive_event(
+    event: &Event,
+    filter: &WatchPathFilter,
+    program_paths: &BTreeSet<PathBuf>,
+    scheduler: &mut WatchScheduler,
+    now: Instant,
+) {
+    if matches!(event.kind, EventKind::Access(_)) {
+        return;
+    }
+    for path in event
+        .paths
+        .iter()
+        .filter(|path| filter.allows(path) || program_paths.contains(*path))
+    {
+        scheduler.record(path.clone(), now);
+    }
+}
+
+#[derive(Default)]
+struct RepeatedError {
+    last: Option<String>,
+    count: u32,
+}
+
+impl RepeatedError {
+    fn observe(&mut self, error: String) -> Option<String> {
+        if self.last.as_deref() == Some(error.as_str()) {
+            self.count = self.count.saturating_add(1);
+            if self.count.is_power_of_two() {
+                return Some(format!("{error} (repeated {} times)", self.count));
+            }
+            return None;
+        }
+        self.last = Some(error.clone());
+        self.count = 1;
+        Some(error)
+    }
+
+    fn clear(&mut self) {
+        self.last = None;
+        self.count = 0;
+    }
+}
+
+fn legacy_next_timeout(last: Option<Instant>, debounce: Duration, poll: Duration) -> Duration {
     last.map_or(poll, |instant| {
         debounce.saturating_sub(instant.elapsed()).min(poll)
     })
@@ -307,6 +876,7 @@ mod tests {
         options.debounce = Duration::from_millis(100);
         options.poll_interval = Duration::from_millis(50);
         options.force_polling = true;
+        options.adaptive = false;
         let handle = thread::spawn(move || {
             watch_local_graph(&options, &thread_stop, |status| {
                 if let Ok(mut values) = thread_statuses.lock() {
@@ -417,6 +987,7 @@ mod tests {
         options.debounce = Duration::from_millis(100);
         options.poll_interval = Duration::from_millis(50);
         options.force_polling = true;
+        options.adaptive = false;
         let handle = thread::spawn(move || {
             watch_local_graph(&options, &thread_stop, |status| {
                 if let Ok(mut values) = thread_statuses.lock() {
@@ -455,6 +1026,104 @@ mod tests {
                 >= 2,
             "watch statuses: {statuses:?}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn adaptive_watch_synchronizes_before_waiting_for_changes() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path().to_path_buf();
+        fs::write(root.join("main.rs"), "fn synchronized() {}\n")?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let statuses = Arc::new(Mutex::new(Vec::new()));
+        let thread_stop = Arc::clone(&stop);
+        let thread_statuses = Arc::clone(&statuses);
+        let mut options = WatchOptions::new(&root);
+        options.build.no_cluster = true;
+        options.build.no_viz = true;
+        options.poll_interval = Duration::from_millis(50);
+        options.force_polling = true;
+        let handle = thread::spawn(move || {
+            watch_local_graph(&options, &thread_stop, |status| {
+                if let Ok(mut values) = thread_statuses.lock() {
+                    values.push(status);
+                }
+            })
+        });
+
+        wait_for_status(&statuses, |status| {
+            matches!(status, WatchStatus::Rebuilt(_))
+        })?;
+        stop.store(true, Ordering::Release);
+        handle.join().map_err(|_| "watch thread panicked")??;
+
+        let graph = compass_model::GraphDocument::load(&root.join("compass-out/graph.json"))?;
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .any(|node| node.label() == "synchronized()")
+        );
+        let statuses = statuses.lock().map_err(|_| "status mutex poisoned")?;
+        assert!(
+            statuses
+                .iter()
+                .any(|status| matches!(status, WatchStatus::Synchronizing))
+        );
+        assert!(statuses.iter().any(|status| matches!(
+            status,
+            WatchStatus::Backend {
+                backend: WatchBackend::Polling,
+                fallback_error: None,
+                ..
+            }
+        )));
+        Ok(())
+    }
+
+    #[test]
+    fn adaptive_watch_retries_a_transient_initial_build_failure() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path().to_path_buf();
+        fs::write(root.join("main.rs"), "fn recovered() {}\n")?;
+        fs::write(root.join("compass-out"), "temporarily obstructed\n")?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let statuses = Arc::new(Mutex::new(Vec::new()));
+        let thread_stop = Arc::clone(&stop);
+        let thread_statuses = Arc::clone(&statuses);
+        let mut options = WatchOptions::new(&root);
+        options.build.no_cluster = true;
+        options.build.no_viz = true;
+        options.poll_interval = Duration::from_millis(50);
+        options.force_polling = true;
+        let handle = thread::spawn(move || {
+            watch_local_graph(&options, &thread_stop, |status| {
+                if let Ok(mut values) = thread_statuses.lock() {
+                    values.push(status);
+                }
+            })
+        });
+
+        wait_for_status(&statuses, |status| {
+            matches!(status, WatchStatus::RetryScheduled { .. })
+        })?;
+        fs::remove_file(root.join("compass-out"))?;
+        wait_for_status(&statuses, |status| {
+            matches!(status, WatchStatus::Rebuilt(_))
+        })?;
+        stop.store(true, Ordering::Release);
+        handle.join().map_err(|_| "watch thread panicked")??;
+
+        assert!(root.join("compass-out/graph.json").is_file());
+        let statuses = statuses.lock().map_err(|_| "status mutex poisoned")?;
+        assert!(statuses.iter().any(|status| matches!(
+            status,
+            WatchStatus::Building {
+                reason: WatchBuildReason::Retry
+            }
+        )));
         Ok(())
     }
 

--- a/crates/compass-core/src/watch_scheduler.rs
+++ b/crates/compass-core/src/watch_scheduler.rs
@@ -1,0 +1,178 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+const MAX_ADAPTIVE_WINDOW: Duration = Duration::from_secs(5);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+pub(crate) struct WatchScheduler {
+    quiet_window: Duration,
+    maximum_window: Duration,
+    reconciliation_interval: Duration,
+    pending: BTreeSet<PathBuf>,
+    first_event: Option<Instant>,
+    last_event: Option<Instant>,
+    next_reconciliation: Instant,
+}
+
+impl WatchScheduler {
+    pub(crate) fn new(
+        now: Instant,
+        quiet_window: Duration,
+        reconciliation_interval: Duration,
+    ) -> Self {
+        Self {
+            quiet_window,
+            maximum_window: quiet_window.saturating_mul(5).min(MAX_ADAPTIVE_WINDOW),
+            reconciliation_interval,
+            pending: BTreeSet::new(),
+            first_event: None,
+            last_event: None,
+            next_reconciliation: now + reconciliation_interval,
+        }
+    }
+
+    pub(crate) fn record(&mut self, path: PathBuf, now: Instant) {
+        self.pending.insert(path);
+        self.first_event.get_or_insert(now);
+        self.last_event = Some(now);
+    }
+
+    pub(crate) fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub(crate) fn is_batch_ready(&self, now: Instant) -> bool {
+        !self.pending.is_empty()
+            && (self
+                .last_event
+                .is_some_and(|last| now.saturating_duration_since(last) >= self.quiet_window)
+                || self.first_event.is_some_and(|first| {
+                    now.saturating_duration_since(first) >= self.maximum_window
+                }))
+    }
+
+    pub(crate) fn take_batch(&mut self) -> Vec<PathBuf> {
+        self.first_event = None;
+        self.last_event = None;
+        std::mem::take(&mut self.pending).into_iter().collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn restore_batch(&mut self, paths: Vec<PathBuf>, now: Instant) {
+        self.pending.extend(paths);
+        self.first_event = Some(now);
+        self.last_event = Some(now);
+    }
+
+    pub(crate) fn reconciliation_due(&self, now: Instant) -> bool {
+        self.pending.is_empty() && now >= self.next_reconciliation
+    }
+
+    pub(crate) fn mark_build_succeeded(&mut self, now: Instant) {
+        self.next_reconciliation = now + self.reconciliation_interval;
+    }
+
+    pub(crate) fn next_timeout(
+        &self,
+        now: Instant,
+        poll_interval: Duration,
+        retry_at: Option<Instant>,
+    ) -> Duration {
+        let mut timeout = poll_interval;
+        if let Some(retry_at) = retry_at {
+            timeout = timeout.min(duration_until(now, retry_at));
+        } else {
+            if let Some(last) = self.last_event {
+                timeout = timeout.min(duration_until(now, last + self.quiet_window));
+            }
+            if let Some(first) = self.first_event {
+                timeout = timeout.min(duration_until(now, first + self.maximum_window));
+            }
+            timeout = timeout.min(duration_until(now, self.next_reconciliation));
+        }
+        timeout
+    }
+
+    pub(crate) fn maximum_window(&self) -> Duration {
+        self.maximum_window
+    }
+}
+
+pub(crate) fn retry_delay(failures: u32) -> Duration {
+    let shift = failures.saturating_sub(1).min(5);
+    Duration::from_secs(1_u64 << shift).min(MAX_RETRY_DELAY)
+}
+
+fn duration_until(now: Instant, deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesces_bursts_but_enforces_the_maximum_window() {
+        let start = Instant::now();
+        let mut scheduler =
+            WatchScheduler::new(start, Duration::from_millis(150), Duration::from_secs(300));
+        scheduler.record(PathBuf::from("src/a.rs"), start);
+        scheduler.record(
+            PathBuf::from("src/b.rs"),
+            start + Duration::from_millis(140),
+        );
+        assert!(!scheduler.is_batch_ready(start + Duration::from_millis(200)));
+        assert!(scheduler.is_batch_ready(start + Duration::from_millis(290)));
+
+        scheduler.take_batch();
+        for offset in [0, 140, 280, 420, 560, 700] {
+            scheduler.record(
+                PathBuf::from(format!("src/{offset}.rs")),
+                start + Duration::from_millis(offset),
+            );
+        }
+        assert!(scheduler.is_batch_ready(start + Duration::from_millis(750)));
+    }
+
+    #[test]
+    fn deduplicates_paths_restores_failed_work_and_resets_reconciliation() {
+        let start = Instant::now();
+        let mut scheduler =
+            WatchScheduler::new(start, Duration::from_millis(100), Duration::from_secs(10));
+        scheduler.record(PathBuf::from("src/lib.rs"), start);
+        scheduler.record(
+            PathBuf::from("src/lib.rs"),
+            start + Duration::from_millis(50),
+        );
+        assert_eq!(scheduler.pending_len(), 1);
+        let batch = scheduler.take_batch();
+        scheduler.restore_batch(batch, start + Duration::from_secs(1));
+        assert_eq!(scheduler.pending_len(), 1);
+        scheduler.take_batch();
+        assert!(scheduler.reconciliation_due(start + Duration::from_secs(10)));
+        scheduler.mark_build_succeeded(start + Duration::from_secs(10));
+        assert!(!scheduler.reconciliation_due(start + Duration::from_secs(15)));
+        assert!(scheduler.reconciliation_due(start + Duration::from_secs(20)));
+    }
+
+    #[test]
+    fn retry_delay_is_bounded() {
+        assert_eq!(retry_delay(1), Duration::from_secs(1));
+        assert_eq!(retry_delay(2), Duration::from_secs(2));
+        assert_eq!(retry_delay(5), Duration::from_secs(16));
+        assert_eq!(retry_delay(6), Duration::from_secs(30));
+        assert_eq!(retry_delay(100), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn custom_debounce_caps_the_maximum_window() {
+        let scheduler = WatchScheduler::new(
+            Instant::now(),
+            Duration::from_secs(2),
+            Duration::from_secs(300),
+        );
+        assert_eq!(scheduler.maximum_window(), Duration::from_secs(5));
+    }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -354,7 +354,8 @@ An incremental update should preserve unchanged extraction work and republish a
 coherent artifact set. Do not edit `graph.json` or `manifest.json` by hand and
 expect an update to preserve those edits.
 
-For continuous local changes, `compass watch` can keep the output current. Read
+For continuous local changes, `compass watch` synchronizes once at startup and
+then keeps the output current with adaptive filesystem-event builds. Read
 [Operations](guides/operations.md) before using a long-running process in CI or
 an editor integration.
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -49,9 +49,16 @@ Current options include:
 --poll
 ```
 
-Watch mode observes relevant changes, debounces bursts, and refreshes the
-output. Choose polling only when native filesystem events are unavailable or
-unreliable.
+Watch mode first synchronizes the current graph, then observes relevant native
+filesystem events. Its adaptive 150 ms quiet window coalesces editor save
+bursts, while a 750 ms maximum prevents continuous changes from postponing a
+build indefinitely. Only one build runs at once; changes received during that
+build produce one follow-up.
+
+Transient build failures retry with bounded backoff, and a five-minute idle
+reconciliation catches missed events without rewriting unchanged artifacts.
+Compass automatically falls back to content-aware polling when native watcher
+startup fails. Use `--poll` only when you want to force that backend.
 
 ### Good use cases
 
@@ -64,12 +71,13 @@ unreliable.
 - starting multiple watchers for the same output directory;
 - using watch as an unbounded CI step;
 - watching dependency caches or generated directories;
-- assuming the output is current after the watcher has failed.
+- ignoring repeated retry messages without fixing a persistent build error.
 
 ### Operate it
 
-Capture logs and stop it through your process supervisor or foreground terminal.
-After a failure, run one manual update:
+Capture logs and stop it through your process supervisor or foreground
+terminal. Redirected native status output includes timestamps. If automatic
+retries cannot recover, stop the watcher and run one manual update:
 
 ```bash
 compass update .

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -107,7 +107,16 @@ compass watch [PATH]
   [--poll]
 ```
 
-Long-running filesystem watcher. Use a manual `update` as its recovery oracle.
+Long-running adaptive filesystem watcher. Compass synchronizes once at startup,
+then coalesces native filesystem events with a 150 ms quiet window and a 750 ms
+maximum delay. `--debounce` changes the quiet window; the maximum becomes five
+times that value, capped at five seconds.
+
+Only one build runs at a time. Changes received during a build queue one
+follow-up, transient build failures retry with bounded backoff, and an idle
+five-minute reconciliation catches missed events. Native watcher startup
+automatically falls back to content-aware polling; `--poll` forces that backend.
+A manual `compass update` remains the recovery oracle.
 
 ### `cluster-only`
 

--- a/docs/superpowers/plans/2026-07-24-adaptive-compass-watch.md
+++ b/docs/superpowers/plans/2026-07-24-adaptive-compass-watch.md
@@ -1,0 +1,79 @@
+# Adaptive Compass Watch Implementation Plan
+
+**Goal:** Make native `compass watch` feel immediate and recover gracefully while preserving the existing cached build as the correctness oracle.
+
+**Architecture:** Add a small timing/state unit in `compass-core`, then use it from the existing watcher loop to coalesce events, run an initial synchronization, serialize builds, retry transient failures, and reconcile periodically. Keep Graphify compatibility on its current legacy path and render the richer native statuses in `compass-cli`.
+
+**Tech stack:** Rust, `notify`, `std::sync::mpsc`, existing Compass build/cache pipeline.
+
+## Global constraints
+
+- Do not use TDD; add focused regression tests after each implementation unit.
+- Do not introduce async runtimes, daemon processes, or new dependencies.
+- Run at most one graph build at a time.
+- Keep native Compass defaults at a 150 ms quiet window and a 750 ms maximum batch window.
+- Preserve Graphify compatibility messages, three-second timing, initial behavior, and macOS polling choice.
+- Preserve scope, ignore, safety, completeness, and atomic-publication behavior.
+- Retain `--poll` and `--debounce SECONDS`.
+- Keep unrelated generated and untracked files out of commits.
+
+## File map
+
+- Create `crates/compass-core/src/watch_scheduler.rs`: pure adaptive deadlines, retry backoff, reconciliation timing, and scheduler state.
+- Modify `crates/compass-core/src/lib.rs`: register the scheduler module.
+- Modify `crates/compass-core/src/watch.rs`: backend startup/fallback, initial sync, adaptive event loop, retry/reconciliation, richer statuses.
+- Modify `crates/compass-cli/src/lib.rs`: native defaults, Graphify legacy options, status rendering, parser tests.
+- Modify `crates/compass-cli/src/help.rs`: explain adaptive behavior and fallback.
+- Modify `crates/compass-core` watcher tests: lifecycle and end-to-end recovery coverage.
+- Modify `crates/compass-cli/tests/watch_cli.rs`: native startup synchronization and output coverage.
+- Modify `docs/reference/commands.md` and `docs/guides/operations.md`: user-facing behavior.
+
+## Task 1: Adaptive scheduler
+
+- [ ] Add `WatchScheduler` with pending-path storage, first/last event timestamps, quiet/max deadlines, retry count, and next reconciliation deadline.
+- [ ] Expose operations to record paths, decide the next wake duration, take a ready batch, retain work after failure, reset after success, and request reconciliation.
+- [ ] Use retry delays of 1, 2, 4, 8, 16, and 30 seconds, capped at 30 seconds.
+- [ ] Make `--debounce` derive a maximum window of five times the baseline, capped at five seconds.
+- [ ] Add post-implementation unit tests using explicit `Instant` values for burst coalescing, maximum delay, retry, success reset, and reconciliation.
+- [ ] Run `cargo test -p compass-core watch_scheduler`.
+
+## Task 2: Resilient watch lifecycle
+
+- [ ] Extend `WatchOptions` with native/legacy lifecycle selection and reconciliation timing without changing public build behavior.
+- [ ] Start the event backend before native initial synchronization.
+- [ ] Attempt `RecommendedWatcher` first and fall back to content-aware `PollWatcher` when native startup or root attachment fails.
+- [ ] Attempt polling fallback once if the native event channel disconnects.
+- [ ] Preserve explicit `--poll` behavior without emitting a fallback warning.
+- [ ] Feed filtered paths into `WatchScheduler`; ignore access-only events and generated/noise paths before changing deadlines.
+- [ ] Run native builds for initial synchronization, ready change batches, retries, and reconciliation.
+- [ ] Keep Graphify compatibility on the previous fixed-debounce, no-initial-sync loop.
+- [ ] Retain failed pending work and continue watching; emit one retry status with the bounded delay.
+- [ ] Collapse repeated identical backend/build errors into a count and clear the summary after recovery.
+- [ ] Stop scheduling new work after cancellation and emit a clean stopped status.
+- [ ] Add post-implementation tests for initial sync, changes during/after sync, transient build failure state, and polling behavior.
+- [ ] Run `cargo test -p compass-core watch`.
+
+## Task 3: Native watcher UX
+
+- [ ] Add typed `WatchStatus` variants for backend activation/fallback, synchronization, settling, build reason, up-to-date result, follow-up, retry, and stopping.
+- [ ] Keep existing variants used by Graphify compatibility unchanged.
+- [ ] Render concise native messages with resolved root, scope counts, backend, timing, output directory, build progress, fallback, and retries.
+- [ ] Keep redirected output as complete lines; do not add animation, color, or terminal dependencies.
+- [ ] Prefix redirected native status lines with stable timestamps while preserving the legacy Graphify byte contract.
+- [ ] Set native defaults to 150 ms while explicitly assigning three seconds for Graphify compatibility.
+- [ ] Update help copy to describe initial synchronization, adaptive maximum delay, automatic polling fallback, and `--debounce`.
+- [ ] Extend parser/status tests after implementation.
+- [ ] Run `cargo test -p compass-cli --test watch_cli --test help_cli` and the focused CLI unit tests.
+
+## Task 4: Documentation and regression verification
+
+- [ ] Update the command reference and operations guide with the new lifecycle and recovery behavior.
+- [ ] Run `cargo fmt --all -- --check`.
+- [ ] Run `cargo test -p compass-files`.
+- [ ] Run `cargo test -p compass-core`.
+- [ ] Run `cargo test -p compass-cli --test watch_cli --test help_cli --test update_cli --test init_cli --test compass_product`.
+- [ ] Run `cargo clippy -p compass-core -p compass-cli --all-targets --no-deps -- -D warnings`.
+- [ ] Run shell completion syntax checks and `git diff --check`.
+- [ ] Run `graphify update .` from the parent repository.
+- [ ] Review the final diff for Graphify output regressions and unrelated files.
+- [ ] Commit the implementation with a focused message.

--- a/docs/superpowers/specs/2026-07-24-adaptive-compass-watch-design.md
+++ b/docs/superpowers/specs/2026-07-24-adaptive-compass-watch-design.md
@@ -1,0 +1,348 @@
+# Adaptive Compass Watch Design
+
+**Status:** Approved  
+**Date:** 2026-07-24  
+**Scope:** Native `compass watch`; Graphify compatibility behavior remains frozen
+
+## Problem
+
+Compass already uses native filesystem events by default and falls back to
+content-aware polling when users pass `--poll`. The current watcher filters
+irrelevant paths and coalesces changes, but it uses a fixed three-second
+debounce and invokes the cached build pipeline only after that delay.
+
+The result is correct but feels slower than necessary during an editor session.
+The watcher also exits on some infrastructure failures, does not synchronize
+the graph when it starts, and provides limited feedback while work is queued or
+running. A burst of events received during a build is not represented by an
+explicit scheduling policy.
+
+## Goals
+
+- Make native filesystem-event watching the fast, reliable default.
+- Start isolated builds after a short quiet period without allowing continuous
+  edits to postpone builds indefinitely.
+- Run at most one build at a time and coalesce events received during a build
+  into one follow-up.
+- Synchronize missing or stale graph artifacts when watch mode starts.
+- Recover from transient watcher and build failures without requiring users to
+  restart the process.
+- Keep terminal output concise, actionable, and useful both interactively and
+  in redirected logs.
+- Preserve configured scope, ignore, safety, and atomic-publication behavior.
+- Retain the ordinary incremental build as the correctness oracle.
+- Keep scheduler boundaries suitable for future file-level graph patching.
+
+## Non-goals
+
+- Directly patching individual graph nodes or edges in this release.
+- Publishing partially clustered or mixed-generation artifact bundles.
+- Running semantic provider extraction automatically.
+- Adding a persistent background daemon or operating-system service.
+- Changing Graphify compatibility output, default timing, or macOS polling.
+- Guaranteeing identical native filesystem event sequences across platforms.
+
+## Chosen approach
+
+This release adds a correctness-first adaptive scheduler around the existing
+cached incremental build. Native events provide prompt invalidation, while the
+normal build pipeline remains responsible for detection, extraction, graph
+construction, clustering, rendering, completeness checks, and atomic
+publication.
+
+This approach improves perceived latency and operational resilience without
+introducing a second graph mutation model. A future file-delta builder can
+implement the same scheduler-facing build interface.
+
+Alternatives considered:
+
+1. A two-speed build that publishes structural output before clustering and
+   visualization. This improves perceived speed but risks exposing artifacts
+   from different generations.
+2. Immediate file-level graph patching. This offers the lowest eventual
+   latency but requires separate correctness work for renames, deletions,
+   cross-file resolution, clustering, and atomic publication.
+
+## Architecture
+
+### Responsibilities
+
+The enhanced watch path is divided into four units:
+
+1. **Event source:** owns the native or polling `notify` watcher and sends raw
+   events to the process.
+2. **Event filter:** applies project root, saved scope, Git ignore, explicit
+   exclusion, generated-output, sensitive-file, and program-artifact rules.
+3. **Adaptive scheduler:** normalizes paths, coalesces events, tracks timing and
+   retry state, and decides when one build may run.
+4. **Build executor:** invokes the existing cached incremental build and reports
+   success or failure without owning scheduling policy.
+
+The scheduler does not inspect or mutate graph documents. The build executor
+does not sleep, debounce, retry, or consume filesystem events.
+
+### State model
+
+```text
+Starting
+  ├─ watcher ready ─> Synchronizing
+  └─ native start failure ─> Polling fallback ─> Synchronizing
+
+Synchronizing
+  ├─ success, no queued events ─> Idle
+  ├─ success, queued events ─> Settling
+  └─ failure ─> Backoff
+
+Idle
+  ├─ relevant event ─> Settling
+  └─ reconciliation due ─> Building
+
+Settling
+  ├─ quiet window elapsed ─> Building
+  └─ maximum window elapsed ─> Building
+
+Building
+  ├─ success, no queued events ─> Idle
+  ├─ success, queued events ─> Settling
+  └─ failure ─> Backoff
+
+Backoff
+  ├─ retry due ─> Building
+  └─ new events ─> Backoff with merged pending paths
+```
+
+Only one build executor call may be active. The first event received while a
+build is active marks the scheduler dirty; later events join the same pending
+batch. Completion schedules at most one follow-up build.
+
+## Adaptive timing
+
+- The default quiet-window baseline is 150 milliseconds.
+- The first relevant event starts both a quiet deadline and an absolute batch
+  deadline.
+- Each additional relevant event moves the quiet deadline to 150 milliseconds
+  after that event.
+- The absolute deadline is 750 milliseconds after the first event and never
+  moves.
+- A build starts when either deadline expires.
+- Events received during a build form a new batch with their own deadlines once
+  the active build completes.
+- A reconciliation build is requested every five minutes while watch mode is
+  otherwise idle.
+
+`--debounce SECONDS` remains supported. It replaces the 150-millisecond
+baseline, and the maximum batch window becomes five times the configured
+baseline, capped at five seconds. This keeps the existing option meaningful
+without adding a second timing flag.
+
+The polling interval remains independent of debounce timing.
+
+## Startup lifecycle
+
+Watch startup follows this order:
+
+1. Resolve and canonicalize the project root.
+2. Load and validate `.compass/config.toml`.
+3. Compile watch filters and report configuration errors before long-running
+   work begins.
+4. Start the native event source.
+5. If native startup fails, start content-aware polling and emit one warning
+   explaining the fallback.
+6. Begin collecting events.
+7. Run an initial cached synchronization.
+8. If changes arrived during synchronization, schedule one adaptive follow-up.
+9. Enter the normal idle watch loop.
+
+Starting the event source before synchronization closes the gap in which edits
+could otherwise be missed. If outputs are already current, the build pipeline
+leaves them untouched and watch mode reports `up to date`.
+
+## Event handling
+
+Access-only events are ignored. Relevant create, modify, remove, rename, and
+metadata events contribute their normalized project-relative paths to an
+ordered set. Duplicate paths do not extend a pending batch unless they arrive
+as a later event and therefore represent continued activity.
+
+Rename events retain both paths when the backend supplies them. The existing
+incremental detector remains responsible for interpreting additions,
+deletions, and renames from the current filesystem and manifest state.
+
+Generated output paths never reach the scheduler, preventing recursive rebuild
+loops. Scope and ignore filtering also happen before timing state changes, so
+noise outside the configured corpus cannot delay a useful build.
+
+## Failure recovery
+
+### Watcher startup
+
+If the recommended native watcher cannot start or attach to a path, Compass
+attempts a content-aware `PollWatcher`. A successful fallback keeps the process
+running and emits one warning containing the native error and active polling
+interval. If both backends fail, startup returns an error.
+
+### Event errors
+
+Recoverable event errors are reported and the watcher continues. Repeated
+identical errors are counted and summarized rather than printed for every
+occurrence. A disconnected event channel is treated as a backend failure:
+Compass attempts polling fallback once before terminating.
+
+### Build errors
+
+A build failure does not discard the pending batch or stop watch mode. Retry
+delays are 1, 2, 4, 8, 16, and then 30 seconds. Additional failures stay capped
+at 30 seconds. New events merge into the retained batch without resetting the
+retry counter.
+
+A successful build clears the retry counter and duplicate-error summary.
+Atomic publication and existing incomplete-build guards remain authoritative,
+so failed attempts cannot expose partial graph artifacts.
+
+### Reconciliation
+
+The five-minute reconciliation invokes the same incremental build even if no
+event is pending. It catches dropped native events and backend-specific event
+ambiguities. An unchanged reconciliation does not rewrite public artifacts.
+
+## Shutdown
+
+Ctrl+C stops acceptance of new work and cancels pending timers. If no build is
+active, Compass exits immediately. If a build is active, Compass reports that
+the atomic build is finishing, allows it to complete, emits the final result,
+and then exits.
+
+Retries and periodic reconciliation do not start after shutdown is requested.
+
+## User experience
+
+### Interactive terminal
+
+Startup reports:
+
+- resolved project root;
+- configured include and exclude rule counts;
+- native or polling backend;
+- adaptive quiet and maximum windows;
+- five-minute reconciliation interval;
+- output directory.
+
+Runtime status uses concise state-oriented messages:
+
+```text
+[compass watch] Starting native watcher…
+[compass watch] Synchronizing current graph…
+[compass watch] Up to date. Watching for changes.
+[compass watch] 3 paths changed; settling for 0.15s…
+[compass watch] Building…
+[compass watch] Rebuilt: 142 nodes, 318 edges in 0.42s
+[compass watch] Changes arrived during build; one follow-up queued.
+[compass watch] Build failed; retrying in 2s: <reason>
+[compass watch] Native watcher unavailable; using polling every 0.5s: <reason>
+```
+
+The implementation may update an active TTY status line in place, but it must
+not require animation or color for comprehension.
+
+### Redirected output
+
+When standard output is not a terminal, every status is written as a complete
+stable line with a timestamp. No carriage-return rewriting or spinner output is
+used. Repeated identical errors produce an initial line and later summary
+counts.
+
+### CLI compatibility
+
+- Adaptive native watching is the default for `compass watch`.
+- `--poll` continues to force content-aware polling.
+- `--debounce SECONDS` configures the adaptive baseline.
+- Existing scope and build flags retain their meanings.
+- No new required configuration is introduced.
+- Help and operations documentation explain startup synchronization, adaptive
+  timing, automatic fallback, retry behavior, and the recovery role of manual
+  `compass update`.
+
+Graphify compatibility mode retains its fixed three-second debounce, existing
+messages, existing initial behavior, and macOS polling selection.
+
+## Public status model
+
+`WatchStatus` should expose lifecycle events without embedding terminal
+formatting:
+
+- watcher starting and active backend;
+- initial synchronization;
+- settling with pending count and remaining quiet window;
+- build started with reason (`initial`, `changes`, `retry`, or
+  `reconciliation`);
+- batch details;
+- rebuilt or up-to-date result;
+- follow-up queued;
+- backend fallback;
+- retry scheduled;
+- summarized event error;
+- finishing active build;
+- stopped.
+
+Frontends decide how these states are rendered. Tests can therefore validate
+scheduler behavior without parsing terminal control sequences.
+
+## Verification
+
+Scheduler tests use a controllable clock and synthetic events rather than
+wall-clock sleeps. They cover:
+
+- one isolated event;
+- burst coalescing;
+- the 750-millisecond maximum delay;
+- duplicate paths;
+- events received during a build;
+- rename and delete batches;
+- reconciliation scheduling;
+- bounded retry backoff;
+- repeated-error summarization;
+- shutdown while idle, settling, backing off, and building.
+
+Filter tests verify saved scope, Git ignores, explicit exclusions, generated
+outputs, sensitive files, and program artifacts before events reach the
+scheduler.
+
+Integration tests cover:
+
+- initial synchronization with missing output;
+- unchanged startup output;
+- a change received during initial synchronization;
+- automatic fallback when native watcher startup is unavailable;
+- transient build failure followed by recovery;
+- polling end-to-end behavior;
+- clean interrupted shutdown.
+
+Native backend tests validate startup and configuration but do not assert exact
+OS event sequences. One polling end-to-end test remains the portable event
+oracle.
+
+Existing Graphify compatibility tests must remain byte-for-byte stable.
+
+## Acceptance criteria
+
+- An isolated relevant save begins building approximately 150 milliseconds
+  after the last event.
+- Continuous relevant edits trigger a build no later than approximately 750
+  milliseconds after the first event in the batch.
+- No more than one build runs concurrently.
+- Events arriving during a build cause at most one immediate follow-up batch.
+- Watch startup produces a current graph without requiring an edit.
+- Native startup failure transparently falls back to polling when possible.
+- A transient build failure recovers without restarting watch mode.
+- Scope, ignore, safety, and generated-output filtering remain consistent with
+  one-shot updates.
+- Unchanged startup and reconciliation builds do not rewrite public artifacts.
+- Ctrl+C never leaves a partially published artifact bundle.
+- Graphify compatibility tests remain unchanged.
+
+## Future extension
+
+The build executor boundary may later accept a normalized change set and return
+whether a full reconciliation is required. That permits file-level graph
+patching or deferred clustering without changing the event source, scheduler,
+status model, fallback behavior, or terminal UX defined here.

--- a/docs/superpowers/specs/2026-07-24-adaptive-compass-watch-design.md
+++ b/docs/superpowers/specs/2026-07-24-adaptive-compass-watch-design.md
@@ -1,7 +1,7 @@
 # Adaptive Compass Watch Design
 
-**Status:** Approved  
-**Date:** 2026-07-24  
+**Status:** Approved
+**Date:** 2026-07-24
 **Scope:** Native `compass watch`; Graphify compatibility behavior remains frozen
 
 ## Problem


### PR DESCRIPTION
## Summary

- make native filesystem events the default for `compass watch`, with a 150 ms quiet debounce and bounded maximum coalescing window
- keep collecting changes while a single build runs, then schedule one follow-up build for queued paths
- add content-aware polling fallback, periodic reconciliation, bounded retry backoff, and clearer terminal/non-terminal status output
- preserve the existing Graphify-compatible watch behavior behind its compatibility path
- document the adaptive watcher behavior and operational controls

## Why

The previous continuous-build loop traded responsiveness for correctness by polling and rebuilding broadly. Native events make routine edits visible immediately, while reconciliation and polling fallback retain correctness when event delivery is incomplete or unavailable.

## User impact

`compass watch` now performs an initial synchronization, reacts quickly to save bursts, avoids concurrent builds, reports degraded/retry states clearly, and finishes an active build cleanly on shutdown. `--poll` remains available as an explicit fallback.

## Dependency

This is a stacked PR based on `agent/scoped-compass-init` and depends on #29. After #29 merges, this PR can be retargeted to `main`.

## Validation

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy -p compass-core -p compass-cli --all-targets --no-deps -- -D warnings`
- `bash -n completions/compass.bash`
- `zsh -n completions/_compass`
- `git diff --check agent/scoped-compass-init...HEAD`
