### PR TITLE
Release Compass 0.1.5 for macOS and Linux

### DIFF
--- a/.github/workflows/compass-ci.yml
+++ b/.github/workflows/compass-ci.yml
@@ -113,7 +113,7 @@ jobs:
           sh -n scripts/check_critical_coverage.sh
           bash -n scripts/publish_crates.sh
           sh -n scripts/install.sh
-          sh -n scripts/package_macos.sh
+          sh -n scripts/package_release.sh
           sh -n scripts/test_release_scripts.sh
           sh scripts/test_release_scripts.sh
           bash -n completions/compass.bash

--- a/.github/workflows/compass-release.yml
+++ b/.github/workflows/compass-release.yml
@@ -1,4 +1,4 @@
-name: Release Compass for macOS
+name: Release Compass for macOS and Linux
 
 on:
   push:
@@ -36,6 +36,10 @@ jobs:
             target: x86_64-apple-darwin
           - runner: macos-15
             target: aarch64-apple-darwin
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -58,9 +62,9 @@ jobs:
         run: sh scripts/test_release_scripts.sh
       - name: Build locked Compass binary
         run: cargo build --release --locked -p compass-cli --bin compass --target ${{ matrix.target }}
-      - name: Package macOS distribution
+      - name: Package release distribution
         run: >-
-          scripts/package_macos.sh
+          scripts/package_release.sh
           ${{ matrix.target }}
           target/${{ matrix.target }}/release/compass
           dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-ir",
  "serde",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-model",
  "glob",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-analysis",
  "compass-files",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-model",
  "regex",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "axum",
  "compass-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-cypher",
  "compass-files",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "compass-parity"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-cli",
  "compass-core",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-model",
  "regex",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ commands.
 
 ### 1. Install
 
-On macOS (Apple Silicon or Intel):
+On macOS or Linux (Apple Silicon/ARM64 or Intel/AMD64):
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,9 +46,10 @@ file for each question.
 
 ## 1. Choose an installation path
 
-### Install a macOS release
+### Install a macOS or Linux release
 
-The current release workflow publishes Intel and Apple Silicon macOS archives.
+The release workflow publishes native Intel/AMD64 and Apple Silicon/ARM64
+archives for macOS and Linux.
 The installer downloads the latest archive, verifies its SHA-256 checksum, and
 installs `compass` into `~/.local/bin` by default:
 
@@ -65,8 +66,8 @@ process:
 COMPASS_INSTALL_DIR="$PWD/bin" sh install.sh
 ```
 
-The current macOS release is unsigned and not notarized. Read the release notes
-and [security policy](../SECURITY.md) before using an installer in a controlled
+The macOS release is unsigned and not notarized. Read the release notes and
+[security policy](../SECURITY.md) before using an installer in a controlled
 environment.
 
 ### Build from source

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,16 +5,15 @@ repository=${COMPASS_REPOSITORY:-crabbuild/compass}
 release_base_url=${COMPASS_RELEASE_BASE_URL:-https://github.com/$repository/releases/latest/download}
 install_dir=${COMPASS_INSTALL_DIR:-$HOME/.local/bin}
 
-if [ "$(uname -s)" != Darwin ]; then
-    echo "error: this installer currently supports macOS only" >&2
-    exit 1
-fi
-
-case "$(uname -m)" in
-    arm64|aarch64) target=aarch64-apple-darwin ;;
-    x86_64|amd64) target=x86_64-apple-darwin ;;
+os=$(uname -s)
+arch=$(uname -m)
+case "$os:$arch" in
+    Darwin:arm64|Darwin:aarch64) target=aarch64-apple-darwin ;;
+    Darwin:x86_64|Darwin:amd64) target=x86_64-apple-darwin ;;
+    Linux:arm64|Linux:aarch64) target=aarch64-unknown-linux-gnu ;;
+    Linux:x86_64|Linux:amd64) target=x86_64-unknown-linux-gnu ;;
     *)
-        echo "error: unsupported macOS architecture: $(uname -m)" >&2
+        echo "error: unsupported platform: $os $arch" >&2
         exit 1
         ;;
 esac
@@ -30,11 +29,22 @@ download() {
         --output "$temporary/$2" "$release_base_url/$1"
 }
 
+verify_checksum() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c "$1"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -c "$1"
+    else
+        echo "error: sha256sum or shasum is required" >&2
+        return 1
+    fi
+}
+
 download "$archive" "$archive"
 download "$checksum" "$checksum"
 (
     cd "$temporary"
-    shasum -a 256 -c "$checksum"
+    verify_checksum "$checksum"
 )
 
 tar -C "$temporary" -xzf "$temporary/$archive"

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -2,7 +2,7 @@
 set -eu
 
 if [ "$#" -ne 3 ]; then
-    echo "usage: package_macos.sh <target> <compass-binary> <dist-directory>" >&2
+    echo "usage: package_release.sh <target> <compass-binary> <dist-directory>" >&2
     exit 2
 fi
 
@@ -10,9 +10,10 @@ target=$1
 binary=$2
 dist=$3
 case "$target" in
-    aarch64-apple-darwin|x86_64-apple-darwin) ;;
+    aarch64-apple-darwin|x86_64-apple-darwin|\
+    aarch64-unknown-linux-gnu|x86_64-unknown-linux-gnu) ;;
     *)
-        echo "error: unsupported macOS target: $target" >&2
+        echo "error: unsupported release target: $target" >&2
         exit 2
         ;;
 esac
@@ -37,7 +38,14 @@ archive="$dist/$name.tar.gz"
 tar -C "$staging" -czf "$archive" "$name"
 (
     cd "$dist"
-    shasum -a 256 "$(basename "$archive")" > "$(basename "$archive").sha256"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$(basename "$archive")"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$(basename "$archive")"
+    else
+        echo "error: sha256sum or shasum is required" >&2
+        exit 1
+    fi > "$(basename "$archive").sha256"
 )
 
 printf '%s\n' "$archive"

--- a/scripts/test_release_scripts.sh
+++ b/scripts/test_release_scripts.sh
@@ -4,14 +4,33 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+mkdir -p "$test_root/fake-checksum-bin"
 
-fake_binary="$test_root/fake-compass"
-printf '#!/bin/sh\necho compass 0.1.0\n' > "$fake_binary"
-chmod +x "$fake_binary"
+cat > "$test_root/fake-checksum-bin/shasum" <<'EOF'
+#!/bin/sh
+echo "shasum must not be required when sha256sum is available" >&2
+exit 99
+EOF
+chmod +x "$test_root/fake-checksum-bin/shasum"
 
-for target in aarch64-apple-darwin x86_64-apple-darwin; do
+cat > "$test_root/fake-checksum-bin/sha256sum" <<'EOF'
+#!/bin/sh
+exec /usr/bin/shasum -a 256 "$@"
+EOF
+chmod +x "$test_root/fake-checksum-bin/sha256sum"
+
+for target in \
+    aarch64-apple-darwin \
+    x86_64-apple-darwin \
+    aarch64-unknown-linux-gnu \
+    x86_64-unknown-linux-gnu
+do
+    fake_binary="$test_root/fake-compass-$target"
+    printf '#!/bin/sh\necho %s\n' "$target" > "$fake_binary"
+    chmod +x "$fake_binary"
     dist="$test_root/dist-$target"
-    "$repo_root/scripts/package_macos.sh" "$target" "$fake_binary" "$dist"
+    PATH="$test_root/fake-checksum-bin:$PATH" \
+        "$repo_root/scripts/package_release.sh" "$target" "$fake_binary" "$dist"
     archive="$dist/compass-$target.tar.gz"
     checksum="$archive.sha256"
     test -f "$archive"
@@ -25,6 +44,8 @@ release_dir="$test_root/release"
 mkdir -p "$release_dir" "$test_root/fake-bin"
 cp "$test_root/dist-aarch64-apple-darwin/"* "$release_dir/"
 cp "$test_root/dist-x86_64-apple-darwin/"* "$release_dir/"
+cp "$test_root/dist-aarch64-unknown-linux-gnu/"* "$release_dir/"
+cp "$test_root/dist-x86_64-unknown-linux-gnu/"* "$release_dir/"
 
 cat > "$test_root/fake-bin/curl" <<'EOF'
 #!/bin/sh
@@ -48,29 +69,40 @@ chmod +x "$test_root/fake-bin/curl"
 cat > "$test_root/fake-bin/uname" <<'EOF'
 #!/bin/sh
 case "${1:-}" in
-    -s) printf '%s\n' Darwin ;;
+    -s) printf '%s\n' "$FIXTURE_OS" ;;
     -m) printf '%s\n' "$FIXTURE_ARCH" ;;
     *) exit 1 ;;
 esac
 EOF
 chmod +x "$test_root/fake-bin/uname"
 
-for arch in arm64 x86_64; do
-    install_dir="$test_root/install-$arch"
-    PATH="$test_root/fake-bin:$PATH" \
+for platform in \
+    "Darwin arm64 aarch64-apple-darwin" \
+    "Darwin x86_64 x86_64-apple-darwin" \
+    "Linux aarch64 aarch64-unknown-linux-gnu" \
+    "Linux x86_64 x86_64-unknown-linux-gnu"
+do
+    set -- $platform
+    os=$1
+    arch=$2
+    target=$3
+    install_dir="$test_root/install-$target"
+    PATH="$test_root/fake-bin:$test_root/fake-checksum-bin:$PATH" \
+        FIXTURE_OS="$os" \
         FIXTURE_ARCH="$arch" \
         FIXTURE_RELEASE="$release_dir" \
         COMPASS_RELEASE_BASE_URL="https://example.invalid/releases/latest/download" \
         COMPASS_INSTALL_DIR="$install_dir" \
         sh "$repo_root/scripts/install.sh"
     test -x "$install_dir/compass"
-    test "$($install_dir/compass)" = "compass 0.1.0"
+    test "$($install_dir/compass)" = "$target"
 done
 
 cp "$release_dir/compass-aarch64-apple-darwin.tar.gz.sha256" "$test_root/good.sha256"
 printf '%064d  compass-aarch64-apple-darwin.tar.gz\n' 0 \
     > "$release_dir/compass-aarch64-apple-darwin.tar.gz.sha256"
-if PATH="$test_root/fake-bin:$PATH" \
+if PATH="$test_root/fake-bin:$test_root/fake-checksum-bin:$PATH" \
+    FIXTURE_OS=Darwin \
     FIXTURE_ARCH=arm64 \
     FIXTURE_RELEASE="$release_dir" \
     COMPASS_RELEASE_BASE_URL="https://example.invalid/releases/latest/download" \


### PR DESCRIPTION
## Summary

- bump the Compass workspace to 0.1.5
- publish stable per-architecture macOS and Linux GNU archives with checksums and provenance
- extend the one-line installer to Apple Silicon/ARM64 and Intel/AMD64 on both operating systems
- prefer sha256sum on Linux while retaining shasum compatibility
- update README and getting-started installation guidance

## Validation

- release-script syntax and behavioral tests pass for all four targets
- workflow YAML parses successfully
- locked workspace metadata resolves only version 0.1.5
- Compass product contract: 5 passed
- optimized Apple Silicon build and packaged archive verified as compass 0.1.5
- graphify update . completed (generated graph remains local)

## Existing main baseline

The full workspace suite still has the pre-existing help catalog count failure (36 actual vs 35 expected) already present in origin/main CI run 30137859831. This PR changes no Rust source; the release workflow's focused product and script checks pass.
