### PR TITLE
Release Compass 0.1.6 for macOS and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-model",
  "glob",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-analysis",
  "compass-files",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-model",
  "regex",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "axum",
  "compass-core",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-cypher",
  "compass-files",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-model",
  "regex",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-languages",
  "compass-model",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the Compass workspace and lockfile from 0.1.5 to 0.1.6
- retain the existing native macOS and Linux release matrix for ARM64 and x86_64
- publish the stable per-architecture archives, checksums, provenance, and one-line installer after merge

## Validation

- release-script syntax and behavioral tests pass for all four targets
- release workflow YAML parses successfully
- locked workspace metadata resolves only version 0.1.6
- Compass product contract: 5 passed
- optimized Apple Silicon build and packaged archive verified as compass 0.1.6

## Existing main baseline

The full workspace lib/bin test build reproduces the existing origin/main compiler failure at crates/compass-cli/src/history_commands.rs:1552, where ParsedCommonOptions is destructured as the previous tuple shape. Main CI run 30169308669 has the same failure. This version-only PR changes no Rust source; the dedicated release workflow uses the green product and release-script checks above.
