### PR TITLE
Version fixed VSIX as 0.1.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Allow the Codebase Evolution diff renderer's generated grid-span styles so
+  installed VSIX builds display every changed source line at its natural height.
+
 ## 0.1.0
 
 - Guided setup for a separately installed Compass CLI.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "editors/vscode": {
       "name": "compass-vscode",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",


### PR DESCRIPTION
## Summary
- version the fixed VSIX as 0.1.1 so VS Code recognizes it as an upgrade instead of another 0.1.0 replacement
- document the installed Codebase Evolution diff-height fix in the extension changelog

## Root cause
The fixed 0.1.0 files were installed correctly, but the active VS Code extension hosts had started before installation and retained the old extension bundle in memory. A distinct patch version makes the required extension-host reload visible and unambiguous.

## Verification
- VS Code extension typecheck
- 47 VS Code extension tests
- 13 Codebase Evolution browser tests
- packaged and installed compass-vscode-0.1.1.vsix
- verified the registered extension is crabbuild.compass-vscode@0.1.1 and the installed bundle contains the required style-src-attr CSP directive
