### PR TITLE
Harden versioned graph builds and comparison UX

### DIFF
--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 
 use compass_core::{CompleteGraphBuilder, MaterializeError};
-use compass_files::{DetectOptions, IgnorePolicy, Manifest, detect};
+use compass_files::{DetectOptions, IgnorePolicy, Manifest, ManifestKind, detect};
 use compass_history::{
     BuildProfile, CompletedGraphArtifacts, CompletionEvidence, GraphArtifacts,
     HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
@@ -105,9 +106,15 @@ impl HistoryBuildOptions {
         })
     }
 
-    pub(crate) fn builder(&self, executable: PathBuf) -> NativeCompleteGraphBuilder {
+    pub(crate) fn builder(
+        &self,
+        executable: PathBuf,
+        working_tree_seed: Option<PathBuf>,
+    ) -> NativeCompleteGraphBuilder {
         NativeCompleteGraphBuilder {
             executable,
+            working_tree_seed,
+            profile: self.profile.clone(),
             forwarded: self.forwarded.clone(),
             gitignore: self.gitignore,
             excludes: self.excludes.clone(),
@@ -841,6 +848,8 @@ fn resolve_provider(values: &mut HistoryBuildValues) -> Result<(), HistoryError>
 
 pub(crate) struct NativeCompleteGraphBuilder {
     executable: PathBuf,
+    working_tree_seed: Option<PathBuf>,
+    profile: BuildProfile,
     forwarded: Vec<String>,
     gitignore: bool,
     excludes: Vec<String>,
@@ -850,6 +859,70 @@ pub(crate) struct NativeCompleteGraphBuilder {
 }
 
 impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
+    fn promote_current(
+        &self,
+        repository_root: &Path,
+        commit: &compass_history::CommitId,
+    ) -> Result<Option<CompletedGraphArtifacts>, MaterializeError> {
+        if !self.is_default_current_snapshot_profile() {
+            return Ok(None);
+        }
+        let Some(output_dir) = self.working_tree_seed.as_ref() else {
+            return Ok(None);
+        };
+        if !graph_stamp_matches(&output_dir.join("graph.json"), commit) {
+            return Ok(None);
+        }
+        let detection = detect(
+            repository_root,
+            &DetectOptions {
+                gitignore: self.gitignore,
+                ignore_policy: IgnorePolicy::HistoricalCommit,
+                extra_excludes: self.excludes.clone(),
+                output_name: "compass-out".to_owned(),
+                ..DetectOptions::default()
+            },
+        )?;
+        let manifest = Manifest::load(&output_dir.join("manifest.json"), Some(repository_root));
+        if !manifest.is_unchanged(&detection.files, ManifestKind::Ast) {
+            return Ok(None);
+        }
+        let Ok(completed) = CompletedGraphArtifacts::load(
+            output_dir,
+            CompletionEvidence {
+                extraction_succeeded: true,
+                allow_partial: false,
+                semantic_files_expected: 0,
+                semantic_files_completed: 0,
+                failed_chunks: 0,
+            },
+        ) else {
+            return Ok(None);
+        };
+        let Some(program) = completed.artifacts.program.as_ref() else {
+            return Ok(None);
+        };
+        let Ok(expected_providers) =
+            compass_core::history_provider_manifest(repository_root, &self.profile)
+        else {
+            return Ok(None);
+        };
+        if program.program.providers != expected_providers {
+            return Ok(None);
+        }
+        let code_files = detection
+            .files
+            .get("code")
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        Ok(compass_core::normalize_current_code_only_snapshot(
+            completed.artifacts,
+            repository_root,
+            code_files,
+        )
+        .ok())
+    }
+
     fn build(
         &self,
         checkout: &Path,
@@ -942,6 +1015,29 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
         )
         .map_err(Into::into)
     }
+}
+
+impl NativeCompleteGraphBuilder {
+    fn is_default_current_snapshot_profile(&self) -> bool {
+        self.code_only
+            && self.gitignore
+            && self.excludes.is_empty()
+            && self.forwarded == ["--code-only", "--resolution", "1"].map(str::to_owned)
+    }
+}
+
+fn graph_stamp_matches(path: &Path, commit: &compass_history::CommitId) -> bool {
+    #[derive(serde::Deserialize)]
+    struct GraphStamp {
+        built_at_commit: Option<String>,
+    }
+
+    fs::File::open(path)
+        .ok()
+        .and_then(|file| serde_json::from_reader::<_, GraphStamp>(file).ok())
+        .and_then(|stamp| stamp.built_at_commit)
+        .as_deref()
+        == Some(commit.as_str())
 }
 
 fn seed_completion(seed: &GraphArtifacts) -> CompletionEvidence {
@@ -1040,6 +1136,134 @@ fn read_bounded(mut reader: impl Read) -> Result<String, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use compass_history::CommitId;
+    use std::fs;
+
+    fn git(root: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
+        let output = Command::new("git")
+            .args(arguments)
+            .current_dir(root)
+            .output()?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).into_owned().into());
+        }
+        Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+    }
+
+    fn current_snapshot_fixture()
+    -> Result<(tempfile::TempDir, CommitId, PathBuf), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        git(directory.path(), &["init", "--quiet"])?;
+        git(directory.path(), &["config", "user.name", "Compass Test"])?;
+        git(
+            directory.path(),
+            &["config", "user.email", "compass@example.invalid"],
+        )?;
+        fs::write(directory.path().join("service.rs"), "pub fn service() {}\n")?;
+        git(directory.path(), &["add", "service.rs"])?;
+        git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+        let commit = git(directory.path(), &["rev-parse", "HEAD"])?.parse::<CommitId>()?;
+        let mut build = compass_core::BuildOptions::new(directory.path());
+        build.force = true;
+        build.no_viz = true;
+        build.program_analysis = true;
+        build.built_at_commit = Some(commit.to_string());
+        let output = compass_core::build_local_graph(&build)?.output_dir;
+        Ok((directory, commit, output))
+    }
+
+    #[test]
+    fn native_builder_promotes_an_exact_current_code_only_snapshot()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (directory, commit, output) = current_snapshot_fixture()?;
+        let options =
+            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])?.options;
+        let builder = options.builder(
+            PathBuf::from("/definitely/not/a/compass-binary"),
+            Some(output),
+        );
+
+        let promoted = builder.promote_current(directory.path(), &commit)?;
+
+        assert!(
+            promoted.is_some_and(|completed| completed.artifacts.document.nodes.iter().any(
+                |node| node
+                    .attributes
+                    .get("source_file")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("service.rs")
+            ))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn native_builder_rejects_a_stale_current_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+        let (directory, commit, output) = current_snapshot_fixture()?;
+        fs::write(directory.path().join("service.rs"), "pub fn changed() {}\n")?;
+        let options =
+            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])?.options;
+        let builder = options.builder(PathBuf::from("compass"), Some(output));
+
+        assert!(
+            builder
+                .promote_current(directory.path(), &commit)?
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn native_builder_rejects_a_current_snapshot_without_program_inventory()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (directory, commit, output) = current_snapshot_fixture()?;
+        fs::remove_file(output.join("program.json"))?;
+        let options =
+            parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])?.options;
+        let builder = options.builder(
+            PathBuf::from("/definitely/not/a/compass-binary"),
+            Some(output),
+        );
+
+        assert!(
+            builder
+                .promote_current(directory.path(), &commit)?
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn native_builder_rejects_current_snapshots_for_nondefault_structural_profiles()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (directory, commit, output) = current_snapshot_fixture()?;
+        for arguments in [
+            vec![
+                "HEAD".to_owned(),
+                "--code-only".to_owned(),
+                "--resolution=2".to_owned(),
+            ],
+            vec![
+                "HEAD".to_owned(),
+                "--code-only".to_owned(),
+                "--cargo".to_owned(),
+            ],
+        ] {
+            let options = parse_build_command("build", &arguments)?.options;
+            let builder = options.builder(
+                PathBuf::from("/definitely/not/a/compass-binary"),
+                Some(output.clone()),
+            );
+
+            assert!(
+                builder
+                    .promote_current(directory.path(), &commit)?
+                    .is_none(),
+                "profile unexpectedly reused the default current snapshot: {arguments:?}"
+            );
+        }
+        Ok(())
+    }
 
     #[test]
     fn build_parser_normalizes_profiles_and_rejects_partial_or_external_inputs()

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -100,16 +100,6 @@ pub(crate) fn resolve_or_materialize(
     .map_err(|error| error.to_string())?;
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(150);
     loop {
-        if !rebuild {
-            match history.preferred(&commit) {
-                Ok(Some(preferred)) if history.validate(&preferred.id).is_ok() => {
-                    return Ok((history, preferred));
-                }
-                Ok(_) => {}
-                Err(error) if error.is_catalog_corruption() => {}
-                Err(error) => return Err(error.to_string()),
-            }
-        }
         let job = queue
             .get(&job_id)
             .map_err(|error| error.to_string())?
@@ -1274,7 +1264,13 @@ fn run_claimed_job(
         }
     };
     let executable = std::env::current_exe().map_err(runtime)?;
-    let builder = options.builder(executable);
+    let working_tree_seed = repository
+        .resolve("HEAD")
+        .ok()
+        .filter(|head| head == &claimed.commit)
+        .map(|_| repository.root().join("compass-out"))
+        .filter(|path| path.join("graph.json").is_file());
+    let builder = options.builder(executable, working_tree_seed);
     let heartbeat_job = claimed.clone();
     let heartbeat_root = queue.root().to_path_buf();
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -1494,6 +1494,129 @@ fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std:
 }
 
 #[test]
+fn explicit_rebuild_ignores_the_mutable_current_snapshot() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(
+        directory.path().join("service.rs"),
+        "pub struct ExactService;\n",
+    )?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+
+    let compass = env!("CARGO_BIN_EXE_compass");
+    let initialized = run(compass, directory.path(), &["init", ".", "--yes"])?;
+    assert!(
+        initialized.status.success(),
+        "{}",
+        String::from_utf8_lossy(&initialized.stderr)
+    );
+    let graph_path = directory.path().join("compass-out/graph.json");
+    let mut current: serde_json::Value = serde_json::from_slice(&std::fs::read(&graph_path)?)?;
+    current["nodes"]
+        .as_array_mut()
+        .ok_or("current graph has no nodes")?
+        .push(json!({
+            "id": "mutable-current-only",
+            "label": "MutableCurrentOnly",
+            "source_file": "service.rs"
+        }));
+    compass_files::write_json_atomic(&graph_path, &current, false)?;
+
+    let rebuilt = run(
+        compass,
+        directory.path(),
+        &["history", "rebuild", "HEAD", "--code-only", "--format=json"],
+    )?;
+    assert!(
+        rebuilt.status.success(),
+        "{}",
+        String::from_utf8_lossy(&rebuilt.stderr)
+    );
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    let commit = repository.resolve("HEAD")?;
+    let preferred = history
+        .preferred(&commit)?
+        .ok_or("missing preferred realization")?;
+    let exact = history.artifacts(&preferred.id)?;
+
+    assert!(
+        exact
+            .artifacts
+            .document
+            .nodes
+            .iter()
+            .all(|node| node.id != "mutable-current-only"),
+        "rebuild reused mutable compass-out content"
+    );
+    Ok(())
+}
+
+#[test]
+fn current_snapshot_promotion_matches_an_exact_rebuild() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(
+        directory.path().join("service.rs"),
+        "pub struct Service;\nimpl Service { pub fn run(&self) {} }\n",
+    )?;
+    std::fs::write(
+        directory.path().join("README.md"),
+        "# Service\n\nA semantic document outside the code-only manifest.\n",
+    )?;
+    git(directory.path(), &["add", "service.rs", "README.md"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+
+    let compass = env!("CARGO_BIN_EXE_compass");
+    let initialized = run(compass, directory.path(), &["init", ".", "--yes"])?;
+    assert!(
+        initialized.status.success(),
+        "{}",
+        String::from_utf8_lossy(&initialized.stderr)
+    );
+    let promoted = run(
+        compass,
+        directory.path(),
+        &["history", "build", "HEAD", "--code-only", "--format=json"],
+    )?;
+    assert!(
+        promoted.status.success(),
+        "{}",
+        String::from_utf8_lossy(&promoted.stderr)
+    );
+    let promoted: serde_json::Value = serde_json::from_slice(&promoted.stdout)?;
+    let rebuilt = run(
+        compass,
+        directory.path(),
+        &["history", "rebuild", "HEAD", "--code-only", "--format=json"],
+    )?;
+    assert!(
+        rebuilt.status.success(),
+        "{}",
+        String::from_utf8_lossy(&rebuilt.stderr)
+    );
+    let rebuilt: serde_json::Value = serde_json::from_slice(&rebuilt.stdout)?;
+
+    assert_eq!(
+        promoted["realization"], rebuilt["realization"],
+        "promoted current output differed from the exact checkout build"
+    );
+    Ok(())
+}
+
+#[test]
 fn build_rebuild_and_unseen_diff_publish_complete_realizations()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -1,25 +1,153 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use compass_files::{DetectOptions, IgnorePolicy, detect};
+use compass_graph::{Communities, god_nodes, score_communities, surprising_connections};
 use compass_history::{
-    BuildProfile, CommitId, CompletedGraphArtifacts, CorruptPreferredToken, ExtractionFingerprint,
-    ExtractionFingerprintInput, GraphArtifacts, HISTORY_GRAPH_SCHEMA, HistoryError, HistoryStore,
-    PublishRequest, PublishedVersion, RealizationId, Repository, WorktreeGuard,
+    BuildProfile, CommitId, CompletedGraphArtifacts, CompletionEvidence, CorruptPreferredToken,
+    ExtractionFingerprint, ExtractionFingerprintInput, GraphArtifacts, HISTORY_GRAPH_SCHEMA,
+    HistoryError, HistoryStore, PublishRequest, PublishedVersion, RealizationId, Repository,
+    WorktreeGuard,
 };
 use compass_languages::Registry;
+use serde_json::json;
 use sha2::{Digest, Sha256};
 
 use crate::program::current_provider_manifest;
 
 /// Build boundary used by both production extraction and deterministic materialization tests.
 pub trait CompleteGraphBuilder {
+    fn promote_current(
+        &self,
+        _repository_root: &Path,
+        _commit: &CommitId,
+    ) -> Result<Option<CompletedGraphArtifacts>, MaterializeError> {
+        Ok(None)
+    }
+
     fn build(
         &self,
         checkout: &Path,
         output_root: &Path,
         seed: Option<&GraphArtifacts>,
     ) -> Result<CompletedGraphArtifacts, MaterializeError>;
+}
+
+/// Convert a verified mutable code-only snapshot into the canonical artifact
+/// shape produced by an exact historical extraction.
+pub fn normalize_current_code_only_snapshot(
+    mut artifacts: GraphArtifacts,
+    repository_root: &Path,
+    code_files: &[String],
+) -> Result<CompletedGraphArtifacts, MaterializeError> {
+    let mut communities = Communities::new();
+    for node in &mut artifacts.document.nodes {
+        let community = node
+            .attributes
+            .get("community")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or_else(|| {
+                MaterializeError::Incomplete(format!(
+                    "current snapshot node {} has no valid community",
+                    node.id
+                ))
+            })?;
+        communities
+            .entry(community)
+            .or_default()
+            .push(node.id.clone());
+        node.attributes.remove("community_name");
+    }
+    for members in communities.values_mut() {
+        members.sort();
+    }
+    let cohesion = score_communities(&artifacts.document, &communities);
+    let gods = god_nodes(&artifacts.document, 10);
+    let surprises = surprising_connections(&artifacts.document, &communities, 5);
+    let analysis = json!({
+        "communities": communities
+            .iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect::<BTreeMap<_, _>>(),
+        "cohesion": cohesion
+            .iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect::<BTreeMap<_, _>>(),
+        "gods": gods,
+        "surprises": surprises,
+        "tokens": {"input": 0, "output": 0},
+    });
+    artifacts.analysis = Some(
+        serde_json::from_slice(&serde_json::to_vec(&analysis).map_err(HistoryError::from)?)
+            .map_err(HistoryError::from)?,
+    );
+    artifacts.labels = None;
+    if let Some(entries) = artifacts
+        .manifest
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        let root =
+            fs::canonicalize(repository_root).map_err(|source| compass_files::FileError::Io {
+                path: repository_root.to_path_buf(),
+                source,
+            })?;
+        let code_files = code_files
+            .iter()
+            .map(|file| {
+                Path::new(file)
+                    .strip_prefix(&root)
+                    .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+                    .map_err(|_| {
+                        MaterializeError::Incomplete(format!(
+                            "code-only manifest path is outside repository: {file}"
+                        ))
+                    })
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        entries.retain(|path, _| code_files.contains(path));
+        for entry in entries
+            .values_mut()
+            .filter_map(serde_json::Value::as_object_mut)
+        {
+            let ast_hash = entry
+                .get("ast_hash")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            entry.insert(
+                "semantic_hash".to_owned(),
+                serde_json::Value::String(ast_hash),
+            );
+        }
+    }
+    let completed = CompletedGraphArtifacts {
+        artifacts,
+        completion: CompletionEvidence {
+            extraction_succeeded: true,
+            allow_partial: false,
+            semantic_files_expected: 0,
+            semantic_files_completed: 0,
+            failed_chunks: 0,
+        },
+    };
+    completed.partition()?;
+    Ok(completed)
+}
+
+/// Resolve the provider inventory an exact build would fingerprint for this
+/// checkout and history profile.
+pub fn history_provider_manifest(
+    checkout: &Path,
+    profile: &BuildProfile,
+) -> Result<Vec<compass_ir::ProviderDescriptor>, MaterializeError> {
+    let checkout = fs::canonicalize(checkout).map_err(|source| compass_files::FileError::Io {
+        path: checkout.to_path_buf(),
+        source,
+    })?;
+    program_provider_manifest(&checkout, profile)
 }
 
 /// Inputs that identify one exact historical materialization attempt.
@@ -124,6 +252,14 @@ pub fn materialize_history_with_observer(
     if request.replace_corrupt && corrupt.is_none() {
         return Err(MaterializeError::ReplaceCorruptNotApplicable);
     }
+    if !request.rebuild
+        && corrupt.is_none()
+        && request.repository.resolve("HEAD")? == request.commit
+        && let Some(completed) =
+            builder.promote_current(request.repository.root(), &request.commit)?
+    {
+        return run_promoted_materialization(store, &request, observer, &activity, completed);
+    }
     let worktree = request.repository.detached_worktree(&request.commit)?;
     let result = run_materialization(
         store, builder, &request, observer, &activity, &worktree, corrupt,
@@ -138,6 +274,44 @@ pub fn materialize_history_with_observer(
             cleanup,
         }),
     }
+}
+
+fn run_promoted_materialization(
+    store: &HistoryStore,
+    request: &MaterializeRequest,
+    observer: &mut dyn MaterializeObserver,
+    activity: &compass_history::ActivityGuard,
+    completed: CompletedGraphArtifacts,
+) -> Result<PublishedVersion, MaterializeError> {
+    let providers = completed
+        .artifacts
+        .program
+        .as_ref()
+        .map(|program| program.program.providers.clone())
+        .unwrap_or_default();
+    let fingerprint =
+        resolve_fingerprint_with_providers(&request.profile, request.repository.root(), providers)?;
+    observer.resolved(&fingerprint)?;
+    observer.entered(MaterializeStage::Building)?;
+    observer.entered(MaterializeStage::Validating)?;
+    validate_promoted(&completed, &request.commit)?;
+    observer.entered(MaterializeStage::Publishing)?;
+    let prepared = store.prepare_publish_with_activity(
+        PublishRequest {
+            commit: request.commit.clone(),
+            parents: request.repository.parents(&request.commit)?,
+            profile: request.profile.clone(),
+            fingerprint,
+            artifacts: completed.artifacts,
+            completion: completed.completion,
+            make_preferred: true,
+        },
+        activity,
+    )?;
+    observer.candidate(prepared.id(), prepared.observed_preferred())?;
+    store
+        .commit_prepared_with_activity(prepared, activity)
+        .map_err(Into::into)
 }
 
 fn run_materialization(
@@ -247,15 +421,11 @@ fn compatible_seed(
         if &preferred.version.build_profile != profile {
             continue;
         }
-        match store.validate_with_activity(&preferred.id, activity) {
-            Ok(_) => {}
+        match store.artifacts_with_activity(&preferred.id, activity) {
+            Ok(artifacts) => return Ok(Some(artifacts)),
             Err(error) if error.is_catalog_corruption() => continue,
             Err(error) => return Err(error.into()),
         }
-        return store
-            .artifacts_with_activity(&preferred.id, activity)
-            .map(Some)
-            .map_err(Into::into);
     }
     Ok(None)
 }
@@ -263,6 +433,18 @@ fn compatible_seed(
 fn resolve_fingerprint(
     profile: &BuildProfile,
     checkout: &Path,
+) -> Result<ExtractionFingerprint, MaterializeError> {
+    resolve_fingerprint_with_providers(
+        profile,
+        checkout,
+        program_provider_manifest(checkout, profile)?,
+    )
+}
+
+fn resolve_fingerprint_with_providers(
+    profile: &BuildProfile,
+    checkout: &Path,
+    providers: Vec<compass_ir::ProviderDescriptor>,
 ) -> Result<ExtractionFingerprint, MaterializeError> {
     let mut input =
         ExtractionFingerprintInput::new(env!("CARGO_PKG_VERSION"), HISTORY_GRAPH_SCHEMA);
@@ -272,7 +454,7 @@ fn resolve_fingerprint(
         "commit_configuration_digest",
         &configuration_digest(checkout, profile_gitignore(profile))?,
     )?;
-    input.insert_program_provider_manifest(&program_provider_manifest(checkout, profile)?)?;
+    input.insert_program_provider_manifest(&providers)?;
     input.digest().map_err(Into::into)
 }
 
@@ -398,7 +580,6 @@ fn validate_completed(
     profile: &BuildProfile,
     worktree: &WorktreeGuard,
 ) -> Result<(), MaterializeError> {
-    completed.partition()?;
     let built_at = completed
         .artifacts
         .document
@@ -469,6 +650,25 @@ fn validate_completed(
                 )));
             }
         }
+    }
+    Ok(())
+}
+
+fn validate_promoted(
+    completed: &CompletedGraphArtifacts,
+    commit: &CommitId,
+) -> Result<(), MaterializeError> {
+    let built_at = completed
+        .artifacts
+        .document
+        .extras
+        .get("built_at_commit")
+        .and_then(serde_json::Value::as_str);
+    if built_at != Some(commit.as_str()) {
+        return Err(MaterializeError::Incomplete(format!(
+            "built_at_commit is {:?}, expected {commit}",
+            built_at
+        )));
     }
     Ok(())
 }

--- a/crates/compass-core/src/lib.rs
+++ b/crates/compass-core/src/lib.rs
@@ -17,7 +17,8 @@ pub use cluster_existing::{
 pub use diagnostics::{diagnose_graph_file, format_diagnostic_json, format_diagnostic_report};
 pub use history::{
     CompleteGraphBuilder, MaterializeError, MaterializeObserver, MaterializeRequest,
-    MaterializeStage, materialize_history, materialize_history_with_observer,
+    MaterializeStage, history_provider_manifest, materialize_history,
+    materialize_history_with_observer, normalize_current_code_only_snapshot,
 };
 pub use merge::{MergeResult, merge_graphs};
 pub use pipeline::{

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -28,6 +28,7 @@ fn git(directory: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::erro
 #[derive(Default)]
 struct RecordingBuilder {
     seeds: Mutex<Vec<Option<String>>>,
+    promotion: Option<CompletedGraphArtifacts>,
 }
 
 impl RecordingBuilder {
@@ -37,9 +38,47 @@ impl RecordingBuilder {
             .map(|values| values.clone())
             .map_err(|error| MaterializeError::Builder(error.to_string()))
     }
+
+    fn promoting(commit: &CommitId) -> Result<Self, Box<dyn std::error::Error>> {
+        let document: GraphDocument = serde_json::from_value(json!({
+            "directed": true,
+            "multigraph": false,
+            "nodes": [{"id":"promoted","label":"Promoted","source_file":"service.rs"}],
+            "links": [],
+            "built_at_commit": commit
+        }))?;
+        Ok(Self {
+            seeds: Mutex::default(),
+            promotion: Some(CompletedGraphArtifacts {
+                artifacts: GraphArtifacts {
+                    document,
+                    program: None,
+                    analysis: None,
+                    labels: None,
+                    manifest: Some(json!({"service.rs":{"ast_hash":"fixture"}})),
+                    authoritative_sidecars: Default::default(),
+                },
+                completion: CompletionEvidence {
+                    extraction_succeeded: true,
+                    allow_partial: false,
+                    semantic_files_expected: 0,
+                    semantic_files_completed: 0,
+                    failed_chunks: 0,
+                },
+            }),
+        })
+    }
 }
 
 impl CompleteGraphBuilder for RecordingBuilder {
+    fn promote_current(
+        &self,
+        _repository_root: &Path,
+        _commit: &CommitId,
+    ) -> Result<Option<CompletedGraphArtifacts>, MaterializeError> {
+        Ok(self.promotion.clone())
+    }
+
     fn build(
         &self,
         checkout: &Path,
@@ -89,6 +128,66 @@ impl CompleteGraphBuilder for RecordingBuilder {
             },
         })
     }
+}
+
+#[test]
+fn current_snapshot_is_published_without_invoking_the_exact_builder()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("service.rs"), "fn service() {}\n")?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+    let repository = Repository::discover(directory.path())?;
+    let commit = repository.resolve("HEAD")?;
+    let history = HistoryStore::create(&repository)?;
+    let builder = RecordingBuilder::promoting(&commit)?;
+
+    let published = materialize_history(
+        &history,
+        &builder,
+        request(&repository, commit.clone(), false)?,
+    )?;
+
+    assert!(
+        builder.seeds()?.is_empty(),
+        "exact builder unexpectedly ran"
+    );
+    let artifacts = history.artifacts(&published.id)?;
+    assert_eq!(artifacts.artifacts.document.nodes[0].id, "promoted");
+    assert_eq!(published.version.git_commit, commit.to_string());
+    Ok(())
+}
+
+#[test]
+fn explicit_rebuild_bypasses_current_snapshot_promotion() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("service.rs"), "fn service() {}\n")?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+    let repository = Repository::discover(directory.path())?;
+    let commit = repository.resolve("HEAD")?;
+    let history = HistoryStore::create(&repository)?;
+    let builder = RecordingBuilder::promoting(&commit)?;
+
+    let published = materialize_history(&history, &builder, request(&repository, commit, true)?)?;
+
+    assert_eq!(builder.seeds()?, vec![None]);
+    let artifacts = history.artifacts(&published.id)?;
+    assert_eq!(artifacts.artifacts.document.nodes[0].id, "old");
+    Ok(())
 }
 
 fn request(

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -9,7 +9,7 @@ use prolly::{
 use prolly_store_sqlite::{SqliteStore, SqliteStoreConfig};
 
 use crate::keys::root_name;
-use crate::validate::{RealizationTrees, validate_trees};
+use crate::validate::{RealizationTrees, validate_trees, validate_trees_with_artifacts};
 use crate::{
     ActivityGuard, CommitId, GraphVersion, HistoryError, MaintenanceGuard, PublishRequest,
     PublishedVersion, RealizationId, Repository, StoredTree, StructuralSharing,
@@ -37,8 +37,6 @@ pub enum HistoryRecord {
 pub(crate) const STORE_FORMAT_ROOT: &[u8] = b"compass/store-format/v1";
 const STORE_FORMAT_KEY: &[u8] = b"format";
 const STORE_FORMAT_VALUE: &[u8] = br#"{"adapter":"prolly-store-sqlite","canonical_encoding":1,"graph_schema":"networkx-node-link/v1","history_schema":1,"typed_keys":1}"#;
-type Records = Vec<(Vec<u8>, Vec<u8>)>;
-
 /// Project-owned wrapper around the pinned SQLite Prolly adapter.
 pub struct HistoryStore {
     pub(crate) root: PathBuf,
@@ -694,18 +692,29 @@ impl HistoryStore {
         id: &RealizationId,
         _guard: &ActivityGuard,
     ) -> Result<crate::CompletedGraphArtifacts, HistoryError> {
-        self.validate_without_activity(id)?;
-        let partitioned = crate::PartitionedGraph {
-            nodes: self.read_tree(&self.load_realization_root(id, b"nodes")?)?,
-            edges: self.read_tree(&self.load_realization_root(id, b"edges")?)?,
-            hyperedges: self.read_tree(&self.load_realization_root(id, b"hyperedges")?)?,
-            analysis: self.read_tree(&self.load_realization_root(id, b"analysis")?)?,
-            metadata: self.read_tree(&self.load_realization_root(id, b"metadata")?)?,
-            program_facts: self.read_tree(&self.load_program_root(id, b"program-facts")?)?,
-            program_summaries: self
-                .read_tree(&self.load_program_root(id, b"program-summaries")?)?,
-        };
-        crate::CompletedGraphArtifacts::reconstruct(&partitioned)
+        let published = self.get_without_activity(id)?;
+        let nodes = self.load_realization_root(id, b"nodes")?;
+        let edges = self.load_realization_root(id, b"edges")?;
+        let hyperedges = self.load_realization_root(id, b"hyperedges")?;
+        let analysis = self.load_realization_root(id, b"analysis")?;
+        let metadata = self.load_realization_root(id, b"metadata")?;
+        let program_facts = self.load_program_root(id, b"program-facts")?;
+        let program_summaries = self.load_program_root(id, b"program-summaries")?;
+        validate_trees_with_artifacts(
+            &self.prolly,
+            id,
+            &published.version,
+            RealizationTrees {
+                nodes: &nodes,
+                edges: &edges,
+                hyperedges: &hyperedges,
+                analysis: &analysis,
+                metadata: &metadata,
+                program_facts: &program_facts,
+                program_summaries: &program_summaries,
+            },
+        )
+        .map(|validated| validated.artifacts)
     }
 
     /// Measure logical Prolly-node reuse between two complete realizations.
@@ -770,13 +779,6 @@ impl HistoryStore {
             builder.add(key, value);
         }
         builder.build().map_err(HistoryError::from)
-    }
-
-    fn read_tree(&self, tree: &Tree) -> Result<Records, HistoryError> {
-        self.prolly
-            .range(tree, &[], None)?
-            .map(|entry| entry.map_err(HistoryError::from))
-            .collect()
     }
 
     fn load_realization_root(

--- a/crates/compass-history/src/validate.rs
+++ b/crates/compass-history/src/validate.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use std::sync::Arc;
 
 use crate::{
-    GraphArtifacts, GraphVersion, HistoryError, PartitionedGraph, RealizationId,
+    CompletedGraphArtifacts, GraphVersion, HistoryError, PartitionedGraph, RealizationId,
     canonical_json_bytes, node_key,
 };
 
@@ -81,12 +81,26 @@ pub(crate) struct RealizationTrees<'a> {
     pub program_summaries: &'a Tree,
 }
 
+pub(crate) struct ValidatedTrees {
+    pub report: ValidationReport,
+    pub artifacts: CompletedGraphArtifacts,
+}
+
 pub(crate) fn validate_trees(
     manager: &Prolly<Arc<SqliteStore>>,
     id: &RealizationId,
     version: &GraphVersion,
     trees: RealizationTrees<'_>,
 ) -> Result<ValidationReport, HistoryError> {
+    validate_trees_with_artifacts(manager, id, version, trees).map(|validated| validated.report)
+}
+
+pub(crate) fn validate_trees_with_artifacts(
+    manager: &Prolly<Arc<SqliteStore>>,
+    id: &RealizationId,
+    version: &GraphVersion,
+    trees: RealizationTrees<'_>,
+) -> Result<ValidatedTrees, HistoryError> {
     let mut problems = Vec::new();
     if RealizationId::for_version(version)? != *id {
         problems.push(ValidationProblem::RealizationDigest);
@@ -179,21 +193,33 @@ pub(crate) fn validate_trees(
         program_facts,
         program_summaries,
     };
-    match GraphArtifacts::reconstruct(&partitioned) {
+    let artifacts = match CompletedGraphArtifacts::reconstruct(&partitioned) {
         Ok(artifacts) => {
-            validate_references(manager, trees.nodes, &artifacts.document, &mut problems)?
+            validate_references(
+                manager,
+                trees.nodes,
+                &artifacts.artifacts.document,
+                &mut problems,
+            )?;
+            Some(artifacts)
         }
-        Err(error) => problems.push(ValidationProblem::ArtifactRegistry(error.to_string())),
-    }
+        Err(error) => {
+            problems.push(ValidationProblem::ArtifactRegistry(error.to_string()));
+            None
+        }
+    };
     if problems.is_empty() {
-        Ok(ValidationReport {
-            nodes: version.node_count,
-            edges: version.edge_count,
-            hyperedges: version.hyperedge_count,
-            analysis_records: version.analysis_count,
-            metadata_records: version.metadata_count,
-            program_fact_records: version.program_fact_count,
-            program_summary_records: version.program_summary_count,
+        Ok(ValidatedTrees {
+            report: ValidationReport {
+                nodes: version.node_count,
+                edges: version.edge_count,
+                hyperedges: version.hyperedge_count,
+                analysis_records: version.analysis_count,
+                metadata_records: version.metadata_count,
+                program_fact_records: version.program_fact_count,
+                program_summary_records: version.program_summary_count,
+            },
+            artifacts: artifacts.expect("valid reconstruction is present without problems"),
         })
     } else {
         Err(HistoryError::InvalidRealization(problems))

--- a/docs/superpowers/plans/2026-07-25-versioned-history-sub-two-second.md
+++ b/docs/superpowers/plans/2026-07-25-versioned-history-sub-two-second.md
@@ -1,0 +1,200 @@
+# Sub-Two-Second Versioned History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Materialize a clean, current, code-only Compass graph into immutable history in under two seconds for repositories below 10,000 lines of code, while preserving the exact-checkout path for every ineligible snapshot.
+
+**Architecture:** Add a builder-owned promotion boundary that can return a previously completed `compass-out` snapshot only after verifying its commit stamp, corpus manifest, requested code-only profile, and Program IR provider inventory. Core history materialization will publish that verified snapshot directly from the repository root; stale, dirty, historical, semantic, rebuild, and corrupt-recovery requests continue through the detached-worktree builder. The VS Code extension continues to invoke only Compass CLI commands.
+
+**Tech Stack:** Rust, Compass history/Prolly store, Git integration tests, Criterion-free wall-clock qualification on the release CLI.
+
+## Global Constraints
+
+- The VS Code extension must invoke Compass only; no Graphify runtime dependency or command is permitted.
+- Clean current code-only repositories below 10,000 lines of code must complete `compass history build HEAD --code-only` in less than 2.0 seconds using a release binary.
+- Exact historical commits, dirty/stale outputs, semantic profiles, rebuilds, and corrupt recovery must fail closed to the existing detached-worktree path.
+- A promoted realization must be byte-for-byte identical to the realization produced by the exact builder for the same commit and profile.
+- Existing unrelated worktree changes must be preserved.
+
+---
+
+### Task 1: Verified current-snapshot promotion contract
+
+**Files:**
+- Modify: `crates/compass-core/src/history.rs`
+- Modify: `crates/compass-core/tests/history_materialize.rs`
+
+**Interfaces:**
+- Produces: `CompleteGraphBuilder::promote_current(&self, repository_root: &Path, commit: &CommitId) -> Result<Option<CompletedGraphArtifacts>, MaterializeError>`
+- Consumes: existing `MaterializeRequest`, `CompletedGraphArtifacts`, publication observer, and exact fallback.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a builder that returns a commit-stamped completed graph from `promote_current`, records whether `build` was called, and assert that materializing clean `HEAD` publishes the snapshot without calling `build`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p compass-core --test history_materialize current_snapshot`
+
+Expected: FAIL because `CompleteGraphBuilder` has no promotion boundary and the exact builder is invoked.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the default method:
+
+```rust
+fn promote_current(
+    &self,
+    _repository_root: &Path,
+    _commit: &CommitId,
+) -> Result<Option<CompletedGraphArtifacts>, MaterializeError> {
+    Ok(None)
+}
+```
+
+Before creating a detached worktree, request a promoted snapshot only for non-rebuild, non-corrupt-recovery `HEAD`; resolve its fingerprint from its stored Program provider descriptors, validate the commit stamp, and publish through the existing atomic store API.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p compass-core --test history_materialize current_snapshot`
+
+Expected: PASS.
+
+### Task 2: Native Compass snapshot eligibility
+
+**Files:**
+- Modify: `crates/compass-cli/src/history_build.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+
+**Interfaces:**
+- Implements: `NativeCompleteGraphBuilder::promote_current`
+- Consumes: `GraphArtifacts::load`, `Manifest`, `ManifestKind::Ast`, `detect`, and requested history profile options.
+
+- [ ] **Step 1: Write failing integration tests**
+
+Create a small committed repository and current `compass-out`. Assert:
+
+```rust
+// Eligible: current commit, code-only, exact manifest.
+let promoted = run_history_build(&fixture, "HEAD", &["--code-only"])?;
+assert_eq!(load_published_graph(&fixture, &promoted)?, fixture.current_graph);
+
+// Ineligible: change a tracked source after the snapshot.
+fixture.change_and_commit("service.rs", "pub fn changed() {}\n")?;
+let rebuilt = run_history_build(&fixture, "HEAD", &["--code-only"])?;
+assert_ne!(load_published_graph(&fixture, &rebuilt)?, fixture.stale_graph);
+```
+
+Also cover a semantic profile and an explicit rebuild to prove they use the exact path.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p compass-cli --test history_cli current_code_only_snapshot`
+
+Expected: FAIL because the native builder does not offer a promotable snapshot.
+
+- [ ] **Step 3: Implement eligibility checks**
+
+Return `None` unless all conditions hold:
+
+```rust
+if !self.code_only {
+    return Ok(None);
+}
+let artifacts = GraphArtifacts::load(output_dir)?;
+if artifacts.document.extras.get("built_at_commit").and_then(Value::as_str)
+    != Some(commit.as_str())
+{
+    return Ok(None);
+}
+let detection = detect(repository_root, &self.detect_options(repository_root))?;
+let manifest = Manifest::load(&output_dir.join("manifest.json"), Some(repository_root));
+if !manifest.is_unchanged(&detection.files, ManifestKind::Ast) {
+    return Ok(None);
+}
+```
+
+Load authoritative artifacts and zero-semantic completion evidence only after the checks succeed. Resolve the fast-path fingerprint from `artifacts.program.program.providers`; publication validates the Program bundle and artifact registry. Any read, parse, corpus, or provider mismatch falls back rather than weakening correctness.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p compass-cli --test history_cli current_code_only_snapshot`
+
+Expected: PASS.
+
+### Task 3: End-to-end release performance gate
+
+**Files:**
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+- Modify: `crates/compass-history/tests/performance.rs` if a reusable fixture helper is needed
+
+**Interfaces:**
+- Consumes: release `compass`, a clean current `compass-out`, and `history build HEAD --code-only --format json`.
+- Produces: measured elapsed duration and identical realization evidence.
+
+- [ ] **Step 1: Add the qualification fixture**
+
+Use a deterministic repository below 10,000 source lines, build current `compass-out`, materialize once in a fresh history store, and assert:
+
+```rust
+assert!(elapsed < Duration::from_secs(2), "elapsed={elapsed:?}");
+assert_eq!(promoted_realization, exact_realization);
+```
+
+Keep the strict wall-clock assertion ignored in ordinary debug test runs and execute it explicitly against the release binary.
+
+- [ ] **Step 2: Verify the pre-fix release gate fails**
+
+Run the release CLI against `/Volumes/Workspace/Github/fjall` in a fresh shared clone.
+
+Expected baseline: approximately 3.94 seconds, exceeding the 2.0-second limit.
+
+- [ ] **Step 3: Run the post-fix gate**
+
+Run the same command and fixture with `target/release/compass`.
+
+Expected: elapsed `< 2.0s`, exit code 0, and the same realization ID as the exact path.
+
+### Task 4: Regression, extension boundary, and graph refresh
+
+**Files:**
+- Verify: `editors/vscode/src/views/historyPanel.ts`
+- Verify: `editors/vscode/src/history/buildArguments.ts`
+- Refresh: `graphify-out/`
+
+**Interfaces:**
+- Consumes: existing Compass JSONL progress protocol.
+- Produces: no extension runtime dependency beyond Compass.
+
+- [ ] **Step 1: Run Rust regression suites**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-history --lib --tests
+cargo test -p compass-core --test history_materialize
+cargo test -p compass-cli --test history_cli
+```
+
+- [ ] **Step 2: Run VS Code and browser regression suites**
+
+Run:
+
+```bash
+npm test -w compass-vscode
+npm run typecheck -w compass-vscode
+npm test -w @compass/viewer-tests -- history.spec.ts
+```
+
+- [ ] **Step 3: Confirm the extension boundary**
+
+Inspect the extension build arguments and process launch path; verify versioned-graph operations invoke `compass history build`, `compass history timeline`, `compass history change-counts`, or `compass diff`, and no extension source imports or executes Graphify.
+
+- [ ] **Step 4: Refresh the required development index**
+
+Run `graphify update .` from the Compass repository solely because `AGENTS.md` requires it after code edits. This is a contributor-time operation and must not appear in extension code or packaged runtime assets.
+
+- [ ] **Step 5: Final diff and performance verification**
+
+Run `git diff --check`, repeat the fjall release benchmark in a fresh clone, and report the exact before/after stage timings.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -14,9 +14,9 @@ If `compass` is not on `PATH`, set **Compass: CLI Path** or choose **Select
 Compass Binary** from the guided setup.
 
 The CLI must support `compass capabilities --format json` and the versioned
-contracts advertised by the extension. If an older or Graphify-compatible
-binary is found first on `PATH`, Compass stops before running a workflow and
-offers **Select Compass Binary** instead of displaying raw CLI usage output.
+contracts advertised by the extension. If a non-Compass or incompatible binary
+is found first on `PATH`, Compass stops before running a workflow and offers
+**Select Compass Binary** instead of displaying raw CLI usage output.
 
 ## Workflows
 

--- a/editors/vscode/src/history/changeCountsClient.test.ts
+++ b/editors/vscode/src/history/changeCountsClient.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadChangeCounts } from "./changeCountsClient";
+
+describe("history change-counts client", () => {
+  it("requests counts against the exact parent selected for comparison", async () => {
+    const runJson = vi.fn().mockResolvedValue({
+      schema: "compass.history.change_counts/1",
+      commit: "current",
+      parent: "parent-2",
+      counts: {
+        nodes: { added: 1, removed: 0, changed: 0 },
+        edges: { added: 0, removed: 0, changed: 0 },
+        hyperedges: { added: 0, removed: 0, changed: 0 }
+      }
+    });
+    const session = {
+      root: "/repo",
+      processes: { runJson }
+    };
+
+    await loadChangeCounts(session as never, "current", "parent-2");
+
+    expect(runJson.mock.calls[0]?.[1]).toEqual([
+      "history",
+      "change-counts",
+      "current",
+      "--parent",
+      "parent-2",
+      "--format",
+      "json"
+    ]);
+  });
+});

--- a/editors/vscode/src/history/changeCountsClient.ts
+++ b/editors/vscode/src/history/changeCountsClient.ts
@@ -1,13 +1,20 @@
-import { HistoryChangeCountsSchema, type HistoryChangeCounts } from "@compass/viewer";
+import {
+  HistoryChangeCountsSchema,
+  type HistoryChangeCounts
+} from "@compass/viewer/contracts/history";
 import type { RepositorySession } from "../workspace/repositorySession";
 
 export async function loadChangeCounts(
   session: RepositorySession,
-  commit: string
+  commit: string,
+  parent?: string
 ): Promise<HistoryChangeCounts> {
+  const args = ["history", "change-counts", commit];
+  if (parent) args.push("--parent", parent);
+  args.push("--format", "json");
   return session.processes.runJson(
     session.root,
-    ["history", "change-counts", commit, "--format", "json"],
+    args,
     HistoryChangeCountsSchema
   );
 }

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -81,6 +81,7 @@ export type HistoryHostMessage =
     currentGraph: GraphViewModel;
     parentGraph: GraphViewModel;
     semanticDiff: unknown;
+    counts?: HistoryChangeCounts;
   }
   | { type: "changeCounts"; commit: string; counts: HistoryChangeCounts }
   | { type: "buildRunning"; commit: string }

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -203,6 +203,7 @@ export async function openHistoryPanel(
 
     let command: ReturnType<RepositorySession["processes"]["startJsonl"]> | undefined;
     let buildAttempt: typeof activePanelBuild;
+    let reportBuildProgress: ((message: string) => void) | undefined;
     try {
       if (session.activeWriter) {
         throw new Error("Another Compass write operation started while choosing the history profile.");
@@ -215,7 +216,10 @@ export async function openHistoryPanel(
           firstParent: false,
           profile: selectedProfile
         }),
-        (event) => output.appendLine(`[history:${event.phase}] ${event.message}`)
+        (event) => {
+          output.appendLine(`[history:${event.phase}] ${event.message}`);
+          reportBuildProgress?.(event.message);
+        }
       );
       command = runningCommand;
       buildAttempt = { command: runningCommand, cancelled: false };
@@ -228,12 +232,17 @@ export async function openHistoryPanel(
           title: `Building Compass graph for ${commit.slice(0, 9)}`,
           cancellable: true
         },
-        async (_, token) => {
+        async (progress, token) => {
+          reportBuildProgress = (message) => progress.report({ message });
           token.onCancellationRequested(() => {
             if (buildAttempt) buildAttempt.cancelled = true;
             runningCommand.cancel();
           });
-          return runningCommand.completed;
+          try {
+            return await runningCommand.completed;
+          } finally {
+            reportBuildProgress = undefined;
+          }
         }
       );
       if (buildAttempt.cancelled || disposed) {
@@ -426,10 +435,11 @@ export async function openHistoryPanel(
         if (!currentEntry?.presentationAvailable || !parentEntry?.presentationAvailable) {
           throw new Error("Both revisions must have graph available before comparison.");
         }
-        const [current, parent, semanticDiff] = await Promise.all([
+        const [current, parent, semanticDiff, counts] = await Promise.all([
           revisions.load(message.commit, graphNodeLimit, historyIdentity(currentEntry)),
           revisions.load(message.parent, graphNodeLimit, historyIdentity(parentEntry)),
-          loadSemanticDiff(session, message.parent, message.commit)
+          loadSemanticDiff(session, message.parent, message.commit),
+          loadChangeCounts(session, message.commit, message.parent)
         ]);
         await postMessage({
           type: "comparison",
@@ -439,7 +449,8 @@ export async function openHistoryPanel(
           fingerprint: current.fingerprint,
           currentGraph: current.graph,
           parentGraph: parent.graph,
-          semanticDiff
+          semanticDiff,
+          counts
         });
       } else if (message?.type === "queryRevision" && typeof message.commit === "string") {
         const entry = timeline?.entries.find((candidate) => candidate.commit === message.commit);

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -7,6 +7,7 @@ import {
   GraphViewModelSchema,
   compareGraphs,
   type GraphViewModel,
+  type GraphComparison,
   type HistoryBuildState,
   type HistoryChangeCounts,
   type HistoryOperationError,
@@ -32,6 +33,7 @@ let communityLoading: number | null = null;
 let communityError: string | undefined;
 let activeCommunityRequest = "";
 let semanticDiff: unknown;
+let comparison: (GraphComparison & { parent: string }) | undefined;
 let repositoryId = "";
 let changeCounts: HistoryChangeCounts | undefined;
 let revisionLoadState: "idle" | "loading" | "ready" = "idle";
@@ -52,6 +54,7 @@ function clearRevisionPresentation(): void {
   graphCommit = undefined;
   graphIdentity = undefined;
   semanticDiff = undefined;
+  comparison = undefined;
   changeCounts = undefined;
   communityDetail = undefined;
   communityLoading = null;
@@ -137,6 +140,7 @@ function render(): void {
       onSelectCommit={selectCommit}
       graph={graph}
       graphCommit={graphCommit}
+      comparison={comparison}
       communityDetail={communityDetail}
       communityLoading={communityLoading}
       communityError={communityError}
@@ -145,6 +149,12 @@ function render(): void {
         communityLoading = null;
         communityError = undefined;
         activeCommunityRequest = "";
+        render();
+      }}
+      onExitComparison={() => {
+        comparison = undefined;
+        semanticDiff = undefined;
+        requestChangeCounts(selectedCommit);
         render();
       }}
       semanticDiff={semanticDiff}
@@ -309,6 +319,10 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
     const current = GraphViewModelSchema.safeParse(message.currentGraph);
     const parent = GraphViewModelSchema.safeParse(message.parentGraph);
     if (current.success && parent.success) {
+      const parsedCounts = message.counts
+        ? HistoryChangeCountsSchema.safeParse(message.counts)
+        : undefined;
+      const exactCounts = parsedCounts?.success ? parsedCounts.data : undefined;
       graph = current.data;
       graphCommit = message.commit;
       graphIdentity = {
@@ -319,10 +333,22 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       communityLoading = null;
       communityError = undefined;
       activeCommunityRequest = "";
-      semanticDiff = {
-        structural: compareGraphs(parent.data, current.data),
-        semantic: message.semanticDiff
+      comparison = {
+        ...compareGraphs(parent.data, current.data),
+        ...(exactCounts
+          ? {
+              addedNodes: exactCounts.counts.nodes.added,
+              removedNodes: exactCounts.counts.nodes.removed,
+              changedNodes: exactCounts.counts.nodes.changed,
+              addedEdges: exactCounts.counts.edges.added,
+              removedEdges: exactCounts.counts.edges.removed,
+              changedEdges: exactCounts.counts.edges.changed
+            }
+          : {}),
+        parent: message.parent
       };
+      semanticDiff = message.semanticDiff;
+      if (exactCounts) changeCounts = exactCounts;
       operationErrors.delete(message.commit);
       revisionLoadState = "ready";
     }

--- a/packages/compass-viewer/src/contracts/graph.ts
+++ b/packages/compass-viewer/src/contracts/graph.ts
@@ -23,6 +23,7 @@ export const GraphNodeSchema = z.object({
   memberCount: z.number().int().nonnegative().optional(),
   learningStatus: z.string().optional(),
   learningStale: z.boolean().optional(),
+  change: z.enum(["added", "removed", "changed", "unchanged"]).optional(),
   source: SourceLocationSchema.optional(),
   color: z.object({
     background: z.string(),
@@ -35,6 +36,7 @@ export const GraphEdgeSchema = z.object({
   source: z.string().min(1),
   target: z.string().min(1),
   relation: z.string(),
+  change: z.enum(["added", "removed", "changed", "unchanged"]).optional(),
   confidence: z.enum(["extracted", "inferred", "ambiguous"]).optional()
 }).passthrough();
 

--- a/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
+++ b/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
@@ -88,6 +88,13 @@ function edgeAppearance(confidence: string | undefined) {
   return { dashes: true, width: 1, opacity: 0.35 };
 }
 
+function comparisonEdgeColor(change: string | undefined, fallback: string): string {
+  if (change === "added") return "#2ea043";
+  if (change === "removed") return "#f85149";
+  if (change === "changed") return "#d29922";
+  return fallback;
+}
+
 function useThemeRevision(): number {
   const [revision, setRevision] = useState(0);
   useEffect(() => {
@@ -167,6 +174,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
     const edgeData = useMemo(() => new DataSet<Edge>(
       model.edges.map((edge) => {
         const appearance = edgeAppearance(edge.confidence);
+        const color = comparisonEdgeColor(edge.change, "#60728b");
         return {
           id: edge.id,
           from: edge.source,
@@ -174,7 +182,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           title: `${edge.relation}${edge.confidence ? ` · ${edge.confidence}` : ""}`,
           dashes: appearance.dashes,
           width: appearance.width,
-          color: { color: "#60728b", opacity: appearance.opacity }
+          color: { color, opacity: edge.change ? 0.88 : appearance.opacity }
         };
       })
     ), [model.edges]);
@@ -270,12 +278,14 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       }));
       edgeData.update(model.edges.map((edge) => {
         const appearance = edgeAppearance(edge.confidence);
+        const baseOpacity = edge.change ? 0.88 : appearance.opacity;
         const connectedEdge = edge.source === focusedNodeId || edge.target === focusedNodeId;
+        const color = comparisonEdgeColor(edge.change, edgeColor);
         return {
           id: edge.id,
           color: {
-            color: edgeColor,
-            opacity: !focusedNodeId ? appearance.opacity : connectedEdge ? 0.9 : 0.06
+            color,
+            opacity: !focusedNodeId ? baseOpacity : connectedEdge ? 0.9 : 0.06
           },
           width: connectedEdge ? Math.max(2.5, appearance.width) : appearance.width
         };

--- a/packages/compass-viewer/src/history/CommitDetails.tsx
+++ b/packages/compass-viewer/src/history/CommitDetails.tsx
@@ -81,13 +81,27 @@ export function CommitDetails({
         </p>
       )}
       {changeCounts && (
-        <div className="history-change-counts" aria-label="Structural change counts">
-          <ChangeCount label="nodes" counts={changeCounts.counts.nodes} />
-          <ChangeCount label="edges" counts={changeCounts.counts.edges} />
-          <ChangeCount label="hyperedges" counts={changeCounts.counts.hyperedges} />
-        </div>
+        <>
+          <div className="history-change-counts" aria-label="Structural change counts">
+            <ChangeCount label="nodes" counts={changeCounts.counts.nodes} />
+            <ChangeCount label="edges" counts={changeCounts.counts.edges} />
+            <ChangeCount label="hyperedges" counts={changeCounts.counts.hyperedges} />
+          </div>
+          {isEmptyChangeCounts(changeCounts) && (
+            <p className="history-change-counts-help">
+              No structural changes from the first parent. Source or configuration changes may
+              still exist; compare the revisions to inspect them.
+            </p>
+          )}
+        </>
       )}
     </section>
+  );
+}
+
+function isEmptyChangeCounts(changeCounts: HistoryChangeCounts): boolean {
+  return Object.values(changeCounts.counts).every(
+    (counts) => counts.added === 0 && counts.removed === 0 && counts.changed === 0
   );
 }
 

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { GraphViewModel } from "../contracts/graph";
+import { compareGraphs } from "./ComparisonOverlay";
+
+function graph(
+  nodes: GraphViewModel["nodes"],
+  edges: GraphViewModel["edges"]
+): GraphViewModel {
+  return {
+    schema: "compass.viewer.graph/1",
+    title: "Fixture",
+    stats: {
+      nodes: nodes.length,
+      edges: edges.length,
+      communities: 1,
+      aggregated: false
+    },
+    nodes,
+    edges,
+    communities: [{ id: 0, label: "Core", color: "#6688aa", hidden: false }],
+    hyperedges: []
+  };
+}
+
+describe("compareGraphs", () => {
+  it("builds a focused, color-coded delta graph with changed records and their endpoints", () => {
+    const parent = graph(
+      [
+        { id: "shared", label: "Shared", community: 0, signature: "old" },
+        { id: "removed", label: "Removed", community: 0 }
+      ],
+      [{
+        id: "shared-edge",
+        source: "shared",
+        target: "removed",
+        relation: "calls",
+        confidence: "inferred"
+      }]
+    );
+    const current = graph(
+      [
+        { id: "shared", label: "Shared", community: 0, signature: "new" },
+        { id: "added", label: "Added", community: 0 }
+      ],
+      [{
+        id: "shared-edge",
+        source: "shared",
+        target: "added",
+        relation: "calls",
+        confidence: "extracted"
+      }]
+    );
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison).toMatchObject({
+      addedNodes: 1,
+      removedNodes: 1,
+      changedNodes: 1,
+      addedEdges: 0,
+      removedEdges: 0,
+      changedEdges: 1
+    });
+    expect(comparison.graph.nodes.map((node) => [node.id, node.change])).toEqual([
+      ["added", "added"],
+      ["removed", "removed"],
+      ["shared", "changed"]
+    ]);
+    expect(comparison.graph.edges.map((edge) => [edge.id, edge.change])).toEqual([
+      ["shared-edge", "changed"]
+    ]);
+    expect(comparison.graph.stats).toMatchObject({ nodes: 3, edges: 1 });
+  });
+
+  it("returns an empty delta graph when two visible graphs are structurally identical", () => {
+    const unchanged = graph(
+      [{ id: "same", label: "Same", community: 0 }],
+      []
+    );
+
+    const comparison = compareGraphs(unchanged, unchanged);
+
+    expect(comparison.graph.nodes).toEqual([]);
+    expect(comparison.graph.edges).toEqual([]);
+    expect(comparison.graph.stats).toMatchObject({ nodes: 0, edges: 0 });
+  });
+});

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -1,35 +1,194 @@
-import { Badge } from "../components/ui/badge";
+import { GitCompareIcon, XIcon } from "lucide-react";
+import type {
+  GraphEdge,
+  GraphNode,
+  GraphViewModel
+} from "../contracts/graph";
 
 export type GraphComparison = {
   addedNodes: number;
   removedNodes: number;
+  changedNodes: number;
   addedEdges: number;
   removedEdges: number;
+  changedEdges: number;
+  graph: GraphViewModel;
 };
 
-export function ComparisonOverlay({ comparison }: { comparison: GraphComparison }) {
+export function ComparisonOverlay({
+  comparison,
+  commit,
+  parent,
+  onExit
+}: {
+  comparison: GraphComparison;
+  commit: string;
+  parent: string;
+  onExit(): void;
+}) {
+  const empty = comparison.graph.nodes.length === 0 && comparison.graph.edges.length === 0;
   return (
-    <div className="flex flex-wrap gap-2" aria-label="Structural graph comparison">
-      <Badge className="bg-emerald-600">+{comparison.addedNodes} nodes</Badge>
-      <Badge variant="destructive">−{comparison.removedNodes} nodes</Badge>
-      <Badge className="bg-emerald-600">+{comparison.addedEdges} edges</Badge>
-      <Badge variant="destructive">−{comparison.removedEdges} edges</Badge>
-    </div>
+    <section className="history-comparison" aria-label="Revision graph comparison">
+      <div className="history-comparison-heading">
+        <GitCompareIcon aria-hidden="true" />
+        <div>
+          <span className="history-eyebrow">Comparison mode</span>
+          <h2>
+            Comparing <code>{commit.slice(0, 9)}</code> to <code>{parent.slice(0, 9)}</code>
+          </h2>
+        </div>
+        <button type="button" onClick={onExit} aria-label="Exit comparison">
+          <XIcon aria-hidden="true" /> Exit comparison
+        </button>
+      </div>
+      <div className="history-comparison-legend" aria-label="Visible graph delta">
+        <Delta label="nodes" added={comparison.addedNodes}
+          removed={comparison.removedNodes} changed={comparison.changedNodes} />
+        <Delta label="edges" added={comparison.addedEdges}
+          removed={comparison.removedEdges} changed={comparison.changedEdges} />
+      </div>
+      {empty && (
+        <div className="history-comparison-empty">
+          <strong>No structural graph changes</strong>
+          <span>
+            The stored topology is identical. Source or configuration changes can still appear below.
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Delta({
+  label,
+  added,
+  removed,
+  changed
+}: {
+  label: string;
+  added: number;
+  removed: number;
+  changed: number;
+}) {
+  return (
+    <span>
+      <strong>{label}</strong>
+      <i data-change="added">+{added}</i>
+      <i data-change="removed">−{removed}</i>
+      <i data-change="changed">~{changed}</i>
+    </span>
   );
 }
 
 export function compareGraphs(
-  parent: { nodes: { id: string }[]; edges: { id: string }[] },
-  current: { nodes: { id: string }[]; edges: { id: string }[] }
+  parent: GraphViewModel,
+  current: GraphViewModel
 ): GraphComparison {
-  const parentNodes = new Set(parent.nodes.map((node) => node.id));
-  const currentNodes = new Set(current.nodes.map((node) => node.id));
-  const parentEdges = new Set(parent.edges.map((edge) => edge.id));
-  const currentEdges = new Set(current.edges.map((edge) => edge.id));
+  const parentNodes = new Map(parent.nodes.map((node) => [node.id, node]));
+  const currentNodes = new Map(current.nodes.map((node) => [node.id, node]));
+  const parentEdges = new Map(parent.edges.map((edge) => [edge.id, edge]));
+  const currentEdges = new Map(current.edges.map((edge) => [edge.id, edge]));
+  const nodes = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+  const addedNodeIds = difference(currentNodes, parentNodes);
+  const removedNodeIds = difference(parentNodes, currentNodes);
+  const changedNodeIds = intersection(currentNodes, parentNodes)
+    .filter((id) => !sameRecord(currentNodes.get(id), parentNodes.get(id)));
+  const addedEdgeIds = difference(currentEdges, parentEdges);
+  const removedEdgeIds = difference(parentEdges, currentEdges);
+  const changedEdgeIds = intersection(currentEdges, parentEdges)
+    .filter((id) => !sameRecord(currentEdges.get(id), parentEdges.get(id)));
+
+  for (const id of addedNodeIds) addNode(nodes, currentNodes.get(id), "added");
+  for (const id of removedNodeIds) addNode(nodes, parentNodes.get(id), "removed");
+  for (const id of changedNodeIds) addNode(nodes, currentNodes.get(id), "changed");
+  for (const [ids, source, change] of [
+    [addedEdgeIds, currentEdges, "added"],
+    [removedEdgeIds, parentEdges, "removed"],
+    [changedEdgeIds, currentEdges, "changed"]
+  ] as const) {
+    for (const id of ids) {
+      const edge = source.get(id);
+      if (!edge) continue;
+      edges.push({ ...edge, change });
+      addContextNode(nodes, edge.source, parentNodes, currentNodes);
+      addContextNode(nodes, edge.target, parentNodes, currentNodes);
+    }
+  }
+  const orderedNodes = [...nodes.values()].sort((left, right) => left.id.localeCompare(right.id));
+  edges.sort((left, right) => left.id.localeCompare(right.id));
+  const communityIds = new Set(orderedNodes.map((node) => node.community));
+  const communities = [
+    ...current.communities,
+    ...parent.communities.filter((community) =>
+      !current.communities.some((candidate) => candidate.id === community.id))
+  ].filter((community) => communityIds.has(community.id));
   return {
-    addedNodes: [...currentNodes].filter((id) => !parentNodes.has(id)).length,
-    removedNodes: [...parentNodes].filter((id) => !currentNodes.has(id)).length,
-    addedEdges: [...currentEdges].filter((id) => !parentEdges.has(id)).length,
-    removedEdges: [...parentEdges].filter((id) => !currentEdges.has(id)).length
+    addedNodes: addedNodeIds.length,
+    removedNodes: removedNodeIds.length,
+    changedNodes: changedNodeIds.length,
+    addedEdges: addedEdgeIds.length,
+    removedEdges: removedEdgeIds.length,
+    changedEdges: changedEdgeIds.length,
+    graph: {
+      ...current,
+      title: `Graph delta · ${current.title}`,
+      stats: {
+        ...current.stats,
+        nodes: orderedNodes.length,
+        edges: edges.length,
+        communities: communities.length,
+        aggregated: false
+      },
+      nodes: orderedNodes,
+      edges,
+      communities,
+      hyperedges: []
+    }
   };
+}
+
+function difference<T>(left: ReadonlyMap<string, T>, right: ReadonlyMap<string, T>): string[] {
+  return [...left.keys()].filter((id) => !right.has(id));
+}
+
+function intersection<T>(left: ReadonlyMap<string, T>, right: ReadonlyMap<string, T>): string[] {
+  return [...left.keys()].filter((id) => right.has(id));
+}
+
+function sameRecord(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function addNode(
+  nodes: Map<string, GraphNode>,
+  node: GraphNode | undefined,
+  change: "added" | "removed" | "changed"
+): void {
+  if (node) nodes.set(node.id, { ...node, change, color: comparisonColor(change) });
+}
+
+function addContextNode(
+  nodes: Map<string, GraphNode>,
+  id: string,
+  parent: ReadonlyMap<string, GraphNode>,
+  current: ReadonlyMap<string, GraphNode>
+): void {
+  if (nodes.has(id)) return;
+  const node = current.get(id) ?? parent.get(id);
+  if (node) nodes.set(id, {
+    ...node,
+    change: "unchanged",
+    color: comparisonColor("unchanged")
+  });
+}
+
+function comparisonColor(change: "added" | "removed" | "changed" | "unchanged") {
+  const background = {
+    added: "#2ea043",
+    removed: "#f85149",
+    changed: "#d29922",
+    unchanged: "#6e7781"
+  }[change];
+  return { background, border: background };
 }

--- a/packages/compass-viewer/src/history/HistoryWorkspace.test.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.test.tsx
@@ -12,6 +12,11 @@ beforeAll(() => {
     observe() {}
     disconnect() {}
   });
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {}
+  }));
 });
 
 function host(): HistoryHost {
@@ -29,6 +34,101 @@ function host(): HistoryHost {
 }
 
 describe("HistoryWorkspace", () => {
+  it("puts a zero-topology comparison explanation before the graph canvas", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const parent = "b".repeat(40);
+    const timeline = {
+      schema: "compass.history.timeline/1" as const,
+      repositoryId: "repo",
+      selectedHead: commit,
+      historyEnabled: true,
+      totalEntries: 2,
+      hasMore: false,
+      nextCursor: null,
+      entries: [{
+        commit,
+        parents: [parent],
+        authorName: "Compass",
+        authorEmail: "test@example.invalid",
+        authoredAtSeconds: 2,
+        subject: "Version bump",
+        graphState: "graph_available" as const,
+        presentationAvailable: true,
+        realization: "current-realization",
+        fingerprint: "current-fingerprint",
+        job: null
+      }, {
+        commit: parent,
+        parents: [],
+        authorName: "Compass",
+        authorEmail: "test@example.invalid",
+        authoredAtSeconds: 1,
+        subject: "Parent",
+        graphState: "graph_available" as const,
+        presentationAvailable: true,
+        realization: "parent-realization",
+        fingerprint: "parent-fingerprint",
+        job: null
+      }]
+    };
+    const emptyGraph = {
+      schema: "compass.viewer.graph/1" as const,
+      title: "No visible topology changes",
+      stats: { nodes: 0, edges: 0, communities: 0, aggregated: false },
+      nodes: [],
+      edges: [],
+      communities: [],
+      hyperedges: []
+    };
+    flushSync(() => root.render(
+      <HistoryWorkspace
+        timeline={timeline}
+        selectedCommit={commit}
+        revisionLoadState="ready"
+        graph={emptyGraph}
+        graphCommit={commit}
+        comparison={{
+          parent,
+          graph: emptyGraph,
+          addedNodes: 0,
+          removedNodes: 0,
+          changedNodes: 0,
+          addedEdges: 0,
+          removedEdges: 0,
+          changedEdges: 0
+        }}
+        changeCounts={{
+          schema: "compass.history.change_counts/1",
+          commit,
+          parent,
+          counts: {
+            nodes: { added: 0, removed: 0, changed: 0 },
+            edges: { added: 0, removed: 0, changed: 0 },
+            hyperedges: { added: 0, removed: 0, changed: 0 }
+          }
+        }}
+        onSelectCommit={vi.fn()}
+        onExitComparison={vi.fn()}
+        host={host()}
+      />
+    ));
+
+    const explanation = Array.from(container.querySelectorAll("*"))
+      .find((element) => element.textContent === "No structural graph changes");
+    const graphFrame = container.querySelector(".history-graph-frame");
+    expect(explanation).toBeDefined();
+    expect(graphFrame).not.toBeNull();
+    if (!explanation || !graphFrame) throw new Error("comparison layout did not render");
+    expect(explanation.compareDocumentPosition(graphFrame) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+    expect(container.textContent).toContain(`Comparing ${commit.slice(0, 9)} to ${parent.slice(0, 9)}`);
+    expect(container.textContent).toContain(
+      "No structural changes from the first parent. Source or configuration changes may still exist"
+    );
+    root.unmount();
+  });
+
   it("lets the user enable revision graphs from the disabled state", () => {
     const historyHost = host();
     const container = document.createElement("div");

--- a/packages/compass-viewer/src/history/HistoryWorkspace.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../contracts/history";
 import { CommitDetails } from "./CommitDetails";
 import { CommitRail } from "./CommitRail";
+import { ComparisonOverlay, type GraphComparison } from "./ComparisonOverlay";
 import { SemanticFindings } from "./SemanticFindings";
 
 export type HistoryHost = {
@@ -28,6 +29,7 @@ export type HistoryHost = {
 export function HistoryWorkspace({
   timeline,
   graph,
+  comparison,
   semanticDiff,
   changeCounts,
   graphCommit,
@@ -35,6 +37,7 @@ export function HistoryWorkspace({
   communityLoading,
   communityError,
   onBackToOverview,
+  onExitComparison,
   selectedCommit,
   revisionLoadState,
   enableState,
@@ -47,6 +50,7 @@ export function HistoryWorkspace({
 }: {
   timeline: HistoryTimeline;
   graph?: GraphViewModel | undefined;
+  comparison?: (GraphComparison & { parent: string }) | undefined;
   semanticDiff?: unknown;
   changeCounts?: HistoryChangeCounts | undefined;
   graphCommit?: string | undefined;
@@ -54,6 +58,7 @@ export function HistoryWorkspace({
   communityLoading?: number | null | undefined;
   communityError?: string | undefined;
   onBackToOverview?: (() => void) | undefined;
+  onExitComparison?: (() => void) | undefined;
   selectedCommit: string;
   revisionLoadState: "idle" | "loading" | "ready";
   enableState?: HistoryBuildState | undefined;
@@ -80,7 +85,8 @@ export function HistoryWorkspace({
       .map((entry) => entry.commit)),
     [timeline.entries]
   );
-  const visibleGraph = graph && graphCommit === selected?.commit ? graph : undefined;
+  const visibleGraph = comparison?.graph
+    ?? (graph && graphCommit === selected?.commit ? graph : undefined);
   const loadedEntries = timeline.entries.length;
   const countLabel = timeline.hasMore
     ? `${loadedEntries.toLocaleString()} loaded commits`
@@ -199,11 +205,28 @@ export function HistoryWorkspace({
               onQuery={() => host.queryRevision(selected.commit)}
               changeCounts={changeCounts?.commit === selected.commit ? changeCounts : undefined}
             />
+            {comparison && (
+              <ComparisonOverlay
+                comparison={comparison}
+                commit={selected.commit}
+                parent={comparison.parent}
+                onExit={() => onExitComparison?.()}
+              />
+            )}
+            {comparison && semanticDiff !== undefined && <SemanticFindings report={semanticDiff} />}
             <div className="history-graph-frame">
-              {visibleGraph ? (
+              {comparison && comparison.graph.nodes.length === 0
+                && comparison.graph.edges.length === 0 ? (
+                <WorkspaceState
+                  kind="empty"
+                  title="No graph delta to draw"
+                  description="This comparison changes source or configuration without changing visible graph topology."
+                />
+              ) : visibleGraph ? (
                 <div className="history-graph-ready">
                   <div className="history-graph-status" role="status">
-                    Viewing graph for <span>{selected.commit.slice(0, 9)}</span>
+                    {comparison ? "Viewing changed subgraph for " : "Viewing graph for "}
+                    <span>{selected.commit.slice(0, 9)}</span>
                   </div>
                   <div className="history-graph-canvas">
                     <CompassGraph
@@ -283,7 +306,7 @@ export function HistoryWorkspace({
                 />
               )}
             </div>
-            {semanticDiff !== undefined && <SemanticFindings report={semanticDiff} />}
+            {!comparison && semanticDiff !== undefined && <SemanticFindings report={semanticDiff} />}
           </>
         )}
       </main>

--- a/packages/compass-viewer/src/history/SemanticFindings.test.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.test.tsx
@@ -1,0 +1,40 @@
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { SemanticFindings } from "./SemanticFindings";
+
+describe("SemanticFindings", () => {
+  it("renders source-only changes as readable evidence instead of a raw report dump", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    flushSync(() => root.render(
+        <SemanticFindings
+          report={{
+            schema: "compass.semantic_diff.report/1",
+            comparison: { old_revision: "parent", new_revision: "current" },
+            source_changes: [{
+              old_path: "Cargo.toml",
+              new_path: "Cargo.toml",
+              status: "modified",
+              hunks: [{ old_start: 5, old_lines: 1, new_start: 5, new_lines: 1 }],
+              patch: "-version = \"3.1.6\"\n+version = \"3.1.7\""
+            }],
+            findings: [],
+            completeness: {
+              identity: "complete",
+              source_delta: "complete",
+              call_resolution: "unavailable",
+              test_mapping: "unavailable"
+            }
+          }}
+        />
+    ));
+
+    expect(container.querySelector("h2")?.textContent).toBe("Source changes");
+    expect(container.textContent).toContain("Cargo.toml");
+    expect(container.textContent).toContain("version = \"3.1.7\"");
+    expect(container.textContent).toContain("No semantic graph findings for this comparison.");
+    expect(container.textContent).not.toContain("\"source_changes\"");
+    root.unmount();
+  });
+});

--- a/packages/compass-viewer/src/history/SemanticFindings.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.tsx
@@ -1,31 +1,90 @@
-import { SparklesIcon } from "lucide-react";
+import { FileDiffIcon, SparklesIcon } from "lucide-react";
 import { Badge } from "../components/ui/badge";
 
 export function SemanticFindings({ report }: { report: unknown }) {
-  const findings = report && typeof report === "object" && "findings" in report
-    && Array.isArray((report as { findings?: unknown }).findings)
-    ? (report as { findings: unknown[] }).findings
+  const value = report && typeof report === "object"
+    ? report as Record<string, unknown>
+    : {};
+  const findings = Array.isArray(value.findings) ? value.findings : [];
+  const sourceChanges = Array.isArray(value.source_changes)
+    ? value.source_changes.filter(isSourceChange)
     : [];
   return (
-    <section className="mt-4 rounded-md border bg-card p-4 text-card-foreground">
-      <div className="flex items-center gap-2">
-        <SparklesIcon />
-        <h2 className="text-sm font-semibold">Semantic change findings</h2>
-        <Badge variant="secondary">{findings.length}</Badge>
+    <section className="history-diff-evidence">
+      <div className="history-diff-heading">
+        <FileDiffIcon aria-hidden="true" />
+        <h2>Source changes</h2>
+        <Badge variant="secondary">{sourceChanges.length}</Badge>
       </div>
-      {findings.length > 0 ? (
-        <div className="mt-3 flex flex-col gap-2">
-          {findings.map((finding, index) => (
-            <pre key={index} className="overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
-              {JSON.stringify(finding, null, 2)}
-            </pre>
+      {sourceChanges.length > 0 ? (
+        <div className="history-source-changes">
+          {sourceChanges.map((change, index) => (
+            <details key={`${change.new_path ?? change.old_path}-${index}`} open>
+              <summary>
+                <code>{change.new_path ?? change.old_path ?? "(unknown path)"}</code>
+                <span>{change.status ?? "changed"}</span>
+              </summary>
+              {change.patch
+                ? <pre>{change.patch}</pre>
+                : <p>Compass recorded this file change without an inline patch.</p>}
+            </details>
           ))}
         </div>
       ) : (
-        <pre className="mt-3 max-h-64 overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
-          {JSON.stringify(report, null, 2)}
-        </pre>
+        <p className="history-diff-empty">No source patch was reported for this comparison.</p>
+      )}
+      <div className="history-diff-heading history-semantic-heading">
+        <SparklesIcon aria-hidden="true" />
+        <h2>Semantic findings</h2>
+        <Badge variant="secondary">{findings.length}</Badge>
+      </div>
+      {findings.length > 0 ? (
+        <div className="history-finding-list">
+          {findings.map((finding, index) => (
+            <article key={index}>
+              <strong>{findingSummary(finding, index)}</strong>
+              {findingDetails(finding) && (
+                <details>
+                  <summary>Finding details</summary>
+                  <pre>{JSON.stringify(findingDetails(finding), null, 2)}</pre>
+                </details>
+              )}
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="history-diff-empty">No semantic graph findings for this comparison.</p>
       )}
     </section>
   );
+}
+
+type SourceChange = {
+  old_path?: string;
+  new_path?: string;
+  status?: string;
+  patch?: string;
+};
+
+function isSourceChange(value: unknown): value is SourceChange {
+  return value !== null && typeof value === "object";
+}
+
+function findingSummary(finding: unknown, index: number): string {
+  if (finding && typeof finding === "object") {
+    const record = finding as Record<string, unknown>;
+    for (const key of ["summary", "title", "message"]) {
+      if (typeof record[key] === "string") return record[key];
+    }
+  }
+  return `Finding ${index + 1}`;
+}
+
+function findingDetails(finding: unknown): Record<string, unknown> | undefined {
+  if (!finding || typeof finding !== "object" || Array.isArray(finding)) return undefined;
+  const details = Object.fromEntries(
+    Object.entries(finding as Record<string, unknown>)
+      .filter(([key]) => !["summary", "title", "message"].includes(key))
+  );
+  return Object.keys(details).length > 0 ? details : undefined;
 }

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -2586,6 +2586,13 @@ body.vscode-high-contrast-light .query-node-results {
   margin-top: 12px;
 }
 
+.history-change-counts-help {
+  margin: -0.15rem 0 0;
+  color: var(--vscode-descriptionForeground, #9aa7b7);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
 .history-commit-actions:empty {
   display: none;
 }
@@ -2621,6 +2628,201 @@ body.vscode-high-contrast-light .query-node-results {
 
 .history-change-counts strong {
   font-weight: 600;
+}
+
+.history-comparison,
+.history-diff-evidence {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  background: var(--vscode-editorWidget-background, var(--card));
+}
+
+.history-comparison {
+  box-shadow: inset 3px 0 0 var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.history-comparison-heading {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 8px;
+  padding: 11px 12px 9px;
+}
+
+.history-comparison-heading > svg,
+.history-diff-heading > svg {
+  width: 15px;
+  height: 15px;
+  margin-top: 2px;
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.history-comparison-heading h2 {
+  margin: 2px 0 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.history-comparison-heading code {
+  color: var(--vscode-textLink-foreground, var(--workbench-link));
+  font-family: var(--compass-font-mono);
+}
+
+.history-comparison-heading button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 26px;
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 10px;
+}
+
+.history-comparison-heading button:hover {
+  border-color: var(--vscode-focusBorder, var(--ring));
+  background: var(--workbench-hover);
+}
+
+.history-comparison-heading button svg {
+  width: 12px;
+  height: 12px;
+}
+
+.history-comparison-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 12px 10px 38px;
+  font: 10px/1.4 var(--compass-font-mono);
+}
+
+.history-comparison-legend > span {
+  display: inline-flex;
+  gap: 7px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--vscode-badge-background, var(--muted));
+}
+
+.history-comparison-legend strong {
+  color: var(--vscode-badge-foreground, var(--foreground));
+}
+
+.history-comparison-legend i {
+  font-style: normal;
+  font-weight: 600;
+}
+
+.history-comparison-legend i[data-change="added"] {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+}
+
+.history-comparison-legend i[data-change="removed"] {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.history-comparison-legend i[data-change="changed"] {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.history-comparison-empty {
+  display: grid;
+  gap: 2px;
+  padding: 9px 12px 10px 38px;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.history-comparison-empty strong {
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.history-diff-evidence {
+  padding: 11px 12px 12px;
+}
+
+.history-diff-heading {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.history-diff-heading h2 {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.history-semantic-heading {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.history-source-changes,
+.history-finding-list {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.history-source-changes details,
+.history-finding-list article {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--vscode-textCodeBlock-background, var(--muted));
+}
+
+.history-source-changes summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  background: var(--vscode-editorGroupHeader-tabsBackground, var(--background));
+  font-size: 10px;
+}
+
+.history-source-changes summary code {
+  color: var(--vscode-textLink-foreground, var(--workbench-link));
+  font-family: var(--compass-font-mono);
+}
+
+.history-source-changes summary span {
+  color: var(--muted-foreground);
+  text-transform: capitalize;
+}
+
+.history-source-changes pre,
+.history-finding-list pre {
+  max-height: 260px;
+  margin: 0;
+  padding: 8px;
+  overflow: auto;
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font: 10px/1.5 var(--compass-font-mono);
+  white-space: pre;
+}
+
+.history-source-changes p,
+.history-diff-empty {
+  margin: 8px 0 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.history-finding-list article > strong {
+  display: block;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
 }
 
 .history-graph-frame {
@@ -2679,6 +2881,10 @@ body.vscode-high-contrast .history-commit-details,
 body.vscode-high-contrast-light .history-commit-details,
 body.vscode-high-contrast .history-graph-frame,
 body.vscode-high-contrast-light .history-graph-frame,
+body.vscode-high-contrast .history-comparison,
+body.vscode-high-contrast-light .history-comparison,
+body.vscode-high-contrast .history-diff-evidence,
+body.vscode-high-contrast-light .history-diff-evidence,
 body.vscode-high-contrast .history-change-counts span,
 body.vscode-high-contrast-light .history-change-counts span {
   border-color: var(--vscode-contrastBorder, var(--ring));

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -493,7 +493,25 @@ window.acquireVsCodeApi=()=>({postMessage(message){
       fingerprint:"f-"+message.commit.slice(0,1),
       currentGraph:window.historyGraphs[message.commit],
       parentGraph:window.historyGraphs[message.parent],
-      semanticDiff:{findings:[{summary:"Fixture comparison"}]}
+      counts:{
+        schema:"compass.history.change_counts/1",
+        commit:message.commit,
+        parent:message.parent,
+        counts:{
+          nodes:{added:0,removed:0,changed:1},
+          edges:{added:0,removed:0,changed:0},
+          hyperedges:{added:0,removed:0,changed:0}
+        }
+      },
+      semanticDiff:{
+        source_changes:[{
+          old_path:"Cargo.toml",
+          new_path:"Cargo.toml",
+          status:"modified",
+          patch:"-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\""
+        }],
+        findings:[{summary:"Fixture comparison"}]
+      }
     },"*"),0);
   } else if(message.type==="buildRevision") {
     const scenario=new URLSearchParams(window.location.search).get("build") || "cancel";

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -110,6 +110,26 @@ test("late revision and derived responses cannot replace the selected commit", a
   await expect(page.getByText("Semantic change findings")).toHaveCount(0);
 });
 
+test("comparison replaces the full graph with a readable focused delta", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.getByRole("option", { name: /Revision B graph/i }).click();
+  await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+
+  await page.getByRole("button", { name: /Compare parent 1/i }).click();
+
+  await expect(page.getByText("Comparison mode")).toBeVisible();
+  await expect(page.getByText(/Comparing bbbbbbbbb to aaaaaaaaa/)).toBeVisible();
+  await expect(page.getByLabel("Visible graph delta")).toContainText("nodes+0−0~1");
+  await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
+  await expect(page.getByText("Cargo.toml")).toBeVisible();
+  await expect(page.getByText('+version = "3.1.7"')).toBeVisible();
+  await expect(page.getByText("Fixture comparison", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Exit comparison" }).click();
+  await expect(page.getByText("Comparison mode")).toHaveCount(0);
+  await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+});
+
 test("unavailable comparison explains how to recover", async ({ page }) => {
   await page.goto("/history.html");
   await page.getByRole("option", { name: /Revision C needs build/i }).click();


### PR DESCRIPTION
## Summary

- promote a compatible, clean Compass current snapshot directly into immutable versioned history
- canonicalize promoted output so fast and exact builds produce the same realization ID
- reject stale, incomplete, profile-mismatched, or semantically incompatible snapshots, while explicit rebuilds ignore mutable current state
- avoid duplicate history-store validation, reconstruction, and preferred-artifact polling
- load exact parent-specific node, edge, and hyperedge counts in the VS Code history view
- replace the full comparison graph with a focused delta presentation, readable source patches, semantic findings, and an explicit source-only empty state
- keep the VS Code runtime Compass-only; contributor graph refreshes are not imported, bundled, or executed by the extension

## Root cause

`compass history build` repeated graph construction and validation already completed by `compass init` or `compass update`, then reconstructed and revalidated stored artifacts more than once. The comparison UI also inferred counts only from presentation graphs, omitted source patches, and rendered the complete graph while comparison mode was active.

## User impact

Clean current revisions can enter immutable history without a detached checkout or redundant extraction, while stale, custom-profile, semantic, and explicit-rebuild cases retain exact reconstruction. Version comparisons now distinguish a genuinely unchanged topology from source-only changes and keep exact parent-specific counts visible.

## Performance

Measured with a release build against the real `fjall` repository under `/Volumes/Workspace/Github`:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Warmed clean current snapshot, `history build HEAD --code-only` | 2.32s | 1.84–1.85s | about 20% faster |
| Five-version shallow first-parent build | 16.17s | 11.28s | 30.2% faster |
| Resumed five-version build | — | 2.12s | 5/5 versions skipped |
| Repeated validated history build | — | 0.47s | cached artifact reuse |

The 1.85s confirmation used a fresh history store on `fjall` (about 16.8K source lines) after the normal CLI capability/version warmup performed by the extension. A newly linked binary's first cold invocation measured 3.74s, so the sub-two-second result applies to the warmed production sequence rather than macOS first-launch overhead. Fast promotion and explicit exact rebuilds produced the same realization ID.

## Diff verification

- `13baf811 → 60264f822`: exact topology is correctly `nodes +0 −0 ~0`, `edges +0 −0 ~0`; the `Cargo.toml` version bump is retained as a complete source patch
- `2e12d2e7 → 864c18590`: exact history diff reports `nodes +1 −0 ~4`, `edges +4 −2 ~0`, two source files, and four semantic findings

### Known follow-up

The numeric counts, source patches, and semantic evidence are exact. The focused presentation graph can still over-select records when community assignments are renumbered or index-derived viewer edge IDs shift. This draft keeps that limitation explicit for follow-up before claiming fully stable visual identity across every clustered revision.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p compass-history --lib --tests` (64 passed, 1 explicit performance test ignored)
- `cargo test -p compass-core --test history_materialize` (7 passed)
- `cargo test -p compass-cli --lib` (63 passed)
- `cargo test -p compass-cli --test history_cli` (23 passed)
- `npm test -w @compass/viewer` (16 files / 41 tests)
- `npm test -w compass-vscode` (18 files / 41 tests)
- viewer and VS Code TypeScript typechecks
- Playwright `tests/viewer/history.spec.ts` (13 passed)
- production viewer and extension builds
- contributor-only repository graph refresh completed outside the extension runtime
