### PR TITLE
Lazy-load Codebase Evolution history and enable revision graphs

### DIFF
--- a/crates/compass-cli/src/capability_commands.rs
+++ b/crates/compass-cli/src/capability_commands.rs
@@ -40,6 +40,7 @@ pub fn command(frontend: Frontend, args: &[String]) -> Outcome {
             ("program", true),
             ("query", true),
             ("history", true),
+            ("history_timeline_pagination", true),
             ("semantic_diff", true),
             ("community_detail", true),
         ]),

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -15,7 +15,7 @@ use crate::{Frontend, Outcome};
 pub(crate) fn help(_frontend: Frontend) -> String {
     let prefix = "compass";
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
     )
 }
 
@@ -862,6 +862,8 @@ fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, 
     let mut revision = "HEAD".to_owned();
     let mut revision_selected = false;
     let mut format = "json".to_owned();
+    let mut limit = None;
+    let mut after = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -885,6 +887,28 @@ fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, 
                 revision_selected = true;
             }
             value if value.starts_with("--format=") => format = value[9..].to_owned(),
+            "--limit" => {
+                index += 1;
+                let value = args
+                    .get(index)
+                    .ok_or_else(|| usage("--limit requires a value"))?;
+                limit = Some(parse_timeline_limit(value)?);
+            }
+            value if value.starts_with("--limit=") => {
+                limit = Some(parse_timeline_limit(&value[8..])?);
+            }
+            "--after" => {
+                index += 1;
+                after = Some(
+                    args.get(index)
+                        .filter(|value| !value.is_empty())
+                        .ok_or_else(|| usage("--after requires a cursor"))?
+                        .clone(),
+                );
+            }
+            value if value.starts_with("--after=") && value.len() > 8 => {
+                after = Some(value[8..].to_owned());
+            }
             value => return Err(usage(format!("unknown history timeline option {value}"))),
         }
         index += 1;
@@ -892,30 +916,72 @@ fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, 
     if format != "json" {
         return Err(usage("history timeline requires --format json"));
     }
+    if after.is_some() && limit.is_none() {
+        return Err(usage("history timeline --after requires --limit"));
+    }
     let head = repository.resolve(&revision).map_err(runtime)?;
-    let mut commits = if revision_selected {
-        repository
-            .reachable_commits(&head, false)
-            .map_err(runtime)?
+    let snapshot = if revision_selected {
+        format!("revision-{}", head.as_str())
     } else {
-        repository.all_reachable_commits().map_err(runtime)?
+        repository.reference_snapshot().map_err(runtime)?
     };
-    commits.reverse();
+    let start = after
+        .as_deref()
+        .map(parse_timeline_cursor)
+        .transpose()?
+        .map(|cursor| {
+            if cursor.snapshot != snapshot {
+                Err(usage(
+                    "history timeline snapshot changed; reload the timeline",
+                ))
+            } else {
+                Ok(cursor.offset)
+            }
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let (commits, has_more) = if let Some(limit) = limit {
+        let request_limit = limit.saturating_add(1);
+        let mut page = if revision_selected {
+            repository
+                .reachable_commit_page(&head, start, request_limit)
+                .map_err(runtime)?
+        } else {
+            repository
+                .all_reachable_commit_page(start, request_limit)
+                .map_err(runtime)?
+        };
+        let has_more = page.len() > limit;
+        page.truncate(limit);
+        (page, has_more)
+    } else {
+        let mut commits = if revision_selected {
+            repository
+                .reachable_commits(&head, false)
+                .map_err(runtime)?
+        } else {
+            repository.all_reachable_commits().map_err(runtime)?
+        };
+        commits.reverse();
+        (commits, false)
+    };
+    let end = start.saturating_add(commits.len());
+    let total_entries = (!has_more).then_some(end);
+    let next_cursor = has_more.then(|| timeline_cursor(&snapshot, end));
     let history = HistoryStore::open_existing(repository).map_err(runtime)?;
     let versions = history
         .as_ref()
-        .map(|store| store.list(None))
+        .map(|store| store.preferred_many(&commits))
         .transpose()
         .map_err(runtime)?
         .unwrap_or_default();
     let preferred = versions
         .into_iter()
-        .filter(|version| version.preferred)
         .map(|version| (version.version.git_commit.clone(), version))
         .collect::<std::collections::BTreeMap<_, _>>();
     let jobs = HistoryQueue::open_existing(repository)
         .map_err(runtime)?
-        .map(|queue| queue.list())
+        .map(|queue| queue.latest_for_commits(&commits))
         .transpose()
         .map_err(runtime)?
         .unwrap_or_default()
@@ -932,10 +998,11 @@ fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, 
                 latest
             },
         );
+    let metadata = repository.timeline_commits(&commits).map_err(runtime)?;
     let entries = commits
         .into_iter()
-        .map(|commit| {
-            let metadata = repository.timeline_commit(&commit).map_err(runtime)?;
+        .zip(metadata)
+        .map(|(commit, metadata)| {
             let version = preferred.get(commit.as_str());
             let job = jobs.get(commit.as_str());
             let graph_state = if version.is_some() {
@@ -968,9 +1035,59 @@ fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, 
         "repositoryId": repository.common_dir().to_string_lossy(),
         "selectedHead": head,
         "historyEnabled": config.enabled,
+        "totalEntries": total_entries,
+        "hasMore": has_more,
+        "nextCursor": next_cursor,
         "entries": entries,
     }))
     .map_err(runtime)
+}
+
+fn parse_timeline_limit(value: &str) -> Result<usize, CommandFailure> {
+    let limit = value
+        .parse::<usize>()
+        .map_err(|_| usage("history timeline --limit must be a positive integer"))?;
+    if !(1..=1000).contains(&limit) {
+        return Err(usage("history timeline --limit must be between 1 and 1000"));
+    }
+    Ok(limit)
+}
+
+struct TimelineCursor {
+    snapshot: String,
+    offset: usize,
+}
+
+fn timeline_cursor(snapshot: &str, offset: usize) -> String {
+    format!("v1:{snapshot}:{offset}")
+}
+
+fn parse_timeline_cursor(value: &str) -> Result<TimelineCursor, CommandFailure> {
+    let mut fields = value.split(':');
+    let version = fields.next();
+    let snapshot = fields.next();
+    let offset = fields.next();
+    if version != Some("v1")
+        || snapshot.is_none_or(|snapshot| {
+            snapshot.is_empty()
+                || snapshot.len() > 80
+                || !snapshot
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+        || fields.next().is_some()
+    {
+        return Err(usage(
+            "history timeline cursor is invalid; reload the timeline",
+        ));
+    }
+    let offset = offset
+        .and_then(|offset| offset.parse::<usize>().ok())
+        .ok_or_else(|| usage("history timeline cursor is invalid; reload the timeline"))?;
+    Ok(TimelineCursor {
+        snapshot: snapshot.unwrap_or_default().to_owned(),
+        offset,
+    })
 }
 
 fn execute_gc(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {

--- a/crates/compass-cli/tests/capabilities_cli.rs
+++ b/crates/compass-cli/tests/capabilities_cli.rs
@@ -14,6 +14,7 @@ fn capabilities_reports_versioned_ide_contracts() -> Result<(), Box<dyn Error>> 
     assert_eq!(value["schema"], "compass.ide.capabilities/1");
     assert_eq!(value["contracts"]["graph_viewer"], "compass.viewer.graph/1");
     assert_eq!(value["features"]["community_detail"], true);
+    assert_eq!(value["features"]["history_timeline_pagination"], true);
     assert!(value["compass_version"].is_string());
     Ok(())
 }

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -121,6 +121,84 @@ fn history_help_and_empty_status_are_actionable_and_non_mutating()
 }
 
 #[test]
+fn timeline_pages_newest_commits_with_a_stable_cursor() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    for subject in ["first", "second", "third"] {
+        std::fs::write(directory.path().join("fixture"), subject)?;
+        git(directory.path(), &["add", "fixture"])?;
+        git(directory.path(), &["commit", "--quiet", "-m", subject])?;
+    }
+    let compass = env!("CARGO_BIN_EXE_compass");
+    let first_page = run(
+        compass,
+        directory.path(),
+        &["history", "timeline", "--limit", "2", "--format=json"],
+    )?;
+    assert!(
+        first_page.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first_page.stderr)
+    );
+    let first_page: serde_json::Value = serde_json::from_slice(&first_page.stdout)?;
+    assert_eq!(first_page["totalEntries"], serde_json::Value::Null);
+    assert_eq!(first_page["hasMore"], true);
+    assert_eq!(first_page["entries"][0]["subject"], "third");
+    assert_eq!(first_page["entries"][1]["subject"], "second");
+    let cursor = first_page["nextCursor"].as_str().ok_or("missing cursor")?;
+
+    let second_page = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "timeline",
+            "--limit",
+            "2",
+            "--after",
+            cursor,
+            "--format=json",
+        ],
+    )?;
+    assert!(second_page.status.success());
+    let second_page: serde_json::Value = serde_json::from_slice(&second_page.stdout)?;
+    assert_eq!(second_page["totalEntries"], 3);
+    assert_eq!(second_page["hasMore"], false);
+    assert_eq!(second_page["nextCursor"], serde_json::Value::Null);
+    assert_eq!(second_page["entries"].as_array().map(Vec::len), Some(1));
+    assert_eq!(second_page["entries"][0]["subject"], "first");
+
+    std::fs::write(directory.path().join("fixture"), "fourth")?;
+    git(directory.path(), &["add", "fixture"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "fourth"])?;
+    let stale_page = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "timeline",
+            "--limit",
+            "2",
+            "--after",
+            cursor,
+            "--format=json",
+        ],
+    )?;
+    assert_eq!(stale_page.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&stale_page.stderr).contains("snapshot changed"),
+        "{}",
+        String::from_utf8_lossy(&stale_page.stderr)
+    );
+    Ok(())
+}
+
+#[test]
 fn enable_disable_are_explicit_idempotent_and_invalid_profiles_roll_back()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-history/src/gc.rs
+++ b/crates/compass-history/src/gc.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use crate::config::now_millis;
-use crate::durable::remove_file_durable;
 use crate::store::{STORE_FORMAT_ROOT, reject_directory, reject_symlink};
 use crate::{HistoryError, HistoryQueue, HistoryStore, JobState, RealizationId};
 
@@ -248,21 +247,19 @@ impl HistoryStore {
     }
 
     fn delete_expired_jobs(&self, names: &[String]) -> Result<usize, HistoryError> {
-        let root = self.root.join("jobs");
-        let mut deleted = 0;
+        if names.is_empty() {
+            return Ok(0);
+        }
+        let queue = HistoryQueue::open_root_existing(&self.root)?.ok_or_else(|| {
+            HistoryError::OperationalState(
+                "history queue disappeared before job cleanup".to_owned(),
+            )
+        })?;
         for name in names {
             validate_cleanup_name(name, ".json")?;
-            let path = root.join(name);
-            if path.parent() != Some(root.as_path()) {
-                return Err(HistoryError::UnsafePath {
-                    path,
-                    reason: "job cleanup target escaped its root".to_owned(),
-                });
-            }
-            remove_file_durable(&path)?;
-            deleted += 1;
         }
-        Ok(deleted)
+        // Queue writers use the same lock across invalidation, deletion, and index rebuild.
+        queue.delete_job_records(names)
     }
 
     fn delete_expired_temp_directories(&self, names: &[String]) -> Result<usize, HistoryError> {

--- a/crates/compass-history/src/git.rs
+++ b/crates/compass-history/src/git.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::{CommitId, HistoryError, TimelineCommit};
 
@@ -237,53 +238,101 @@ impl Repository {
             .collect()
     }
 
-    /// Return presentation metadata for one exact commit without touching the worktree.
-    pub fn timeline_commit(&self, commit: &CommitId) -> Result<TimelineCommit, HistoryError> {
+    /// Return a bounded newest-first page reachable from one exact tip.
+    pub fn reachable_commit_page(
+        &self,
+        tip: &CommitId,
+        skip: usize,
+        limit: usize,
+    ) -> Result<Vec<CommitId>, HistoryError> {
+        let max_count = format!("--max-count={limit}");
+        let skip = format!("--skip={skip}");
         let output = git_output(
             &self.root,
             &[
-                "show",
-                "-s",
-                "--format=%H%x00%P%x00%an%x00%ae%x00%at%x00%s",
+                "rev-list",
+                "--topo-order",
+                &max_count,
+                &skip,
                 "--end-of-options",
-                commit.as_str(),
+                tip.as_str(),
             ],
         )?;
-        let text = std::str::from_utf8(&output).map_err(|error| {
-            HistoryError::Git(format!("Git returned non-UTF-8 history: {error}"))
-        })?;
-        let fields = text.trim_end().split('\0').collect::<Vec<_>>();
-        if fields.len() != 6 {
-            return Err(HistoryError::Git(
-                "Git returned malformed timeline metadata".to_owned(),
-            ));
+        parse_commit_lines(&output)
+    }
+
+    /// Return a bounded newest-first page reachable from current local references.
+    pub fn all_reachable_commit_page(
+        &self,
+        skip: usize,
+        limit: usize,
+    ) -> Result<Vec<CommitId>, HistoryError> {
+        let max_count = format!("--max-count={limit}");
+        let skip = format!("--skip={skip}");
+        let output = git_output(
+            &self.root,
+            &["rev-list", "--topo-order", &max_count, &skip, "--all"],
+        )?;
+        parse_commit_lines(&output)
+    }
+
+    /// Hash the current local reference tips so a stateless page cursor can reject ref changes.
+    pub fn reference_snapshot(&self) -> Result<String, HistoryError> {
+        let output = git_output(&self.root, &["show-ref", "--head"])?;
+        Ok(format!("{:x}", Sha256::digest(output)))
+    }
+
+    /// Return presentation metadata for one exact commit without touching the worktree.
+    pub fn timeline_commit(&self, commit: &CommitId) -> Result<TimelineCommit, HistoryError> {
+        self.timeline_commits(std::slice::from_ref(commit))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| HistoryError::Git(format!("Git did not return commit {commit}")))
+    }
+
+    /// Return presentation metadata for exact commits using bounded batched Git processes.
+    pub fn timeline_commits(
+        &self,
+        commits: &[CommitId],
+    ) -> Result<Vec<TimelineCommit>, HistoryError> {
+        const BATCH_SIZE: usize = 256;
+        let mut metadata = std::collections::HashMap::with_capacity(commits.len());
+        for batch in commits.chunks(BATCH_SIZE) {
+            let mut arguments = vec![
+                "log",
+                "--no-walk=unsorted",
+                "-z",
+                "--format=%H%x00%P%x00%an%x00%ae%x00%at%x00%s",
+                "--end-of-options",
+            ];
+            arguments.extend(batch.iter().map(CommitId::as_str));
+            let output = git_output(&self.root, &arguments)?;
+            let text = std::str::from_utf8(&output).map_err(|error| {
+                HistoryError::Git(format!("Git returned non-UTF-8 history: {error}"))
+            })?;
+            let mut fields = text.split('\0').collect::<Vec<_>>();
+            if fields.last() == Some(&"") {
+                fields.pop();
+            }
+            if fields.len() != batch.len() * 6 {
+                return Err(HistoryError::Git(
+                    "Git returned malformed timeline metadata".to_owned(),
+                ));
+            }
+            for fields in fields.chunks_exact(6) {
+                let entry = parse_timeline_fields(fields)?;
+                metadata.insert(entry.commit.to_string(), entry);
+            }
         }
-        let commit = fields[0]
-            .parse()
-            .map_err(|_| HistoryError::Git("Git returned an invalid commit ID".to_owned()))?;
-        let parents = if fields[1].is_empty() {
-            Vec::new()
-        } else {
-            fields[1]
-                .split_ascii_whitespace()
-                .map(|value| {
-                    value.parse().map_err(|_| {
-                        HistoryError::Git(format!("Git returned invalid parent ID {value}"))
-                    })
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        };
-        let authored_at_seconds = fields[4].parse().map_err(|_| {
-            HistoryError::Git("Git returned an invalid author timestamp".to_owned())
-        })?;
-        Ok(TimelineCommit {
-            commit,
-            parents,
-            author_name: fields[2].to_owned(),
-            author_email: fields[3].to_owned(),
-            authored_at_seconds,
-            subject: fields[5].to_owned(),
-        })
+        commits
+            .iter()
+            .map(|commit| {
+                metadata
+                    .get(commit.as_str())
+                    .cloned()
+                    .ok_or_else(|| HistoryError::Git(format!("Git did not return commit {commit}")))
+            })
+            .collect()
     }
 
     /// Inspect committed-tree and repository filter limitations without creating a worktree.
@@ -392,6 +441,47 @@ impl Repository {
         guard.limitations = target_limitations(&guard.path)?;
         Ok(guard)
     }
+}
+
+fn parse_commit_lines(output: &[u8]) -> Result<Vec<CommitId>, HistoryError> {
+    std::str::from_utf8(output)
+        .map_err(|error| HistoryError::Git(format!("Git returned non-UTF-8 history: {error}")))?
+        .lines()
+        .map(|value| {
+            value.parse().map_err(|_| {
+                HistoryError::Git(format!("Git returned invalid reachable commit ID {value}"))
+            })
+        })
+        .collect()
+}
+
+fn parse_timeline_fields(fields: &[&str]) -> Result<TimelineCommit, HistoryError> {
+    let commit = fields[0]
+        .parse()
+        .map_err(|_| HistoryError::Git("Git returned an invalid commit ID".to_owned()))?;
+    let parents = if fields[1].is_empty() {
+        Vec::new()
+    } else {
+        fields[1]
+            .split_ascii_whitespace()
+            .map(|value| {
+                value.parse().map_err(|_| {
+                    HistoryError::Git(format!("Git returned invalid parent ID {value}"))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let authored_at_seconds = fields[4]
+        .parse()
+        .map_err(|_| HistoryError::Git("Git returned an invalid author timestamp".to_owned()))?;
+    Ok(TimelineCommit {
+        commit,
+        parents,
+        author_name: fields[2].to_owned(),
+        author_email: fields[3].to_owned(),
+        authored_at_seconds,
+        subject: fields[5].to_owned(),
+    })
 }
 
 fn parse_name_status(bytes: &[u8]) -> Result<Vec<SourceFileDelta>, HistoryError> {

--- a/crates/compass-history/src/jobs.rs
+++ b/crates/compass-history/src/jobs.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::{now_millis, operational_root};
-use crate::durable::{read_json_bounded, write_json_atomic};
+use crate::durable::{read_json_bounded, remove_file_durable, write_json_atomic};
 use crate::leases;
 use crate::store::{create_owner_dir, reject_directory, reject_symlink};
 use crate::validate::exceeds_limit;
@@ -86,8 +87,19 @@ pub struct JobRequest {
 pub struct HistoryQueue {
     root: PathBuf,
     jobs: PathBuf,
+    latest: PathBuf,
     leases: PathBuf,
     lock_root: PathBuf,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LatestJobPointer {
+    id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct LatestIndexState {
+    complete: bool,
 }
 
 impl HistoryQueue {
@@ -95,17 +107,22 @@ impl HistoryQueue {
     pub fn open(root: &Path) -> Result<Self, HistoryError> {
         create_owner_dir(root)?;
         let jobs = root.join("jobs");
+        let latest = root.join("latest");
         let leases = root.join("leases");
         let lock_root = root.join("locks");
         create_owner_dir(&jobs)?;
+        create_owner_dir(&latest)?;
         create_owner_dir(&leases)?;
         create_owner_dir(&lock_root)?;
-        Ok(Self {
+        let queue = Self {
             root: root.to_path_buf(),
             jobs,
+            latest,
             leases,
             lock_root,
-        })
+        };
+        queue.ensure_latest_index()?;
+        Ok(queue)
     }
 
     pub fn for_repository(repository: &Repository) -> Result<Self, HistoryError> {
@@ -132,12 +149,19 @@ impl HistoryQueue {
         }
         let leases = root.join("leases");
         let lock_root = root.join("locks");
+        let latest = root.join("latest");
         reject_directory(&jobs)?;
+        if latest.exists() {
+            reject_directory(&latest)?;
+        } else {
+            reject_symlink(&latest, true)?;
+        }
         reject_directory(&leases)?;
         reject_directory(&lock_root)?;
         Ok(Some(Self {
             root,
             jobs,
+            latest,
             leases,
             lock_root,
         }))
@@ -206,7 +230,7 @@ impl HistoryQueue {
             created_at_millis,
             updated_at_millis: created_at_millis,
         };
-        write_json_atomic(&self.job_path(&id)?, &record)?;
+        self.write_job(&record)?;
         Ok(id)
     }
 
@@ -222,6 +246,58 @@ impl HistoryQueue {
     pub fn list(&self) -> Result<Vec<JobRecord>, HistoryError> {
         let _lock = QueueLock::acquire(&self.lock_root)?;
         self.list_unlocked()
+    }
+
+    /// Load only the latest indexed job for each requested commit.
+    ///
+    /// Legacy queues are scanned once to populate the derived index. Subsequent calls read one
+    /// pointer per requested commit, and a damaged or stale index is repaired from job records.
+    pub fn latest_for_commits(&self, commits: &[CommitId]) -> Result<Vec<JobRecord>, HistoryError> {
+        if self.latest_index_complete()
+            && let Some(jobs) = self.read_latest_index(commits)
+        {
+            return Ok(jobs);
+        }
+
+        let latest = self.list_unlocked()?.into_iter().fold(
+            HashMap::<CommitId, JobRecord>::new(),
+            |mut latest, job| {
+                let replace = latest
+                    .get(&job.commit)
+                    .is_none_or(|current| job_is_newer(&job, current));
+                if replace {
+                    latest.insert(job.commit.clone(), job);
+                }
+                latest
+            },
+        );
+        Ok(commits
+            .iter()
+            .filter_map(|commit| latest.get(commit).cloned())
+            .collect())
+    }
+
+    fn read_latest_index(&self, commits: &[CommitId]) -> Option<Vec<JobRecord>> {
+        if !self.latest.is_dir() {
+            return None;
+        }
+        let mut jobs = Vec::with_capacity(commits.len());
+        for commit in commits {
+            let path = self.latest.join(format!("{commit}.json"));
+            if !path.exists() {
+                if reject_symlink(&path, true).is_err() {
+                    return None;
+                }
+                continue;
+            }
+            let pointer: LatestJobPointer = read_json_bounded(&path).ok()?;
+            let job = self.get(&pointer.id).ok()??;
+            if &job.commit != commit {
+                return None;
+            }
+            jobs.push(job);
+        }
+        Some(jobs)
     }
 
     pub fn claim_next(&self) -> Result<Option<ClaimedJob>, HistoryError> {
@@ -244,7 +320,7 @@ impl HistoryQueue {
             job.lease_generation = lease.generation();
             job.updated_at_millis = now_millis();
             job.diagnostic = None;
-            write_json_atomic(&self.job_path(&job.id)?, &job)?;
+            self.write_job(&job)?;
             return Ok(Some(ClaimedJob { record: job, lease }));
         }
         Ok(None)
@@ -273,7 +349,7 @@ impl HistoryQueue {
         job.lease_generation = lease.generation();
         job.updated_at_millis = now_millis();
         job.diagnostic = None;
-        write_json_atomic(&self.job_path(&job.id)?, &job)?;
+        self.write_job(&job)?;
         Ok(Some(ClaimedJob { record: job, lease }))
     }
 
@@ -299,7 +375,7 @@ impl HistoryQueue {
         current.state = state;
         current.updated_at_millis = now_millis();
         current.diagnostic = diagnostic.map(redact_diagnostic);
-        write_json_atomic(&self.job_path(&current.id)?, &current)?;
+        self.write_job(&current)?;
         Ok(current)
     }
 
@@ -330,7 +406,7 @@ impl HistoryQueue {
             current.observed_preferred = observed_preferred;
         }
         current.updated_at_millis = now_millis();
-        write_json_atomic(&self.job_path(&current.id)?, &current)?;
+        self.write_job(&current)?;
         Ok(current)
     }
 
@@ -358,7 +434,7 @@ impl HistoryQueue {
         record.updated_at_millis = now_millis();
         record.diagnostic = diagnostic.map(redact_diagnostic);
         record.preferred = preferred;
-        write_json_atomic(&self.job_path(&record.id)?, &record)?;
+        self.write_job(&record)?;
         leases::release(&claimed.lease)?;
         Ok(record)
     }
@@ -418,6 +494,153 @@ impl HistoryQueue {
         Ok(job)
     }
 
+    fn write_job(&self, job: &JobRecord) -> Result<(), HistoryError> {
+        let restore_complete = self.invalidate_latest_index()?;
+        write_json_atomic(&self.job_path(&job.id)?, job)?;
+        // Latest-job pointers are a repairable cache. Once the authoritative record is durable,
+        // cache maintenance must not make a state transition appear to have failed or retain a
+        // worker lease that should have been released.
+        let _index_result = self.update_latest_index(job, restore_complete);
+        Ok(())
+    }
+
+    pub(crate) fn invalidate_latest_index(&self) -> Result<bool, HistoryError> {
+        let was_complete = self.latest_index_complete();
+        // This must become durable before the authoritative job write. If the process stops
+        // after that write but before its pointer is published, readers will scan job records
+        // instead of trusting a stale complete index.
+        self.write_latest_index_state(false)?;
+        Ok(was_complete)
+    }
+
+    fn update_latest_index(
+        &self,
+        job: &JobRecord,
+        restore_complete: bool,
+    ) -> Result<(), HistoryError> {
+        create_owner_dir(&self.latest)?;
+        let pointer_path = self.latest.join(format!("{}.json", job.commit));
+        let replace = if pointer_path.exists() {
+            let pointer: LatestJobPointer = read_json_bounded(&pointer_path)?;
+            self.get(&pointer.id)?
+                .is_none_or(|current| job_is_newer(job, &current))
+        } else {
+            reject_symlink(&pointer_path, true)?;
+            true
+        };
+        if replace {
+            write_json_atomic(&pointer_path, &LatestJobPointer { id: job.id.clone() })?;
+        }
+        if restore_complete {
+            self.write_latest_index_state(true)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn ensure_latest_index(&self) -> Result<(), HistoryError> {
+        if self.latest_index_complete() {
+            return Ok(());
+        }
+        let _lock = QueueLock::acquire(&self.lock_root)?;
+        if self.latest_index_complete() {
+            return Ok(());
+        }
+        self.rebuild_latest_index_from_jobs()
+    }
+
+    pub(crate) fn delete_job_records(&self, names: &[String]) -> Result<usize, HistoryError> {
+        let paths = names
+            .iter()
+            .map(|name| {
+                let id = name.strip_suffix(".json").ok_or_else(|| {
+                    HistoryError::OperationalState("invalid job cleanup target".to_owned())
+                })?;
+                let path = self.job_path(id)?;
+                if path.file_name().and_then(|value| value.to_str()) != Some(name) {
+                    return Err(HistoryError::OperationalState(
+                        "invalid job cleanup target".to_owned(),
+                    ));
+                }
+                Ok(path)
+            })
+            .collect::<Result<Vec<_>, HistoryError>>()?;
+        let _lock = QueueLock::acquire(&self.lock_root)?;
+        self.invalidate_latest_index()?;
+        for path in &paths {
+            remove_file_durable(path)?;
+        }
+        self.rebuild_latest_index_from_jobs()?;
+        Ok(paths.len())
+    }
+
+    fn rebuild_latest_index_from_jobs(&self) -> Result<(), HistoryError> {
+        let latest = self.list_unlocked()?.into_iter().fold(
+            HashMap::<CommitId, JobRecord>::new(),
+            |mut latest, job| {
+                let replace = latest
+                    .get(&job.commit)
+                    .is_none_or(|current| job_is_newer(&job, current));
+                if replace {
+                    latest.insert(job.commit.clone(), job);
+                }
+                latest
+            },
+        );
+        self.rebuild_latest_index(&latest)
+    }
+
+    fn rebuild_latest_index(
+        &self,
+        latest: &HashMap<CommitId, JobRecord>,
+    ) -> Result<(), HistoryError> {
+        self.write_latest_index_state(false)?;
+        create_owner_dir(&self.latest)?;
+        for job in latest.values() {
+            write_json_atomic(
+                &self.latest.join(format!("{}.json", job.commit)),
+                &LatestJobPointer { id: job.id.clone() },
+            )?;
+        }
+        for entry in fs::read_dir(&self.latest)
+            .map_err(|source| crate::error::io_error(&self.latest, source))?
+        {
+            let entry = entry.map_err(|source| crate::error::io_error(&self.latest, source))?;
+            let path = entry.path();
+            let Some(commit) = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .and_then(|stem| stem.parse::<CommitId>().ok())
+            else {
+                continue;
+            };
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "json")
+                && !latest.contains_key(&commit)
+            {
+                remove_file_durable(&path)?;
+            }
+        }
+        self.write_latest_index_state(true)
+    }
+
+    fn latest_index_complete(&self) -> bool {
+        let path = self.latest_index_state_path();
+        path.exists()
+            && read_json_bounded::<LatestIndexState>(&path).is_ok_and(|state| state.complete)
+    }
+
+    fn write_latest_index_state(&self, complete: bool) -> Result<(), HistoryError> {
+        write_json_atomic(
+            &self.latest_index_state_path(),
+            &LatestIndexState { complete },
+        )
+    }
+
+    fn latest_index_state_path(&self) -> PathBuf {
+        self.root.join("latest-index.json")
+    }
+
     fn job_path(&self, id: &str) -> Result<PathBuf, HistoryError> {
         if id.len() != 64
             || !id
@@ -433,6 +656,18 @@ impl HistoryQueue {
         self.leases
             .join(format!("{}-{}.lease", job.commit, job.profile_digest))
     }
+}
+
+fn job_is_newer(candidate: &JobRecord, current: &JobRecord) -> bool {
+    (
+        candidate.updated_at_millis,
+        candidate.created_at_millis,
+        &candidate.id,
+    ) >= (
+        current.updated_at_millis,
+        current.created_at_millis,
+        &current.id,
+    )
 }
 
 fn valid_transition(old: JobState, new: JobState) -> bool {

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -390,6 +390,21 @@ impl HistoryStore {
         self.preferred_with_activity(commit, &guard)
     }
 
+    /// Load preferred realizations for exact commits under one shared activity guard.
+    pub fn preferred_many(
+        &self,
+        commits: &[CommitId],
+    ) -> Result<Vec<PublishedVersion>, HistoryError> {
+        let _guard = self.activity()?;
+        let mut versions = Vec::with_capacity(commits.len());
+        for commit in commits {
+            if let Some(version) = self.preferred_without_activity(commit)? {
+                versions.push(version);
+            }
+        }
+        Ok(versions)
+    }
+
     pub fn preferred_with_activity(
         &self,
         commit: &CommitId,

--- a/crates/compass-history/tests/git.rs
+++ b/crates/compass-history/tests/git.rs
@@ -111,6 +111,45 @@ fn reachable_commits_are_parent_first_and_can_follow_only_first_parents()
 }
 
 #[test]
+fn timeline_commits_preserve_requested_order_in_one_batch() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("fixture"), "one")?;
+    git(directory.path(), &["add", "fixture"])?;
+    git(
+        directory.path(),
+        &["commit", "--quiet", "-m", "first subject"],
+    )?;
+    let repository = Repository::discover(directory.path())?;
+    let first = repository.resolve("HEAD")?;
+    std::fs::write(directory.path().join("fixture"), "two")?;
+    git(directory.path(), &["add", "fixture"])?;
+    git(
+        directory.path(),
+        &["commit", "--quiet", "-m", "second subject"],
+    )?;
+    let second = repository.resolve("HEAD")?;
+
+    let timeline = repository.timeline_commits(&[second.clone(), first.clone()])?;
+
+    assert_eq!(
+        timeline
+            .iter()
+            .map(|entry| (&entry.commit, entry.subject.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(&second, "second subject"), (&first, "first subject")]
+    );
+    assert_eq!(timeline[0].parents, vec![first]);
+    Ok(())
+}
+
+#[test]
 fn sha256_repository_ids_are_accepted_when_git_supports_them()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-history/tests/jobs.rs
+++ b/crates/compass-history/tests/jobs.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use std::sync::{Arc, Barrier};
 
 use compass_history::{
-    BuildProfile, HistoryConfig, HistoryQueue, JobRequest, JobState, Repository,
+    BuildProfile, CommitId, HistoryConfig, HistoryQueue, JobRequest, JobState, Repository,
 };
 
 fn git(directory: &Path, arguments: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
@@ -67,6 +67,83 @@ fn jobs_follow_the_allowed_state_machine_and_survive_reopen()
             .state,
         JobState::Published
     );
+    Ok(())
+}
+
+#[test]
+fn latest_jobs_are_loaded_directly_for_requested_commits() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_directory, repository) = repository()?;
+    let queue = HistoryQueue::for_repository(&repository)?;
+    let queue_root = queue.root().to_path_buf();
+    let first: CommitId = "1111111111111111111111111111111111111111".parse()?;
+    let second: CommitId = "2222222222222222222222222222222222222222".parse()?;
+    let ignored: CommitId = "3333333333333333333333333333333333333333".parse()?;
+    queue.enqueue(JobRequest {
+        commit: first.clone(),
+        profile: profile()?,
+    })?;
+    let second_id = queue.enqueue(JobRequest {
+        commit: second.clone(),
+        profile: profile()?,
+    })?;
+    queue.enqueue(JobRequest {
+        commit: ignored,
+        profile: profile()?,
+    })?;
+    drop(queue);
+
+    // Queues created before the latest-job index was introduced have only job records.
+    std::fs::remove_dir_all(queue_root.join("latest"))?;
+    std::fs::remove_file(queue_root.join("latest-index.json"))?;
+    let queue = HistoryQueue::open_existing(&repository)?.ok_or("queue")?;
+
+    let latest = queue.latest_for_commits(&[second, first])?;
+
+    assert_eq!(latest.len(), 2);
+    assert_eq!(latest[0].id, second_id);
+    assert!(!queue_root.join("latest").exists());
+    assert!(!queue_root.join("latest-index.json").exists());
+    drop(queue);
+
+    // The next writer performs the one-time migration.
+    let queue = HistoryQueue::for_repository(&repository)?;
+    assert!(queue_root.join("latest").is_dir());
+    assert!(queue_root.join("latest-index.json").is_file());
+    assert_eq!(
+        queue.latest_for_commits(&[latest[0].commit.clone()])?.len(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn derived_index_failure_does_not_fail_a_durable_job_transition()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let queue = HistoryQueue::open(directory.path())?;
+    let id = queue.enqueue(JobRequest {
+        commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse()?,
+        profile: profile()?,
+    })?;
+    let claimed = queue.claim_next()?.ok_or("claim")?;
+    queue.transition(&claimed, JobState::Validating, None)?;
+
+    let latest = directory.path().join("latest");
+    let saved_latest = directory.path().join("latest.saved");
+    std::fs::rename(&latest, &saved_latest)?;
+    std::fs::write(&latest, b"index unavailable")?;
+    let finished = queue.finish(&claimed, JobState::Published, Some(true), None);
+    std::fs::remove_file(&latest)?;
+    std::fs::rename(&saved_latest, &latest)?;
+
+    assert_eq!(finished?.state, JobState::Published);
+    assert_eq!(queue.get(&id)?.ok_or("job")?.state, JobState::Published);
+    let lease = directory.path().join("leases").join(format!(
+        "{}-{}.lease",
+        claimed.commit, claimed.profile_digest
+    ));
+    assert!(!lease.exists());
     Ok(())
 }
 

--- a/crates/compass-history/tests/maintenance.rs
+++ b/crates/compass-history/tests/maintenance.rs
@@ -136,8 +136,9 @@ fn cleanup_respects_age_terminal_state_and_live_leases() -> Result<(), Box<dyn s
     let history = HistoryStore::create(&fixture.repository)?;
     let queue = HistoryQueue::for_repository(&fixture.repository)?;
     let profile = BuildProfile::default();
+    let old_commit = "1111111111111111111111111111111111111111".parse()?;
     let old_terminal = queue.enqueue(JobRequest {
-        commit: "1111111111111111111111111111111111111111".parse()?,
+        commit: old_commit,
         profile: profile.clone(),
     })?;
     let claimed = queue.claim_or_join(&old_terminal)?.ok_or("claim")?;
@@ -171,6 +172,15 @@ fn cleanup_respects_age_terminal_state_and_live_leases() -> Result<(), Box<dyn s
     assert!(queue.get(&old_terminal)?.is_none());
     assert!(queue.get(&young_terminal)?.is_some());
     assert!(queue.get(&active)?.is_some());
+    assert!(
+        !queue
+            .root()
+            .join("latest/1111111111111111111111111111111111111111.json")
+            .exists()
+    );
+    let index: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(queue.root().join("latest-index.json"))?)?;
+    assert_eq!(index["complete"], true);
     assert!(!stale.exists());
     Ok(())
 }

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -611,16 +611,19 @@ compass export json [--community ID]
 compass export callflow-json --output PATH
 compass program call-graph (--symbol SYMBOL | --source FILE --byte BYTE)
   [--direction callers|callees|both] [--depth N] --format json
-compass history timeline [--rev REV] --format json
+compass history timeline [--rev REV] [--limit N [--after CURSOR]] --format json
 compass history change-counts REV [--parent REV] --format json
 compass history export REV --format json [--community ID] [--node-limit N] --output PATH
 ```
 
 `history timeline` is inspection-only and defaults to all commits reachable
-from local refs. `history change-counts` requires existing preferred
-realizations for both revisions and never builds them. Guided writers accept
-`--events jsonl`; stdout then contains `compass.ide.progress/1` events and
-human diagnostics move to stderr.
+from local refs. `--limit` returns the newest bounded page, and `--after` uses
+the preceding page's opaque `nextCursor`. A cursor rejects local-ref changes
+instead of silently mixing snapshots. Responses include `hasMore`,
+`nextCursor`, and `totalEntries` once the final page establishes the exact
+count. `history change-counts` requires existing preferred realizations for
+both revisions and never builds them. Guided writers accept `--events jsonl`; stdout then contains
+`compass.ide.progress/1` events and human diagnostics move to stderr.
 
 `json` is the canonical versioned graph-presentation export. `viewer-json`
 remains accepted as a deprecated compatibility alias.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -70,7 +70,14 @@ you to choose one.
 
 Open **Codebase evolution** from **Workspace > Explore** or the Command Palette.
 The left rail lists every reachable Git commit and shows whether its Compass
-graph is available, not materialized, building, or failed.
+graph is available, not materialized, building, or failed. Compass opens the
+newest 100 commits first and loads more as you scroll; loaded pages remain
+cached while the Codebase Evolution panel is open.
+
+If revision graphs are disabled, choose **Enable revision graphs** inside
+Codebase Evolution, then select either the recommended local **Code only**
+profile or the **Compass default profile** resolved by the CLI. The timeline
+reloads automatically after enablement.
 
 Select a commit, then:
 

--- a/editors/vscode/src/history/buildArguments.test.ts
+++ b/editors/vscode/src/history/buildArguments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildHistoryArgs } from "./buildArguments";
+import { buildEnableHistoryArgs, buildHistoryArgs } from "./buildArguments";
 
 describe("history build arguments", () => {
   it("supports configured, code-only, and inherited profiles with JSONL events", () => {
@@ -18,5 +18,14 @@ describe("history build arguments", () => {
       firstParent: false,
       profile: { kind: "code-only" }
     })).toContain("--code-only");
+  });
+
+  it("enables either a local code-only profile or the CLI default profile", () => {
+    expect(buildEnableHistoryArgs("code-only")).toEqual([
+      "history", "enable", "--code-only"
+    ]);
+    expect(buildEnableHistoryArgs("default")).toEqual([
+      "history", "enable"
+    ]);
   });
 });

--- a/editors/vscode/src/history/buildArguments.ts
+++ b/editors/vscode/src/history/buildArguments.ts
@@ -19,3 +19,11 @@ export function buildHistoryArgs(options: {
     "jsonl"
   ];
 }
+
+export function buildEnableHistoryArgs(profile: "code-only" | "default"): string[] {
+  return [
+    "history",
+    "enable",
+    ...(profile === "code-only" ? ["--code-only"] : [])
+  ];
+}

--- a/editors/vscode/src/history/panelMessages.test.ts
+++ b/editors/vscode/src/history/panelMessages.test.ts
@@ -3,8 +3,10 @@ import type { HistoryHostMessage } from "./panelMessages";
 import { historyOperationFor } from "./panelMessages";
 
 describe("history panel messages", () => {
-  it("labels retryTimeline as history loading", () => {
+  it("labels timeline and enablement operations", () => {
     expect(historyOperationFor({ type: "retryTimeline" })).toBe("Load history");
+    expect(historyOperationFor({ type: "loadMoreTimeline" })).toBe("Load more history");
+    expect(historyOperationFor({ type: "enableHistory" })).toBe("Enable history");
   });
 
   it("supports recoverable bootstrap failures", () => {

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -7,6 +7,8 @@ import type {
 
 export type HistoryOperation =
   | "Load history"
+  | "Load more history"
+  | "Enable history"
   | "Load graph"
   | "Build graph"
   | "Compare revisions"
@@ -18,6 +20,8 @@ export type HistoryOperation =
 export type HistoryWebviewMessage =
   | { type: "ready" }
   | { type: "retryTimeline" }
+  | { type: "loadMoreTimeline" }
+  | { type: "enableHistory" }
   | { type: "loadRevision"; commit: string }
   | { type: "buildRevision"; commit: string }
   | { type: "compare"; commit: string; parent: string }
@@ -39,8 +43,14 @@ export type HistoryWebviewMessage =
   };
 
 export type HistoryHostMessage =
-  | { type: "timeline"; timeline: HistoryTimeline; repositoryId: string }
+  | { type: "timeline"; timeline: HistoryTimeline; repositoryId: string; generation: number }
+  | { type: "timelinePage"; timeline: HistoryTimeline; repositoryId: string; generation: number }
+  | { type: "timelinePageError"; message: string; generation: number }
   | { type: "bootstrapError"; message: string }
+  | { type: "enableRunning" }
+  | { type: "enableSucceeded" }
+  | { type: "enableCancelled" }
+  | { type: "enableFailed"; message: string }
   | {
     type: "graph";
     commit: string;
@@ -90,6 +100,8 @@ export function historyOperationFor(message: unknown): HistoryOperation {
     : undefined;
   switch (type) {
     case "retryTimeline": return "Load history";
+    case "loadMoreTimeline": return "Load more history";
+    case "enableHistory": return "Enable history";
     case "loadRevision": return "Load graph";
     case "buildRevision": return "Build graph";
     case "compare": return "Compare revisions";

--- a/editors/vscode/src/history/timelineClient.test.ts
+++ b/editors/vscode/src/history/timelineClient.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadTimeline } from "./timelineClient";
+
+describe("history timeline client", () => {
+  it("requests a bounded first page and continues from the last loaded commit", async () => {
+    const runJson = vi.fn().mockResolvedValue({
+      schema: "compass.history.timeline/1",
+      repositoryId: "repo",
+      selectedHead: "head",
+      historyEnabled: true,
+      totalEntries: 200,
+      hasMore: true,
+      nextCursor: "cursor",
+      entries: []
+    });
+    const session = {
+      root: "/repo",
+      processes: { runJson }
+    };
+
+    await loadTimeline(session as never, { limit: 100 });
+    await loadTimeline(session as never, { limit: 100, after: "cursor" });
+    await loadTimeline(session as never, { limit: 1, revision: "selected" });
+
+    expect(runJson.mock.calls.map((call) => call[1])).toEqual([
+      ["history", "timeline", "--limit", "100", "--format", "json"],
+      ["history", "timeline", "--limit", "100", "--after", "cursor", "--format", "json"],
+      ["history", "timeline", "--rev", "selected", "--limit", "1", "--format", "json"]
+    ]);
+  });
+});

--- a/editors/vscode/src/history/timelineClient.ts
+++ b/editors/vscode/src/history/timelineClient.ts
@@ -1,10 +1,21 @@
 import { HistoryTimelineSchema, type HistoryTimeline } from "@compass/viewer/contracts/history";
 import type { RepositorySession } from "../workspace/repositorySession";
 
-export async function loadTimeline(session: RepositorySession): Promise<HistoryTimeline> {
+export async function loadTimeline(
+  session: RepositorySession,
+  page?: { limit: number; after?: string; revision?: string }
+): Promise<HistoryTimeline> {
   return session.processes.runJson(
     session.root,
-    ["history", "timeline", "--format", "json"],
+    [
+      "history",
+      "timeline",
+      ...(page?.revision ? ["--rev", page.revision] : []),
+      ...(page ? ["--limit", String(page.limit)] : []),
+      ...(page?.after ? ["--after", page.after] : []),
+      "--format",
+      "json"
+    ],
     HistoryTimelineSchema
   );
 }

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import * as vscode from "vscode";
 import type { HistoryTimeline } from "@compass/viewer";
-import { buildHistoryArgs } from "../history/buildArguments";
+import { buildEnableHistoryArgs, buildHistoryArgs } from "../history/buildArguments";
 import { loadSemanticDiff } from "../history/diffClient";
 import { loadChangeCounts } from "../history/changeCountsClient";
 import { RevisionStore } from "../history/revisionStore";
@@ -13,6 +13,8 @@ import {
 import type { RepositorySession } from "../workspace/repositorySession";
 import { openGraphSource } from "./sourceNavigation";
 import { openQueryPanel } from "./queryPanel";
+
+const TIMELINE_PAGE_SIZE = 100;
 
 export async function openHistoryPanel(
   context: vscode.ExtensionContext,
@@ -37,6 +39,8 @@ export async function openHistoryPanel(
   );
   let timeline: HistoryTimeline | undefined;
   let initialization: Promise<void> | undefined;
+  let timelinePageLoading = false;
+  let timelineGeneration = 0;
   const graphNodeLimit = vscode.workspace
     .getConfiguration("compass")
     .get("graphNodeLimit", 5000);
@@ -52,17 +56,90 @@ export async function openHistoryPanel(
     initialization ??= revisions.initialize();
     return initialization;
   };
+  const pagedTimeline = session.capabilities?.features.history_timeline_pagination === true;
   const sendTimeline = async (): Promise<void> => {
+    const generation = ++timelineGeneration;
     try {
       await ensureInitialized();
-      timeline = await loadTimeline(session);
-      await postMessage({ type: "timeline", timeline, repositoryId: session.id });
+      const loaded = await loadTimeline(
+        session,
+        pagedTimeline ? { limit: TIMELINE_PAGE_SIZE } : undefined
+      );
+      if (generation !== timelineGeneration) return;
+      timeline = loaded;
+      await postMessage({ type: "timeline", timeline, repositoryId: session.id, generation });
     } catch (error) {
+      if (generation !== timelineGeneration) return;
       initialization = undefined;
       const detail = error instanceof Error ? error.message : String(error);
       output.appendLine(`[history:error] ${detail}`);
       await postMessage({ type: "bootstrapError", message: detail });
     }
+  };
+  const sendMoreTimeline = async (): Promise<void> => {
+    if (timelinePageLoading || !pagedTimeline || !timeline?.hasMore) return;
+    const cursor = timeline.nextCursor ?? timeline.entries.at(-1)?.commit;
+    if (!cursor) return;
+    const generation = timelineGeneration;
+    timelinePageLoading = true;
+    try {
+      const page = await loadTimeline(session, {
+        limit: TIMELINE_PAGE_SIZE,
+        after: cursor
+      });
+      if (generation !== timelineGeneration || !timeline) return;
+      const loaded = new Set(timeline.entries.map((entry) => entry.commit));
+      timeline = {
+        ...page,
+        entries: [
+          ...timeline.entries,
+          ...page.entries.filter((entry) => !loaded.has(entry.commit))
+        ]
+      };
+      await postMessage({
+        type: "timelinePage",
+        timeline: page,
+        repositoryId: session.id,
+        generation
+      });
+    } catch (error) {
+      if (generation !== timelineGeneration) return;
+      const detail = error instanceof Error ? error.message : String(error);
+      output.appendLine(`[history:error] ${detail}`);
+      if (detail.includes("snapshot changed") || detail.includes("cursor is invalid")) {
+        await sendTimeline();
+      } else {
+        await postMessage({ type: "timelinePageError", message: detail, generation });
+      }
+    } finally {
+      timelinePageLoading = false;
+    }
+  };
+  const refreshTimelineEntry = async (commit: string): Promise<void> => {
+    const generation = ++timelineGeneration;
+    let refreshedTimeline: HistoryTimeline;
+    if (!pagedTimeline) {
+      refreshedTimeline = await loadTimeline(session);
+    } else {
+      const refreshed = await loadTimeline(session, {
+        limit: 1,
+        revision: commit
+      });
+      const entry = refreshed.entries.find((candidate) => candidate.commit === commit);
+      if (timeline && entry) {
+        refreshedTimeline = {
+          ...timeline,
+          historyEnabled: refreshed.historyEnabled,
+          entries: timeline.entries.map((candidate) =>
+            candidate.commit === commit ? entry : candidate)
+        };
+      } else {
+        refreshedTimeline = refreshed;
+      }
+    }
+    if (generation !== timelineGeneration) return;
+    timeline = refreshedTimeline;
+    await postMessage({ type: "timeline", timeline, repositoryId: session.id, generation });
   };
   panel.onDidDispose(() => {
     disposed = true;
@@ -168,9 +245,17 @@ export async function openHistoryPanel(
       if (result.code !== 0) {
         throw new Error(result.stderr || `Compass exited with ${result.code}`);
       }
-      timeline = await loadTimeline(session);
-      await postMessage({ type: "timeline", timeline, repositoryId: session.id });
       await postMessage({ type: "buildSucceeded", commit });
+      try {
+        await refreshTimelineEntry(commit);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        output.appendLine(`[history:error] ${detail}`);
+        await postMessage({
+          type: "bootstrapError",
+          message: `The revision graph was built, but commit history could not be refreshed: ${detail}`
+        });
+      }
     } catch (error) {
       if (command && !buildAttempt?.cancelled) command.cancel();
       if (buildAttempt?.cancelled || disposed) {
@@ -193,10 +278,99 @@ export async function openHistoryPanel(
       }
     }
   };
+  const enableHistory = async (): Promise<void> => {
+    if (session.activeWriter) {
+      await postMessage({
+        type: "enableFailed",
+        message: "Another Compass write operation is already running."
+      });
+      return;
+    }
+    const picked = await vscode.window.showQuickPick(
+      [
+        {
+          label: "Code only",
+          description: "Recommended · local AST and inferred evidence; no model credentials",
+          value: "code-only" as const
+        },
+        {
+          label: "Compass default profile",
+          description: "Let the CLI resolve its configured provider; may be local or non-semantic",
+          value: "default" as const
+        }
+      ],
+      { title: "Enable Compass revision graphs" }
+    );
+    if (disposed) return;
+    if (!picked) {
+      await postMessage({ type: "enableCancelled" });
+      return;
+    }
+    if (session.activeWriter) {
+      await postMessage({
+        type: "enableFailed",
+        message: "Another Compass write operation started while choosing the history profile."
+      });
+      return;
+    }
+    const args = buildEnableHistoryArgs(picked.value);
+    const command = session.processes.startCommand(session.root, args);
+    let cancelled = false;
+    session.activeWriter = command;
+    await postMessage({ type: "enableRunning" });
+    try {
+      const result = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Enabling Compass revision graphs",
+          cancellable: true
+        },
+        async (_, token) => {
+          token.onCancellationRequested(() => {
+            cancelled = true;
+            command.cancel();
+          });
+          output.appendLine(`> compass ${args.join(" ")}`);
+          return command.completed;
+        }
+      );
+      output.append(result.stdout);
+      output.append(result.stderr);
+      if (result.code !== 0) {
+        if (cancelled || disposed) {
+          await postMessage({ type: "enableCancelled" });
+          return;
+        }
+        throw new Error(result.stderr || `Compass exited with ${result.code}`);
+      }
+      if (disposed) return;
+      await postMessage({ type: "enableSucceeded" });
+      await sendTimeline();
+    } catch (error) {
+      if (cancelled || disposed) {
+        await postMessage({ type: "enableCancelled" });
+      } else {
+        const detail = error instanceof Error ? error.message : String(error);
+        output.appendLine(`[history:error] ${detail}`);
+        await postMessage({
+          type: "enableFailed",
+          message: conciseBuildError(detail)
+        });
+      }
+    } finally {
+      if (session.activeWriter?.operationId === command.operationId) {
+        session.activeWriter = undefined;
+      }
+    }
+  };
   panel.webview.onDidReceiveMessage(async (message) => {
     try {
       if (message?.type === "ready" || message?.type === "retryTimeline") {
         await sendTimeline();
+      } else if (message?.type === "loadMoreTimeline") {
+        await sendMoreTimeline();
+      } else if (message?.type === "enableHistory") {
+        await enableHistory();
       } else if (message?.type === "loadRevision" && typeof message.commit === "string") {
         const entry = timeline?.entries.find((candidate) => candidate.commit === message.commit);
         if (!entry) throw new Error("Reload commit history before opening this revision.");

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -36,6 +36,10 @@ let repositoryId = "";
 let changeCounts: HistoryChangeCounts | undefined;
 let revisionLoadState: "idle" | "loading" | "ready" = "idle";
 let bootstrapError: string | undefined;
+let loadingMore = false;
+let loadMoreError: string | undefined;
+let enableState: HistoryBuildState | undefined;
+let timelineGeneration = 0;
 const buildStates = new Map<string, HistoryBuildState>();
 const operationErrors = new Map<string, HistoryOperationError>();
 
@@ -58,14 +62,14 @@ function clearRevisionPresentation(): void {
 
 function requestChangeCounts(commit: string): void {
   const entry = timeline?.entries.find((candidate) => candidate.commit === commit);
-  if (entry?.presentationAvailable && entry.parents.length > 0) {
+  if (timeline?.historyEnabled && entry?.presentationAvailable && entry.parents.length > 0) {
     postMessage({ type: "changeCounts", commit });
   }
 }
 
 function requestSelectedRevision(commit: string): void {
   const entry = timeline?.entries.find((candidate) => candidate.commit === commit);
-  if (!entry?.presentationAvailable) {
+  if (!timeline?.historyEnabled || !entry?.presentationAvailable) {
     revisionLoadState = "idle";
     return;
   }
@@ -125,6 +129,9 @@ function render(): void {
       timeline={timeline}
       selectedCommit={selectedCommit}
       revisionLoadState={revisionLoadState}
+      enableState={enableState}
+      loadingMore={loadingMore}
+      loadMoreError={loadMoreError}
       buildState={buildStates.get(selectedCommit)}
       operationError={operationErrors.get(selectedCommit)}
       onSelectCommit={selectCommit}
@@ -143,6 +150,18 @@ function render(): void {
       semanticDiff={semanticDiff}
       changeCounts={changeCounts}
       host={{
+        enableHistory() {
+          enableState = { status: "requesting" };
+          render();
+          postMessage({ type: "enableHistory" });
+        },
+        loadMore() {
+          if (loadingMore || !timeline?.hasMore) return;
+          loadingMore = true;
+          loadMoreError = undefined;
+          render();
+          postMessage({ type: "loadMoreTimeline" });
+        },
         loadRevision(commit) {
           revisionLoadState = "loading";
           operationErrors.delete(commit);
@@ -192,10 +211,15 @@ function render(): void {
 window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => {
   const message = event.data;
   if (message?.type === "timeline") {
+    if (message.generation < timelineGeneration) return;
     const parsed = HistoryTimelineSchema.safeParse(message.timeline);
     if (parsed.success) {
+      timelineGeneration = message.generation;
       timeline = parsed.data;
       bootstrapError = undefined;
+      loadingMore = false;
+      loadMoreError = undefined;
+      enableState = undefined;
       repositoryId = message.repositoryId;
       const retainedCommit = timeline.entries.some((entry) => entry.commit === selectedCommit)
         ? selectedCommit
@@ -212,10 +236,38 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       requestChangeCounts(nextCommit);
       if (nextCommit && graphCommit !== nextCommit) requestSelectedRevision(nextCommit);
     }
+  } else if (message?.type === "timelinePage") {
+    const parsed = HistoryTimelineSchema.safeParse(message.timeline);
+    if (parsed.success
+      && timeline
+      && message.repositoryId === repositoryId
+      && message.generation === timelineGeneration) {
+      const loaded = new Set(timeline.entries.map((entry) => entry.commit));
+      timeline = {
+        ...parsed.data,
+        entries: [
+          ...timeline.entries,
+          ...parsed.data.entries.filter((entry) => !loaded.has(entry.commit))
+        ]
+      };
+      loadingMore = false;
+      loadMoreError = undefined;
+    }
+  } else if (message?.type === "timelinePageError") {
+    if (message.generation === timelineGeneration) {
+      loadingMore = false;
+      loadMoreError = message.message;
+    }
   } else if (message?.type === "bootstrapError") {
     bootstrapError = message.message;
     timeline = undefined;
     clearRevisionPresentation();
+  } else if (message?.type === "enableRunning") {
+    enableState = { status: "running" };
+  } else if (message?.type === "enableSucceeded" || message?.type === "enableCancelled") {
+    enableState = undefined;
+  } else if (message?.type === "enableFailed") {
+    enableState = { status: "failed", message: message.message };
   } else if (message?.type === "graph") {
     if (!acceptsCommit(message.commit)) return;
     const parsed = GraphViewModelSchema.safeParse(message.graph);

--- a/packages/compass-viewer/src/contracts/history.ts
+++ b/packages/compass-viewer/src/contracts/history.ts
@@ -12,6 +12,9 @@ export const HistoryTimelineSchema = z.object({
   repositoryId: z.string(),
   selectedHead: z.string(),
   historyEnabled: z.boolean(),
+  totalEntries: z.number().int().nonnegative().nullable().optional(),
+  hasMore: z.boolean().optional(),
+  nextCursor: z.string().nullable().optional(),
   entries: z.array(z.object({
     commit: z.string(),
     parents: z.array(z.string()),

--- a/packages/compass-viewer/src/history/CommitRail.tsx
+++ b/packages/compass-viewer/src/history/CommitRail.tsx
@@ -7,10 +7,16 @@ const ROW_HEIGHT = 68;
 export function CommitRail({
   entries,
   selected,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
   onSelect
 }: {
   entries: HistoryEntry[];
   selected: string;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?(): void;
   onSelect(commit: string): void;
 }) {
   const [scrollTop, setScrollTop] = useState(0);
@@ -35,7 +41,17 @@ export function CommitRail({
       aria-label="Git commit timeline"
       tabIndex={0}
       className="history-rail"
-      onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+      onScroll={(event) => {
+        const rail = event.currentTarget;
+        setScrollTop(rail.scrollTop);
+        if (
+          hasMore
+          && !loadingMore
+          && rail.scrollHeight - rail.scrollTop - rail.clientHeight <= ROW_HEIGHT * 5
+        ) {
+          onLoadMore?.();
+        }
+      }}
       onKeyDown={(event) => {
         const index = entries.findIndex((entry) => entry.commit === selected);
         const next = entries[index + 1];

--- a/packages/compass-viewer/src/history/HistoryWorkspace.test.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.test.tsx
@@ -1,0 +1,115 @@
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { CommitRail } from "./CommitRail";
+import type { HistoryHost } from "./HistoryWorkspace";
+import { HistoryWorkspace } from "./HistoryWorkspace";
+
+const commit = "a".repeat(40);
+
+beforeAll(() => {
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    disconnect() {}
+  });
+});
+
+function host(): HistoryHost {
+  return {
+    loadRevision: vi.fn(),
+    buildRevision: vi.fn(),
+    compare: vi.fn(),
+    queryRevision: vi.fn(),
+    loadChangeCounts: vi.fn(),
+    openSource: vi.fn(),
+    openCommunity: vi.fn(),
+    enableHistory: vi.fn(),
+    loadMore: vi.fn()
+  };
+}
+
+describe("HistoryWorkspace", () => {
+  it("lets the user enable revision graphs from the disabled state", () => {
+    const historyHost = host();
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    flushSync(() => root.render(
+      <HistoryWorkspace
+        timeline={{
+          schema: "compass.history.timeline/1",
+          repositoryId: "repo",
+          selectedHead: commit,
+          historyEnabled: false,
+          totalEntries: 1,
+          hasMore: false,
+          nextCursor: null,
+          entries: [{
+            commit,
+            parents: [],
+            authorName: "Compass",
+            authorEmail: "test@example.invalid",
+            authoredAtSeconds: 1,
+            subject: "Initial revision",
+            graphState: "not_materialized",
+            presentationAvailable: false,
+            realization: null,
+            fingerprint: null,
+            job: null
+          }]
+        }}
+        selectedCommit={commit}
+        revisionLoadState="idle"
+        onSelectCommit={vi.fn()}
+        host={historyHost}
+      />
+    ));
+
+    const button = Array.from(container.querySelectorAll("button"))
+      .find((candidate) => candidate.textContent === "Enable revision graphs");
+    button?.click();
+
+    expect(historyHost.enableHistory).toHaveBeenCalledOnce();
+    root.unmount();
+  });
+
+  it("loads another commit page when the user scrolls near the rail end", () => {
+    const loadMore = vi.fn();
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    flushSync(() => root.render(
+      <CommitRail
+        entries={Array.from({ length: 10 }, (_, index) => ({
+          commit: String(index).padStart(40, "a"),
+          parents: [],
+          authorName: "Compass",
+          authorEmail: "test@example.invalid",
+          authoredAtSeconds: index,
+          subject: `Revision ${index}`,
+          graphState: "not_materialized" as const,
+          presentationAvailable: false,
+          realization: null,
+          fingerprint: null,
+          job: null
+        }))}
+        selected=""
+        hasMore
+        loadingMore={false}
+        onLoadMore={loadMore}
+        onSelect={vi.fn()}
+      />
+    ));
+    const rail = container.querySelector<HTMLElement>('[role="listbox"]');
+    expect(rail).not.toBeNull();
+    if (!rail) return;
+    Object.defineProperties(rail, {
+      clientHeight: { value: 400 },
+      scrollHeight: { value: 800 },
+      scrollTop: { value: 350, configurable: true }
+    });
+
+    rail.dispatchEvent(new Event("scroll", { bubbles: true }));
+
+    expect(loadMore).toHaveBeenCalledOnce();
+    root.unmount();
+  });
+});

--- a/packages/compass-viewer/src/history/HistoryWorkspace.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.tsx
@@ -14,6 +14,8 @@ import { CommitRail } from "./CommitRail";
 import { SemanticFindings } from "./SemanticFindings";
 
 export type HistoryHost = {
+  enableHistory(): void;
+  loadMore(): void;
   loadRevision(commit: string): void;
   buildRevision(commit: string): void;
   compare(commit: string, parent: string): void;
@@ -35,6 +37,9 @@ export function HistoryWorkspace({
   onBackToOverview,
   selectedCommit,
   revisionLoadState,
+  enableState,
+  loadingMore = false,
+  loadMoreError,
   buildState,
   operationError,
   onSelectCommit,
@@ -51,6 +56,9 @@ export function HistoryWorkspace({
   onBackToOverview?: (() => void) | undefined;
   selectedCommit: string;
   revisionLoadState: "idle" | "loading" | "ready";
+  enableState?: HistoryBuildState | undefined;
+  loadingMore?: boolean | undefined;
+  loadMoreError?: string | undefined;
   buildState?: HistoryBuildState | undefined;
   operationError?: HistoryOperationError | undefined;
   onSelectCommit(commit: string): void;
@@ -73,6 +81,10 @@ export function HistoryWorkspace({
     [timeline.entries]
   );
   const visibleGraph = graph && graphCommit === selected?.commit ? graph : undefined;
+  const loadedEntries = timeline.entries.length;
+  const countLabel = timeline.hasMore
+    ? `${loadedEntries.toLocaleString()} loaded commits`
+    : `${(timeline.totalEntries ?? loadedEntries).toLocaleString()} reachable commits`;
 
   return (
     <div className="history-shell">
@@ -82,7 +94,7 @@ export function HistoryWorkspace({
             <HistoryIcon aria-hidden="true" />
             <div>
               <h1>Codebase evolution</h1>
-              <p>{timeline.entries.length.toLocaleString()} reachable commits</p>
+              <p>{countLabel}</p>
             </div>
           </div>
           <label className="history-search">
@@ -91,7 +103,9 @@ export function HistoryWorkspace({
             <input
               type="search"
               value={query}
-              placeholder="Search commits and graph states"
+              placeholder={timeline.hasMore
+                ? "Search loaded commits and graph states"
+                : "Search commits and graph states"}
               aria-label="Search commit history"
               onChange={(event) => setQuery(event.target.value)}
             />
@@ -114,17 +128,56 @@ export function HistoryWorkspace({
         <CommitRail
           entries={entries}
           selected={selected?.commit ?? ""}
+          hasMore={timeline.hasMore ?? false}
+          loadingMore={loadingMore}
+          onLoadMore={host.loadMore}
           onSelect={onSelectCommit}
         />
+        {timeline.hasMore && (
+          <div className="history-pagination" role={loadingMore ? "status" : undefined}>
+            {loadingMore ? (
+              "Loading more commits…"
+            ) : (
+              <>
+                {loadMoreError && <span role="alert">{loadMoreError}</span>}
+                <button type="button" className="workbench-button" onClick={host.loadMore}>
+                  {loadMoreError ? "Retry loading commits" : "Load more commits"}
+                </button>
+              </>
+            )}
+          </div>
+        )}
       </aside>
 
       <main className="history-content">
         {!timeline.historyEnabled ? (
-          <WorkspaceState
-            kind="unavailable"
-            title="Revision graphs are not enabled"
-            description="Enable a Compass history profile for this repository, then reload Codebase Evolution."
-          />
+          enableState?.status === "requesting" ? (
+            <WorkspaceState
+              kind="running"
+              title="Choosing a history profile"
+              description="Select the profile Compass should use for future revision graphs."
+            />
+          ) : enableState?.status === "running" ? (
+            <WorkspaceState
+              kind="running"
+              title="Enabling revision graphs"
+              description="Compass is saving the repository history profile and installing its managed hook."
+            />
+          ) : enableState?.status === "failed" ? (
+            <WorkspaceState
+              kind="error"
+              title="Revision graphs could not be enabled"
+              description={enableState.message}
+              action={{ label: "Retry enablement", onClick: host.enableHistory }}
+            />
+          ) : (
+            <WorkspaceState
+              kind="unavailable"
+              title="Revision graphs are not enabled"
+              description="Choose a local code-only profile or use the semantic provider detected by Compass."
+              action={{ label: "Enable revision graphs", onClick: host.enableHistory }}
+            />
+          )
         ) : !selected ? (
           <WorkspaceState
             kind="empty"

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -2403,6 +2403,21 @@ body.vscode-high-contrast-light .query-node-results {
   outline: none;
 }
 
+.history-pagination {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 6px;
+  justify-items: start;
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.history-pagination [role="alert"] {
+  color: var(--destructive);
+}
+
 .history-commit {
   position: absolute;
   left: 0;

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -372,6 +372,7 @@ window.fixtureTimeline=${JSON.stringify(timeline)};
 window.historyGraphs=${JSON.stringify(graphs)};
 window.historyHostMessages=[];
 window.historyBootstrapAttempts=0;
+window.historyGeneration=0;
 window.emitHistoryMessage=(message)=>window.postMessage(message,"*");
 window.acquireVsCodeApi=()=>({postMessage(message){
   window.historyHostMessages.push(message);
@@ -381,8 +382,32 @@ window.acquireVsCodeApi=()=>({postMessage(message){
     if(scenario==="error" && window.historyBootstrapAttempts===1) {
       setTimeout(()=>window.postMessage({type:"bootstrapError",message:"Fixture history unavailable"},"*"),40);
     } else {
-      setTimeout(()=>window.postMessage({type:"timeline",repositoryId:"fixture",timeline:window.fixtureTimeline},"*"),40);
+      window.historyGeneration+=1;
+      const parameters=new URLSearchParams(window.location.search);
+      const paginated=parameters.get("pagination")==="true";
+      const baseTimeline=parameters.get("historyEnabled")==="false"
+        ? {...window.fixtureTimeline,historyEnabled:false}
+        : window.fixtureTimeline;
+      const initialTimeline=paginated
+        ? {...baseTimeline,totalEntries:null,hasMore:true,nextCursor:"fixture-cursor",entries:baseTimeline.entries.slice(0,2)}
+        : baseTimeline;
+      setTimeout(()=>window.postMessage({type:"timeline",repositoryId:"fixture",generation:window.historyGeneration,timeline:initialTimeline},"*"),40);
     }
+  } else if(message.type==="loadMoreTimeline") {
+    const pageGeneration=window.historyGeneration;
+    setTimeout(()=>window.postMessage({
+      type:"timelinePage",
+      repositoryId:"fixture",
+      generation:pageGeneration,
+      timeline:{...window.fixtureTimeline,totalEntries:window.fixtureTimeline.entries.length,hasMore:false,nextCursor:null,entries:window.fixtureTimeline.entries.slice(2)}
+    },"*"),40);
+  } else if(message.type==="enableHistory") {
+    setTimeout(()=>window.postMessage({type:"enableRunning"},"*"),20);
+    setTimeout(()=>{
+      window.historyGeneration+=1;
+      window.postMessage({type:"timeline",repositoryId:"fixture",generation:window.historyGeneration,timeline:{...window.fixtureTimeline,historyEnabled:true}},"*");
+      window.postMessage({type:"enableSucceeded"},"*");
+    },120);
   } else if(message.type==="loadRevision") {
     const loadScenario=new URLSearchParams(window.location.search).get("load");
     const delay=loadScenario==="slow" ? 500 : message.commit.startsWith("a") ? 180 : 120;
@@ -443,7 +468,8 @@ window.acquireVsCodeApi=()=>({postMessage(message){
         setTimeout(()=>{
           const entry=window.fixtureTimeline.entries.find(candidate=>candidate.commit===message.commit);
           Object.assign(entry,{graphState:"graph_available",presentationAvailable:true,realization:"rc",fingerprint:"fc"});
-          window.postMessage({type:"timeline",repositoryId:"fixture",timeline:window.fixtureTimeline},"*");
+          window.historyGeneration+=1;
+          window.postMessage({type:"timeline",repositoryId:"fixture",generation:window.historyGeneration,timeline:window.fixtureTimeline},"*");
           window.postMessage({type:"buildSucceeded",commit:message.commit},"*");
         },220);
       }

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -173,3 +173,59 @@ test("history bootstrap failure offers a working retry", async ({ page }) => {
     return messages.filter((message) => message.type === "retryTimeline").length;
   })).toBe(1);
 });
+
+test("timeline loads another cached page on demand", async ({ page }) => {
+  await page.goto("/history.html?pagination=true");
+  await expect(page.getByText("2 loaded commits")).toBeVisible();
+  await page.getByRole("button", { name: "Load more commits" }).click();
+  await expect(page.getByText("3 reachable commits")).toBeVisible();
+  await expect(page.getByRole("option", { name: /Revision C needs build/i })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => {
+    const messages = (window as typeof window & {
+      historyHostMessages: Array<Record<string, unknown>>;
+    }).historyHostMessages;
+    return messages.filter((message) => message.type === "loadMoreTimeline").length;
+  })).toBe(1);
+});
+
+test("a late commit page cannot overwrite a newer timeline generation", async ({ page }) => {
+  await page.goto("/history.html?pagination=true");
+  await page.getByRole("button", { name: "Load more commits" }).click();
+  await page.evaluate(() => {
+    const fixture = window as typeof window & {
+      fixtureTimeline: { entries: unknown[] };
+      historyGeneration: number;
+      emitHistoryMessage(message: unknown): void;
+    };
+    fixture.historyGeneration = 2;
+    fixture.emitHistoryMessage({
+      type: "timeline",
+      repositoryId: "fixture",
+      generation: 2,
+      timeline: {
+        ...fixture.fixtureTimeline,
+        totalEntries: null,
+        hasMore: true,
+        nextCursor: "new-cursor",
+        entries: fixture.fixtureTimeline.entries.slice(0, 2)
+      }
+    });
+  });
+  await page.waitForTimeout(120);
+  await expect(page.getByRole("option", { name: /Revision C needs build/i })).toHaveCount(0);
+  await expect(page.getByText("2 loaded commits")).toBeVisible();
+});
+
+test("disabled history can be enabled from Codebase Evolution", async ({ page }) => {
+  await page.goto("/history.html?historyEnabled=false");
+  await expect(page.getByText("Revision graphs are not enabled")).toBeVisible();
+  await page.getByRole("button", { name: "Enable revision graphs" }).click();
+  await expect(page.getByRole("status")).toContainText("Enabling revision graphs");
+  await expect(page.getByText(/Viewing graph for aaaaaaaaa/)).toBeVisible();
+  await expect.poll(() => page.evaluate(() => {
+    const messages = (window as typeof window & {
+      historyHostMessages: Array<Record<string, unknown>>;
+    }).historyHostMessages;
+    return messages.filter((message) => message.type === "enableHistory").length;
+  })).toBe(1);
+});


### PR DESCRIPTION
## What changed

- Paginate Codebase Evolution history, loading the newest 100 commits first and fetching additional pages as the user scrolls.
- Batch Git metadata reads and cache timeline pages plus latest revision-job status.
- Reject stale timeline generations and restart pagination when repository refs change.
- Add an in-view **Enable revision graphs** action with code-only and default-profile choices.
- Keep the history status cache crash-consistent, backward-compatible with legacy queues, and synchronized with garbage collection.
- Document the new timeline pagination contract and extension workflow.

## Why

Codebase Evolution previously traversed every reachable commit and spawned a separate Git metadata command for each commit before rendering anything. Large repositories therefore had a long initial wait. When revision graphs were disabled, the panel only told users to configure history elsewhere and offered no direct recovery action.

## Impact

Users see recent history quickly, can continuously load older commits, and can enable revision graphs without leaving Codebase Evolution. Existing CLI clients retain the unpaginated behavior unless they advertise the pagination capability.

## Validation

- `cargo test -p compass-history`
- `cargo test -p compass-cli --test history_cli`
- `cargo test -p compass-cli --test capabilities_cli`
- Viewer and VS Code TypeScript typechecks
- Viewer unit tests: 33 passed
- VS Code unit tests: 39 passed
- Codebase Evolution Playwright tests: 12 passed
- `git diff --check`
- `graphify update .`
