### PR TITLE
feat(vscode): make graph exploration trustworthy and polished

### DIFF
--- a/docs/superpowers/plans/2026-07-25-vscode-inspector-callgraph-loading.md
+++ b/docs/superpowers/plans/2026-07-25-vscode-inspector-callgraph-loading.md
@@ -1,0 +1,400 @@
+# VS Code Inspector and Call-Graph Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate exact source navigation and community identity in the graph inspector, and replace the raw call-graph resolver sentence with Compass’s balanced, recoverable loading experience.
+
+**Architecture:** `GraphInspector` keeps its existing host callbacks but renders navigable source metadata as one native button and neighbor community colors as dots. `GraphLoadingState` gains optional loading copy so the call-graph webview can reuse the established constellation, accessibility, and error-recovery surface without duplicating a visual system. The call-graph host adds retry and output actions around its existing cursor-position query.
+
+**Tech Stack:** TypeScript, React 19, Lucide React, VS Code Webview API, Compass viewer CSS, Vitest, Playwright.
+
+## Global Constraints
+
+- Implement behavior before adding regression coverage; do not use a TDD/red-green-refactor sequence.
+- Keep Compass runtime artifacts under `compass-out/`; do not introduce a `graphify-out/` runtime path.
+- Use existing VS Code theme tokens and the existing Compass constellation loader.
+- Do not change graph contracts, source-range calculation, CLI query limits, or serializers.
+- Preserve keyboard access, high-contrast behavior, and reduced-motion behavior.
+- Do not stage generated output directories or unrelated user files.
+
+---
+
+### Task 1: Integrated Source Card and Neighbor Dots
+
+**Context:** The inspector duplicates source information across metadata and a separate action, while neighbor community color is presented as a heavy left border.
+
+**Goal:** Make the Source metadata surface the exact navigation action and use compact colored dots for neighbor identity.
+
+**Expected outcome:** A selected node with source data exposes one clear Source button containing path, exact line range, and an ExternalLink icon. Connected-node rows have community-color dots and no colored border.
+
+**Files:**
+
+- Modify: `packages/compass-viewer/src/graph/GraphInspector.tsx`
+- Modify: `packages/compass-viewer/src/theme.css`
+- Test after implementation: `tests/viewer/graph-parity.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `navigableSource(node): SourceLocation | undefined`
+- Consumes: `onOpenSource(source: SourceLocation): void`
+- Consumes: `onFocus(nodeId: string): void`
+- Produces: `.compass-source-card`, `.compass-source-path`, `.compass-source-range`, and `.compass-neighbor-dot` presentation hooks
+- Preserves: the exact `SourceLocation` object sent to `onOpenSource`
+
+- [ ] **Step 1: Add source display helpers**
+
+Keep `lineRange(node)` for compact metadata and add an accessible source action label:
+
+```ts
+function sourceActionLabel(node: GraphNode, source: SourceLocation): string {
+  const start = node.source?.startLine;
+  const end = node.source?.endLine;
+  if (start === undefined) return `Open source ${source.file}`;
+  if (end !== undefined && end !== start) {
+    return `Open source ${source.file} at lines ${start}–${end}`;
+  }
+  return `Open source ${source.file} at line ${start}`;
+}
+```
+
+Import `ExternalLinkIcon` from `lucide-react`.
+
+- [ ] **Step 2: Replace the static Source metadata and duplicate action**
+
+Inside the wide Source metadata entry:
+
+```tsx
+<div className="compass-metadata-wide compass-source-metadata">
+  <dt>Source</dt>
+  <dd>
+    {source ? (
+      <button
+        className="compass-source-card"
+        type="button"
+        aria-label={sourceActionLabel(selected, source)}
+        title={sourceActionLabel(selected, source)}
+        onClick={() => onOpenSource(source)}
+      >
+        <span className="compass-source-copy">
+          <span className="compass-source-path">{source.file}</span>
+          {range && (
+            <span className="compass-source-range">
+              {range.includes("–") ? `Lines ${range}` : `Line ${range}`}
+            </span>
+          )}
+        </span>
+        <ExternalLinkIcon aria-hidden="true" />
+      </button>
+    ) : (
+      <span>{selected.source?.file ?? "Not recorded"}</span>
+    )}
+  </dd>
+</div>
+```
+
+Remove only the source-specific `.compass-inspector-action` button. Preserve the Open community action.
+
+- [ ] **Step 3: Replace neighbor borders with dots**
+
+Render each neighbor as:
+
+```tsx
+<button
+  key={neighbor.id}
+  type="button"
+  className="compass-neighbor-link"
+  title={neighbor.label}
+  onClick={() => onFocus(neighbor.id)}
+>
+  <span
+    className="compass-neighbor-dot"
+    aria-hidden="true"
+    style={{ background: neighbor.color?.background
+      ?? model.communities.find((item) => item.id === neighbor.community)?.color
+      ?? "var(--border)" }}
+  />
+  <span className="compass-neighbor-label">{neighbor.label}</span>
+</button>
+```
+
+- [ ] **Step 4: Style the integrated controls**
+
+In `theme.css`:
+
+- remove Source-specific dependence on `.compass-inspector-action`;
+- make `.compass-source-card` a full-width, borderless inner button with path/range columns and a trailing 15-pixel icon;
+- add hover and focus border/background treatment to `.compass-source-metadata`;
+- make `.compass-neighbor-link` a flex row with no left border;
+- add an 8-pixel circular `.compass-neighbor-dot`;
+- truncate `.compass-neighbor-label`;
+- include `.compass-source-card` in focus-visible and high-contrast selectors.
+
+- [ ] **Step 5: Build the viewer and extension**
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:viewer
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:vscode
+```
+
+Expected: both builds exit 0.
+
+- [ ] **Step 6: Add post-implementation browser coverage**
+
+Update `graph-parity.spec.ts` to assert:
+
+```ts
+const sourceCard = page.getByRole("button", {
+  name: "Open source src/lib.rs at lines 5–7"
+});
+await expect(sourceCard).toBeVisible();
+await expect(sourceCard.locator(".compass-source-path")).toHaveText("src/lib.rs");
+await expect(sourceCard.locator(".compass-source-range")).toHaveText("Lines 5–7");
+await expect(page.locator(".compass-neighbor-link")).not.toHaveCSS(
+  "border-left-width",
+  "3px"
+);
+await expect(page.locator(".compass-neighbor-dot")).toHaveCount(2);
+```
+
+Click the Source card in the web-export fixture and assert the existing
+`compass:open-source` event receives:
+
+```ts
+{ file: "src/lib.rs", startLine: 5, endLine: 7 }
+```
+
+Keep the file-only README assertion, verify it still displays `README.md`, and
+verify it has no Source button.
+
+---
+
+### Task 2: Balanced Call-Graph Resolver
+
+**Context:** The call-graph panel initially renders only “Resolving the function under your cursor…” at the top-left. The main graph webview already has a centered, theme-aware, reduced-motion-safe constellation and recoverable error state.
+
+**Goal:** Reuse the established loader with call-graph-specific progress copy and working Retry/Show output actions.
+
+**Expected outcome:** Call-graph resolution opens with a centered Compass mark and calm graph constellation, explains the three useful phases, then transitions to the call graph. Errors retain the same balanced shell and expose recovery.
+
+**Files:**
+
+- Modify: `editors/vscode/src/webviews/GraphLoadingState.tsx`
+- Modify: `editors/vscode/src/webviews/GraphLoadingState.test.tsx`
+- Modify: `editors/vscode/src/webviews/callGraph.tsx`
+- Modify: `editors/vscode/src/views/callGraphPanel.ts`
+- Modify: `editors/vscode/src/extension.ts`
+- Modify: `tests/viewer/fixtures/generate.ts`
+- Test after implementation: `tests/viewer/callflow.spec.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export type GraphLoadingCopy = {
+  eyebrow: string;
+  title: string;
+  steps: readonly string[];
+};
+```
+
+- Extends:
+
+```ts
+GraphLoadingState({
+  state,
+  loadingCopy?,
+  onRetry,
+  onShowOutput
+})
+```
+
+- Webview-to-host messages: `{ type: "retry" }` and `{ type: "showOutput" }`
+- Host dependency: `vscode.OutputChannel`
+
+- [ ] **Step 1: Make loading copy contextual**
+
+Add `GraphLoadingCopy` and a `DEFAULT_LOADING_COPY`:
+
+```ts
+const DEFAULT_LOADING_COPY: GraphLoadingCopy = {
+  eyebrow: "Compass graph",
+  title: "Mapping your codebase",
+  steps: ["Reading graph", "Arranging relationships", "Preparing inspector"]
+};
+```
+
+Use `loadingCopy ?? DEFAULT_LOADING_COPY` only in the loading branch. Preserve the current error copy and actions.
+
+- [ ] **Step 2: Render the call-graph loading and error states**
+
+In `webviews/callGraph.tsx`, import `GraphLoadingState` and define:
+
+```ts
+const CALL_GRAPH_LOADING_COPY = {
+  eyebrow: "Compass call graph",
+  title: "Resolving the function under your cursor",
+  steps: ["Locating symbol", "Tracing callers", "Tracing callees"]
+} as const;
+```
+
+Add:
+
+```ts
+function renderLoading(): void {
+  root.render(
+    <GraphLoadingState
+      state={{ kind: "loading" }}
+      loadingCopy={CALL_GRAPH_LOADING_COPY}
+      onRetry={() => {
+        graph = undefined;
+        renderLoading();
+        vscode.postMessage({ type: "retry" });
+      }}
+      onShowOutput={() => vscode.postMessage({ type: "showOutput" })}
+    />
+  );
+}
+```
+
+Render `GraphLoadingState` with `state={{ kind: "error", message }}` for host errors. Call `renderLoading()` before posting `ready`.
+
+- [ ] **Step 3: Add host recovery actions**
+
+Change:
+
+```ts
+CallGraphPanel.open(context, session, editor, output)
+```
+
+Handle `ready` and `retry` by rerunning the original cursor query. Handle
+`showOutput` with `output.show(true)`. Continue using the panel
+`AbortController` on disposal.
+
+Update the call site in `extension.ts` to pass the existing Compass output
+channel.
+
+- [ ] **Step 4: Add post-implementation unit coverage**
+
+Extend `GraphLoadingState.test.tsx` with contextual copy:
+
+```tsx
+<GraphLoadingState
+  state={{ kind: "loading" }}
+  loadingCopy={{
+    eyebrow: "Compass call graph",
+    title: "Resolving the function under your cursor",
+    steps: ["Locating symbol", "Tracing callers", "Tracing callees"]
+  }}
+  onRetry={vi.fn()}
+  onShowOutput={vi.fn()}
+/>
+```
+
+Assert the contextual title and all three phases render while the default test
+continues to assert “Mapping your codebase”.
+
+- [ ] **Step 5: Add post-implementation browser coverage**
+
+Replace the generic call-graph fixture harness with a call-graph-specific
+harness that:
+
+- delays successful hydration by 250 milliseconds;
+- posts an error when the URL contains `?error`;
+- records Retry and Show output messages.
+
+Add Playwright assertions that:
+
+```ts
+await page.goto("/calls.html");
+await expect(page.getByRole("status")).toContainText(
+  "Resolving the function under your cursor"
+);
+await expect(page.getByText("Locating symbol")).toBeVisible();
+await expect(page.getByText("Tracing callers")).toBeVisible();
+await expect(page.getByText("Tracing callees")).toBeVisible();
+await expect(page.getByText("Calls from run")).toBeVisible();
+```
+
+For `/calls.html?error`, assert the error surface exposes Retry and Show Compass
+output and that both actions post their expected host messages.
+
+- [ ] **Step 6: Run focused verification**
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test -w @compass/viewer
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm test -w @compass/viewer-tests -- graph-parity.spec.ts callflow.spec.ts accessibility.spec.ts
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run typecheck:js
+```
+
+Expected: all focused tests and typechecks pass.
+
+---
+
+### Task 3: Final Verification and Publication
+
+**Context:** Both changes ship inside the same VSIX and affect shared viewer assets.
+
+**Goal:** Verify the complete extension, refresh repository graph metadata, commit only intended files, and update the existing PR.
+
+**Expected outcome:** The branch contains reviewed implementation and post-implementation coverage, a fresh smoke-tested VSIX is available locally, and PR #38 includes the new commits.
+
+**Files:**
+
+- Review all modified files.
+- Do not stage `.superpowers/`, `code-review-graph/`, `codegraph/`, `compass-out/`, or `graphify-out/`.
+
+**Interfaces:**
+
+- Existing branch: `agent/vscode-trust-correctness`
+- Existing draft PR: `crabbuild/compass#38`
+
+- [ ] **Step 1: Run the final matrix**
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run typecheck:js
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test:js
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:viewer
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test:integration -w editors/vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run package -w editors/vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run smoke:vsix -w editors/vscode
+```
+
+- [ ] **Step 2: Refresh the repository graph**
+
+From `/Users/haipingfu/graphify`, run:
+
+```bash
+graphify update .
+```
+
+Do not stage generated graph output.
+
+- [ ] **Step 3: Audit and commit explicit files**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+Stage only the two design/plan documents, implementation files, and regression
+coverage. Commit with:
+
+```bash
+git commit -m "feat(vscode): polish graph navigation states"
+```
+
+- [ ] **Step 4: Push and verify PR**
+
+Push `agent/vscode-trust-correctness`, then confirm PR #38 still targets `main`
+and contains the new commit.

--- a/docs/superpowers/plans/2026-07-25-vscode-trust-correctness.md
+++ b/docs/superpowers/plans/2026-07-25-vscode-trust-correctness.md
@@ -1,0 +1,411 @@
+# VS Code Trust and Correctness Implementation Plan
+
+> **For Codex:** Use the executing-plans workflow to implement this plan task by task. This plan intentionally uses implementation-first sequencing; regression coverage is added after the behavior exists, per the project request.
+
+**Goal:** Make historical graph browsing trustworthy under asynchronous updates, make revision builds recover cleanly from cancellation and failure, and disclose every UI truncation that can hide graph content.
+
+**Architecture:** The VS Code history webview becomes the authoritative adapter for selected-commit presentation state. Every graph-derived message is commit-scoped and ignored when it does not match the current selection. The extension host reports an explicit build lifecycle keyed by commit and retains graph identities per revision so late loads cannot corrupt community navigation. Viewer components receive controlled state and render recovery/disclosure UI using VS Code theme tokens.
+
+**Tech Stack:** TypeScript, React, VS Code Webview API, existing Compass viewer components, Playwright browser fixtures, VS Code integration tests.
+
+**Constraints:**
+
+- Do not use a TDD/red-green-refactor sequence.
+- Implement each behavior before adding its regression coverage.
+- Do not change Compass CLI limits or serializers.
+- Runtime graph artifacts remain under `compass-out/`; do not introduce a `graphify-out/` runtime path.
+- Preserve unrelated and untracked workspace files.
+
+---
+
+## Task 1: Make historical presentation state commit-scoped
+
+**Context:** The history viewer currently owns a local selected commit while the VS Code adapter owns graph, comparison, counts, and community data. Because these states are independent, a late response for an old revision can overwrite the screen after the user selects a new revision.
+
+**Goal:** Give the adapter one selected-commit authority and make every visible graph-derived value belong to that commit.
+
+**Expected outcome:** Selecting a commit immediately clears the prior graph and derived information. Late graph, comparison, count, and community responses for another commit are ignored. The visible graph always labels its revision.
+
+**Files:**
+
+- Modify: `packages/compass-viewer/src/history/HistoryWorkspace.tsx`
+- Modify: `packages/compass-viewer/src/history/CommitDetails.tsx`
+- Modify: `packages/compass-viewer/src/index.ts`
+- Modify: `editors/vscode/src/webviews/history.tsx`
+- Create: `editors/vscode/src/history/panelMessages.ts`
+
+### Step 1: Define the webview protocol
+
+Create discriminated message types for:
+
+- Timeline replacement.
+- Revision graph loaded for a specific commit.
+- Community graph loaded or failed for a specific commit.
+- Comparison loaded for a specific commit.
+- Change counts loaded for a specific commit.
+- Build requesting/running/succeeded/failed/cancelled for a specific commit.
+- Operation errors carrying an operation name and optional commit.
+
+Define the webview-to-host requests in the same module so the two sides share commit identity and operation names.
+
+### Step 2: Convert `HistoryWorkspace` to controlled revision state
+
+Replace its internal selected-commit reducer ownership with props:
+
+```ts
+selectedCommit: string;
+graphCommit?: string;
+buildState?: HistoryBuildState;
+operationError?: HistoryOperationError;
+onSelectCommit(commit: string): void;
+```
+
+Keep local query/filter state in the viewer. Derive the selected entry from `selectedCommit`, and render a graph only when `graphCommit === selectedCommit`.
+
+Add a compact context strip above a visible graph:
+
+```text
+Viewing graph for <short commit>
+```
+
+### Step 3: Make selection synchronous in the adapter
+
+In `webviews/history.tsx`, add a single `selectCommit(commit)` transition that:
+
+1. Sets `selectedCommit`.
+2. Clears graph and graph identity.
+3. Clears semantic comparison data.
+4. Clears change counts and community drilldown data.
+5. Clears selection-scoped operation errors.
+6. Renders the empty/loading revision state.
+
+When a refreshed timeline arrives:
+
+- Retain the selected commit if it still exists.
+- Otherwise select `selectedHead` when it exists.
+- Otherwise select the first timeline entry.
+
+### Step 4: Reject stale responses
+
+For graph, comparison, counts, community, and community-error messages:
+
+```ts
+if (message.commit !== selectedCommit) {
+  return;
+}
+```
+
+Do not route operational failures into `semanticDiff`. Store and render them as operation errors.
+
+### Step 5: Disable unavailable comparisons
+
+Pass the set of materialized timeline commits to `CommitDetails`. A parent comparison is enabled only when:
+
+- The selected revision has a presentation.
+- The parent revision has a presentation.
+
+Render a concise explanation for disabled comparison controls, such as “Build this revision first” or “Parent graph is not available.”
+
+### Step 6: Build the affected packages
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:viewer
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:vscode
+```
+
+Expected: both packages compile without TypeScript or bundling errors.
+
+---
+
+## Task 2: Add explicit build recovery and race-safe host identity
+
+**Context:** The current build command has a boolean “building” state and emits a generic error on failure. Profile/source cancellation can leave the UI ambiguous. The host also retains one active historical graph, so a late revision load can make a different visible revision use the wrong community identity.
+
+**Goal:** Make every build terminal path explicit and keep historical graph identity keyed by commit.
+
+**Expected outcome:** A build always leaves requesting/running state through success, failure, or cancellation. Failure is actionable, cancellation is neutral, and late loads cannot corrupt community navigation.
+
+**Files:**
+
+- Modify: `editors/vscode/src/views/historyPanel.ts`
+- Use: `editors/vscode/src/history/panelMessages.ts`
+- Modify: `packages/compass-viewer/src/history/CommitDetails.tsx`
+- Modify: `packages/compass-viewer/src/history/HistoryWorkspace.tsx`
+- Modify: `editors/vscode/src/webviews/history.tsx`
+
+### Step 1: Model build state by commit in the webview
+
+Use a map keyed by commit:
+
+```ts
+type HistoryBuildState =
+  | { status: "requesting" }
+  | { status: "running" }
+  | { status: "failed"; message: string };
+```
+
+Set `requesting` synchronously before posting `buildRevision`. Apply host lifecycle events only to their matching commit. Remove the state after success or cancellation.
+
+### Step 2: Report every host lifecycle transition
+
+In the extension host:
+
+- Post `buildRunning` after profile/source input is complete and before the CLI starts.
+- Post `buildSucceeded` only after the command succeeds and the refreshed timeline is available.
+- Post `buildFailed` with a concise error for writer conflicts, CLI errors, or timeline refresh failures.
+- Post `buildCancelled` when profile selection, source input, or progress cancellation is dismissed.
+
+Track progress cancellation separately from process exit so a killed command is not shown as a failure.
+
+### Step 3: Render recovery near revision actions
+
+In `CommitDetails`:
+
+- Disable the build button while requesting/running.
+- Show “Choosing profile…” for requesting.
+- Show “Building…” for running.
+- Show “Retry build” after failure.
+- Render failure copy near the actions using `role="alert"`.
+- Render cancellation as a neutral return to idle, without an error banner.
+
+Operation errors for load, compare, counts, and community actions appear in the same revision context and never as semantic findings.
+
+### Step 4: Replace single active historical graph identity
+
+Replace the host’s single `activeGraph` value with a small commit-keyed identity cache containing:
+
+```ts
+{
+  commit: string;
+  realization: string;
+  fingerprint: string;
+}
+```
+
+Use the request commit to resolve the identity for community loads. Bound the cache to the existing revision cache scale so browsing many revisions does not retain every full graph.
+
+### Step 5: Typecheck and build
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run typecheck:js
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:vscode
+```
+
+Expected: the shared protocol exhaustively covers the handled messages and the extension compiles.
+
+---
+
+## Task 3: Disclose architecture and call-graph truncation
+
+**Context:** Architecture overview links are silently limited to 24 and call continuations to 20. Call graph contracts already expose a `truncated` flag, but the UI does not disclose it.
+
+**Goal:** Ensure users can distinguish “complete” from “currently summarized” graph views and reveal all data already loaded in memory.
+
+**Expected outcome:** Every client-side limit displays visible counts and a Show all action. A server-truncated call graph displays an explicit partial-results alert.
+
+**Files:**
+
+- Modify: `packages/compass-viewer/src/architecture/ArchitectureFlow.tsx`
+- Modify: `packages/compass-viewer/src/calls/CallGraph.tsx`
+
+### Step 1: Disclose architecture flow limits
+
+Keep the initial 24-card rendering for layout performance. When more links exist, add:
+
+```text
+Showing 24 of N flows
+[Show all N flows]
+```
+
+The action reveals all links already present in the overview response. Use existing Button and theme-token styling.
+
+### Step 2: Disclose call graph size and partial results
+
+Always show node and edge counts derived from the loaded graph.
+
+When `graph.truncated` is true, render an alert:
+
+```text
+Partial call graph
+Compass reached the configured graph limit. Counts and paths may be incomplete.
+```
+
+### Step 3: Disclose continuation limits
+
+Keep the initial 20 continuation rows. When more are loaded, add:
+
+```text
+Showing 20 of N continuations
+[Show all N continuations]
+```
+
+Do not change CLI query limits or fetch additional data in this PR.
+
+### Step 4: Build the viewer
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:viewer
+```
+
+Expected: viewer components compile and retain existing design-system styling.
+
+---
+
+## Task 4: Add post-implementation regression coverage
+
+**Context:** The trust fixes depend on event ordering and visible disclosure. These behaviors need browser-level protection after implementation.
+
+**Goal:** Cover stale-event rejection, build recovery, comparison availability, and truncation disclosure without changing the implementation sequence to TDD.
+
+**Expected outcome:** Regression tests fail if historical data leaks across selection, builds become stuck, unavailable comparisons become actionable, or summary limits become silent again.
+
+**Files:**
+
+- Modify: `tests/viewer/fixtures/generate.ts`
+- Modify: `tests/viewer/history.spec.ts`
+- Modify: `tests/viewer/callflow.spec.ts`
+- Modify if needed: `editors/vscode/src/test/suite/extension.integration.ts`
+
+### Step 1: Expand the history harness
+
+Generate a timeline with:
+
+- Two materialized revisions with visibly distinct graph content.
+- One unmaterialized revision for build recovery.
+- Available and unavailable parent relationships.
+
+Support delayed revision responses so an older response can arrive after a newer selection. Support build cancellation, failure, and success lifecycle messages.
+
+### Step 2: Cover stale historical events
+
+Add a browser test that:
+
+1. Requests revision A with a delayed response.
+2. Selects and loads revision B.
+3. Allows revision A to arrive.
+4. Confirms only revision B’s graph and context strip are visible.
+
+Also verify stale comparison/count/community messages cannot alter revision B.
+
+### Step 3: Cover build recovery
+
+Add scenarios for:
+
+- Cancelled build returns the action to idle.
+- Failed build shows the failure and Retry build.
+- Successful build refreshes the timeline and clears the busy state.
+
+### Step 4: Cover comparison availability
+
+Confirm comparison controls are disabled with explanatory copy when either side lacks a presentation and become enabled after the revision is available.
+
+### Step 5: Cover truncation disclosure
+
+Generate:
+
+- An architecture overview with 25 flows.
+- A call graph with 21 continuations and `truncated: true`.
+
+Assert the initial counts, partial-results alert, and Show all transitions.
+
+### Step 6: Run focused coverage
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm test -w @compass/viewer-tests -- history.spec.ts callflow.spec.ts
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test:integration -w editors/vscode
+```
+
+Expected: focused browser and extension integration coverage passes.
+
+---
+
+## Task 5: Verify, review, update the knowledge graph, and publish
+
+**Context:** The change crosses viewer state, extension-host process lifecycle, and browser behavior. It should be verified at package and extension boundaries before publication.
+
+**Goal:** Produce fresh evidence that the implementation is correct, review the final diff, keep the repository knowledge graph current, and publish an auditable draft PR.
+
+**Expected outcome:** All relevant checks pass, only intended files are committed, the feature branch is pushed, and a draft PR summarizes trust behavior and verification.
+
+**Files:**
+
+- Review all modified files.
+- Update existing project graph metadata via the repository-required command, without staging runtime/output directories.
+
+### Step 1: Run the full relevant verification matrix
+
+Run:
+
+```bash
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run typecheck:js
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test:js
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:viewer
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run build:vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm test -w @compass/viewer-tests
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run test:integration -w editors/vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run package -w editors/vscode
+PATH=/tmp/compass-codex-node-runtime-20260725:$PATH npm run smoke:vsix -w editors/vscode
+```
+
+If a check fails, diagnose the failure, fix only in-scope causes, and rerun the failed check plus any affected upstream checks.
+
+### Step 2: Review the final diff
+
+Inspect:
+
+```bash
+git status --short
+git diff --check
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+Confirm:
+
+- No runtime paths were changed from `compass-out/`.
+- No unrelated untracked directories are staged.
+- Errors are separate from semantic findings.
+- Every async response is commit-scoped.
+- Every build path reaches a terminal event.
+- Every in-memory list limit is disclosed.
+
+### Step 3: Request focused code review
+
+Review the final branch specifically for:
+
+- Async ordering and stale-response races.
+- Cancellation/failure terminal paths.
+- Accessibility of status, alerts, and disabled explanations.
+- Retained large graph data or avoidable rerenders.
+
+Address actionable issues and rerun affected verification.
+
+### Step 4: Refresh repository knowledge metadata
+
+From the repository root, run:
+
+```bash
+graphify update .
+```
+
+Do not stage `graphify-out/`, `compass-out/`, or other generated/untracked output directories.
+
+### Step 5: Commit and publish a draft PR
+
+Stage only the explicit implementation, coverage, and documentation files. Create scoped commits, push `agent/vscode-trust-correctness`, and open a draft PR against `main`.
+
+PR body sections:
+
+- Context: why stale history and ambiguous builds reduce trust.
+- Changes: synchronization, build recovery, truncation disclosure.
+- Validation: exact commands and results.
+- Scope boundaries: no CLI limit, serializer, or runtime output-path changes.
+

--- a/docs/superpowers/plans/2026-07-25-vscode-trust-correctness.md
+++ b/docs/superpowers/plans/2026-07-25-vscode-trust-correctness.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make historical graph browsing trustworthy under asynchronous updates, make revision builds recover cleanly from cancellation and failure, and disclose every UI truncation that can hide graph content.
 
-**Architecture:** The VS Code history webview becomes the authoritative adapter for selected-commit presentation state. Every graph-derived message is commit-scoped and ignored when it does not match the current selection. The extension host reports an explicit build lifecycle keyed by commit and retains graph identities per revision so late loads cannot corrupt community navigation. Viewer components receive controlled state and render recovery/disclosure UI using VS Code theme tokens.
+**Architecture:** The VS Code history webview becomes the authoritative adapter for selected-commit presentation state. Every graph-derived message is commit-scoped and ignored when it does not match the current selection. The extension host reports an explicit build lifecycle keyed by commit, while each accepted graph carries its exact realization and fingerprint back with community requests so late loads cannot corrupt navigation. Viewer components receive controlled state and render recovery/disclosure UI using VS Code theme tokens.
 
 **Tech Stack:** TypeScript, React, VS Code Webview API, existing Compass viewer components, Playwright browser fixtures, VS Code integration tests.
 
@@ -123,7 +123,7 @@ Expected: both packages compile without TypeScript or bundling errors.
 
 **Context:** The current build command has a boolean “building” state and emits a generic error on failure. Profile/source cancellation can leave the UI ambiguous. The host also retains one active historical graph, so a late revision load can make a different visible revision use the wrong community identity.
 
-**Goal:** Make every build terminal path explicit and keep historical graph identity keyed by commit.
+**Goal:** Make every build terminal path explicit and bind community requests to the exact historical graph accepted by the webview.
 
 **Expected outcome:** A build always leaves requesting/running state through success, failure, or cancellation. Failure is actionable, cancellation is neutral, and late loads cannot corrupt community navigation.
 
@@ -172,19 +172,18 @@ In `CommitDetails`:
 
 Operation errors for load, compare, counts, and community actions appear in the same revision context and never as semantic findings.
 
-### Step 4: Replace single active historical graph identity
+### Step 4: Round-trip the accepted historical graph identity
 
-Replace the host’s single `activeGraph` value with a small commit-keyed identity cache containing:
+Include this identity on graph and comparison messages:
 
 ```ts
 {
-  commit: string;
   realization: string;
   fingerprint: string;
 }
 ```
 
-Use the request commit to resolve the identity for community loads. Bound the cache to the existing revision cache scale so browsing many revisions does not retain every full graph.
+Store it beside the selected graph in the adapter and return it with each community request. Validate the community export against that exact realization and fingerprint. This avoids completion-order cache eviction and does not retain duplicate graph models in the host.
 
 ### Step 5: Typecheck and build
 
@@ -408,4 +407,3 @@ PR body sections:
 - Changes: synchronization, build recovery, truncation disclosure.
 - Validation: exact commands and results.
 - Scope boundaries: no CLI limit, serializer, or runtime output-path changes.
-

--- a/docs/superpowers/specs/2026-07-25-vscode-graph-inspector-source-design.md
+++ b/docs/superpowers/specs/2026-07-25-vscode-graph-inspector-source-design.md
@@ -1,0 +1,139 @@
+# VS Code Graph Inspector Source and Neighbor Design
+
+## Context
+
+The graph inspector currently presents source metadata and source navigation as
+two separate controls. The metadata card shows the file path, while a full-width
+button below it repeats the path and line range. This consumes vertical space,
+splits one task across two controls, and makes the source card appear
+non-interactive.
+
+Connected-node rows currently use a colored left border to indicate community.
+In a narrow inspector this resembles selection or validation state and creates a
+heavy visual rail.
+
+## Goal
+
+Make source navigation a single compact, precise action and make connected-node
+community identity readable without decorative borders.
+
+The user should be able to:
+
+1. recognize the source location immediately;
+2. open the exact recorded source range from the Source metadata card;
+3. understand each connected node's community from a quiet colored dot; and
+4. use every action with mouse, keyboard, high-contrast themes, or reduced
+   motion.
+
+## Selected design
+
+### Clickable Source metadata card
+
+When the selected graph node has a navigable source:
+
+- the wide Source metadata card becomes a button;
+- the primary line contains the source path;
+- the secondary line contains `Line N` or `Lines N–M`;
+- a Lucide `ExternalLink` icon appears at the trailing edge;
+- activating the card calls the existing `onOpenSource` callback with the
+  existing `SourceLocation`;
+- the tooltip and accessible label contain the complete path and exact line
+  range even when the visible path is truncated.
+
+The separate full-width Open source button is removed.
+
+When no navigable source exists, the Source card remains non-interactive and
+shows `Not recorded`. It does not render a disabled button.
+
+### Connected-node rows
+
+Each connected-node row:
+
+- removes the colored left border;
+- adds an 8-pixel circular dot before the label;
+- uses the neighbor's explicit background color when present;
+- otherwise uses the neighbor community's color;
+- falls back to the standard border color when no graph color exists;
+- keeps the node label on one line with ellipsis;
+- uses a subtle full-row hover and focus surface;
+- retains the existing click behavior that focuses the connected node.
+
+The dot is decorative because the community relationship is already available
+through graph content and color alone must not carry action state.
+
+## Visual system
+
+The design continues to inherit VS Code theme tokens. It does not introduce
+fixed product colors or new typography.
+
+- Source card: existing metadata surface, slightly stronger hover/focus border.
+- Source icon: `--compass-focus` at rest, foreground on hover.
+- Neighbor dot: graph/community color.
+- Neighbor row: transparent at rest, `--compass-focus-soft` on hover/focus.
+
+The distinguishing gesture is consolidation: one source surface contains both
+location evidence and the navigation action.
+
+## Component boundaries
+
+`GraphInspector` remains responsible for deriving:
+
+- the navigable `SourceLocation`;
+- the display line range;
+- the community color for each neighbor.
+
+No host protocol changes are required. The component continues to call the
+existing `onOpenSource(source)` and `onFocus(nodeId)` callbacks.
+
+Styling remains in the shared viewer theme so the web export and VS Code
+webview retain visual parity.
+
+## Accessibility
+
+- The clickable Source card is a native `button`.
+- Its accessible name uses an action phrase: `Open <path> at line N` or
+  `Open <path> at lines N–M`.
+- The full location is available through `title`.
+- The ExternalLink icon and community dots are `aria-hidden`.
+- Existing visible keyboard focus treatment is extended to the source card.
+- High-contrast mode receives the same explicit border treatment as other
+  inspector actions.
+- No new animation is introduced.
+
+## Error handling
+
+The inspector only renders the interactive Source card when
+`navigableSource(selected)` succeeds. Source-opening failures remain handled by
+the existing VS Code host navigation path.
+
+Long source paths and node labels truncate visually without losing their full
+tooltip or accessible name.
+
+## Verification
+
+Post-implementation coverage will verify:
+
+- navigable source renders one interactive Source card and no duplicate Open
+  source button;
+- the card exposes the exact path and line range;
+- activation sends the unchanged `SourceLocation`;
+- source-less nodes render a static `Not recorded` card;
+- connected-node rows render dots and no colored left border;
+- keyboard focus and serious accessibility checks remain clean;
+- viewer and VS Code packages still build and the packaged VSIX passes smoke
+  validation.
+
+## Scope boundaries
+
+This design does not change:
+
+- graph contracts or source-range calculation;
+- VS Code source-navigation behavior;
+- graph canvas node styling;
+- loading-screen design;
+- Repository or Operations tree design;
+- runtime output paths or Compass CLI behavior.
+
+Loading and tree-view improvements will be designed and implemented as separate
+follow-up deliverables so their state models and acceptance criteria remain
+clear.

--- a/docs/superpowers/specs/2026-07-25-vscode-graph-inspector-source-design.md
+++ b/docs/superpowers/specs/2026-07-25-vscode-graph-inspector-source-design.md
@@ -42,8 +42,9 @@ When the selected graph node has a navigable source:
 
 The separate full-width Open source button is removed.
 
-When no navigable source exists, the Source card remains non-interactive and
-shows `Not recorded`. It does not render a disabled button.
+When a source file is recorded without a navigable range, the Source card
+remains non-interactive and shows that file path. It shows `Not recorded` only
+when the node has no source file. It does not render a disabled button.
 
 ### Connected-node rows
 
@@ -117,7 +118,8 @@ Post-implementation coverage will verify:
   source button;
 - the card exposes the exact path and line range;
 - activation sends the unchanged `SourceLocation`;
-- source-less nodes render a static `Not recorded` card;
+- file-only nodes render their recorded path without a Source button;
+- nodes without source metadata render a static `Not recorded` card;
 - connected-node rows render dots and no colored left border;
 - keyboard focus and serious accessibility checks remain clean;
 - viewer and VS Code packages still build and the packaged VSIX passes smoke

--- a/docs/superpowers/specs/2026-07-25-vscode-trust-correctness-design.md
+++ b/docs/superpowers/specs/2026-07-25-vscode-trust-correctness-design.md
@@ -1,0 +1,207 @@
+# VS Code Trust and Correctness Design
+
+**Date:** 2026-07-25
+
+**Status:** Approved scope; implementation contract for PR 1
+
+## Context
+
+Compass Codebase Evolution currently keeps the selected commit inside
+`HistoryWorkspace`, while the webview adapter separately owns the loaded graph,
+comparison, community detail, and change counts. Selecting a new commit therefore
+does not invalidate the previously loaded revision. A late response for an older
+selection can also repaint the graph after the user has moved elsewhere.
+
+Historical builds have a second split-brain state. The React component marks a
+commit as building before asking the extension host to choose a profile. The host
+does not send a terminal build event when profile selection is cancelled, a build
+fails, or a build succeeds. A failed or cancelled build can consequently leave
+the action disabled until the panel is reopened.
+
+Architecture and call-graph views also hide bounded output. Architecture renders
+only the first 24 overview flows, call graph renders only the first 20
+continuations, and the call-graph `truncated` contract field is not presented.
+These omissions undermine trust because a partial result looks complete.
+
+## Goal
+
+Make every displayed historical graph provably match the selected commit, make
+every historical build reach a visible recoverable terminal state, and make every
+bounded architecture or call-graph result disclose its incompleteness.
+
+## Non-goals
+
+- Redesigning the complete History, Architecture, or Call Graph surfaces.
+- Adding webview serializers or cross-reload persistence.
+- Changing CLI graph limits or materialization semantics.
+- Adding background or implicit historical builds.
+- Optimizing extension activation or bundle size.
+- Adding telemetry.
+- Creating or using a `graphify-out/` runtime path. Compass artifacts remain
+  under `compass-out/`.
+
+## Considered approaches
+
+### 1. Controlled history state in the webview adapter — selected
+
+The webview adapter owns the selected commit and all revision-bound presentation
+state. `HistoryWorkspace` receives the selected commit, build state, and errors as
+props. Selecting a commit synchronously clears graph, comparison, community, and
+change-count state. Incoming graph, comparison, community, and change-count
+messages are accepted only when their commit still matches the selection.
+
+This approach fixes both ordinary selection changes and late-response races while
+keeping CLI orchestration in the extension host.
+
+### 2. Reset `HistoryWorkspace` with a React key
+
+Remounting the workspace on selection or timeline changes would clear local state
+with little code. It would not prevent the webview adapter from accepting an old
+host response, and it would discard unrelated search state. This is insufficient.
+
+### 3. Move all history presentation state into the extension host
+
+The extension host could become the single state machine and send complete view
+snapshots. This would be robust but would substantially expand the PR into panel
+serialization and lifecycle architecture. It is deferred.
+
+## Historical selection model
+
+The webview adapter owns:
+
+- `selectedCommit`;
+- the loaded `graph` and its `graphCommit`;
+- comparison output;
+- change counts;
+- community detail and its active request;
+- build state keyed by commit;
+- operation errors keyed by commit.
+
+When a timeline first arrives, the adapter selects `selectedHead` when it is
+present in the entries, otherwise the first entry. A later timeline refresh keeps
+the current selection if it still exists.
+
+Selecting another commit performs one synchronous transition:
+
+1. set `selectedCommit`;
+2. clear graph and graph identity;
+3. clear comparison output;
+4. clear change counts;
+5. clear community detail, loading state, and active request;
+6. render the selected commit's empty graph state.
+
+Search text remains component-local and is not cleared by selection.
+
+Host responses for graph load, comparison, community detail, and change counts
+carry commit identity. The adapter ignores a response whose commit does not equal
+`selectedCommit`. An ignored response does not alter visible errors or loading
+state for the current commit.
+
+When a graph is visible, the workspace shows a context strip containing the short
+commit identity. The strip is presentation evidence, not the source of truth.
+
+## Historical build lifecycle
+
+Each commit can have one of these webview build states:
+
+- `requesting`: the user requested a build and the host is gathering a profile;
+- `running`: a Compass process is active;
+- `failed`: the last request failed and can be retried;
+- no state: idle or successfully completed.
+
+The webview marks a commit `requesting` immediately when Build graph is selected.
+The extension host must answer every accepted `buildRevision` request with a
+terminal or running event:
+
+- `buildRunning` after the CLI process starts;
+- `buildSucceeded` after the refreshed timeline has been posted;
+- `buildFailed` with a concise message on process, validation, or refresh failure;
+- `buildCancelled` when profile selection, profile-source entry, progress
+  cancellation, or process cancellation prevents completion.
+
+`buildRunning` may include the latest JSONL phase message, but progress expansion
+is not required in this PR.
+
+`requesting` and `running` disable Build graph. `failed`, `cancelled`, and
+`succeeded` make it actionable again. Failure copy appears directly below the
+selected commit actions. Cancellation is neutral and does not render as a
+semantic comparison error.
+
+Generic history operations send an error with an operation name and commit when
+available. Load and comparison errors appear beside the selected commit rather
+than being placed inside semantic findings. Community errors remain in the graph
+because that is the surface that initiated them.
+
+When a parent revision is not presentation-available, Compare parent is disabled
+and explains that both revision graphs must be built first.
+
+## Truncation disclosure
+
+### Architecture
+
+Architecture continues to render at most 24 overview flows initially. When more
+exist, the view shows `Showing 24 of N flows` and a Show all action. Choosing Show
+all renders the complete contract result. No result is dropped without a visible
+count.
+
+### Call graph
+
+The call-graph status panel always shows rendered node and edge counts. When
+`graph.truncated` is true, it renders an alert explaining that the graph reached
+its configured size boundary and that continuations expand the bounded result.
+
+At most 20 continuation actions are shown initially. If more exist, the panel
+shows `Showing 20 of N continuations` and a Show all action. Expansion preserves
+the merged `truncated` value already provided by the call-graph state helper.
+
+## Error and race handling
+
+- Selecting a commit while a prior graph or comparison is loading invalidates
+  the prior response by identity.
+- Selecting another commit while a build runs does not cancel the build. Its
+  state remains keyed to the original commit and is visible again if reselected.
+- A successful build refreshes the timeline before clearing the build state.
+- A timeline refresh never silently moves selection when the selected commit
+  still exists.
+- A failed timeline refresh sends `buildFailed`; it does not report success just
+  because the CLI process exited successfully.
+- Disposing the panel continues to terminate work through existing controllers
+  and process cancellation boundaries.
+
+## Acceptance criteria
+
+1. Selecting commit B after opening commit A immediately removes A's graph,
+   comparison, community detail, and counts.
+2. A delayed graph or comparison response for A cannot become visible while B is
+   selected.
+3. Every visible historical graph includes the selected short commit identity.
+4. Cancelling profile selection restores Build graph without an error.
+5. Cancelling, failing, or successfully completing a historical build restores a
+   usable action state without reopening the panel.
+6. Build and load failures appear beside the selected commit and do not masquerade
+   as semantic findings.
+7. Compare parent is disabled with an explanation when either graph is missing.
+8. A truncated call graph visibly reports that it is partial and shows rendered
+   node and edge counts.
+9. More than 20 call continuations expose their total and can all be revealed.
+10. More than 24 architecture flows expose their total and can all be revealed.
+11. Existing community drilldown, source navigation, explicit-build behavior,
+    reduced motion, and local-only webview behavior remain intact.
+
+## Verification approach
+
+This PR does not use a red/green TDD workflow. Implementation comes first,
+followed by focused verification:
+
+- viewer/browser scenarios for revision selection, stale response rejection,
+  build terminal states, comparison availability, architecture disclosure, and
+  call-graph disclosure;
+- TypeScript type checks for the viewer and VS Code extension;
+- existing viewer and extension unit suites;
+- Chromium viewer qualification;
+- VS Code integration tests where the fake CLI boundary covers the changed host
+  behavior;
+- production builds and VSIX smoke qualification.
+
+No acceptance criterion is considered complete until the corresponding
+post-implementation check has passed.

--- a/editors/vscode/src/cli/processManager.test.ts
+++ b/editors/vscode/src/cli/processManager.test.ts
@@ -63,4 +63,18 @@ describe("CompassProcessManager", () => {
       stderr: "note"
     });
   });
+
+  it("rejects malformed JSONL progress instead of throwing outside the command", async () => {
+    const { child, stdout } = childProcess();
+    const processes = new CompassProcessManager(
+      "compass",
+      vi.fn(() => child) as never
+    );
+    const command = processes.startJsonl("/repo", ["history", "build"], vi.fn());
+
+    stdout.write("{not-json}\n");
+
+    await expect(command.completed).rejects.toBeInstanceOf(Error);
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
 });

--- a/editors/vscode/src/cli/processManager.ts
+++ b/editors/vscode/src/cli/processManager.ts
@@ -55,18 +55,26 @@ export class CompassProcessManager {
     const child = this.start(cwd, args);
     let buffered = "";
     let terminals = 0;
+    let progressError: unknown;
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      buffered += chunk;
-      const lines = buffered.split(/\r?\n/);
-      buffered = lines.pop() ?? "";
-      for (const line of lines.filter(Boolean)) {
-        const event = ProgressEventSchema.parse(JSON.parse(line));
-        if (event.terminal) terminals += 1;
-        onEvent(event);
+      if (progressError) return;
+      try {
+        buffered = bounded(buffered, chunk);
+        const lines = buffered.split(/\r?\n/);
+        buffered = lines.pop() ?? "";
+        for (const line of lines.filter(Boolean)) {
+          const event = ProgressEventSchema.parse(JSON.parse(line));
+          if (event.terminal) terminals += 1;
+          onEvent(event);
+        }
+      } catch (error) {
+        progressError = error;
+        child.kill();
       }
     });
     const completed = collect(child, false).then((result) => {
+      if (progressError) throw progressError;
       if (terminals !== 1) {
         throw new Error(`Compass emitted ${terminals} terminal progress events`);
       }
@@ -92,18 +100,35 @@ function collect(
   return new Promise((resolve, reject) => {
     let stdout = "";
     let stderr = "";
+    let streamError: unknown;
+    const append = (current: string, chunk: string): string => {
+      if (streamError) return current;
+      try {
+        return bounded(current, chunk);
+      } catch (error) {
+        streamError = error;
+        child.kill();
+        return current;
+      }
+    };
     if (captureStdout) {
       child.stdout.setEncoding("utf8");
       child.stdout.on("data", (chunk: string) => {
-        stdout = bounded(stdout, chunk);
+        stdout = append(stdout, chunk);
       });
     }
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
-      stderr = bounded(stderr, chunk);
+      stderr = append(stderr, chunk);
     });
     child.once("error", reject);
-    child.once("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+    child.once("close", (code) => {
+      if (streamError) {
+        reject(streamError);
+      } else {
+        resolve({ code: code ?? 1, stdout, stderr });
+      }
+    });
   });
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -161,7 +161,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
       if (!await ensureCompatible(session, COMPASS_REQUIREMENTS.calls)) return;
       try {
-        await CallGraphPanel.open(context, session, editor);
+        await CallGraphPanel.open(context, session, editor, output);
       } catch (error) {
         void vscode.window.showErrorMessage(`Compass call graph failed: ${message(error)}`);
       }

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -1,0 +1,98 @@
+import type {
+  GraphViewModel,
+  HistoryChangeCounts,
+  HistoryTimeline,
+  SourceLocation
+} from "@compass/viewer";
+
+export type HistoryOperation =
+  | "Load graph"
+  | "Build graph"
+  | "Compare revisions"
+  | "Load change counts"
+  | "Open community"
+  | "Open source"
+  | "Query revision";
+
+export type HistoryWebviewMessage =
+  | { type: "ready" }
+  | { type: "loadRevision"; commit: string }
+  | { type: "buildRevision"; commit: string }
+  | { type: "compare"; commit: string; parent: string }
+  | { type: "queryRevision"; commit: string }
+  | { type: "changeCounts"; commit: string }
+  | {
+    type: "openCommunity";
+    requestId: string;
+    commit: string;
+    realization: string;
+    fingerprint: string;
+    communityId: number;
+  }
+  | {
+    type: "openSource";
+    commit: string;
+    repositoryId: string;
+    source: SourceLocation;
+  };
+
+export type HistoryHostMessage =
+  | { type: "timeline"; timeline: HistoryTimeline; repositoryId: string }
+  | {
+    type: "graph";
+    commit: string;
+    realization: string;
+    fingerprint: string;
+    graph: GraphViewModel;
+  }
+  | {
+    type: "communityGraph";
+    requestId: string;
+    commit: string;
+    communityId: number;
+    graph: GraphViewModel;
+  }
+  | {
+    type: "communityError";
+    requestId: string;
+    commit: string;
+    communityId: number;
+    message: string;
+  }
+  | {
+    type: "comparison";
+    commit: string;
+    parent: string;
+    realization: string;
+    fingerprint: string;
+    currentGraph: GraphViewModel;
+    parentGraph: GraphViewModel;
+    semanticDiff: unknown;
+  }
+  | { type: "changeCounts"; commit: string; counts: HistoryChangeCounts }
+  | { type: "buildRunning"; commit: string }
+  | { type: "buildSucceeded"; commit: string }
+  | { type: "buildFailed"; commit: string; message: string }
+  | { type: "buildCancelled"; commit: string }
+  | {
+    type: "error";
+    operation: HistoryOperation;
+    commit?: string;
+    message: string;
+  };
+
+export function historyOperationFor(message: unknown): HistoryOperation {
+  const type = typeof message === "object" && message !== null && "type" in message
+    ? (message as { type?: unknown }).type
+    : undefined;
+  switch (type) {
+    case "loadRevision": return "Load graph";
+    case "buildRevision": return "Build graph";
+    case "compare": return "Compare revisions";
+    case "changeCounts": return "Load change counts";
+    case "openCommunity": return "Open community";
+    case "openSource": return "Open source";
+    case "queryRevision": return "Query revision";
+    default: return "Load graph";
+  }
+}

--- a/editors/vscode/src/views/callGraphPanel.ts
+++ b/editors/vscode/src/views/callGraphPanel.ts
@@ -10,7 +10,8 @@ export class CallGraphPanel {
   static async open(
     context: vscode.ExtensionContext,
     session: RepositorySession,
-    editor: vscode.TextEditor
+    editor: vscode.TextEditor,
+    output: vscode.OutputChannel
   ): Promise<void> {
     const relative = path.relative(session.root, editor.document.uri.fsPath)
       .split(path.sep)
@@ -30,15 +31,19 @@ export class CallGraphPanel {
       }
     );
     const controller = new AbortController();
+    let rootGeneration = 0;
     panel.onDidDispose(() => controller.abort());
     panel.webview.html = html(context, panel.webview);
     panel.webview.onDidReceiveMessage(async (message) => {
-      if (message?.type === "ready") {
+      if (message?.type === "ready" || message?.type === "retry") {
+        rootGeneration += 1;
         await send([
           "--at", `${relative}:${byte}`,
           "--direction", "both",
           "--depth", "2"
-        ], "hydrateCallGraph");
+        ], "hydrateCallGraph", rootGeneration);
+      } else if (message?.type === "showOutput") {
+        output.show(true);
       } else if (message?.type === "expand"
         && typeof message.symbol === "string"
         && ["callers", "callees", "both"].includes(message.direction)
@@ -47,13 +52,17 @@ export class CallGraphPanel {
           "--symbol", message.symbol,
           "--direction", message.direction,
           "--depth", String(message.depth)
-        ], "mergeCallGraph");
+        ], "mergeCallGraph", rootGeneration);
       } else if (message?.type === "openSource") {
         await openGraphSource(session, message.repositoryId, message.source);
       }
     });
 
-    async function send(rootArgs: string[], type: string): Promise<void> {
+    async function send(
+      rootArgs: string[],
+      type: "hydrateCallGraph" | "mergeCallGraph",
+      generation: number
+    ): Promise<void> {
       try {
         const graphArgs = [
           "program", "call-graph",
@@ -70,6 +79,7 @@ export class CallGraphPanel {
           CallGraphResponseSchema,
           controller.signal
         );
+        if (generation !== rootGeneration || controller.signal.aborted) return;
         await panel.webview.postMessage({
           type,
           requestId: randomUUID(),
@@ -77,9 +87,12 @@ export class CallGraphPanel {
           graph
         });
       } catch (error) {
+        if (generation !== rootGeneration || controller.signal.aborted) return;
+        const message = error instanceof Error ? error.message : String(error);
+        output.appendLine(`[error] Call graph failed for ${relative}:${byte}: ${message}`);
         await panel.webview.postMessage({
           type: "error",
-          message: error instanceof Error ? error.message : String(error)
+          message
         });
       }
     }
@@ -98,6 +111,6 @@ function html(context: vscode.ExtensionContext, webview: vscode.Webview): string
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
 <link rel="stylesheet" href="${styles}"><title>Compass Call Graph</title>
-</head><body><div id="root" role="status">Resolving the function under your cursor…</div>
+</head><body><div id="root"></div>
 <script nonce="${nonce}" src="${script}"></script></body></html>`;
 }

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -5,6 +5,10 @@ import { loadSemanticDiff } from "../history/diffClient";
 import { loadChangeCounts } from "../history/changeCountsClient";
 import { RevisionStore } from "../history/revisionStore";
 import { loadTimeline } from "../history/timelineClient";
+import {
+  historyOperationFor,
+  type HistoryHostMessage
+} from "../history/panelMessages";
 import type { RepositorySession } from "../workspace/repositorySession";
 import { openGraphSource } from "./sourceNavigation";
 import { openQueryPanel } from "./queryPanel";
@@ -32,16 +36,151 @@ export async function openHistoryPanel(
   );
   await revisions.initialize();
   let timeline = await loadTimeline(session);
-  let activeGraph: Awaited<ReturnType<RevisionStore["load"]>> | undefined;
   const graphNodeLimit = vscode.workspace
     .getConfiguration("compass")
     .get("graphNodeLimit", 5000);
   const countCache = new Map<string, Awaited<ReturnType<typeof loadChangeCounts>>>();
   panel.webview.html = html(context, panel.webview);
+  let disposed = false;
+  let activePanelBuild: {
+    command: ReturnType<RepositorySession["processes"]["startJsonl"]>;
+    cancelled: boolean;
+  } | undefined;
+  const postMessage = (message: HistoryHostMessage): Thenable<boolean> =>
+    disposed ? Promise.resolve(false) : panel.webview.postMessage(message);
+  panel.onDidDispose(() => {
+    disposed = true;
+    if (activePanelBuild) {
+      activePanelBuild.cancelled = true;
+      activePanelBuild.command.cancel();
+    }
+  });
+  const buildRevision = async (commit: string): Promise<void> => {
+    if (disposed) return;
+    if (session.activeWriter) {
+      await postMessage({
+        type: "buildFailed",
+        commit,
+        message: "Another Compass write operation is already running."
+      });
+      return;
+    }
+    const profile = await vscode.window.showQuickPick(
+      [
+        {
+          label: "Configured history profile",
+          description: "Use the repository's enabled Compass history profile",
+          value: { kind: "configured" as const }
+        },
+        {
+          label: "Code only",
+          description: "Build locally from AST and inferred evidence without model credentials",
+          value: { kind: "code-only" as const }
+        },
+        {
+          label: "Reuse a profile",
+          description: "Copy the build profile from another revision or realization",
+          value: { kind: "from" as const }
+        }
+      ],
+      { title: `Build graph for ${commit.slice(0, 9)}` }
+    );
+    if (disposed) return;
+    if (!profile) {
+      await postMessage({ type: "buildCancelled", commit });
+      return;
+    }
+    let selectedProfile:
+      | { kind: "configured" | "code-only" }
+      | { kind: "from"; source: string };
+    if (profile.value.kind === "from") {
+      const source = await vscode.window.showInputBox({
+        title: "Reuse Compass history profile",
+        prompt: "Enter a revision or realization ID"
+      });
+      if (disposed) return;
+      if (source === undefined) {
+        await postMessage({ type: "buildCancelled", commit });
+        return;
+      }
+      selectedProfile = { kind: "from", source };
+    } else {
+      selectedProfile = profile.value;
+    }
+
+    let command: ReturnType<RepositorySession["processes"]["startJsonl"]> | undefined;
+    let buildAttempt: typeof activePanelBuild;
+    try {
+      if (session.activeWriter) {
+        throw new Error("Another Compass write operation started while choosing the history profile.");
+      }
+      const runningCommand = session.processes.startJsonl(
+        session.root,
+        buildHistoryArgs({
+          revision: commit,
+          all: false,
+          firstParent: false,
+          profile: selectedProfile
+        }),
+        (event) => output.appendLine(`[history:${event.phase}] ${event.message}`)
+      );
+      command = runningCommand;
+      buildAttempt = { command: runningCommand, cancelled: false };
+      activePanelBuild = buildAttempt;
+      session.activeWriter = runningCommand;
+      await postMessage({ type: "buildRunning", commit });
+      const result = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Building Compass graph for ${commit.slice(0, 9)}`,
+          cancellable: true
+        },
+        async (_, token) => {
+          token.onCancellationRequested(() => {
+            if (buildAttempt) buildAttempt.cancelled = true;
+            runningCommand.cancel();
+          });
+          return runningCommand.completed;
+        }
+      );
+      if (buildAttempt.cancelled || disposed) {
+        await postMessage({ type: "buildCancelled", commit });
+        return;
+      }
+      output.append(result.stdout);
+      output.append(result.stderr);
+      if (result.code !== 0) {
+        throw new Error(result.stderr || `Compass exited with ${result.code}`);
+      }
+      timeline = await loadTimeline(session);
+      await postMessage({ type: "timeline", timeline, repositoryId: session.id });
+      await postMessage({ type: "buildSucceeded", commit });
+    } catch (error) {
+      if (command && !buildAttempt?.cancelled) command.cancel();
+      if (buildAttempt?.cancelled || disposed) {
+        await postMessage({ type: "buildCancelled", commit });
+      } else {
+        const fullMessage = error instanceof Error ? error.message : String(error);
+        output.appendLine(`[history:error] ${fullMessage}`);
+        await postMessage({
+          type: "buildFailed",
+          commit,
+          message: conciseBuildError(fullMessage)
+        });
+      }
+    } finally {
+      if (command && activePanelBuild?.command.operationId === command.operationId) {
+        activePanelBuild = undefined;
+      }
+      if (command && session.activeWriter?.operationId === command.operationId) {
+        session.activeWriter = undefined;
+      }
+    }
+  };
   panel.webview.onDidReceiveMessage(async (message) => {
     try {
       if (message?.type === "ready") {
-        await panel.webview.postMessage({ type: "timeline", timeline, repositoryId: session.id });
+        await postMessage({ type: "timeline", timeline, repositoryId: session.id });
       } else if (message?.type === "loadRevision" && typeof message.commit === "string") {
         const entry = timeline.entries.find((candidate) => candidate.commit === message.commit);
         const revision = await revisions.load(
@@ -49,10 +188,11 @@ export async function openHistoryPanel(
           graphNodeLimit,
           historyIdentity(entry)
         );
-        activeGraph = revision;
-        await panel.webview.postMessage({
+        await postMessage({
           type: "graph",
           commit: message.commit,
+          realization: revision.realization,
+          fingerprint: revision.fingerprint,
           graph: revision.graph
         });
       } else if (message?.type === "openCommunity"
@@ -64,22 +204,21 @@ export async function openHistoryPanel(
             "The installed Compass CLI does not support historical community details. Upgrade Compass and reload VS Code."
           );
         }
-        const expected = activeGraph;
-        if (!expected || message.commit !== expected.commit) {
-          throw new Error("The selected historical graph changed before this community loaded.");
+        if (typeof message.realization !== "string"
+          || typeof message.fingerprint !== "string") {
+          throw new Error("The historical graph identity is missing. Reopen the revision and try again.");
         }
+        const expected = {
+          realization: message.realization,
+          fingerprint: message.fingerprint
+        };
         const revision = await revisions.loadCommunity(
           message.commit,
           message.communityId,
           graphNodeLimit,
           expected
         );
-        if (activeGraph?.commit !== expected.commit
-          || activeGraph.realization !== expected.realization
-          || activeGraph.fingerprint !== expected.fingerprint) {
-          throw new Error("The selected historical graph changed before this community loaded.");
-        }
-        await panel.webview.postMessage({
+        await postMessage({
           type: "communityGraph",
           requestId: message.requestId,
           commit: message.commit,
@@ -87,77 +226,7 @@ export async function openHistoryPanel(
           graph: revision.graph
         });
       } else if (message?.type === "buildRevision" && typeof message.commit === "string") {
-        if (session.activeWriter) {
-          throw new Error("Another Compass write operation is already running.");
-        }
-        const profile = await vscode.window.showQuickPick(
-          [
-            {
-              label: "Configured history profile",
-              description: "Use the repository's enabled Compass history profile",
-              value: { kind: "configured" as const }
-            },
-            {
-              label: "Code only",
-              description: "Build locally from AST and inferred evidence without model credentials",
-              value: { kind: "code-only" as const }
-            },
-            {
-              label: "Reuse a profile",
-              description: "Copy the build profile from another revision or realization",
-              value: { kind: "from" as const }
-            }
-          ],
-          { title: `Build graph for ${message.commit.slice(0, 9)}` }
-        );
-        if (!profile) return;
-        let selectedProfile:
-          | { kind: "configured" | "code-only" }
-          | { kind: "from"; source: string };
-        if (profile.value.kind === "from") {
-          const source = await vscode.window.showInputBox({
-            title: "Reuse Compass history profile",
-            prompt: "Enter a revision or realization ID"
-          });
-          if (!source) return;
-          selectedProfile = { kind: "from", source };
-        } else {
-          selectedProfile = profile.value;
-        }
-        const command = session.processes.startJsonl(
-          session.root,
-          buildHistoryArgs({
-            revision: message.commit,
-            all: false,
-            firstParent: false,
-            profile: selectedProfile
-          }),
-          (event) => output.appendLine(`[history:${event.phase}] ${event.message}`)
-        );
-        session.activeWriter = command;
-        let result: Awaited<typeof command.completed>;
-        try {
-          result = await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: `Building Compass graph for ${message.commit.slice(0, 9)}`,
-              cancellable: true
-            },
-            async (_, token) => {
-              token.onCancellationRequested(() => command.cancel());
-              return command.completed;
-            }
-          );
-        } finally {
-          if (session.activeWriter?.operationId === command.operationId) {
-            session.activeWriter = undefined;
-          }
-        }
-        output.append(result.stdout);
-        output.append(result.stderr);
-        if (result.code !== 0) throw new Error(result.stderr || `Compass exited with ${result.code}`);
-        timeline = await loadTimeline(session);
-        await panel.webview.postMessage({ type: "timeline", timeline, repositoryId: session.id });
+        await buildRevision(message.commit);
       } else if (message?.type === "compare"
         && typeof message.commit === "string"
         && typeof message.parent === "string") {
@@ -171,11 +240,12 @@ export async function openHistoryPanel(
           revisions.load(message.parent, graphNodeLimit, historyIdentity(parentEntry)),
           loadSemanticDiff(session, message.parent, message.commit)
         ]);
-        activeGraph = current;
-        await panel.webview.postMessage({
+        await postMessage({
           type: "comparison",
           commit: message.commit,
           parent: message.parent,
+          realization: current.realization,
+          fingerprint: current.fingerprint,
           currentGraph: current.graph,
           parentGraph: parent.graph,
           semanticDiff
@@ -192,28 +262,47 @@ export async function openHistoryPanel(
           counts = await loadChangeCounts(session, message.commit);
           countCache.set(message.commit, counts);
         }
-        await panel.webview.postMessage({ type: "changeCounts", counts });
+        await postMessage({ type: "changeCounts", commit: message.commit, counts });
       } else if (message?.type === "openSource") {
         await openGraphSource(session, message.repositoryId, message.source);
       }
     } catch (error) {
+      if (message?.type === "buildRevision" && typeof message.commit === "string") {
+        const fullMessage = error instanceof Error ? error.message : String(error);
+        output.appendLine(`[history:error] ${fullMessage}`);
+        await postMessage({
+          type: "buildFailed",
+          commit: message.commit,
+          message: conciseBuildError(fullMessage)
+        });
+        return;
+      }
       if (message?.type === "openCommunity"
         && typeof message.requestId === "string"
         && typeof message.communityId === "number") {
-        await panel.webview.postMessage({
+        await postMessage({
           type: "communityError",
           requestId: message.requestId,
+          commit: typeof message.commit === "string" ? message.commit : "",
           communityId: message.communityId,
           message: error instanceof Error ? error.message : String(error)
         });
         return;
       }
-      await panel.webview.postMessage({
+      const commit = typeof message?.commit === "string" ? message.commit : undefined;
+      await postMessage({
         type: "error",
+        operation: historyOperationFor(message),
+        ...(commit ? { commit } : {}),
         message: error instanceof Error ? error.message : String(error)
       });
     }
   });
+}
+
+function conciseBuildError(message: string): string {
+  const normalized = message.replace(/\s+/g, " ").trim() || "Compass build failed.";
+  return normalized.length <= 320 ? normalized : `${normalized.slice(0, 317)}…`;
 }
 
 function historyIdentity(

--- a/editors/vscode/src/webviews/GraphLoadingState.test.tsx
+++ b/editors/vscode/src/webviews/GraphLoadingState.test.tsx
@@ -33,4 +33,24 @@ describe("GraphLoadingState", () => {
     expect(markup).toContain("Retry");
     expect(markup).toContain("Show Compass output");
   });
+
+  it("accepts purpose-specific loading copy", () => {
+    const markup = renderToStaticMarkup(
+      <GraphLoadingState
+        state={{ kind: "loading" }}
+        loadingCopy={{
+          eyebrow: "Compass call graph",
+          title: "Resolving the function under your cursor",
+          steps: ["Locating symbol", "Tracing callers", "Tracing callees"]
+        }}
+        onRetry={vi.fn()}
+        onShowOutput={vi.fn()}
+      />
+    );
+
+    expect(markup).toContain("Compass call graph");
+    expect(markup).toContain("Resolving the function under your cursor");
+    expect(markup).toContain("Tracing callers");
+    expect(markup).toContain("Tracing callees");
+  });
 });

--- a/editors/vscode/src/webviews/GraphLoadingState.tsx
+++ b/editors/vscode/src/webviews/GraphLoadingState.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import {
   AlertTriangleIcon,
   CompassIcon,
@@ -9,14 +10,28 @@ export type GraphLoadState =
   | { kind: "loading" }
   | { kind: "error"; message: string };
 
+export type GraphLoadingCopy = {
+  eyebrow: string;
+  title: string;
+  steps: readonly string[];
+};
+
+const DEFAULT_LOADING_COPY: GraphLoadingCopy = {
+  eyebrow: "Compass graph",
+  title: "Mapping your codebase",
+  steps: ["Reading graph", "Arranging relationships", "Preparing inspector"]
+};
+
 export function GraphLoadingState({
   state,
   onRetry,
-  onShowOutput
+  onShowOutput,
+  loadingCopy = DEFAULT_LOADING_COPY
 }: {
   state: GraphLoadState;
   onRetry(): void;
   onShowOutput(): void;
+  loadingCopy?: GraphLoadingCopy;
 }) {
   const loading = state.kind === "loading";
   return (
@@ -50,13 +65,18 @@ export function GraphLoadingState({
         role={loading ? "status" : "alert"}
         aria-live="polite"
       >
-        <span className="compass-load-eyebrow">Compass graph</span>
-        <h1>{loading ? "Mapping your codebase" : "Compass could not load this graph"}</h1>
+        <span className="compass-load-eyebrow">
+          {loading ? loadingCopy.eyebrow : "Compass graph"}
+        </span>
+        <h1>{loading ? loadingCopy.title : "Compass could not load this graph"}</h1>
         {loading ? (
           <p className="compass-load-steps">
-            <span>Reading graph</span><b>·</b>
-            <span>Arranging relationships</span><b>·</b>
-            <span>Preparing inspector</span>
+            {loadingCopy.steps.map((step, index) => (
+              <Fragment key={step}>
+                {index > 0 && <b aria-hidden="true">·</b>}
+                <span>{step}</span>
+              </Fragment>
+            ))}
           </p>
         ) : (
           <>

--- a/editors/vscode/src/webviews/callGraph.tsx
+++ b/editors/vscode/src/webviews/callGraph.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import { CallGraph, CallGraphResponseSchema, mergeExpansion, type CallGraphResponse } from "@compass/viewer";
+import { GraphLoadingState, type GraphLoadingCopy } from "./GraphLoadingState";
 
 declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
 const vscode = acquireVsCodeApi();
@@ -8,6 +9,37 @@ if (!element) throw new Error("Compass call graph root is missing");
 const root = createRoot(element);
 let graph: CallGraphResponse | undefined;
 let repositoryId = "";
+
+const CALL_GRAPH_LOADING_COPY: GraphLoadingCopy = {
+  eyebrow: "Compass call graph",
+  title: "Resolving the function under your cursor",
+  steps: ["Locating symbol", "Tracing callers", "Tracing callees"]
+};
+
+function renderLoading(): void {
+  root.render(
+    <GraphLoadingState
+      state={{ kind: "loading" }}
+      loadingCopy={CALL_GRAPH_LOADING_COPY}
+      onRetry={() => vscode.postMessage({ type: "retry" })}
+      onShowOutput={() => vscode.postMessage({ type: "showOutput" })}
+    />
+  );
+}
+
+function renderError(message: string): void {
+  root.render(
+    <GraphLoadingState
+      state={{ kind: "error", message }}
+      loadingCopy={CALL_GRAPH_LOADING_COPY}
+      onRetry={() => {
+        renderLoading();
+        vscode.postMessage({ type: "retry" });
+      }}
+      onShowOutput={() => vscode.postMessage({ type: "showOutput" })}
+    />
+  );
+}
 
 function render(): void {
   if (!graph) return;
@@ -28,7 +60,11 @@ function render(): void {
 
 window.addEventListener("message", (event) => {
   if (event.data?.type === "error") {
-    root.render(<main className="grid min-h-screen place-items-center p-8">{event.data.message}</main>);
+    renderError(
+      typeof event.data.message === "string"
+        ? event.data.message
+        : "Compass could not resolve this function."
+    );
     return;
   }
   if (!["hydrateCallGraph", "mergeCallGraph"].includes(event.data?.type)) return;
@@ -40,4 +76,5 @@ window.addEventListener("message", (event) => {
     : parsed.data;
   render();
 });
+renderLoading();
 vscode.postMessage({ type: "ready" });

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -6,9 +6,15 @@ import {
   GraphViewModelSchema,
   compareGraphs,
   type GraphViewModel,
+  type HistoryBuildState,
   type HistoryChangeCounts,
+  type HistoryOperationError,
   type HistoryTimeline
 } from "@compass/viewer";
+import type {
+  HistoryHostMessage,
+  HistoryWebviewMessage
+} from "../history/panelMessages";
 
 declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
 const vscode = acquireVsCodeApi();
@@ -16,8 +22,10 @@ const element = document.getElementById("root");
 if (!element) throw new Error("Compass history root is missing");
 const root = createRoot(element);
 let timeline: HistoryTimeline | undefined;
+let selectedCommit = "";
 let graph: GraphViewModel | undefined;
 let graphCommit: string | undefined;
+let graphIdentity: { realization: string; fingerprint: string } | undefined;
 let communityDetail: { communityId: number; model: GraphViewModel } | undefined;
 let communityLoading: number | null = null;
 let communityError: string | undefined;
@@ -25,12 +33,53 @@ let activeCommunityRequest = "";
 let semanticDiff: unknown;
 let repositoryId = "";
 let changeCounts: HistoryChangeCounts | undefined;
+const buildStates = new Map<string, HistoryBuildState>();
+const operationErrors = new Map<string, HistoryOperationError>();
+
+function postMessage(message: HistoryWebviewMessage): void {
+  vscode.postMessage(message);
+}
+
+function clearRevisionPresentation(): void {
+  graph = undefined;
+  graphCommit = undefined;
+  graphIdentity = undefined;
+  semanticDiff = undefined;
+  changeCounts = undefined;
+  communityDetail = undefined;
+  communityLoading = null;
+  communityError = undefined;
+  activeCommunityRequest = "";
+}
+
+function requestChangeCounts(commit: string): void {
+  const entry = timeline?.entries.find((candidate) => candidate.commit === commit);
+  if (entry?.presentationAvailable && entry.parents.length > 0) {
+    postMessage({ type: "changeCounts", commit });
+  }
+}
+
+function selectCommit(commit: string): void {
+  if (commit === selectedCommit) return;
+  selectedCommit = commit;
+  clearRevisionPresentation();
+  requestChangeCounts(commit);
+  render();
+}
+
+function acceptsCommit(commit: unknown): commit is string {
+  return typeof commit === "string" && commit === selectedCommit;
+}
 
 function render(): void {
   if (!timeline) return;
   root.render(
     <HistoryWorkspace
       timeline={timeline}
+      selectedCommit={selectedCommit}
+      buildState={buildStates.get(selectedCommit)}
+      operationError={operationErrors.get(selectedCommit)}
+      onSelectCommit={selectCommit}
       graph={graph}
       graphCommit={graphCommit}
       communityDetail={communityDetail}
@@ -47,32 +96,41 @@ function render(): void {
       changeCounts={changeCounts}
       host={{
         loadRevision(commit) {
-          vscode.postMessage({ type: "loadRevision", commit });
+          operationErrors.delete(commit);
+          render();
+          postMessage({ type: "loadRevision", commit });
         },
         buildRevision(commit) {
-          vscode.postMessage({ type: "buildRevision", commit });
+          buildStates.set(commit, { status: "requesting" });
+          operationErrors.delete(commit);
+          render();
+          postMessage({ type: "buildRevision", commit });
         },
         compare(commit, parent) {
-          vscode.postMessage({ type: "compare", commit, parent });
+          operationErrors.delete(commit);
+          render();
+          postMessage({ type: "compare", commit, parent });
         },
         queryRevision(commit) {
-          vscode.postMessage({ type: "queryRevision", commit });
+          postMessage({ type: "queryRevision", commit });
         },
         loadChangeCounts(commit) {
-          vscode.postMessage({ type: "changeCounts", commit });
+          postMessage({ type: "changeCounts", commit });
         },
-        openSource(source) {
-          vscode.postMessage({ type: "openSource", repositoryId, source });
+        openSource(commit, source) {
+          postMessage({ type: "openSource", commit, repositoryId, source });
         },
         openCommunity(commit, communityId) {
-          if (communityLoading !== null) return;
+          if (communityLoading !== null || !graphIdentity) return;
           communityLoading = communityId;
           communityError = undefined;
           activeCommunityRequest = crypto.randomUUID();
-          vscode.postMessage({
+          postMessage({
             type: "openCommunity",
             requestId: activeCommunityRequest,
             commit,
+            realization: graphIdentity.realization,
+            fingerprint: graphIdentity.fingerprint,
             communityId
           });
           render();
@@ -81,65 +139,110 @@ function render(): void {
     />
   );
 }
-window.addEventListener("message", (event) => {
-  if (event.data?.type === "timeline") {
-    const parsed = HistoryTimelineSchema.safeParse(event.data.timeline);
+
+window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => {
+  const message = event.data;
+  if (message?.type === "timeline") {
+    const parsed = HistoryTimelineSchema.safeParse(message.timeline);
     if (parsed.success) {
       timeline = parsed.data;
-      if (typeof event.data.repositoryId === "string") {
-        repositoryId = event.data.repositoryId;
+      repositoryId = message.repositoryId;
+      const retainedCommit = timeline.entries.some((entry) => entry.commit === selectedCommit)
+        ? selectedCommit
+        : "";
+      const nextCommit = retainedCommit
+        || (timeline.entries.some((entry) => entry.commit === timeline?.selectedHead)
+          ? timeline.selectedHead
+          : timeline.entries[0]?.commit)
+        || "";
+      if (nextCommit !== selectedCommit) {
+        selectedCommit = nextCommit;
+        clearRevisionPresentation();
       }
+      requestChangeCounts(nextCommit);
     }
-  } else if (event.data?.type === "graph") {
-    const parsed = GraphViewModelSchema.safeParse(event.data.graph);
+  } else if (message?.type === "graph") {
+    if (!acceptsCommit(message.commit)) return;
+    const parsed = GraphViewModelSchema.safeParse(message.graph);
     if (parsed.success) {
       graph = parsed.data;
-      graphCommit = typeof event.data.commit === "string" ? event.data.commit : undefined;
+      graphCommit = message.commit;
+      graphIdentity = {
+        realization: message.realization,
+        fingerprint: message.fingerprint
+      };
       communityDetail = undefined;
       communityLoading = null;
       communityError = undefined;
       activeCommunityRequest = "";
+      operationErrors.delete(message.commit);
     }
-  } else if (event.data?.type === "communityGraph") {
-    const parsed = GraphViewModelSchema.safeParse(event.data.graph);
+  } else if (message?.type === "communityGraph") {
+    if (!acceptsCommit(message.commit)) return;
+    const parsed = GraphViewModelSchema.safeParse(message.graph);
     if (parsed.success
-      && event.data.requestId === activeCommunityRequest
-      && event.data.commit === graphCommit) {
+      && message.requestId === activeCommunityRequest
+      && message.commit === graphCommit) {
       communityDetail = {
-        communityId: event.data.communityId,
+        communityId: message.communityId,
         model: parsed.data
       };
       communityLoading = null;
       communityError = undefined;
     }
-  } else if (event.data?.type === "communityError") {
-    if (event.data.requestId === activeCommunityRequest) {
+  } else if (message?.type === "communityError") {
+    if (!acceptsCommit(message.commit)) return;
+    if (message.requestId === activeCommunityRequest) {
       communityLoading = null;
-      communityError = String(event.data.message);
+      communityError = message.message;
     }
-  } else if (event.data?.type === "comparison") {
-    const current = GraphViewModelSchema.safeParse(event.data.currentGraph);
-    const parent = GraphViewModelSchema.safeParse(event.data.parentGraph);
+  } else if (message?.type === "comparison") {
+    if (!acceptsCommit(message.commit)) return;
+    const current = GraphViewModelSchema.safeParse(message.currentGraph);
+    const parent = GraphViewModelSchema.safeParse(message.parentGraph);
     if (current.success && parent.success) {
       graph = current.data;
-      graphCommit = typeof event.data.commit === "string" ? event.data.commit : undefined;
+      graphCommit = message.commit;
+      graphIdentity = {
+        realization: message.realization,
+        fingerprint: message.fingerprint
+      };
       communityDetail = undefined;
       communityLoading = null;
       communityError = undefined;
       activeCommunityRequest = "";
       semanticDiff = {
         structural: compareGraphs(parent.data, current.data),
-        semantic: event.data.semanticDiff
+        semantic: message.semanticDiff
       };
+      operationErrors.delete(message.commit);
     }
-  } else if (event.data?.type === "changeCounts") {
-    const parsed = HistoryChangeCountsSchema.safeParse(event.data.counts);
+  } else if (message?.type === "changeCounts") {
+    if (!acceptsCommit(message.commit)) return;
+    const parsed = HistoryChangeCountsSchema.safeParse(message.counts);
     if (parsed.success) changeCounts = parsed.data;
-  } else if (event.data?.type === "error") {
-    semanticDiff = { error: String(event.data.message) };
+  } else if (message?.type === "buildRunning") {
+    buildStates.set(message.commit, { status: "running" });
+  } else if (message?.type === "buildSucceeded") {
+    buildStates.delete(message.commit);
+    operationErrors.delete(message.commit);
+  } else if (message?.type === "buildFailed") {
+    buildStates.set(message.commit, { status: "failed", message: message.message });
+  } else if (message?.type === "buildCancelled") {
+    buildStates.delete(message.commit);
+  } else if (message?.type === "error") {
+    if (message.commit !== undefined && message.commit !== selectedCommit) return;
+    const commit = message.commit ?? selectedCommit;
+    if (commit) {
+      operationErrors.set(commit, {
+        operation: message.operation,
+        message: message.message
+      });
+    }
   } else {
     return;
   }
   render();
 });
-vscode.postMessage({ type: "ready" });
+
+postMessage({ type: "ready" });

--- a/packages/compass-viewer/src/architecture/ArchitectureFlow.tsx
+++ b/packages/compass-viewer/src/architecture/ArchitectureFlow.tsx
@@ -19,7 +19,11 @@ export function ArchitectureFlow({
 }) {
   const first = model.sections.find((section) => section.id !== "overview")?.id ?? "overview";
   const [sectionId, setSectionId] = useState(first);
+  const [showAllFlows, setShowAllFlows] = useState(false);
   const section = model.sections.find((candidate) => candidate.id === sectionId);
+  const visibleOverviewLinks = showAllFlows
+    ? model.overviewLinks
+    : model.overviewLinks.slice(0, 24);
   const nodeNames = useMemo(
     () => new Map(model.sections.flatMap((item) => item.nodes.map((node) => [node.id, node.label]))),
     [model.sections]
@@ -72,7 +76,7 @@ export function ArchitectureFlow({
             <Badge variant="outline"><NetworkIcon /> {model.overviewLinks.length} flows</Badge>
           </div>
           <div className="architecture-flow-grid">
-            {model.overviewLinks.slice(0, 24).map((link) => (
+            {visibleOverviewLinks.map((link) => (
               <div
                 key={`${link.sourceSection}:${link.targetSection}`}
                 className="flex items-center gap-2 rounded-md border bg-card px-3 py-2 text-sm text-card-foreground"
@@ -84,6 +88,16 @@ export function ArchitectureFlow({
               </div>
             ))}
           </div>
+          {!showAllFlows && model.overviewLinks.length > visibleOverviewLinks.length && (
+            <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground" role="status">
+                Showing {visibleOverviewLinks.length} of {model.overviewLinks.length} flows
+              </p>
+              <Button size="xs" variant="outline" onClick={() => setShowAllFlows(true)}>
+                Show all {model.overviewLinks.length} flows
+              </Button>
+            </div>
+          )}
         </section>
 
         {section && (

--- a/packages/compass-viewer/src/calls/CallGraph.tsx
+++ b/packages/compass-viewer/src/calls/CallGraph.tsx
@@ -1,4 +1,12 @@
-import { ArrowDownIcon, ArrowUpIcon, GitForkIcon, PlusIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  GitForkIcon,
+  PlusIcon,
+  TriangleAlertIcon
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import type { SourceLocation } from "../contracts/graph";
@@ -18,37 +26,73 @@ export function CallGraph({
   graph: CallGraphResponse;
   host: CallGraphHost;
 }) {
+  const [showAllContinuations, setShowAllContinuations] = useState(false);
+  const visibleContinuations = showAllContinuations
+    ? graph.continuations
+    : graph.continuations.slice(0, 20);
   return (
     <div className="relative h-screen">
       <CallCanvas graph={graph} host={host} />
       <section className="absolute bottom-3 left-3 z-20 flex max-w-[min(44rem,calc(100%-1.5rem))] flex-col gap-2 rounded-md border bg-popover/95 p-3 text-popover-foreground shadow-xl backdrop-blur">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="outline"><GitForkIcon /> depth {graph.depth}</Badge>
+          <Badge variant="outline">
+            {graph.nodes.length} {graph.nodes.length === 1 ? "node" : "nodes"}
+          </Badge>
+          <Badge variant="outline">
+            {graph.edges.length} {graph.edges.length === 1 ? "edge" : "edges"}
+          </Badge>
           <Badge variant="secondary">{graph.coverage.resolved} resolved</Badge>
           <Badge variant="outline">{graph.coverage.inferred} inferred</Badge>
           <Badge variant="outline">{graph.coverage.ambiguous} ambiguous</Badge>
           <Badge variant="destructive">{graph.coverage.unresolved} unresolved</Badge>
         </div>
+        {graph.truncated && (
+          <Alert>
+            <TriangleAlertIcon />
+            <AlertTitle>Partial call graph</AlertTitle>
+            <AlertDescription>
+              Compass reached the configured graph limit. Counts and paths may be incomplete.
+            </AlertDescription>
+          </Alert>
+        )}
         <CoverageNotice coverage={graph.coverage} />
         {graph.continuations.length > 0 && (
-          <div className="flex max-h-24 flex-wrap gap-1 overflow-auto" aria-label="Call graph continuations">
-            {graph.continuations.slice(0, 20).map((continuation) => (
-              <Button
-                key={`${continuation.symbol}:${continuation.direction}:${continuation.nextDepth}`}
-                size="xs"
-                variant="outline"
-                onClick={() => host.expand(
-                  continuation.symbol,
-                  continuation.direction,
-                  continuation.nextDepth
-                )}
-              >
-                {continuation.direction === "callers"
-                  ? <ArrowUpIcon /> : continuation.direction === "callees"
-                    ? <ArrowDownIcon /> : <PlusIcon />}
-                Expand {continuation.direction}
-              </Button>
-            ))}
+          <div>
+            <div className="flex max-h-24 flex-wrap gap-1 overflow-auto" aria-label="Call graph continuations">
+              {visibleContinuations.map((continuation) => (
+                <Button
+                  key={`${continuation.symbol}:${continuation.direction}:${continuation.nextDepth}`}
+                  size="xs"
+                  variant="outline"
+                  onClick={() => host.expand(
+                    continuation.symbol,
+                    continuation.direction,
+                    continuation.nextDepth
+                  )}
+                >
+                  {continuation.direction === "callers"
+                    ? <ArrowUpIcon /> : continuation.direction === "callees"
+                      ? <ArrowDownIcon /> : <PlusIcon />}
+                  Expand {continuation.direction}
+                </Button>
+              ))}
+            </div>
+            {!showAllContinuations
+              && graph.continuations.length > visibleContinuations.length && (
+              <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-muted-foreground" role="status">
+                  Showing {visibleContinuations.length} of {graph.continuations.length} continuations
+                </p>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onClick={() => setShowAllContinuations(true)}
+                >
+                  Show all {graph.continuations.length} continuations
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/packages/compass-viewer/src/contracts/history.ts
+++ b/packages/compass-viewer/src/contracts/history.ts
@@ -47,3 +47,11 @@ export type HistoryTimeline = z.infer<typeof HistoryTimelineSchema>;
 export type HistoryEntry = HistoryTimeline["entries"][number];
 export type HistoricalGraph = z.infer<typeof HistoricalGraphSchema>;
 export type HistoryChangeCounts = z.infer<typeof HistoryChangeCountsSchema>;
+export type HistoryBuildState =
+  | { status: "requesting" }
+  | { status: "running" }
+  | { status: "failed"; message: string };
+export type HistoryOperationError = {
+  operation: string;
+  message: string;
+};

--- a/packages/compass-viewer/src/graph/GraphInspector.tsx
+++ b/packages/compass-viewer/src/graph/GraphInspector.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type KeyboardEvent } from "react";
 import {
   CompassIcon,
+  ExternalLinkIcon,
   PanelRightCloseIcon,
   PanelRightOpenIcon,
   SearchIcon
@@ -13,6 +14,31 @@ function lineRange(node: GraphNode): string | undefined {
   const end = node.source?.endLine;
   if (start === undefined) return undefined;
   return end !== undefined && end !== start ? `${start}–${end}` : String(start);
+}
+
+function sourceDisplayRange(node: GraphNode): {
+  text: string;
+  action: string;
+} | undefined {
+  const startLine = node.source?.startLine;
+  const endLine = node.source?.endLine;
+  if (startLine !== undefined) {
+    return endLine !== undefined && endLine !== startLine
+      ? { text: `Lines ${startLine}–${endLine}`, action: `at lines ${startLine}–${endLine}` }
+      : { text: `Line ${startLine}`, action: `at line ${startLine}` };
+  }
+
+  const startByte = node.source?.startByte;
+  const endByte = node.source?.endByte;
+  if (startByte === undefined) return undefined;
+  return endByte !== undefined && endByte !== startByte
+    ? { text: `Bytes ${startByte}–${endByte}`, action: `at bytes ${startByte}–${endByte}` }
+    : { text: `Byte ${startByte}`, action: `at byte ${startByte}` };
+}
+
+function sourceActionLabel(node: GraphNode, source: SourceLocation): string {
+  const range = sourceDisplayRange(node);
+  return `Open source ${source.file}${range ? ` ${range.action}` : ""}`;
 }
 
 export function GraphInspector({
@@ -49,6 +75,7 @@ export function GraphInspector({
   const [activeResult, setActiveResult] = useState(0);
   const source = selected ? navigableSource(selected) : undefined;
   const range = selected ? lineRange(selected) : undefined;
+  const sourceRange = selected ? sourceDisplayRange(selected) : undefined;
   const communityCounts = useMemo(() => {
     const counts = new Map<number, number>();
     for (const node of model.nodes) {
@@ -201,25 +228,48 @@ export function GraphInspector({
               </div>
               {selected.language && <div><dt>Language</dt><dd>{selected.language}</dd></div>}
               {range && <div><dt>Lines</dt><dd>{range}</dd></div>}
-              <div className="compass-metadata-wide">
-                <dt>Source</dt>
-                <dd title={selected.source?.file ?? "Not recorded"}>
-                  {selected.source?.file ?? "Not recorded"}
-                </dd>
+              <div
+                className="compass-metadata-wide compass-source-metadata"
+                data-interactive={source !== undefined}
+              >
+                {source ? (
+                  <>
+                    <dt className="sr-only">Source</dt>
+                    <dd>
+                      <button
+                        className="compass-source-card"
+                        type="button"
+                        aria-label={sourceActionLabel(selected, source)}
+                        title={sourceActionLabel(selected, source)}
+                        onClick={() => onOpenSource(source)}
+                      >
+                        <span className="compass-source-copy">
+                          <span className="compass-source-eyebrow" aria-hidden="true">
+                            Source
+                          </span>
+                          <span className="compass-source-path">{source.file}</span>
+                          {sourceRange && (
+                            <span className="compass-source-range">
+                              {sourceRange.text}
+                            </span>
+                          )}
+                        </span>
+                        <ExternalLinkIcon aria-hidden="true" />
+                      </button>
+                    </dd>
+                  </>
+                ) : (
+                  <>
+                    <dt>Source</dt>
+                    <dd title={selected.source?.file ?? "Not recorded"}>
+                      {selected.source?.file ?? "Not recorded"}
+                    </dd>
+                  </>
+                )}
               </div>
             </dl>
             {selected.signature && (
               <code className="compass-signature-block">{selected.signature}</code>
-            )}
-            {source && (
-              <button
-                className="compass-inspector-action"
-                type="button"
-                onClick={() => onOpenSource(source)}
-              >
-                Open source
-                <span>{source.file}{range ? `:${range}` : ""}</span>
-              </button>
             )}
             {model.stats.aggregated
               && selected.memberCount !== undefined
@@ -243,11 +293,17 @@ export function GraphInspector({
                   key={neighbor.id}
                   type="button"
                   className="compass-neighbor-link"
-                  style={{ borderLeftColor: neighbor.color?.background
-                    ?? model.communities.find((item) => item.id === neighbor.community)?.color }}
+                  title={neighbor.label}
                   onClick={() => onFocus(neighbor.id)}
                 >
-                  {neighbor.label}
+                  <span
+                    className="compass-neighbor-dot"
+                    aria-hidden="true"
+                    style={{ background: neighbor.color?.background
+                      ?? model.communities.find((item) => item.id === neighbor.community)?.color
+                      ?? "var(--border)" }}
+                  />
+                  <span className="compass-neighbor-label">{neighbor.label}</span>
                 </button>
               )) : <span className="compass-empty">No connected nodes</span>}
             </div>

--- a/packages/compass-viewer/src/history/CommitDetails.tsx
+++ b/packages/compass-viewer/src/history/CommitDetails.tsx
@@ -1,12 +1,18 @@
 import { GitCompareIcon, HammerIcon, NetworkIcon, SearchIcon } from "lucide-react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
-import type { HistoryEntry } from "../contracts/history";
-import type { HistoryChangeCounts } from "../contracts/history";
+import type {
+  HistoryBuildState,
+  HistoryChangeCounts,
+  HistoryEntry,
+  HistoryOperationError
+} from "../contracts/history";
 
 export function CommitDetails({
   entry,
-  building,
+  buildState,
+  operationError,
+  availableCommits,
   onLoad,
   onBuild,
   onCompare,
@@ -14,13 +20,25 @@ export function CommitDetails({
   changeCounts
 }: {
   entry: HistoryEntry;
-  building: boolean;
+  buildState?: HistoryBuildState | undefined;
+  operationError?: HistoryOperationError | undefined;
+  availableCommits: ReadonlySet<string>;
   onLoad(): void;
   onBuild(): void;
   onCompare(parent: string): void;
   onQuery(): void;
   changeCounts?: HistoryChangeCounts | undefined;
 }) {
+  const buildBusy = buildState?.status === "requesting" || buildState?.status === "running";
+  const buildLabel = buildState?.status === "requesting"
+    ? "Choosing profile…"
+    : buildState?.status === "running"
+      ? "Building…"
+      : buildState?.status === "failed"
+        ? "Retry build"
+        : "Build graph";
+  const unavailableParents = entry.parents.filter((parent) => !availableCommits.has(parent));
+  const comparisonUnavailable = !entry.presentationAvailable || unavailableParents.length > 0;
   return (
     <section className="rounded-md border bg-card p-4 text-card-foreground">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -45,16 +63,44 @@ export function CommitDetails({
           </Button>
         )}
         {!entry.presentationAvailable && (
-          <Button size="sm" variant="outline" disabled={building} onClick={onBuild}>
-            <HammerIcon /> {building ? "Building…" : "Build graph"}
+          <Button size="sm" variant="outline" disabled={buildBusy} onClick={onBuild}>
+            <HammerIcon /> {buildLabel}
           </Button>
         )}
         {entry.parents.map((parent, index) => (
-          <Button key={parent} size="sm" variant="ghost" onClick={() => onCompare(parent)}>
+          <Button
+            key={parent}
+            size="sm"
+            variant="ghost"
+            disabled={!entry.presentationAvailable || !availableCommits.has(parent)}
+            title={!entry.presentationAvailable
+              ? "Build this revision first"
+              : !availableCommits.has(parent)
+                ? "Parent graph is not available"
+                : undefined}
+            onClick={() => onCompare(parent)}
+          >
             <GitCompareIcon /> Compare parent {index + 1}
           </Button>
         ))}
       </div>
+      {comparisonUnavailable && entry.parents.length > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Comparison unavailable: {!entry.presentationAvailable
+            ? "build this revision first."
+            : "one or more parent graphs are not available."}
+        </p>
+      )}
+      {buildState?.status === "failed" && (
+        <p className="mt-3 text-sm text-destructive" role="alert">
+          Build failed: {buildState.message}
+        </p>
+      )}
+      {operationError && (
+        <p className="mt-3 text-sm text-destructive" role="alert">
+          {operationError.operation}: {operationError.message}
+        </p>
+      )}
       {changeCounts && (
         <div className="mt-3 flex flex-wrap gap-2 text-xs" aria-label="Structural change counts">
           <Badge variant="secondary">

--- a/packages/compass-viewer/src/history/HistoryWorkspace.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useMemo, useReducer, useRef } from "react";
+import { useMemo, useState } from "react";
 import { HistoryIcon, SearchIcon } from "lucide-react";
 import { CompassGraph } from "../graph/CompassGraph";
 import { Input } from "../components/ui/input";
 import type { GraphViewModel, SourceLocation } from "../contracts/graph";
-import type { HistoryChangeCounts, HistoryTimeline } from "../contracts/history";
+import type {
+  HistoryBuildState,
+  HistoryChangeCounts,
+  HistoryOperationError,
+  HistoryTimeline
+} from "../contracts/history";
 import { CommitDetails } from "./CommitDetails";
 import { CommitRail } from "./CommitRail";
-import { historyReducer, initialHistoryState } from "./state";
 import { SemanticFindings } from "./SemanticFindings";
 
 export type HistoryHost = {
@@ -15,7 +19,7 @@ export type HistoryHost = {
   compare(commit: string, parent: string): void;
   queryRevision(commit: string): void;
   loadChangeCounts(commit: string): void;
-  openSource(source: SourceLocation): void;
+  openSource(commit: string, source: SourceLocation): void;
   openCommunity(commit: string, communityId: number): void;
 };
 
@@ -29,6 +33,10 @@ export function HistoryWorkspace({
   communityLoading,
   communityError,
   onBackToOverview,
+  selectedCommit,
+  buildState,
+  operationError,
+  onSelectCommit,
   host
 }: {
   timeline: HistoryTimeline;
@@ -40,26 +48,30 @@ export function HistoryWorkspace({
   communityLoading?: number | null | undefined;
   communityError?: string | undefined;
   onBackToOverview?: (() => void) | undefined;
+  selectedCommit: string;
+  buildState?: HistoryBuildState | undefined;
+  operationError?: HistoryOperationError | undefined;
+  onSelectCommit(commit: string): void;
   host: HistoryHost;
 }) {
-  const [state, dispatch] = useReducer(historyReducer, timeline, initialHistoryState);
+  const [query, setQuery] = useState("");
   const entries = useMemo(() => {
-    const query = state.query.toLocaleLowerCase();
-    return timeline.entries.filter((entry) => !query
-      || entry.commit.includes(query)
-      || entry.subject.toLocaleLowerCase().includes(query)
-      || entry.authorName.toLocaleLowerCase().includes(query)
-      || entry.graphState.includes(query));
-  }, [state.query, timeline.entries]);
-  const selected = timeline.entries.find((entry) => entry.commit === state.selected)
+    const normalizedQuery = query.toLocaleLowerCase();
+    return timeline.entries.filter((entry) => !normalizedQuery
+      || entry.commit.includes(normalizedQuery)
+      || entry.subject.toLocaleLowerCase().includes(normalizedQuery)
+      || entry.authorName.toLocaleLowerCase().includes(normalizedQuery)
+      || entry.graphState.includes(normalizedQuery));
+  }, [query, timeline.entries]);
+  const selected = timeline.entries.find((entry) => entry.commit === selectedCommit)
     ?? entries[0];
-  const requestedCounts = useRef(new Set<string>());
-  useEffect(() => {
-    if (!selected?.presentationAvailable || selected.parents.length === 0
-      || requestedCounts.current.has(selected.commit)) return;
-    requestedCounts.current.add(selected.commit);
-    host.loadChangeCounts(selected.commit);
-  }, [host, selected]);
+  const availableCommits = useMemo(
+    () => new Set(timeline.entries
+      .filter((entry) => entry.presentationAvailable)
+      .map((entry) => entry.commit)),
+    [timeline.entries]
+  );
+  const visibleGraph = graph && graphCommit === selected?.commit ? graph : undefined;
   return (
     <div className="history-shell">
       <aside className="history-sidebar">
@@ -75,49 +87,62 @@ export function HistoryWorkspace({
             <SearchIcon className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
             <Input
               className="pl-8"
-              value={state.query}
+              value={query}
               placeholder="Search commits and states"
               aria-label="Search commit history"
-              onChange={(event) => dispatch({ type: "search", query: event.target.value })}
+              onChange={(event) => setQuery(event.target.value)}
             />
           </div>
         </header>
         <CommitRail
           entries={entries}
           selected={selected?.commit ?? ""}
-          onSelect={(commit) => dispatch({ type: "select", commit })}
+          onSelect={onSelectCommit}
         />
       </aside>
       <main className="min-w-0 overflow-auto p-4">
         {selected && (
           <CommitDetails
             entry={selected}
-            building={state.building.has(selected.commit)}
+            buildState={buildState}
+            operationError={operationError}
+            availableCommits={availableCommits}
             onLoad={() => host.loadRevision(selected.commit)}
-            onBuild={() => {
-              dispatch({ type: "building", commit: selected.commit, building: true });
-              host.buildRevision(selected.commit);
-            }}
+            onBuild={() => host.buildRevision(selected.commit)}
             onCompare={(parent) => host.compare(selected.commit, parent)}
             onQuery={() => host.queryRevision(selected.commit)}
             changeCounts={changeCounts?.commit === selected.commit ? changeCounts : undefined}
           />
         )}
         <div className="mt-4 h-[calc(100vh-12rem)] min-h-96 overflow-hidden rounded-md border">
-          {graph ? (
-            <CompassGraph
-              model={graph}
-              communityDetail={communityDetail}
-              communityLoading={communityLoading}
-              communityError={communityError}
-              onBackToOverview={onBackToOverview}
-              host={{
-                openSource: host.openSource,
-                openCommunity(communityId) {
-                  if (graphCommit) host.openCommunity(graphCommit, communityId);
-                }
-              }}
-            />
+          {visibleGraph ? (
+            <div className="flex h-full min-h-0 flex-col">
+              <div
+                className="border-b bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+                role="status"
+              >
+                Viewing graph for <span className="font-mono text-foreground">
+                  {selected?.commit.slice(0, 9)}
+                </span>
+              </div>
+              <div className="min-h-0 flex-1">
+                <CompassGraph
+                  model={visibleGraph}
+                  communityDetail={communityDetail}
+                  communityLoading={communityLoading}
+                  communityError={communityError}
+                  onBackToOverview={onBackToOverview}
+                  host={{
+                    openSource(source) {
+                      if (selected) host.openSource(selected.commit, source);
+                    },
+                    openCommunity(communityId) {
+                      if (graphCommit) host.openCommunity(graphCommit, communityId);
+                    }
+                  }}
+                />
+              </div>
+            </div>
           ) : (
             <div className="grid h-full place-items-center text-center text-sm text-muted-foreground">
               Select an available commit and choose Open graph. Missing commits are never built implicitly.

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -496,6 +496,7 @@ button:not(:disabled),
 .compass-search-field input:focus-visible,
 .compass-search-item:focus-visible,
 .compass-inspector-action:focus-visible,
+.compass-source-card:focus-visible,
 .compass-inspector-disclosure:focus-visible,
 .compass-inspector-resizer:focus-visible,
 .compass-load-action:focus-visible,
@@ -854,6 +855,83 @@ button:not(:disabled),
   white-space: nowrap;
 }
 
+.compass-source-metadata[data-interactive="true"] {
+  padding: 0;
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.compass-source-metadata[data-interactive="true"]:hover,
+.compass-source-metadata[data-interactive="true"]:focus-within {
+  border-color: var(--compass-focus);
+  background: var(--compass-focus-soft);
+}
+
+.compass-source-metadata[data-interactive="true"] dd {
+  margin: 0;
+  overflow: visible;
+  white-space: normal;
+}
+
+.compass-source-card {
+  display: flex;
+  width: 100%;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: 9px;
+  outline: none;
+  background: transparent;
+  color: var(--foreground);
+  text-align: left;
+}
+
+.compass-source-copy {
+  display: block;
+  min-width: 0;
+}
+
+.compass-source-eyebrow,
+.compass-source-path,
+.compass-source-range {
+  display: block;
+}
+
+.compass-source-eyebrow {
+  color: var(--compass-faint);
+  font-family: var(--compass-font-sans);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.compass-source-path {
+  margin-top: 4px;
+  overflow: hidden;
+  font: 11px/1.35 var(--compass-font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compass-source-range {
+  margin-top: 3px;
+  color: var(--muted-foreground);
+  font: 10px/1.25 var(--compass-font-sans);
+}
+
+.compass-source-card > svg {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  color: var(--compass-focus);
+}
+
+.compass-source-card:hover > svg {
+  color: var(--foreground);
+}
+
 .compass-signature-block {
   display: block;
   margin-bottom: 15px;
@@ -905,25 +983,39 @@ button:not(:disabled),
 }
 
 .compass-neighbor-link {
-  display: block;
+  display: flex;
   width: 100%;
   min-height: 36px;
+  align-items: center;
+  gap: 9px;
   margin: 3px 0;
   padding: 8px 9px;
   overflow: hidden;
   border: 0;
-  border-left: 3px solid var(--border);
   border-radius: 7px;
   background: transparent;
   color: var(--muted-foreground);
   text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .compass-neighbor-link:hover {
   background: var(--compass-focus-soft);
   color: var(--foreground);
+}
+
+.compass-neighbor-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--foreground) 10%, transparent);
+}
+
+.compass-neighbor-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .compass-empty {
@@ -1072,11 +1164,13 @@ body.vscode-high-contrast .compass-graph-inspector,
 body.vscode-high-contrast .compass-inspector-resizer,
 body.vscode-high-contrast .compass-load-mark,
 body.vscode-high-contrast .compass-load-action,
+body.vscode-high-contrast .compass-source-metadata,
 body.vscode-high-contrast-light .compass-glass-panel,
 body.vscode-high-contrast-light .compass-graph-inspector,
 body.vscode-high-contrast-light .compass-inspector-resizer,
 body.vscode-high-contrast-light .compass-load-mark,
-body.vscode-high-contrast-light .compass-load-action {
+body.vscode-high-contrast-light .compass-load-action,
+body.vscode-high-contrast-light .compass-source-metadata {
   border-width: 2px;
   border-color: var(--vscode-contrastBorder, var(--compass-focus));
 }

--- a/tests/viewer/callflow.spec.ts
+++ b/tests/viewer/callflow.spec.ts
@@ -25,3 +25,57 @@ test("architecture and call graph have separate purpose-built views", async ({ p
   await expect(page.getByRole("button", { name: /Expand (callers|callees)/ })).toHaveCount(21);
   await expect(page.getByText("Showing 20 of 21 continuations")).toHaveCount(0);
 });
+
+test("call graph uses a balanced cursor-resolution state and recoverable error", async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await page.goto("/calls.html");
+  await expect(
+    page.getByRole("heading", { name: "Resolving the function under your cursor" })
+  ).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("Locating symbol");
+  await expect(page.getByRole("status")).toContainText("Tracing callers");
+  await expect(page.getByRole("status")).toContainText("Tracing callees");
+
+  const shell = await page.locator(".compass-load-shell").boundingBox();
+  const content = await page.locator(".compass-load-copy").boundingBox();
+  expect(shell).not.toBeNull();
+  expect(content).not.toBeNull();
+  expect(Math.abs(
+    (content!.x + content!.width / 2) - (shell!.x + shell!.width / 2)
+  )).toBeLessThan(2);
+  await expect(page.getByText("Calls from run")).toBeVisible();
+  await page.getByRole("combobox", { name: "Search graph nodes" }).fill("helper");
+  await page.getByRole("option", { name: /helper/i }).click();
+  const source = page.getByRole("button", {
+    name: "Open source src/lib.rs at bytes 11–20"
+  });
+  await expect(source.locator(".compass-source-range")).toHaveText("Bytes 11–20");
+  await source.click();
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { openedCallGraphSource?: unknown }
+  ).openedCallGraphSource)).toEqual({
+    file: "src/lib.rs",
+    startByte: 11,
+    endByte: 20
+  });
+
+  await page.goto("/calls.html?error=1");
+  await expect(page.getByRole("alert")).toContainText(
+    "No function could be resolved at this cursor position."
+  );
+  await page.getByRole("button", { name: "Show Compass output" }).click();
+  expect(await page.evaluate(() => (
+    window as typeof window & { showedCallGraphOutput?: boolean }
+  ).showedCallGraphOutput)).toBe(true);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { callGraphHostMessages: Array<{ type: string }> }
+  ).callGraphHostMessages.map(({ type }) => type))).toEqual([
+    "ready",
+    "showOutput",
+    "retry"
+  ]);
+});

--- a/tests/viewer/callflow.spec.ts
+++ b/tests/viewer/callflow.spec.ts
@@ -4,7 +4,24 @@ test("architecture and call graph have separate purpose-built views", async ({ p
   await page.goto("/architecture.html");
   await expect(page.getByRole("heading", { name: "System call flow" })).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Architecture sections" })).toBeVisible();
+  await expect(page.getByText("Showing 24 of 25 flows")).toBeVisible();
+  await expect(page.locator(".architecture-flow-grid > div")).toHaveCount(24);
+  await page.getByRole("button", { name: "Show all 25 flows" }).click();
+  await expect(page.locator(".architecture-flow-grid > div")).toHaveCount(25);
+  await expect(page.getByText("Showing 24 of 25 flows")).toHaveCount(0);
+
   await page.goto("/calls.html");
   await expect(page.getByText("depth 1")).toBeVisible();
   await expect(page.getByText("Calls from run")).toBeVisible();
+  await expect(page.getByText("2 nodes", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 edge", { exact: true })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("Partial call graph");
+  await expect(page.getByRole("alert")).toContainText(
+    "Compass reached the configured graph limit. Counts and paths may be incomplete."
+  );
+  await expect(page.getByText("Showing 20 of 21 continuations")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Expand (callers|callees)/ })).toHaveCount(20);
+  await page.getByRole("button", { name: "Show all 21 continuations" }).click();
+  await expect(page.getByRole("button", { name: /Expand (callers|callees)/ })).toHaveCount(21);
+  await expect(page.getByText("Showing 20 of 21 continuations")).toHaveCount(0);
 });

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -174,7 +174,7 @@ export default async function generate(): Promise<void> {
     title: "Revision C graph"
   };
   await writeFile(path.join(output, "architecture.html"), harness("architecture", { type: "hydrate", repositoryId: "fixture", model: architecture }));
-  await writeFile(path.join(output, "calls.html"), harness("callGraph", { type: "hydrateCallGraph", repositoryId: "fixture", graph: calls }));
+  await writeFile(path.join(output, "calls.html"), callGraphHarness(calls));
   await writeFile(
     path.join(output, "history.html"),
     historyHarness(
@@ -204,6 +204,32 @@ window.acquireVsCodeApi=()=>({
     }
   }
 })</script><script src="/vscodeGraph.js"></script></body></html>`;
+}
+
+function callGraphHarness(graph: unknown): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Compass call graph fixture</title><link rel="stylesheet" href="/viewer.css"></head><body><div id="root"></div><script>
+window.callGraphHostMessages=[];
+window.acquireVsCodeApi=()=>({postMessage(message){
+  window.callGraphHostMessages.push(message);
+  if(message.type==="openSource") {
+    window.openedCallGraphSource=message.source;
+    return;
+  }
+  if(message.type==="showOutput") {
+    window.showedCallGraphOutput=true;
+    return;
+  }
+  if(message.type!=="ready" && message.type!=="retry") return;
+  if(new URLSearchParams(window.location.search).has("error")) {
+    setTimeout(()=>window.postMessage({type:"error",message:"No function could be resolved at this cursor position."},"*"),20);
+    return;
+  }
+  setTimeout(()=>window.postMessage({
+    type:"hydrateCallGraph",
+    repositoryId:"fixture",
+    graph:${JSON.stringify(graph)}
+  },"*"),1000);
+}})</script><script src="/callGraph.js"></script></body></html>`;
 }
 
 function communityHarness(overview: unknown, detail: unknown): string {

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -83,16 +83,27 @@ export default async function generate(): Promise<void> {
     path.join(output, "community.html"),
     communityHarness(communityOverview, communityDetail)
   );
+  const architectureSections = Array.from({ length: 26 }, (_, index) => ({
+    id: `section-${index}`,
+    name: `Section ${index}`,
+    communities: [`${index}`],
+    nodes: index === 0
+      ? [{ id: "run", label: "run", kind: "function", sourceFile: "src/lib.rs" }]
+      : [],
+    edges: []
+  }));
   const architecture = {
     schema: "compass.viewer.callflow/1",
     title: "Fixture — Architecture Flow",
     sections: [
       { id: "overview", name: "Overview", communities: [], nodes: [], edges: [] },
-      { id: "core", name: "Core", communities: ["0"], nodes: [
-        { id: "run", label: "run", kind: "function", sourceFile: "src/lib.rs" }
-      ], edges: [] }
+      ...architectureSections
     ],
-    overviewLinks: [],
+    overviewLinks: Array.from({ length: 25 }, (_, index) => ({
+      sourceSection: `section-${index}`,
+      targetSection: `section-${index + 1}`,
+      calls: index + 1
+    })),
     reportHighlights: [],
     statistics: { nodes: 1, edges: 0, communities: 1, hyperedges: 0, extracted: 0, inferred: 0, ambiguous: 0 },
     provenance: { projectName: "Fixture", builtAtCommit: null, generatedAt: null }
@@ -102,28 +113,79 @@ export default async function generate(): Promise<void> {
     rootSymbol: "run",
     direction: "both",
     depth: 1,
-    nodes: [{ id: "run", symbol: "run", name: "run", file: "src/lib.rs", anchor: { source_file: "src/lib.rs", start_byte: 0, end_byte: 10 }, graphNodeId: "run", unresolved: false }],
-    edges: [],
-    truncated: false,
-    continuations: [],
-    coverage: { resolved: 0, inferred: 0, ambiguous: 0, unresolved: 0, warning: "Unresolved calls never prove absence." }
+    nodes: [
+      { id: "run", symbol: "run", name: "run", file: "src/lib.rs", anchor: { source_file: "src/lib.rs", start_byte: 0, end_byte: 10 }, graphNodeId: "run", unresolved: false },
+      { id: "helper", symbol: "helper", name: "helper", file: "src/lib.rs", anchor: { source_file: "src/lib.rs", start_byte: 11, end_byte: 20 }, graphNodeId: "helper", unresolved: false }
+    ],
+    edges: [{
+      id: "run-helper", source: "run", target: "helper", callee: "helper",
+      resolution: "resolved",
+      callSites: [{ anchor: { source_file: "src/lib.rs", start_byte: 4, end_byte: 10 }, evidence: ["fixture"] }]
+    }],
+    truncated: true,
+    continuations: Array.from({ length: 21 }, (_, index) => ({
+      symbol: `continuation-${index}`,
+      direction: index % 2 === 0 ? "callers" : "callees",
+      nextDepth: 2
+    })),
+    coverage: { resolved: 1, inferred: 0, ambiguous: 0, unresolved: 0, warning: "Unresolved calls never prove absence." }
   };
+  const commitA = "a".repeat(40);
+  const commitB = "b".repeat(40);
+  const commitC = "c".repeat(40);
   const timeline = {
     schema: "compass.history.timeline/1",
     repositoryId: "fixture",
-    selectedHead: "a".repeat(40),
+    selectedHead: commitA,
     historyEnabled: true,
-    entries: [{
-      commit: "a".repeat(40), parents: [], authorName: "Compass", authorEmail: "test@example.invalid",
-      authoredAtSeconds: 1, subject: "Initial graph", graphState: "graph_available",
-      presentationAvailable: true, realization: "r", fingerprint: "f", job: null
-    }]
+    entries: [
+      {
+        commit: commitA, parents: [], authorName: "Compass", authorEmail: "test@example.invalid",
+        authoredAtSeconds: 1, subject: "Revision A graph", graphState: "graph_available",
+        presentationAvailable: true, realization: "ra", fingerprint: "fa", job: null
+      },
+      {
+        commit: commitB, parents: [commitA], authorName: "Compass", authorEmail: "test@example.invalid",
+        authoredAtSeconds: 2, subject: "Revision B graph", graphState: "graph_available",
+        presentationAvailable: true, realization: "rb", fingerprint: "fb", job: null
+      },
+      {
+        commit: commitC, parents: [commitB], authorName: "Compass", authorEmail: "test@example.invalid",
+        authoredAtSeconds: 3, subject: "Revision C needs build", graphState: "not_materialized",
+        presentationAvailable: false, realization: null, fingerprint: null, job: null
+      }
+    ]
+  };
+  const historyOverviewA = { ...communityOverview, title: "Revision A graph" };
+  const historyOverviewB = {
+    ...communityOverview,
+    title: "Revision B graph",
+    nodes: communityOverview.nodes.map((node) => ({
+      ...node,
+      label: `${node.label} B`
+    })),
+    communities: communityOverview.communities.map((community) => ({
+      ...community,
+      label: `${community.label} B`
+    }))
+  };
+  const historyOverviewC = {
+    ...historyOverviewB,
+    title: "Revision C graph"
   };
   await writeFile(path.join(output, "architecture.html"), harness("architecture", { type: "hydrate", repositoryId: "fixture", model: architecture }));
   await writeFile(path.join(output, "calls.html"), harness("callGraph", { type: "hydrateCallGraph", repositoryId: "fixture", graph: calls }));
   await writeFile(
     path.join(output, "history.html"),
-    historyHarness(timeline, communityOverview, communityDetail)
+    historyHarness(
+      timeline,
+      {
+        [commitA]: historyOverviewA,
+        [commitB]: historyOverviewB,
+        [commitC]: historyOverviewC
+      },
+      communityDetail
+    )
   );
   await writeFile(path.join(output, "query.html"), harness("query", { type: "state", running: false }));
 }
@@ -165,17 +227,75 @@ window.acquireVsCodeApi=()=>({getState(){return window.webviewState},setState(st
 }})</script><script src="/vscodeGraph.js"></script></body></html>`;
 }
 
-function historyHarness(timeline: { entries: Array<{ commit: string }> }, overview: unknown, detail: unknown): string {
-  const commit = timeline.entries[0]?.commit ?? "";
+function historyHarness(
+  timeline: { entries: Array<{ commit: string }> },
+  graphs: Record<string, unknown>,
+  detail: unknown
+): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Compass history fixture</title><link rel="stylesheet" href="/viewer.css"></head><body><div id="root"></div><script>
+window.fixtureTimeline=${JSON.stringify(timeline)};
+window.historyGraphs=${JSON.stringify(graphs)};
+window.historyHostMessages=[];
+window.emitHistoryMessage=(message)=>window.postMessage(message,"*");
 window.acquireVsCodeApi=()=>({postMessage(message){
+  window.historyHostMessages.push(message);
   if(message.type==="ready") {
-    setTimeout(()=>window.postMessage({type:"timeline",repositoryId:"fixture",timeline:${JSON.stringify(timeline)}},"*"),0);
+    setTimeout(()=>window.postMessage({type:"timeline",repositoryId:"fixture",timeline:window.fixtureTimeline},"*"),0);
   } else if(message.type==="loadRevision") {
-    setTimeout(()=>window.postMessage({type:"graph",commit:${JSON.stringify(commit)},graph:${JSON.stringify(overview)}},"*"),0);
+    const delay=message.commit.startsWith("a") ? 180 : 0;
+    setTimeout(()=>window.postMessage({
+      type:"graph",
+      commit:message.commit,
+      realization:"r-"+message.commit.slice(0,1),
+      fingerprint:"f-"+message.commit.slice(0,1),
+      graph:window.historyGraphs[message.commit]
+    },"*"),delay);
+  } else if(message.type==="changeCounts") {
+    setTimeout(()=>window.postMessage({
+      type:"changeCounts",
+      commit:message.commit,
+      counts:{
+        schema:"compass.history.change_counts/1",
+        commit:message.commit,
+        parent:message.commit.startsWith("c") ? "b".repeat(40) : "a".repeat(40),
+        counts:{
+          nodes:{added:2,removed:0,changed:1},
+          edges:{added:1,removed:0,changed:0},
+          hyperedges:{added:0,removed:0,changed:0}
+        }
+      }
+    },"*"),20);
   } else if(message.type==="openCommunity") {
     window.openedHistoricalCommunity=message.communityId;
-    setTimeout(()=>window.postMessage({type:"communityGraph",requestId:message.requestId,commit:${JSON.stringify(commit)},communityId:message.communityId,graph:${JSON.stringify(detail)}},"*"),0);
+    setTimeout(()=>window.postMessage({type:"communityGraph",requestId:message.requestId,commit:message.commit,communityId:message.communityId,graph:${JSON.stringify(detail)}},"*"),0);
+  } else if(message.type==="compare") {
+    setTimeout(()=>window.postMessage({
+      type:"comparison",
+      commit:message.commit,
+      parent:message.parent,
+      realization:"r-"+message.commit.slice(0,1),
+      fingerprint:"f-"+message.commit.slice(0,1),
+      currentGraph:window.historyGraphs[message.commit],
+      parentGraph:window.historyGraphs[message.parent],
+      semanticDiff:{findings:[{summary:"Fixture comparison"}]}
+    },"*"),0);
+  } else if(message.type==="buildRevision") {
+    const scenario=new URLSearchParams(window.location.search).get("build") || "cancel";
+    if(scenario==="cancel") {
+      setTimeout(()=>window.postMessage({type:"buildCancelled",commit:message.commit},"*"),180);
+    } else {
+      setTimeout(()=>window.postMessage({type:"buildRunning",commit:message.commit},"*"),100);
+      if(scenario==="fail") {
+        setTimeout(()=>window.postMessage({type:"buildFailed",commit:message.commit,message:"Fixture build failed"},"*"),220);
+      } else {
+        setTimeout(()=>{
+          const entry=window.fixtureTimeline.entries.find(candidate=>candidate.commit===message.commit);
+          Object.assign(entry,{graphState:"graph_available",presentationAvailable:true,realization:"rc",fingerprint:"fc"});
+          window.postMessage({type:"timeline",repositoryId:"fixture",timeline:window.fixtureTimeline},"*");
+          window.postMessage({type:"buildSucceeded",commit:message.commit},"*");
+        },220);
+      }
+    }
   } else if(message.type==="openSource") {
     window.openedSource=message.source;
   }

--- a/tests/viewer/graph-parity.spec.ts
+++ b/tests/viewer/graph-parity.spec.ts
@@ -26,7 +26,26 @@ test("VS Code graph mirrors Compass export structure and exposes source metadata
   await expect(page.getByRole("status")).toContainText("Inspecting helper");
   await expect(page.locator(".compass-metadata-grid")).toContainText("5–7");
   await expect(page.locator(".compass-signature-block")).toContainText("fn helper()");
-  await expect(page.getByRole("button", { name: /open source/i })).toBeVisible();
+  const source = page.getByRole("button", {
+    name: "Open source src/lib.rs at lines 5–7"
+  });
+  await expect(source).toBeVisible();
+  await expect(source.locator(".compass-source-path")).toHaveText("src/lib.rs");
+  await expect(source.locator(".compass-source-range")).toHaveText("Lines 5–7");
+  const neighbors = page.locator(".compass-neighbor-link");
+  await expect(neighbors).toHaveCount(2);
+  await expect(neighbors.locator(".compass-neighbor-dot")).toHaveCount(2);
+  await expect(neighbors.first()).toHaveCSS("border-left-width", "0px");
+
+  await page.evaluate(() => {
+    window.addEventListener("compass:open-source", ((event: CustomEvent) => {
+      (window as typeof window & { openedSource?: unknown }).openedSource = event.detail;
+    }) as EventListener);
+  });
+  await source.click();
+  await expect.poll(() => page.evaluate(
+    () => (window as typeof window & { openedSource?: unknown }).openedSource
+  )).toEqual({ file: "src/lib.rs", startLine: 5, endLine: 7 });
   expect(external).toEqual([]);
 });
 
@@ -46,6 +65,11 @@ test("file-only graph nodes stay inspectable without source navigation", async (
   expect(await page.evaluate(
     () => (window as typeof window & { openedSource?: unknown }).openedSource
   )).toBeUndefined();
+
+  await page.getByRole("combobox", { name: "Search graph nodes" }).fill("Store");
+  await page.getByRole("option", { name: /Store/i }).click();
+  await expect(page.locator(".compass-source-metadata")).toContainText("Not recorded");
+  await expect(page.getByRole("button", { name: /open source/i })).toHaveCount(0);
 });
 
 test("single-click inspects and double-click opens the selected node's exact range", async ({

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -13,14 +13,149 @@ test("historical graph lazily enters a community and returns to its overview", a
   const search = page.getByRole("combobox", { name: "Search graph nodes" });
   await search.fill("Core");
   await page.getByRole("option", { name: /Core/i }).click();
-  await expect(page.getByRole("status")).toContainText("Inspecting Core");
+  await expect(
+    page.getByRole("toolbar", { name: "Graph controls" }).getByRole("status")
+  ).toContainText("Inspecting Core");
   await page.getByRole("button", { name: "Open community" }).click();
   await expect.poll(() => page.evaluate(
     () => (window as typeof window & { openedHistoricalCommunity?: number })
       .openedHistoricalCommunity
   )).toBe(0);
+  await expect.poll(() => page.evaluate(() => {
+    const messages = (window as typeof window & {
+      historyHostMessages: Array<Record<string, unknown>>;
+    }).historyHostMessages;
+    return messages.find((message) => message.type === "openCommunity");
+  })).toMatchObject({
+    commit: "a".repeat(40),
+    realization: "r-a",
+    fingerprint: "f-a"
+  });
   await expect(page.getByRole("button", { name: "Back to community overview" })).toBeVisible();
   await page.getByRole("button", { name: "Back to community overview" }).click();
   await expect(page.getByRole("button", { name: "Back to community overview" })).toHaveCount(0);
   await expect(page.getByText("Data", { exact: true })).toBeVisible();
+});
+
+test("late revision and derived responses cannot replace the selected commit", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.getByRole("button", { name: /open graph/i }).click();
+  await page.getByRole("option", { name: /Revision B graph/i }).click();
+  await page.getByRole("button", { name: /open graph/i }).click();
+
+  await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+  await expect(page.locator("small").filter({ hasText: "Revision B graph" })).toBeVisible();
+  await expect(page.getByText("nodes +2 −0 ~1", { exact: true })).toBeVisible();
+
+  await page.evaluate(() => {
+    const fixture = window as typeof window & {
+      emitHistoryMessage(message: unknown): void;
+      historyGraphs: Record<string, unknown>;
+    };
+    const commitA = "a".repeat(40);
+    fixture.emitHistoryMessage({
+      type: "comparison",
+      commit: commitA,
+      parent: "",
+      realization: "r-a",
+      fingerprint: "f-a",
+      currentGraph: fixture.historyGraphs[commitA],
+      parentGraph: fixture.historyGraphs[commitA],
+      semanticDiff: { findings: [{ summary: "Stale comparison" }] }
+    });
+    fixture.emitHistoryMessage({
+      type: "changeCounts",
+      commit: commitA,
+      counts: {
+        schema: "compass.history.change_counts/1",
+        commit: commitA,
+        parent: "",
+        counts: {
+          nodes: { added: 99, removed: 0, changed: 0 },
+          edges: { added: 99, removed: 0, changed: 0 },
+          hyperedges: { added: 99, removed: 0, changed: 0 }
+        }
+      }
+    });
+    fixture.emitHistoryMessage({
+      type: "communityError",
+      requestId: "stale",
+      commit: commitA,
+      communityId: 0,
+      message: "Stale community failure"
+    });
+    fixture.emitHistoryMessage({
+      type: "error",
+      operation: "Compare revisions",
+      commit: commitA,
+      message: "Revision A comparison failed"
+    });
+  });
+
+  await page.waitForTimeout(250);
+  await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+  await expect(page.locator("small").filter({ hasText: "Revision B graph" })).toBeVisible();
+  await expect(page.getByText("nodes +2 −0 ~1", { exact: true })).toBeVisible();
+  await expect(page.getByText("Semantic change findings")).toHaveCount(0);
+  await expect(page.getByText("Stale community failure")).toHaveCount(0);
+  await expect(page.getByText("Revision A comparison failed")).toHaveCount(0);
+
+  await page.getByRole("option", { name: /Revision A graph/i }).click();
+  await expect(page.getByText("Revision A comparison failed")).toHaveCount(0);
+  await expect(page.getByText("Semantic change findings")).toHaveCount(0);
+});
+
+test("unavailable comparison explains how to recover", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.getByRole("option", { name: /Revision C needs build/i }).click();
+  await expect(page.getByRole("button", { name: /Compare parent 1/i })).toBeDisabled();
+  await expect(page.getByText("Comparison unavailable: build this revision first.")).toBeVisible();
+});
+
+test("selected operation errors stay beside the commit and out of semantic findings", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.evaluate(() => {
+    const fixture = window as typeof window & {
+      emitHistoryMessage(message: unknown): void;
+    };
+    fixture.emitHistoryMessage({
+      type: "error",
+      operation: "Load graph",
+      commit: "a".repeat(40),
+      message: "Fixture graph load failed"
+    });
+  });
+  await expect(page.getByRole("alert")).toContainText(
+    "Load graph: Fixture graph load failed"
+  );
+  await expect(page.getByText("Semantic change findings")).toHaveCount(0);
+});
+
+test("cancelled build returns the revision action to idle", async ({ page }) => {
+  await page.goto("/history.html?build=cancel");
+  await page.getByRole("option", { name: /Revision C needs build/i }).click();
+  await page.getByRole("button", { name: "Build graph" }).click();
+  await expect(page.getByRole("button", { name: "Choosing profile…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Build graph" })).toBeEnabled();
+  await expect(page.getByRole("alert")).toHaveCount(0);
+});
+
+test("failed build reports recovery and permits retry", async ({ page }) => {
+  await page.goto("/history.html?build=fail");
+  await page.getByRole("option", { name: /Revision C needs build/i }).click();
+  await page.getByRole("button", { name: "Build graph" }).click();
+  await expect(page.getByRole("button", { name: "Choosing profile…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Building…" })).toBeDisabled();
+  await expect(page.getByRole("alert")).toContainText("Build failed: Fixture build failed");
+  await expect(page.getByRole("button", { name: "Retry build" })).toBeEnabled();
+});
+
+test("successful build refreshes availability and comparison controls", async ({ page }) => {
+  await page.goto("/history.html?build=success");
+  await page.getByRole("option", { name: /Revision C needs build/i }).click();
+  await page.getByRole("button", { name: "Build graph" }).click();
+  await expect(page.getByRole("button", { name: "Building…" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Open graph" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: /Compare parent 1/i })).toBeEnabled();
+  await expect(page.getByText(/Comparison unavailable/)).toHaveCount(0);
 });


### PR DESCRIPTION
## Context

Historical graph responses could arrive out of order and replace presentation
state for a newer selection. Revision builds also lacked explicit
cancellation/failure recovery, and architecture/call-graph list limits silently
hid loaded results.

The graph inspector also split source evidence and navigation across duplicate
controls, connected-node colors read as heavy selection rails, and the call
graph opened with an unbalanced top-left resolver sentence and no recovery
surface.

## Changes

### Trust and correctness

- Make the history webview the controlled authority for selected-commit graph,
  comparison, counts, community, build, and operation state.
- Reject stale revision-bound responses and show the accepted short commit
  beside every visible historical graph.
- Round-trip realization/fingerprint identity with community requests so late
  load completion order cannot corrupt drilldown.
- Add explicit requesting, running, succeeded, failed, and cancelled build
  transitions; cancel active work when the panel closes; bound user-facing
  failures; and route JSONL validation failures through the command promise.
- Keep operational failures beside revision actions and separate from semantic
  findings.
- Disable unavailable parent comparisons with recovery guidance.
- Disclose the 24-flow and 20-continuation initial limits with counts and Show
  all actions.
- Show call-graph node/edge counts and an explicit partial-results alert when
  the contract is truncated.

### Inspector and loading UX

- Make the Source metadata card the single source-navigation action, with an
  External Link icon and exact line or byte range in its visible and accessible
  labels.
- Preserve file-only metadata without presenting a false action, and show
  `Not recorded` when no source exists.
- Replace connected-node color rails with compact community-colored dots.
- Reuse Compass's centered, theme-aware, reduced-motion constellation while
  resolving the function under the editor cursor.
- Add call-graph-specific progress phases and recoverable Retry / Show Compass
  output actions.
- Gate root and expansion responses by resolution generation so superseded
  requests and disposed panels cannot overwrite fresh state.

## Validation

- `npm run typecheck:js`
- `npm run test:js` — 22 viewer unit tests, 33 extension unit tests, and 27
  Playwright tests passed, including accessibility and performance coverage
- `npm run build:viewer`
- `npm run build:vscode`
- `npm run test:integration -w editors/vscode` — 1 extension-host integration
  test passed
- `npm run package -w editors/vscode`
- `npm run smoke:vsix -w editors/vscode`
- `git diff --check`
- Independent final code review: no Critical or Important findings

## Scope boundaries

- No Compass CLI query-limit changes.
- No serializer or graph-contract limit changes.
- No runtime output-path changes; Compass artifacts remain under
  `compass-out/`.
- Generated `graphify-out/`, `compass-out/`, VSIX, and other local output
  directories are not committed.
