### PR TITLE
Harden versioned semantic history diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ fingerprints. Current and historical graphs can be queried, compared, and
 exported without putting generated graph data into Git. Semantic diff leads
 with likely breaks, behavior changes, affected callers/modules, and test
 evidence; use `--all` to expand routine symbol churn.
+Default text output reports any findings beyond its display budget; use
+`--limit N` to raise that budget or `--all` for exhaustive output.
 
 Read the [versioned history guide](docs/guides/versioned-history.md) and
 [storage design](docs/design/storage-and-history.md).

--- a/crates/compass-analysis/src/lib.rs
+++ b/crates/compass-analysis/src/lib.rs
@@ -6,5 +6,5 @@ mod summary;
 pub use invalidation::affected_summaries;
 pub use summary::{AnalysisBundle, AnalysisError, FunctionSummary, analyze};
 
-pub const ANALYSIS_SCHEMA_VERSION: u32 = 2;
-pub const ANALYZER_VERSION: u32 = 2;
+pub const ANALYSIS_SCHEMA_VERSION: u32 = 1;
+pub const ANALYZER_VERSION: u32 = 1;

--- a/crates/compass-analysis/src/lib.rs
+++ b/crates/compass-analysis/src/lib.rs
@@ -6,5 +6,5 @@ mod summary;
 pub use invalidation::affected_summaries;
 pub use summary::{AnalysisBundle, AnalysisError, FunctionSummary, analyze};
 
-pub const ANALYSIS_SCHEMA_VERSION: u32 = 1;
-pub const ANALYZER_VERSION: u32 = 1;
+pub const ANALYSIS_SCHEMA_VERSION: u32 = 2;
+pub const ANALYZER_VERSION: u32 = 2;

--- a/crates/compass-analysis/src/summary.rs
+++ b/crates/compass-analysis/src/summary.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use compass_ir::{
-    Coverage, IrError, OperationKind, ProgramBundle, SymbolId, canonical_json_bytes, hex_sha256,
+    Coverage, ExceptionEffect, IrError, OperationKind, ProgramBundle, SymbolId,
+    canonical_json_bytes, hex_sha256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +16,7 @@ pub struct FunctionSummary {
     pub reads: Vec<String>,
     pub writes: Vec<String>,
     pub effects: Vec<String>,
-    pub errors: Vec<String>,
+    pub exceptions: Vec<ExceptionEffect>,
     pub evidence: Vec<String>,
     pub coverage: Coverage,
     pub summary_digest: String,
@@ -82,7 +83,7 @@ impl AnalysisBundle {
             sort_dedup(&mut summary.reads);
             sort_dedup(&mut summary.writes);
             sort_dedup(&mut summary.effects);
-            sort_dedup(&mut summary.errors);
+            sort_dedup(&mut summary.exceptions);
             sort_dedup(&mut summary.evidence);
         }
         bundle
@@ -129,7 +130,7 @@ pub(crate) fn summarize(
     let mut reads = Vec::new();
     let mut writes = Vec::new();
     let mut effects = Vec::new();
-    let mut errors = Vec::new();
+    let mut exceptions = Vec::new();
     let mut evidence = function.evidence.clone();
     for block in &function.blocks {
         evidence.extend(block.evidence.clone());
@@ -150,9 +151,9 @@ pub(crate) fn summarize(
                 OperationKind::Read { path } => reads.push(path.clone()),
                 OperationKind::Write { path } => writes.push(path.clone()),
                 OperationKind::Await => effects.push("await".to_owned()),
-                OperationKind::Throw { value } => {
+                OperationKind::Throw { effect } => {
                     effects.push("throw".to_owned());
-                    errors.push(value.clone());
+                    exceptions.push(effect.clone());
                 }
             }
         }
@@ -162,7 +163,7 @@ pub(crate) fn summarize(
     sort_dedup(&mut reads);
     sort_dedup(&mut writes);
     sort_dedup(&mut effects);
-    sort_dedup(&mut errors);
+    sort_dedup(&mut exceptions);
     sort_dedup(&mut evidence);
     let semantic_digest = semantic_digest(function)?;
     let summary_payload = (
@@ -174,7 +175,7 @@ pub(crate) fn summarize(
         &reads,
         &writes,
         &effects,
-        &errors,
+        &exceptions,
         &evidence,
         &function.coverage,
     );
@@ -188,7 +189,7 @@ pub(crate) fn summarize(
         reads,
         writes,
         effects,
-        errors,
+        exceptions,
         evidence,
         coverage: function.coverage.clone(),
         summary_digest,

--- a/crates/compass-cli/assets/compass-skill/references/history.md
+++ b/crates/compass-cli/assets/compass-skill/references/history.md
@@ -17,6 +17,10 @@ History stores immutable realizations outside normal Git history. Enabling eager
 history records a repository build profile and installs managed enqueueing
 hooks. `--code-only` is the explicit local no-model profile.
 
+History uses only `networkx-node-link/v6`. Pre-v6 build profiles, realizations,
+and stores are intentionally unsupported and must be archived or removed before
+building fresh history.
+
 Use `history build REF --all` to build every locally reachable commit in one
 oldest-first batch. Add `--first-parent` to exclude merged branch histories.
 The batch continues after commit failures and exits nonzero after printing its

--- a/crates/compass-cli/assets/compass-skill/references/history.md
+++ b/crates/compass-cli/assets/compass-skill/references/history.md
@@ -17,9 +17,9 @@ History stores immutable realizations outside normal Git history. Enabling eager
 history records a repository build profile and installs managed enqueueing
 hooks. `--code-only` is the explicit local no-model profile.
 
-History uses only `networkx-node-link/v6`. Pre-v6 build profiles, realizations,
-and stores are intentionally unsupported and must be archived or removed before
-building fresh history.
+History uses only the current `networkx-node-link/v1` contract. Any store,
+profile, or realization written under another contract is intentionally
+unsupported and must be archived or removed before building fresh history.
 
 Use `history build REF --all` to build every locally reachable commit in one
 oldest-first batch. Add `--first-parent` to exclude merged branch histories.
@@ -50,7 +50,7 @@ offline worktree. Report the resolved revision when answering.
 compass diff v1.2.0 HEAD
 compass diff HEAD~1 HEAD --all
 compass diff HEAD~1 HEAD --format json
-compass diff HEAD~1 HEAD --explain sd2-...
+compass diff HEAD~1 HEAD --explain sd1-...
 compass history list HEAD --format json
 compass history show HEAD
 compass history export HEAD --format compass-out --output historical-output

--- a/crates/compass-cli/assets/compass-skill/references/history.md
+++ b/crates/compass-cli/assets/compass-skill/references/history.md
@@ -46,7 +46,7 @@ offline worktree. Report the resolved revision when answering.
 compass diff v1.2.0 HEAD
 compass diff HEAD~1 HEAD --all
 compass diff HEAD~1 HEAD --format json
-compass diff HEAD~1 HEAD --explain sd1-...
+compass diff HEAD~1 HEAD --explain sd2-...
 compass history list HEAD --format json
 compass history show HEAD
 compass history export HEAD --format compass-out --output historical-output

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -307,7 +307,7 @@ const PAGES: &[Page] = &[
         "diff",
         "Review semantic changes between two Git revisions",
         ["compass diff <OLD> <NEW> [OPTIONS]"],
-        "Arguments:\n  <OLD>                         Base Git revision\n  <NEW>                         Target Git revision\n\nOptions:\n  --format <text|json>          Output format [default: text]\n  --all                         Include routine symbol churn\n  --explain <FINDING_ID>        Expand one semantic finding\n  --fingerprint <SHA256>        Select one extraction fingerprint\n\nExamples:\n  compass diff v1.2.0 HEAD\n  compass diff HEAD~1 HEAD --format json\n  compass diff main feature --all\n\nNotes:\n  Findings report callable breaks, behavior, dependencies, affected consumers, and evidence limitations."
+        "Arguments:\n  <OLD>                         Base Git revision\n  <NEW>                         Target Git revision\n\nOptions:\n  --format <text|json>          Output format [default: text]\n  --limit <N>                   Show at most N findings per text section [default: 20]\n  --all                         Include routine churn and show every finding\n  --explain <FINDING_ID>        Expand one semantic finding\n  --fingerprint <SHA256>        Select one extraction fingerprint\n\nExamples:\n  compass diff v1.2.0 HEAD\n  compass diff HEAD~1 HEAD --format json\n  compass diff main feature --limit 50\n  compass diff main feature --all\n\nNotes:\n  Findings report callable breaks, behavior, dependencies, affected consumers, and evidence limitations. JSON and --all are exhaustive."
     ),
     page!(
         "tree",
@@ -978,7 +978,7 @@ mod tests {
     #[test]
     fn catalog_has_unique_complete_public_roots() {
         let roots = root_commands();
-        assert_eq!(roots.len(), 35);
+        assert_eq!(roots.len(), 36);
         for root in roots {
             let matches = PAGES.iter().filter(|page| page.path == root).count();
             assert_eq!(matches, 1, "{root}");

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -1129,7 +1129,7 @@ mod tests {
                 .map_err(HistoryError::InvalidFingerprint)?
                 .options
                 .profile();
-        profile.insert("graph_schema", "networkx-node-link/v1")?;
+        profile.insert("graph_schema", "networkx-node-link/v6")?;
 
         let result = HistoryBuildOptions::from_profile(profile);
         assert!(matches!(

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -42,8 +42,7 @@ impl HistoryBuildOptions {
         self.profile.clone()
     }
 
-    pub(crate) fn from_profile(mut profile: BuildProfile) -> Result<Self, HistoryError> {
-        upgrade_persisted_profile(&mut profile)?;
+    pub(crate) fn from_profile(profile: BuildProfile) -> Result<Self, HistoryError> {
         validate_persisted_profile(&profile)?;
         let gitignore = profile.value("gitignore") != Some("false");
         let excludes = profile
@@ -278,39 +277,6 @@ impl HistoryBuildOptions {
             code_only: values.code_only,
         })
     }
-}
-
-fn upgrade_persisted_profile(profile: &mut BuildProfile) -> Result<(), HistoryError> {
-    if profile.value("graph_schema") == Some("networkx-node-link/v1") {
-        profile.insert("graph_schema", HISTORY_GRAPH_SCHEMA)?;
-    }
-    for (key, value) in [
-        (
-            "program_provider_policy",
-            "offline-artifacts-first".to_owned(),
-        ),
-        (
-            "program_ir_schema",
-            compass_ir::PROGRAM_SCHEMA_VERSION.to_string(),
-        ),
-        (
-            "program_merger_version",
-            compass_program::MERGER_VERSION.to_string(),
-        ),
-        (
-            "program_analysis_schema",
-            compass_analysis::ANALYSIS_SCHEMA_VERSION.to_string(),
-        ),
-        (
-            "program_analyzer_version",
-            compass_analysis::ANALYZER_VERSION.to_string(),
-        ),
-    ] {
-        if profile.value(key).is_none() {
-            profile.insert(key, &value)?;
-        }
-    }
-    Ok(())
 }
 
 fn validate_persisted_profile(profile: &BuildProfile) -> Result<(), HistoryError> {
@@ -1157,7 +1123,7 @@ mod tests {
     }
 
     #[test]
-    fn persisted_v1_profile_is_migrated_to_force_v2_realization() -> Result<(), HistoryError> {
+    fn previous_graph_schema_profiles_are_rejected() -> Result<(), HistoryError> {
         let mut profile =
             parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])
                 .map_err(HistoryError::InvalidFingerprint)?
@@ -1165,12 +1131,11 @@ mod tests {
                 .profile();
         profile.insert("graph_schema", "networkx-node-link/v1")?;
 
-        let options = HistoryBuildOptions::from_profile(profile)?;
-
-        assert_eq!(
-            options.profile().value("graph_schema"),
-            Some(HISTORY_GRAPH_SCHEMA)
-        );
+        let result = HistoryBuildOptions::from_profile(profile);
+        assert!(matches!(
+            result,
+            Err(error) if error.to_string().contains(HISTORY_GRAPH_SCHEMA)
+        ));
         Ok(())
     }
 

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -228,9 +228,7 @@ pub(crate) fn resolve_comparable_pair(
             (history, old, new)
         }
     };
-    let old_profile = normalized_profile_for_comparison(&old.version.build_profile)?;
-    let new_profile = normalized_profile_for_comparison(&new.version.build_profile)?;
-    if old_profile != new_profile {
+    if old.version.build_profile != new.version.build_profile {
         return Err(format!(
             "realizations are not semantically comparable\n\nOLD {} ({}) profile: {}\nNEW {} ({}) profile: {}\n\nBuild a comparable realization:\n  compass history build {} --profile-from {}",
             old.version.git_commit,
@@ -244,39 +242,6 @@ pub(crate) fn resolve_comparable_pair(
         ));
     }
     Ok(ResolvedDiff { history, old, new })
-}
-
-fn normalized_profile_for_comparison(profile: &BuildProfile) -> Result<BuildProfile, String> {
-    let mut normalized = profile.clone();
-    for (key, value) in [
-        (
-            "program_provider_policy",
-            "offline-artifacts-first".to_owned(),
-        ),
-        (
-            "program_ir_schema",
-            compass_ir::PROGRAM_SCHEMA_VERSION.to_string(),
-        ),
-        (
-            "program_merger_version",
-            compass_program::MERGER_VERSION.to_string(),
-        ),
-        (
-            "program_analysis_schema",
-            compass_analysis::ANALYSIS_SCHEMA_VERSION.to_string(),
-        ),
-        (
-            "program_analyzer_version",
-            compass_analysis::ANALYZER_VERSION.to_string(),
-        ),
-    ] {
-        if normalized.value(key).is_none() {
-            normalized
-                .insert(key, &value)
-                .map_err(|error| error.to_string())?;
-        }
-    }
-    Ok(normalized)
 }
 
 fn select_existing(

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -1171,8 +1171,7 @@ fn command_tree(frontend: Frontend, args: &[String]) -> Outcome {
             grouped_decimal(cap)
         ));
     }
-    let document = match compass_model::GraphDocument::load_for_recluster_compatibility(&graph_path)
-    {
+    let document = match compass_model::GraphDocument::load_for_recluster(&graph_path) {
         Ok(document) => document,
         Err(error) => return Outcome::failure(format!("error: {error}")),
     };

--- a/crates/compass-cli/src/program_commands.rs
+++ b/crates/compass-cli/src/program_commands.rs
@@ -650,7 +650,6 @@ fn program_graph(analysis: &AnalysisBundle) -> Result<GraphDocument, compass_mod
         nodes,
         links,
         extras: BTreeMap::new(),
-        used_legacy_edges_key: false,
     })
 }
 

--- a/crates/compass-cli/src/program_commands.rs
+++ b/crates/compass-cli/src/program_commands.rs
@@ -675,7 +675,7 @@ fn operation_properties(operation: &Operation) -> (&'static str, String) {
         OperationKind::Read { path } => ("read", path.clone()),
         OperationKind::Write { path } => ("write", path.clone()),
         OperationKind::Await => ("await", "await".to_owned()),
-        OperationKind::Throw { value } => ("throw", value.clone()),
+        OperationKind::Throw { effect } => ("throw", effect.display_name()),
     }
 }
 

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -24,6 +24,7 @@ struct Options {
     new: String,
     format: Format,
     all: bool,
+    limit: Option<usize>,
     explain: Option<String>,
     fingerprint: Option<String>,
 }
@@ -35,7 +36,7 @@ pub(crate) fn help(frontend: Frontend) -> String {
         "graphify"
     };
     format!(
-        "Usage: {command} diff <OLD> <NEW> [OPTIONS]\n\nOptions:\n  --format <text|json>       Output format [default: text]\n  --all                      Include routine symbol churn\n  --explain <FINDING_ID>     Expand one semantic finding\n  --fingerprint <SHA256>     Select one extraction fingerprint"
+        "Usage: {command} diff <OLD> <NEW> [OPTIONS]\n\nOptions:\n  --format <text|json>       Output format [default: text]\n  --limit <N>                Show at most N findings per text section [default: 20]\n  --all                      Include routine churn and show every finding\n  --explain <FINDING_ID>     Expand one semantic finding\n  --fingerprint <SHA256>     Select one extraction fingerprint"
     )
 }
 
@@ -108,6 +109,7 @@ fn execute(args: &[String]) -> Result<String, CommandError> {
     .map_err(runtime)?;
     let render = RenderOptions {
         include_routine: options.all,
+        max_findings_per_section: options.limit.or((!options.all).then_some(20)),
         explain: options.explain.as_deref(),
     };
     match options.format {
@@ -121,6 +123,7 @@ fn parse(args: &[String]) -> Result<Options, String> {
     let mut format = Format::Text;
     let mut format_set = false;
     let mut all = false;
+    let mut limit = None;
     let mut explain = None;
     let mut fingerprint = None;
     let mut parse_options = true;
@@ -134,6 +137,18 @@ fn parse(args: &[String]) -> Result<Options, String> {
                     return Err("duplicate --all".to_owned());
                 }
                 all = true;
+            }
+            "--limit" if parse_options => {
+                index += 1;
+                let value = args.get(index).ok_or("--limit requires a value")?;
+                if limit.replace(parse_limit(value)?).is_some() {
+                    return Err("duplicate --limit".to_owned());
+                }
+            }
+            value if parse_options && value.starts_with("--limit=") => {
+                if limit.replace(parse_limit(&value[8..])?).is_some() {
+                    return Err("duplicate --limit".to_owned());
+                }
             }
             "--format" if parse_options => {
                 index += 1;
@@ -187,6 +202,9 @@ fn parse(args: &[String]) -> Result<Options, String> {
     if revisions.len() != 2 {
         return Err("diff requires exactly OLD and NEW revisions".to_owned());
     }
+    if all && limit.is_some() {
+        return Err("--all conflicts with --limit; --all is intentionally exhaustive".to_owned());
+    }
     if let Some(value) = &fingerprint {
         value
             .parse::<ExtractionFingerprint>()
@@ -197,9 +215,18 @@ fn parse(args: &[String]) -> Result<Options, String> {
         new: revisions.remove(0),
         format,
         all,
+        limit,
         explain,
         fingerprint,
     })
+}
+
+fn parse_limit(value: &str) -> Result<usize, String> {
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| "--limit must be a positive integer".to_owned())
 }
 
 fn parse_format(value: &str) -> Result<Format, String> {
@@ -456,7 +483,7 @@ mod tests {
             "new".to_owned(),
             "--format=json".to_owned(),
             "--all".to_owned(),
-            "--explain=sd1-0123456789abcdef01234567".to_owned(),
+            "--explain=sd2-0123456789abcdef01234567".to_owned(),
             format!("--fingerprint={fingerprint}"),
         ]);
         let Ok(parsed) = parsed else {
@@ -465,9 +492,10 @@ mod tests {
         };
         assert_eq!(parsed.format, Format::Json);
         assert!(parsed.all);
+        assert_eq!(parsed.limit, None);
         assert_eq!(
             parsed.explain.as_deref(),
-            Some("sd1-0123456789abcdef01234567")
+            Some("sd2-0123456789abcdef01234567")
         );
         assert_eq!(parsed.fingerprint.as_deref(), Some(fingerprint.as_str()));
 
@@ -477,6 +505,15 @@ mod tests {
                 "old".to_owned(),
                 "new".to_owned(),
                 "--format=yaml".to_owned(),
+            ])
+            .is_err()
+        );
+        assert!(
+            parse(&[
+                "old".to_owned(),
+                "new".to_owned(),
+                "--all".to_owned(),
+                "--limit=10".to_owned(),
             ])
             .is_err()
         );

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -483,7 +483,7 @@ mod tests {
             "new".to_owned(),
             "--format=json".to_owned(),
             "--all".to_owned(),
-            "--explain=sd2-0123456789abcdef01234567".to_owned(),
+            "--explain=sd1-0123456789abcdef01234567".to_owned(),
             format!("--fingerprint={fingerprint}"),
         ]);
         let Ok(parsed) = parsed else {
@@ -495,7 +495,7 @@ mod tests {
         assert_eq!(parsed.limit, None);
         assert_eq!(
             parsed.explain.as_deref(),
-            Some("sd2-0123456789abcdef01234567")
+            Some("sd1-0123456789abcdef01234567")
         );
         assert_eq!(parsed.fingerprint.as_deref(), Some(fingerprint.as_str()));
 

--- a/crates/compass-cli/src/semantic_diff_render.rs
+++ b/crates/compass-cli/src/semantic_diff_render.rs
@@ -8,6 +8,7 @@ use compass_semantic_diff::{
 
 pub(crate) struct RenderOptions<'a> {
     pub include_routine: bool,
+    pub max_findings_per_section: Option<usize>,
     pub explain: Option<&'a str>,
 }
 
@@ -50,6 +51,10 @@ pub(crate) fn render_text(
         .iter()
         .map(|finding| finding.affected_consumers.len())
         .sum::<usize>();
+    let public_changes = visible
+        .iter()
+        .filter(|finding| finding.public_surface)
+        .count();
     let gaps = visible
         .iter()
         .filter(|finding| finding.verification.state == VerificationState::Gap)
@@ -61,9 +66,63 @@ pub(crate) fn render_text(
         short_revision(&report.comparison.old_commit),
         short_revision(&report.comparison.new_commit)
     );
+    let test_mapping = report
+        .completeness
+        .get("test_mapping")
+        .copied()
+        .unwrap_or(compass_semantic_diff::Completeness::Unavailable);
+    let call_resolution = report
+        .completeness
+        .get("call_resolution")
+        .copied()
+        .unwrap_or(compass_semantic_diff::Completeness::Unavailable);
+    let consumer_summary = if call_resolution == compass_semantic_diff::Completeness::Complete {
+        format!("{consumers} affected consumers")
+    } else {
+        format!(
+            "{consumers} resolved affected consumers · call mapping {}",
+            completeness_name(call_resolution)
+        )
+    };
+    let gap_summary = if test_mapping == compass_semantic_diff::Completeness::Complete {
+        format!("{gaps} test gaps")
+    } else {
+        format!(
+            "{gaps} proven test gaps · test mapping {}",
+            completeness_name(test_mapping)
+        )
+    };
     let _ = writeln!(
         output,
-        "{breaks} likely breaks · {behaviors} behavior changes · {consumers} affected consumers · {gaps} test gaps"
+        "{breaks} likely breaks · {public_changes} public-surface changes · {behaviors} behavior changes · {consumer_summary} · {gap_summary}"
+    );
+    if !report.feature_groups.is_empty() {
+        output.push_str("\nFeature-level changes\n");
+        let group_limit = if options.include_routine {
+            report.feature_groups.len()
+        } else {
+            5
+        };
+        for group in report.feature_groups.iter().take(group_limit) {
+            let _ = writeln!(output, "  {} ({})", group.headline, group.id);
+            let _ = writeln!(output, "    {}", group.summary);
+        }
+        if report.feature_groups.len() > group_limit {
+            let _ = writeln!(
+                output,
+                "  … {} more feature groups",
+                report.feature_groups.len() - group_limit
+            );
+        }
+    }
+    render_section(
+        &mut output,
+        "Public API changes",
+        visible
+            .iter()
+            .copied()
+            .filter(|finding| finding.public_surface),
+        options.max_findings_per_section,
     );
     render_section(
         &mut output,
@@ -72,8 +131,9 @@ pub(crate) fn render_text(
             matches!(
                 finding.compatibility,
                 Compatibility::ProvenBreak | Compatibility::PossibleBreak
-            )
+            ) && !finding.public_surface
         }),
+        options.max_findings_per_section,
     );
     render_section(
         &mut output,
@@ -82,11 +142,13 @@ pub(crate) fn render_text(
             matches!(
                 finding.finding_type,
                 FindingType::BehaviorChange | FindingType::DependencyChange
-            ) && !matches!(
-                finding.compatibility,
-                Compatibility::ProvenBreak | Compatibility::PossibleBreak
-            )
+            ) && !finding.public_surface
+                && !matches!(
+                    finding.compatibility,
+                    Compatibility::ProvenBreak | Compatibility::PossibleBreak
+                )
         }),
+        options.max_findings_per_section,
     );
     render_section(
         &mut output,
@@ -95,13 +157,15 @@ pub(crate) fn render_text(
             !matches!(
                 finding.compatibility,
                 Compatibility::ProvenBreak | Compatibility::PossibleBreak
-            ) && !matches!(
-                finding.finding_type,
-                FindingType::BehaviorChange
-                    | FindingType::DependencyChange
-                    | FindingType::VerificationGap
-            )
+            ) && !finding.public_surface
+                && !matches!(
+                    finding.finding_type,
+                    FindingType::BehaviorChange
+                        | FindingType::DependencyChange
+                        | FindingType::VerificationGap
+                )
         }),
+        options.max_findings_per_section,
     );
     if !options.include_routine {
         let count = report
@@ -110,9 +174,15 @@ pub(crate) fn render_text(
             .map(|group| group.count)
             .sum::<usize>();
         if count > 0 {
+            let detail = report
+                .collapsed_groups
+                .iter()
+                .map(|group| format!("{} {}", group.count, group.label))
+                .collect::<Vec<_>>()
+                .join(", ");
             let _ = writeln!(
                 output,
-                "\nRoutine changes collapsed: {count} (use --all to expand)"
+                "\nRoutine changes collapsed: {count} ({detail}; use --all to expand)"
             );
         }
     }
@@ -147,6 +217,7 @@ fn render_section<'a>(
     output: &mut String,
     title: &str,
     findings: impl Iterator<Item = &'a SemanticFinding>,
+    limit: Option<usize>,
 ) {
     let findings = findings.collect::<Vec<_>>();
     if findings.is_empty() {
@@ -154,8 +225,11 @@ fn render_section<'a>(
     }
     let _ = write!(output, "\n{title}\n");
     let mut shown = 0_usize;
+    let total = findings.len();
     for finding in findings {
-        if shown >= 20 && finding.compatibility != Compatibility::ProvenBreak {
+        if limit.is_some_and(|limit| shown >= limit)
+            && finding.compatibility != Compatibility::ProvenBreak
+        {
             continue;
         }
         shown += 1;
@@ -187,6 +261,14 @@ fn render_section<'a>(
             );
         }
         let _ = writeln!(output, "    Review: {}", finding.reviewer_action);
+    }
+    let hidden = total.saturating_sub(shown);
+    if hidden > 0 {
+        let _ = writeln!(
+            output,
+            "  … {hidden} more findings (use --limit {} or --all)",
+            shown.saturating_add(hidden)
+        );
     }
 }
 
@@ -265,6 +347,85 @@ fn verification_name(state: VerificationState) -> &'static str {
     }
 }
 
+fn completeness_name(completeness: compass_semantic_diff::Completeness) -> &'static str {
+    match completeness {
+        compass_semantic_diff::Completeness::Complete => "complete",
+        compass_semantic_diff::Completeness::Partial => "partial",
+        compass_semantic_diff::Completeness::Unavailable => "unavailable",
+    }
+}
+
 fn short_revision(revision: &str) -> &str {
     revision.get(..revision.len().min(12)).unwrap_or(revision)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use compass_semantic_diff::{
+        Compatibility, Confidence, FindingOrigin, FindingType, SemanticFinding, Verification,
+        VerificationState,
+    };
+
+    use super::render_section;
+
+    fn finding(index: usize, compatibility: Compatibility) -> SemanticFinding {
+        SemanticFinding {
+            id: format!("sd2-{index:024x}"),
+            finding_type: FindingType::BehaviorChange,
+            subject: format!("subject-{index}"),
+            origin: FindingOrigin::Direct,
+            headline: format!("finding {index}"),
+            explanation: "changed".to_owned(),
+            compatibility,
+            confidence: Confidence::Exact,
+            review_priority: 1,
+            public_surface: false,
+            routine: false,
+            before: None,
+            after: None,
+            affected_consumers: Vec::new(),
+            witness_paths: Vec::new(),
+            verification: Verification {
+                state: VerificationState::Unknown,
+                exact_tests: Vec::new(),
+                recommended_tests: Vec::new(),
+                reason: "unavailable".to_owned(),
+            },
+            reviewer_action: "review".to_owned(),
+            evidence: Vec::new(),
+            completeness: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn section_limits_are_explicit_and_unlimited_is_exhaustive() {
+        let findings = (0..23)
+            .map(|index| finding(index, Compatibility::Behavioral))
+            .collect::<Vec<_>>();
+        let mut limited = String::new();
+        render_section(&mut limited, "Changes", findings.iter(), Some(20));
+        assert!(limited.contains("… 3 more findings (use --limit 23 or --all)"));
+        assert!(!limited.contains("finding 22"));
+
+        let mut exhaustive = String::new();
+        render_section(&mut exhaustive, "Changes", findings.iter(), None);
+        assert!(exhaustive.contains("finding 22"));
+        assert!(!exhaustive.contains("more findings"));
+    }
+
+    #[test]
+    fn limits_never_hide_proven_breaks() {
+        let findings = [
+            finding(0, Compatibility::Behavioral),
+            finding(1, Compatibility::Behavioral),
+            finding(2, Compatibility::ProvenBreak),
+        ];
+        let mut output = String::new();
+        render_section(&mut output, "Changes", findings.iter(), Some(1));
+        assert!(output.contains("finding 0"));
+        assert!(output.contains("finding 2"));
+        assert!(output.contains("… 1 more finding"));
+    }
 }

--- a/crates/compass-cli/src/semantic_diff_render.rs
+++ b/crates/compass-cli/src/semantic_diff_render.rs
@@ -372,7 +372,7 @@ mod tests {
 
     fn finding(index: usize, compatibility: Compatibility) -> SemanticFinding {
         SemanticFinding {
-            id: format!("sd2-{index:024x}"),
+            id: format!("sd1-{index:024x}"),
             finding_type: FindingType::BehaviorChange,
             subject: format!("subject-{index}"),
             origin: FindingOrigin::Direct,

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -35,6 +35,13 @@ fn run(
         .output()?)
 }
 
+fn current_history_profile() -> Result<compass_history::BuildProfile, compass_history::HistoryError>
+{
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
+    Ok(profile)
+}
+
 #[test]
 fn history_help_and_empty_status_are_actionable_and_non_mutating()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -380,7 +387,7 @@ fn worker_reconciles_catalog_and_preferred_crash_windows() -> Result<(), Box<dyn
     let candidate = history.publish(PublishRequest {
         commit: commit.clone(),
         parents: repository.parents(&commit)?,
-        profile: compass_history::BuildProfile::default(),
+        profile: current_history_profile()?,
         fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -501,7 +508,7 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
         Ok(history.publish(PublishRequest {
             commit: commit.clone(),
             parents: repository.parents(&commit)?,
-            profile: compass_history::BuildProfile::default(),
+            profile: current_history_profile()?,
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,
@@ -721,7 +728,7 @@ fn gc_requires_explicit_confirmation_for_non_preferred_realizations()
         history.publish(PublishRequest {
             commit: commit.clone(),
             parents: Vec::new(),
-            profile: compass_history::BuildProfile::default(),
+            profile: current_history_profile()?,
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,
@@ -891,7 +898,7 @@ fn diff_emits_semantic_text_json_and_rejects_removed_flags()
     history.publish(PublishRequest {
         commit: old_commit.clone(),
         parents: repository.parents(&old_commit)?,
-        profile: compass_history::BuildProfile::default(),
+        profile: current_history_profile()?,
         fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -941,7 +948,7 @@ fn diff_emits_semantic_text_json_and_rejects_removed_flags()
     history.publish(PublishRequest {
         commit: new_commit.clone(),
         parents: repository.parents(&new_commit)?,
-        profile: compass_history::BuildProfile::default(),
+        profile: current_history_profile()?,
         fingerprint: std::iter::repeat_n('c', 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -997,7 +1004,7 @@ fn diff_emits_semantic_text_json_and_rejects_removed_flags()
     let empty = run(compass, directory.path(), &["diff", "HEAD", "HEAD"])?;
     assert!(String::from_utf8_lossy(&empty.stdout).contains("0 likely breaks"));
     let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
-    let mut incompatible_profile = compass_history::BuildProfile::default();
+    let mut incompatible_profile = current_history_profile()?;
     incompatible_profile.insert("compass_version", "incompatible")?;
     let incompatible = history.publish(PublishRequest {
         commit: new_commit,
@@ -1064,7 +1071,7 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
         history.publish(PublishRequest {
             parents: repository.parents(&commit)?,
             commit,
-            profile: compass_history::BuildProfile::default(),
+            profile: current_history_profile()?,
             fingerprint: std::iter::repeat_n(fingerprint, 64)
                 .collect::<String>()
                 .parse::<ExtractionFingerprint>()?,

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -607,7 +607,7 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
         "{}",
         String::from_utf8_lossy(&export.stderr)
     );
-    let exported = GraphDocument::load_for_recluster_compatibility(&graph_json)?;
+    let exported = GraphDocument::load_for_recluster(&graph_json)?;
     assert_eq!(exported.nodes[0].label(), "First");
 
     let graph_directory = directory.path().join("not-a-graph-file");
@@ -980,7 +980,7 @@ fn diff_emits_semantic_text_json_and_rejects_removed_flags()
     )?;
     assert!(json_output.status.success());
     let envelope: serde_json::Value = serde_json::from_slice(&json_output.stdout)?;
-    assert_eq!(envelope["schema"], "compass.semantic_diff.report/2");
+    assert_eq!(envelope["schema"], "compass.semantic_diff.report/1");
     assert!(envelope["findings"].is_array());
     assert!(envelope.get("changes").is_none());
     for removed in [
@@ -1265,7 +1265,7 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
         String::from_utf8_lossy(&diff.stderr)
     );
     let envelope: serde_json::Value = serde_json::from_slice(&diff.stdout)?;
-    assert_eq!(envelope["schema"], "compass.semantic_diff.report/2");
+    assert_eq!(envelope["schema"], "compass.semantic_diff.report/1");
     assert!(envelope["findings"].is_array());
     let repository = Repository::discover(directory.path())?;
     let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
@@ -1386,7 +1386,7 @@ fn semantic_diff_end_to_end_languages() -> Result<(), Box<dyn std::error::Error>
             String::from_utf8_lossy(&diff.stderr)
         );
         let report: serde_json::Value = serde_json::from_slice(&diff.stdout)?;
-        assert_eq!(report["schema"], "compass.semantic_diff.report/2");
+        assert_eq!(report["schema"], "compass.semantic_diff.report/1");
         let findings = report["findings"].as_array().ok_or("findings")?;
         let finding = findings
             .iter()

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -973,7 +973,7 @@ fn diff_emits_semantic_text_json_and_rejects_removed_flags()
     )?;
     assert!(json_output.status.success());
     let envelope: serde_json::Value = serde_json::from_slice(&json_output.stdout)?;
-    assert_eq!(envelope["schema"], "compass.semantic_diff.report/1");
+    assert_eq!(envelope["schema"], "compass.semantic_diff.report/2");
     assert!(envelope["findings"].is_array());
     assert!(envelope.get("changes").is_none());
     for removed in [
@@ -1258,7 +1258,7 @@ fn build_rebuild_and_unseen_diff_publish_complete_realizations()
         String::from_utf8_lossy(&diff.stderr)
     );
     let envelope: serde_json::Value = serde_json::from_slice(&diff.stdout)?;
-    assert_eq!(envelope["schema"], "compass.semantic_diff.report/1");
+    assert_eq!(envelope["schema"], "compass.semantic_diff.report/2");
     assert!(envelope["findings"].is_array());
     let repository = Repository::discover(directory.path())?;
     let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
@@ -1379,7 +1379,7 @@ fn semantic_diff_end_to_end_languages() -> Result<(), Box<dyn std::error::Error>
             String::from_utf8_lossy(&diff.stderr)
         );
         let report: serde_json::Value = serde_json::from_slice(&diff.stdout)?;
-        assert_eq!(report["schema"], "compass.semantic_diff.report/1");
+        assert_eq!(report["schema"], "compass.semantic_diff.report/2");
         let findings = report["findings"].as_array().ok_or("findings")?;
         let finding = findings
             .iter()

--- a/crates/compass-core/src/cluster_existing.rs
+++ b/crates/compass-core/src/cluster_existing.rs
@@ -119,7 +119,7 @@ where
             "warning: graph.json exceeds cap ({size} bytes); falling back to community-aggregation view (node_limit=5000)"
         )
     });
-    let mut document = GraphDocument::load_for_recluster_compatibility(&options.graph_path)?;
+    let mut document = GraphDocument::load_for_recluster(&options.graph_path)?;
     normalize_recluster_document(&mut document);
     if document.nodes.is_empty() {
         return Err(CoreError::EmptyGraph);

--- a/crates/compass-core/src/merge.rs
+++ b/crates/compass-core/src/merge.rs
@@ -81,7 +81,6 @@ pub fn merge_graphs(paths: &[PathBuf], output: &Path) -> Result<MergeResult, Cor
         nodes,
         links: edges,
         extras: BTreeMap::new(),
-        used_legacy_edges_key: false,
     };
     write_json_atomic(output, &document, true)?;
     Ok(MergeResult {

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -820,7 +820,15 @@ fn build_graph_inner(
         });
     }
 
-    let previous = previous_communities(&output_dir.join("graph.json"));
+    // A history realization must depend only on the target commit and build
+    // profile. Incremental seeds may accelerate extraction, but their prior
+    // community numbering is operational state and cannot influence the
+    // content-addressed result.
+    let previous = if std::env::var_os("COMPASS_HISTORY_BUILD").is_some() {
+        HashMap::new()
+    } else {
+        previous_communities(&output_dir.join("graph.json"))
+    };
     let current = cluster(
         &document,
         ClusterOptions {
@@ -1344,6 +1352,38 @@ fn collect_ast_id_remap(
         }
         if node.id == make_id(&[source]) {
             id_remap.insert(node.id.clone(), new_prefix);
+        } else if node.id == old_prefix
+            && node
+                .attributes
+                .get("symbol_kind")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|kind| kind != "file")
+        {
+            // Permissive grammars can surface punctuation-only constructs
+            // such as a TypeScript `[]` type as symbols. Their normalized
+            // label is empty, so the extractor falls back to the absolute
+            // file-stem ID. Keep the symbol distinct from the file node while
+            // replacing that checkout-root identity with a stable location.
+            let label = node
+                .attributes
+                .get("label")
+                .and_then(serde_json::Value::as_str)
+                .map(|value| make_id(&[value]))
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "symbol".to_owned());
+            let line = node
+                .attributes
+                .get("line_start")
+                .and_then(serde_json::Value::as_u64)
+                .or_else(|| {
+                    node.attributes
+                        .get("source_location")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(|value| value.strip_prefix('L'))
+                        .and_then(|value| value.parse::<u64>().ok())
+                })
+                .unwrap_or_default();
+            id_remap.insert(node.id.clone(), format!("{new_prefix}_{label}_{line}"));
         } else if let Some(suffix) = node.id.strip_prefix(&format!("{old_prefix}_")) {
             id_remap.insert(node.id.clone(), format!("{new_prefix}_{suffix}"));
         }
@@ -2186,7 +2226,7 @@ mod tests {
             fs::create_dir_all(root.join(".hidden"))?;
             fs::write(
                 source.join("Page.astro"),
-                "---\nimport Layout from '../.hidden/Layout.astro';\n---\n<Layout />\n",
+                "---\nimport Layout from '../.hidden/Layout.astro';\nconst values: string[] = [];\n---\n<Layout />\n",
             )?;
             fs::write(root.join(".hidden/Layout.astro"), "<slot />\n")?;
             let mut options = BuildOptions::new(root);
@@ -2244,6 +2284,20 @@ mod tests {
         assert!(!encoded.contains(&make_id(&[&second.path().to_string_lossy()])));
         assert!(!encoded.contains(&first.path().to_string_lossy().to_string()));
         assert!(!encoded.contains(&second.path().to_string_lossy().to_string()));
+        let punctuation_symbols = first_graph
+            .nodes
+            .iter()
+            .filter(|node| node.string("label") == "[]")
+            .collect::<Vec<_>>();
+        assert!(
+            !punctuation_symbols.is_empty(),
+            "fixture must exercise the punctuation-symbol identity collision"
+        );
+        assert!(
+            punctuation_symbols
+                .iter()
+                .all(|node| node.id.starts_with("src_page_"))
+        );
         Ok(())
     }
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -2474,7 +2474,6 @@ mod tests {
             }],
             links: Vec::new(),
             extras: BTreeMap::new(),
-            used_legacy_edges_key: false,
         };
         write_json_atomic(&graph_path, &semantic, true)?;
 

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -91,14 +91,20 @@ impl CompleteGraphBuilder for RecordingBuilder {
     }
 }
 
-fn request(repository: &Repository, commit: CommitId, rebuild: bool) -> MaterializeRequest {
-    MaterializeRequest {
+fn request(
+    repository: &Repository,
+    commit: CommitId,
+    rebuild: bool,
+) -> Result<MaterializeRequest, compass_history::HistoryError> {
+    let mut profile = BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
+    Ok(MaterializeRequest {
         repository: repository.clone(),
         commit,
-        profile: BuildProfile::default(),
+        profile,
         rebuild,
         replace_corrupt: false,
-    }
+    })
 }
 
 #[test]
@@ -126,7 +132,7 @@ fn materializer_reuses_preferred_ancestor_and_publishes_target()
     materialize_history(
         &store,
         &builder,
-        request(&repository, parent.clone(), false),
+        request(&repository, parent.clone(), false)?,
     )?;
     let mut phases = Vec::new();
     struct Observer<'a>(&'a mut Vec<MaterializeStage>);
@@ -139,7 +145,7 @@ fn materializer_reuses_preferred_ancestor_and_publishes_target()
     let published = materialize_history_with_observer(
         &store,
         &builder,
-        request(&repository, target.clone(), false),
+        request(&repository, target.clone(), false)?,
         &mut Observer(&mut phases),
     )?;
     assert_eq!(published.version.git_commit, target.to_string());
@@ -159,11 +165,11 @@ fn materializer_reuses_preferred_ancestor_and_publishes_target()
     );
 
     let before = builder.seeds()?.len();
-    let existing = materialize_history(&store, &builder, request(&repository, target, false))?;
+    let existing = materialize_history(&store, &builder, request(&repository, target, false)?)?;
     assert_eq!(existing.id, published.id);
     assert_eq!(builder.seeds()?.len(), before);
 
-    let mut invalid_recovery = request(&repository, parent, true);
+    let mut invalid_recovery = request(&repository, parent, true)?;
     invalid_recovery.replace_corrupt = true;
     assert!(matches!(
         materialize_history(&store, &builder, invalid_recovery),
@@ -203,7 +209,7 @@ fn incomplete_builder_output_is_never_published() -> Result<(), Box<dyn std::err
         materialize_history(
             &store,
             &IncompleteBuilder,
-            request(&repository, commit.clone(), false)
+            request(&repository, commit.clone(), false)?
         )
         .is_err()
     );
@@ -271,7 +277,7 @@ fn semantic_manifest_must_cover_each_exact_commit_source() -> Result<(), Box<dyn
     let error = materialize_history(
         &store,
         &MissingSemanticManifestBuilder,
-        request(&repository, commit.clone(), false),
+        request(&repository, commit.clone(), false)?,
     )
     .err()
     .ok_or("incomplete semantic manifest unexpectedly published")?;
@@ -360,7 +366,7 @@ fn observers_can_abort_every_materialization_boundary_without_publication()
         let result = materialize_history_with_observer(
             &store,
             &builder,
-            request(&repository, commit.clone(), false),
+            request(&repository, commit.clone(), false)?,
             &mut FailingObserver(point),
         );
         assert!(matches!(result, Err(MaterializeError::Observer(_))));
@@ -448,7 +454,7 @@ fn exact_tree_validation_rejects_commit_inventory_and_manifest_mismatches()
         let result = materialize_history(
             &store,
             &InvalidBuilder(variant),
-            request(&repository, commit.clone(), false),
+            request(&repository, commit.clone(), false)?,
         );
         assert!(matches!(result, Err(MaterializeError::Incomplete(_))));
         assert!(store.preferred(&commit)?.is_none());

--- a/crates/compass-core/tests/program_pipeline.rs
+++ b/crates/compass-core/tests/program_pipeline.rs
@@ -190,7 +190,10 @@ fn program_pipeline_is_deterministic_incremental_and_uses_program_json()
         document["program"]["schema"],
         "http://crab.build/compass/v1"
     );
-    assert_eq!(document["analysis_schema_version"], 1);
+    assert_eq!(
+        document["analysis_schema_version"],
+        compass_analysis::ANALYSIS_SCHEMA_VERSION
+    );
 
     let warm = build_local_graph(&options)?;
     assert_eq!(warm.program_syntax_analyzed, 0);

--- a/crates/compass-global/src/lib.rs
+++ b/crates/compass-global/src/lib.rs
@@ -340,7 +340,6 @@ fn empty_global_graph() -> GraphDocument {
         nodes: Vec::new(),
         links: Vec::new(),
         extras: Default::default(),
-        used_legacy_edges_key: false,
     }
 }
 

--- a/crates/compass-graph/src/cluster.rs
+++ b/crates/compass-graph/src/cluster.rs
@@ -927,7 +927,6 @@ mod tests {
                 })
                 .collect(),
             extras: BTreeMap::new(),
-            used_legacy_edges_key: false,
         }
     }
 

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -193,7 +193,6 @@ pub fn build_from_extraction(
         nodes,
         links,
         extras: BTreeMap::new(),
-        used_legacy_edges_key: false,
     }
 }
 

--- a/crates/compass-history/src/artifacts.rs
+++ b/crates/compass-history/src/artifacts.rs
@@ -78,7 +78,7 @@ struct OrderedRecord {
     location: Option<HyperedgeLocation>,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum HyperedgeLocation {
     Graph,
@@ -230,7 +230,12 @@ impl GraphArtifacts {
             }
         }
 
-        for (rank, node) in self.document.nodes.iter().enumerate() {
+        // Node-link arrays are sets for graph identity. Canonicalize their
+        // presentation order before recording reconstructable ranks so
+        // parallel extraction order cannot change a realization ID.
+        let mut ordered_nodes = self.document.nodes.iter().collect::<Vec<_>>();
+        ordered_nodes.sort_by(|left, right| left.id.as_bytes().cmp(right.id.as_bytes()));
+        for (rank, node) in ordered_nodes.into_iter().enumerate() {
             let mut stored = node.clone();
             for field in MOVED_NODE_FIELDS {
                 if let Some(value) = stored.attributes.remove(field) {
@@ -263,9 +268,15 @@ impl GraphArtifacts {
             ));
         }
 
+        let mut ordered_edges = self
+            .document
+            .links
+            .iter()
+            .map(|edge| Ok((canonical_json_bytes(&serde_json::to_value(edge)?)?, edge)))
+            .collect::<Result<Vec<_>, HistoryError>>()?;
+        ordered_edges.sort_by(|left, right| left.0.cmp(&right.0));
         let mut edge_occurrences = BTreeMap::<Vec<u8>, u64>::new();
-        for (rank, edge) in self.document.links.iter().enumerate() {
-            let canonical = canonical_json_bytes(&serde_json::to_value(edge)?)?;
+        for (rank, (canonical, edge)) in ordered_edges.into_iter().enumerate() {
             let discriminator = edge_discriminator(
                 edge,
                 self.document.multigraph,
@@ -308,7 +319,7 @@ impl GraphArtifacts {
         let top_hyperedges = hyperedge_array(self.document.extras.get("hyperedges"))?;
         let mut hyperedge_occurrences = BTreeMap::<Vec<u8>, u64>::new();
         let mut explicit_hyperedges = BTreeSet::<Vec<u8>>::new();
-        for (rank, (location, hyperedge)) in graph_hyperedges
+        let mut ordered_hyperedges = graph_hyperedges
             .iter()
             .map(|value| (HyperedgeLocation::Graph, value))
             .chain(
@@ -316,9 +327,11 @@ impl GraphArtifacts {
                     .iter()
                     .map(|value| (HyperedgeLocation::TopLevel, value)),
             )
-            .enumerate()
-        {
-            let canonical = canonical_json_bytes(hyperedge)?;
+            .map(|(location, value)| Ok((location, canonical_json_bytes(value)?, value)))
+            .collect::<Result<Vec<_>, HistoryError>>()?;
+        ordered_hyperedges
+            .sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+        for (rank, (location, canonical, hyperedge)) in ordered_hyperedges.into_iter().enumerate() {
             let (identity, occurrence) = if let Some(id) = hyperedge.get("id") {
                 let mut identity = vec![1];
                 identity.extend(canonical_json_bytes(id)?);
@@ -395,9 +408,10 @@ impl GraphArtifacts {
             self.labels.as_ref(),
         )?;
         if let Some(manifest) = &self.manifest {
+            let manifest = canonical_manifest(manifest);
             partitioned.metadata.push((
                 metadata_key(&[b"manifest"]),
-                encode_record("compass.metadata.manifest", manifest)?,
+                encode_record("compass.metadata.manifest", &manifest)?,
             ));
         }
         for (path, bytes) in &self.authoritative_sidecars {
@@ -720,7 +734,7 @@ fn add_optional_analysis(
 fn artifact_registry(
     artifacts: &GraphArtifacts,
 ) -> Result<Vec<ArtifactRegistryEntry>, HistoryError> {
-    let graph_bytes = canonical_json_bytes(&serde_json::to_value(&artifacts.document)?)?;
+    let graph_bytes = canonical_graph_bytes(&artifacts.document)?;
     let mut registry = vec![authoritative_entry(
         "graph.json",
         "application/json",
@@ -739,6 +753,13 @@ fn artifact_registry(
         ("manifest.json", artifacts.manifest.as_ref()),
     ] {
         if let Some(value) = value {
+            let canonical;
+            let value = if path == "manifest.json" {
+                canonical = canonical_manifest(value);
+                &canonical
+            } else {
+                value
+            };
             registry.push(authoritative_entry(
                 path,
                 "application/json",
@@ -928,9 +949,7 @@ fn verify_builtin_registry_content(
         .filter(|entry| entry.class == ArtifactClass::Authoritative)
     {
         let bytes = match entry.relative_path.as_str() {
-            "graph.json" => Some(canonical_json_bytes(&serde_json::to_value(
-                &artifacts.document,
-            )?)?),
+            "graph.json" => Some(canonical_graph_bytes(&artifacts.document)?),
             ".compass_analysis.json" => artifacts
                 .analysis
                 .as_ref()
@@ -944,7 +963,7 @@ fn verify_builtin_registry_content(
             "manifest.json" => artifacts
                 .manifest
                 .as_ref()
-                .map(canonical_json_bytes)
+                .map(|manifest| canonical_json_bytes(&canonical_manifest(manifest)))
                 .transpose()?,
             _ => None,
         };
@@ -958,6 +977,54 @@ fn verify_builtin_registry_content(
             verify_registry_content(entry, &bytes)?;
         }
     }
+    Ok(())
+}
+
+fn canonical_graph_bytes(document: &GraphDocument) -> Result<Vec<u8>, HistoryError> {
+    let mut canonical = document.clone();
+    canonical
+        .nodes
+        .sort_by(|left, right| left.id.as_bytes().cmp(right.id.as_bytes()));
+    let mut links = canonical
+        .links
+        .into_iter()
+        .map(|edge| Ok((canonical_json_bytes(&serde_json::to_value(&edge)?)?, edge)))
+        .collect::<Result<Vec<_>, HistoryError>>()?;
+    links.sort_by(|left, right| left.0.cmp(&right.0));
+    canonical.links = links.into_iter().map(|(_, edge)| edge).collect();
+    canonicalize_hyperedge_array(canonical.graph.get_mut("hyperedges"))?;
+    canonicalize_hyperedge_array(canonical.extras.get_mut("hyperedges"))?;
+    canonical_json_bytes(&serde_json::to_value(canonical)?)
+}
+
+fn canonical_manifest(manifest: &Value) -> Value {
+    let mut canonical = manifest.clone();
+    let Some(entries) = canonical.as_object_mut() else {
+        return canonical;
+    };
+    for entry in entries.values_mut() {
+        if let Some(fields) = entry.as_object_mut() {
+            fields.insert("mtime".to_owned(), Value::from(0));
+        } else if entry.is_number() {
+            *entry = Value::from(0);
+        }
+    }
+    canonical
+}
+
+fn canonicalize_hyperedge_array(value: Option<&mut Value>) -> Result<(), HistoryError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let values = value
+        .as_array_mut()
+        .ok_or_else(|| HistoryError::InvalidArtifacts("hyperedges must be an array".to_owned()))?;
+    let mut canonical = values
+        .drain(..)
+        .map(|value| Ok((canonical_json_bytes(&value)?, value)))
+        .collect::<Result<Vec<_>, HistoryError>>()?;
+    canonical.sort_by(|left, right| left.0.cmp(&right.0));
+    values.extend(canonical.into_iter().map(|(_, value)| value));
     Ok(())
 }
 

--- a/crates/compass-history/src/artifacts.rs
+++ b/crates/compass-history/src/artifacts.rs
@@ -66,7 +66,6 @@ struct DocumentHeader {
     multigraph: bool,
     graph: Map<String, Value>,
     extras: BTreeMap<String, Value>,
-    used_legacy_edges_key: bool,
     graph_hyperedges_present: bool,
     top_hyperedges_present: bool,
 }
@@ -148,9 +147,7 @@ impl GraphArtifacts {
             authoritative_sidecars.insert(entry.relative_path.clone(), bytes);
         }
         let artifacts = Self {
-            document: GraphDocument::load_for_recluster_compatibility(
-                &output_dir.join("graph.json"),
-            )?,
+            document: GraphDocument::load_for_recluster(&output_dir.join("graph.json"))?,
             program: read_optional_program(&output_dir.join("program.json"))?,
             analysis: read_optional_json(&output_dir.join(".compass_analysis.json"))?,
             labels: read_optional_json(&output_dir.join(".compass_labels.json"))?,
@@ -284,7 +281,7 @@ impl GraphArtifacts {
                 &mut edge_occurrences,
             )?;
             let (source, target) = edge_identity_endpoints(edge);
-            // Compass keeps a legacy undirected NetworkX header while its
+            // Compass keeps an undirected NetworkX header while its
             // persisted link endpoints retain the true semantic direction.
             let key = edge_key(
                 source,
@@ -383,7 +380,6 @@ impl GraphArtifacts {
                     multigraph: self.document.multigraph,
                     graph,
                     extras,
-                    used_legacy_edges_key: self.document.used_legacy_edges_key,
                     graph_hyperedges_present,
                     top_hyperedges_present,
                 })?,
@@ -590,7 +586,6 @@ impl GraphArtifacts {
                 nodes: ordered_nodes,
                 links: ordered_edges,
                 extras: header.extras,
-                used_legacy_edges_key: header.used_legacy_edges_key,
             },
             program,
             analysis,

--- a/crates/compass-history/src/gc.rs
+++ b/crates/compass-history/src/gc.rs
@@ -338,7 +338,7 @@ fn validate_root_listing(
         })?;
         let valid = match segments.as_slice() {
             [compass, version, kind, id, root_kind]
-                if compass == b"compass" && version == b"v2" && kind == b"version" =>
+                if compass == b"compass" && version == b"v1" && kind == b"version" =>
             {
                 let parsed = std::str::from_utf8(id)
                     .ok()
@@ -356,7 +356,7 @@ fn validate_root_listing(
                 }
             }
             [compass, version, kind, commit]
-                if compass == b"compass" && version == b"v2" && kind == b"preferred" =>
+                if compass == b"compass" && version == b"v1" && kind == b"preferred" =>
             {
                 let parsed = std::str::from_utf8(commit)
                     .ok()
@@ -411,7 +411,7 @@ fn roots_for_realizations(
         })?;
         if let [compass, version, kind, id, _] = segments.as_slice()
             && compass == b"compass"
-            && version == b"v2"
+            && version == b"v1"
             && kind == b"version"
             && std::str::from_utf8(id).is_ok_and(|id| ids.contains(id))
         {

--- a/crates/compass-history/src/gc.rs
+++ b/crates/compass-history/src/gc.rs
@@ -14,14 +14,6 @@ use crate::{HistoryError, HistoryQueue, HistoryStore, JobState, RealizationId};
 const GC_SCHEMA_VERSION: u32 = 1;
 const TERMINAL_JOB_RETENTION_MILLIS: u64 = 30 * 24 * 60 * 60 * 1_000;
 const TEMP_RETENTION_MILLIS: u64 = 24 * 60 * 60 * 1_000;
-const LEGACY_REALIZATION_ROOT_KINDS: [&[u8]; 6] = [
-    b"nodes",
-    b"edges",
-    b"hyperedges",
-    b"analysis",
-    b"metadata",
-    b"manifest",
-];
 const REALIZATION_ROOT_KINDS: [&[u8]; 8] = [
     b"nodes",
     b"edges",
@@ -346,7 +338,7 @@ fn validate_root_listing(
         })?;
         let valid = match segments.as_slice() {
             [compass, version, kind, id, root_kind]
-                if compass == b"compass" && version == b"v1" && kind == b"version" =>
+                if compass == b"compass" && version == b"v2" && kind == b"version" =>
             {
                 let parsed = std::str::from_utf8(id)
                     .ok()
@@ -364,7 +356,7 @@ fn validate_root_listing(
                 }
             }
             [compass, version, kind, commit]
-                if compass == b"compass" && version == b"v1" && kind == b"preferred" =>
+                if compass == b"compass" && version == b"v2" && kind == b"preferred" =>
             {
                 let parsed = std::str::from_utf8(commit)
                     .ok()
@@ -389,14 +381,10 @@ fn validate_root_listing(
         .iter()
         .map(|kind| kind.to_vec())
         .collect::<BTreeSet<_>>();
-    let legacy_expected = LEGACY_REALIZATION_ROOT_KINDS
-        .iter()
-        .map(|kind| kind.to_vec())
-        .collect::<BTreeSet<_>>();
     for (id, kinds) in realization_roots {
-        if kinds != expected && kinds != legacy_expected {
+        if kinds != expected {
             return Err(HistoryError::CorruptHistory(format!(
-                "realization {id} does not have a complete schema-2 or schema-3 root set"
+                "realization {id} does not have the complete current root set"
             )));
         }
     }
@@ -423,7 +411,7 @@ fn roots_for_realizations(
         })?;
         if let [compass, version, kind, id, _] = segments.as_slice()
             && compass == b"compass"
-            && version == b"v1"
+            && version == b"v2"
             && kind == b"version"
             && std::str::from_utf8(id).is_ok_and(|id| ids.contains(id))
         {

--- a/crates/compass-history/src/jobs.rs
+++ b/crates/compass-history/src/jobs.rs
@@ -42,9 +42,7 @@ pub struct JobRecord {
     pub commit: CommitId,
     pub profile: BuildProfile,
     pub profile_digest: String,
-    #[serde(default)]
     pub rebuild: bool,
-    #[serde(default)]
     pub replace_corrupt: bool,
     pub resolved_fingerprint: Option<String>,
     pub state: JobState,

--- a/crates/compass-history/src/lib.rs
+++ b/crates/compass-history/src/lib.rs
@@ -45,4 +45,4 @@ pub use validate::{
 };
 
 /// Current node-link graph schema included in history build profiles and fingerprints.
-pub const HISTORY_GRAPH_SCHEMA: &str = "networkx-node-link/v2";
+pub const HISTORY_GRAPH_SCHEMA: &str = "networkx-node-link/v6";

--- a/crates/compass-history/src/lib.rs
+++ b/crates/compass-history/src/lib.rs
@@ -45,4 +45,4 @@ pub use validate::{
 };
 
 /// Current node-link graph schema included in history build profiles and fingerprints.
-pub const HISTORY_GRAPH_SCHEMA: &str = "networkx-node-link/v6";
+pub const HISTORY_GRAPH_SCHEMA: &str = "networkx-node-link/v1";

--- a/crates/compass-history/src/model.rs
+++ b/crates/compass-history/src/model.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Version of the Compass history realization schema.
-pub const HISTORY_SCHEMA_VERSION: u32 = 3;
+pub const HISTORY_SCHEMA_VERSION: u32 = 1;
 
 /// Persistence treatment for one realization artifact.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/compass-history/src/model.rs
+++ b/crates/compass-history/src/model.rs
@@ -101,9 +101,7 @@ pub struct GraphVersion {
     pub schema_version: u32,
     pub git_commit: String,
     pub git_parents: Vec<String>,
-    #[serde(default)]
     pub build_profile: BuildProfile,
-    #[serde(default)]
     pub profile_digest: String,
     pub extraction_fingerprint: String,
     pub nodes_root: StoredTree,
@@ -111,26 +109,15 @@ pub struct GraphVersion {
     pub hyperedges_root: StoredTree,
     pub analysis_root: StoredTree,
     pub metadata_root: StoredTree,
-    #[serde(default = "empty_stored_tree")]
     pub program_facts_root: StoredTree,
-    #[serde(default = "empty_stored_tree")]
     pub program_summaries_root: StoredTree,
     pub node_count: u64,
     pub edge_count: u64,
     pub hyperedge_count: u64,
     pub analysis_count: u64,
     pub metadata_count: u64,
-    #[serde(default)]
     pub program_fact_count: u64,
-    #[serde(default)]
     pub program_summary_count: u64,
-}
-
-fn empty_stored_tree() -> StoredTree {
-    StoredTree {
-        root: None,
-        format: Config::default().format,
-    }
 }
 
 /// SHA-256 identity of canonical [`GraphVersion`] bytes.
@@ -140,19 +127,7 @@ pub struct RealizationId([u8; 32]);
 impl RealizationId {
     /// Derive a realization ID without operational fields.
     pub fn for_version(version: &GraphVersion) -> Result<Self, HistoryError> {
-        let mut value = serde_json::to_value(version)?;
-        if version.schema_version == 2
-            && let Some(object) = value.as_object_mut()
-        {
-            for field in [
-                "program_facts_root",
-                "program_summaries_root",
-                "program_fact_count",
-                "program_summary_count",
-            ] {
-                object.remove(field);
-            }
-        }
+        let value = serde_json::to_value(version)?;
         Ok(Self(Sha256::digest(canonical_json_bytes(&value)?).into()))
     }
 

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -34,9 +34,9 @@ pub enum HistoryRecord {
     ReverseCallers(Vec<String>),
 }
 
-pub(crate) const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v2";
+pub(crate) const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v1";
 const STORE_FORMAT_KEY: &[u8] = b"format";
-const STORE_FORMAT_VALUE: &[u8] = br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"graph_schema":"networkx-node-link/v6","history_schema":3,"typed_keys":1}"#;
+const STORE_FORMAT_VALUE: &[u8] = br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"graph_schema":"networkx-node-link/v1","history_schema":1,"typed_keys":1}"#;
 type Records = Vec<(Vec<u8>, Vec<u8>)>;
 
 /// Project-owned wrapper around the pinned SQLite Prolly adapter.
@@ -464,7 +464,7 @@ impl HistoryStore {
             };
             if segments.len() != 5
                 || segments[0] != b"compass"
-                || segments[1] != b"v2"
+                || segments[1] != b"v1"
                 || segments[2] != b"version"
                 || segments[4] != b"manifest"
             {
@@ -706,18 +706,16 @@ impl HistoryStore {
         self.get_without_activity(first)?;
         self.get_without_activity(second)?;
         let roots = |id: &RealizationId| -> Result<Vec<Tree>, HistoryError> {
-            let published = self.get_without_activity(id)?;
-            let mut kinds = vec![
+            let kinds = [
                 b"nodes".as_slice(),
                 b"edges".as_slice(),
                 b"hyperedges".as_slice(),
                 b"analysis".as_slice(),
                 b"metadata".as_slice(),
                 b"manifest".as_slice(),
+                b"program-facts".as_slice(),
+                b"program-summaries".as_slice(),
             ];
-            if published.version.schema_version >= 3 {
-                kinds.extend([b"program-facts".as_slice(), b"program-summaries".as_slice()]);
-            }
             kinds
                 .into_iter()
                 .map(|kind| self.load_realization_root(id, kind))
@@ -898,22 +896,18 @@ impl HistoryStore {
         id: &RealizationId,
         version: &GraphVersion,
     ) -> Result<(), HistoryError> {
-        let mut expected_roots = vec![
+        let expected_roots = [
             (b"nodes".as_slice(), &version.nodes_root),
             (b"edges".as_slice(), &version.edges_root),
             (b"hyperedges".as_slice(), &version.hyperedges_root),
             (b"analysis".as_slice(), &version.analysis_root),
             (b"metadata".as_slice(), &version.metadata_root),
+            (b"program-facts".as_slice(), &version.program_facts_root),
+            (
+                b"program-summaries".as_slice(),
+                &version.program_summaries_root,
+            ),
         ];
-        if version.schema_version >= 3 {
-            expected_roots.extend([
-                (b"program-facts".as_slice(), &version.program_facts_root),
-                (
-                    b"program-summaries".as_slice(),
-                    &version.program_summaries_root,
-                ),
-            ]);
-        }
         for (kind, expected) in expected_roots {
             let actual = self
                 .prolly
@@ -986,11 +980,11 @@ impl HistoryStore {
 }
 
 pub(crate) fn version_root_name(id: &RealizationId, kind: &[u8]) -> Vec<u8> {
-    root_name(&[b"compass", b"v2", b"version", id.as_hex().as_bytes(), kind])
+    root_name(&[b"compass", b"v1", b"version", id.as_hex().as_bytes(), kind])
 }
 
 fn preferred_root_name(commit: &CommitId) -> Vec<u8> {
-    root_name(&[b"compass", b"v2", b"preferred", commit.as_str().as_bytes()])
+    root_name(&[b"compass", b"v1", b"preferred", commit.as_str().as_bytes()])
 }
 
 fn count(value: usize) -> Result<u64, HistoryError> {

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -34,9 +34,9 @@ pub enum HistoryRecord {
     ReverseCallers(Vec<String>),
 }
 
-pub(crate) const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v1";
+pub(crate) const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v2";
 const STORE_FORMAT_KEY: &[u8] = b"format";
-const STORE_FORMAT_VALUE: &[u8] = br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"history_schema":1,"typed_keys":1}"#;
+const STORE_FORMAT_VALUE: &[u8] = br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"graph_schema":"networkx-node-link/v6","history_schema":3,"typed_keys":1}"#;
 type Records = Vec<(Vec<u8>, Vec<u8>)>;
 
 /// Project-owned wrapper around the pinned SQLite Prolly adapter.
@@ -154,22 +154,22 @@ impl HistoryStore {
                 "compass.node",
             ),
             HistoryRecordKey::ProgramModule(source_file) => (
-                self.load_program_root(realization, &published.version, b"program-facts")?,
+                self.load_program_root(realization, b"program-facts")?,
                 crate::artifacts::program_key("module", source_file),
                 "compass.program.module",
             ),
             HistoryRecordKey::ProgramFunction(symbol_id) => (
-                self.load_program_root(realization, &published.version, b"program-facts")?,
+                self.load_program_root(realization, b"program-facts")?,
                 crate::artifacts::program_key("function", symbol_id),
                 "compass.program.function",
             ),
             HistoryRecordKey::ProgramSummary(symbol_id) => (
-                self.load_program_root(realization, &published.version, b"program-summaries")?,
+                self.load_program_root(realization, b"program-summaries")?,
                 crate::artifacts::program_key("summary", symbol_id),
                 "compass.program.summary",
             ),
             HistoryRecordKey::ReverseCallers(symbol_id) => (
-                self.load_program_root(realization, &published.version, b"program-summaries")?,
+                self.load_program_root(realization, b"program-summaries")?,
                 crate::artifacts::program_key("reverse-call", symbol_id),
                 "compass.program.reverse-call",
             ),
@@ -464,7 +464,7 @@ impl HistoryStore {
             };
             if segments.len() != 5
                 || segments[0] != b"compass"
-                || segments[1] != b"v1"
+                || segments[1] != b"v2"
                 || segments[2] != b"version"
                 || segments[4] != b"manifest"
             {
@@ -647,9 +647,8 @@ impl HistoryStore {
         let hyperedges = self.load_realization_root(id, b"hyperedges")?;
         let analysis = self.load_realization_root(id, b"analysis")?;
         let metadata = self.load_realization_root(id, b"metadata")?;
-        let program_facts = self.load_program_root(id, &published.version, b"program-facts")?;
-        let program_summaries =
-            self.load_program_root(id, &published.version, b"program-summaries")?;
+        let program_facts = self.load_program_root(id, b"program-facts")?;
+        let program_summaries = self.load_program_root(id, b"program-summaries")?;
         validate_trees(
             &self.prolly,
             id,
@@ -681,23 +680,15 @@ impl HistoryStore {
         _guard: &ActivityGuard,
     ) -> Result<crate::CompletedGraphArtifacts, HistoryError> {
         self.validate_without_activity(id)?;
-        let published = self.get_without_activity(id)?;
         let partitioned = crate::PartitionedGraph {
             nodes: self.read_tree(&self.load_realization_root(id, b"nodes")?)?,
             edges: self.read_tree(&self.load_realization_root(id, b"edges")?)?,
             hyperedges: self.read_tree(&self.load_realization_root(id, b"hyperedges")?)?,
             analysis: self.read_tree(&self.load_realization_root(id, b"analysis")?)?,
             metadata: self.read_tree(&self.load_realization_root(id, b"metadata")?)?,
-            program_facts: self.read_tree(&self.load_program_root(
-                id,
-                &published.version,
-                b"program-facts",
-            )?)?,
-            program_summaries: self.read_tree(&self.load_program_root(
-                id,
-                &published.version,
-                b"program-summaries",
-            )?)?,
+            program_facts: self.read_tree(&self.load_program_root(id, b"program-facts")?)?,
+            program_summaries: self
+                .read_tree(&self.load_program_root(id, b"program-summaries")?)?,
         };
         crate::CompletedGraphArtifacts::reconstruct(&partitioned)
     }
@@ -800,20 +791,8 @@ impl HistoryStore {
     fn load_program_root(
         &self,
         id: &RealizationId,
-        version: &GraphVersion,
         kind: &'static [u8],
     ) -> Result<Tree, HistoryError> {
-        if version.schema_version == 2 {
-            return Ok(match kind {
-                b"program-facts" => version.program_facts_root.to_tree(),
-                b"program-summaries" => version.program_summaries_root.to_tree(),
-                _ => {
-                    return Err(HistoryError::CorruptHistory(
-                        "invalid program root kind".to_owned(),
-                    ));
-                }
-            });
-        }
         self.load_realization_root(id, kind)
     }
 
@@ -862,10 +841,20 @@ impl HistoryStore {
             HistoryError::CorruptHistory("manifest tree has no manifest record".to_owned())
         })?;
         let version: GraphVersion = serde_json::from_slice(&bytes)?;
-        if !matches!(version.schema_version, 2 | crate::HISTORY_SCHEMA_VERSION) {
+        if version.schema_version != crate::HISTORY_SCHEMA_VERSION {
             return Err(HistoryError::CorruptHistory(format!(
                 "unsupported realization schema {}",
                 version.schema_version
+            )));
+        }
+        if version.build_profile.value("graph_schema") != Some(crate::HISTORY_GRAPH_SCHEMA) {
+            return Err(HistoryError::CorruptHistory(format!(
+                "unsupported history graph schema {}; only {} is accepted",
+                version
+                    .build_profile
+                    .value("graph_schema")
+                    .unwrap_or("<missing>"),
+                crate::HISTORY_GRAPH_SCHEMA
             )));
         }
         let _: CommitId = version.git_commit.parse()?;
@@ -997,11 +986,11 @@ impl HistoryStore {
 }
 
 pub(crate) fn version_root_name(id: &RealizationId, kind: &[u8]) -> Vec<u8> {
-    root_name(&[b"compass", b"v1", b"version", id.as_hex().as_bytes(), kind])
+    root_name(&[b"compass", b"v2", b"version", id.as_hex().as_bytes(), kind])
 }
 
 fn preferred_root_name(commit: &CommitId) -> Vec<u8> {
-    root_name(&[b"compass", b"v1", b"preferred", commit.as_str().as_bytes()])
+    root_name(&[b"compass", b"v2", b"preferred", commit.as_str().as_bytes()])
 }
 
 fn count(value: usize) -> Result<u64, HistoryError> {

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -63,10 +63,12 @@ fn request(
         "links": links,
         "hyperedges": hyperedges
     }))?;
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: Vec::new(),
-        profile: compass_history::BuildProfile::default(),
+        profile,
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,

--- a/crates/compass-history/tests/maintenance.rs
+++ b/crates/compass-history/tests/maintenance.rs
@@ -60,10 +60,12 @@ fn request(fingerprint: char, label: &str) -> Result<PublishRequest, Box<dyn std
         "nodes": [{"id": "fixture", "label": label}],
         "links": []
     }))?;
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: Vec::new(),
-        profile: compass_history::BuildProfile::default(),
+        profile,
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -240,7 +242,7 @@ fn gc_rejects_incomplete_realization_root_sets() -> Result<(), Box<dyn std::erro
         Ok(_) => return Err("incomplete roots unexpectedly accepted".into()),
         Err(error) => error,
     };
-    assert!(error.to_string().contains("complete schema-2 or schema-3"));
+    assert!(error.to_string().contains("complete current root set"));
     Ok(())
 }
 

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -70,9 +70,11 @@ fn request(
     changed: bool,
 ) -> Result<PublishRequest, Box<dyn std::error::Error>> {
     let commit = repository.resolve("HEAD")?;
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
     Ok(PublishRequest {
         parents: repository.parents(&commit)?,
-        profile: compass_history::BuildProfile::default(),
+        profile,
         artifacts: GraphArtifacts {
             document: graph(commit.as_str(), changed)?,
             program: None,

--- a/crates/compass-history/tests/publication.rs
+++ b/crates/compass-history/tests/publication.rs
@@ -5,15 +5,14 @@ use std::sync::Arc;
 
 use compass_analysis::{AnalysisBundle, analyze};
 use compass_history::{
-    CommitId, CompletionEvidence, ExtractionFingerprint, GraphArtifacts, GraphVersion,
-    HistoryStore, PublishRequest, RealizationId, Repository, canonical_json_bytes,
+    CommitId, CompletionEvidence, ExtractionFingerprint, GraphArtifacts, HistoryStore,
+    PublishRequest, Repository,
 };
 use compass_ir::{ProgramBundle, ProviderDescriptor, ProviderKind, hex_sha256};
 use compass_model::GraphDocument;
 use prolly::{Config, KeyBuilder, Prolly};
 use prolly_store_sqlite::SqliteStore;
 use serde_json::json;
-use sha2::{Digest, Sha256};
 
 struct Fixture {
     _directory: tempfile::TempDir,
@@ -68,10 +67,12 @@ fn request(
         "nodes": nodes,
         "links": links
     }))?;
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
     Ok(PublishRequest {
         commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
         parents: vec!["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".parse()?],
-        profile: compass_history::BuildProfile::default(),
+        profile,
         fingerprint: std::iter::repeat_n(fingerprint, 64)
             .collect::<String>()
             .parse::<ExtractionFingerprint>()?,
@@ -143,30 +144,20 @@ fn publication_is_atomic_reopenable_and_content_idempotent()
 }
 
 #[test]
-fn schema_two_manifests_deserialize_with_identity_preserving_empty_program_trees()
+fn previous_graph_schema_profiles_are_rejected_at_publication()
 -> Result<(), Box<dyn std::error::Error>> {
     let fixture = Fixture::new()?;
     let repository = Repository::discover(&fixture.path)?;
-    let published = HistoryStore::create(&repository)?.publish(request('9', false)?)?;
-    let mut legacy = serde_json::to_value(&published.version)?;
-    let object = legacy.as_object_mut().ok_or("version is not an object")?;
-    object.insert("schema_version".to_owned(), json!(2));
-    for field in [
-        "program_facts_root",
-        "program_summaries_root",
-        "program_fact_count",
-        "program_summary_count",
-    ] {
-        object.remove(field);
-    }
-    let expected = format!("{:x}", Sha256::digest(canonical_json_bytes(&legacy)?));
-    let parsed: GraphVersion = serde_json::from_value(legacy)?;
-    assert_eq!(parsed.schema_version, 2);
-    assert!(parsed.program_facts_root.root.is_none());
-    assert!(parsed.program_summaries_root.root.is_none());
-    assert_eq!(parsed.program_fact_count, 0);
-    assert_eq!(parsed.program_summary_count, 0);
-    assert_eq!(RealizationId::for_version(&parsed)?.as_hex(), expected);
+    let history = HistoryStore::create(&repository)?;
+    let mut publish = request('a', false)?;
+    publish
+        .profile
+        .insert("graph_schema", "networkx-node-link/v5")?;
+    let error = match history.publish(publish) {
+        Ok(_) => return Err("previous graph schema must not be published".into()),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("networkx-node-link/v6"));
     Ok(())
 }
 
@@ -363,7 +354,7 @@ fn corrupt_preferred_recovery_requires_the_exact_observation_and_commit()
     let prolly = Prolly::new(adapter, Config::default());
     let preferred_name = KeyBuilder::new()
         .push_segment(b"compass")
-        .push_segment(b"v1")
+        .push_segment(b"v2")
         .push_segment(b"preferred")
         .push_segment(commit.as_str().as_bytes())
         .finish();

--- a/crates/compass-history/tests/publication.rs
+++ b/crates/compass-history/tests/publication.rs
@@ -152,12 +152,12 @@ fn previous_graph_schema_profiles_are_rejected_at_publication()
     let mut publish = request('a', false)?;
     publish
         .profile
-        .insert("graph_schema", "networkx-node-link/v5")?;
+        .insert("graph_schema", "networkx-node-link/v6")?;
     let error = match history.publish(publish) {
         Ok(_) => return Err("previous graph schema must not be published".into()),
         Err(error) => error,
     };
-    assert!(error.to_string().contains("networkx-node-link/v6"));
+    assert!(error.to_string().contains("networkx-node-link/v1"));
     Ok(())
 }
 
@@ -354,7 +354,7 @@ fn corrupt_preferred_recovery_requires_the_exact_observation_and_commit()
     let prolly = Prolly::new(adapter, Config::default());
     let preferred_name = KeyBuilder::new()
         .push_segment(b"compass")
-        .push_segment(b"v2")
+        .push_segment(b"v1")
         .push_segment(b"preferred")
         .push_segment(commit.as_str().as_bytes())
         .finish();

--- a/crates/compass-history/tests/roundtrip.rs
+++ b/crates/compass-history/tests/roundtrip.rs
@@ -166,18 +166,16 @@ fn complete_graph_and_build_state_round_trip() -> Result<(), Box<dyn std::error:
 }
 
 #[test]
-fn legacy_unicode_and_empty_hyperedge_placement_round_trip()
--> Result<(), Box<dyn std::error::Error>> {
+fn unicode_and_empty_hyperedge_placement_round_trip() -> Result<(), Box<dyn std::error::Error>> {
     let document: GraphDocument = serde_json::from_value(json!({
         "directed": true,
         "multigraph": false,
         "graph": {"hyperedges": []},
         "nodes": [{"id":"a\u{0000}雪","label":"雪"}],
-        "edges": [],
+        "links": [],
         "hyperedges": [],
         "extension": true
     }))?;
-    assert!(document.used_legacy_edges_key);
     let artifacts = GraphArtifacts {
         document,
         program: None,
@@ -189,7 +187,7 @@ fn legacy_unicode_and_empty_hyperedge_placement_round_trip()
     let restored = GraphArtifacts::reconstruct(&artifacts.partition(&completion())?)?;
     assert_eq!(restored, artifacts);
     let value = serde_json::to_value(&restored.document)?;
-    assert!(value.get("edges").is_some());
+    assert!(value.get("links").is_some());
     assert!(
         value["graph"]["hyperedges"]
             .as_array()

--- a/crates/compass-history/tests/roundtrip.rs
+++ b/crates/compass-history/tests/roundtrip.rs
@@ -120,7 +120,7 @@ fn complete_graph_and_build_state_round_trip() -> Result<(), Box<dyn std::error:
         program: Some(program_fixture(b"first")?),
         analysis: Some(json!({"communities":{"1":["a","b"]}})),
         labels: Some(json!({"1":"Core"})),
-        manifest: Some(json!({"a.py":{"ast_hash":"abc","semantic_hash":"abc","mtime":1.0}})),
+        manifest: Some(json!({"a.py":{"ast_hash":"abc","semantic_hash":"abc","mtime":0}})),
         authoritative_sidecars: BTreeMap::from([(
             "semantic/custom.bin".to_owned(),
             vec![0, 1, 2, 255],
@@ -130,6 +130,36 @@ fn complete_graph_and_build_state_round_trip() -> Result<(), Box<dyn std::error:
     let restored = GraphArtifacts::reconstruct(&partitioned)?;
     assert_eq!(restored, artifacts);
     assert_eq!(restored.document, document);
+    let mut reordered = artifacts.clone();
+    reordered.document.nodes.reverse();
+    reordered.document.links.reverse();
+    reordered
+        .document
+        .graph
+        .get_mut("hyperedges")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or("missing graph hyperedges")?
+        .reverse();
+    reordered
+        .document
+        .extras
+        .get_mut("hyperedges")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or("missing top-level hyperedges")?
+        .reverse();
+    reordered
+        .manifest
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .and_then(|entries| entries.get_mut("a.py"))
+        .and_then(serde_json::Value::as_object_mut)
+        .ok_or("missing manifest fixture")?
+        .insert("mtime".to_owned(), json!(1234.5));
+    assert_eq!(
+        partitioned,
+        reordered.partition(&completion())?,
+        "node-link array order must not change realization identity"
+    );
     assert_eq!(partitioned.program_facts.len(), 5);
     assert_eq!(partitioned.program_summaries.len(), 2);
     Ok(())
@@ -367,7 +397,7 @@ fn registry_loading_verifies_builtin_opaque_derived_and_operational_artifacts()
     let graph = canonical_json_bytes(&serde_json::to_value(&document)?)?;
     let analysis = canonical_json_bytes(&json!({"score": 1}))?;
     let labels = canonical_json_bytes(&json!({"0": "Core"}))?;
-    let manifest = canonical_json_bytes(&json!({"a.rs": {"ast_hash": "a"}}))?;
+    let manifest = canonical_json_bytes(&json!({"a.rs": {"ast_hash": "a", "mtime": 0}}))?;
     let opaque = vec![0, 1, 255];
     for (path, bytes) in [
         ("graph.json", graph.as_slice()),

--- a/crates/compass-history/tests/sqlite_contract.rs
+++ b/crates/compass-history/tests/sqlite_contract.rs
@@ -148,6 +148,33 @@ fn incompatible_store_format_fails_closed() -> Result<(), Box<dyn std::error::Er
         b"format".to_vec(),
         br#"{"history_schema":999}"#.to_vec(),
     )?;
+    manager.publish_named_root(b"compass/store-format/v2", &tree)?;
+    drop(manager);
+
+    assert!(HistoryStore::open_existing(&repository).is_err());
+    Ok(())
+}
+
+#[test]
+fn previous_store_format_is_not_opened() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = CommittedRepository::new()?;
+    let repository = Repository::discover(fixture.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let database_path = history.database_path().to_path_buf();
+    drop(history);
+
+    let backend = Arc::new(SqliteStore::open_with_config(
+        &database_path,
+        sqlite_config(),
+    )?);
+    let manager = Prolly::new(backend, Config::default());
+    manager.delete_named_root(b"compass/store-format/v2")?;
+    let tree = manager.put(
+        &manager.create(),
+        b"format".to_vec(),
+        br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"history_schema":1,"typed_keys":1}"#
+            .to_vec(),
+    )?;
     manager.publish_named_root(b"compass/store-format/v1", &tree)?;
     drop(manager);
 

--- a/crates/compass-history/tests/sqlite_contract.rs
+++ b/crates/compass-history/tests/sqlite_contract.rs
@@ -148,7 +148,7 @@ fn incompatible_store_format_fails_closed() -> Result<(), Box<dyn std::error::Er
         b"format".to_vec(),
         br#"{"history_schema":999}"#.to_vec(),
     )?;
-    manager.publish_named_root(b"compass/store-format/v2", &tree)?;
+    manager.publish_named_root(b"compass/store-format/v1", &tree)?;
     drop(manager);
 
     assert!(HistoryStore::open_existing(&repository).is_err());
@@ -168,14 +168,14 @@ fn previous_store_format_is_not_opened() -> Result<(), Box<dyn std::error::Error
         sqlite_config(),
     )?);
     let manager = Prolly::new(backend, Config::default());
-    manager.delete_named_root(b"compass/store-format/v2")?;
+    manager.delete_named_root(b"compass/store-format/v1")?;
     let tree = manager.put(
         &manager.create(),
         b"format".to_vec(),
-        br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"history_schema":1,"typed_keys":1}"#
+        br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"graph_schema":"networkx-node-link/v6","history_schema":3,"typed_keys":1}"#
             .to_vec(),
     )?;
-    manager.publish_named_root(b"compass/store-format/v1", &tree)?;
+    manager.publish_named_root(b"compass/store-format/v2", &tree)?;
     drop(manager);
 
     assert!(HistoryStore::open_existing(&repository).is_err());

--- a/crates/compass-ir/src/lib.rs
+++ b/crates/compass-ir/src/lib.rs
@@ -6,13 +6,14 @@ mod validation;
 
 pub use canonical::{canonical_json_bytes, hex_sha256};
 pub use model::{
-    BasicBlock, Capability, Coverage, CoverageState, EvidenceId, EvidenceRecord, ExecutionMode,
-    FunctionIr, ModuleIr, Operation, OperationKind, ParameterIr, ParameterKind, ProgramBundle,
-    ProviderDescriptor, ProviderKind, SourceAnchor, SymbolId, Terminator, TypeRef, Visibility,
+    BasicBlock, Capability, Coverage, CoverageState, EvidenceId, EvidenceRecord, ExceptionEffect,
+    ExceptionKind, ExecutionMode, FunctionIr, ModuleIr, Operation, OperationKind, ParameterIr,
+    ParameterKind, ProgramBundle, ProviderDescriptor, ProviderKind, SourceAnchor, SymbolId,
+    Terminator, TypeRef, Visibility,
 };
 pub use validation::IrError;
 
 /// Stable serialized Program IR schema identifier.
 pub const PROGRAM_SCHEMA: &str = "http://crab.build/compass/v1";
 /// Numeric Program IR schema version used by caches and history.
-pub const PROGRAM_SCHEMA_VERSION: u32 = 2;
+pub const PROGRAM_SCHEMA_VERSION: u32 = 3;

--- a/crates/compass-ir/src/lib.rs
+++ b/crates/compass-ir/src/lib.rs
@@ -16,4 +16,4 @@ pub use validation::IrError;
 /// Stable serialized Program IR schema identifier.
 pub const PROGRAM_SCHEMA: &str = "http://crab.build/compass/v1";
 /// Numeric Program IR schema version used by caches and history.
-pub const PROGRAM_SCHEMA_VERSION: u32 = 3;
+pub const PROGRAM_SCHEMA_VERSION: u32 = 1;

--- a/crates/compass-ir/src/model.rs
+++ b/crates/compass-ir/src/model.rs
@@ -195,6 +195,51 @@ pub struct Operation {
     pub kind: OperationKind,
 }
 
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExceptionKind {
+    Rethrow,
+    Exception,
+    Dynamic,
+    Panic,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct ExceptionEffect {
+    pub kind: ExceptionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(default)]
+    pub chained: bool,
+}
+
+impl ExceptionEffect {
+    #[must_use]
+    pub fn display_name(&self) -> String {
+        match self.kind {
+            ExceptionKind::Rethrow => "rethrow current exception".to_owned(),
+            ExceptionKind::Panic => self
+                .expression
+                .as_deref()
+                .map_or_else(|| "panic".to_owned(), |value| format!("panic: {value}")),
+            ExceptionKind::Exception => {
+                let name = self.type_name.as_deref().unwrap_or("exception");
+                if self.chained {
+                    format!("{name} (chained)")
+                } else {
+                    name.to_owned()
+                }
+            }
+            ExceptionKind::Dynamic => self.expression.as_deref().map_or_else(
+                || "dynamic exception".to_owned(),
+                |value| format!("dynamic exception: {value}"),
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum OperationKind {
@@ -214,7 +259,7 @@ pub enum OperationKind {
     },
     Await,
     Throw {
-        value: String,
+        effect: ExceptionEffect,
     },
 }
 

--- a/crates/compass-ir/tests/schema.rs
+++ b/crates/compass-ir/tests/schema.rs
@@ -144,9 +144,9 @@ fn validation_rejects_duplicate_provider_and_evidence_ids() {
 }
 
 #[test]
-fn public_v2_schema_uses_the_four_coverage_states() {
+fn public_v1_schema_uses_the_four_coverage_states() {
     assert_eq!(compass_ir::PROGRAM_SCHEMA, "http://crab.build/compass/v1");
-    assert_eq!(compass_ir::PROGRAM_SCHEMA_VERSION, 3);
+    assert_eq!(compass_ir::PROGRAM_SCHEMA_VERSION, 1);
 
     let mut current = bundle();
     current.modules[0].coverage.insert(
@@ -163,9 +163,7 @@ fn public_v2_schema_uses_the_four_coverage_states() {
     );
     assert!(current.validate().is_ok());
 
-    for pre_release_schema in ["compass.program/1", "compass.program/2"] {
-        let mut pre_release = bundle();
-        pre_release.schema = pre_release_schema.to_owned();
-        assert!(matches!(pre_release.validate(), Err(IrError::Schema(_))));
-    }
+    let mut unsupported = bundle();
+    unsupported.schema = "unsupported".to_owned();
+    assert!(matches!(unsupported.validate(), Err(IrError::Schema(_))));
 }

--- a/crates/compass-ir/tests/schema.rs
+++ b/crates/compass-ir/tests/schema.rs
@@ -146,7 +146,7 @@ fn validation_rejects_duplicate_provider_and_evidence_ids() {
 #[test]
 fn public_v2_schema_uses_the_four_coverage_states() {
     assert_eq!(compass_ir::PROGRAM_SCHEMA, "http://crab.build/compass/v1");
-    assert_eq!(compass_ir::PROGRAM_SCHEMA_VERSION, 2);
+    assert_eq!(compass_ir::PROGRAM_SCHEMA_VERSION, 3);
 
     let mut current = bundle();
     current.modules[0].coverage.insert(

--- a/crates/compass-languages/src/program/mod.rs
+++ b/crates/compass-languages/src/program/mod.rs
@@ -11,7 +11,7 @@ use compass_program::{
 
 use crate::{Engine, ExtractorKind, Registry};
 
-pub const TREE_SITTER_PROGRAM_PROVIDER_VERSION: u32 = 3;
+pub const TREE_SITTER_PROGRAM_PROVIDER_VERSION: u32 = 1;
 
 #[derive(Default)]
 pub struct TreeSitterSyntaxProvider {

--- a/crates/compass-languages/src/program/python.rs
+++ b/crates/compass-languages/src/program/python.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use compass_ir::{
-    BasicBlock, Capability, Coverage, CoverageState, ExecutionMode, FunctionIr, ModuleIr,
-    Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor, SourceAnchor,
-    Terminator, TypeRef, Visibility, hex_sha256,
+    BasicBlock, Capability, Coverage, CoverageState, ExceptionEffect, ExceptionKind, ExecutionMode,
+    FunctionIr, ModuleIr, Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor,
+    SourceAnchor, Terminator, TypeRef, Visibility, hex_sha256,
 };
 use compass_program::{EvidenceBatch, FileInput, evidence_record};
 use tree_sitter::Node;
@@ -302,11 +302,12 @@ fn collect_operations(
                 .trim_start_matches("raise")
                 .trim()
                 .to_owned();
+            let effect = python_exception_effect(&value);
             Some((
                 Capability::Effects,
                 "throw",
-                value.clone(),
-                OperationKind::Throw { value },
+                effect.display_name(),
+                OperationKind::Throw { effect },
             ))
         }
         _ => None,
@@ -332,6 +333,48 @@ fn collect_operations(
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         collect_operations(input, child, provider_id, evidence, operations);
+    }
+}
+
+fn python_exception_effect(value: &str) -> ExceptionEffect {
+    if value.is_empty() {
+        return ExceptionEffect {
+            kind: ExceptionKind::Rethrow,
+            type_name: None,
+            expression: None,
+            chained: false,
+        };
+    }
+    let (expression, chained) = value
+        .split_once(" from ")
+        .map_or((value, false), |(expression, _)| (expression.trim(), true));
+    let type_name = expression
+        .split_once('(')
+        .map(|(candidate, _)| candidate.trim())
+        .filter(|candidate| {
+            !candidate.is_empty()
+                && candidate.split('.').all(|part| {
+                    !part.is_empty()
+                        && part
+                            .chars()
+                            .all(|character| character == '_' || character.is_alphanumeric())
+                })
+        })
+        .map(str::to_owned);
+    if let Some(type_name) = type_name {
+        ExceptionEffect {
+            kind: ExceptionKind::Exception,
+            type_name: Some(type_name),
+            expression: None,
+            chained,
+        }
+    } else {
+        ExceptionEffect {
+            kind: ExceptionKind::Dynamic,
+            type_name: None,
+            expression: Some(expression.to_owned()),
+            chained,
+        }
     }
 }
 

--- a/crates/compass-languages/src/program/rust.rs
+++ b/crates/compass-languages/src/program/rust.rs
@@ -2,9 +2,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use compass_ir::{
-    BasicBlock, Capability, Coverage, CoverageState, ExecutionMode, FunctionIr, ModuleIr,
-    Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor, SourceAnchor,
-    Terminator, TypeRef, Visibility, hex_sha256,
+    BasicBlock, Capability, Coverage, CoverageState, ExceptionEffect, ExceptionKind, ExecutionMode,
+    FunctionIr, ModuleIr, Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor,
+    SourceAnchor, Terminator, TypeRef, Visibility, hex_sha256,
 };
 use compass_program::{EvidenceBatch, FileInput, evidence_record};
 use tree_sitter::Node;
@@ -362,7 +362,17 @@ fn collect_operations(
                     node,
                     "throw",
                     OperationKind::Throw {
-                        value: value.to_owned(),
+                        effect: ExceptionEffect {
+                            kind: if value.starts_with("panic!") {
+                                ExceptionKind::Panic
+                            } else {
+                                ExceptionKind::Exception
+                            },
+                            type_name: (!value.starts_with("panic!"))
+                                .then(|| "error result".to_owned()),
+                            expression: Some(value.to_owned()),
+                            chained: false,
+                        },
                     },
                     evidence,
                     operations,

--- a/crates/compass-languages/src/program/typescript.rs
+++ b/crates/compass-languages/src/program/typescript.rs
@@ -2,9 +2,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use compass_ir::{
-    BasicBlock, Capability, Coverage, CoverageState, ExecutionMode, FunctionIr, ModuleIr,
-    Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor, SourceAnchor,
-    Terminator, TypeRef, Visibility, hex_sha256,
+    BasicBlock, Capability, Coverage, CoverageState, ExceptionEffect, ExceptionKind, ExecutionMode,
+    FunctionIr, ModuleIr, Operation, OperationKind, ParameterIr, ParameterKind, ProviderDescriptor,
+    SourceAnchor, Terminator, TypeRef, Visibility, hex_sha256,
 };
 use compass_program::{EvidenceBatch, FileInput, evidence_record};
 use tree_sitter::Node;
@@ -395,7 +395,7 @@ fn collect_operations(
             node,
             "throw",
             OperationKind::Throw {
-                value: text(input.source, node).to_owned(),
+                effect: typescript_exception_effect(text(input.source, node)),
             },
             evidence,
             operations,
@@ -414,6 +414,34 @@ fn collect_operations(
             reasons,
         );
     }
+}
+
+fn typescript_exception_effect(statement: &str) -> ExceptionEffect {
+    let expression = statement
+        .trim()
+        .strip_prefix("throw")
+        .unwrap_or(statement)
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    let constructor = expression
+        .strip_prefix("new ")
+        .and_then(|value| value.split_once('(').map(|(name, _)| name.trim()))
+        .filter(|name| !name.is_empty());
+    constructor.map_or_else(
+        || ExceptionEffect {
+            kind: ExceptionKind::Dynamic,
+            type_name: None,
+            expression: (!expression.is_empty()).then(|| expression.to_owned()),
+            chained: false,
+        },
+        |name| ExceptionEffect {
+            kind: ExceptionKind::Exception,
+            type_name: Some(name.to_owned()),
+            expression: None,
+            chained: false,
+        },
+    )
 }
 
 fn push_path(

--- a/crates/compass-languages/tests/program_evidence.rs
+++ b/crates/compass-languages/tests/program_evidence.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeSet;
 use std::error::Error;
 
 use compass_ir::{
-    Capability, CoverageState, ExecutionMode, OperationKind, ParameterKind, Visibility,
+    Capability, CoverageState, ExceptionKind, ExecutionMode, OperationKind, ParameterKind,
+    Visibility,
 };
 use compass_languages::TreeSitterSyntaxProvider;
-use compass_program::{FileInput, SyntaxProvider};
+use compass_program::{FileInput, SyntaxProvider, merge_evidence};
 
 #[test]
 fn rust_provider_emits_conservative_program_evidence() -> Result<(), Box<dyn Error>> {
@@ -128,6 +129,80 @@ fn repeated_signatures_in_distinct_lexical_scopes_have_unique_syntax_symbols()
         );
         compass_program::merge_evidence(vec![batch])?.validate()?;
     }
+    Ok(())
+}
+
+#[test]
+fn syntax_merge_resolves_unique_local_calls() -> Result<(), Box<dyn Error>> {
+    let batch = TreeSitterSyntaxProvider::default()
+        .analyze_file(FileInput {
+            source_file: "src/app.py",
+            language: "python",
+            source: b"def helper():\n    return 1\n\ndef run():\n    return helper()\n",
+        })?
+        .ok_or("missing Python batch")?;
+    let bundle = merge_evidence(vec![batch])?;
+    let helper = bundle.modules[0]
+        .functions
+        .iter()
+        .find(|function| function.name == "helper")
+        .ok_or("missing helper")?;
+    let run = bundle.modules[0]
+        .functions
+        .iter()
+        .find(|function| function.name == "run")
+        .ok_or("missing run")?;
+    let resolved = run
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .find_map(|operation| match &operation.kind {
+            OperationKind::Call {
+                callee,
+                resolved_symbols,
+                ..
+            } if callee == "helper" => Some(resolved_symbols),
+            _ => None,
+        })
+        .ok_or("missing helper call")?;
+    assert_eq!(resolved, std::slice::from_ref(&helper.symbol_id));
+    Ok(())
+}
+
+#[test]
+fn python_exceptions_are_structured_without_inventing_error_types() -> Result<(), Box<dyn Error>> {
+    let batch = TreeSitterSyntaxProvider::default()
+        .analyze_file(FileInput {
+            source_file: "src/app.py",
+            language: "python",
+            source: b"def reroute(result):\n    try:\n        work()\n    except Exception as cause:\n        raise RetryError('again') from cause\n\ndef relay():\n    try:\n        work()\n    except:\n        raise\n\ndef dynamic(result):\n    raise result.error\n",
+        })?
+        .ok_or("missing Python batch")?;
+    let throws = batch.modules[0]
+        .functions
+        .iter()
+        .flat_map(|function| &function.blocks)
+        .flat_map(|block| &block.operations)
+        .filter_map(|operation| match &operation.kind {
+            OperationKind::Throw { effect } => Some(effect),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(throws.iter().any(|effect| {
+        effect.kind == ExceptionKind::Exception
+            && effect.type_name.as_deref() == Some("RetryError")
+            && effect.chained
+    }));
+    assert!(
+        throws
+            .iter()
+            .any(|effect| effect.kind == ExceptionKind::Rethrow)
+    );
+    assert!(throws.iter().any(|effect| {
+        effect.kind == ExceptionKind::Dynamic
+            && effect.expression.as_deref() == Some("result.error")
+            && effect.type_name.is_none()
+    }));
     Ok(())
 }
 

--- a/crates/compass-model/src/document.rs
+++ b/crates/compass-model/src/document.rs
@@ -64,11 +64,10 @@ pub struct GraphDocument {
     pub nodes: Vec<NodeRecord>,
     pub links: Vec<EdgeRecord>,
     pub extras: BTreeMap<String, Value>,
-    pub used_legacy_edges_key: bool,
 }
 
 impl GraphDocument {
-    /// Load a node-link document under the compatible extension and size guards.
+    /// Load a node-link document under the extension and size guards.
     pub fn load(path: &Path) -> Result<Self, GraphError> {
         if path.extension().and_then(|part| part.to_str()) != Some("json") {
             return Err(GraphError::InvalidExtension(path.to_path_buf()));
@@ -88,7 +87,7 @@ impl GraphDocument {
             let _ = write_affected_cache(path, signature, &document);
             return Ok(document);
         }
-        let document = Self::load_for_recluster_compatibility(path)?;
+        let document = Self::load_for_recluster(path)?;
         if let Some(signature) = before
             && graph_signature(path) == Some(signature)
         {
@@ -141,7 +140,7 @@ impl GraphDocument {
     ///
     /// That command accepts arbitrary filenames and warns on oversized files
     /// while still refreshing the core graph artifacts.
-    pub fn load_for_recluster_compatibility(path: &Path) -> Result<Self, GraphError> {
+    pub fn load_for_recluster(path: &Path) -> Result<Self, GraphError> {
         if !path.exists() {
             return Err(GraphError::NotFound(crate::graph::absolute_path(path)));
         }
@@ -203,7 +202,6 @@ impl GraphDocument {
             nodes,
             links,
             extras: BTreeMap::new(),
-            used_legacy_edges_key: self.used_legacy_edges_key,
         }
     }
 }
@@ -408,7 +406,8 @@ impl<'de> Deserialize<'de> for GraphDocument {
         D: serde::Deserializer<'de>,
     {
         let raw = RawGraphDocument::deserialize(deserializer)?;
-        let used_legacy_edges_key = raw.links.is_none() && raw.edges.is_some();
+        // Raw extraction fragments use `edges`; persisted node-link documents use
+        // `links`. Both are current inputs and serialize to the single `links` form.
         let links = raw.links.or(raw.edges).unwrap_or_default();
         Ok(Self {
             directed: raw.directed,
@@ -417,7 +416,6 @@ impl<'de> Deserialize<'de> for GraphDocument {
             nodes: raw.nodes,
             links,
             extras: raw.extras,
-            used_legacy_edges_key,
         })
     }
 }
@@ -434,11 +432,7 @@ impl Serialize for GraphDocument {
         map.serialize_entry("multigraph", &self.multigraph)?;
         map.serialize_entry("graph", &self.graph)?;
         map.serialize_entry("nodes", &self.nodes)?;
-        if self.used_legacy_edges_key {
-            map.serialize_entry("edges", &self.links)?;
-        } else {
-            map.serialize_entry("links", &self.links)?;
-        }
+        map.serialize_entry("links", &self.links)?;
         for (key, value) in &self.extras {
             map.serialize_entry(key, value)?;
         }

--- a/crates/compass-model/src/graph.rs
+++ b/crates/compass-model/src/graph.rs
@@ -347,7 +347,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn accepts_legacy_edges_key_and_forces_direction() {
+    fn normalizes_edges_key_to_links() {
         let raw = r#"{
             "directed": false,
             "multigraph": false,
@@ -358,12 +358,13 @@ mod tests {
         let document: GraphDocument = serde_json::from_str(raw).unwrap_or_else(|_error| {
             std::process::abort();
         });
+        let serialized = serde_json::to_value(&document).unwrap_or_else(|_error| {
+            std::process::abort();
+        });
+        assert!(serialized.get("edges").is_none());
+        assert!(serialized.get("links").is_some());
         let graph = Graph::from_document(document).unwrap_or_else(|_| std::process::abort());
-        assert_eq!(graph.node_count(), 2);
         assert_eq!(graph.edge_count(), 1);
-        assert_eq!(graph.successors(0).collect::<Vec<_>>(), vec![1]);
-        assert_eq!(graph.predecessors(1).collect::<Vec<_>>(), vec![0]);
-        assert_eq!(graph.successors(1).collect::<Vec<_>>(), vec![0]);
     }
 
     #[test]

--- a/crates/compass-model/tests/contracts_coverage.rs
+++ b/crates/compass-model/tests/contracts_coverage.rs
@@ -29,7 +29,7 @@ fn document_loading_serialization_and_python_strings_cover_boundary_shapes()
                 {"id":"a","label":"Alpha","null":null,"bool":true,"number":7,"array":[1],"object":{"x":1}},
                 {"id":"a","label":"Merged","extra":"kept"}
             ],
-            "edges":[
+            "links":[
                 {"source":"a","target":"ghost","relation":"first","context":"call"},
                 {"source":"a","target":"ghost","relation":"merged","weight":2}
             ],
@@ -37,7 +37,6 @@ fn document_loading_serialization_and_python_strings_cover_boundary_shapes()
         }))?,
     )?;
     let document = GraphDocument::load(&graph_path)?;
-    assert!(document.used_legacy_edges_key);
     assert_eq!(document.extras["custom"], "value");
     assert_eq!(document.nodes[0].string("null"), "");
     assert_eq!(document.nodes[0].string("bool"), "True");
@@ -54,8 +53,8 @@ fn document_loading_serialization_and_python_strings_cover_boundary_shapes()
         "fallback"
     );
     let encoded = serde_json::to_value(&document)?;
-    assert!(encoded.get("edges").is_some());
-    assert!(encoded.get("links").is_none());
+    assert!(encoded.get("edges").is_none());
+    assert!(encoded.get("links").is_some());
 
     let graph = Graph::from_document(document)?;
     assert_eq!((graph.node_count(), graph.edge_count()), (2, 1));

--- a/crates/compass-output/src/history_bundle.rs
+++ b/crates/compass-output/src/history_bundle.rs
@@ -199,7 +199,7 @@ fn validate_requests(requests: &[DerivedArtifactRequest]) -> Result<(), OutputEr
 }
 
 fn validate_staging(staging: &Path, input: &HistoryBundleInput<'_>) -> Result<(), OutputError> {
-    let restored = GraphDocument::load_for_recluster_compatibility(&staging.join("graph.json"))
+    let restored = GraphDocument::load_for_recluster(&staging.join("graph.json"))
         .map_err(|error| OutputError::InvalidHistoryBundle(error.to_string()))?;
     if &restored != input.document {
         return Err(OutputError::InvalidHistoryBundle(

--- a/crates/compass-output/src/html.rs
+++ b/crates/compass-output/src/html.rs
@@ -597,7 +597,6 @@ fn aggregate(
             nodes,
             links,
             extras: BTreeMap::new(),
-            used_legacy_edges_key: false,
         },
         meta_communities,
         members,

--- a/crates/compass-output/src/obsidian.rs
+++ b/crates/compass-output/src/obsidian.rs
@@ -777,7 +777,6 @@ mod tests {
             nodes: Vec::new(),
             links: Vec::new(),
             extras: BTreeMap::new(),
-            used_legacy_edges_key: false,
         })
     }
 }

--- a/crates/compass-output/tests/history_bundle.rs
+++ b/crates/compass-output/tests/history_bundle.rs
@@ -56,7 +56,7 @@ fn v1_renderer_publishes_a_valid_complete_bundle_atomically()
         },
     )?;
     assert_eq!(
-        GraphDocument::load_for_recluster_compatibility(&destination.join("graph.json"))?,
+        GraphDocument::load_for_recluster(&destination.join("graph.json"))?,
         document
     );
     assert!(destination.join("GRAPH_REPORT.md").is_file());

--- a/crates/compass-program/src/merge.rs
+++ b/crates/compass-program/src/merge.rs
@@ -7,7 +7,7 @@ use compass_ir::{
 
 use crate::{EvidenceBatch, EvidenceFact, FactKind, ProviderError, normalize_source_path};
 
-pub const MERGER_VERSION: u32 = 1;
+pub const MERGER_VERSION: u32 = 2;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MergeError {
@@ -102,6 +102,7 @@ pub fn merge_evidence(batches: Vec<EvidenceBatch>) -> Result<ProgramBundle, Merg
             merge_coverage(&mut module.coverage, coverage);
         }
     }
+    resolve_unique_syntax_calls(&mut modules, &mut evidence);
     for module in modules.values_mut() {
         for function in &mut module.functions {
             let mut conflicts = false;
@@ -140,6 +141,96 @@ pub fn merge_evidence(batches: Vec<EvidenceBatch>) -> Result<ProgramBundle, Merg
     .canonicalized();
     bundle.validate()?;
     Ok(bundle)
+}
+
+fn resolve_unique_syntax_calls(
+    modules: &mut BTreeMap<String, ModuleIr>,
+    evidence: &mut BTreeMap<String, EvidenceRecord>,
+) {
+    let mut local = BTreeMap::<String, BTreeMap<String, Vec<String>>>::new();
+    let mut global = BTreeMap::<String, Vec<String>>::new();
+    for (source_file, module) in modules.iter() {
+        for function in &module.functions {
+            let short = function
+                .name
+                .rsplit('.')
+                .next()
+                .unwrap_or(&function.name)
+                .to_owned();
+            local
+                .entry(source_file.clone())
+                .or_default()
+                .entry(short.clone())
+                .or_default()
+                .push(function.symbol_id.clone());
+            global
+                .entry(short)
+                .or_default()
+                .push(function.symbol_id.clone());
+        }
+    }
+    for definitions in local.values_mut() {
+        for symbols in definitions.values_mut() {
+            symbols.sort();
+            symbols.dedup();
+        }
+    }
+    for symbols in global.values_mut() {
+        symbols.sort();
+        symbols.dedup();
+    }
+
+    for (source_file, module) in modules.iter_mut() {
+        for function in &mut module.functions {
+            for operation in function
+                .blocks
+                .iter_mut()
+                .flat_map(|block| &mut block.operations)
+            {
+                let OperationKind::Call {
+                    callee,
+                    resolved_symbols,
+                    ..
+                } = &mut operation.kind
+                else {
+                    continue;
+                };
+                if !resolved_symbols.is_empty() {
+                    continue;
+                }
+                let short = callee.rsplit('.').next().unwrap_or(callee);
+                let local_match = local
+                    .get(source_file)
+                    .and_then(|definitions| definitions.get(short))
+                    .filter(|symbols| symbols.len() == 1)
+                    .and_then(|symbols| symbols.first());
+                let global_match = global
+                    .get(short)
+                    .filter(|symbols| symbols.len() == 1)
+                    .and_then(|symbols| symbols.first());
+                if let Some(symbol) = local_match.or(global_match) {
+                    resolved_symbols.push(symbol.clone());
+                    let provider_id = operation
+                        .evidence
+                        .iter()
+                        .find_map(|id| evidence.get(id))
+                        .map(|record| record.provider_id.clone())
+                        .unwrap_or_else(|| "syntax:inferred".to_owned());
+                    let record = crate::evidence_record(
+                        &provider_id,
+                        Some(source_file),
+                        Capability::CallResolution,
+                        format!("unique syntax call {callee} resolved to {symbol}"),
+                        Some(&operation.anchor),
+                        "syntax_call_resolution",
+                        symbol,
+                    );
+                    operation.evidence.push(record.id.clone());
+                    evidence.entry(record.id.clone()).or_insert(record);
+                }
+            }
+        }
+    }
 }
 
 fn canonical_batches(batches: Vec<EvidenceBatch>) -> Result<Vec<EvidenceBatch>, MergeError> {

--- a/crates/compass-program/src/merge.rs
+++ b/crates/compass-program/src/merge.rs
@@ -7,7 +7,7 @@ use compass_ir::{
 
 use crate::{EvidenceBatch, EvidenceFact, FactKind, ProviderError, normalize_source_path};
 
-pub const MERGER_VERSION: u32 = 2;
+pub const MERGER_VERSION: u32 = 1;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MergeError {

--- a/crates/compass-prs/src/lib.rs
+++ b/crates/compass-prs/src/lib.rs
@@ -540,7 +540,7 @@ pub fn attach_graph_impact(
     }
     // `graphify prs --graph` accepts any filename, not only a `.json`
     // extension, while retaining the same graph-size guard.
-    let Ok(document) = GraphDocument::load_for_recluster_compatibility(graph_path) else {
+    let Ok(document) = GraphDocument::load_for_recluster(graph_path) else {
         return BTreeMap::new();
     };
     let (file_communities, file_counts) = graph_file_index(&document);

--- a/crates/compass-semantic-diff/src/engine.rs
+++ b/crates/compass-semantic-diff/src/engine.rs
@@ -11,10 +11,10 @@ use crate::SemanticDiffError;
 use crate::model::{
     AffectedConsumer, CLASSIFIER_VERSION, ChangeDirection, ChangedEntity, CollapsedGroup,
     Comparison, Compatibility, Completeness, Confidence, DependencyDelta, EntitySnapshot,
-    EvidenceRef, FindingOrigin, FindingType, MAX_DIRECT_ENTITIES, MAX_EVIDENCE_PER_FINDING,
-    MAX_FINDINGS, MAX_IMPACT_DEPTH, MAX_TRAVERSED_CALL_EDGES, REPORT_SCHEMA, SemanticDiffInput,
-    SemanticDiffReport, SemanticFinding, SnapshotSide, TestEvidence, Verification,
-    VerificationState, WitnessHop, WitnessPath,
+    EvidenceRef, FeatureGroup, FindingOrigin, FindingType, MAX_DIRECT_ENTITIES,
+    MAX_EVIDENCE_PER_FINDING, MAX_FINDINGS, MAX_IMPACT_DEPTH, MAX_TRAVERSED_CALL_EDGES,
+    REPORT_SCHEMA, SemanticDiffInput, SemanticDiffReport, SemanticFinding, SnapshotSide,
+    TestEvidence, Verification, VerificationState, WitnessHop, WitnessPath,
 };
 
 pub fn compare(input: SemanticDiffInput<'_>) -> Result<SemanticDiffReport, SemanticDiffError> {
@@ -61,11 +61,11 @@ pub fn compare(input: SemanticDiffInput<'_>) -> Result<SemanticDiffReport, Seman
             ));
             continue;
         }
-        findings.push(dependency_finding(dependency));
+        findings.push(dependency_finding(&input, dependency)?);
     }
 
     for finding in &mut findings {
-        attach_impact(&input, finding)?;
+        limitations.extend(attach_impact(&input, finding)?);
         apply_verification(input.test_evidence.tests_for(&finding.subject), finding);
     }
     add_verification_findings(&mut findings);
@@ -153,7 +153,7 @@ fn collect_changed_entities(
                     })
                     .map(|(index, _)| index)
                     .collect::<Vec<_>>();
-                (matches.len() == 1).then_some(matches[0])
+                (matches.len() == 1).then(|| matches[0])
             };
             let matched = exact.or_else(named);
             let new = matched.map(|index| {
@@ -249,8 +249,8 @@ fn added_function_finding(
     snapshot: &EntitySnapshot,
     _hunks: &[compass_history::SourceHunk],
 ) -> SemanticFinding {
-    let public = snapshot.function.visibility == compass_ir::Visibility::Public;
-    base_finding(
+    let public = function_is_public_surface(snapshot);
+    let mut finding = base_finding(
         FindingType::StructuralChange,
         &snapshot.function.symbol_id,
         FindingOrigin::Direct,
@@ -270,15 +270,17 @@ fn added_function_finding(
         } else {
             "No reviewer action is required unless this internal addition is unexpected."
         },
-    )
+    );
+    finding.public_surface = public;
+    finding
 }
 
 fn removed_function_finding(
     snapshot: &EntitySnapshot,
     _hunks: &[compass_history::SourceHunk],
 ) -> SemanticFinding {
-    let public = snapshot.function.visibility == compass_ir::Visibility::Public;
-    base_finding(
+    let public = function_is_public_surface(snapshot);
+    let mut finding = base_finding(
         FindingType::ContractChange,
         &snapshot.function.symbol_id,
         FindingOrigin::Direct,
@@ -298,7 +300,9 @@ fn removed_function_finding(
         None,
         snapshot_evidence(snapshot, "contracts"),
         "Review affected callers and update or remove them.",
-    )
+    );
+    finding.public_surface = public;
+    finding
 }
 
 fn contract_finding(
@@ -361,7 +365,7 @@ fn contract_finding(
     if !complete && matches!(compatibility, Compatibility::ProvenBreak) {
         compatibility = Compatibility::PossibleBreak;
     }
-    Some(base_finding(
+    let mut finding = base_finding(
         FindingType::ContractChange,
         &new.function.symbol_id,
         FindingOrigin::Direct,
@@ -376,7 +380,9 @@ fn contract_finding(
             snapshot_evidence(new, "contracts"),
         ),
         "Update affected callers for the new callable contract.",
-    ))
+    );
+    finding.public_surface = function_is_public_surface(old) || function_is_public_surface(new);
+    Some(finding)
 }
 
 fn compare_parameters(
@@ -469,19 +475,46 @@ fn behavior_finding(
         ));
     }
     let changes = describe_summary_changes(old_summary, new_summary);
-    Some(base_finding(
+    let unresolved_delta = old_summary.unresolved_calls != new_summary.unresolved_calls;
+    let call_change = old_summary.resolved_calls != new_summary.resolved_calls || unresolved_delta;
+    let call_resolution_complete =
+        capability_complete(&old_summary.coverage, Capability::CallResolution)
+            && capability_complete(&new_summary.coverage, Capability::CallResolution);
+    let mut finding = base_finding(
         FindingType::BehaviorChange,
         &new.function.symbol_id,
         FindingOrigin::Direct,
         format!("{} behavior changed", new.function.name),
         changes.join("; "),
         Compatibility::Behavioral,
-        Confidence::Exact,
+        if !call_change {
+            Confidence::Exact
+        } else if unresolved_delta {
+            Confidence::Unknown
+        } else if call_resolution_complete {
+            Confidence::Exact
+        } else {
+            Confidence::Inferred
+        },
         Some(before),
         Some(after),
         snapshot_evidence(new, "behavior"),
         "Review the changed calls, effects, errors, and state access.",
-    ))
+    );
+    if call_change {
+        finding.completeness.insert(
+            "call_resolution".to_owned(),
+            if call_resolution_complete
+                && old_summary.unresolved_calls.is_empty()
+                && new_summary.unresolved_calls.is_empty()
+            {
+                Completeness::Complete
+            } else {
+                Completeness::Partial
+            },
+        );
+    }
+    Some(finding)
 }
 
 fn describe_summary_changes(old: &FunctionSummary, new: &FunctionSummary) -> Vec<String> {
@@ -501,7 +534,17 @@ fn describe_summary_changes(old: &FunctionSummary, new: &FunctionSummary) -> Vec
     describe_set("reads", &old.reads, &new.reads, &mut changes);
     describe_set("writes", &old.writes, &new.writes, &mut changes);
     describe_set("effects", &old.effects, &new.effects, &mut changes);
-    describe_set("errors", &old.errors, &new.errors, &mut changes);
+    let old_exceptions = old
+        .exceptions
+        .iter()
+        .map(compass_ir::ExceptionEffect::display_name)
+        .collect::<Vec<_>>();
+    let new_exceptions = new
+        .exceptions
+        .iter()
+        .map(compass_ir::ExceptionEffect::display_name)
+        .collect::<Vec<_>>();
+    describe_set("exceptions", &old_exceptions, &new_exceptions, &mut changes);
     changes
 }
 
@@ -524,12 +567,48 @@ fn describe_set(label: &str, old: &[String], new: &[String], output: &mut Vec<St
     }
 }
 
-fn dependency_finding(delta: &DependencyDelta) -> SemanticFinding {
+fn dependency_finding(
+    input: &SemanticDiffInput<'_>,
+    delta: &DependencyDelta,
+) -> Result<SemanticFinding, SemanticDiffError> {
     let direction = match delta.change {
         ChangeDirection::Added => "added",
         ChangeDirection::Removed => "removed",
     };
-    base_finding(
+    let side = if delta.change == ChangeDirection::Added {
+        SnapshotSide::New
+    } else {
+        SnapshotSide::Old
+    };
+    let mut evidence = delta.evidence.clone();
+    let source = input.snapshots.node(side, &delta.source)?;
+    let target = input.snapshots.node(side, &delta.target)?;
+    evidence.extend(node_evidence(
+        source.as_ref(),
+        &delta.source,
+        "dependencies",
+    ));
+    evidence.extend(node_evidence(
+        target.as_ref(),
+        &delta.target,
+        "dependencies",
+    ));
+    let source_file = source
+        .as_ref()
+        .and_then(|node| node.attributes.get("source_file"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let target_file = target
+        .as_ref()
+        .and_then(|node| node.attributes.get("source_file"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let routine = evidence
+        .iter()
+        .any(|item| is_test_source(&item.source_file))
+        || matches!(delta.relation.as_str(), "uses" | "references")
+        || (!source_file.is_empty() && source_file == target_file);
+    let mut finding = base_finding(
         FindingType::DependencyChange,
         &format!("{}:{}:{}", delta.source, delta.relation, delta.target),
         FindingOrigin::Direct,
@@ -549,9 +628,11 @@ fn dependency_finding(delta: &DependencyDelta) -> SemanticFinding {
         (delta.change == ChangeDirection::Added).then(
             || json!({"source": delta.source, "relation": delta.relation, "target": delta.target}),
         ),
-        delta.evidence.clone(),
+        evidence,
         "Confirm the new dependency direction and affected module boundary are intentional.",
-    )
+    );
+    finding.routine = routine;
+    Ok(finding)
 }
 
 fn classify_graph_fallbacks(
@@ -570,6 +651,18 @@ fn classify_graph_fallbacks(
         }
         let old = input.snapshots.node(SnapshotSide::Old, node_id)?;
         let new = input.snapshots.node(SnapshotSide::New, node_id)?;
+        match (&old, &new) {
+            (None, Some(node)) => {
+                findings.push(added_graph_node_finding(input, node, node_id));
+                continue;
+            }
+            (Some(node), None) => {
+                findings.push(removed_graph_node_finding(input, node, node_id));
+                continue;
+            }
+            (None, None) => continue,
+            (Some(_), Some(_)) => {}
+        }
         let old_signature = old
             .as_ref()
             .and_then(|node| digest_attribute(node, "signature_hash"));
@@ -615,10 +708,185 @@ fn classify_graph_fallbacks(
     Ok(())
 }
 
+fn added_graph_node_finding(
+    input: &SemanticDiffInput<'_>,
+    node: &compass_model::NodeRecord,
+    node_id: &str,
+) -> SemanticFinding {
+    let label = graph_label(node, node_id);
+    let kind = graph_kind(node);
+    let public = graph_public_surface_candidate(input, node, node_id);
+    let mut finding = base_finding(
+        FindingType::StructuralChange,
+        node_id,
+        FindingOrigin::Direct,
+        if public {
+            format!("Public-surface {kind} {label} was added")
+        } else {
+            format!("{kind} {label} was added")
+        },
+        if public {
+            "A new callable or type is available from the changed source surface."
+        } else {
+            "A new internal graph entity was added."
+        },
+        Compatibility::Compatible,
+        if public {
+            Confidence::Probable
+        } else {
+            Confidence::Exact
+        },
+        None,
+        Some(json!({"id": node_id, "label": label, "kind": kind})),
+        node_evidence(Some(node), node_id, "contracts"),
+        if public {
+            "Confirm the new public surface and its documentation are intentional."
+        } else {
+            "No reviewer action is required unless this addition is unexpected."
+        },
+    );
+    finding.public_surface = public;
+    finding
+}
+
+fn removed_graph_node_finding(
+    input: &SemanticDiffInput<'_>,
+    node: &compass_model::NodeRecord,
+    node_id: &str,
+) -> SemanticFinding {
+    let label = graph_label(node, node_id);
+    let kind = graph_kind(node);
+    let public = graph_public_surface_candidate(input, node, node_id);
+    let mut finding = base_finding(
+        if public {
+            FindingType::ContractChange
+        } else {
+            FindingType::StructuralChange
+        },
+        node_id,
+        FindingOrigin::Direct,
+        if public {
+            format!("Public-surface {kind} {label} was removed")
+        } else {
+            format!("{kind} {label} was removed")
+        },
+        if public {
+            "A callable or type disappeared from the source surface."
+        } else {
+            "An internal graph entity was removed."
+        },
+        if public {
+            Compatibility::PossibleBreak
+        } else {
+            Compatibility::Compatible
+        },
+        if public {
+            Confidence::Probable
+        } else {
+            Confidence::Exact
+        },
+        Some(json!({"id": node_id, "label": label, "kind": kind})),
+        None,
+        node_evidence(Some(node), node_id, "contracts"),
+        if public {
+            "Review external callers before accepting the removed surface."
+        } else {
+            "No reviewer action is required unless this removal is unexpected."
+        },
+    );
+    finding.public_surface = public;
+    finding
+}
+
+fn graph_label<'a>(node: &'a compass_model::NodeRecord, fallback: &'a str) -> &'a str {
+    node.attributes
+        .get("label")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback)
+}
+
+fn graph_kind(node: &compass_model::NodeRecord) -> &str {
+    node.attributes
+        .get("symbol_kind")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("symbol")
+}
+
+fn graph_public_surface_candidate(
+    input: &SemanticDiffInput<'_>,
+    node: &compass_model::NodeRecord,
+    node_id: &str,
+) -> bool {
+    let kind = graph_kind(node);
+    if !matches!(kind, "class" | "function" | "method" | "interface" | "type") {
+        return false;
+    }
+    let label = graph_label(node, "");
+    if label.is_empty() || label.starts_with('_') {
+        return false;
+    }
+    let source = node
+        .attributes
+        .get("source_file")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    let non_test = !source.starts_with("tests/")
+        && !source.contains("/tests/")
+        && !source
+            .rsplit('/')
+            .next()
+            .is_some_and(|name| name.starts_with("test_") || name.ends_with("_test.py"));
+    if !non_test {
+        return false;
+    }
+    !is_internal_source(&source)
+        || input.dependency_deltas.iter().any(|dependency| {
+            dependency.target == node_id
+                && matches!(dependency.relation.as_str(), "imports" | "imports_from")
+                && is_public_facade_identity(&dependency.source)
+        })
+}
+
+fn function_is_public_surface(snapshot: &EntitySnapshot) -> bool {
+    if snapshot.function.visibility != compass_ir::Visibility::Public
+        || snapshot.function.is_test
+        || is_test_source(&snapshot.source_file)
+        || is_test_source(&snapshot.function.anchor.source_file)
+        || is_internal_source(&snapshot.source_file)
+        || is_internal_source(&snapshot.function.anchor.source_file)
+    {
+        return false;
+    }
+    snapshot
+        .function
+        .name
+        .split(['.', ':', '#'])
+        .filter(|component| !component.is_empty())
+        .all(|component| !component.starts_with('_'))
+}
+
+fn is_internal_source(source: &str) -> bool {
+    source
+        .replace('\\', "/")
+        .split('/')
+        .any(|component| component.starts_with('_') && component != "__init__.py")
+}
+
+fn is_public_facade_identity(identity: &str) -> bool {
+    let identity = identity.to_ascii_lowercase();
+    ["_api", "__init__", "_lib", "_prelude"]
+        .iter()
+        .any(|suffix| identity.ends_with(suffix))
+}
+
 fn attach_impact(
     input: &SemanticDiffInput<'_>,
     finding: &mut SemanticFinding,
-) -> Result<(), SemanticDiffError> {
+) -> Result<Vec<String>, SemanticDiffError> {
     if !matches!(
         finding.compatibility,
         Compatibility::ProvenBreak
@@ -627,8 +895,9 @@ fn attach_impact(
             | Compatibility::Indeterminate
     ) || finding.finding_type == FindingType::DependencyChange
     {
-        return Ok(());
+        return Ok(Vec::new());
     }
+    let mut limitations = Vec::new();
     let side = if finding.after.is_some() {
         SnapshotSide::New
     } else {
@@ -641,20 +910,21 @@ fn attach_impact(
         let callers = input.snapshots.reverse_callers(side, &symbol)?;
         if distance >= MAX_IMPACT_DEPTH {
             if !callers.is_empty() {
-                return Err(SemanticDiffError::LimitExceeded {
-                    resource: "impact_depth",
-                    limit: usize::from(MAX_IMPACT_DEPTH),
-                });
+                limitations.push(format!(
+                    "affected-consumer mapping for {} was truncated at depth {}",
+                    finding.subject, MAX_IMPACT_DEPTH
+                ));
             }
             continue;
         }
         for caller in callers {
             traversed += 1;
             if traversed > MAX_TRAVERSED_CALL_EDGES {
-                return Err(SemanticDiffError::LimitExceeded {
-                    resource: "impact_edges",
-                    limit: MAX_TRAVERSED_CALL_EDGES,
-                });
+                limitations.push(format!(
+                    "affected-consumer mapping for {} was truncated after {} call edges",
+                    finding.subject, MAX_TRAVERSED_CALL_EDGES
+                ));
+                return Ok(limitations);
             }
             if !visited.insert(caller.clone()) {
                 continue;
@@ -688,7 +958,7 @@ fn attach_impact(
             queue.push_back((caller, next_distance, witness));
         }
     }
-    Ok(())
+    Ok(limitations)
 }
 
 fn apply_verification(evidence: TestEvidence, finding: &mut SemanticFinding) {
@@ -796,24 +1066,59 @@ fn finalize_report(
             .then_with(|| left.subject.as_bytes().cmp(right.subject.as_bytes()))
             .then_with(|| left.id.as_bytes().cmp(right.id.as_bytes()))
     });
-    let routine_ids = findings
+    let feature_groups = build_feature_groups(&findings)?;
+    let routine_symbol_ids = findings
         .iter()
         .filter(|finding| {
             finding.finding_type == FindingType::StructuralChange
                 && finding.compatibility == Compatibility::Compatible
+                && !finding.public_surface
                 && finding.affected_consumers.is_empty()
         })
         .map(|finding| finding.id.clone())
         .collect::<Vec<_>>();
-    let collapsed_groups = if routine_ids.is_empty() {
-        Vec::new()
-    } else {
-        vec![CollapsedGroup {
+    let routine_test_ids = findings
+        .iter()
+        .filter(|finding| {
+            finding.routine
+                && finding
+                    .evidence
+                    .iter()
+                    .any(|evidence| is_test_source(&evidence.source_file))
+        })
+        .map(|finding| finding.id.clone())
+        .collect::<Vec<_>>();
+    let routine_dependency_ids = findings
+        .iter()
+        .filter(|finding| {
+            finding.routine
+                && finding.finding_type == FindingType::DependencyChange
+                && !routine_test_ids.contains(&finding.id)
+        })
+        .map(|finding| finding.id.clone())
+        .collect::<Vec<_>>();
+    let mut collapsed_groups = Vec::new();
+    if !routine_symbol_ids.is_empty() {
+        collapsed_groups.push(CollapsedGroup {
             label: "routine symbol churn".to_owned(),
-            count: routine_ids.len(),
-            finding_ids: routine_ids,
-        }]
-    };
+            count: routine_symbol_ids.len(),
+            finding_ids: routine_symbol_ids,
+        });
+    }
+    if !routine_dependency_ids.is_empty() {
+        collapsed_groups.push(CollapsedGroup {
+            label: "internal dependency churn".to_owned(),
+            count: routine_dependency_ids.len(),
+            finding_ids: routine_dependency_ids,
+        });
+    }
+    if !routine_test_ids.is_empty() {
+        collapsed_groups.push(CollapsedGroup {
+            label: "test dependency churn".to_owned(),
+            count: routine_test_ids.len(),
+            finding_ids: routine_test_ids,
+        });
+    }
     limitations.sort();
     limitations.dedup();
     let test_mapping = findings
@@ -827,14 +1132,27 @@ fn finalize_report(
         })
         .reduce(least_complete)
         .unwrap_or(Completeness::Unavailable);
+    let call_resolution = findings
+        .iter()
+        .map(|finding| {
+            finding
+                .completeness
+                .get("call_resolution")
+                .copied()
+                .unwrap_or(Completeness::Unavailable)
+        })
+        .reduce(least_complete)
+        .unwrap_or(Completeness::Unavailable);
     Ok(SemanticDiffReport {
         schema: REPORT_SCHEMA.to_owned(),
         comparison,
         findings,
+        feature_groups,
         collapsed_groups,
         completeness: BTreeMap::from([
             ("identity".to_owned(), Completeness::Complete),
             ("source_delta".to_owned(), Completeness::Complete),
+            ("call_resolution".to_owned(), call_resolution),
             ("test_mapping".to_owned(), test_mapping),
         ]),
         limitations,
@@ -872,7 +1190,138 @@ pub fn finding_id(
         relationships,
     ))?;
     let digest = Sha256::digest(bytes);
-    Ok(format!("sd1-{}", hex(&digest[..12])))
+    Ok(format!("sd2-{}", hex(&digest[..12])))
+}
+
+fn build_feature_groups(
+    findings: &[SemanticFinding],
+) -> Result<Vec<FeatureGroup>, SemanticDiffError> {
+    let mut parent = (0..findings.len()).collect::<Vec<_>>();
+    let mut owner = BTreeMap::<String, usize>::new();
+    for (index, finding) in findings.iter().enumerate() {
+        let files = finding
+            .evidence
+            .iter()
+            .map(|evidence| evidence.source_file.replace('\\', "/"))
+            .filter(|path| !path.is_empty())
+            .collect::<BTreeSet<_>>();
+        for file in files {
+            if let Some(other) = owner.get(&file).copied() {
+                union_groups(&mut parent, index, other);
+            } else {
+                owner.insert(file, index);
+            }
+        }
+    }
+    let mut groups = BTreeMap::<usize, Vec<&SemanticFinding>>::new();
+    for (index, finding) in findings.iter().enumerate() {
+        let root = find_group(&mut parent, index);
+        groups.entry(root).or_default().push(finding);
+    }
+    let mut output = Vec::new();
+    for mut members in groups.into_values() {
+        members.sort_by(|left, right| {
+            Reverse(left.review_priority)
+                .cmp(&Reverse(right.review_priority))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        let finding_ids = members
+            .iter()
+            .map(|finding| finding.id.clone())
+            .collect::<Vec<_>>();
+        let source_files = members
+            .iter()
+            .flat_map(|finding| &finding.evidence)
+            .map(|evidence| evidence.source_file.replace('\\', "/"))
+            .filter(|path| !path.is_empty())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let public_surface_changes = members
+            .iter()
+            .filter(|finding| finding.public_surface)
+            .count();
+        let behavior_changes = members
+            .iter()
+            .filter(|finding| finding.finding_type == FindingType::BehaviorChange)
+            .count();
+        let dependency_changes = members
+            .iter()
+            .filter(|finding| finding.finding_type == FindingType::DependencyChange)
+            .count();
+        let test_changes = members
+            .iter()
+            .filter(|finding| {
+                finding
+                    .evidence
+                    .iter()
+                    .any(|evidence| is_test_source(&evidence.source_file))
+            })
+            .count();
+        let anchor = members
+            .iter()
+            .find(|finding| finding.public_surface)
+            .copied()
+            .unwrap_or(members[0]);
+        let headline = if members.len() == 1 {
+            anchor.headline.clone()
+        } else {
+            format!("{} and related changes", anchor.headline)
+        };
+        let summary = format!(
+            "{public_surface_changes} public-surface, {behavior_changes} behavior, \
+             {dependency_changes} dependency, and {test_changes} test-related changes across {} files.",
+            source_files.len()
+        );
+        let digest = Sha256::digest(serde_json::to_vec(&finding_ids)?);
+        output.push(FeatureGroup {
+            id: format!("sg1-{}", hex(&digest[..12])),
+            headline,
+            summary,
+            finding_ids,
+            source_files,
+            public_surface_changes,
+            behavior_changes,
+            dependency_changes,
+            test_changes,
+        });
+    }
+    output.sort_by(|left, right| {
+        Reverse(left.public_surface_changes)
+            .cmp(&Reverse(right.public_surface_changes))
+            .then_with(|| Reverse(left.behavior_changes).cmp(&Reverse(right.behavior_changes)))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    Ok(output)
+}
+
+fn find_group(parent: &mut [usize], index: usize) -> usize {
+    if parent[index] != index {
+        parent[index] = find_group(parent, parent[index]);
+    }
+    parent[index]
+}
+
+fn union_groups(parent: &mut [usize], left: usize, right: usize) {
+    let left = find_group(parent, left);
+    let right = find_group(parent, right);
+    if left != right {
+        let (first, second) = if left < right {
+            (left, right)
+        } else {
+            (right, left)
+        };
+        parent[second] = first;
+    }
+}
+
+fn is_test_source(source: &str) -> bool {
+    let path = source.replace('\\', "/").to_ascii_lowercase();
+    let name = path.rsplit('/').next().unwrap_or(&path);
+    path.starts_with("tests/")
+        || path.contains("/tests/")
+        || name.starts_with("test_")
+        || name.ends_with("_test.py")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -899,6 +1348,8 @@ fn base_finding(
         compatibility,
         confidence,
         review_priority: 0,
+        public_surface: false,
+        routine: false,
         before,
         after,
         affected_consumers: Vec::new(),
@@ -972,15 +1423,16 @@ fn summary_value(summary: &FunctionSummary) -> Value {
         "reads": summary.reads,
         "writes": summary.writes,
         "effects": summary.effects,
-        "errors": summary.errors,
+        "exceptions": summary.exceptions,
     })
 }
 
 fn contracts_complete(coverage: &Coverage) -> bool {
-    matches!(
-        coverage.get(&Capability::Contracts),
-        Some(CoverageState::Complete)
-    )
+    capability_complete(coverage, Capability::Contracts)
+}
+
+fn capability_complete(coverage: &Coverage, capability: Capability) -> bool {
+    matches!(coverage.get(&capability), Some(CoverageState::Complete))
 }
 
 fn visibility_rank(visibility: compass_ir::Visibility) -> u8 {

--- a/crates/compass-semantic-diff/src/engine.rs
+++ b/crates/compass-semantic-diff/src/engine.rs
@@ -1190,7 +1190,7 @@ pub fn finding_id(
         relationships,
     ))?;
     let digest = Sha256::digest(bytes);
-    Ok(format!("sd2-{}", hex(&digest[..12])))
+    Ok(format!("sd1-{}", hex(&digest[..12])))
 }
 
 fn build_feature_groups(

--- a/crates/compass-semantic-diff/src/lib.rs
+++ b/crates/compass-semantic-diff/src/lib.rs
@@ -9,10 +9,10 @@ pub use engine::{compare, finding_id};
 pub use error::SemanticDiffError;
 pub use model::{
     AffectedConsumer, ChangeDirection, CollapsedGroup, Comparison, Compatibility, Completeness,
-    Confidence, DependencyDelta, EvidenceRef, FindingOrigin, FindingType, MAX_DIRECT_ENTITIES,
-    MAX_EVIDENCE_PER_FINDING, MAX_FINDINGS, MAX_IMPACT_DEPTH, MAX_TRAVERSED_CALL_EDGES,
-    NoTestEvidence, REPORT_SCHEMA, SemanticDiffInput, SemanticDiffReport, SemanticFinding,
-    SnapshotIdentity, SnapshotReader, SnapshotSide, TestEvidence, TestEvidenceProvider,
-    Verification, VerificationState, WitnessHop, WitnessPath,
+    Confidence, DependencyDelta, EvidenceRef, FeatureGroup, FindingOrigin, FindingType,
+    MAX_DIRECT_ENTITIES, MAX_EVIDENCE_PER_FINDING, MAX_FINDINGS, MAX_IMPACT_DEPTH,
+    MAX_TRAVERSED_CALL_EDGES, NoTestEvidence, REPORT_SCHEMA, SemanticDiffInput, SemanticDiffReport,
+    SemanticFinding, SnapshotIdentity, SnapshotReader, SnapshotSide, TestEvidence,
+    TestEvidenceProvider, Verification, VerificationState, WitnessHop, WitnessPath,
 };
 pub use verification::StaticTestEvidence;

--- a/crates/compass-semantic-diff/src/model.rs
+++ b/crates/compass-semantic-diff/src/model.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::SemanticDiffError;
 
-pub const REPORT_SCHEMA: &str = "compass.semantic_diff.report/2";
-pub const CLASSIFIER_VERSION: u32 = 2;
+pub const REPORT_SCHEMA: &str = "compass.semantic_diff.report/1";
+pub const CLASSIFIER_VERSION: u32 = 1;
 pub const MAX_DIRECT_ENTITIES: usize = 10_000;
 pub const MAX_TRAVERSED_CALL_EDGES: usize = 200_000;
 pub const MAX_IMPACT_DEPTH: u8 = 4;

--- a/crates/compass-semantic-diff/src/model.rs
+++ b/crates/compass-semantic-diff/src/model.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::SemanticDiffError;
 
-pub const REPORT_SCHEMA: &str = "compass.semantic_diff.report/1";
-pub const CLASSIFIER_VERSION: u32 = 1;
+pub const REPORT_SCHEMA: &str = "compass.semantic_diff.report/2";
+pub const CLASSIFIER_VERSION: u32 = 2;
 pub const MAX_DIRECT_ENTITIES: usize = 10_000;
 pub const MAX_TRAVERSED_CALL_EDGES: usize = 200_000;
 pub const MAX_IMPACT_DEPTH: u8 = 4;
@@ -159,6 +159,12 @@ pub struct SemanticFinding {
     pub compatibility: Compatibility,
     pub confidence: Confidence,
     pub review_priority: u16,
+    /// True when the changed entity is public, or is a conservative
+    /// public-surface candidate from graph evidence.
+    pub public_surface: bool,
+    /// Routine implementation/test churn is retained in JSON and `--all`, but
+    /// collapsed from the default reviewer view.
+    pub routine: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub before: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -179,6 +185,19 @@ pub struct CollapsedGroup {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FeatureGroup {
+    pub id: String,
+    pub headline: String,
+    pub summary: String,
+    pub finding_ids: Vec<String>,
+    pub source_files: Vec<String>,
+    pub public_surface_changes: usize,
+    pub behavior_changes: usize,
+    pub dependency_changes: usize,
+    pub test_changes: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Comparison {
     pub old_commit: String,
     pub new_commit: String,
@@ -190,6 +209,7 @@ pub struct SemanticDiffReport {
     pub schema: String,
     pub comparison: Comparison,
     pub findings: Vec<SemanticFinding>,
+    pub feature_groups: Vec<FeatureGroup>,
     pub collapsed_groups: Vec<CollapsedGroup>,
     pub completeness: BTreeMap<String, Completeness>,
     pub limitations: Vec<String>,

--- a/crates/compass-semantic-diff/tests/semantic_diff.rs
+++ b/crates/compass-semantic-diff/tests/semantic_diff.rs
@@ -8,22 +8,28 @@ use compass_languages::TreeSitterSyntaxProvider;
 use compass_model::NodeRecord;
 use compass_program::{FileInput, SyntaxProvider, merge_evidence};
 use compass_semantic_diff::{
-    Compatibility, NoTestEvidence, REPORT_SCHEMA, SemanticDiffError, SemanticDiffInput,
-    SnapshotIdentity, SnapshotReader, SnapshotSide, compare,
+    ChangeDirection, Compatibility, DependencyDelta, NoTestEvidence, REPORT_SCHEMA,
+    SemanticDiffError, SemanticDiffInput, SnapshotIdentity, SnapshotReader, SnapshotSide, compare,
 };
 
 struct Fixtures {
     old: AnalysisBundle,
     new: AnalysisBundle,
+    old_nodes: BTreeMap<String, NodeRecord>,
+    new_nodes: BTreeMap<String, NodeRecord>,
 }
 
 impl SnapshotReader for Fixtures {
     fn node(
         &self,
-        _side: SnapshotSide,
-        _node_id: &str,
+        side: SnapshotSide,
+        node_id: &str,
     ) -> Result<Option<NodeRecord>, SemanticDiffError> {
-        Ok(None)
+        let nodes = match side {
+            SnapshotSide::Old => &self.old_nodes,
+            SnapshotSide::New => &self.new_nodes,
+        };
+        Ok(nodes.get(node_id).cloned())
     }
 
     fn module(
@@ -89,6 +95,8 @@ fn required_parameter_and_behavior_changes_are_actionable() -> Result<(), Box<dy
         new: analyze_typescript(
             b"export async function load(id: string, mode: string) { await save(id); }",
         )?,
+        old_nodes: BTreeMap::new(),
+        new_nodes: BTreeMap::new(),
     };
     let deltas = [SourceFileDelta {
         old_path: Some("src/app.ts".to_owned()),
@@ -130,7 +138,7 @@ fn required_parameter_and_behavior_changes_are_actionable() -> Result<(), Box<dy
         report
             .findings
             .iter()
-            .all(|finding| finding.id.starts_with("sd1-"))
+            .all(|finding| finding.id.starts_with("sd2-"))
     );
     assert_eq!(
         report.completeness,
@@ -144,10 +152,233 @@ fn required_parameter_and_behavior_changes_are_actionable() -> Result<(), Box<dy
                 compass_semantic_diff::Completeness::Complete,
             ),
             (
+                "call_resolution".to_owned(),
+                compass_semantic_diff::Completeness::Partial,
+            ),
+            (
                 "test_mapping".to_owned(),
                 compass_semantic_diff::Completeness::Unavailable,
             ),
         ])
+    );
+    assert!(!report.feature_groups.is_empty());
+    Ok(())
+}
+
+#[test]
+fn comparisons_complete_in_both_directions_when_one_side_has_no_functions()
+-> Result<(), Box<dyn Error>> {
+    let old = analyze_typescript(b"export function load() { return 1; }")?;
+    let new = analyze_typescript(b"export const value = 1;")?;
+    let delta = [SourceFileDelta {
+        old_path: Some("src/app.ts".to_owned()),
+        new_path: Some("src/app.ts".to_owned()),
+        status: SourceFileStatus::Modified,
+        hunks: Vec::new(),
+    }];
+    let run = |old: AnalysisBundle, new: AnalysisBundle| {
+        let fixtures = Fixtures {
+            old,
+            new,
+            old_nodes: BTreeMap::new(),
+            new_nodes: BTreeMap::new(),
+        };
+        compare(SemanticDiffInput {
+            old: SnapshotIdentity {
+                commit: "a".repeat(40),
+                realization: "old".to_owned(),
+                fingerprint: "f".repeat(64),
+            },
+            new: SnapshotIdentity {
+                commit: "b".repeat(40),
+                realization: "new".to_owned(),
+                fingerprint: "f".repeat(64),
+            },
+            source_deltas: &delta,
+            changed_node_ids: &[],
+            dependency_deltas: &[],
+            snapshots: &fixtures,
+            test_evidence: &NoTestEvidence,
+        })
+    };
+
+    let forward = run(old.clone(), new.clone())?;
+    let reverse = run(new, old)?;
+    assert!(!forward.findings.is_empty());
+    assert!(!reverse.findings.is_empty());
+    Ok(())
+}
+
+#[test]
+fn comparisons_complete_in_both_directions_when_impact_exceeds_depth() -> Result<(), Box<dyn Error>>
+{
+    let mut old = analyze_typescript(b"export function load(id: string) { return id; }")?;
+    let mut new =
+        analyze_typescript(b"export function load(id: string, mode: string) { return mode; }")?;
+    for bundle in [&mut old, &mut new] {
+        let mut callee = bundle
+            .program
+            .modules
+            .iter()
+            .flat_map(|module| &module.functions)
+            .find(|function| function.name == "load")
+            .ok_or("missing load function")?
+            .symbol_id
+            .clone();
+        for depth in 0..=usize::from(compass_semantic_diff::MAX_IMPACT_DEPTH) {
+            let caller = format!("caller-{depth}");
+            bundle
+                .reverse_calls
+                .insert(callee.clone(), vec![caller.clone()]);
+            callee = caller;
+        }
+    }
+    let delta = [SourceFileDelta {
+        old_path: Some("src/app.ts".to_owned()),
+        new_path: Some("src/app.ts".to_owned()),
+        status: SourceFileStatus::Modified,
+        hunks: Vec::new(),
+    }];
+    let run = |old: AnalysisBundle, new: AnalysisBundle| {
+        let fixtures = Fixtures {
+            old,
+            new,
+            old_nodes: BTreeMap::new(),
+            new_nodes: BTreeMap::new(),
+        };
+        compare(SemanticDiffInput {
+            old: SnapshotIdentity {
+                commit: "a".repeat(40),
+                realization: "old".to_owned(),
+                fingerprint: "f".repeat(64),
+            },
+            new: SnapshotIdentity {
+                commit: "b".repeat(40),
+                realization: "new".to_owned(),
+                fingerprint: "f".repeat(64),
+            },
+            source_deltas: &delta,
+            changed_node_ids: &[],
+            dependency_deltas: &[],
+            snapshots: &fixtures,
+            test_evidence: &NoTestEvidence,
+        })
+    };
+
+    for report in [run(old.clone(), new.clone())?, run(new, old)?] {
+        assert!(report.limitations.iter().any(|limitation| {
+            limitation.contains("affected-consumer mapping")
+                && limitation.contains("truncated at depth")
+        }));
+    }
+    Ok(())
+}
+
+#[test]
+fn graph_only_additions_and_removals_are_classified_before_digest_changes()
+-> Result<(), Box<dyn Error>> {
+    let old = analyze_typescript(b"")?;
+    let new = analyze_typescript(b"")?;
+    let added_id = "src_api_new_handler".to_owned();
+    let removed_id = "src_api_old_handler".to_owned();
+    let internal_exported_id = "src_internal_exported".to_owned();
+    let internal_hidden_id = "src_internal_hidden".to_owned();
+    let node = |id: &str, label: &str, source_file: &str| NodeRecord {
+        id: id.to_owned(),
+        attributes: serde_json::Map::from_iter([
+            ("label".to_owned(), serde_json::json!(label)),
+            ("symbol_kind".to_owned(), serde_json::json!("function")),
+            ("source_file".to_owned(), serde_json::json!(source_file)),
+            (
+                "signature_hash".to_owned(),
+                serde_json::json!("digest-that-must-not-be-treated-as-a-modification"),
+            ),
+        ]),
+    };
+    let fixtures = Fixtures {
+        old,
+        new,
+        old_nodes: BTreeMap::from([(
+            removed_id.clone(),
+            node(&removed_id, "old_handler", "src/api.ts"),
+        )]),
+        new_nodes: BTreeMap::from([
+            (
+                added_id.clone(),
+                node(&added_id, "new_handler", "src/api.ts"),
+            ),
+            (
+                internal_exported_id.clone(),
+                node(
+                    &internal_exported_id,
+                    "Exported",
+                    "src/package/_internal.py",
+                ),
+            ),
+            (
+                internal_hidden_id.clone(),
+                node(&internal_hidden_id, "Hidden", "src/package/_internal.py"),
+            ),
+        ]),
+    };
+    let changed = [
+        added_id.clone(),
+        removed_id.clone(),
+        internal_exported_id.clone(),
+        internal_hidden_id.clone(),
+    ];
+    let dependencies = [DependencyDelta {
+        source: "src_package_api".to_owned(),
+        relation: "imports".to_owned(),
+        target: internal_exported_id.clone(),
+        change: ChangeDirection::Added,
+        evidence: Vec::new(),
+    }];
+    let report = compare(SemanticDiffInput {
+        old: SnapshotIdentity {
+            commit: "a".repeat(40),
+            realization: "old".to_owned(),
+            fingerprint: "f".repeat(64),
+        },
+        new: SnapshotIdentity {
+            commit: "b".repeat(40),
+            realization: "new".to_owned(),
+            fingerprint: "f".repeat(64),
+        },
+        source_deltas: &[],
+        changed_node_ids: &changed,
+        dependency_deltas: &dependencies,
+        snapshots: &fixtures,
+        test_evidence: &NoTestEvidence,
+    })?;
+    let added = report
+        .findings
+        .iter()
+        .find(|finding| finding.subject == added_id)
+        .ok_or("missing added finding")?;
+    let removed = report
+        .findings
+        .iter()
+        .find(|finding| finding.subject == removed_id)
+        .ok_or("missing removed finding")?;
+    assert!(added.before.is_none() && added.after.is_some());
+    assert!(removed.before.is_some() && removed.after.is_none());
+    assert!(added.public_surface && removed.public_surface);
+    assert!(added.headline.contains("was added"));
+    assert!(removed.headline.contains("was removed"));
+    assert!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.subject == internal_exported_id)
+            .is_some_and(|finding| finding.public_surface)
+    );
+    assert!(
+        report
+            .findings
+            .iter()
+            .find(|finding| finding.subject == internal_hidden_id)
+            .is_some_and(|finding| !finding.public_surface)
     );
     Ok(())
 }

--- a/crates/compass-semantic-diff/tests/semantic_diff.rs
+++ b/crates/compass-semantic-diff/tests/semantic_diff.rs
@@ -138,7 +138,7 @@ fn required_parameter_and_behavior_changes_are_actionable() -> Result<(), Box<dy
         report
             .findings
             .iter()
-            .all(|finding| finding.id.starts_with("sd2-"))
+            .all(|finding| finding.id.starts_with("sd1-"))
     );
     assert_eq!(
         report.completeness,

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -37,11 +37,12 @@ A **realization** is more specific than a commit. The same commit can have a
 code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
-History graph schema `networkx-node-link/v6` records automatic multigraph
-promotion. This is a hard cutover: Compass accepts only v6 build profiles,
-realizations, and history stores. It does not migrate, normalize, list, query,
-or diff pre-v6 history. Archive or remove the repository's Compass history
-directory in the common Git directory, then build fresh v6 realizations.
+History graph schema `networkx-node-link/v1` records automatic multigraph
+promotion. This is a hard cutover: Compass accepts only the current v1 build
+profiles, realizations, and history stores. It does not migrate, normalize,
+list, query, or diff any other history contract. Archive or remove the
+repository's Compass history directory in the common Git directory, then build
+fresh v1 realizations.
 
 ## 1. Inspect the command contract
 
@@ -242,18 +243,18 @@ compass diff v1.2.0 HEAD --format json
 Explain one finding:
 
 ```bash
-compass diff v1.2.0 HEAD --explain sd2-...
+compass diff v1.2.0 HEAD --explain sd1-...
 ```
 
 The default report is ranked for PR review: likely breaks, behavior changes,
 affected callers/modules, and test evidence come first. Routine symbol churn
 is collapsed. Its five core concepts are contract changes, behavior changes,
 dependency changes, affected consumers, and verification evidence. JSON uses
-schema `compass.semantic_diff.report/2`; deterministic `sd2-...` finding IDs
+schema `compass.semantic_diff.report/1`; deterministic `sd1-...` finding IDs
 make `--explain` and automation stable when the underlying semantic evidence
 does not change.
 
-Semantic diff requires Program IR v3 evidence. Rebuild older realizations with
+Semantic diff requires Program IR v1 evidence. Rebuild older realizations with
 the current Compass binary before comparing them. Static test mapping may
 recommend resolved test callers, but `partial` or `unknown` evidence never
 claims safety or a test gap. AI-generated summaries and hosted PR delivery are

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -38,10 +38,10 @@ code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
 History graph schema `networkx-node-link/v6` records automatic multigraph
-promotion. On upgrade, Compass migrates a stored v1 build profile to v2. The
-fingerprint therefore no longer matches a v1 realization, and the next
-requested build rematerializes that commit instead of reusing stale graph
-metadata.
+promotion. This is a hard cutover: Compass accepts only v6 build profiles,
+realizations, and history stores. It does not migrate, normalize, list, query,
+or diff pre-v6 history. Archive or remove the repository's Compass history
+directory in the common Git directory, then build fresh v6 realizations.
 
 ## 1. Inspect the command contract
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -37,7 +37,7 @@ A **realization** is more specific than a commit. The same commit can have a
 code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
-History graph schema `networkx-node-link/v2` records automatic multigraph
+History graph schema `networkx-node-link/v6` records automatic multigraph
 promotion. On upgrade, Compass migrates a stored v1 build profile to v2. The
 fingerprint therefore no longer matches a v1 realization, and the next
 requested build rematerializes that commit instead of reusing stale graph
@@ -227,6 +227,12 @@ Expand routine symbol churn:
 compass diff v1.2.0 HEAD --all
 ```
 
+Raise the per-section display budget without expanding routine churn:
+
+```bash
+compass diff v1.2.0 HEAD --limit 50
+```
+
 Machine-readable output:
 
 ```bash
@@ -236,18 +242,18 @@ compass diff v1.2.0 HEAD --format json
 Explain one finding:
 
 ```bash
-compass diff v1.2.0 HEAD --explain sd1-...
+compass diff v1.2.0 HEAD --explain sd2-...
 ```
 
 The default report is ranked for PR review: likely breaks, behavior changes,
 affected callers/modules, and test evidence come first. Routine symbol churn
 is collapsed. Its five core concepts are contract changes, behavior changes,
 dependency changes, affected consumers, and verification evidence. JSON uses
-schema `compass.semantic_diff.report/1`; deterministic `sd1-...` finding IDs
+schema `compass.semantic_diff.report/2`; deterministic `sd2-...` finding IDs
 make `--explain` and automation stable when the underlying semantic evidence
 does not change.
 
-Semantic diff requires Program IR v2 evidence. Rebuild older realizations with
+Semantic diff requires Program IR v3 evidence. Rebuild older realizations with
 the current Compass binary before comparing them. Static test mapping may
 recommend resolved test callers, but `partial` or `unknown` evidence never
 claims safety or a test gap. AI-generated summaries and hosted PR delivery are

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -283,6 +283,7 @@ Build-profile options include:
 ```text
 compass diff OLD NEW
   [--format text|json]
+  [--limit N]
   [--all]
   [--explain FINDING_ID]
   [--fingerprint SHA]
@@ -290,9 +291,10 @@ compass diff OLD NEW
 
 The default output is an actionable PR-review summary: likely breaks, behavior
 changes, affected callers/modules, and test evidence. Routine symbol churn is
-collapsed; `--all` expands it. `--explain` prints the evidence and reasoning
-for one finding. Diff requires comparable build profiles; rebuild the newer
-revision with `--profile-from OLD` when needed.
+collapsed; `--limit N` changes the visible per-section budget, while `--all`
+expands routine findings and is exhaustive. `--explain` prints the evidence
+and reasoning for one finding. Diff requires comparable build profiles;
+rebuild the newer revision with `--profile-from OLD` when needed.
 
 ## Service
 

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -241,7 +241,7 @@ Record:
 compass diff OLD NEW --format json
 ```
 
-Uses schema `compass.semantic_diff.report/2`. The report contains ranked
+Uses schema `compass.semantic_diff.report/1`. The report contains ranked
 semantic findings, affected callers/modules, source and graph evidence,
 verification state, completeness, and a collapsed-finding summary. Routine
 symbol churn is collapsed unless `--all` is supplied. Default text output

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -241,11 +241,13 @@ Record:
 compass diff OLD NEW --format json
 ```
 
-Uses schema `compass.semantic_diff.report/1`. The report contains ranked
+Uses schema `compass.semantic_diff.report/2`. The report contains ranked
 semantic findings, affected callers/modules, source and graph evidence,
 verification state, completeness, and a collapsed-finding summary. Routine
-symbol churn is collapsed unless `--all` is supplied. Normal diff requires
-compatible build profiles.
+symbol churn is collapsed unless `--all` is supplied. Default text output
+shows 20 findings per section and reports every hidden count; `--limit N`
+changes that budget, while JSON and `--all` are exhaustive. Normal diff
+requires compatible build profiles.
 
 `verification.state` is `covered`, `gap`, `partial`, or `unknown` for the
 static MVP (runtime adapters may also report `stale`, `failing`, or `not_run`).


### PR DESCRIPTION
## What changed

- make semantic diff total in both directions, including bounded impact traversal with explicit limitations instead of panics/errors
- normalize graph, manifest, and checkout-root identity inputs so identical revision/profile rebuilds produce the same realization ID
- reset every current Compass-owned persisted/fingerprinted contract to v1: history, node-link graph, store/root namespace, Program IR, provider, merger, analysis, and semantic-diff report/classifier
- remove profile migration/comparison normalization, version-conditional realization roots, legacy GC roots, legacy job-field defaults, dual node-link serialization, and old-store opening
- add explicit `--limit` behavior, genuinely exhaustive `--all`, visible truncation counts, and prominent public-surface additions
- distinguish proven test gaps from partial/unavailable test mapping
- classify additions/removals before digest comparisons and group API, behavior, dependency, impact, and test evidence into reviewer narratives
- collapse routine dependency/test churn by default
- resolve unique local/imported calls before assigning semantic confidence
- model thrown exceptions structurally, including chained exceptions, rethrows, and dynamic expressions
- document automatic multigraph promotion and update parity handling for Compass-superset metadata

## Why

The previous history diff could panic or abort in reverse comparisons, emit non-deterministic realization IDs, silently truncate renderer output, overclaim test gaps and public APIs, and describe exception expressions such as `result.error` as if they were exception types. Reciprocal edges could also create invalid non-multigraph artifacts.

## User impact

`compass diff OLD NEW` now leads with likely breaks, public API changes, behavior, affected consumers, and mapping completeness. Routine symbol/test/internal dependency churn stays collapsed unless `--all` is requested, while JSON and `--all` remain exhaustive.

History persistence has no backward-compatibility path in this early phase. Anything other than the current v1 contract fails closed; users archive or remove the repository's Compass history directory and rebuild fresh v1 realizations.

## Validation

- `GRAPHIFY_REPO_ROOT=/Users/haipingfu/graphify CARGO_TARGET_DIR=/Volumes/Workspace/codex-compass-semantic-target cargo test --workspace --quiet`
- strict clippy for every changed crate with `--all-targets --no-deps -- -D warnings`
- `graphify update .`
- real CocoIndex history validation at `90571539fa29..71f9cc9dc693`: 333 findings in both directions; forward reports 1 public addition, 7 behavior changes, 0 likely breaks; reverse completes with explicit depth-limit notes
- `--all` emitted all 333 findings with no truncation marker; `--limit 5` reported the 11 omitted section findings
- identical unseeded and seeded HEAD rebuilds produced realization `4dd10563637031ac43f24390f14b2293109a0d47976e7c9937f68a499273e95d`
- fresh v1 acceptance built two Python revisions and validated history schema 1, `networkx-node-link/v1`, Program IR 1, merger 1, analysis schema/analyzer 1, semantic report `/1`, and `sd1-...` findings
- the fresh semantic diff reported the added required parameter as a probable public-API break
- the existing non-current CocoIndex store fails closed with `compatible:false` and exit code 1

Workspace-wide strict clippy is currently blocked by two pre-existing `too_many_arguments` lints in `compass-output`; all affected crates pass with only those two known lints allowed.
