### PR TITLE
fix(program): disambiguate repeated Python symbols

### DIFF
--- a/crates/compass-languages/src/program/python.rs
+++ b/crates/compass-languages/src/program/python.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use compass_ir::{
@@ -17,6 +17,7 @@ pub(super) fn extract(
     let mut collector = Collector {
         descriptor,
         input,
+        function_occurrences: HashMap::new(),
         functions: Vec::new(),
         evidence: Vec::new(),
     };
@@ -27,6 +28,7 @@ pub(super) fn extract(
 struct Collector<'a> {
     descriptor: ProviderDescriptor,
     input: &'a FileInput<'a>,
+    function_occurrences: HashMap<String, u32>,
     functions: Vec<FunctionIr>,
     evidence: Vec<compass_ir::EvidenceRecord>,
 }
@@ -78,7 +80,7 @@ impl Collector<'_> {
             |owner| format!("{owner}.{short_name}"),
         );
         let signature = signature_bytes(self.input.source, node);
-        let symbol_id = hex_sha256(
+        let base_symbol_id = hex_sha256(
             format!(
                 "{}\0{}\0{}",
                 self.input.source_file,
@@ -87,6 +89,7 @@ impl Collector<'_> {
             )
             .as_bytes(),
         );
+        let symbol_id = unique_symbol_id(base_symbol_id, &mut self.function_occurrences);
         let definition = evidence_record(
             &self.descriptor.id,
             Some(self.input.source_file),
@@ -453,6 +456,17 @@ fn contains_token(source: &[u8], expected: &str) -> bool {
         .unwrap_or_default()
         .split(|character: char| !character.is_alphanumeric() && character != '_')
         .any(|token| token == expected)
+}
+
+fn unique_symbol_id(base: String, occurrences: &mut HashMap<String, u32>) -> String {
+    let occurrence = occurrences.entry(base.clone()).or_default();
+    let symbol = if *occurrence == 0 {
+        base.clone()
+    } else {
+        hex_sha256(format!("{base}\0{occurrence}").as_bytes())
+    };
+    *occurrence = occurrence.saturating_add(1);
+    symbol
 }
 
 fn signature_bytes<'a>(source: &'a [u8], node: Node<'_>) -> &'a [u8] {

--- a/crates/compass-languages/tests/program_evidence.rs
+++ b/crates/compass-languages/tests/program_evidence.rs
@@ -133,6 +133,30 @@ fn repeated_signatures_in_distinct_lexical_scopes_have_unique_syntax_symbols()
 }
 
 #[test]
+fn python_conditional_redefinitions_have_unique_syntax_symbols() -> Result<(), Box<dyn Error>> {
+    let source = b"try:\n    def mogrify(sql, params, connection):\n        return first(sql)\nexcept ImportError:\n    def mogrify(sql, params, connection):\n        return second(sql)\n";
+    let batch = TreeSitterSyntaxProvider::default()
+        .analyze_file(FileInput {
+            source_file: "django/db/backends/postgresql/psycopg_any.py",
+            language: "python",
+            source,
+        })?
+        .ok_or("missing Python batch")?;
+    let functions = &batch.modules[0].functions;
+    assert_eq!(functions.len(), 2);
+    assert_eq!(
+        functions
+            .iter()
+            .map(|function| function.symbol_id.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        functions.len()
+    );
+    merge_evidence(vec![batch])?.validate()?;
+    Ok(())
+}
+
+#[test]
 fn syntax_merge_resolves_unique_local_calls() -> Result<(), Box<dyn Error>> {
     let batch = TreeSitterSyntaxProvider::default()
         .analyze_file(FileInput {


### PR DESCRIPTION
## Summary

- disambiguate repeated Python function symbol IDs by occurrence
- preserve the existing stable ID for the first definition and derive deterministic IDs for later collisions
- add a Django-shaped regression test for conditional `mogrify()` definitions

## Root cause

The Python Program IR extractor hashed source path, qualified name, and signature. Conditional implementations with the same name and signature in one file therefore emitted duplicate IDs and failed provider validation. Rust and TypeScript already applied occurrence-based disambiguation; Python did not.

## Impact

Large Python repositories with conditional alternative definitions, including Django's psycopg 2/3 `mogrify()` implementations, can now complete `compass init` and `compass update` successfully.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-languages` (40 tests passed)
- Django full initialization: 6,051 files indexed, 3,038 Program IR modules, 0 conflicts
- Django cached update completed successfully
