### PR TITLE
Fix diff row layout in VS Code

### DIFF
--- a/packages/compass-viewer/src/history/SourceChanges.tsx
+++ b/packages/compass-viewer/src/history/SourceChanges.tsx
@@ -25,6 +25,13 @@ const DIFF_THEME_CSS = `:host {
   --diffs-line-height: 19px;
   --diffs-gap-inline: 6px;
   --diffs-min-number-column-width: 3ch;
+}
+
+[data-gutter],
+[data-content] {
+  grid-template-rows: none;
+  grid-auto-rows: minmax(var(--diffs-line-height, 19px), auto);
+  align-content: start;
 }`;
 const DIFF_LINE_HEIGHT = 19;
 const DIFF_HUNK_SEPARATOR_HEIGHT = 32;


### PR DESCRIPTION
## Summary
- replace the unsupported nested CSS subgrid row layout with explicit automatic diff rows
- preserve split-view alignment while rendering every added and removed line distinctly

## Verification
- viewer TypeScript typecheck
- 44 viewer tests
- VS Code extension build
- browser fixture: 20 distinct addition rows and 6 distinct deletion rows