### PR TITLE
Make Code Graph open from a prepared overview

### DIFF
--- a/crates/compass-core/src/cluster_existing.rs
+++ b/crates/compass-core/src/cluster_existing.rs
@@ -16,7 +16,7 @@ use compass_output::{
 };
 use serde_json::{Value, json};
 
-use crate::pipeline::{git_commit, remove_if_exists};
+use crate::pipeline::{git_commit, remove_if_exists, write_graph_overview_artifact};
 use crate::{CoreError, load_learning_for_report};
 
 #[derive(Clone, Debug)]
@@ -232,6 +232,7 @@ where
         options.output_dir.join(".compass_labels.json.sig"),
         &signatures,
     )?;
+    write_graph_overview_artifact(&document, &communities, &labels, &options.output_dir)?;
     let html_path = options.output_dir.join("graph.html");
     let html_written = if options.no_viz {
         remove_if_exists(&html_path)?;

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -17,7 +17,7 @@ use compass_languages::{Engine, Extraction, Registry, file_stem, make_id};
 use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
 use compass_output::{
     DetectionSummary, HtmlOptions, JsonExportOptions, OutputError, ReportOptions, TokenCost,
-    generate_report, write_html, write_json,
+    generate_report, graph_view_model_document, write_html, write_json,
 };
 use compass_resolve::{merge_decl_def_classes, resolve_owned_with_root};
 use rayon::prelude::*;
@@ -67,6 +67,9 @@ pub enum BuildPurpose {
 }
 
 const OUTPUT_STATS_FILE: &str = ".compass_output_stats.json";
+const GRAPH_OVERVIEW_FILE: &str = "graph-overview.json";
+const GRAPH_OVERVIEW_SCHEMA: &str = "compass.graph-overview/1";
+const GRAPH_OVERVIEW_NODE_LIMIT: isize = 5_000;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct OutputStats {
@@ -417,6 +420,9 @@ fn build_graph_inner(
         if options.no_viz {
             remove_if_exists(&output_dir.join("graph.html"))?;
         }
+        if options.no_cluster {
+            remove_if_exists(&output_dir.join(GRAPH_OVERVIEW_FILE))?;
+        }
         remove_if_exists(&output_dir.join("needs_update"))?;
         guard.commit()?;
         return Ok(BuildResult {
@@ -721,6 +727,7 @@ fn build_graph_inner(
             options.purpose,
             tokens,
         )?;
+        remove_if_exists(&output_dir.join(GRAPH_OVERVIEW_FILE))?;
         save_output_stats(&output_dir, nodes.len(), edges.len(), 0, false)?;
         write_semantic_marker(&output_dir, semantic)?;
         if options.purpose == BuildPurpose::Update {
@@ -907,6 +914,7 @@ fn build_graph_inner(
             output_dir.join(".compass_root"),
             &options.root.to_string_lossy(),
         )?;
+        write_graph_overview_artifact(&document, &communities, &labels, &output_dir)?;
     }
 
     let mut html_written = false;
@@ -1952,9 +1960,51 @@ fn update_artifacts_complete(output_dir: &Path) -> bool {
         "GRAPH_REPORT.md",
         ".compass_labels.json",
         ".compass_root",
+        GRAPH_OVERVIEW_FILE,
     ]
     .into_iter()
     .all(|name| output_dir.join(name).is_file())
+}
+
+pub(crate) fn write_graph_overview_artifact(
+    document: &GraphDocument,
+    communities: &compass_graph::Communities,
+    labels: &BTreeMap<usize, String>,
+    output_dir: &Path,
+) -> Result<(), CoreError> {
+    let overview_path = output_dir.join(GRAPH_OVERVIEW_FILE);
+    let overview = graph_view_model_document(
+        document,
+        communities,
+        output_dir.join("graph.json"),
+        &HtmlOptions {
+            community_labels: (!labels.is_empty()).then_some(labels),
+            node_limit: Some(GRAPH_OVERVIEW_NODE_LIMIT),
+            ..HtmlOptions::default()
+        },
+    )?;
+    if let Some(model) = overview {
+        let graph_path = output_dir.join("graph.json");
+        let source_graph_bytes = fs::metadata(&graph_path)
+            .map_err(|source| compass_files::FileError::Io {
+                path: graph_path,
+                source,
+            })?
+            .len();
+        write_json_atomic(
+            &overview_path,
+            &json!({
+                "schema": GRAPH_OVERVIEW_SCHEMA,
+                "sourceGraphBytes": source_graph_bytes,
+                "nodeLimit": GRAPH_OVERVIEW_NODE_LIMIT,
+                "model": model,
+            }),
+            false,
+        )?;
+    } else {
+        remove_if_exists(&overview_path)?;
+    }
+    Ok(())
 }
 
 fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<OutputStats> {
@@ -2363,6 +2413,19 @@ mod tests {
         assert!(cold.timings.export > Duration::ZERO);
         assert!(cold.nodes > 0);
         assert!(cold.output_dir.join("graph.json").is_file());
+        let overview_path = cold.output_dir.join("graph-overview.json");
+        assert!(
+            overview_path.is_file(),
+            "clustered updates should prepare the VS Code graph overview even with --no-viz"
+        );
+        let overview: Value = serde_json::from_slice(&fs::read(&overview_path)?)?;
+        assert_eq!(overview["schema"], "compass.graph-overview/1");
+        assert_eq!(overview["nodeLimit"], 5_000);
+        assert_eq!(
+            overview["sourceGraphBytes"],
+            fs::metadata(cold.output_dir.join("graph.json"))?.len()
+        );
+        assert_eq!(overview["model"]["schema"], "compass.viewer.graph/1");
         assert!(cold.output_dir.join("manifest.json").is_file());
         assert!(!cold.output_dir.join(".compass_incomplete").exists());
         let cold_graph = GraphDocument::load(&cold.output_dir.join("graph.json"))?;

--- a/editors/vscode/src/transport/messages.test.ts
+++ b/editors/vscode/src/transport/messages.test.ts
@@ -39,4 +39,19 @@ describe("community graph messages", () => {
       message: "failed"
     }).success).toBe(false);
   });
+
+  it("accepts large graph preparation progress", () => {
+    expect(HostToGraphMessageSchema.safeParse({
+      type: "graphLoadStatus",
+      mode: "large",
+      graphBytes: 44_275_915,
+      phase: "exporting"
+    }).success).toBe(true);
+    expect(HostToGraphMessageSchema.safeParse({
+      type: "graphLoadStatus",
+      mode: "large",
+      graphBytes: -1,
+      phase: "exporting"
+    }).success).toBe(false);
+  });
 });

--- a/editors/vscode/src/transport/messages.ts
+++ b/editors/vscode/src/transport/messages.ts
@@ -9,6 +9,12 @@ export const HostToGraphMessageSchema = z.discriminatedUnion("type", [
     model: GraphViewModelSchema
   }),
   z.object({
+    type: z.literal("graphLoadStatus"),
+    mode: z.literal("large"),
+    graphBytes: z.number().int().nonnegative(),
+    phase: z.enum(["snapshotting", "exporting"])
+  }),
+  z.object({
     type: z.literal("communityGraph"),
     requestId: z.string(),
     repositoryId: z.string(),

--- a/editors/vscode/src/views/graphOverview.test.ts
+++ b/editors/vscode/src/views/graphOverview.test.ts
@@ -1,0 +1,75 @@
+import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPreparedGraphOverview } from "./graphOverview";
+
+const model = {
+  schema: "compass.viewer.graph/1",
+  title: "graph.json",
+  stats: { nodes: 1, edges: 0, communities: 1, aggregated: false },
+  nodes: [{ id: "a", label: "A", community: 0 }],
+  edges: [],
+  communities: [{ id: 0, label: "Community 0", color: "#4E79A7", hidden: false }],
+  hyperedges: []
+};
+
+describe("loadPreparedGraphOverview", () => {
+  let directory: string | undefined;
+
+  afterEach(async () => {
+    if (directory) await rm(directory, { recursive: true, force: true });
+    directory = undefined;
+  });
+
+  async function fixture({
+    sourceGraphBytes = 12,
+    nodeLimit = 5000
+  }: {
+    sourceGraphBytes?: number;
+    nodeLimit?: number;
+  } = {}) {
+    directory = await mkdtemp(path.join(tmpdir(), "compass-graph-overview-"));
+    const output = path.join(directory, "compass-out");
+    await mkdir(output);
+    const graphPath = path.join(output, "graph.json");
+    await writeFile(graphPath, "x".repeat(12));
+    const overviewPath = path.join(output, "graph-overview.json");
+    await writeFile(overviewPath, JSON.stringify({
+      schema: "compass.graph-overview/1",
+      sourceGraphBytes,
+      nodeLimit,
+      model
+    }));
+    const graphStat = await stat(graphPath);
+    await utimes(overviewPath, graphStat.atime, new Date(graphStat.mtimeMs + 1_000));
+    return graphPath;
+  }
+
+  it("loads a prepared overview matching the current graph generation and limit", async () => {
+    const graphPath = await fixture();
+
+    await expect(loadPreparedGraphOverview(graphPath, 5000)).resolves.toEqual(model);
+  });
+
+  it("rejects an overview for a different graph byte count", async () => {
+    const graphPath = await fixture({ sourceGraphBytes: 11 });
+
+    await expect(loadPreparedGraphOverview(graphPath, 5000)).resolves.toBeUndefined();
+  });
+
+  it("rejects an overview generated with a different node limit", async () => {
+    const graphPath = await fixture({ nodeLimit: 2500 });
+
+    await expect(loadPreparedGraphOverview(graphPath, 5000)).resolves.toBeUndefined();
+  });
+
+  it("rejects an overview older than graph.json", async () => {
+    const graphPath = await fixture();
+    const overviewPath = path.join(path.dirname(graphPath), "graph-overview.json");
+    const graphStat = await stat(graphPath);
+    await utimes(overviewPath, graphStat.atime, new Date(graphStat.mtimeMs - 1_000));
+
+    await expect(loadPreparedGraphOverview(graphPath, 5000)).resolves.toBeUndefined();
+  });
+});

--- a/editors/vscode/src/views/graphOverview.ts
+++ b/editors/vscode/src/views/graphOverview.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  GraphViewModelSchema,
+  type GraphViewModel
+} from "@compass/viewer/contracts/graph";
+import { z } from "zod";
+
+export const GRAPH_OVERVIEW_SCHEMA = "compass.graph-overview/1" as const;
+
+const GraphOverviewArtifactSchema = z.object({
+  schema: z.literal(GRAPH_OVERVIEW_SCHEMA),
+  sourceGraphBytes: z.number().int().nonnegative(),
+  sourceGraphModifiedMs: z.number().nonnegative().optional(),
+  nodeLimit: z.number().int().positive(),
+  model: GraphViewModelSchema
+});
+
+export type GraphSourceInfo = {
+  bytes: number;
+  modifiedMs: number;
+};
+
+export async function graphSourceInfo(graphPath: string): Promise<GraphSourceInfo> {
+  const metadata = await stat(graphPath);
+  return {
+    bytes: metadata.size,
+    modifiedMs: metadata.mtimeMs
+  };
+}
+
+export async function loadPreparedGraphOverview(
+  graphPath: string,
+  nodeLimit: number
+): Promise<GraphViewModel | undefined> {
+  const overviewPath = path.join(path.dirname(graphPath), "graph-overview.json");
+  try {
+    const [graph, overviewMetadata, artifact] = await Promise.all([
+      graphSourceInfo(graphPath),
+      stat(overviewPath),
+      readArtifact(overviewPath)
+    ]);
+    if (
+      overviewMetadata.mtimeMs < graph.modifiedMs ||
+      artifact.sourceGraphBytes !== graph.bytes ||
+      artifact.nodeLimit !== nodeLimit
+    ) {
+      return undefined;
+    }
+    return artifact.model;
+  } catch (error) {
+    if (isMissing(error)) return undefined;
+    return undefined;
+  }
+}
+
+export function graphOverviewCachePath(storageRoot: string, repositoryId: string): string {
+  const key = createHash("sha256").update(repositoryId).digest("hex").slice(0, 24);
+  return path.join(storageRoot, "graph-overviews", `${key}.json`);
+}
+
+export async function loadCachedGraphOverview(
+  cachePath: string,
+  graphPath: string,
+  nodeLimit: number
+): Promise<GraphViewModel | undefined> {
+  try {
+    const [graph, artifact] = await Promise.all([
+      graphSourceInfo(graphPath),
+      readArtifact(cachePath)
+    ]);
+    if (
+      artifact.sourceGraphBytes !== graph.bytes ||
+      artifact.sourceGraphModifiedMs !== graph.modifiedMs ||
+      artifact.nodeLimit !== nodeLimit
+    ) {
+      return undefined;
+    }
+    return artifact.model;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeCachedGraphOverview(
+  cachePath: string,
+  graphPath: string,
+  nodeLimit: number,
+  model: GraphViewModel
+): Promise<void> {
+  const graph = await graphSourceInfo(graphPath);
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  const temporary = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporary, JSON.stringify({
+    schema: GRAPH_OVERVIEW_SCHEMA,
+    sourceGraphBytes: graph.bytes,
+    sourceGraphModifiedMs: graph.modifiedMs,
+    nodeLimit,
+    model
+  }));
+  await rename(temporary, cachePath);
+}
+
+async function readArtifact(filePath: string) {
+  const parsed = GraphOverviewArtifactSchema.safeParse(
+    JSON.parse(await readFile(filePath, "utf8"))
+  );
+  if (!parsed.success) throw new Error(`Invalid Compass graph overview: ${filePath}`);
+  return parsed.data;
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}

--- a/editors/vscode/src/views/graphPanel.ts
+++ b/editors/vscode/src/views/graphPanel.ts
@@ -7,8 +7,17 @@ import {
 import type { RepositorySession } from "../workspace/repositorySession";
 import { GraphToHostMessageSchema } from "../transport/messages";
 import { currentGraphExportArgs } from "./communityArguments";
+import {
+  graphOverviewCachePath,
+  graphSourceInfo,
+  loadCachedGraphOverview,
+  loadPreparedGraphOverview,
+  writeCachedGraphOverview
+} from "./graphOverview";
 import { CurrentGraphSnapshot } from "./graphSnapshot";
 import { openGraphSource } from "./sourceNavigation";
+
+const LARGE_GRAPH_BYTES = 8 * 1024 * 1024;
 
 export class GraphPanel {
   static async open(
@@ -34,6 +43,7 @@ export class GraphPanel {
   private readonly controller = new AbortController();
   private readonly communityCache = new Map<number, GraphViewModel>();
   private readonly snapshot = new CurrentGraphSnapshot();
+  private snapshotReady: Promise<string> | undefined;
   private overview: GraphViewModel | undefined;
 
   private constructor(
@@ -76,23 +86,47 @@ export class GraphPanel {
 
   private async hydrate(): Promise<void> {
     try {
-      const graphPath = await this.snapshot.replace(this.session.graphPath);
-      const model = await this.session.processes.runJson(
+      const nodeLimit = vscode.workspace
+        .getConfiguration("compass")
+        .get("graphNodeLimit", 5000);
+      const source = await graphSourceInfo(this.session.graphPath);
+      this.snapshotReady = this.snapshot.replace(this.session.graphPath);
+      const storageRoot = this.context.storageUri ?? this.context.globalStorageUri;
+      const cachePath = graphOverviewCachePath(storageRoot.fsPath, this.session.id);
+      const model =
+        await loadPreparedGraphOverview(this.session.graphPath, nodeLimit) ??
+        await loadCachedGraphOverview(cachePath, this.session.graphPath, nodeLimit);
+
+      if (model) {
+        await this.publishOverview(model);
+        return;
+      }
+
+      if (source.bytes >= LARGE_GRAPH_BYTES) {
+        await this.postLoadStatus(source.bytes, "snapshotting");
+      }
+      const graphPath = await this.snapshotReady;
+      if (source.bytes >= LARGE_GRAPH_BYTES) {
+        await this.postLoadStatus(source.bytes, "exporting");
+      }
+      const exported = await this.session.processes.runJson(
         this.session.root,
-        currentGraphExportArgs(
-          graphPath,
-          vscode.workspace.getConfiguration("compass").get("graphNodeLimit", 5000)
-        ),
+        currentGraphExportArgs(graphPath, nodeLimit),
         GraphViewModelSchema,
         this.controller.signal
       );
-      this.overview = this.withRepositoryTitle(model);
-      this.communityCache.clear();
-      await this.panel.webview.postMessage({
-        type: "hydrateGraph",
-        requestId: randomUUID(),
-        repositoryId: this.session.id,
-        model: this.overview
+      await this.publishOverview(exported);
+      void writeCachedGraphOverview(
+        cachePath,
+        this.session.graphPath,
+        nodeLimit,
+        exported
+      ).catch((error) => {
+        this.output.appendLine(
+          `[graph] Could not cache graph overview: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
       });
     } catch (error) {
       await this.panel.webview.postMessage({
@@ -124,7 +158,7 @@ export class GraphPanel {
       }
       let model = this.communityCache.get(communityId);
       if (!model) {
-        const graphPath = this.snapshot.graphPath;
+        const graphPath = await this.snapshotReady;
         if (!graphPath) throw new Error("The graph snapshot is no longer available.");
         model = await this.session.processes.runJson(
           this.session.root,
@@ -165,6 +199,29 @@ export class GraphPanel {
       ...model,
       title: vscode.workspace.asRelativePath(this.session.graphPath)
     };
+  }
+
+  private async publishOverview(model: GraphViewModel): Promise<void> {
+    this.overview = this.withRepositoryTitle(model);
+    this.communityCache.clear();
+    await this.panel.webview.postMessage({
+      type: "hydrateGraph",
+      requestId: randomUUID(),
+      repositoryId: this.session.id,
+      model: this.overview
+    });
+  }
+
+  private async postLoadStatus(
+    graphBytes: number,
+    phase: "snapshotting" | "exporting"
+  ): Promise<void> {
+    await this.panel.webview.postMessage({
+      type: "graphLoadStatus",
+      mode: "large",
+      graphBytes,
+      phase
+    });
   }
 
   private html(): string {

--- a/editors/vscode/src/webviews/GraphLoadingState.test.tsx
+++ b/editors/vscode/src/webviews/GraphLoadingState.test.tsx
@@ -54,6 +54,25 @@ describe("GraphLoadingState", () => {
     expect(markup).toContain("Tracing callees");
   });
 
+  it("explains when a large graph needs one-time preparation", () => {
+    const markup = renderToStaticMarkup(
+      <GraphLoadingState
+        state={{ kind: "loading" }}
+        loadingCopy={{
+          eyebrow: "Compass code graph · 42.2 MB",
+          title: "Preparing a large code graph",
+          steps: ["Reading graph", "Building overview", "Opening explorer"]
+        }}
+        onRetry={vi.fn()}
+        onShowOutput={vi.fn()}
+      />
+    );
+
+    expect(markup).toContain("Preparing a large code graph");
+    expect(markup).toContain("42.2 MB");
+    expect(markup).toContain("Building overview");
+  });
+
   it("renders a compact Architecture loader with a layout skeleton", () => {
     const markup = renderToStaticMarkup(
       <GraphLoadingState

--- a/editors/vscode/src/webviews/graph.tsx
+++ b/editors/vscode/src/webviews/graph.tsx
@@ -5,7 +5,10 @@ import {
   type InspectorLayout
 } from "@compass/viewer";
 import { HostToGraphMessageSchema } from "../transport/messages";
-import { GraphLoadingState } from "./GraphLoadingState";
+import {
+  GraphLoadingState,
+  type GraphLoadingCopy
+} from "./GraphLoadingState";
 
 type WebviewState = {
   inspector?: InspectorLayout;
@@ -26,6 +29,7 @@ let communityDetail: { communityId: number; model: GraphViewModel } | undefined;
 let communityLoading: number | null = null;
 let communityError: string | undefined;
 let activeCommunityRequest = "";
+let loadingCopy: GraphLoadingCopy | undefined;
 
 function resetGraphState(): void {
   overview = undefined;
@@ -45,6 +49,7 @@ function renderLoading(): void {
   root.render(
     <GraphLoadingState
       state={{ kind: "loading" }}
+      {...(loadingCopy ? { loadingCopy } : {})}
       onRetry={retryHydration}
       onShowOutput={() => vscode.postMessage({ type: "showOutput" })}
     />
@@ -110,6 +115,17 @@ window.addEventListener("message", (event) => {
     renderError(parsed.data.message);
     return;
   }
+  if (parsed.data.type === "graphLoadStatus") {
+    loadingCopy = {
+      eyebrow: `Compass code graph · ${formatBytes(parsed.data.graphBytes)}`,
+      title: "Preparing a large code graph",
+      steps: parsed.data.phase === "snapshotting"
+        ? ["Securing snapshot", "Building overview", "Opening explorer"]
+        : ["Snapshot ready", "Building overview", "Opening explorer"]
+    };
+    renderLoading();
+    return;
+  }
   if (parsed.data.type === "hydrateGraph") {
     repositoryId = parsed.data.repositoryId;
     overview = parsed.data.model;
@@ -134,3 +150,8 @@ window.addEventListener("message", (event) => {
 
 renderLoading();
 vscode.postMessage({ type: "ready" });
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -219,6 +219,14 @@ window.acquireVsCodeApi=()=>({
   setState(state){window.webviewState=state},
   postMessage(message){
     window.hostMessages.push(message);
+    if(new URLSearchParams(window.location.search).has("large") && message.type==="ready") {
+      setTimeout(()=>window.postMessage({
+        type:"graphLoadStatus",
+        mode:"large",
+        graphBytes:44275915,
+        phase:"exporting"
+      },"*"),0);
+    }
     if(new URLSearchParams(window.location.search).has("error") && (message.type==="ready" || message.type==="retry")) {
       setTimeout(()=>window.postMessage({type:"error",message:"The graph export could not be read."},"*"),0);
     }

--- a/tests/viewer/loading.spec.ts
+++ b/tests/viewer/loading.spec.ts
@@ -40,3 +40,15 @@ test("compiled graph webview exposes working recovery actions", async ({ page })
     "showOutput"
   ]);
 });
+
+test("compiled graph webview explains one-time preparation for a large graph", async ({
+  page
+}) => {
+  await page.goto("/loading.html?large=1");
+
+  await expect(
+    page.getByRole("heading", { name: "Preparing a large code graph" })
+  ).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("42.2 MB");
+  await expect(page.getByRole("status")).toContainText("Building overview");
+});


### PR DESCRIPTION
## What changed

- generate an atomic `graph-overview.json` presentation artifact during clustered updates and `cluster-only`
- load and validate the prepared overview directly in the VS Code extension
- cache the one-time CLI fallback in extension storage for repositories built by older Compass versions
- keep immutable full-graph snapshots and lazy community details in the background
- show a design-token-native “Preparing a large code graph” state with graph size and phase for cold graphs over 8 MB

## Why

Opening Code Graph reparsed and aggregated the complete `graph.json` through a new CLI process every time. On a 22 MB real repository graph, that path took 1.33 seconds before the webview could hydrate. The prepared 325 KB overview parses in 0.02 seconds, about 66× faster.

## Compatibility

Existing repositories continue to work. When `graph-overview.json` is missing, stale, malformed, or uses a different configured node limit, Compass falls back to the existing CLI export and caches that result in VS Code storage. The full graph remains authoritative for lazy community exploration.

## Validation

- `cargo fmt --all --check`
- `cargo test -p compass-core -p compass-output`
- `npm test -w compass-vscode`
- `npm run typecheck -w compass-vscode`
- `npm run typecheck -w @compass/viewer`
- `npm run build -w compass-vscode`
- `npm test -w @compass/viewer-tests -- loading.spec.ts performance.spec.ts`
- `git diff --check`
- `graphify update .`
