### PR TITLE
Release Compass 0.1.7 for macOS and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-model",
  "glob",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-model",
  "regex",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "axum",
  "compass-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-model",
  "regex",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the Compass workspace patch version from 0.1.6 to 0.1.7
- update all Compass workspace package versions in Cargo.lock
- keep the existing macOS and Linux release matrix unchanged

## Validation
- `sh scripts/test_release_scripts.sh`
- release and CI workflow YAML parsing
- `cargo metadata --locked --offline --no-deps` (all workspace packages 0.1.7)
- `sh scripts/check_product_boundary.sh`
- `git diff --check`

The tag-triggered release workflow will compile, test, package, checksum, and attest Intel/Apple Silicon macOS and x86_64/ARM64 Linux artifacts.