### PR TITLE
Improve VS Code diff and graph comparison experience

### DIFF
--- a/docs/superpowers/specs/2026-07-25-vscode-history-diff-experience-design.md
+++ b/docs/superpowers/specs/2026-07-25-vscode-history-diff-experience-design.md
@@ -1,0 +1,217 @@
+# VS Code History Diff Experience Design
+
+## Context
+
+The Codebase Evolution comparison view currently renders source patches as raw
+preformatted text. The patches are exact but difficult to scan because they
+lack syntax highlighting, line-number gutters, word-level emphasis, and useful
+layout controls.
+
+The changed graph already assigns added, removed, changed, and context states to
+nodes and edges. However, the canvas, toolbar, inspector, and community filters
+do not explain those states as one coherent comparison mode. Dense deltas can
+look like an ordinary graph with a different palette, and labels compete with
+each other before the user understands what changed.
+
+Compass already vendors Diffs 1.2.12 for standalone semantic-diff HTML reports.
+The VS Code viewer will align with that version and visual language, using
+<https://diffs.com/docs> as the integration authority.
+
+## Goals
+
+The comparison experience should let a developer:
+
+1. scan source edits using a familiar code-review diff;
+2. switch between split and unified layouts without losing the exact patch;
+3. understand graph-change states before interacting with the canvas;
+4. filter the delta by change type;
+5. inspect any node without relying on color alone; and
+6. recover gracefully when an enhanced diff cannot render.
+
+## Selected architecture
+
+The work remains in the shared React viewer. It adds the React entry point from
+`@pierre/diffs` at the same 1.2.12 version already used by the Compass CLI.
+
+`SemanticFindings` delegates each validated source change to a focused source
+diff component. That component owns Diffs rendering, responsive layout,
+collapse state, and the exact-patch fallback. The semantic findings list keeps
+its existing responsibility for non-source findings.
+
+The graph remains the existing `CompassGraph`. Comparison mode is derived from
+node or edge `change` metadata, so no Rust command, JSON schema version, or host
+message changes are required. Comparison-specific state is limited to visible
+change types and display preferences.
+
+## Source changes
+
+### File organization
+
+The Source changes section gains a compact toolbar:
+
+- Split and Unified layout choices;
+- a Wrap lines toggle;
+- Expand all and Collapse all actions;
+- the number of changed files.
+
+Each file is presented as a bordered review card with its path, normalized
+status, and Diffs-provided addition/deletion statistics. The first file opens
+by default; later files remain collapsed until requested. This makes the first
+change immediately useful without turning a long comparison into one
+unstructured page.
+
+### Diffs rendering
+
+Each expanded patch is rendered through the high-level React diff API. The
+renderer uses:
+
+- a split layout on panels wider than 760 pixels;
+- a unified layout at 760 pixels or below;
+- the user's explicit Split or Unified preference on wider panels;
+- classic addition and deletion indicators;
+- word-level changed-token emphasis;
+- metadata-style hunk separators;
+- line numbers;
+- horizontal scrolling by default, with optional wrapping.
+
+The effective layout updates when the webview width crosses the breakpoint.
+Split is disabled while the panel is too narrow to present both sides legibly.
+The selected wide-screen layout and wrapping preference live for the mounted
+history tab.
+
+Expanded files render lazily. Collapsing a file removes its expensive diff body
+while retaining the exact patch data and header. The integration does not add a
+worker pool initially because VS Code webview workers require extra resource
+and content-security wiring; lazy file rendering bounds the initial work.
+
+### Theme
+
+Diffs selects its bundled light or dark syntax theme from the VS Code webview
+theme. Supported Diffs custom properties map the surrounding surface, gutter,
+line-number, addition, deletion, and modified colors to VS Code editor and Git
+decoration tokens. Shadow-DOM overrides stay small and target documented data
+attributes only.
+
+High-contrast themes add explicit borders and preserve line indicators even
+when background colors are unavailable.
+
+### Failure handling
+
+The report is treated as untrusted structured data. A source change is
+renderable only when its path and patch fields are valid strings.
+
+If Diffs fails to parse, highlight, or mount a patch, that file card shows:
+
+> Enhanced diff unavailable. Showing the exact Git patch.
+
+The raw patch then appears unchanged in a scrollable preformatted block. One
+bad file does not prevent other files, semantic findings, or the graph from
+rendering.
+
+## Graph comparison
+
+### Comparison summary
+
+The current compact number strings become readable Node and Edge summaries.
+Each states explicit Added, Removed, and Changed counts. Empty categories remain
+visible as zero only in the summary; the canvas legend omits categories with no
+visible records.
+
+The comparison heading continues to identify both revisions and retain the Exit
+comparison action.
+
+### Change legend and filters
+
+The graph stage receives a persistent comparison legend with four textual,
+toggleable controls:
+
+- Added;
+- Removed;
+- Changed;
+- Context.
+
+Each control contains a marker, label, and count. All are enabled initially.
+Disabling a type hides nodes of that type and any edge whose endpoint becomes
+hidden. Community visibility and change-type visibility compose rather than
+overwriting one another.
+
+In comparison mode, Change types becomes the primary inspector filter.
+Communities move into a collapsed secondary section because change status is
+the first question in this workflow. Outside comparison mode the inspector
+remains unchanged.
+
+### Canvas treatment
+
+Change state takes precedence over ordinary community color:
+
+- Added uses the VS Code Git added-resource color.
+- Removed uses the Git deleted-resource color.
+- Changed uses the Git modified-resource color.
+- Context uses the description foreground with reduced opacity.
+
+Added, removed, and changed nodes are slightly larger than context nodes.
+Context nodes remain available to explain relationships but recede visually.
+
+Edge treatment prioritizes change state over confidence:
+
+- added edges are solid green;
+- removed edges are dashed red;
+- changed edges are emphasized amber;
+- context edges remain quiet gray.
+
+Confidence remains available in the edge tooltip. The comparison legend and
+inspector provide textual meaning, so color is never the only status signal.
+
+Automatic labels are limited to the highest-degree changed nodes, up to twelve,
+plus the focused node. Context labels stay hidden unless focused. The existing
+Show labels action still reveals every label.
+
+### Node inspection
+
+The hover card and pinned inspector show an Added, Removed, Changed, or Context
+badge before ordinary node metadata. The badge uses text and a status marker.
+Source navigation, neighbors, community identity, and signatures continue to
+work as they do in the ordinary graph.
+
+## Data flow
+
+```text
+semantic diff JSON
+  -> validate source_changes
+  -> per-file Diffs renderer
+  -> raw patch fallback on failure
+
+parent + current graph models
+  -> compareGraphs
+  -> nodes/edges with change metadata
+  -> comparison-aware CompassGraph
+  -> change filters + canvas + inspector badges
+```
+
+No comparison preference or diff content leaves the webview.
+
+## Verification
+
+Component and browser coverage will verify:
+
+- valid patches render through Diffs rather than a raw `<pre>`;
+- split, unified, and wrapping controls update mounted file diffs;
+- narrow panels force a usable unified layout;
+- collapsed files do not mount their diff body;
+- malformed or failed patches show the exact fallback;
+- comparison summaries use explicit labels and correct counts;
+- change filters hide the expected nodes and connected edges;
+- status colors follow VS Code tokens and high-contrast borders;
+- hover and inspector surfaces expose textual change status;
+- comparison-mode label selection remains bounded;
+- ordinary non-comparison graphs retain their existing behavior;
+- viewer tests, browser tests, VS Code builds, and VSIX smoke checks pass.
+
+After code changes, `graphify update .` refreshes the project graph.
+
+## Scope boundaries
+
+This design does not add source editing, patch application, comments,
+side-by-side node-property comparison, semantic-diff generation, new Rust
+protocols, or a persistent user setting. It improves the presentation and
+interaction of evidence Compass already produces.

--- a/docs/superpowers/specs/2026-07-25-vscode-query-tab-indicator-design.md
+++ b/docs/superpowers/specs/2026-07-25-vscode-query-tab-indicator-design.md
@@ -1,0 +1,68 @@
+# VS Code Query Tab Indicator Design
+
+## Context
+
+The Ask Codebase workspace exposes two semantic tabs: Ask the codebase and
+CompassQL. Their `role="tab"`, `aria-selected`, and panel associations are
+correct, but the active styling is visually lost against the query composer.
+The existing bottom border sits directly against another horizontal boundary,
+while the active and inactive surfaces are nearly identical.
+
+## Goal
+
+Make the selected query mode immediately recognizable without making the header
+feel heavier than the surrounding VS Code workbench.
+
+## Selected design
+
+The query-mode rail keeps its current two-column layout and content. The active
+tab receives:
+
+- a 2-pixel top accent using `--vscode-tab-activeBorder`, falling back to the
+  existing query focus color;
+- the VS Code active-tab background and foreground, with the existing raised
+  query surface as the fallback;
+- full-opacity icon and title treatment;
+- a quiet inset boundary that separates it from adjacent inactive tabs.
+
+Inactive tabs remain transparent and muted. Hover uses the existing workbench
+hover surface and does not resemble the selected state.
+
+The former active bottom border is removed. The rail's shared bottom border
+continues to connect the tab strip to the composer panel.
+
+## Interaction and accessibility
+
+No component contract or selection behavior changes. The existing button-based
+tabs continue to expose:
+
+- `role="tab"`;
+- `aria-selected`;
+- `aria-controls`;
+- the matching tab panel's `aria-labelledby`.
+
+Keyboard focus remains a separate 2-pixel focus ring so focus and selection are
+not conflated. High-contrast themes use `--vscode-contrastBorder` around the
+active tab in addition to the top indicator. The design introduces no motion.
+
+## Responsive behavior
+
+The indicator remains visible at every supported width. Narrow layouts retain
+the two equal-width tabs, truncate descriptions before labels, and do not
+convert the controls into a menu or dropdown.
+
+## Verification
+
+Browser coverage will verify:
+
+- Ask the codebase starts selected and exposes the top accent;
+- switching to CompassQL transfers the active surface and indicator;
+- the inactive tab does not retain selected styling;
+- tab semantics and keyboard focus remain intact;
+- dark, light, and high-contrast token fallbacks remain readable;
+- the shared viewer and VS Code extension still build.
+
+## Scope boundaries
+
+This change does not alter query execution, query state, result rendering,
+copy, tab order, or host messages.

--- a/editors/vscode/src/views/sourceNavigation.ts
+++ b/editors/vscode/src/views/sourceNavigation.ts
@@ -40,9 +40,14 @@ export async function openGraphSource(
   const start = source.startByte !== undefined
     ? document.positionAt(source.startByte)
     : new vscode.Position(Math.max(0, (source.startLine ?? 1) - 1), 0);
-  const end = source.endByte !== undefined
-    ? document.positionAt(source.endByte)
-    : new vscode.Position(Math.max(start.line, (source.endLine ?? source.startLine ?? 1) - 1), 0);
+  const recordedEndLine = source.endLine ?? source.startLine;
+  const end = recordedEndLine !== undefined
+    ? document.validatePosition(
+      new vscode.Position(Math.max(start.line, recordedEndLine), 0)
+    )
+    : source.endByte !== undefined
+      ? document.positionAt(source.endByte)
+      : start;
   editor.revealRange(new vscode.Range(start, end), vscode.TextEditorRevealType.InCenterIfOutsideViewport);
   editor.selection = new vscode.Selection(start, end);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,6 +1907,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.12.tgz",
+      "integrity": "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.1.0",
+        "@pierre/theming": "0.0.2",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/diffs/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
+    "node_modules/@pierre/theming": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-0.0.2.tgz",
+      "integrity": "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==",
+      "license": "apache-2.0",
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3961,6 +4028,119 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
+      "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
+      "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
+      "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
+      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
+      "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
+      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.3.1.tgz",
+      "integrity": "sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -4493,6 +4673,24 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -4544,6 +4742,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/vscode": {
       "version": "1.125.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
@@ -4565,6 +4769,12 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -5379,6 +5589,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -5427,6 +5647,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -5652,6 +5892,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -5951,7 +6201,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5972,6 +6221,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -6746,6 +7008,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -6800,6 +7098,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -7810,6 +8118,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7900,6 +8214,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -7923,6 +8258,95 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8414,6 +8838,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/open": {
@@ -8970,6 +9411,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -9354,6 +9805,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9613,6 +10088,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
+      "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.3.1",
+        "@shikijs/engine-javascript": "4.3.1",
+        "@shikijs/engine-oniguruma": "4.3.1",
+        "@shikijs/langs": "4.3.1",
+        "@shikijs/themes": "4.3.1",
+        "@shikijs/types": "4.3.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
@@ -9815,6 +10309,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -9944,6 +10448,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -10343,6 +10861,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10463,6 +10991,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -10599,6 +11195,34 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vis-data": {
@@ -11213,10 +11837,21 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/compass-viewer": {
       "name": "@compass/viewer",
       "version": "0.1.0",
       "dependencies": {
+        "@pierre/diffs": "^1.2.12",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",

--- a/packages/compass-viewer/package.json
+++ b/packages/compass-viewer/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@pierre/diffs": "^1.2.12",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",

--- a/packages/compass-viewer/src/graph/CompassGraph.tsx
+++ b/packages/compass-viewer/src/graph/CompassGraph.tsx
@@ -176,7 +176,10 @@ function CompassGraphView({
         "--compass-inspector-width": `${inspectorLayout.width}px`
       } as CSSProperties}
     >
-      <main className="compass-graph-stage">
+      <main
+        className="compass-graph-stage"
+        data-comparison={comparisonMode ? "true" : "false"}
+      >
         <VisNetworkCanvas
           ref={canvasRef}
           model={model}

--- a/packages/compass-viewer/src/graph/CompassGraph.tsx
+++ b/packages/compass-viewer/src/graph/CompassGraph.tsx
@@ -17,7 +17,21 @@ import {
 import { graphNodeActivation } from "./nodeActivation";
 import { NodeHoverCard, type GraphHover } from "./NodeHoverCard";
 import { VisNetworkCanvas, type GraphCanvasHandle } from "./VisNetworkCanvas";
-import { graphReducer, initialGraphState } from "./state";
+import {
+  graphReducer,
+  initialGraphState,
+  type GraphChangeType
+} from "./state";
+
+const CHANGE_TYPES: Array<{
+  value: GraphChangeType;
+  label: string;
+}> = [
+  { value: "added", label: "Added" },
+  { value: "removed", label: "Removed" },
+  { value: "changed", label: "Changed" },
+  { value: "unchanged", label: "Context" }
+];
 
 export type GraphHost = {
   openSource(source: SourceLocation): void;
@@ -96,6 +110,16 @@ function CompassGraphView({
   hostRef.current = host;
   const selected = model.nodes.find((node) => node.id === state.focusedNodeId);
   const hovered = hover ? model.nodes.find((node) => node.id === hover.nodeId) : undefined;
+  const comparisonMode = model.nodes.some((node) => node.change !== undefined)
+    || model.edges.some((edge) => edge.change !== undefined);
+  const changeCounts = useMemo(() => {
+    const counts = new Map<GraphChangeType, number>();
+    for (const node of model.nodes) {
+      const change = node.change ?? "unchanged";
+      counts.set(change, (counts.get(change) ?? 0) + 1);
+    }
+    return counts;
+  }, [model.nodes]);
   const neighbors = useMemo(() => {
     if (!selected) return [];
     const ids = new Set<string>();
@@ -160,6 +184,7 @@ function CompassGraphView({
           physicsRunning={state.physicsRunning}
           forceLabels={state.forceLabels}
           hiddenCommunities={state.hiddenCommunities}
+          hiddenChanges={state.hiddenChanges}
           onFocus={focus}
           onOpenSource={activateNode}
           onHover={setHover}
@@ -185,6 +210,28 @@ function CompassGraphView({
           })}
           onBack={onBackToOverview}
         />
+        {comparisonMode && (
+          <div className="compass-change-legend" aria-label="Graph change filters">
+            {CHANGE_TYPES
+              .filter(({ value }) => (changeCounts.get(value) ?? 0) > 0)
+              .map(({ value, label }) => {
+                const visible = !state.hiddenChanges.has(value);
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    data-change={value}
+                    aria-pressed={visible}
+                    onClick={() => dispatch({ type: "toggleChange", change: value })}
+                  >
+                    <span aria-hidden="true" />
+                    {label}
+                    <small>{changeCounts.get(value) ?? 0}</small>
+                  </button>
+                );
+              })}
+          </div>
+        )}
         {communityError && (
           <div
             className="absolute bottom-4 left-4 z-20 max-w-md rounded-md border border-destructive/50 bg-background/95 px-3 py-2 text-sm text-destructive shadow-lg"
@@ -211,6 +258,7 @@ function CompassGraphView({
         query={state.query}
         matches={matches}
         hiddenCommunities={state.hiddenCommunities}
+        comparisonMode={comparisonMode}
         onQueryChange={(query) => dispatch({ type: "search", query })}
         onFocus={focus}
         onOpenSource={host.openSource}

--- a/packages/compass-viewer/src/graph/GraphInspector.tsx
+++ b/packages/compass-viewer/src/graph/GraphInspector.tsx
@@ -41,6 +41,22 @@ function sourceActionLabel(node: GraphNode, source: SourceLocation): string {
   return `Open source ${source.file}${range ? ` ${range.action}` : ""}`;
 }
 
+function changeLabel(change: GraphNode["change"]): string | undefined {
+  return change === "unchanged"
+    ? "Context"
+    : change ? `${change[0]?.toLocaleUpperCase()}${change.slice(1)}` : undefined;
+}
+
+function changeColor(change: GraphNode["change"]): string | undefined {
+  if (!change) return undefined;
+  return {
+    added: "var(--vscode-gitDecoration-addedResourceForeground, #2ea043)",
+    removed: "var(--vscode-gitDecoration-deletedResourceForeground, #f85149)",
+    changed: "var(--vscode-gitDecoration-modifiedResourceForeground, #d29922)",
+    unchanged: "var(--vscode-descriptionForeground, #6e7781)"
+  }[change];
+}
+
 export function GraphInspector({
   model,
   selected,
@@ -48,6 +64,7 @@ export function GraphInspector({
   query,
   matches,
   hiddenCommunities,
+  comparisonMode,
   onQueryChange,
   onFocus,
   onOpenSource,
@@ -63,6 +80,7 @@ export function GraphInspector({
   query: string;
   matches: GraphNode[];
   hiddenCommunities: ReadonlySet<number>;
+  comparisonMode: boolean;
   onQueryChange(query: string): void;
   onFocus(nodeId: string): void;
   onOpenSource(source: SourceLocation): void;
@@ -207,13 +225,19 @@ export function GraphInspector({
               <span
                 className="compass-node-swatch"
                 aria-hidden="true"
-                style={{ background: selected.color?.background
+                style={{ background: changeColor(selected.change)
+                  ?? selected.color?.background
                   ?? model.communities.find((item) => item.id === selected.community)?.color }}
               />
               <span>
                 <strong>{selected.label}</strong>
                 <small>{selected.kind ?? "Symbol"}</small>
               </span>
+              {changeLabel(selected.change) && (
+                <span className="compass-change-badge" data-change={selected.change}>
+                  {changeLabel(selected.change)}
+                </span>
+              )}
             </div>
             <dl className="compass-metadata-grid">
               <div>
@@ -313,8 +337,65 @@ export function GraphInspector({
         )}
       </section>
 
-      <section className="compass-community-panel" aria-labelledby="compass-communities-title">
-        <h2 id="compass-communities-title">Communities</h2>
+      <section
+        className="compass-community-panel"
+        aria-labelledby="compass-communities-title"
+        data-secondary={comparisonMode}
+      >
+        {comparisonMode ? (
+          <details>
+            <summary id="compass-communities-title">
+              Communities
+              <span>{model.communities.length}</span>
+            </summary>
+            <CommunityControls
+              model={model}
+              communityCounts={communityCounts}
+              hiddenCommunities={hiddenCommunities}
+              allVisible={allVisible}
+              onSetAllVisible={onSetAllVisible}
+              onToggleCommunity={onToggleCommunity}
+            />
+          </details>
+        ) : (
+          <>
+            <h2 id="compass-communities-title">Communities</h2>
+            <CommunityControls
+              model={model}
+              communityCounts={communityCounts}
+              hiddenCommunities={hiddenCommunities}
+              allVisible={allVisible}
+              onSetAllVisible={onSetAllVisible}
+              onToggleCommunity={onToggleCommunity}
+            />
+          </>
+        )}
+      </section>
+      <footer className="compass-graph-stats">
+        {model.stats.nodes.toLocaleString()} nodes · {model.stats.edges.toLocaleString()} edges ·{" "}
+        {model.stats.communities.toLocaleString()} communities
+      </footer>
+    </aside>
+  );
+}
+
+function CommunityControls({
+  model,
+  communityCounts,
+  hiddenCommunities,
+  allVisible,
+  onSetAllVisible,
+  onToggleCommunity
+}: {
+  model: GraphViewModel;
+  communityCounts: ReadonlyMap<number, number>;
+  hiddenCommunities: ReadonlySet<number>;
+  allVisible: boolean;
+  onSetAllVisible(visible: boolean): void;
+  onToggleCommunity(communityId: number): void;
+}) {
+  return (
+    <div className="compass-community-controls">
         <label className="compass-community-control">
           <input
             type="checkbox"
@@ -348,11 +429,6 @@ export function GraphInspector({
             );
           })}
         </div>
-      </section>
-      <footer className="compass-graph-stats">
-        {model.stats.nodes.toLocaleString()} nodes · {model.stats.edges.toLocaleString()} edges ·{" "}
-        {model.stats.communities.toLocaleString()} communities
-      </footer>
-    </aside>
+    </div>
   );
 }

--- a/packages/compass-viewer/src/graph/NodeHoverCard.tsx
+++ b/packages/compass-viewer/src/graph/NodeHoverCard.tsx
@@ -32,6 +32,13 @@ export function NodeHoverCard({
         <strong>{node.label}</strong>
         <span>{(node.kind ?? "symbol").toLocaleUpperCase()}</span>
       </div>
+      {node.change && (
+        <span className="compass-change-badge" data-change={node.change}>
+          {node.change === "unchanged"
+            ? "Context"
+            : `${node.change[0]?.toLocaleUpperCase()}${node.change.slice(1)}`}
+        </span>
+      )}
       {node.memberCount !== undefined ? (
         <p>{node.memberCount.toLocaleString()} symbols</p>
       ) : (

--- a/packages/compass-viewer/src/graph/VisNetworkCanvas.test.ts
+++ b/packages/compass-viewer/src/graph/VisNetworkCanvas.test.ts
@@ -32,4 +32,16 @@ describe("graphNodeColor", () => {
       border: "#ffffff"
     });
   });
+
+  it("uses separate soft fills and strong borders for comparison status colors", () => {
+    expect(graphNodeColor(model, { ...node, change: "changed" }, undefined, {
+      added: { background: "#dafbe1", border: "#1a7f37" },
+      removed: { background: "#ffebe9", border: "#cf222e" },
+      changed: { background: "#f7edcf", border: "#9a6700" },
+      unchanged: { background: "#e7e9eb", border: "#656d76" }
+    })).toEqual({
+      background: "#f7edcf",
+      border: "#9a6700"
+    });
+  });
 });

--- a/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
+++ b/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
@@ -10,6 +10,7 @@ import { DataSet, Network, type Edge, type Node, type Options } from "vis-networ
 import type { GraphNode, GraphViewModel } from "../contracts/graph";
 import type { GraphHover } from "./NodeHoverCard";
 import { bindGraphNetworkEvents } from "./networkEvents";
+import type { GraphChangeType } from "./state";
 
 export type GraphCanvasHandle = {
   fit(): void;
@@ -22,11 +23,21 @@ type Props = {
   physicsRunning: boolean;
   forceLabels: boolean;
   hiddenCommunities: ReadonlySet<number>;
+  hiddenChanges: ReadonlySet<GraphChangeType>;
   onFocus(nodeId: string): void;
   onOpenSource(nodeId: string): void;
   onHover(change: GraphHover | null): void;
   onClear(): void;
   onStabilized(): void;
+};
+
+type ComparisonPalette = Record<GraphChangeType, string>;
+
+const fallbackComparisonPalette: ComparisonPalette = {
+  added: "#2ea043",
+  removed: "#f85149",
+  changed: "#d29922",
+  unchanged: "#6e7781"
 };
 
 const options: Options = {
@@ -66,9 +77,12 @@ const options: Options = {
 export function graphNodeColor(
   model: GraphViewModel,
   node: GraphNode,
-  contrastBorder?: string
+  contrastBorder?: string,
+  comparisonPalette?: ComparisonPalette
 ) {
-  const background = node.color?.background
+  const background = node.change && comparisonPalette
+    ? comparisonPalette[node.change]
+    : node.color?.background
     ?? model.communities.find((candidate) => candidate.id === node.community)?.color
     ?? "#6688aa";
   return {
@@ -88,11 +102,26 @@ function edgeAppearance(confidence: string | undefined) {
   return { dashes: true, width: 1, opacity: 0.35 };
 }
 
-function comparisonEdgeColor(change: string | undefined, fallback: string): string {
-  if (change === "added") return "#2ea043";
-  if (change === "removed") return "#f85149";
-  if (change === "changed") return "#d29922";
-  return fallback;
+function comparisonEdgeAppearance(
+  change: GraphChangeType | undefined,
+  confidence: string | undefined,
+  fallback: string,
+  palette: ComparisonPalette
+) {
+  if (change === "added") {
+    return { color: palette.added, dashes: false, width: 2.5, opacity: 0.92 };
+  }
+  if (change === "removed") {
+    return { color: palette.removed, dashes: [6, 5], width: 2.3, opacity: 0.9 };
+  }
+  if (change === "changed") {
+    return { color: palette.changed, dashes: false, width: 3, opacity: 0.94 };
+  }
+  if (change === "unchanged") {
+    return { color: palette.unchanged, dashes: true, width: 1, opacity: 0.28 };
+  }
+  const appearance = edgeAppearance(confidence);
+  return { color: fallback, ...appearance };
 }
 
 function useThemeRevision(): number {
@@ -125,6 +154,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
     physicsRunning,
     forceLabels,
     hiddenCommunities,
+    hiddenChanges,
     onFocus,
     onOpenSource,
     onHover,
@@ -149,6 +179,27 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       () => cssColor("--vscode-descriptionForeground", "#60728b"),
       [themeRevision]
     );
+    const comparisonPalette = useMemo<ComparisonPalette>(() => ({
+      added: cssColor("--vscode-gitDecoration-addedResourceForeground", "#2ea043"),
+      removed: cssColor("--vscode-gitDecoration-deletedResourceForeground", "#f85149"),
+      changed: cssColor("--vscode-gitDecoration-modifiedResourceForeground", "#d29922"),
+      unchanged: cssColor("--vscode-descriptionForeground", "#6e7781")
+    }), [themeRevision]);
+    const comparisonMode = useMemo(
+      () => model.nodes.some((node) => node.change !== undefined)
+        || model.edges.some((edge) => edge.change !== undefined),
+      [model.edges, model.nodes]
+    );
+    const automaticLabelIds = useMemo(() => new Set(
+      comparisonMode
+        ? model.nodes
+          .filter((node) => node.change !== "unchanged")
+          .sort((left, right) =>
+            (right.degree ?? 0) - (left.degree ?? 0) || left.id.localeCompare(right.id))
+          .slice(0, 12)
+          .map((node) => node.id)
+        : []
+    ), [comparisonMode, model.nodes]);
     const contrastBorder = useMemo(() => {
       const highContrast = document.body.classList.contains("vscode-high-contrast")
         || document.body.classList.contains("vscode-high-contrast-light");
@@ -157,24 +208,42 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
         : undefined;
     }, [themeRevision]);
     const nodeData = useMemo(() => new DataSet<Node>(
-      model.nodes.map((node) => ({
-        id: node.id,
-        label: node.label,
-        color: graphNodeColor(model, node),
-        size: node.size ?? Math.min(40, 10 + 30 * (node.degree ?? 1) / maxDegree),
-        font: {
-          color: "#eef5ff",
-          face: "system-ui",
-          size: (node.degree ?? 1) >= maxDegree * 0.15 ? 12 : 0
-        }
-      }))
+      model.nodes.map((node) => {
+        const baseSize = node.size ?? Math.min(40, 10 + 30 * (node.degree ?? 1) / maxDegree);
+        const size = comparisonMode
+          ? node.change === "unchanged" ? baseSize * 0.72 : baseSize * 1.12
+          : baseSize;
+        return {
+          id: node.id,
+          label: node.label,
+          color: graphNodeColor(model, node, undefined, fallbackComparisonPalette),
+          size,
+          opacity: node.change === "unchanged" ? 0.42 : 1,
+          font: {
+            color: "#eef5ff",
+            face: "system-ui",
+            size: comparisonMode
+              ? automaticLabelIds.has(node.id) ? 12 : 0
+              : (node.degree ?? 1) >= maxDegree * 0.15 ? 12 : 0
+          }
+        };
+      })
       // Styling changes are applied in place below so the Network, its paused
       // physics state, and its saved reset view survive theme and label changes.
-    ), [maxDegree, model]);
+    ), [
+      automaticLabelIds,
+      comparisonMode,
+      maxDegree,
+      model
+    ]);
     const edgeData = useMemo(() => new DataSet<Edge>(
       model.edges.map((edge) => {
-        const appearance = edgeAppearance(edge.confidence);
-        const color = comparisonEdgeColor(edge.change, "#60728b");
+        const appearance = comparisonEdgeAppearance(
+          edge.change,
+          edge.confidence,
+          "#60728b",
+          fallbackComparisonPalette
+        );
         return {
           id: edge.id,
           from: edge.source,
@@ -182,7 +251,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           title: `${edge.relation}${edge.confidence ? ` · ${edge.confidence}` : ""}`,
           dashes: appearance.dashes,
           width: appearance.width,
-          color: { color, opacity: edge.change ? 0.88 : appearance.opacity }
+          color: { color: appearance.color, opacity: appearance.opacity }
         };
       })
     ), [model.edges]);
@@ -236,7 +305,9 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
     useEffect(() => {
       const hiddenNodes = new Set(
         model.nodes
-          .filter((node) => hiddenCommunities.has(node.community))
+          .filter((node) =>
+            hiddenCommunities.has(node.community)
+            || hiddenChanges.has(node.change ?? "unchanged"))
           .map((node) => node.id)
       );
       nodeData.update(model.nodes.map((node) => ({
@@ -247,7 +318,14 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
         id: edge.id,
         hidden: hiddenNodes.has(edge.source) || hiddenNodes.has(edge.target)
       })));
-    }, [edgeData, hiddenCommunities, model.edges, model.nodes, nodeData]);
+    }, [
+      edgeData,
+      hiddenChanges,
+      hiddenCommunities,
+      model.edges,
+      model.nodes,
+      nodeData
+    ]);
 
     useEffect(() => {
       const network = networkRef.current;
@@ -258,11 +336,14 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       nodeData.update(model.nodes.map((node) => {
         const isFocused = node.id === focusedNodeId;
         const isVisible = !focusedNodeId || isFocused || connected.has(node.id);
+        const comparisonOpacity = node.change === "unchanged" ? 0.42 : 1;
         return {
           id: node.id,
-          opacity: isVisible ? 1 : 0.14,
+          opacity: !focusedNodeId
+            ? comparisonOpacity
+            : isVisible ? Math.max(comparisonOpacity, 0.72) : 0.08,
           borderWidth: isFocused ? 4 : contrastBorder ? 2.5 : 1.5,
-          color: graphNodeColor(model, node, contrastBorder),
+          color: graphNodeColor(model, node, contrastBorder, comparisonPalette),
           shadow: isFocused
             ? {
                 enabled: true,
@@ -277,17 +358,21 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
         };
       }));
       edgeData.update(model.edges.map((edge) => {
-        const appearance = edgeAppearance(edge.confidence);
-        const baseOpacity = edge.change ? 0.88 : appearance.opacity;
+        const appearance = comparisonEdgeAppearance(
+          edge.change,
+          edge.confidence,
+          edgeColor,
+          comparisonPalette
+        );
         const connectedEdge = edge.source === focusedNodeId || edge.target === focusedNodeId;
-        const color = comparisonEdgeColor(edge.change, edgeColor);
         return {
           id: edge.id,
+          dashes: appearance.dashes,
           color: {
-            color,
-            opacity: !focusedNodeId ? baseOpacity : connectedEdge ? 0.9 : 0.06
+            color: appearance.color,
+            opacity: !focusedNodeId ? appearance.opacity : connectedEdge ? 0.92 : 0.05
           },
-          width: connectedEdge ? Math.max(2.5, appearance.width) : appearance.width
+          width: connectedEdge ? Math.max(3, appearance.width) : appearance.width
         };
       }));
       if (focusedNodeId) {
@@ -303,6 +388,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       }
     }, [
       contrastBorder,
+      comparisonPalette,
       edgeColor,
       edgeData,
       focusedNodeId,
@@ -315,10 +401,25 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
         id: node.id,
         font: {
           color: labelColor,
-          size: forceLabels || (node.degree ?? 1) >= maxDegree * 0.15 ? 12 : 0
+          size: forceLabels
+            || node.id === focusedNodeId
+            || (comparisonMode
+              ? automaticLabelIds.has(node.id)
+              : (node.degree ?? 1) >= maxDegree * 0.15)
+            ? 12
+            : 0
         }
       })));
-    }, [forceLabels, labelColor, maxDegree, model.nodes, nodeData]);
+    }, [
+      automaticLabelIds,
+      comparisonMode,
+      focusedNodeId,
+      forceLabels,
+      labelColor,
+      maxDegree,
+      model.nodes,
+      nodeData
+    ]);
 
     useImperativeHandle(ref, () => ({
       fit() {

--- a/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
+++ b/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
@@ -40,7 +40,7 @@ const fallbackComparisonPalette: ComparisonPalette = {
   unchanged: "#6e7781"
 };
 
-const options: Options = {
+const defaultOptions: Options = {
   autoResize: true,
   interaction: {
     hover: true,
@@ -70,6 +70,46 @@ const options: Options = {
       springConstant: 0.08,
       damping: 0.4,
       avoidOverlap: 0.8
+    }
+  }
+};
+
+const comparisonOptions: Options = {
+  autoResize: true,
+  interaction: {
+    hover: true,
+    tooltipDelay: 100,
+    hideEdgesOnDrag: true,
+    navigationButtons: false,
+    keyboard: { enabled: true }
+  },
+  layout: {
+    improvedLayout: true,
+    randomSeed: 17
+  },
+  nodes: {
+    borderWidth: 2,
+    shape: "dot"
+  },
+  edges: {
+    arrows: { to: { enabled: true, scaleFactor: 0.38 } },
+    smooth: { enabled: true, type: "continuous", roundness: 0.14 },
+    selectionWidth: 3
+  },
+  physics: {
+    enabled: true,
+    solver: "barnesHut",
+    stabilization: { enabled: true, iterations: 520, fit: true, updateInterval: 25 },
+    maxVelocity: 35,
+    minVelocity: 0.55,
+    barnesHut: {
+      theta: 0.45,
+      gravitationalConstant: -12000,
+      centralGravity: 0.12,
+      springLength: 180,
+      springConstant: 0.025,
+      damping: 0.3,
+      avoidOverlap: 0.85
     }
   }
 };
@@ -109,19 +149,60 @@ function comparisonEdgeAppearance(
   palette: ComparisonPalette
 ) {
   if (change === "added") {
-    return { color: palette.added, dashes: false, width: 2.5, opacity: 0.92 };
+    return { color: palette.added, dashes: false, width: 1.9, opacity: 0.7 };
   }
   if (change === "removed") {
-    return { color: palette.removed, dashes: [6, 5], width: 2.3, opacity: 0.9 };
+    return { color: palette.removed, dashes: [6, 5], width: 1.8, opacity: 0.66 };
   }
   if (change === "changed") {
-    return { color: palette.changed, dashes: false, width: 3, opacity: 0.94 };
+    return { color: palette.changed, dashes: false, width: 2.3, opacity: 0.78 };
   }
   if (change === "unchanged") {
-    return { color: palette.unchanged, dashes: true, width: 1, opacity: 0.28 };
+    return { color: palette.unchanged, dashes: true, width: 1, opacity: 0.2 };
   }
   const appearance = edgeAppearance(confidence);
   return { color: fallback, ...appearance };
+}
+
+function comparisonEdgeCurve(change: GraphChangeType | undefined) {
+  if (change === "added") {
+    return { enabled: true, type: "curvedCW" as const, roundness: 0.13 };
+  }
+  if (change === "removed") {
+    return { enabled: true, type: "curvedCCW" as const, roundness: 0.13 };
+  }
+  return { enabled: true, type: "continuous" as const, roundness: 0.1 };
+}
+
+function seedComparisonPositions(nodes: GraphNode[]): ReadonlyMap<string, { x: number; y: number }> {
+  const groups = new Map<GraphChangeType, GraphNode[]>();
+  for (const node of [...nodes].sort((left, right) => left.id.localeCompare(right.id))) {
+    const change = node.change ?? "unchanged";
+    const group = groups.get(change) ?? [];
+    group.push(node);
+    groups.set(change, group);
+  }
+  const laneOffset: Record<GraphChangeType, number> = {
+    added: -300,
+    changed: 0,
+    removed: 300,
+    unchanged: 0
+  };
+  const positions = new Map<string, { x: number; y: number }>();
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  for (const [change, group] of groups) {
+    group.forEach((node, index) => {
+      const angle = index * goldenAngle;
+      const radius = change === "unchanged"
+        ? 210 + Math.sqrt(index) * 34
+        : 42 + Math.sqrt(index) * 40;
+      positions.set(node.id, {
+        x: laneOffset[change] + Math.cos(angle) * radius,
+        y: Math.sin(angle) * radius
+      });
+    });
+  }
+  return positions;
 }
 
 function useThemeRevision(): number {
@@ -200,6 +281,10 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           .map((node) => node.id)
         : []
     ), [comparisonMode, model.nodes]);
+    const comparisonPositions = useMemo(
+      () => comparisonMode ? seedComparisonPositions(model.nodes) : new Map(),
+      [comparisonMode, model.nodes]
+    );
     const contrastBorder = useMemo(() => {
       const highContrast = document.body.classList.contains("vscode-high-contrast")
         || document.body.classList.contains("vscode-high-contrast-light");
@@ -211,13 +296,17 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       model.nodes.map((node) => {
         const baseSize = node.size ?? Math.min(40, 10 + 30 * (node.degree ?? 1) / maxDegree);
         const size = comparisonMode
-          ? node.change === "unchanged" ? baseSize * 0.72 : baseSize * 1.12
+          ? node.change === "unchanged"
+            ? 7 + 5 * Math.sqrt((node.degree ?? 1) / maxDegree)
+            : 11 + 12 * Math.sqrt((node.degree ?? 1) / maxDegree)
           : baseSize;
+        const position = comparisonPositions.get(node.id);
         return {
           id: node.id,
           label: node.label,
           color: graphNodeColor(model, node, undefined, fallbackComparisonPalette),
           size,
+          ...(position ?? {}),
           opacity: node.change === "unchanged" ? 0.42 : 1,
           font: {
             color: "#eef5ff",
@@ -233,6 +322,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
     ), [
       automaticLabelIds,
       comparisonMode,
+      comparisonPositions,
       maxDegree,
       model
     ]);
@@ -251,10 +341,11 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           title: `${edge.relation}${edge.confidence ? ` · ${edge.confidence}` : ""}`,
           dashes: appearance.dashes,
           width: appearance.width,
+          ...(comparisonMode ? { smooth: comparisonEdgeCurve(edge.change) } : {}),
           color: { color: appearance.color, opacity: appearance.opacity }
         };
       })
-    ), [model.edges]);
+    ), [comparisonMode, model.edges]);
 
     useEffect(() => {
       const container = containerRef.current;
@@ -263,7 +354,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       const network = new Network(container, {
         nodes: nodeData,
         edges: edgeData
-      }, options);
+      }, comparisonMode ? comparisonOptions : defaultOptions);
       network.setOptions({ physics: { enabled: physicsRunningRef.current } });
       if (!physicsRunningRef.current) network.stopSimulation();
       networkRef.current = network;
@@ -287,6 +378,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
     }, [
       edgeData,
       nodeData,
+      comparisonMode,
       onClear,
       onFocus,
       onHover,

--- a/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
+++ b/packages/compass-viewer/src/graph/VisNetworkCanvas.tsx
@@ -31,13 +31,18 @@ type Props = {
   onStabilized(): void;
 };
 
-type ComparisonPalette = Record<GraphChangeType, string>;
+type ComparisonColor = {
+  background: string;
+  border: string;
+};
+
+type ComparisonPalette = Record<GraphChangeType, ComparisonColor>;
 
 const fallbackComparisonPalette: ComparisonPalette = {
-  added: "#2ea043",
-  removed: "#f85149",
-  changed: "#d29922",
-  unchanged: "#6e7781"
+  added: { background: "#163d24", border: "#56d364" },
+  removed: { background: "#4b1f24", border: "#ff7b72" },
+  changed: { background: "#3d3015", border: "#d7a72b" },
+  unchanged: { background: "#29313b", border: "#8b949e" }
 };
 
 const defaultOptions: Options = {
@@ -120,14 +125,17 @@ export function graphNodeColor(
   contrastBorder?: string,
   comparisonPalette?: ComparisonPalette
 ) {
-  const background = node.change && comparisonPalette
+  const comparisonColor = node.change && comparisonPalette
     ? comparisonPalette[node.change]
+    : undefined;
+  const background = comparisonColor
+    ? comparisonColor.background
     : node.color?.background
     ?? model.communities.find((candidate) => candidate.id === node.community)?.color
     ?? "#6688aa";
   return {
     background,
-    border: contrastBorder ?? node.color?.border ?? background
+    border: contrastBorder ?? comparisonColor?.border ?? node.color?.border ?? background
   };
 }
 
@@ -149,16 +157,16 @@ function comparisonEdgeAppearance(
   palette: ComparisonPalette
 ) {
   if (change === "added") {
-    return { color: palette.added, dashes: false, width: 1.9, opacity: 0.7 };
+    return { color: palette.added.border, dashes: false, width: 1.7, opacity: 0.6 };
   }
   if (change === "removed") {
-    return { color: palette.removed, dashes: [6, 5], width: 1.8, opacity: 0.66 };
+    return { color: palette.removed.border, dashes: [6, 5], width: 1.6, opacity: 0.56 };
   }
   if (change === "changed") {
-    return { color: palette.changed, dashes: false, width: 2.3, opacity: 0.78 };
+    return { color: palette.changed.border, dashes: false, width: 1.65, opacity: 0.48 };
   }
   if (change === "unchanged") {
-    return { color: palette.unchanged, dashes: true, width: 1, opacity: 0.2 };
+    return { color: palette.unchanged.border, dashes: true, width: 1, opacity: 0.2 };
   }
   const appearance = edgeAppearance(confidence);
   return { color: fallback, ...appearance };
@@ -228,6 +236,56 @@ function useThemeRevision(): number {
   return revision;
 }
 
+function parseRgb(color: string): [number, number, number] | undefined {
+  const hex = color.match(/^#([\da-f]{3}|[\da-f]{6})$/i)?.[1];
+  if (hex) {
+    const normalized = hex.length === 3
+      ? [...hex].map((value) => `${value}${value}`).join("")
+      : hex;
+    return [
+      Number.parseInt(normalized.slice(0, 2), 16),
+      Number.parseInt(normalized.slice(2, 4), 16),
+      Number.parseInt(normalized.slice(4, 6), 16)
+    ];
+  }
+  const rgb = color.match(/^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i);
+  if (!rgb) return undefined;
+  return [
+    Number.parseFloat(rgb[1] ?? "0"),
+    Number.parseFloat(rgb[2] ?? "0"),
+    Number.parseFloat(rgb[3] ?? "0")
+  ];
+}
+
+function blendColor(background: string, foreground: string, foregroundRatio: number): string {
+  const backgroundRgb = parseRgb(background);
+  const foregroundRgb = parseRgb(foreground);
+  if (!backgroundRgb || !foregroundRgb) return foreground;
+  const values = backgroundRgb.map((value, index) =>
+    Math.round(value * (1 - foregroundRatio) + foregroundRgb[index]! * foregroundRatio));
+  return `rgb(${values[0]}, ${values[1]}, ${values[2]})`;
+}
+
+function isDarkColor(color: string): boolean {
+  const rgb = parseRgb(color);
+  if (!rgb) return true;
+  return (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000 < 145;
+}
+
+function comparisonColor(
+  background: string,
+  border: string,
+  dark: boolean,
+  context = false
+): ComparisonColor {
+  return {
+    background: blendColor(background, border, context
+      ? dark ? 0.18 : 0.1
+      : dark ? 0.26 : 0.14),
+    border
+  };
+}
+
 export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
   function VisNetworkCanvas({
     model,
@@ -260,12 +318,42 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       () => cssColor("--vscode-descriptionForeground", "#60728b"),
       [themeRevision]
     );
-    const comparisonPalette = useMemo<ComparisonPalette>(() => ({
-      added: cssColor("--vscode-gitDecoration-addedResourceForeground", "#2ea043"),
-      removed: cssColor("--vscode-gitDecoration-deletedResourceForeground", "#f85149"),
-      changed: cssColor("--vscode-gitDecoration-modifiedResourceForeground", "#d29922"),
-      unchanged: cssColor("--vscode-descriptionForeground", "#6e7781")
-    }), [themeRevision]);
+    const comparisonPalette = useMemo<ComparisonPalette>(() => {
+      const background = cssColor("--vscode-editor-background", "#08111f");
+      const dark = isDarkColor(background);
+      return {
+        added: comparisonColor(
+          background,
+          cssColor(
+            "--vscode-gitDecoration-addedResourceForeground",
+            dark ? "#56d364" : "#1a7f37"
+          ),
+          dark
+        ),
+        removed: comparisonColor(
+          background,
+          cssColor(
+            "--vscode-gitDecoration-deletedResourceForeground",
+            dark ? "#ff7b72" : "#cf222e"
+          ),
+          dark
+        ),
+        changed: comparisonColor(
+          background,
+          cssColor(
+            "--vscode-gitDecoration-modifiedResourceForeground",
+            dark ? "#d7a72b" : "#9a6700"
+          ),
+          dark
+        ),
+        unchanged: comparisonColor(
+          background,
+          cssColor("--vscode-descriptionForeground", dark ? "#8b949e" : "#656d76"),
+          dark,
+          true
+        )
+      };
+    }, [themeRevision]);
     const comparisonMode = useMemo(
       () => model.nodes.some((node) => node.change !== undefined)
         || model.edges.some((edge) => edge.change !== undefined),
@@ -307,7 +395,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           color: graphNodeColor(model, node, undefined, fallbackComparisonPalette),
           size,
           ...(position ?? {}),
-          opacity: node.change === "unchanged" ? 0.42 : 1,
+          opacity: node.change === "unchanged" ? 0.58 : 1,
           font: {
             color: "#eef5ff",
             face: "system-ui",
@@ -428,7 +516,7 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
       nodeData.update(model.nodes.map((node) => {
         const isFocused = node.id === focusedNodeId;
         const isVisible = !focusedNodeId || isFocused || connected.has(node.id);
-        const comparisonOpacity = node.change === "unchanged" ? 0.42 : 1;
+        const comparisonOpacity = node.change === "unchanged" ? 0.58 : 1;
         return {
           id: node.id,
           opacity: !focusedNodeId
@@ -439,9 +527,11 @@ export const VisNetworkCanvas = forwardRef<GraphCanvasHandle, Props>(
           shadow: isFocused
             ? {
                 enabled: true,
-                color: node.color?.background
-                  ?? model.communities.find((item) => item.id === node.community)?.color
-                  ?? "#76b7ff",
+                color: node.change
+                  ? comparisonPalette[node.change].border
+                  : node.color?.background
+                    ?? model.communities.find((item) => item.id === node.community)?.color
+                    ?? "#76b7ff",
                 size: 24,
                 x: 0,
                 y: 0

--- a/packages/compass-viewer/src/graph/state.ts
+++ b/packages/compass-viewer/src/graph/state.ts
@@ -1,8 +1,13 @@
+import type { GraphNode } from "../contracts/graph";
+
+export type GraphChangeType = NonNullable<GraphNode["change"]>;
+
 export type GraphState = {
   focusedNodeId: string | null;
   physicsRunning: boolean;
   forceLabels: boolean;
   hiddenCommunities: ReadonlySet<number>;
+  hiddenChanges: ReadonlySet<GraphChangeType>;
   query: string;
 };
 
@@ -14,6 +19,7 @@ export type GraphAction =
   | { type: "setLabels"; visible: boolean }
   | { type: "toggleCommunity"; communityId: number }
   | { type: "setHiddenCommunities"; communityIds: number[] }
+  | { type: "toggleChange"; change: GraphChangeType }
   | { type: "search"; query: string };
 
 export const initialGraphState: GraphState = {
@@ -21,6 +27,7 @@ export const initialGraphState: GraphState = {
   physicsRunning: true,
   forceLabels: false,
   hiddenCommunities: new Set<number>(),
+  hiddenChanges: new Set<GraphChangeType>(),
   query: ""
 };
 
@@ -53,5 +60,11 @@ export function graphReducer(state: GraphState, action: GraphAction): GraphState
     }
     case "setHiddenCommunities":
       return { ...state, hiddenCommunities: new Set(action.communityIds) };
+    case "toggleChange": {
+      const hiddenChanges = new Set(state.hiddenChanges);
+      if (hiddenChanges.has(action.change)) hiddenChanges.delete(action.change);
+      else hiddenChanges.add(action.change);
+      return { ...state, hiddenChanges };
+    }
   }
 }

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -71,11 +71,13 @@ function Delta({
   changed: number;
 }) {
   return (
-    <span>
+    <span className="history-delta-card">
       <strong>{label}</strong>
-      <i data-change="added">+{added}</i>
-      <i data-change="removed">−{removed}</i>
-      <i data-change="changed">~{changed}</i>
+      <span>
+        <i data-change="added"><small>Added</small> {added}</i>
+        <i data-change="removed"><small>Removed</small> {removed}</i>
+        <i data-change="changed"><small>Changed</small> {changed}</i>
+      </span>
     </span>
   );
 }

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -167,7 +167,7 @@ function addNode(
   node: GraphNode | undefined,
   change: "added" | "removed" | "changed"
 ): void {
-  if (node) nodes.set(node.id, { ...node, change, color: comparisonColor(change) });
+  if (node) nodes.set(node.id, { ...node, change });
 }
 
 function addContextNode(
@@ -180,17 +180,6 @@ function addContextNode(
   const node = current.get(id) ?? parent.get(id);
   if (node) nodes.set(id, {
     ...node,
-    change: "unchanged",
-    color: comparisonColor("unchanged")
+    change: "unchanged"
   });
-}
-
-function comparisonColor(change: "added" | "removed" | "changed" | "unchanged") {
-  const background = {
-    added: "#2ea043",
-    removed: "#f85149",
-    changed: "#d29922",
-    unchanged: "#6e7781"
-  }[change];
-  return { background, border: background };
 }

--- a/packages/compass-viewer/src/history/SemanticFindings.test.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.test.tsx
@@ -1,8 +1,9 @@
+import { parsePatchFiles } from "@pierre/diffs";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { SemanticFindings } from "./SemanticFindings";
-import { normalizeSourcePatch } from "./SourceChanges";
+import { minimumDiffHeight, normalizeSourcePatch } from "./SourceChanges";
 
 globalThis.ResizeObserver = class {
   observe() {}
@@ -23,6 +24,26 @@ describe("SemanticFindings", () => {
       + "+++ b/config/files.go\n"
       + "@@ -2,2 +2,2 @@"
     );
+  });
+
+  it("reserves enough height for every compact diff hunk", () => {
+    const patch = [
+      "diff --git a/example.ts b/example.ts",
+      "--- a/example.ts",
+      "+++ b/example.ts",
+      "@@ -1,0 +1,2 @@",
+      "+const first = true;",
+      "+const second = true;",
+      "@@ -4 +6 @@",
+      "-const value = 1;",
+      "+const value = 2;",
+      ""
+    ].join("\n");
+    const fileDiff = parsePatchFiles(patch, "height-test", true)[0]?.files?.[0];
+
+    expect(fileDiff).toBeDefined();
+    expect(minimumDiffHeight(fileDiff!, "split")).toBe(137);
+    expect(minimumDiffHeight(fileDiff!, "unified")).toBe(156);
   });
 
   it("renders source-only changes as readable evidence instead of a raw report dump", () => {

--- a/packages/compass-viewer/src/history/SemanticFindings.test.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.test.tsx
@@ -2,8 +2,29 @@ import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { SemanticFindings } from "./SemanticFindings";
+import { normalizeSourcePatch } from "./SourceChanges";
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 describe("SemanticFindings", () => {
+  it("normalizes GitHub hunk fragments into a complete one-file patch", () => {
+    expect(normalizeSourcePatch({
+      old_path: "config/files.go",
+      new_path: "config/files.go",
+      status: "modified",
+      patch: "@@ -2,2 +2,2 @@\n-old\n+new\n"
+    })).toContain(
+      "diff --git a/config/files.go b/config/files.go\n"
+      + "--- a/config/files.go\n"
+      + "+++ b/config/files.go\n"
+      + "@@ -2,2 +2,2 @@"
+    );
+  });
+
   it("renders source-only changes as readable evidence instead of a raw report dump", () => {
     const container = document.createElement("div");
     const root = createRoot(container);
@@ -32,7 +53,7 @@ describe("SemanticFindings", () => {
 
     expect(container.querySelector("h2")?.textContent).toBe("Source changes");
     expect(container.textContent).toContain("Cargo.toml");
-    expect(container.textContent).toContain("version = \"3.1.7\"");
+    expect(container.textContent).toContain("+1−1");
     expect(container.textContent).toContain("No semantic graph findings for this comparison.");
     expect(container.textContent).not.toContain("\"source_changes\"");
     root.unmount();

--- a/packages/compass-viewer/src/history/SemanticFindings.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.tsx
@@ -1,5 +1,6 @@
 import { FileDiffIcon, SparklesIcon } from "lucide-react";
 import { Badge } from "../components/ui/badge";
+import { SourceChanges, type SourceChange } from "./SourceChanges";
 
 export function SemanticFindings({ report }: { report: unknown }) {
   const value = report && typeof report === "object"
@@ -17,19 +18,7 @@ export function SemanticFindings({ report }: { report: unknown }) {
         <Badge variant="secondary">{sourceChanges.length}</Badge>
       </div>
       {sourceChanges.length > 0 ? (
-        <div className="history-source-changes">
-          {sourceChanges.map((change, index) => (
-            <details key={`${change.new_path ?? change.old_path}-${index}`} open>
-              <summary>
-                <code>{change.new_path ?? change.old_path ?? "(unknown path)"}</code>
-                <span>{change.status ?? "changed"}</span>
-              </summary>
-              {change.patch
-                ? <pre>{change.patch}</pre>
-                : <p>Compass recorded this file change without an inline patch.</p>}
-            </details>
-          ))}
-        </div>
+        <SourceChanges changes={sourceChanges} />
       ) : (
         <p className="history-diff-empty">No source patch was reported for this comparison.</p>
       )}
@@ -59,15 +48,12 @@ export function SemanticFindings({ report }: { report: unknown }) {
   );
 }
 
-type SourceChange = {
-  old_path?: string;
-  new_path?: string;
-  status?: string;
-  patch?: string;
-};
-
 function isSourceChange(value: unknown): value is SourceChange {
-  return value !== null && typeof value === "object";
+  if (value === null || typeof value !== "object") return false;
+  const change = value as Record<string, unknown>;
+  return ["old_path", "new_path", "status", "patch"].every(
+    (key) => change[key] === undefined || typeof change[key] === "string"
+  );
 }
 
 function findingSummary(finding: unknown, index: number): string {

--- a/packages/compass-viewer/src/history/SourceChanges.tsx
+++ b/packages/compass-viewer/src/history/SourceChanges.tsx
@@ -1,4 +1,4 @@
-import { parsePatchFiles } from "@pierre/diffs";
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import {
   Component,
@@ -26,6 +26,9 @@ const DIFF_THEME_CSS = `:host {
   --diffs-gap-inline: 6px;
   --diffs-min-number-column-width: 3ch;
 }`;
+const DIFF_LINE_HEIGHT = 19;
+const DIFF_HUNK_SEPARATOR_HEIGHT = 32;
+const DIFF_VERTICAL_PADDING = 16;
 
 export function SourceChanges({ changes }: { changes: SourceChange[] }) {
   const [preferredStyle, setPreferredStyle] = useState<DiffStyle>("split");
@@ -194,7 +197,10 @@ function SourcePatch({
         fileDiff={parsed.fileDiff}
         disableWorkerPool
         className="history-source-diff"
-        style={themeStyle}
+        style={{
+          ...themeStyle,
+          minHeight: minimumDiffHeight(parsed.fileDiff, style)
+        }}
         options={{
           theme: themeType === "light" ? "pierre-light" : "pierre-dark",
           themeType,
@@ -209,6 +215,21 @@ function SourcePatch({
       />
     </DiffErrorBoundary>
   );
+}
+
+export function minimumDiffHeight(
+  fileDiff: FileDiffMetadata,
+  style: DiffStyle
+): number {
+  const lineCount = fileDiff.hunks.reduce(
+    (total, hunk) => total + (
+      style === "split" ? hunk.splitLineCount : hunk.unifiedLineCount
+    ),
+    0
+  );
+  return lineCount * DIFF_LINE_HEIGHT
+    + fileDiff.hunks.length * DIFF_HUNK_SEPARATOR_HEIGHT
+    + DIFF_VERTICAL_PADDING;
 }
 
 function PatchFallback({ patch }: { patch: string }) {

--- a/packages/compass-viewer/src/history/SourceChanges.tsx
+++ b/packages/compass-viewer/src/history/SourceChanges.tsx
@@ -1,0 +1,262 @@
+import { parsePatchFiles } from "@pierre/diffs";
+import { PatchDiff } from "@pierre/diffs/react";
+import {
+  Component,
+  useEffect,
+  useMemo,
+  useState,
+  type ErrorInfo,
+  type ReactNode
+} from "react";
+
+export type SourceChange = {
+  old_path?: string;
+  new_path?: string;
+  status?: string;
+  patch?: string;
+};
+
+type DiffStyle = "split" | "unified";
+
+const DIFF_THEME_CSS = `:host {
+  --diffs-font-family: var(--compass-font-mono);
+  --diffs-font-size: 11px;
+  --diffs-line-height: 19px;
+  --diffs-dark-bg: var(--vscode-textCodeBlock-background, #0f141b);
+  --diffs-light-bg: var(--vscode-textCodeBlock-background, #f6f8fa);
+  --diffs-added-dark: var(--vscode-gitDecoration-addedResourceForeground, #65bd84);
+  --diffs-added-light: var(--vscode-gitDecoration-addedResourceForeground, #1a7f37);
+  --diffs-deleted-dark: var(--vscode-gitDecoration-deletedResourceForeground, #ff7b86);
+  --diffs-deleted-light: var(--vscode-gitDecoration-deletedResourceForeground, #cf222e);
+  --diffs-modified-dark: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+  --diffs-modified-light: var(--vscode-gitDecoration-modifiedResourceForeground, #9a6700);
+  --diffs-bg-context-override: var(--vscode-editor-background);
+  --diffs-bg-context-gutter-override: var(--vscode-editorGutter-background);
+  --diffs-bg-separator-override: var(--vscode-editorGroupHeader-tabsBackground);
+  --diffs-fg-number-override: var(--vscode-editorLineNumber-foreground);
+}`;
+
+export function SourceChanges({ changes }: { changes: SourceChange[] }) {
+  const [preferredStyle, setPreferredStyle] = useState<DiffStyle>("split");
+  const [wrap, setWrap] = useState(false);
+  const [narrow, setNarrow] = useState(
+    () => typeof matchMedia === "function" && matchMedia("(max-width: 760px)").matches
+  );
+  const [openFiles, setOpenFiles] = useState<ReadonlySet<number>>(
+    () => new Set(changes.length ? [0] : [])
+  );
+
+  useEffect(() => {
+    if (typeof matchMedia !== "function") return;
+    const media = matchMedia("(max-width: 760px)");
+    const update = () => setNarrow(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    setOpenFiles((current) => new Set(
+      [...current].filter((index) => index < changes.length)
+    ));
+  }, [changes.length]);
+
+  const style: DiffStyle = narrow ? "unified" : preferredStyle;
+  const allOpen = changes.length > 0 && openFiles.size === changes.length;
+
+  return (
+    <>
+      <div className="history-diff-toolbar" aria-label="Source diff controls">
+        <div className="history-diff-layout" role="group" aria-label="Diff layout">
+          <button
+            type="button"
+            aria-pressed={style === "split"}
+            disabled={narrow}
+            title={narrow ? "Split view needs a wider panel" : "Show side-by-side diff"}
+            onClick={() => setPreferredStyle("split")}
+          >
+            Split
+          </button>
+          <button
+            type="button"
+            aria-pressed={style === "unified"}
+            onClick={() => setPreferredStyle("unified")}
+          >
+            Unified
+          </button>
+        </div>
+        <label className="history-diff-wrap">
+          <input
+            type="checkbox"
+            checked={wrap}
+            onChange={(event) => setWrap(event.target.checked)}
+          />
+          <span>Wrap lines</span>
+        </label>
+        <button
+          type="button"
+          className="history-diff-expand"
+          onClick={() => setOpenFiles(
+            allOpen ? new Set() : new Set(changes.map((_, index) => index))
+          )}
+        >
+          {allOpen ? "Collapse all" : "Expand all"}
+        </button>
+      </div>
+      <div className="history-source-changes">
+        {changes.map((change, index) => {
+          const open = openFiles.has(index);
+          return (
+            <details
+              key={`${change.new_path ?? change.old_path}-${index}`}
+              open={open}
+              onToggle={(event) => {
+                const nextOpen = event.currentTarget.open;
+                setOpenFiles((current) => {
+                  const next = new Set(current);
+                  if (nextOpen) next.add(index);
+                  else next.delete(index);
+                  return next;
+                });
+              }}
+            >
+              <summary>
+                <span className="history-source-path">
+                  <code>{change.new_path ?? change.old_path ?? "(unknown path)"}</code>
+                  <small>{change.status ?? "changed"}</small>
+                </span>
+                <ChangeStats patch={change.patch} />
+              </summary>
+              {open && (
+                <SourcePatch
+                  patch={change.patch}
+                  cacheKey={`compass-history-${index}`}
+                  style={style}
+                  wrap={wrap}
+                />
+              )}
+            </details>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function ChangeStats({ patch }: { patch: string | undefined }) {
+  const counts = useMemo(() => {
+    if (!patch) return { additions: 0, deletions: 0 };
+    let additions = 0;
+    let deletions = 0;
+    for (const line of patch.split("\n")) {
+      if (line.startsWith("+") && !line.startsWith("+++")) additions += 1;
+      if (line.startsWith("-") && !line.startsWith("---")) deletions += 1;
+    }
+    return { additions, deletions };
+  }, [patch]);
+  return (
+    <span className="history-source-stats" aria-label={
+      `${counts.additions} additions and ${counts.deletions} deletions`
+    }>
+      <i data-change="added">+{counts.additions}</i>
+      <i data-change="removed">−{counts.deletions}</i>
+    </span>
+  );
+}
+
+function SourcePatch({
+  patch,
+  cacheKey,
+  style,
+  wrap
+}: {
+  patch: string | undefined;
+  cacheKey: string;
+  style: DiffStyle;
+  wrap: boolean;
+}) {
+  const validation = useMemo(() => {
+    if (!patch) return { valid: false, reason: "missing" } as const;
+    try {
+      const files = parsePatchFiles(patch, cacheKey, true)
+        .flatMap((parsed) => parsed.files ?? []);
+      return files.length
+        ? { valid: true } as const
+        : { valid: false, reason: "unparseable" } as const;
+    } catch {
+      return { valid: false, reason: "unparseable" } as const;
+    }
+  }, [cacheKey, patch]);
+  const themeType = useVscodeThemeType();
+
+  if (!patch) {
+    return <p>Compass recorded this file change without an inline patch.</p>;
+  }
+  if (!validation.valid) return <PatchFallback patch={patch} />;
+
+  return (
+    <DiffErrorBoundary fallback={<PatchFallback patch={patch} />}>
+      <PatchDiff
+        patch={patch}
+        disableWorkerPool
+        className="history-source-diff"
+        options={{
+          theme: { dark: "pierre-dark", light: "pierre-light" },
+          themeType,
+          diffStyle: style,
+          diffIndicators: "classic",
+          hunkSeparators: "metadata",
+          lineDiffType: "word-alt",
+          overflow: wrap ? "wrap" : "scroll",
+          disableFileHeader: true,
+          disableVirtualizationBuffers: true,
+          unsafeCSS: DIFF_THEME_CSS
+        }}
+      />
+    </DiffErrorBoundary>
+  );
+}
+
+function PatchFallback({ patch }: { patch: string }) {
+  return (
+    <div className="history-diff-fallback" role="note">
+      <p>Enhanced diff unavailable. Showing the exact Git patch.</p>
+      <pre>{patch}</pre>
+    </div>
+  );
+}
+
+function useVscodeThemeType(): "light" | "dark" {
+  const read = () => (
+    document.body.classList.contains("vscode-light")
+    || document.body.classList.contains("vscode-high-contrast-light")
+      ? "light"
+      : "dark"
+  );
+  const [theme, setTheme] = useState<"light" | "dark">(read);
+  useEffect(() => {
+    const observer = new MutationObserver(() => setTheme(read()));
+    observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+  return theme;
+}
+
+class DiffErrorBoundary extends Component<{
+  fallback: ReactNode;
+  children: ReactNode;
+}, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.warn("Compass could not render an enhanced source diff", error, info);
+  }
+
+  override render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}

--- a/packages/compass-viewer/src/history/SourceChanges.tsx
+++ b/packages/compass-viewer/src/history/SourceChanges.tsx
@@ -1,10 +1,11 @@
 import { parsePatchFiles } from "@pierre/diffs";
-import { PatchDiff } from "@pierre/diffs/react";
+import { FileDiff } from "@pierre/diffs/react";
 import {
   Component,
   useEffect,
   useMemo,
   useState,
+  type CSSProperties,
   type ErrorInfo,
   type ReactNode
 } from "react";
@@ -22,18 +23,8 @@ const DIFF_THEME_CSS = `:host {
   --diffs-font-family: var(--compass-font-mono);
   --diffs-font-size: 11px;
   --diffs-line-height: 19px;
-  --diffs-dark-bg: var(--vscode-textCodeBlock-background, #0f141b);
-  --diffs-light-bg: var(--vscode-textCodeBlock-background, #f6f8fa);
-  --diffs-added-dark: var(--vscode-gitDecoration-addedResourceForeground, #65bd84);
-  --diffs-added-light: var(--vscode-gitDecoration-addedResourceForeground, #1a7f37);
-  --diffs-deleted-dark: var(--vscode-gitDecoration-deletedResourceForeground, #ff7b86);
-  --diffs-deleted-light: var(--vscode-gitDecoration-deletedResourceForeground, #cf222e);
-  --diffs-modified-dark: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
-  --diffs-modified-light: var(--vscode-gitDecoration-modifiedResourceForeground, #9a6700);
-  --diffs-bg-context-override: var(--vscode-editor-background);
-  --diffs-bg-context-gutter-override: var(--vscode-editorGutter-background);
-  --diffs-bg-separator-override: var(--vscode-editorGroupHeader-tabsBackground);
-  --diffs-fg-number-override: var(--vscode-editorLineNumber-foreground);
+  --diffs-gap-inline: 6px;
+  --diffs-min-number-column-width: 3ch;
 }`;
 
 export function SourceChanges({ changes }: { changes: SourceChange[] }) {
@@ -129,7 +120,7 @@ export function SourceChanges({ changes }: { changes: SourceChange[] }) {
               </summary>
               {open && (
                 <SourcePatch
-                  patch={change.patch}
+                  change={change}
                   cacheKey={`compass-history-${index}`}
                   style={style}
                   wrap={wrap}
@@ -165,43 +156,47 @@ function ChangeStats({ patch }: { patch: string | undefined }) {
 }
 
 function SourcePatch({
-  patch,
+  change,
   cacheKey,
   style,
   wrap
 }: {
-  patch: string | undefined;
+  change: SourceChange;
   cacheKey: string;
   style: DiffStyle;
   wrap: boolean;
 }) {
-  const validation = useMemo(() => {
+  const parsed = useMemo(() => {
+    const patch = normalizeSourcePatch(change);
     if (!patch) return { valid: false, reason: "missing" } as const;
     try {
       const files = parsePatchFiles(patch, cacheKey, true)
         .flatMap((parsed) => parsed.files ?? []);
-      return files.length
-        ? { valid: true } as const
+      const fileDiff = files[0];
+      return files.length === 1 && fileDiff
+        ? { valid: true, fileDiff } as const
         : { valid: false, reason: "unparseable" } as const;
     } catch {
       return { valid: false, reason: "unparseable" } as const;
     }
-  }, [cacheKey, patch]);
-  const themeType = useVscodeThemeType();
+  }, [cacheKey, change]);
+  const { themeType, style: themeStyle } = useVscodeDiffTheme();
 
-  if (!patch) {
+  if (!change.patch) {
     return <p>Compass recorded this file change without an inline patch.</p>;
   }
-  if (!validation.valid) return <PatchFallback patch={patch} />;
+  if (!parsed.valid) return <PatchFallback patch={change.patch} />;
 
   return (
-    <DiffErrorBoundary fallback={<PatchFallback patch={patch} />}>
-      <PatchDiff
-        patch={patch}
+    <DiffErrorBoundary fallback={<PatchFallback patch={change.patch} />}>
+      <FileDiff
+        key={`${cacheKey}-${themeType}`}
+        fileDiff={parsed.fileDiff}
         disableWorkerPool
         className="history-source-diff"
+        style={themeStyle}
         options={{
-          theme: { dark: "pierre-dark", light: "pierre-light" },
+          theme: themeType === "light" ? "pierre-light" : "pierre-dark",
           themeType,
           diffStyle: style,
           diffIndicators: "classic",
@@ -209,7 +204,6 @@ function SourcePatch({
           lineDiffType: "word-alt",
           overflow: wrap ? "wrap" : "scroll",
           disableFileHeader: true,
-          disableVirtualizationBuffers: true,
           unsafeCSS: DIFF_THEME_CSS
         }}
       />
@@ -226,20 +220,118 @@ function PatchFallback({ patch }: { patch: string }) {
   );
 }
 
-function useVscodeThemeType(): "light" | "dark" {
+export function normalizeSourcePatch(change: SourceChange): string | undefined {
+  const patch = change.patch?.trimEnd();
+  if (!patch) return undefined;
+  if (patch.startsWith("diff --git ")) return `${patch}\n`;
+  if (/^--- .+\n\+\+\+ /m.test(patch)) return `${patch}\n`;
+
+  const oldPath = change.old_path ?? change.new_path ?? "unknown";
+  const newPath = change.new_path ?? change.old_path ?? "unknown";
+  const status = change.status?.toLocaleLowerCase();
+  const oldHeader = status === "added" || status === "new"
+    ? "/dev/null"
+    : `a/${oldPath}`;
+  const newHeader = status === "deleted" || status === "removed"
+    ? "/dev/null"
+    : `b/${newPath}`;
+  const hunk = patch.startsWith("@@ ")
+    ? patch
+    : `${syntheticHunkHeader(patch)}\n${patch}`;
+  return [
+    `diff --git a/${oldPath} b/${newPath}`,
+    `--- ${oldHeader}`,
+    `+++ ${newHeader}`,
+    hunk,
+    ""
+  ].join("\n");
+}
+
+function syntheticHunkHeader(patch: string): string {
+  let oldLines = 0;
+  let newLines = 0;
+  for (const line of patch.split("\n")) {
+    if (!line.startsWith("+")) oldLines += 1;
+    if (!line.startsWith("-")) newLines += 1;
+  }
+  return `@@ -1,${oldLines} +1,${newLines} @@`;
+}
+
+function useVscodeDiffTheme(): {
+  themeType: "light" | "dark";
+  style: CSSProperties;
+} {
   const read = () => (
     document.body.classList.contains("vscode-light")
+    || document.documentElement.classList.contains("vscode-light")
     || document.body.classList.contains("vscode-high-contrast-light")
+    || document.documentElement.classList.contains("vscode-high-contrast-light")
       ? "light"
       : "dark"
   );
   const [theme, setTheme] = useState<"light" | "dark">(read);
+  const [revision, setRevision] = useState(0);
   useEffect(() => {
-    const observer = new MutationObserver(() => setTheme(read()));
-    observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    const refresh = () => {
+      setTheme(read());
+      setRevision((current) => current + 1);
+    };
+    const observer = new MutationObserver(refresh);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["class", "style"]
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"]
+    });
     return () => observer.disconnect();
   }, []);
-  return theme;
+  const style = useMemo(() => {
+    const light = theme === "light";
+    const background = cssToken("--vscode-editor-background", light ? "#ffffff" : "#0f141b");
+    const foreground = cssToken("--vscode-editor-foreground", light ? "#24292f" : "#e6edf3");
+    const gutter = cssToken("--vscode-editorGutter-background", background);
+    const separator = cssToken("--vscode-editorGroupHeader-tabsBackground", background);
+    const lineNumber = cssToken(
+      "--vscode-editorLineNumber-foreground",
+      light ? "#656d76" : "#8b949e"
+    );
+    const added = cssToken(
+      "--vscode-gitDecoration-addedResourceForeground",
+      light ? "#1a7f37" : "#65bd84"
+    );
+    const removed = cssToken(
+      "--vscode-gitDecoration-deletedResourceForeground",
+      light ? "#cf222e" : "#ff7b86"
+    );
+    const modified = cssToken(
+      "--vscode-gitDecoration-modifiedResourceForeground",
+      light ? "#9a6700" : "#d29922"
+    );
+    return {
+      colorScheme: theme,
+      "--diffs-light-bg": background,
+      "--diffs-dark-bg": background,
+      "--diffs-light": foreground,
+      "--diffs-dark": foreground,
+      "--diffs-bg-context-override": background,
+      "--diffs-bg-context-gutter-override": gutter,
+      "--diffs-bg-separator-override": separator,
+      "--diffs-fg-number-override": lineNumber,
+      "--diffs-light-addition-color": added,
+      "--diffs-dark-addition-color": added,
+      "--diffs-light-deletion-color": removed,
+      "--diffs-dark-deletion-color": removed,
+      "--diffs-light-modified-color": modified,
+      "--diffs-dark-modified-color": modified
+    } as CSSProperties;
+  }, [revision, theme]);
+  return { themeType: theme, style };
+}
+
+function cssToken(name: string, fallback: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
 class DiffErrorBoundary extends Component<{

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -882,6 +882,7 @@ button:not(:disabled),
 }
 
 .compass-tool-button:focus-visible,
+.compass-change-legend button:focus-visible,
 .compass-search-field input:focus-visible,
 .compass-search-item:focus-visible,
 .compass-inspector-action:focus-visible,
@@ -893,6 +894,69 @@ button:not(:disabled),
 .compass-community-item:focus-within {
   outline: 2px solid var(--compass-focus);
   outline-offset: 2px;
+}
+
+.compass-change-legend {
+  position: absolute;
+  z-index: 4;
+  top: 64px;
+  left: 12px;
+  display: flex;
+  max-width: calc(100% - 24px);
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 5px;
+  border: 1px solid var(--compass-line);
+  border-radius: 4px;
+  background: var(--vscode-editorWidget-background, var(--compass-panel));
+}
+
+.compass-change-legend button {
+  display: inline-flex;
+  min-height: 27px;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 7px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.compass-change-legend button:hover,
+.compass-change-legend button[aria-pressed="true"] {
+  border-color: var(--compass-line);
+  background: var(--workbench-hover);
+  color: var(--foreground);
+}
+
+.compass-change-legend button[aria-pressed="false"] {
+  opacity: 0.42;
+}
+
+.compass-change-legend button > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vscode-descriptionForeground, #6e7781);
+}
+
+.compass-change-legend button[data-change="added"] > span {
+  background: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+}
+
+.compass-change-legend button[data-change="removed"] > span {
+  background: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.compass-change-legend button[data-change="changed"] > span {
+  background: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.compass-change-legend button small {
+  color: var(--compass-faint);
+  font: 9px/1 var(--compass-font-mono);
 }
 
 .compass-inspector-resizer {
@@ -1167,8 +1231,9 @@ button:not(:disabled),
   margin-bottom: 15px;
 }
 
-.compass-node-identity > span:last-child {
+.compass-node-identity > span:nth-child(2) {
   min-width: 0;
+  flex: 1;
 }
 
 .compass-node-identity strong,
@@ -1202,6 +1267,38 @@ button:not(:disabled),
   height: 36px;
   flex: 0 0 auto;
   border-radius: 5px;
+}
+
+.compass-change-badge {
+  display: inline-flex;
+  width: max-content;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: var(--vscode-descriptionForeground, #6e7781);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.compass-node-identity .compass-change-badge {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.compass-change-badge[data-change="added"] {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+}
+
+.compass-change-badge[data-change="removed"] {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.compass-change-badge[data-change="changed"] {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
 
 .compass-metadata-grid {
@@ -1419,6 +1516,33 @@ button:not(:disabled),
   margin-bottom: 10px;
 }
 
+.compass-community-panel[data-secondary="true"] {
+  flex: 0 1 auto;
+  padding-top: 12px;
+}
+
+.compass-community-panel details > summary {
+  display: flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.compass-community-panel details > summary span {
+  color: var(--compass-faint);
+  font: 9px/1 var(--compass-font-mono);
+}
+
+.compass-community-controls {
+  min-height: 0;
+}
+
 .compass-community-control,
 .compass-community-item {
   display: flex;
@@ -1496,6 +1620,10 @@ button:not(:disabled),
   font-size: 12px;
   line-height: 1.35;
   pointer-events: none;
+}
+
+.compass-node-hover-card > .compass-change-badge {
+  margin: 0;
 }
 
 .compass-hover-heading {
@@ -1720,7 +1848,7 @@ body.vscode-high-contrast-light .compass-source-metadata {
   gap: 8px;
   padding: 7px 12px 8px;
   border: 0;
-  border-bottom: 2px solid transparent;
+  border-top: 2px solid transparent;
   border-radius: 0;
   background: transparent;
   color: var(--muted-foreground);
@@ -1734,9 +1862,17 @@ body.vscode-high-contrast-light .compass-source-metadata {
 }
 
 .query-mode button[aria-selected="true"] {
-  border-bottom-color: var(--vscode-tab-activeBorder, var(--query-accent));
+  border-top-color: var(--vscode-tab-activeBorder, var(--query-accent));
   background: var(--vscode-tab-activeBackground, var(--query-surface-raised));
+  box-shadow:
+    inset 1px 0 var(--query-border),
+    inset -1px 0 var(--query-border);
   color: var(--vscode-tab-activeForeground, var(--foreground));
+}
+
+.query-mode button[aria-selected="true"] svg,
+.query-mode button[aria-selected="true"] strong {
+  opacity: 1;
 }
 
 .query-mode svg {
@@ -2288,6 +2424,12 @@ body.vscode-high-contrast-light .query-node-results {
   border-color: var(--vscode-contrastBorder, var(--ring));
 }
 
+body.vscode-high-contrast .query-mode button[aria-selected="true"],
+body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
+  border: 2px solid var(--vscode-contrastBorder, var(--ring));
+  border-bottom: 0;
+}
+
 .history-shell {
   display: grid;
   grid-template-columns: minmax(270px, 340px) minmax(0, 1fr);
@@ -2699,33 +2841,47 @@ body.vscode-high-contrast-light .query-node-results {
   font: 10px/1.4 var(--compass-font-mono);
 }
 
-.history-comparison-legend > span {
-  display: inline-flex;
-  gap: 7px;
-  padding: 3px 6px;
+.history-delta-card {
+  display: grid;
+  min-width: 210px;
+  gap: 4px;
+  padding: 6px 8px;
   border: 1px solid var(--border);
   border-radius: 2px;
   background: var(--vscode-badge-background, var(--muted));
 }
 
-.history-comparison-legend strong {
-  color: var(--vscode-badge-foreground, var(--foreground));
+.history-delta-card > span {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
 }
 
-.history-comparison-legend i {
+.history-delta-card strong {
+  color: var(--vscode-badge-foreground, var(--foreground));
+  text-transform: capitalize;
+}
+
+.history-delta-card i {
   font-style: normal;
   font-weight: 600;
 }
 
-.history-comparison-legend i[data-change="added"] {
+.history-delta-card i small {
+  color: var(--muted-foreground);
+  font-size: 9px;
+  font-weight: 400;
+}
+
+.history-delta-card i[data-change="added"] {
   color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
 }
 
-.history-comparison-legend i[data-change="removed"] {
+.history-delta-card i[data-change="removed"] {
   color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
 }
 
-.history-comparison-legend i[data-change="changed"] {
+.history-delta-card i[data-change="changed"] {
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
 
@@ -2779,8 +2935,70 @@ body.vscode-high-contrast-light .query-node-results {
   background: var(--vscode-textCodeBlock-background, var(--muted));
 }
 
+.history-diff-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.history-diff-layout {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.history-diff-toolbar button {
+  min-height: 25px;
+  padding: 3px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.history-diff-layout button + button {
+  border-left: 1px solid var(--border);
+}
+
+.history-diff-toolbar button:hover:not(:disabled) {
+  background: var(--workbench-hover);
+  color: var(--foreground);
+}
+
+.history-diff-toolbar button[aria-pressed="true"] {
+  background: var(--vscode-button-secondaryBackground, var(--muted));
+  color: var(--vscode-button-secondaryForeground, var(--foreground));
+}
+
+.history-diff-toolbar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.history-diff-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 25px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.history-diff-wrap input {
+  margin: 0;
+}
+
+.history-diff-expand {
+  margin-left: auto;
+  border: 1px solid var(--border) !important;
+  border-radius: 2px;
+}
+
 .history-source-changes summary {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
   padding: 6px 8px;
@@ -2790,17 +3008,61 @@ body.vscode-high-contrast-light .query-node-results {
   font-size: 10px;
 }
 
-.history-source-changes summary code {
-  color: var(--vscode-textLink-foreground, var(--workbench-link));
-  font-family: var(--compass-font-mono);
+.history-source-path {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
 }
 
-.history-source-changes summary span {
+.history-source-path code {
+  overflow: hidden;
+  color: var(--vscode-textLink-foreground, var(--workbench-link));
+  font-family: var(--compass-font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-source-path small {
   color: var(--muted-foreground);
+  font-size: 9px;
   text-transform: capitalize;
 }
 
-.history-source-changes pre,
+.history-source-stats {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 6px;
+  font-family: var(--compass-font-mono);
+}
+
+.history-source-stats i {
+  font-style: normal;
+  font-weight: 600;
+}
+
+.history-source-stats i[data-change="added"] {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+}
+
+.history-source-stats i[data-change="removed"] {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.history-source-diff {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.history-diff-fallback > p {
+  margin: 0;
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.history-diff-fallback pre,
 .history-finding-list pre {
   max-height: 260px;
   margin: 0;
@@ -2885,8 +3147,18 @@ body.vscode-high-contrast .history-comparison,
 body.vscode-high-contrast-light .history-comparison,
 body.vscode-high-contrast .history-diff-evidence,
 body.vscode-high-contrast-light .history-diff-evidence,
+body.vscode-high-contrast .history-source-changes details,
+body.vscode-high-contrast-light .history-source-changes details,
 body.vscode-high-contrast .history-change-counts span,
 body.vscode-high-contrast-light .history-change-counts span {
+  border-color: var(--vscode-contrastBorder, var(--ring));
+  border-width: 2px;
+}
+
+body.vscode-high-contrast .compass-change-legend,
+body.vscode-high-contrast-light .compass-change-legend,
+body.vscode-high-contrast .compass-change-badge,
+body.vscode-high-contrast-light .compass-change-badge {
   border-color: var(--vscode-contrastBorder, var(--ring));
   border-width: 2px;
 }
@@ -2904,6 +3176,14 @@ body.vscode-high-contrast-light .history-change-counts span {
 
   .query-mode {
     align-self: flex-start;
+  }
+
+  .history-diff-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .history-diff-expand {
+    margin-left: 0;
   }
 
   .query-composer-footer {

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -783,6 +783,14 @@ button:not(:disabled),
   background-size: 22px 22px;
 }
 
+.compass-graph-stage[data-comparison="true"] {
+  background: var(--vscode-editor-background, var(--compass-canvas));
+}
+
+.compass-graph-stage[data-comparison="true"]::after {
+  opacity: 0.09;
+}
+
 .compass-canvas {
   position: absolute;
   inset: 0;
@@ -939,19 +947,39 @@ button:not(:disabled),
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--vscode-descriptionForeground, #6e7781);
+  border: 1px solid var(--vscode-descriptionForeground, #6e7781);
+  background: color-mix(
+    in srgb,
+    var(--vscode-descriptionForeground, #6e7781) 18%,
+    var(--vscode-editor-background, var(--background))
+  );
 }
 
 .compass-change-legend button[data-change="added"] > span {
-  background: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+  border-color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+  background: color-mix(
+    in srgb,
+    var(--vscode-gitDecoration-addedResourceForeground, #2ea043) 22%,
+    var(--vscode-editor-background, var(--background))
+  );
 }
 
 .compass-change-legend button[data-change="removed"] > span {
-  background: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+  border-color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+  background: color-mix(
+    in srgb,
+    var(--vscode-gitDecoration-deletedResourceForeground, #f85149) 22%,
+    var(--vscode-editor-background, var(--background))
+  );
 }
 
 .compass-change-legend button[data-change="changed"] > span {
-  background: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+  border-color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+  background: color-mix(
+    in srgb,
+    var(--vscode-gitDecoration-modifiedResourceForeground, #d29922) 22%,
+    var(--vscode-editor-background, var(--background))
+  );
 }
 
 .compass-change-legend button small {

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -3004,9 +3004,20 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
   color: var(--foreground);
 }
 
-.history-diff-toolbar button[aria-pressed="true"] {
-  background: var(--vscode-button-secondaryBackground, var(--muted));
-  color: var(--vscode-button-secondaryForeground, var(--foreground));
+.history-diff-toolbar button[aria-pressed="true"],
+.history-diff-toolbar button[aria-pressed="true"]:hover {
+  background: var(
+    --vscode-tab-activeBackground,
+    var(--vscode-editor-background, var(--background))
+  );
+  color: var(
+    --vscode-tab-activeForeground,
+    var(--vscode-editor-foreground, var(--foreground))
+  );
+  box-shadow: inset 0 2px 0 var(
+    --vscode-tab-activeBorder,
+    var(--vscode-focusBorder, var(--ring))
+  );
 }
 
 .history-diff-toolbar button:disabled {

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -2776,11 +2776,12 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
 .history-diff-evidence {
   margin-top: 12px;
   border: 1px solid var(--border);
-  background: var(--vscode-editorWidget-background, var(--card));
+  background: var(--vscode-editor-background, var(--background));
+  color: var(--vscode-editor-foreground, var(--foreground));
 }
 
 .history-comparison {
-  box-shadow: inset 3px 0 0 var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+  box-shadow: inset 3px 0 0 var(--vscode-focusBorder, var(--ring));
 }
 
 .history-comparison-heading {
@@ -2796,17 +2797,19 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
   width: 15px;
   height: 15px;
   margin-top: 2px;
-  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+  color: var(--vscode-focusBorder, var(--ring));
 }
 
 .history-comparison-heading h2 {
   margin: 2px 0 0;
+  color: var(--vscode-editor-foreground, var(--foreground));
   font-size: 13px;
   font-weight: 600;
 }
 
 .history-comparison-heading code {
   color: var(--vscode-textLink-foreground, var(--workbench-link));
+  background: transparent;
   font-family: var(--compass-font-mono);
 }
 
@@ -2843,12 +2846,17 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
 
 .history-delta-card {
   display: grid;
-  min-width: 210px;
+  min-width: 200px;
   gap: 4px;
   padding: 6px 8px;
   border: 1px solid var(--border);
   border-radius: 2px;
-  background: var(--vscode-badge-background, var(--muted));
+  background: color-mix(
+    in srgb,
+    var(--vscode-editor-foreground, var(--foreground)) 5%,
+    var(--vscode-editor-background, var(--background))
+  );
+  color: var(--vscode-editor-foreground, var(--foreground));
 }
 
 .history-delta-card > span {
@@ -2858,7 +2866,7 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
 }
 
 .history-delta-card strong {
-  color: var(--vscode-badge-foreground, var(--foreground));
+  color: var(--vscode-editor-foreground, var(--foreground));
   text-transform: capitalize;
 }
 
@@ -2932,7 +2940,8 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 2px;
-  background: var(--vscode-textCodeBlock-background, var(--muted));
+  background: var(--vscode-editor-background, var(--background));
+  color: var(--vscode-editor-foreground, var(--foreground));
 }
 
 .history-diff-toolbar {
@@ -3051,8 +3060,11 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
 
 .history-source-diff {
   display: block;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
+  contain: inline-size;
+  background: var(--vscode-editor-background, var(--background));
 }
 
 .history-diff-fallback > p {
@@ -3126,6 +3138,7 @@ body.vscode-high-contrast-light .query-mode button[aria-selected="true"] {
 .history-graph-canvas {
   position: relative;
   flex: 1;
+  isolation: isolate;
 }
 
 .history-graph-canvas .compass-workspace {

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -516,7 +516,7 @@ window.acquireVsCodeApi=()=>({postMessage(message){
           old_path:"Cargo.toml",
           new_path:"Cargo.toml",
           status:"modified",
-          patch:"-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\""
+          patch:"diff --git a/Cargo.toml b/Cargo.toml\\nindex 1111111..2222222 100644\\n--- a/Cargo.toml\\n+++ b/Cargo.toml\\n@@ -5 +5 @@\\n-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\"\\n"
         }],
         findings:[{summary:"Fixture comparison"}]
       }

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -516,7 +516,7 @@ window.acquireVsCodeApi=()=>({postMessage(message){
           old_path:"Cargo.toml",
           new_path:"Cargo.toml",
           status:"modified",
-          patch:"diff --git a/Cargo.toml b/Cargo.toml\\nindex 1111111..2222222 100644\\n--- a/Cargo.toml\\n+++ b/Cargo.toml\\n@@ -5 +5 @@\\n-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\"\\n"
+          patch:"@@ -3,3 +3,3 @@ [package]\\n name = \\"compass\\"\\n-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\"\\n edition = \\"2021\\"\\n"
         }],
         findings:[{summary:"Fixture comparison"}]
       }

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -119,10 +119,20 @@ test("comparison replaces the full graph with a readable focused delta", async (
 
   await expect(page.getByText("Comparison mode")).toBeVisible();
   await expect(page.getByText(/Comparing bbbbbbbbb to aaaaaaaaa/)).toBeVisible();
-  await expect(page.getByLabel("Visible graph delta")).toContainText("nodes+0−0~1");
+  await expect(page.getByLabel("Visible graph delta")).toContainText(
+    "nodesAdded 0Removed 0Changed 1"
+  );
   await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
   await expect(page.getByText("Cargo.toml")).toBeVisible();
-  await expect(page.getByText('+version = "3.1.7"')).toBeVisible();
+  await expect(page.locator(".history-source-diff")).toBeVisible();
+  await expect(
+    page.locator(".history-source-diff").getByText('version = "3.1.7"', { exact: false })
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Split" })).toHaveAttribute(
+    "aria-pressed",
+    "true"
+  );
+  await expect(page.getByLabel("Graph change filters")).toContainText("Changed2");
   await expect(page.getByText("Fixture comparison", { exact: true })).toBeVisible();
 
   await page.getByRole("button", { name: "Exit comparison" }).click();

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -128,6 +128,10 @@ test("comparison replaces the full graph with a readable focused delta", async (
   await expect(
     page.locator(".history-source-diff").getByText('version = "3.1.7"', { exact: false })
   ).toBeVisible();
+  await expect(
+    page.locator(".history-source-diff").getByText('name = "compass"', { exact: false }).first()
+  ).toBeVisible();
+  await expect(page.locator(".history-source-diff [data-line]")).toHaveCount(6);
   await expect(page.getByRole("button", { name: "Split" })).toHaveAttribute(
     "aria-pressed",
     "true"

--- a/tests/viewer/query.spec.ts
+++ b/tests/viewer/query.spec.ts
@@ -38,9 +38,19 @@ test("query modes use a full-width tab rail", async ({ page }) => {
   const tabs = page.getByRole("tablist", { name: "Query mode" });
   await expect(tabs).toBeVisible();
   expect((await tabs.boundingBox())?.width).toBeGreaterThan(500);
-  await expect(page.getByRole("tab", { name: "Ask the codebase" }))
-    .toHaveAttribute("aria-selected", "true");
-  await page.getByRole("tab", { name: "CompassQL" }).click();
+  const natural = page.getByRole("tab", { name: "Ask the codebase" });
+  const cql = page.getByRole("tab", { name: "CompassQL" });
+  await expect(natural).toHaveAttribute("aria-selected", "true");
+  expect(await natural.evaluate((element) => getComputedStyle(element).borderTopColor))
+    .not.toBe("rgba(0, 0, 0, 0)");
+  expect(await cql.evaluate((element) => getComputedStyle(element).borderTopColor))
+    .toBe("rgba(0, 0, 0, 0)");
+  await cql.click();
+  await expect(cql).toHaveAttribute("aria-selected", "true");
+  expect(await cql.evaluate((element) => getComputedStyle(element).borderTopColor))
+    .not.toBe("rgba(0, 0, 0, 0)");
+  expect(await natural.evaluate((element) => getComputedStyle(element).borderTopColor))
+    .toBe("rgba(0, 0, 0, 0)");
   await expect(page.getByRole("textbox", { name: "CompassQL query" })).toBeVisible();
 });
 

--- a/tests/viewer/theme.spec.ts
+++ b/tests/viewer/theme.spec.ts
@@ -83,6 +83,10 @@ test("history comparison and source diffs follow the light VS Code theme", async
     .toHaveCSS("background-color", "rgb(244, 244, 244)");
   await expect(page.locator(".history-source-diff"))
     .toHaveCSS("color-scheme", "light");
+  await expect(page.getByRole("button", { name: "Split" }))
+    .toHaveCSS("background-color", "rgb(244, 244, 244)");
+  await expect(page.getByRole("button", { name: "Split" }))
+    .toHaveCSS("color", "rgb(32, 32, 32)");
   await expect(page.locator(".compass-graph-stage"))
     .toHaveAttribute("data-comparison", "true");
   await expect(page.locator(".compass-graph-stage"))

--- a/tests/viewer/theme.spec.ts
+++ b/tests/viewer/theme.spec.ts
@@ -67,6 +67,24 @@ test("high-contrast themes use the VS Code contrast border", async ({ page }) =>
   await expect(page.locator(".history-commit-details")).toHaveCSS("border-top-width", "2px");
 });
 
+test("history comparison and source diffs follow the light VS Code theme", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.getByRole("option", { name: /Revision B graph/i }).click();
+  await page.getByRole("button", { name: /Compare parent 1/i }).click();
+  await expect(page.locator(".history-source-diff")).toBeVisible();
+
+  await applyTheme(page, themeCases[0]);
+
+  await expect(page.locator(".history-comparison"))
+    .toHaveCSS("background-color", "rgb(244, 244, 244)");
+  await expect(page.locator(".history-comparison"))
+    .toHaveCSS("color", "rgb(32, 32, 32)");
+  await expect(page.locator(".history-source-diff"))
+    .toHaveCSS("background-color", "rgb(244, 244, 244)");
+  await expect(page.locator(".history-source-diff"))
+    .toHaveCSS("color-scheme", "light");
+});
+
 test("Architecture symbol titles use editor foreground in light themes", async ({ page }) => {
   await page.goto("/architecture.html");
   await applyTheme(page, themeCases[0]);

--- a/tests/viewer/theme.spec.ts
+++ b/tests/viewer/theme.spec.ts
@@ -83,6 +83,12 @@ test("history comparison and source diffs follow the light VS Code theme", async
     .toHaveCSS("background-color", "rgb(244, 244, 244)");
   await expect(page.locator(".history-source-diff"))
     .toHaveCSS("color-scheme", "light");
+  await expect(page.locator(".compass-graph-stage"))
+    .toHaveAttribute("data-comparison", "true");
+  await expect(page.locator(".compass-graph-stage"))
+    .toHaveCSS("background-color", "rgb(244, 244, 244)");
+  await expect(page.locator(".compass-graph-stage"))
+    .toHaveCSS("background-image", "none");
 });
 
 test("Architecture symbol titles use editor foreground in light themes", async ({ page }) => {


### PR DESCRIPTION
## What changed

- add a VS Code-style top accent and raised active surface to the Ask Codebase tabs
- render Codebase Evolution source changes with `@pierre/diffs`, including split/unified modes, wrapping, responsive layout, file collapsing, and raw-patch fallback
- make versioned graph comparisons status-first with Added/Removed/Changed/Context filters, readable Git colors, quieter context nodes, bounded labels, and secondary community controls
- move source navigation selections through the beginning of the line after a node's recorded end line
- add browser coverage for the tab state, source diff renderer, and graph comparison controls

## Why

The query tabs did not clearly communicate which mode was active, raw patches were difficult to scan, and graph deltas mixed change state with community and confidence styling. Source navigation also left the cursor on the recorded last line instead of immediately below the selected range.

## User impact

Users can identify the active query mode at a glance, review revision diffs in a familiar code-review layout, isolate graph changes by status, and continue editing directly below a selected graph node's source range.

## Validation

- TypeScript checks for all JavaScript workspaces
- 88 unit tests
- 57 Playwright browser and accessibility tests
- production VS Code extension build
- VSIX package and smoke check
- `graphify update .`
