### PR TITLE
Add interactive semantic diff graph explorer

### DIFF
--- a/crates/compass-cli/assets/semantic-diff-graph.css
+++ b/crates/compass-cli/assets/semantic-diff-graph.css
@@ -1,0 +1,329 @@
+.graph-explorer {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(280px, 3fr);
+  min-height: 520px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface-inset);
+}
+
+.graph-canvas {
+  position: relative;
+  min-width: 0;
+  min-height: 520px;
+  overflow: hidden;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px),
+    var(--surface-inset);
+  background-size: 32px 32px;
+  background-position: -1px -1px;
+}
+
+.graph-canvas svg {
+  display: block;
+  width: 100%;
+  height: 560px;
+}
+
+.graph-edge {
+  stroke: var(--border-strong);
+  stroke-width: 1.15;
+  opacity: .64;
+  transition: opacity 140ms ease, stroke-width 140ms ease;
+}
+
+.graph-edge.added { stroke: var(--green); }
+.graph-edge.removed {
+  stroke: var(--red);
+  stroke-dasharray: 5 4;
+}
+.graph-edge.changed {
+  stroke: var(--amber);
+  stroke-dasharray: 2 3;
+}
+
+.graph-arrow.context { fill: var(--border-strong); }
+.graph-arrow.added { fill: var(--green); }
+.graph-arrow.removed { fill: var(--red); }
+.graph-arrow.changed { fill: var(--amber); }
+
+.graph-node {
+  cursor: pointer;
+  outline: none;
+  transition: opacity 140ms ease;
+}
+
+.graph-node-surface {
+  fill: var(--surface-raised);
+  stroke: var(--muted);
+  stroke-width: 1.35;
+}
+
+.graph-node.added .graph-node-surface { stroke: var(--green); }
+.graph-node.removed .graph-node-surface {
+  stroke: var(--red);
+  stroke-dasharray: 4 3;
+}
+.graph-node.changed .graph-node-surface { stroke: var(--amber); }
+
+.graph-node-mark {
+  stroke: none;
+  font: 700 13px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.graph-node.added .graph-node-mark { fill: var(--green); }
+.graph-node.removed .graph-node-mark { fill: var(--red); }
+.graph-node.changed .graph-node-mark { fill: var(--amber); }
+.graph-node.context .graph-node-mark { fill: var(--muted); }
+
+.graph-node-label {
+  fill: var(--text);
+  stroke: none;
+  font: 600 11px/1.2 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  pointer-events: none;
+}
+
+.graph-node-meta {
+  fill: var(--muted);
+  stroke: none;
+  font: 9px/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  pointer-events: none;
+}
+
+.graph-node.is-selected .graph-node-surface,
+.graph-node:focus-visible .graph-node-surface {
+  stroke: var(--accent);
+  stroke-width: 2.7;
+  filter: drop-shadow(0 0 5px rgba(138, 180, 248, .32));
+}
+
+.graph-node.is-neighbor { opacity: 1; }
+.graph-node.is-dimmed,
+.graph-edge.is-dimmed { opacity: .16; }
+.graph-edge.is-related {
+  opacity: 1;
+  stroke-width: 2.25;
+}
+
+.graph-inspector {
+  min-width: 0;
+  max-height: 560px;
+  overflow: auto;
+  padding: 18px;
+  background: var(--surface);
+}
+
+.graph-inspector-empty {
+  display: grid;
+  min-height: 100%;
+  place-content: center;
+  margin: 0;
+  color: var(--muted);
+  text-align: center;
+  font-size: 12px;
+}
+
+.graph-inspector-header {
+  padding-bottom: 15px;
+  border-bottom: 1px solid var(--border);
+}
+
+.graph-inspector-header h3 {
+  margin: 9px 0 4px;
+  overflow-wrap: anywhere;
+  font-size: 16px;
+  line-height: 1.3;
+}
+
+.graph-inspector-header code {
+  display: block;
+  color: var(--muted);
+  font: 9px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  overflow-wrap: anywhere;
+}
+
+.graph-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 2px 7px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+.graph-status.added { color: var(--green); }
+.graph-status.removed { color: var(--red); }
+.graph-status.changed { color: var(--amber); }
+.graph-status.context { color: var(--muted); }
+
+.graph-inspector-facts {
+  margin: 0;
+  padding: 8px 0;
+}
+
+.graph-inspector-facts > div {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 10px;
+  padding: 7px 0;
+}
+
+.graph-inspector-facts dt {
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+
+.graph-inspector-facts dd {
+  margin: 0;
+  color: var(--text-soft);
+  overflow-wrap: anywhere;
+  font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.graph-inspector-section {
+  padding: 13px 0 2px;
+  border-top: 1px solid var(--border);
+}
+
+.graph-inspector-section h4 {
+  margin: 0 0 7px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+
+.graph-inspector-section > p {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.graph-relation {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  padding: 8px 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.graph-relation:hover {
+  border-color: var(--border-strong);
+  background: transparent;
+}
+
+.graph-relation:focus-visible,
+.graph-list-link:focus-visible,
+.graph-inspector a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.graph-relation strong,
+.graph-relation span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-relation strong {
+  color: var(--text-soft);
+  font: 10px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.graph-relation span {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.graph-inspector-link,
+.graph-list-link {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  margin: 5px 0;
+  padding: 7px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface-inset);
+  color: var(--text-soft);
+  text-align: left;
+  text-decoration: none;
+  font-size: 10px;
+}
+
+.graph-inspector-link:hover,
+.graph-list-link:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-raised);
+}
+
+.graph-render-fallback {
+  display: grid;
+  min-height: 440px;
+  place-content: center;
+  margin: 0;
+  padding: 24px;
+  color: var(--muted);
+  text-align: center;
+  font-size: 12px;
+}
+
+.delta-row.graph-list-focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .graph-explorer { grid-template-columns: 1fr; }
+  .graph-canvas {
+    min-height: 390px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .graph-canvas svg { height: 430px; }
+  .graph-inspector {
+    min-height: 220px;
+    max-height: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-node,
+  .graph-edge { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .graph-node-surface { stroke: CanvasText; }
+  .graph-node.is-selected .graph-node-surface { stroke: Highlight; }
+  .graph-edge.is-related { stroke: Highlight; }
+}

--- a/crates/compass-cli/assets/semantic-diff-graph.js
+++ b/crates/compass-cli/assets/semantic-diff-graph.js
@@ -1,0 +1,534 @@
+(() => {
+  "use strict";
+
+  const NS = "http://www.w3.org/2000/svg";
+  const MAX_VISUAL_NODES = 42;
+  const MAX_VISUAL_EDGES = 100;
+  const STATUS_PRIORITY = Object.freeze({
+    context: 0,
+    added: 1,
+    removed: 2,
+    changed: 3
+  });
+  const STATUS_MARK = Object.freeze({
+    context: "·",
+    added: "+",
+    removed: "−",
+    changed: "~"
+  });
+
+  function element(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function svgElement(tag, className) {
+    const node = document.createElementNS(NS, tag);
+    if (className) node.setAttribute("class", className);
+    return node;
+  }
+
+  function richer(current, candidate) {
+    return current || candidate || "";
+  }
+
+  function rememberNode(nodes, raw, status) {
+    const source = typeof raw === "string" ? { id: raw } : raw || {};
+    const id = source.id;
+    if (!id) return;
+    const existing = nodes.get(id);
+    if (!existing) {
+      nodes.set(id, {
+        id,
+        label: source.label || id,
+        kind: source.kind || "",
+        sourceFile: source.source_file || "",
+        changedFields: [...(source.changed_fields || [])],
+        status,
+        degree: 0
+      });
+      return;
+    }
+    existing.label = richer(
+      existing.label === existing.id ? "" : existing.label,
+      source.label
+    ) || id;
+    existing.kind = richer(existing.kind, source.kind);
+    existing.sourceFile = richer(existing.sourceFile, source.source_file);
+    if (source.changed_fields?.length) {
+      existing.changedFields = [...new Set([
+        ...existing.changedFields,
+        ...source.changed_fields
+      ])].sort();
+    }
+    if (STATUS_PRIORITY[status] > STATUS_PRIORITY[existing.status]) {
+      existing.status = status;
+    }
+  }
+
+  function buildGraphModel(delta) {
+    if (!delta) throw new Error("Missing graph delta");
+    const nodes = new Map();
+    for (const node of delta.changed_nodes || []) rememberNode(nodes, node, "changed");
+    for (const node of delta.removed_nodes || []) rememberNode(nodes, node, "removed");
+    for (const node of delta.added_nodes || []) rememberNode(nodes, node, "added");
+    const edges = [
+      ...(delta.changed_edges || []).map((edge) => ({ ...edge, status: "changed" })),
+      ...(delta.removed_edges || []).map((edge) => ({ ...edge, status: "removed" })),
+      ...(delta.added_edges || []).map((edge) => ({ ...edge, status: "added" }))
+    ].filter((edge) => edge.source && edge.target);
+    for (const edge of edges) {
+      rememberNode(nodes, edge.source, "context");
+      rememberNode(nodes, edge.target, "context");
+      nodes.get(edge.source).degree += 1;
+      nodes.get(edge.target).degree += 1;
+    }
+    return { nodes, edges };
+  }
+
+  function rankVisualNodes(model) {
+    return [...model.nodes.values()].sort((left, right) => {
+      const directDifference =
+        Number(right.status !== "context") - Number(left.status !== "context");
+      if (directDifference) return directDifference;
+      const statusDifference =
+        STATUS_PRIORITY[right.status] - STATUS_PRIORITY[left.status];
+      if (statusDifference) return statusDifference;
+      const degreeDifference = right.degree - left.degree;
+      return degreeDifference || left.id.localeCompare(right.id);
+    });
+  }
+
+  function displayLabel(node) {
+    return node.label || node.id;
+  }
+
+  function truncate(value, max) {
+    return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+  }
+
+  function basename(value) {
+    const normalized = value.replaceAll("\\", "/");
+    return normalized.split("/").filter(Boolean).at(-1) || normalized;
+  }
+
+  function capsuleWidth(node) {
+    const visible = truncate(displayLabel(node), 21);
+    return Math.max(118, Math.min(172, 46 + visible.length * 6.25));
+  }
+
+  function layoutVisualNodes(nodes, width, height) {
+    const columns = Math.max(1, Math.min(5, nodes.length));
+    const rows = Math.max(1, Math.ceil(nodes.length / columns));
+    const xSpacing = width / columns;
+    const ySpacing = height / rows;
+    return nodes.map((node, index) => {
+      const row = Math.floor(index / columns);
+      const offset = index % columns;
+      const column = row % 2 === 0 ? offset : columns - offset - 1;
+      return {
+        ...node,
+        width: capsuleWidth(node),
+        height: 44,
+        x: xSpacing * (column + .5),
+        y: ySpacing * (row + .5)
+      };
+    });
+  }
+
+  function edgeEndpoints(source, target) {
+    const dx = target.x - source.x;
+    const dy = target.y - source.y;
+    const distance = Math.max(Math.hypot(dx, dy), 1);
+    const ux = dx / distance;
+    const uy = dy / distance;
+    const sourceInset = Math.min(source.width / 2, 24 / Math.max(Math.abs(uy), .2));
+    const targetInset = Math.min(target.width / 2, 24 / Math.max(Math.abs(uy), .2));
+    return {
+      x1: source.x + ux * sourceInset,
+      y1: source.y + uy * sourceInset,
+      x2: target.x - ux * (targetInset + 7),
+      y2: target.y - uy * (targetInset + 7)
+    };
+  }
+
+  function markerDefinitions() {
+    const definitions = svgElement("defs");
+    for (const status of ["added", "removed", "changed", "context"]) {
+      const marker = svgElement("marker");
+      marker.id = `arrow-${status}`;
+      marker.setAttribute("viewBox", "0 0 10 10");
+      marker.setAttribute("refX", "8");
+      marker.setAttribute("refY", "5");
+      marker.setAttribute("markerWidth", "5");
+      marker.setAttribute("markerHeight", "5");
+      marker.setAttribute("orient", "auto-start-reverse");
+      const path = svgElement("path", `graph-arrow ${status}`);
+      path.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
+      marker.append(path);
+      definitions.append(marker);
+    }
+    return definitions;
+  }
+
+  function nodeAccessibleName(node) {
+    const kind = node.kind ? ` ${node.kind}` : "";
+    return `${node.status} ${kind} ${displayLabel(node)}`.trim();
+  }
+
+  function renderSvg(model, visualNodes, visualEdges, host) {
+    const width = 980;
+    const height = 560;
+    const positioned = layoutVisualNodes(visualNodes, width, height);
+    const byId = new Map(positioned.map((node) => [node.id, node]));
+    const svg = svgElement("svg");
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    svg.setAttribute("aria-label", "Changed code graph");
+    svg.append(markerDefinitions());
+
+    const edgeElements = [];
+    for (const edge of visualEdges) {
+      const source = byId.get(edge.source);
+      const target = byId.get(edge.target);
+      if (!source || !target) continue;
+      const points = edgeEndpoints(source, target);
+      const line = svgElement("line", `graph-edge ${edge.status}`);
+      for (const [name, value] of Object.entries(points)) {
+        line.setAttribute(name, String(value));
+      }
+      line.dataset.source = edge.source;
+      line.dataset.target = edge.target;
+      line.dataset.relation = edge.relation || "";
+      line.setAttribute("marker-end", `url(#arrow-${edge.status})`);
+      const title = svgElement("title");
+      title.textContent =
+        `${edge.source} —${edge.relation || "related"}→ ${edge.target}`;
+      line.append(title);
+      svg.append(line);
+      edgeElements.push(line);
+    }
+
+    const nodeElements = new Map();
+    for (const node of positioned) {
+      const group = svgElement("g", `graph-node ${node.status}`);
+      group.dataset.nodeId = node.id;
+      group.setAttribute("transform", `translate(${node.x} ${node.y})`);
+      group.setAttribute("role", "button");
+      group.setAttribute("tabindex", "0");
+      group.setAttribute("aria-pressed", "false");
+      group.setAttribute("aria-label", nodeAccessibleName(node));
+      const title = svgElement("title");
+      title.textContent = nodeAccessibleName(node);
+      const surface = svgElement("rect", "graph-node-surface");
+      surface.setAttribute("x", String(-node.width / 2));
+      surface.setAttribute("y", "-22");
+      surface.setAttribute("width", String(node.width));
+      surface.setAttribute("height", "44");
+      surface.setAttribute("rx", "8");
+      surface.setAttribute("ry", "8");
+      const mark = svgElement("text", "graph-node-mark");
+      mark.setAttribute("x", String(-node.width / 2 + 13));
+      mark.setAttribute("y", "4");
+      mark.textContent = STATUS_MARK[node.status];
+      const label = svgElement("text", "graph-node-label");
+      label.setAttribute("x", String(-node.width / 2 + 31));
+      label.setAttribute("y", "-4");
+      label.textContent = truncate(displayLabel(node), 21);
+      const meta = svgElement("text", "graph-node-meta");
+      meta.setAttribute("x", String(-node.width / 2 + 31));
+      meta.setAttribute("y", "12");
+      const metadata = [node.kind, node.sourceFile && basename(node.sourceFile)]
+        .filter(Boolean)
+        .join(" · ");
+      meta.textContent = truncate(metadata || node.id, 30);
+      group.append(title, surface, mark, label, meta);
+      svg.append(group);
+      nodeElements.set(node.id, group);
+    }
+    host.replaceChildren(svg);
+    return { svg, nodeElements, edgeElements, visualNodeIds: new Set(byId.keys()) };
+  }
+
+  function section(title, emptyText) {
+    const wrapper = element("section", "graph-inspector-section");
+    wrapper.append(element("h4", "", title));
+    if (emptyText) wrapper.append(element("p", "", emptyText));
+    return wrapper;
+  }
+
+  function fact(term, value) {
+    const wrapper = element("div");
+    wrapper.append(element("dt", "", term), element("dd", "", value));
+    return wrapper;
+  }
+
+  function relationshipsFor(model, nodeId) {
+    return {
+      incoming: model.edges.filter((edge) => edge.target === nodeId),
+      outgoing: model.edges.filter((edge) => edge.source === nodeId)
+    };
+  }
+
+  function findingsFor(report, nodeId) {
+    return (report.findings || []).filter((finding) =>
+      finding.subject === nodeId ||
+      (finding.evidence || []).some((evidence) => evidence.record_key === nodeId)
+    );
+  }
+
+  function normalizePath(value) {
+    return (value || "").replaceAll("\\", "/").replace(/^\.\/+/, "");
+  }
+
+  function sourceIndexFor(report, sourceFile) {
+    const wanted = normalizePath(sourceFile);
+    if (!wanted) return -1;
+    return (report.source_changes || []).findIndex((change) =>
+      normalizePath(change.old_path) === wanted ||
+      normalizePath(change.new_path) === wanted
+    );
+  }
+
+  function relationButton(edge, direction, model) {
+    const neighborId = direction === "incoming" ? edge.source : edge.target;
+    const neighbor = model.nodes.get(neighborId);
+    const button = element("button", "graph-relation");
+    button.type = "button";
+    button.dataset.neighborId = neighborId;
+    button.append(
+      element("strong", "", neighbor ? displayLabel(neighbor) : neighborId),
+      element(
+        "span",
+        "",
+        `${direction === "incoming" ? "←" : "→"} ${edge.relation || "related"} · ${edge.status}`
+      )
+    );
+    return button;
+  }
+
+  function emptyInspector(inspector) {
+    const heading = element("h3", "sr-only", "Node inspector");
+    heading.id = "graph-inspector-heading";
+    inspector.replaceChildren(
+      heading,
+      element("p", "graph-inspector-empty", "Select a node to inspect its change.")
+    );
+  }
+
+  function renderInspector(report, model, node, inspector) {
+    const header = element("header", "graph-inspector-header");
+    const status = element("span", `graph-status ${node.status}`, node.status);
+    const heading = element("h3", "", displayLabel(node));
+    heading.id = "graph-inspector-heading";
+    header.append(status, heading, element("code", "", node.id));
+
+    const facts = element("dl", "graph-inspector-facts");
+    if (node.kind) facts.append(fact("Kind", node.kind));
+    if (node.sourceFile) facts.append(fact("Source", node.sourceFile));
+    if (node.changedFields.length) {
+      facts.append(fact("Changed fields", node.changedFields.join(", ")));
+    }
+
+    const relationships = relationshipsFor(model, node.id);
+    const incoming = section(
+      "Incoming relationships",
+      relationships.incoming.length ? "" : "No changed incoming relationships."
+    );
+    for (const edge of relationships.incoming) {
+      incoming.append(relationButton(edge, "incoming", model));
+    }
+    const outgoing = section(
+      "Outgoing relationships",
+      relationships.outgoing.length ? "" : "No changed outgoing relationships."
+    );
+    for (const edge of relationships.outgoing) {
+      outgoing.append(relationButton(edge, "outgoing", model));
+    }
+
+    const related = findingsFor(report, node.id);
+    const findings = section(
+      "Related findings",
+      related.length ? "" : "No related semantic findings."
+    );
+    for (const finding of related) {
+      if (!document.getElementById(finding.id)) continue;
+      const link = element("a", "graph-inspector-link", finding.headline || finding.id);
+      link.href = `#${finding.id}`;
+      findings.append(link);
+    }
+
+    const navigation = section("Navigate");
+    const sourceIndex = sourceIndexFor(report, node.sourceFile);
+    if (sourceIndex >= 0 && document.getElementById(`source-change-${sourceIndex}`)) {
+      const sourceLink = element("a", "graph-inspector-link", "View source patch");
+      sourceLink.href = `#source-change-${sourceIndex}`;
+      navigation.append(sourceLink);
+    }
+    const listRow = [...document.querySelectorAll("[data-graph-node-id]")]
+      .find((row) => row.dataset.graphNodeId === node.id);
+    if (listRow) {
+      const listButton = element("button", "graph-list-link", "Show in exhaustive list");
+      listButton.type = "button";
+      listButton.dataset.listNodeId = node.id;
+      navigation.append(listButton);
+    }
+    if (!navigation.querySelector("a,button")) {
+      navigation.append(element("p", "", "No exact navigation target is available."));
+    }
+    inspector.replaceChildren(header, facts, incoming, outgoing, findings, navigation);
+  }
+
+  function mount({ report, host, inspector, liveRegion, note }) {
+    if (!report || !host || !inspector || !liveRegion || !note) {
+      console.warn("Compass could not mount the changed graph");
+      return Object.freeze({ clear() {}, select() {}, destroy() {} });
+    }
+    const listeners = [];
+    try {
+      const model = buildGraphModel(report.graph_delta);
+      const ranked = rankVisualNodes(model);
+      const visualNodes = ranked.slice(0, MAX_VISUAL_NODES);
+      const selectedIds = new Set(visualNodes.map((node) => node.id));
+      const visualEdges = model.edges
+        .filter((edge) => selectedIds.has(edge.source) && selectedIds.has(edge.target))
+        .sort((left, right) =>
+          `${left.source}\0${left.relation || ""}\0${left.target}\0${left.key || ""}`
+            .localeCompare(
+              `${right.source}\0${right.relation || ""}\0${right.target}\0${right.key || ""}`
+            )
+        )
+        .slice(0, MAX_VISUAL_EDGES);
+      const rendered = renderSvg(model, visualNodes, visualEdges, host);
+      const defaultNote = note.textContent;
+      const truncated =
+        ranked.length > visualNodes.length || model.edges.length > visualEdges.length;
+      const sampleNote =
+        `Visual sample: ${visualNodes.length} of ${model.nodes.size} involved nodes ` +
+        `and ${visualEdges.length} of ${model.edges.length} changed edges. ` +
+        "The lists below and embedded JSON remain exhaustive.";
+      if (truncated) {
+        note.textContent = sampleNote;
+      }
+      emptyInspector(inspector);
+
+      function clear() {
+        for (const group of rendered.nodeElements.values()) {
+          group.classList.remove("is-selected", "is-neighbor", "is-dimmed");
+          group.setAttribute("aria-pressed", "false");
+        }
+        for (const edge of rendered.edgeElements) {
+          edge.classList.remove("is-related", "is-dimmed");
+        }
+        emptyInspector(inspector);
+        note.textContent = truncated ? sampleNote : defaultNote;
+        liveRegion.textContent = "Graph selection cleared";
+      }
+
+      function select(nodeId) {
+        const node = model.nodes.get(nodeId);
+        if (!node) return;
+        const relationships = relationshipsFor(model, nodeId);
+        const neighbors = new Set([
+          ...relationships.incoming.map((edge) => edge.source),
+          ...relationships.outgoing.map((edge) => edge.target)
+        ]);
+        for (const [id, group] of rendered.nodeElements) {
+          const selected = id === nodeId;
+          const neighbor = neighbors.has(id);
+          group.classList.toggle("is-selected", selected);
+          group.classList.toggle("is-neighbor", neighbor);
+          group.classList.toggle("is-dimmed", !selected && !neighbor);
+          group.setAttribute("aria-pressed", String(selected));
+        }
+        for (const edge of rendered.edgeElements) {
+          const related =
+            edge.dataset.source === nodeId || edge.dataset.target === nodeId;
+          edge.classList.toggle("is-related", related);
+          edge.classList.toggle("is-dimmed", !related);
+        }
+        renderInspector(report, model, node, inspector);
+        liveRegion.textContent = `Inspecting ${displayLabel(node)}`;
+        if (!rendered.visualNodeIds.has(nodeId)) {
+          note.textContent =
+            "Inspecting a node outside the bounded visual sample. Its changed " +
+            "relationships remain available here and in the exhaustive lists.";
+        } else if (truncated) {
+          note.textContent = sampleNote;
+        } else {
+          note.textContent = defaultNote;
+        }
+      }
+
+      const onHostClick = (event) => {
+        const node = event.target.closest?.("[data-node-id]");
+        if (node && host.contains(node)) {
+          select(node.dataset.nodeId);
+          return;
+        }
+        if (event.target === rendered.svg || event.target === host) clear();
+      };
+      const onHostKeydown = (event) => {
+        const node = event.target.closest?.("[data-node-id]");
+        if (node && (event.key === "Enter" || event.key === " ")) {
+          event.preventDefault();
+          select(node.dataset.nodeId);
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          clear();
+        }
+      };
+      const onInspectorClick = (event) => {
+        const neighbor = event.target.closest?.("[data-neighbor-id]");
+        if (neighbor && inspector.contains(neighbor)) {
+          select(neighbor.dataset.neighborId);
+          return;
+        }
+        const list = event.target.closest?.("[data-list-node-id]");
+        if (!list || !inspector.contains(list)) return;
+        const row = [...document.querySelectorAll("[data-graph-node-id]")]
+          .find((candidate) => candidate.dataset.graphNodeId === list.dataset.listNodeId);
+        if (!row) return;
+        row.tabIndex = -1;
+        row.classList.add("graph-list-focus");
+        row.scrollIntoView({ block: "center" });
+        row.focus({ preventScroll: true });
+        globalThis.setTimeout(() => row.classList.remove("graph-list-focus"), 1600);
+      };
+      host.addEventListener("click", onHostClick);
+      host.addEventListener("keydown", onHostKeydown);
+      inspector.addEventListener("click", onInspectorClick);
+      listeners.push(
+        () => host.removeEventListener("click", onHostClick),
+        () => host.removeEventListener("keydown", onHostKeydown),
+        () => inspector.removeEventListener("click", onInspectorClick)
+      );
+      return Object.freeze({
+        clear,
+        select,
+        destroy() {
+          for (const remove of listeners) remove();
+          host.replaceChildren();
+          inspector.replaceChildren();
+        }
+      });
+    } catch (error) {
+      host.replaceChildren(
+        element(
+          "p",
+          "graph-render-fallback",
+          "Interactive graph unavailable. Use the exhaustive node and edge lists below."
+        )
+      );
+      emptyInspector(inspector);
+      note.textContent =
+        "The embedded report data and exhaustive graph-change lists remain available.";
+      console.warn("Compass could not render the changed graph", error);
+      return Object.freeze({ clear() {}, select() {}, destroy() {} });
+    }
+  }
+
+  globalThis.CompassSemanticDiffGraph = Object.freeze({ mount });
+})();

--- a/crates/compass-cli/assets/semantic-diff-graph.js
+++ b/crates/compass-cli/assets/semantic-diff-graph.js
@@ -89,16 +89,24 @@
   }
 
   function rankVisualNodes(model) {
-    return [...model.nodes.values()].sort((left, right) => {
-      const directDifference =
-        Number(right.status !== "context") - Number(left.status !== "context");
-      if (directDifference) return directDifference;
-      const statusDifference =
-        STATUS_PRIORITY[right.status] - STATUS_PRIORITY[left.status];
-      if (statusDifference) return statusDifference;
+    const rankWithinStatus = (left, right) => {
       const degreeDifference = right.degree - left.degree;
       return degreeDifference || left.id.localeCompare(right.id);
-    });
+    };
+    const nodes = [...model.nodes.values()];
+    const buckets = ["changed", "added", "removed"].map((status) =>
+      nodes.filter((node) => node.status === status).sort(rankWithinStatus)
+    );
+    const ranked = [];
+    for (let index = 0; buckets.some((bucket) => index < bucket.length); index += 1) {
+      for (const bucket of buckets) {
+        if (index < bucket.length) ranked.push(bucket[index]);
+      }
+    }
+    ranked.push(
+      ...nodes.filter((node) => node.status === "context").sort(rankWithinStatus)
+    );
+    return ranked;
   }
 
   function displayLabel(node) {

--- a/crates/compass-cli/src/semantic_diff_render.rs
+++ b/crates/compass-cli/src/semantic_diff_render.rs
@@ -8,6 +8,8 @@ use compass_semantic_diff::{
 };
 
 const PIERRE_DIFFS_JS: &str = include_str!("../assets/vendor/pierre-diffs-v1.2.12.js");
+const SEMANTIC_DIFF_GRAPH_CSS: &str = include_str!("../assets/semantic-diff-graph.css");
+const SEMANTIC_DIFF_GRAPH_JS: &str = include_str!("../assets/semantic-diff-graph.js");
 
 pub(crate) struct RenderOptions<'a> {
     pub include_routine: bool,
@@ -409,7 +411,11 @@ footer{color:var(--muted);border-top:1px solid var(--border);margin-top:40px;pad
 @media(max-width:900px){main{width:min(100% - 32px,1120px)}.metrics{grid-template-columns:repeat(3,1fr)}.metric:nth-child(4){border-left:0;padding-left:0}.feature{grid-template-columns:1fr}.files{grid-column:1;margin-top:-16px}.toolbar{position:static;grid-template-columns:1fr 180px auto auto}.shown{grid-column:1/-1;text-align:left}.detail{grid-template-columns:112px minmax(0,1fr)}.graph-summary{grid-template-columns:repeat(3,1fr)}.graph-stat:nth-child(4){border-left:0;padding-left:0}}
 @media(max-width:620px){main{width:min(100% - 24px,1120px);padding-top:28px}.title-row{display:block}.schema{margin-top:12px}.metrics{grid-template-columns:1fr 1fr}.metric:nth-child(odd){border-left:0;padding-left:0}.metric:nth-child(even){border-left:1px solid var(--border);padding-left:14px}.report-nav{gap:16px}.toolbar{grid-template-columns:1fr 1fr}.toolbar input{grid-column:1/-1}.toolbar label{grid-column:1/-1}.detail{display:block;padding:16px}.detail h4{margin:18px 0 5px}.detail h4:first-child{margin-top:0}.detail>p,.detail>ul,.detail>pre{margin:0}.feature{gap:7px}.files{margin-top:0}.code-heading{display:block}.code-heading-copy{margin-bottom:9px}.code-controls{justify-content:space-between}.source-summary{display:block}.source-meta{display:block;margin-top:4px}.graph-summary{grid-template-columns:1fr 1fr}.graph-stat:nth-child(odd){border-left:0;padding-left:0}.graph-stat:nth-child(even){border-left:1px solid var(--border);padding-left:12px}.delta-grid{grid-template-columns:1fr}.graph-canvas svg{height:360px}}
 @media(prefers-reduced-motion:reduce){.finding summary:after{transition:none}}
-</style>
+"#,
+    );
+    output.push_str(SEMANTIC_DIFF_GRAPH_CSS);
+    output.push_str(
+        r#"</style>
 </head>
 <body>
 <main>
@@ -533,6 +539,9 @@ footer{color:var(--muted);border-top:1px solid var(--border);margin-top:40px;pad
     output.push_str("<script>");
     output.push_str(&PIERRE_DIFFS_JS.replace("</script", "<\\/script"));
     output.push_str("</script>");
+    output.push_str("<script>");
+    output.push_str(&SEMANTIC_DIFF_GRAPH_JS.replace("</script", "<\\/script"));
+    output.push_str("</script>");
     output.push_str(
         r#"<script>
 const cards=[...document.querySelectorAll(".finding")];
@@ -639,134 +648,13 @@ document.getElementById("diff-wrap")?.addEventListener("change",event=>{
     instance.rerender();
   }
 });
-function renderChangedGraph(delta){
-  const host=document.getElementById("graph-canvas");
-  if(!host||!delta)return;
-  const nodeStates=new Map();
-  const nodeLabels=new Map();
-  const priority={context:0,changed:1,removed:2,added:3};
-  const rememberNode=(node,state)=>{
-    const id=typeof node==="string"?node:node.id;
-    if(!id)return;
-    if(!nodeStates.has(id)||priority[state]>priority[nodeStates.get(id)])nodeStates.set(id,state);
-    if(typeof node!=="string")nodeLabels.set(id,node.label||node.id);
-  };
-  for(const node of delta.changed_nodes||[])rememberNode(node,"changed");
-  for(const node of delta.removed_nodes||[])rememberNode(node,"removed");
-  for(const node of delta.added_nodes||[])rememberNode(node,"added");
-  const edgeSets=[
-    ...((delta.changed_edges||[]).map(edge=>({...edge,status:"changed"}))),
-    ...((delta.removed_edges||[]).map(edge=>({...edge,status:"removed"}))),
-    ...((delta.added_edges||[]).map(edge=>({...edge,status:"added"})))
-  ];
-  for(const edge of edgeSets){
-    rememberNode(edge.source,"context");
-    rememberNode(edge.target,"context");
-  }
-  const ranked=[...nodeStates.keys()].sort((a,b)=>{
-    const stateDifference=priority[nodeStates.get(b)]-priority[nodeStates.get(a)];
-    return stateDifference||a.localeCompare(b);
-  });
-  const maxNodes=80;
-  const maxEdges=120;
-  const selectedIds=ranked.slice(0,maxNodes);
-  const selected=new Set(selectedIds);
-  const edges=edgeSets
-    .filter(edge=>selected.has(edge.source)&&selected.has(edge.target))
-    .sort((a,b)=>`${a.source}\0${a.relation}\0${a.target}\0${a.key||""}`.localeCompare(`${b.source}\0${b.relation}\0${b.target}\0${b.key||""}`))
-    .slice(0,maxEdges);
-  const width=960;
-  const height=420;
-  const centerX=width/2;
-  const centerY=height/2;
-  const nodes=selectedIds.map((id,index)=>{
-    const angle=(Math.PI*2*index)/Math.max(selectedIds.length,1);
-    const ring=110+(index%7)*9;
-    return{id,state:nodeStates.get(id),label:nodeLabels.get(id)||id,x:centerX+Math.cos(angle)*ring,y:centerY+Math.sin(angle)*ring,vx:0,vy:0};
-  });
-  const byId=new Map(nodes.map(node=>[node.id,node]));
-  for(let step=0;step<170;step++){
-    for(let left=0;left<nodes.length;left++){
-      for(let right=left+1;right<nodes.length;right++){
-        const a=nodes[left],b=nodes[right];
-        let dx=b.x-a.x,dy=b.y-a.y;
-        const distanceSquared=Math.max(dx*dx+dy*dy,36);
-        const force=260/distanceSquared;
-        const distance=Math.sqrt(distanceSquared);
-        dx/=distance;dy/=distance;
-        a.vx-=dx*force;a.vy-=dy*force;b.vx+=dx*force;b.vy+=dy*force;
-      }
-    }
-    for(const edge of edges){
-      const source=byId.get(edge.source),target=byId.get(edge.target);
-      if(!source||!target)continue;
-      let dx=target.x-source.x,dy=target.y-source.y;
-      const distance=Math.max(Math.sqrt(dx*dx+dy*dy),1);
-      const force=(distance-105)*.0018;
-      dx/=distance;dy/=distance;
-      source.vx+=dx*force;source.vy+=dy*force;target.vx-=dx*force;target.vy-=dy*force;
-    }
-    for(const node of nodes){
-      node.vx+=(centerX-node.x)*.0007;
-      node.vy+=(centerY-node.y)*.0007;
-      node.vx*=.88;node.vy*=.88;
-      node.x=Math.max(24,Math.min(width-24,node.x+node.vx));
-      node.y=Math.max(22,Math.min(height-22,node.y+node.vy));
-    }
-  }
-  const ns="http://www.w3.org/2000/svg";
-  const svg=document.createElementNS(ns,"svg");
-  svg.setAttribute("viewBox",`0 0 ${width} ${height}`);
-  svg.setAttribute("aria-hidden","true");
-  const defs=document.createElementNS(ns,"defs");
-  for(const status of ["added","removed","changed","context"]){
-    const marker=document.createElementNS(ns,"marker");
-    marker.id=`arrow-${status}`;
-    marker.setAttribute("viewBox","0 0 10 10");
-    marker.setAttribute("refX","8");
-    marker.setAttribute("refY","5");
-    marker.setAttribute("markerWidth","5");
-    marker.setAttribute("markerHeight","5");
-    marker.setAttribute("orient","auto-start-reverse");
-    const path=document.createElementNS(ns,"path");
-    path.setAttribute("d","M 0 0 L 10 5 L 0 10 z");
-    path.setAttribute("class",`graph-arrow ${status}`);
-    marker.append(path);defs.append(marker);
-  }
-  svg.append(defs);
-  for(const edge of edges){
-    const source=byId.get(edge.source),target=byId.get(edge.target);
-    const line=document.createElementNS(ns,"line");
-    line.setAttribute("x1",source.x);line.setAttribute("y1",source.y);
-    line.setAttribute("x2",target.x);line.setAttribute("y2",target.y);
-    line.setAttribute("class",`graph-edge ${edge.status}`);
-    line.setAttribute("marker-end",`url(#arrow-${edge.status})`);
-    const title=document.createElementNS(ns,"title");
-    title.textContent=`${edge.source} —${edge.relation}→ ${edge.target}`;
-    line.append(title);svg.append(line);
-  }
-  const symbols={added:"+",removed:"−",changed:"~",context:"·"};
-  for(const node of nodes){
-    const group=document.createElementNS(ns,"g");
-    group.setAttribute("class",`graph-node ${node.state}`);
-    group.setAttribute("transform",`translate(${node.x} ${node.y})`);
-    const circle=document.createElementNS(ns,"circle");
-    circle.setAttribute("r","7");
-    const title=document.createElementNS(ns,"title");
-    title.textContent=`${symbols[node.state]} ${node.label}`;
-    circle.append(title);
-    const label=document.createElementNS(ns,"text");
-    label.setAttribute("x","11");label.setAttribute("y","3.5");
-    const shortLabel=node.label.length>34?`${node.label.slice(0,33)}…`:node.label;
-    label.textContent=`${symbols[node.state]} ${shortLabel}`;
-    group.append(circle,label);svg.append(group);
-  }
-  host.replaceChildren(svg);
-  if(ranked.length>maxNodes||edgeSets.length>edges.length){
-    document.getElementById("graph-note").textContent=`Visual sample: ${nodes.length} of ${ranked.length} involved nodes and ${edges.length} of ${edgeSets.length} changed edges. The lists below and embedded JSON remain exhaustive.`;
-  }
-}
-renderChangedGraph(reportData.graph_delta);
+globalThis.CompassSemanticDiffGraph.mount({
+  report:reportData,
+  host:document.getElementById("graph-canvas"),
+  inspector:document.getElementById("graph-inspector"),
+  liveRegion:document.getElementById("graph-live"),
+  note:document.getElementById("graph-note")
+});
 </script>
 <footer>Generated by Compass · Source diffs rendered with @pierre/diffs 1.2.12 · Embedded report data is available in <code>#semantic-diff-data</code>.</footer>
 </main>
@@ -795,7 +683,7 @@ fn render_source_changes(output: &mut String, changes: &[SourceFileDelta]) {
         let path = source_change_path(change);
         let _ = write!(
             output,
-            "<details class=\"source-file\" data-source-index=\"{index}\"{open}><summary><div class=\"source-summary\"><span class=\"source-path\">{}</span><span class=\"source-meta\">{} · {} hunks</span></div></summary>",
+            "<details id=\"source-change-{index}\" class=\"source-file\" data-source-index=\"{index}\"{open}><summary><div class=\"source-summary\"><span class=\"source-path\">{}</span><span class=\"source-meta\">{} · {} hunks</span></div></summary>",
             html_escape(&path),
             source_status_name(change.status),
             change.hunks.len()
@@ -848,7 +736,7 @@ fn render_graph_delta(output: &mut String, delta: &GraphDelta) {
             .push_str("<div class=\"graph-canvas graph-empty\">No meaningful graph changes.</div>");
     } else {
         output.push_str(
-            "<div id=\"graph-canvas\" class=\"graph-canvas\" role=\"img\" aria-label=\"Changed code graph\"></div><div class=\"graph-legend\"><span class=\"added\">Added (+)</span><span class=\"removed\">Removed (−)</span><span class=\"changed\">Changed (~)</span><span class=\"context\">Context (·)</span></div><p class=\"graph-note\" id=\"graph-note\">The visualization focuses on the changed subgraph. The lists below and embedded JSON are exhaustive.</p>",
+            "<div class=\"graph-explorer\"><div id=\"graph-canvas\" class=\"graph-canvas\" aria-label=\"Changed code graph\"></div><aside id=\"graph-inspector\" class=\"graph-inspector\" aria-labelledby=\"graph-inspector-heading\"><h3 id=\"graph-inspector-heading\" class=\"sr-only\">Node inspector</h3><p class=\"graph-inspector-empty\">Select a node to inspect its change.</p></aside></div><p id=\"graph-live\" class=\"sr-only\" aria-live=\"polite\"></p><div class=\"graph-legend\"><span class=\"added\">Added (+)</span><span class=\"removed\">Removed (−)</span><span class=\"changed\">Changed (~)</span><span class=\"context\">Context (·)</span></div><p class=\"graph-note\" id=\"graph-note\">The visualization focuses on the changed subgraph. The lists below and embedded JSON are exhaustive.</p>",
         );
     }
     output.push_str("<div class=\"delta-grid\"><div class=\"delta-column\"><h3>Nodes</h3>");
@@ -910,7 +798,8 @@ fn render_node_delta_group(
         }
         let _ = write!(
             output,
-            "<li class=\"delta-row\"><span class=\"delta-mark {class}\">{mark}</span><span class=\"delta-primary\">{}</span>",
+            "<li class=\"delta-row\" data-graph-node-id=\"{}\"><span class=\"delta-mark {class}\">{mark}</span><span class=\"delta-primary\">{}</span>",
+            html_attr(&node.id),
             html_escape(display)
         );
         if !metadata.is_empty() {
@@ -951,7 +840,10 @@ fn render_edge_delta_group(
         }
         let _ = write!(
             output,
-            "<li class=\"delta-row\"><span class=\"delta-mark {class}\">{mark}</span><span class=\"delta-primary\">{} —{}→ {}</span>",
+            "<li class=\"delta-row\" data-graph-edge-source=\"{}\" data-graph-edge-target=\"{}\" data-graph-edge-relation=\"{}\"><span class=\"delta-mark {class}\">{mark}</span><span class=\"delta-primary\">{} —{}→ {}</span>",
+            html_attr(&edge.source),
+            html_attr(&edge.target),
+            html_attr(&edge.relation),
             html_escape(&edge.source),
             html_escape(&edge.relation),
             html_escape(&edge.target)
@@ -1485,6 +1377,19 @@ mod tests {
         assert!(html.contains("<span class=\"diff-line remove\">-old()</span>"));
         assert!(html.contains("id=\"graph\""));
         assert!(html.contains("id=\"graph-canvas\""));
+        assert!(html.contains("globalThis.CompassSemanticDiffGraph"));
+        assert!(html.contains("class=\"graph-explorer\""));
+        assert!(html.contains("id=\"graph-inspector\""));
+        assert!(html.contains("id=\"graph-live\""));
+        assert!(html.contains("aria-live=\"polite\""));
+        assert!(html.contains("id=\"source-change-0\""));
+        assert!(html.contains("data-graph-node-id=\"new\""));
+        assert!(html.contains("data-graph-edge-source=\"caller\""));
+        assert!(html.contains("Select a node to inspect its change."));
+        assert!(html.contains("Interactive graph unavailable."));
+        assert!(html.contains("@media (max-width: 760px)"));
+        assert!(html.contains("@media (prefers-reduced-motion: reduce)"));
+        assert!(!html.contains("href=\"#source-change-undefined\""));
         assert!(html.contains("caller —calls→ new"));
         assert!(!html.contains("<script src="));
         assert!(!html.contains("<link rel="));

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -1232,6 +1232,13 @@ fn diff_emits_semantic_text_json_html_and_rejects_removed_flags()
     assert!(!html.contains("<script src="));
     assert!(html.contains("id=\"graph\""));
     assert!(html.contains("id=\"graph-canvas\""));
+    assert!(html.contains("globalThis.CompassSemanticDiffGraph"));
+    assert!(html.contains("class=\"graph-explorer\""));
+    assert!(html.contains("id=\"graph-inspector\""));
+    assert!(html.contains("id=\"graph-live\""));
+    assert!(html.contains("aria-live=\"polite\""));
+    assert!(html.contains("data-graph-node-id="));
+    assert!(html.contains("data-graph-edge-source="));
 
     let missing_html_output = run(
         compass,

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -267,6 +267,14 @@ exact source patch and the meaningful code-graph delta in the same report. The
 graph visualization focuses on the changed subgraph; its node/edge lists and
 embedded JSON remain exhaustive.
 
+In the graph view, select a changed node, inspect its incoming and outgoing
+changed relationships, follow any related semantic findings, then open the
+exact source patch when one is available. Connected nodes and edges remain
+prominent while unrelated topology dims; clear the selection to restore the
+whole sampled graph. The inspector can also follow relationships to nodes
+outside the bounded visual sample, while the lists below retain every graph
+change.
+
 Program IR v1 provides the richest behavior evidence. For graph-only languages,
 Compass can also report changed branch conditions when an exact zero-context
 source hunk overlaps the changed function's recorded line span. That evidence

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -276,6 +276,16 @@ edge-identity shifts that preserve multigraph multiplicity. HTML output always
 requires an explicit path; `compass export html` remains the full graph
 renderer and does not accept semantic-diff reports.
 
+The graph visualization is a bounded interactive sample backed by those
+exhaustive lists and the embedded JSON. Select a node to focus its direct
+changed-edge neighborhood and open a persistent inspector with its retained
+kind, source path, changed-field names, incoming and outgoing relationships,
+and related semantic findings. Inspector links open an exact source patch or
+finding only when the report contains a matching target. Context-only endpoints
+show their identifier and known relationships without implying unavailable
+metadata. If JavaScript is disabled, the exhaustive lists remain the
+authoritative fallback.
+
 After writing any HTML page, an interactive Compass CLI asks before opening it
 in the default browser; Enter or `n` leaves the page closed. Scripts, pipes,
 redirected commands, and CI never prompt or launch a browser.

--- a/docs/superpowers/plans/2026-07-26-interactive-semantic-diff-graph.md
+++ b/docs/superpowers/plans/2026-07-26-interactive-semantic-diff-graph.md
@@ -553,7 +553,7 @@ Use the working Node installation explicitly:
 ```bash
 cargo test -p compass-cli semantic_diff_render --lib
 PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
-  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+  npm test --prefix tests/viewer -- semantic-diff-graph.spec.ts
 ```
 
 Expected: Rust renderer tests and the Chromium capsule test pass.
@@ -732,7 +732,7 @@ labels and links `sd1-fixture`.
 
 ```bash
 PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
-  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+  npm test --prefix tests/viewer -- semantic-diff-graph.spec.ts
 cargo test -p compass-cli semantic_diff_render --lib
 ```
 
@@ -934,7 +934,7 @@ cargo test -p compass-cli --test history_cli \
   diff_emits_semantic_text_json_html_and_rejects_removed_flags \
   -- --exact
 PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
-  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+  npm test --prefix tests/viewer -- semantic-diff-graph.spec.ts
 git diff --check
 ```
 
@@ -998,7 +998,7 @@ Expected: all commands exit `0`.
 
 ```bash
 PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
-  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+  npm test --prefix tests/viewer -- semantic-diff-graph.spec.ts
 ```
 
 Expected: all graph explorer Chromium tests pass.

--- a/docs/superpowers/plans/2026-07-26-interactive-semantic-diff-graph.md
+++ b/docs/superpowers/plans/2026-07-26-interactive-semantic-diff-graph.md
@@ -1,0 +1,1094 @@
+# Interactive Semantic-Diff Graph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. This plan intentionally follows the user-approved implementation-first order: production behavior first, regression coverage immediately afterward, then a commit.
+
+**Goal:** Replace the standalone semantic-diff report's crowded static graph with a readable, selectable changed-subgraph explorer and persistent node inspector.
+
+**Architecture:** Keep the report deterministic, bounded, offline, and dependency-free. Extract the graph-specific CSS and JavaScript into first-party assets that Rust embeds inline, then progressively add capsule layout, selection, inspector navigation, accessibility, and responsive behavior. The existing exhaustive node/edge lists remain the non-JavaScript fallback.
+
+**Tech Stack:** Rust 2024, embedded first-party CSS and browser JavaScript, SVG and semantic HTML, Playwright Chromium, existing Compass semantic-diff report schema.
+
+## Global Constraints
+
+- Scope is the standalone `compass diff --format html` report only; do not modify the VS Code `CompassGraph` experience.
+- Do not change `compass.semantic_diff.report/1`, `GraphNodeDelta`, or `GraphEdgeDelta`.
+- The output remains one self-contained HTML file with no remote or external runtime assets.
+- Preserve deterministic node/edge ordering, bounded visual sampling, and exhaustive lists.
+- Use text-only DOM assignment for report-derived content; never use `innerHTML` with graph data.
+- Show only retained facts: status, label, ID, kind, source file, changed-field names, relationships, related findings, and valid source-patch targets.
+- Use the existing report colors: accent `#8ab4f8`, added `#65bd84`, removed `#ff7b86`, changed `#d9a441`, and context `#8d96a5`.
+- Encode status with marks and border styles in addition to color.
+- Enter and Space select nodes; Escape clears; reduced-motion users receive immediate transitions.
+- The inspector moves below the graph below 760 pixels.
+- Follow the requested implementation-first order. Add tests after each production slice and before its commit.
+- After code changes, run `graphify update .`.
+
+---
+
+## File map
+
+### New files
+
+- `crates/compass-cli/assets/semantic-diff-graph.css`
+  - Owns only the standalone graph explorer, capsule, edge, focus, inspector,
+    fallback, and responsive styles.
+- `crates/compass-cli/assets/semantic-diff-graph.js`
+  - Owns graph indexing, deterministic sampling/layout, SVG rendering,
+    selection, inspector rendering, navigation, keyboard behavior, and fallback.
+- `tests/viewer/semantic-diff-graph.spec.ts`
+  - Exercises the exact embedded graph JavaScript and CSS in Chromium.
+
+### Modified files
+
+- `crates/compass-cli/src/semantic_diff_render.rs`
+  - Embeds the new assets, renders the graph explorer shell, supplies source/list
+    anchors, and invokes the graph mount interface.
+- `crates/compass-cli/tests/history_cli.rs`
+  - Verifies the generated CLI report remains self-contained and contains the
+    graph explorer contract.
+- `tests/viewer/fixtures/generate.ts`
+  - Copies the graph assets and emits a deterministic standalone interaction
+    fixture using the production DOM contract.
+- `docs/reference/outputs.md`
+  - Documents node selection, neighborhood focus, inspector data, and fallback.
+- `docs/guides/versioned-history.md`
+  - Adds the graph-inspection workflow to the existing diff guide.
+
+## Stable interfaces
+
+The JavaScript asset exposes exactly one global:
+
+```js
+globalThis.CompassSemanticDiffGraph = Object.freeze({
+  mount(options) {
+    // Returns { clear(), select(nodeId), destroy() }.
+  }
+});
+```
+
+`mount(options)` consumes:
+
+```ts
+type MountOptions = {
+  report: {
+    graph_delta: GraphDelta;
+    findings: SemanticFinding[];
+    source_changes: SourceFileDelta[];
+  };
+  host: HTMLElement;
+  inspector: HTMLElement;
+  liveRegion: HTMLElement;
+  note: HTMLElement;
+};
+```
+
+The Rust renderer supplies these stable elements:
+
+```html
+<div class="graph-explorer">
+  <div id="graph-canvas"
+       class="graph-canvas"
+       aria-label="Changed code graph"></div>
+  <aside id="graph-inspector"
+         class="graph-inspector"
+         aria-labelledby="graph-inspector-heading"></aside>
+</div>
+<p id="graph-live" class="sr-only" aria-live="polite"></p>
+<p id="graph-note" class="graph-note"></p>
+```
+
+Every rendered SVG node has:
+
+```html
+<g class="graph-node added"
+   data-node-id="node-id"
+   role="button"
+   tabindex="0"
+   aria-pressed="false"
+   aria-label="Added function RetryWithSmallerBatch"></g>
+```
+
+The exhaustive rows expose data hooks rather than interpolating IDs into CSS:
+
+```html
+<li class="delta-row" data-graph-node-id="node-id">...</li>
+<li class="delta-row"
+    data-graph-edge-source="caller"
+    data-graph-edge-target="target"
+    data-graph-edge-relation="calls">...</li>
+```
+
+---
+
+### Task 1: Isolate the graph assets and establish the explorer shell
+
+**Files:**
+- Create: `crates/compass-cli/assets/semantic-diff-graph.css`
+- Create: `crates/compass-cli/assets/semantic-diff-graph.js`
+- Modify: `crates/compass-cli/src/semantic_diff_render.rs:10`
+- Modify: `crates/compass-cli/src/semantic_diff_render.rs:373-410`
+- Modify: `crates/compass-cli/src/semantic_diff_render.rs:642-769`
+- Modify: `crates/compass-cli/src/semantic_diff_render.rs:829-900`
+- Test: `crates/compass-cli/src/semantic_diff_render.rs:1412`
+- Test: `crates/compass-cli/tests/history_cli.rs:1079`
+
+**Interfaces:**
+- Consumes: existing `SemanticDiffReport.graph_delta`, `.findings`, and
+  `.source_changes`.
+- Produces: `CompassSemanticDiffGraph.mount(options)` and the stable explorer
+  DOM contract used by all later tasks.
+
+- [ ] **Step 1: Add first-party asset constants**
+
+Add beside `PIERRE_DIFFS_JS`:
+
+```rust
+const SEMANTIC_DIFF_GRAPH_CSS: &str =
+    include_str!("../assets/semantic-diff-graph.css");
+const SEMANTIC_DIFF_GRAPH_JS: &str =
+    include_str!("../assets/semantic-diff-graph.js");
+```
+
+- [ ] **Step 2: Move the current graph styles into the CSS asset**
+
+Move the existing `.graph-summary` through `.delta-grid` graph rules out of the
+large Rust raw string. Start the asset with the current behavior-preserving
+rules, then add shell-only rules:
+
+```css
+.graph-explorer {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(280px, 3fr);
+  min-height: 440px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-inset);
+}
+
+.graph-canvas {
+  min-width: 0;
+  min-height: 440px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.graph-inspector {
+  min-width: 0;
+  padding: 18px;
+  background: var(--surface);
+}
+
+.graph-inspector-empty {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+Split the renderer's `<style>` output before `</head>`, append
+`SEMANTIC_DIFF_GRAPH_CSS`, then close the style element. Do not create a
+stylesheet link.
+
+- [ ] **Step 3: Move the existing SVG renderer into the JavaScript asset**
+
+Wrap the current `renderChangedGraph` behavior in this public boundary:
+
+```js
+(() => {
+  "use strict";
+
+  function mount({ report, host, inspector, liveRegion, note }) {
+    renderCurrentGraph(report.graph_delta, host, note);
+    inspector.replaceChildren(
+      element("p", "graph-inspector-empty", "Select a node to inspect its change.")
+    );
+    return Object.freeze({
+      clear() {},
+      select() {},
+      destroy() {
+        host.replaceChildren();
+        inspector.replaceChildren();
+      }
+    });
+  }
+
+  function element(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  globalThis.CompassSemanticDiffGraph = Object.freeze({ mount });
+})();
+```
+
+Use the existing SVG implementation as `renderCurrentGraph`; do not redesign
+the layout in this task.
+
+- [ ] **Step 4: Embed the JavaScript asset and mount the explorer**
+
+After the embedded JSON and Pierre script, append a separate inline script:
+
+```rust
+output.push_str("<script>");
+output.push_str(&SEMANTIC_DIFF_GRAPH_JS.replace("</script", "<\\/script"));
+output.push_str("</script>");
+```
+
+Replace the old `renderChangedGraph(reportData.graph_delta)` call with:
+
+```js
+const graphExplorer = globalThis.CompassSemanticDiffGraph.mount({
+  report: reportData,
+  host: document.getElementById("graph-canvas"),
+  inspector: document.getElementById("graph-inspector"),
+  liveRegion: document.getElementById("graph-live"),
+  note: document.getElementById("graph-note")
+});
+```
+
+Change `render_graph_delta` to emit the approved explorer/inspector/live-region
+markup. Preserve the current no-change empty state without mounting JavaScript.
+
+- [ ] **Step 5: Add data hooks to exhaustive graph rows**
+
+Render node rows with an escaped `data-graph-node-id`. Render edge rows with
+escaped source, target, and relation attributes by using the existing
+`html_attr` helper:
+
+```rust
+let _ = write!(
+    output,
+    "<li class=\"delta-row\" data-graph-node-id=\"{}\">",
+    html_attr(&node.id)
+);
+```
+
+Do not add report-derived content through raw HTML.
+
+- [ ] **Step 6: Verify production compilation and formatting**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p compass-cli
+```
+
+Expected: both commands exit `0`; the report remains a single HTML document.
+
+- [ ] **Step 7: Add renderer and CLI regression assertions**
+
+Extend `html_report_is_standalone_exhaustive_and_escapes_report_data` and
+`diff_emits_semantic_text_json_html_and_rejects_removed_flags` with:
+
+```rust
+assert!(html.contains("globalThis.CompassSemanticDiffGraph"));
+assert!(html.contains("class=\"graph-explorer\""));
+assert!(html.contains("id=\"graph-inspector\""));
+assert!(html.contains("id=\"graph-live\""));
+assert!(html.contains("data-graph-node-id=\"new\""));
+assert!(html.contains("data-graph-edge-source=\"caller\""));
+assert!(html.contains("Select a node to inspect its change."));
+assert!(!html.contains("semantic-diff-graph.js"));
+assert!(!html.contains("semantic-diff-graph.css"));
+```
+
+- [ ] **Step 8: Run focused Rust tests**
+
+Run:
+
+```bash
+cargo test -p compass-cli \
+  semantic_diff_render::tests::html_report_is_standalone_exhaustive_and_escapes_report_data \
+  -- --exact
+cargo test -p compass-cli --test history_cli \
+  diff_emits_semantic_text_json_html_and_rejects_removed_flags \
+  -- --exact
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 9: Commit the asset boundary**
+
+```bash
+git add \
+  crates/compass-cli/assets/semantic-diff-graph.css \
+  crates/compass-cli/assets/semantic-diff-graph.js \
+  crates/compass-cli/src/semantic_diff_render.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "refactor: isolate semantic diff graph explorer"
+```
+
+---
+
+### Task 2: Implement readable capsules and deterministic collision-aware layout
+
+**Files:**
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.js`
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.css`
+- Modify: `tests/viewer/fixtures/generate.ts`
+- Create: `tests/viewer/semantic-diff-graph.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `mount(options)` and stable graph DOM.
+- Produces: `buildGraphModel(delta)`, `rankVisualNodes(model)`,
+  `layoutVisualNodes(nodes, edges, width, height)`, and capsule SVG nodes with
+  deterministic `data-node-id` attributes.
+
+- [ ] **Step 1: Implement the normalized graph model**
+
+Inside the JavaScript asset, define:
+
+```js
+const STATUS_PRIORITY = Object.freeze({
+  context: 0,
+  changed: 1,
+  removed: 2,
+  added: 3
+});
+const MAX_VISUAL_NODES = 42;
+const MAX_VISUAL_EDGES = 100;
+
+function buildGraphModel(delta) {
+  const nodes = new Map();
+  const edges = [
+    ...(delta.changed_edges || []).map((edge) => ({ ...edge, status: "changed" })),
+    ...(delta.removed_edges || []).map((edge) => ({ ...edge, status: "removed" })),
+    ...(delta.added_edges || []).map((edge) => ({ ...edge, status: "added" }))
+  ];
+  // Remember node deltas first, then context-only edge endpoints.
+  return { nodes, edges };
+}
+```
+
+Every normalized node has:
+
+```ts
+type ExplorerNode = {
+  id: string;
+  label: string;
+  kind: string;
+  sourceFile: string;
+  changedFields: string[];
+  status: "added" | "removed" | "changed" | "context";
+  degree: number;
+};
+```
+
+When duplicate IDs occur, retain the higher-priority status and the richest
+non-empty metadata. Count degree from all changed-edge records.
+
+- [ ] **Step 2: Implement deterministic ranking and sampling**
+
+Sort changed nodes by status priority, then degree descending, then identifier.
+After direct deltas, include their connected context endpoints by degree and ID.
+Finally include remaining context nodes by ID. Slice to
+`MAX_VISUAL_NODES`. Filter edges to sampled endpoints, sort by
+`source + relation + target + key`, and slice to `MAX_VISUAL_EDGES`.
+
+The note must use:
+
+```js
+note.textContent =
+  `Visual sample: ${visualNodes.length} of ${model.nodes.size} involved nodes `
+  + `and ${visualEdges.length} of ${model.edges.length} changed edges. `
+  + "The lists below and embedded JSON remain exhaustive.";
+```
+
+Only show this sampled note when either cap truncates data.
+
+- [ ] **Step 3: Implement capsule sizing and layout**
+
+Use deterministic dimensions:
+
+```js
+function capsuleWidth(node) {
+  const visible = displayLabel(node).slice(0, 28);
+  return Math.max(112, Math.min(210, 42 + visible.length * 6.4));
+}
+
+function displayLabel(node) {
+  return node.label || node.id;
+}
+```
+
+Initialize nodes on concentric rings from their ranked index. Run a fixed 180
+iterations containing:
+
+- rectangle-aware repulsion using half-width plus 12-pixel padding;
+- an edge spring targeting 150 pixels;
+- a weak center force;
+- velocity damping; and
+- bounds clamping using each capsule's half-width and 22-pixel half-height.
+
+Never read wall-clock time or random values. The same report must produce the
+same SVG coordinates.
+
+- [ ] **Step 4: Render capsules instead of circles and free labels**
+
+Each SVG group contains:
+
+```html
+<rect class="graph-node-surface" rx="8" ry="8"></rect>
+<text class="graph-node-mark">+</text>
+<text class="graph-node-label">RetryWithSmallerBatch</text>
+<text class="graph-node-meta">function · batching.py</text>
+```
+
+Use `textContent` for every dynamic text node. Truncate the visible label to 28
+characters and meta to 30; retain the complete accessible label on the group.
+Render edges before nodes.
+
+- [ ] **Step 5: Implement the capsule visual system**
+
+The CSS asset must include:
+
+```css
+.graph-node {
+  cursor: pointer;
+  outline: none;
+  transition: opacity 140ms ease;
+}
+
+.graph-node-surface {
+  fill: var(--surface-raised);
+  stroke: var(--muted);
+  stroke-width: 1.3;
+}
+
+.graph-node.added .graph-node-surface { stroke: var(--green); }
+.graph-node.removed .graph-node-surface {
+  stroke: var(--red);
+  stroke-dasharray: 4 3;
+}
+.graph-node.changed .graph-node-surface { stroke: var(--amber); }
+.graph-node-label {
+  fill: var(--text);
+  font: 600 11px/1.2 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.graph-node-meta {
+  fill: var(--muted);
+  font: 9px/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+```
+
+Remove the old circle/free-label rules.
+
+- [ ] **Step 6: Add the browser fixture using production assets**
+
+In `tests/viewer/fixtures/generate.ts`, copy the two assets into
+`fixtures/out/`, then generate `semanticDiffGraph.html` containing:
+
+- a changed node `changed-core`;
+- an added neighbor `added-leaf`;
+- a removed incoming neighbor `removed-caller`;
+- an unrelated node `unrelated`;
+- a context-only endpoint `context-api`;
+- 44 deterministic overflow context endpoints connected to `changed-core`, with
+  `zz-outside-sample` sorting beyond the 42-node visual cap;
+- one related semantic finding with ID `sd1-fixture`;
+- one source change for `src/core.ts`; and
+- the exact Task 1 explorer markup.
+
+The fixture script reads its embedded JSON and calls the production
+`CompassSemanticDiffGraph.mount`.
+
+- [ ] **Step 7: Add layout and safety browser assertions**
+
+Create `tests/viewer/semantic-diff-graph.spec.ts` with:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/semanticDiffGraph.html");
+});
+
+test("renders deterministic readable node capsules", async ({ page }) => {
+  const nodes = page.locator("#graph-canvas [data-node-id]");
+  await expect(nodes).toHaveCount(42);
+  await expect(page.getByText("changed-core", { exact: true })).toBeVisible();
+  await expect(page.locator("#graph-canvas img")).toHaveCount(0);
+
+  const boxes = await nodes.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect();
+      return { left: box.left, right: box.right, top: box.top, bottom: box.bottom };
+    })
+  );
+  for (let left = 0; left < boxes.length; left += 1) {
+    for (let right = left + 1; right < boxes.length; right += 1) {
+      const overlaps = boxes[left].left < boxes[right].right
+        && boxes[left].right > boxes[right].left
+        && boxes[left].top < boxes[right].bottom
+        && boxes[left].bottom > boxes[right].top;
+      expect(overlaps).toBe(false);
+    }
+  }
+});
+```
+
+Add a hostile label containing `</script><img src=x onerror=alert(1)>` and
+assert it renders as text with no injected `img` element.
+
+- [ ] **Step 8: Run focused Rust and Chromium checks**
+
+Use the working Node installation explicitly:
+
+```bash
+cargo test -p compass-cli semantic_diff_render --lib
+PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
+  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+```
+
+Expected: Rust renderer tests and the Chromium capsule test pass.
+
+- [ ] **Step 9: Commit the readable graph**
+
+```bash
+git add \
+  crates/compass-cli/assets/semantic-diff-graph.css \
+  crates/compass-cli/assets/semantic-diff-graph.js \
+  tests/viewer/fixtures/generate.ts \
+  tests/viewer/semantic-diff-graph.spec.ts
+git commit -m "feat: render readable semantic diff graph"
+```
+
+---
+
+### Task 3: Add neighborhood focus and the persistent inspector
+
+**Files:**
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.js`
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.css`
+- Modify: `tests/viewer/semantic-diff-graph.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 2's normalized model and sampled SVG.
+- Produces: `selectionFor(model, nodeId)`, `renderInspector(...)`,
+  `select(nodeId)`, and `clear()` behavior returned by `mount`.
+
+- [ ] **Step 1: Implement exhaustive relationship and finding indexes**
+
+Build once during mount:
+
+```js
+function relationshipsFor(model, nodeId) {
+  return {
+    incoming: model.edges.filter((edge) => edge.target === nodeId),
+    outgoing: model.edges.filter((edge) => edge.source === nodeId)
+  };
+}
+
+function findingsFor(report, nodeId) {
+  return (report.findings || []).filter((finding) =>
+    finding.subject === nodeId
+    || (finding.evidence || []).some((evidence) => evidence.record_key === nodeId)
+  );
+}
+```
+
+The model uses exhaustive edges, not the sampled visual-edge array.
+
+- [ ] **Step 2: Implement selection and neighborhood classes**
+
+`select(nodeId)` must:
+
+1. resolve the normalized node, including out-of-sample context nodes;
+2. compute direct neighbor IDs from exhaustive edges;
+3. set selected SVG node `aria-pressed="true"` and `.is-selected`;
+4. apply `.is-neighbor` to direct visible neighbors;
+5. apply `.is-dimmed` to unrelated visible nodes;
+6. apply `.is-related` to touching visible edges and `.is-dimmed` elsewhere;
+7. render the inspector; and
+8. announce `Inspecting {label}` in the live region.
+
+`clear()` removes all selection classes, resets `aria-pressed`, renders the
+empty inspector, and announces `Graph selection cleared`.
+
+- [ ] **Step 3: Render the inspector with text-only DOM APIs**
+
+Render this semantic hierarchy:
+
+```html
+<header class="graph-inspector-header">
+  <span class="graph-status added">Added</span>
+  <h3 id="graph-inspector-heading">RetryWithSmallerBatch</h3>
+  <code>python_..._retrywithsmallerbatch</code>
+</header>
+<dl class="graph-inspector-facts">
+  <div><dt>Kind</dt><dd>function</dd></div>
+  <div><dt>Source</dt><dd>python/.../batching.py</dd></div>
+  <div><dt>Changed fields</dt><dd>signature, implementation</dd></div>
+</dl>
+<section>
+  <h4>Incoming relationships</h4>
+  <button data-neighbor-id="caller">caller <span>calls · added</span></button>
+</section>
+<section>
+  <h4>Outgoing relationships</h4>
+  ...
+</section>
+<section>
+  <h4>Related findings</h4>
+  <a href="#sd1-fixture">Behavior changed</a>
+</section>
+```
+
+For unknown kind/source, omit the fact row. For empty relationship/finding
+groups, render `No changed incoming relationships`, `No changed outgoing
+relationships`, or `No related semantic findings`.
+
+- [ ] **Step 4: Connect pointer selection and inspector neighbor navigation**
+
+Use one delegated click listener on the host and one on the inspector. Find the
+nearest `[data-node-id]` or `[data-neighbor-id]`, read its dataset, and call
+`select`. A click whose target is the SVG background calls `clear`.
+
+Do not interpolate node IDs into selector strings; use maps and dataset values.
+
+- [ ] **Step 5: Style the change lens and inspector**
+
+Add:
+
+```css
+.graph-node.is-selected .graph-node-surface {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+}
+.graph-node.is-neighbor { opacity: 1; }
+.graph-node.is-dimmed,
+.graph-edge.is-dimmed { opacity: .18; }
+.graph-edge.is-related {
+  opacity: 1;
+  stroke-width: 2.2;
+}
+.graph-inspector-header {
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.graph-inspector-section {
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.graph-relation {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  padding: 8px 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  text-align: left;
+}
+```
+
+Preserve the original added/removed/changed border when a connected neighbor is
+focused. Selection blue is an outer emphasis, not a replacement for status.
+
+- [ ] **Step 6: Add browser interaction assertions**
+
+Add:
+
+```ts
+test("selects a node, focuses its neighborhood, and navigates relationships", async ({ page }) => {
+  const changed = page.locator('[data-node-id="changed-core"]');
+  await changed.click();
+
+  await expect(changed).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator('[data-node-id="added-leaf"]')).toHaveClass(/is-neighbor/);
+  await expect(page.locator('[data-node-id="unrelated"]')).toHaveClass(/is-dimmed/);
+  await expect(page.getByRole("heading", { name: "changed-core" })).toBeVisible();
+
+  await page.locator('[data-neighbor-id="context-api"]').click();
+  await expect(page.locator("#graph-live")).toContainText("Inspecting context-api");
+
+  await page.locator("#graph-canvas svg").click({ position: { x: 4, y: 4 } });
+  await expect(page.locator('[data-node-id="changed-core"]'))
+    .toHaveAttribute("aria-pressed", "false");
+});
+```
+
+Also assert the inspector reports the expected incoming and outgoing relation
+labels and links `sd1-fixture`.
+
+- [ ] **Step 7: Run focused browser and Rust regression checks**
+
+```bash
+PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
+  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+cargo test -p compass-cli semantic_diff_render --lib
+```
+
+Expected: selection, inspector, and renderer tests pass.
+
+- [ ] **Step 8: Commit selection and inspection**
+
+```bash
+git add \
+  crates/compass-cli/assets/semantic-diff-graph.css \
+  crates/compass-cli/assets/semantic-diff-graph.js \
+  tests/viewer/semantic-diff-graph.spec.ts
+git commit -m "feat: inspect changed graph nodes"
+```
+
+---
+
+### Task 4: Complete navigation, keyboard, responsive, and failure behavior
+
+**Files:**
+- Modify: `crates/compass-cli/src/semantic_diff_render.rs`
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.js`
+- Modify: `crates/compass-cli/assets/semantic-diff-graph.css`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+- Modify: `tests/viewer/semantic-diff-graph.spec.ts`
+- Modify: `docs/reference/outputs.md:264-279`
+- Modify: `docs/guides/versioned-history.md:239-272`
+
+**Interfaces:**
+- Consumes: Tasks 1–3 explorer and inspector.
+- Produces: valid source/finding navigation, out-of-sample selection state,
+  keyboard equivalence, responsive inspector, and safe runtime fallback.
+
+- [ ] **Step 1: Add stable source-change anchors**
+
+In `render_source_changes`, add the source index to each details element:
+
+```rust
+let _ = write!(
+    output,
+    "<details id=\"source-change-{index}\" class=\"source-file\" \
+     data-source-index=\"{index}\"{}>",
+    if index == 0 { " open" } else { "" }
+);
+```
+
+Finding cards already use their validated `sd1-...` IDs. Do not create links
+for arbitrary finding IDs that are absent from the DOM.
+
+- [ ] **Step 2: Implement valid navigation targets**
+
+Build a source target map by comparing normalized slash-separated
+`node.sourceFile` with each source change's `old_path` and `new_path`.
+
+Inspector links are:
+
+```js
+sourceLink.href = `#source-change-${sourceIndex}`;
+findingLink.href = `#${finding.id}`;
+```
+
+Create them only after verifying the corresponding DOM element exists. Add a
+`Show in exhaustive list` button only when a row with matching
+`data-graph-node-id` exists; on activation, call `scrollIntoView` and focus the
+row temporarily with `tabindex="-1"`.
+
+- [ ] **Step 3: Implement keyboard behavior**
+
+On the graph host:
+
+```js
+host.addEventListener("keydown", (event) => {
+  const node = event.target.closest("[data-node-id]");
+  if (node && (event.key === "Enter" || event.key === " ")) {
+    event.preventDefault();
+    select(node.dataset.nodeId);
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    clear();
+  }
+});
+```
+
+Inspector relationship buttons already use native keyboard semantics. Clicking
+or activating an out-of-sample neighbor updates the inspector and live region;
+the note becomes:
+
+```text
+Inspecting a node outside the bounded visual sample. Its changed relationships
+remain available here and in the exhaustive lists.
+```
+
+- [ ] **Step 4: Implement runtime fallback and cleanup**
+
+Wrap mount initialization in `try/catch`. On failure:
+
+```js
+host.replaceChildren(
+  element("p", "graph-render-fallback",
+    "Interactive graph unavailable. Use the exhaustive node and edge lists below.")
+);
+note.textContent =
+  "The embedded report data and exhaustive graph-change lists remain available.";
+console.warn("Compass could not render the changed graph", error);
+```
+
+`destroy()` removes host and inspector event listeners before clearing DOM.
+
+- [ ] **Step 5: Finish responsive, focus, and reduced-motion CSS**
+
+Add:
+
+```css
+.graph-node:focus-visible .graph-node-surface,
+.graph-relation:focus-visible,
+.graph-inspector a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 760px) {
+  .graph-explorer { grid-template-columns: 1fr; }
+  .graph-canvas {
+    min-height: 390px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .graph-inspector { min-height: 220px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-node,
+  .graph-edge { transition: none; }
+}
+
+@media (forced-colors: active) {
+  .graph-node-surface { stroke: CanvasText; }
+  .graph-node.is-selected .graph-node-surface { stroke: Highlight; }
+  .graph-edge.is-related { stroke: Highlight; }
+}
+```
+
+Use SVG stroke styling rather than CSS `outline` on SVG groups if Chromium does
+not paint the group outline; retain the same visible focus requirement.
+
+- [ ] **Step 6: Extend Rust and CLI output assertions**
+
+Assert:
+
+```rust
+assert!(html.contains("id=\"source-change-0\""));
+assert!(html.contains("aria-live=\"polite\""));
+assert!(html.contains("Interactive graph unavailable."));
+assert!(html.contains("@media (max-width: 760px)"));
+assert!(html.contains("@media (prefers-reduced-motion: reduce)"));
+assert!(!html.contains("href=\"#source-change-undefined\""));
+```
+
+- [ ] **Step 7: Add keyboard, responsive, and fallback browser coverage**
+
+Add tests that:
+
+- focus `changed-core`, press Enter, and see `aria-pressed="true"`;
+- press Escape and see selection cleared;
+- select the context-only endpoint and see unavailable kind/source omitted;
+- select the out-of-sample fixture neighbor and see the bounded-sample note;
+- set viewport width to 720 and assert inspector top is at or below canvas
+  bottom;
+- assert the source link targets `#source-change-0`;
+- assert the finding link targets `#sd1-fixture`; and
+- intentionally remove `report.graph_delta` before mount and verify the safe
+  fallback without removing exhaustive list fixture content.
+
+- [ ] **Step 8: Document how reviewers use the explorer**
+
+In `docs/reference/outputs.md`, state that the graph:
+
+- is a bounded visual sample backed by exhaustive lists and JSON;
+- uses selection to focus direct changed-edge neighborhoods;
+- shows only retained node/edge metadata;
+- links to findings and source patches when exact targets exist; and
+- remains useful without JavaScript through exhaustive lists.
+
+In `docs/guides/versioned-history.md`, add this reading order:
+
+```text
+Select a changed node, inspect incoming and outgoing changed relationships,
+follow related semantic findings, then open the exact source patch. Clear the
+selection to restore the whole sampled topology.
+```
+
+- [ ] **Step 9: Run focused checks**
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-cli semantic_diff_render --lib
+cargo test -p compass-cli --test history_cli \
+  diff_emits_semantic_text_json_html_and_rejects_removed_flags \
+  -- --exact
+PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
+  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+git diff --check
+```
+
+Expected: all commands pass with no whitespace errors.
+
+- [ ] **Step 10: Commit the complete interaction**
+
+```bash
+git add \
+  crates/compass-cli/src/semantic_diff_render.rs \
+  crates/compass-cli/assets/semantic-diff-graph.css \
+  crates/compass-cli/assets/semantic-diff-graph.js \
+  crates/compass-cli/tests/history_cli.rs \
+  tests/viewer/semantic-diff-graph.spec.ts \
+  docs/reference/outputs.md \
+  docs/guides/versioned-history.md
+git commit -m "feat: complete semantic diff graph interaction"
+```
+
+---
+
+### Task 5: Qualify the completed report on CocoIndex and run release gates
+
+**Files:**
+- Modify only if qualification reveals a defect in the files from Tasks 1–4.
+- Regenerate, do not commit: `tests/viewer/fixtures/out/*`
+- Generate outside the repository:
+  `/tmp/compass-cocoindex-interactive-semantic-diff.html`
+
+**Interfaces:**
+- Consumes: the complete standalone graph explorer.
+- Produces: fresh real-repository evidence, deterministic output evidence, and
+  final verification results.
+
+- [ ] **Step 1: Refresh the Graphify knowledge graph**
+
+```bash
+graphify update .
+```
+
+Expected: update completes without API cost and reports refreshed Compass graph
+counts.
+
+- [ ] **Step 2: Run formatting, strict focused lint, and Rust tests**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p compass-cli --all-targets --no-deps -- -D warnings
+cargo test -p compass-cli semantic_diff_render --lib
+cargo test -p compass-cli --test history_cli \
+  diff_emits_semantic_text_json_html_and_rejects_removed_flags \
+  -- --exact
+cargo test -p compass-cli --test history_cli \
+  semantic_diff_end_to_end_languages \
+  -- --exact --nocapture
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 3: Run the browser suite for the production assets**
+
+```bash
+PATH=/Users/haipingfu/.nvm/versions/node/v24.13.1/bin:$PATH \
+  npm exec --prefix tests/viewer playwright test semantic-diff-graph.spec.ts
+```
+
+Expected: all graph explorer Chromium tests pass.
+
+- [ ] **Step 4: Rebuild Compass from the current commit**
+
+```bash
+cargo build -p compass-cli
+./target/debug/compass --version
+```
+
+Expected: build exits `0` and the command reports the current Compass version.
+
+- [ ] **Step 5: Generate a fresh real CocoIndex report**
+
+Run from `/Volumes/workspace/Github/cocoindex-compass-audit-20260726`:
+
+```bash
+/Users/haipingfu/graphify/compass/target/debug/compass diff \
+  90571539fa291fc6e6b248095bd2c8a2ff68bab4 \
+  71f9cc9dc693080310181a2d011fb737420f7907 \
+  --format html \
+  --output /tmp/compass-cocoindex-interactive-semantic-diff.html \
+  </dev/null
+```
+
+Expected: the command exits `0` and writes one self-contained report.
+
+- [ ] **Step 6: Verify the real report's interaction contract and evidence**
+
+```bash
+REAL_REPORT=/tmp/compass-cocoindex-interactive-semantic-diff.html
+test -s "$REAL_REPORT"
+rg -q 'globalThis.CompassSemanticDiffGraph' "$REAL_REPORT"
+rg -q 'class="graph-explorer"' "$REAL_REPORT"
+rg -q 'id="graph-inspector"' "$REAL_REPORT"
+rg -q 'data-graph-node-id=' "$REAL_REPORT"
+rg -q 'if not _is_global_litellm_error\\(e\\)' "$REAL_REPORT"
+rg -q 'sd1-6a303dab4ee88cb6df047cce' "$REAL_REPORT"
+if rg -q '<script src=|<link rel=' "$REAL_REPORT"; then exit 1; fi
+```
+
+Expected: every required contract/evidence check passes and no external asset
+tag exists.
+
+- [ ] **Step 7: Verify deterministic JSON and a clean upstream checkout**
+
+Run from the CocoIndex audit repository:
+
+```bash
+COMPASS_BIN=/Users/haipingfu/graphify/compass/target/debug/compass
+OLD_REV=90571539fa291fc6e6b248095bd2c8a2ff68bab4
+NEW_REV=71f9cc9dc693080310181a2d011fb737420f7907
+HASH_ONE=$("$COMPASS_BIN" diff "$OLD_REV" "$NEW_REV" --format json \
+  | shasum -a 256 | awk '{print $1}')
+HASH_TWO=$("$COMPASS_BIN" diff "$OLD_REV" "$NEW_REV" --format json \
+  | shasum -a 256 | awk '{print $1}')
+test "$HASH_ONE" = "$HASH_TWO"
+test -z "$(git status --porcelain=v1)"
+printf 'semantic_diff_sha256=%s\ncheckout_clean=yes\n' "$HASH_ONE"
+```
+
+Expected: hashes match and the upstream checkout remains clean.
+
+- [ ] **Step 8: Run final workspace and whitespace gates**
+
+```bash
+cargo test --workspace
+git diff --check
+git status -sb
+```
+
+Expected: workspace tests pass; only known user-owned untracked directories
+remain; no implementation changes are left uncommitted.
+
+- [ ] **Step 9: If qualification required fixes, commit them**
+
+Only when Steps 1–8 exposed and you fixed a defect:
+
+```bash
+git add \
+  crates/compass-cli/src/semantic_diff_render.rs \
+  crates/compass-cli/assets/semantic-diff-graph.css \
+  crates/compass-cli/assets/semantic-diff-graph.js \
+  crates/compass-cli/tests/history_cli.rs \
+  tests/viewer/fixtures/generate.ts \
+  tests/viewer/semantic-diff-graph.spec.ts \
+  docs/reference/outputs.md \
+  docs/guides/versioned-history.md
+git commit -m "fix: qualify semantic diff graph explorer"
+```
+
+Do not create an empty commit when qualification required no fixes.

--- a/docs/superpowers/specs/2026-07-26-interactive-semantic-diff-graph-design.md
+++ b/docs/superpowers/specs/2026-07-26-interactive-semantic-diff-graph-design.md
@@ -1,0 +1,256 @@
+# Interactive semantic-diff graph design
+
+**Date:** 2026-07-26
+**Status:** Approved for implementation planning
+
+## Problem
+
+The standalone `compass diff --format html` report renders its changed graph as
+a bounded custom SVG. It is deterministic and self-contained, but dense reports
+produce overlapping labels, weak hierarchy, and no selection behavior. The
+result communicates that graph changes exist without helping a reviewer inspect
+an individual changed node or understand its immediate impact.
+
+The VS Code Codebase Evolution graph is outside this design. It already uses the
+shared interactive `CompassGraph` component. This work applies only to the
+standalone offline semantic-diff HTML report.
+
+## Goals
+
+- Make the sampled changed subgraph readable at a glance.
+- Let mouse and keyboard users select a node.
+- Keep the selected node and its immediate neighborhood visually prominent.
+- Show accurate node, relationship, source, and semantic-finding details in a
+  persistent inspector.
+- Preserve deterministic output, offline operation, strict CSP compatibility,
+  bounded rendering, and exhaustive list fallbacks.
+- Remain useful on narrow screens and with reduced motion or high contrast.
+
+## Non-goals
+
+- Replacing the standalone renderer with the React/vis-network Compass viewer.
+- Changing the semantic-diff JSON schema.
+- Adding old and new attribute values that the current `GraphNodeDelta` and
+  `GraphEdgeDelta` records do not retain.
+- Rendering every changed node or edge in the visual sample.
+- Adding remote assets, hosted services, or runtime dependencies.
+- Changing the VS Code comparison graph.
+
+## Chosen approach
+
+Enhance the existing deterministic SVG as a **change lens**. The report keeps a
+bounded topology view, but nodes become readable capsules with collision-aware
+placement. Selecting a node opens a persistent inspector and emphasizes its
+direct neighborhood while dimming unrelated topology.
+
+Embedding the full Compass viewer was rejected because it would add a large
+runtime and duplicate application infrastructure inside every offline report.
+A status-column dependency map was rejected because it makes change categories
+clear but weakens arbitrary topology exploration.
+
+## Layout
+
+Desktop uses a graph explorer split:
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Graph summary and change legend                              │
+├──────────────────────────────────────┬───────────────────────┤
+│ Interactive changed-subgraph        │ Selected node inspector│
+│                                     │                        │
+│ readable node capsules              │ identity and status    │
+│ directional relationship lines      │ kind and source file   │
+│ selected neighborhood focus         │ changed field names    │
+│                                     │ incoming relationships │
+│                                     │ outgoing relationships │
+│                                     │ related findings       │
+│                                     │ source-patch link      │
+├──────────────────────────────────────┴───────────────────────┤
+│ Exhaustive node and edge lists                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The graph occupies approximately 70% of the available width and the inspector
+30%, with a practical minimum inspector width near 280 pixels. Below 760 pixels,
+the inspector moves below the graph and uses the full width.
+
+The inspector starts with a short invitation to select a node. It does not
+preselect a node or dim the graph before the reviewer acts.
+
+## Visual system
+
+The graph derives all styling from the report's existing palette:
+
+| Role | Token |
+| --- | --- |
+| Canvas | `--surface-inset` (`#0b0e13`) |
+| Node surface | `--surface-raised` (`#191e27`) |
+| Selection and keyboard focus | `--accent` (`#8ab4f8`) |
+| Added | `--green` (`#65bd84`) |
+| Removed | `--red` (`#ff7b86`) |
+| Changed | `--amber` (`#d9a441`) |
+| Context | `--muted` (`#8d96a5`) |
+
+Node capsules use the UI font for the readable label and the monospace stack
+for kind, path, and identifier details. Change state is encoded by border
+style, a visible `+`, `−`, `~`, or `·` mark, and an accessible label; color is
+not the only signal.
+
+Directly changed and higher-degree nodes may receive slightly stronger visual
+weight. Node size does not encode arbitrary magnitude. The renderer avoids
+glow, gradients, and continuous physics animation. Selection and hover opacity
+transitions last about 140 milliseconds and are disabled under
+`prefers-reduced-motion`.
+
+## Graph construction and sampling
+
+The renderer creates one node index from:
+
+- added, removed, and changed node deltas;
+- source and target endpoints from added, removed, and changed edge deltas; and
+- any available label, kind, source-file, and changed-field metadata.
+
+An endpoint without a corresponding node delta is a context node. It displays
+its identifier and known relationships without inventing kind or source data.
+
+The visual sample remains bounded. Ranking proceeds in this order:
+
+1. changed, removed, and added node deltas;
+2. direct endpoints connected to those nodes, ordered by changed-edge degree;
+3. remaining context endpoints in deterministic identifier order.
+
+The exact node and edge caps remain implementation constants and must be covered
+by tests. The note below the canvas reports sampled and exhaustive counts when
+the visual is truncated.
+
+Placement remains deterministic and topology-first. The layout uses capsule
+dimensions in collision calculations so labels do not overlap neighboring
+nodes. Edges render behind nodes with directional arrowheads. Labels truncate
+inside capsules, while full labels remain available to accessibility APIs and
+the inspector.
+
+## Selection and neighborhood focus
+
+A node can be selected by click, Enter, or Space. Selection:
+
+- adds a strong accent focus ring to the selected capsule;
+- retains full status styling for directly connected neighbors;
+- brightens incoming and outgoing edges that touch the selection;
+- dims unrelated nodes and edges to approximately 15–20% opacity; and
+- updates the persistent inspector and an `aria-live` status.
+
+Clicking another node or an inspector relationship selects that node. Clicking
+empty canvas space or pressing Escape clears selection and restores the full
+graph. Hover may preview emphasis but must not replace persistent selection.
+
+## Inspector
+
+The inspector shows only facts available in the report:
+
+- change status;
+- label and identifier;
+- kind, when known;
+- source file, when known;
+- changed field names, when present;
+- incoming changed relationships;
+- outgoing changed relationships;
+- related semantic findings; and
+- a source-patch navigation link when the file has a matching source change.
+
+Each relationship row includes direction, relation, neighbor label or
+identifier, and edge change status. Selecting a relationship row moves focus to
+the neighbor even when that neighbor is outside the visual sample. In that
+case, the inspector remains useful and the canvas explains that the selected
+node is outside the bounded visual sample.
+
+Related findings are matched through finding subjects and evidence record keys.
+Source navigation matches normalized node source paths against old and new
+source-change paths. Links are omitted when no valid target exists.
+
+The schema currently retains changed-field names but not before-and-after field
+values. The inspector must not imply that those values are available.
+
+## Exhaustive fallback
+
+The existing node and edge delta lists remain authoritative and exhaustive.
+They continue to render below the explorer. If JavaScript is unavailable or
+fails, those lists and the embedded `compass.semantic_diff.report/1` payload
+still expose the complete comparison.
+
+Graph list rows may gain stable anchors so inspector links can reveal the
+matching exhaustive record. This must not alter report data or require
+JavaScript for the list itself.
+
+## Accessibility
+
+- SVG nodes expose button semantics, readable names, and keyboard focus.
+- Enter and Space select; Escape clears.
+- Focus styling remains visible in high-contrast environments.
+- Change marks and text accompany semantic colors.
+- Selection updates a polite `aria-live` status.
+- Inspector headings and relationship groups use semantic HTML.
+- Truncated visible labels retain complete accessible names.
+- Reduced-motion users receive immediate state changes.
+- The responsive inspector follows the graph in reading order.
+
+## Failure behavior
+
+- Missing node metadata renders an explicit unavailable value or omits the
+  unsupported row.
+- Empty relationship and finding groups say that no changed records are known.
+- Missing source matches do not create dead links.
+- A graph with no meaningful changes retains the existing empty state.
+- A graph-rendering exception leaves the exhaustive lists intact and reports a
+  concise canvas fallback message without exposing internal paths.
+- Hostile labels, identifiers, fields, relations, and paths remain escaped in
+  HTML and are assigned to dynamic DOM through text-only APIs.
+
+## Testing
+
+Follow test-driven development. Tests must fail for the missing interaction
+before production changes are written.
+
+Rust renderer tests cover:
+
+- explorer, inspector, live-region, and fallback markup;
+- embedded report safety and absence of external scripts or styles;
+- deterministic anchors and escaped hostile content;
+- empty and populated graph states; and
+- source/finding navigation targets.
+
+Pure interaction tests cover:
+
+- deterministic ranking and bounded sampling;
+- context-node construction;
+- incoming and outgoing relationship classification;
+- selection, neighborhood membership, and clear behavior;
+- inspector models for added, removed, changed, and context nodes; and
+- out-of-sample neighbor selection.
+
+A browser-level fixture covers:
+
+- pointer selection;
+- keyboard selection and Escape;
+- unrelated-node dimming;
+- inspector updates;
+- clickable neighbor navigation;
+- source or finding navigation when present; and
+- the narrow-screen inspector layout.
+
+Existing semantic-diff CLI and full-workspace tests remain regression gates.
+
+## Acceptance criteria
+
+1. The generated HTML remains one self-contained file with no network
+   dependency.
+2. Node labels in the bounded graph do not overlap other node capsules at the
+   supported fixture sizes.
+3. Selecting a node reveals accurate details and emphasizes exactly its direct
+   changed-edge neighborhood.
+4. Inspector relationship rows can select both visible and out-of-sample
+   neighbors.
+5. Keyboard and pointer interactions produce equivalent selections.
+6. The exhaustive graph-delta lists remain present and complete.
+7. Missing metadata and partial evidence are represented honestly.
+8. The report passes its strict CSP, renderer tests, browser fixture, and
+   workspace verification.

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -10,6 +10,14 @@ export default async function generate(): Promise<void> {
   await mkdir(output, { recursive: true });
   await cp(path.join(root, "packages/compass-viewer/dist/viewer.css"), path.join(output, "viewer.css"));
   await cp(path.join(root, "packages/compass-viewer/dist/graph.js"), path.join(output, "graph.js"));
+  await cp(
+    path.join(root, "crates/compass-cli/assets/semantic-diff-graph.css"),
+    path.join(output, "semantic-diff-graph.css")
+  );
+  await cp(
+    path.join(root, "crates/compass-cli/assets/semantic-diff-graph.js"),
+    path.join(output, "semantic-diff-graph.js")
+  );
   for (const name of ["architecture", "callGraph", "history", "initialize", "query"]) {
     await cp(
       path.join(root, `editors/vscode/dist/webviews/${name}.js`),
@@ -56,6 +64,10 @@ export default async function generate(): Promise<void> {
   const viewerJs = await readFile(path.join(output, "graph.js"), "utf8");
   const viewerCss = await readFile(path.join(output, "viewer.css"), "utf8");
   await writeFile(path.join(output, "graph.html"), `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Compass graph fixture</title><style>${viewerCss}</style></head><body><div id="compass-viewer-root"></div><script id="compass-viewer-model" type="application/json">${JSON.stringify(graph)}</script><script>${viewerJs}</script></body></html>`);
+  await writeFile(
+    path.join(output, "semanticDiffGraph.html"),
+    semanticDiffGraphHarness()
+  );
   const communityOverview = {
     schema: "compass.viewer.graph/1",
     title: "Community fixture",
@@ -208,6 +220,164 @@ export default async function generate(): Promise<void> {
   );
   await writeFile(path.join(output, "query.html"), queryHarness());
   await writeFile(path.join(output, "initialize.html"), initializationHarness());
+}
+
+function semanticDiffGraphHarness(): string {
+  const overflowEdges = Array.from({ length: 44 }, (_, index) => ({
+    source: "changed-core",
+    target: `overflow-context-${String(index).padStart(2, "0")}`,
+    relation: "calls",
+    key: `overflow-${index}`,
+    source_file: "src/core.ts",
+    changed_fields: []
+  }));
+  const report = {
+    schema: "compass.semantic_diff.report/1",
+    comparison: {
+      old_commit: "a".repeat(40),
+      new_commit: "b".repeat(40),
+      fingerprint: "c".repeat(64)
+    },
+    findings: [{
+      id: "sd1-fixture",
+      subject: "changed-core",
+      headline: "Changed core behavior",
+      evidence: [{ record_key: "changed-core" }]
+    }],
+    source_changes: [{
+      old_path: "src/core.ts",
+      new_path: "src/core.ts",
+      patch: "@@ -1 +1 @@\n-old\n+new"
+    }],
+    graph_delta: {
+      changed_nodes: [
+        {
+          id: "changed-core",
+          label: "changed-core",
+          kind: "function",
+          source_file: "src/core.ts",
+          changed_fields: ["implementation"]
+        },
+        {
+          id: "hostile",
+          label: "</script><img src=x onerror=alert(1)>",
+          kind: "function",
+          source_file: "src/hostile.ts",
+          changed_fields: ["body"]
+        }
+      ],
+      added_nodes: [
+        {
+          id: "added-leaf",
+          label: "added-leaf",
+          kind: "function",
+          source_file: "src/leaf.ts",
+          changed_fields: []
+        },
+        {
+          id: "unrelated",
+          label: "unrelated",
+          kind: "type",
+          source_file: "src/unrelated.ts",
+          changed_fields: []
+        }
+      ],
+      removed_nodes: [{
+        id: "removed-caller",
+        label: "removed-caller",
+        kind: "function",
+        source_file: "src/caller.ts",
+        changed_fields: []
+      }],
+      changed_edges: [{
+        source: "removed-caller",
+        target: "changed-core",
+        relation: "calls",
+        key: "removed-core",
+        source_file: "src/core.ts",
+        changed_fields: ["confidence"]
+      }],
+      added_edges: [
+        {
+          source: "changed-core",
+          target: "added-leaf",
+          relation: "calls",
+          key: "core-leaf",
+          source_file: "src/core.ts",
+          changed_fields: []
+        },
+        {
+          source: "changed-core",
+          target: "context-api",
+          relation: "uses",
+          key: "core-context",
+          source_file: "src/core.ts",
+          changed_fields: []
+        },
+        ...overflowEdges,
+        {
+          source: "changed-core",
+          target: "zz-outside-sample",
+          relation: "calls",
+          key: "outside",
+          source_file: "src/core.ts",
+          changed_fields: []
+        }
+      ],
+      removed_edges: [],
+      collapsed_attribute_changes: {}
+    }
+  };
+  const rows = [
+    ...report.graph_delta.changed_nodes,
+    ...report.graph_delta.added_nodes,
+    ...report.graph_delta.removed_nodes
+  ].map((node) =>
+    `<li class="delta-row" data-graph-node-id="${node.id}">${node.id}</li>`
+  ).join("");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Semantic diff graph fixture</title>
+  <style>
+    :root{color-scheme:dark;--canvas:#0e1116;--surface:#141820;--surface-raised:#191e27;--surface-inset:#0b0e13;--border:#2b313b;--border-strong:#3a424e;--text:#e7eaf0;--text-soft:#c5cad3;--muted:#8d96a5;--accent:#8ab4f8;--red:#ff7b86;--amber:#d9a441;--green:#65bd84}
+    *{box-sizing:border-box}
+    body{margin:0;padding:20px;background:var(--canvas);color:var(--text);font:14px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+    button{font:inherit;color:inherit}
+    .graph-note{color:var(--muted);font-size:11px}
+    .delta-row{padding:5px}
+  </style>
+  <link rel="stylesheet" href="/semantic-diff-graph.css">
+</head>
+<body>
+  <article id="sd1-fixture">Changed core behavior</article>
+  <details id="source-change-0"><summary>src/core.ts</summary><pre>source patch</pre></details>
+  <div class="graph-explorer">
+    <div id="graph-canvas" class="graph-canvas" aria-label="Changed code graph"></div>
+    <aside id="graph-inspector" class="graph-inspector" aria-labelledby="graph-inspector-heading">
+      <h3 id="graph-inspector-heading" class="sr-only">Node inspector</h3>
+      <p class="graph-inspector-empty">Select a node to inspect its change.</p>
+    </aside>
+  </div>
+  <p id="graph-live" class="sr-only" aria-live="polite"></p>
+  <p id="graph-note" class="graph-note">The visualization focuses on the changed subgraph.</p>
+  <ul id="exhaustive-list">${rows}</ul>
+  <script id="semantic-diff-data" type="application/json">${JSON.stringify(report).replaceAll("<", "\\u003c")}</script>
+  <script src="/semantic-diff-graph.js"></script>
+  <script>
+    const report = JSON.parse(document.getElementById("semantic-diff-data").textContent);
+    globalThis.graphFixture = globalThis.CompassSemanticDiffGraph.mount({
+      report,
+      host: document.getElementById("graph-canvas"),
+      inspector: document.getElementById("graph-inspector"),
+      liveRegion: document.getElementById("graph-live"),
+      note: document.getElementById("graph-note")
+    });
+  </script>
+</body>
+</html>`;
 }
 
 function graphLoadingHarness(): string {

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -282,13 +282,22 @@ function semanticDiffGraphHarness(): string {
           changed_fields: []
         }
       ],
-      removed_nodes: [{
-        id: "removed-caller",
-        label: "removed-caller",
-        kind: "function",
-        source_file: "src/caller.ts",
-        changed_fields: []
-      }],
+      removed_nodes: [
+        {
+          id: "removed-caller",
+          label: "removed-caller",
+          kind: "function",
+          source_file: "src/caller.ts",
+          changed_fields: []
+        },
+        ...Array.from({ length: 44 }, (_, index) => ({
+          id: `removed-overflow-${String(index).padStart(2, "0")}`,
+          label: `removed-overflow-${String(index).padStart(2, "0")}`,
+          kind: "function",
+          source_file: "src/removed.ts",
+          changed_fields: []
+        }))
+      ],
       changed_edges: [{
         source: "removed-caller",
         target: "changed-core",

--- a/tests/viewer/semantic-diff-graph.spec.ts
+++ b/tests/viewer/semantic-diff-graph.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/semanticDiffGraph.html");
+});
+
+test("renders a bounded collision-free capsule graph safely", async ({ page }) => {
+  const nodes = page.locator("#graph-canvas [data-node-id]");
+  await expect(nodes).toHaveCount(42);
+  await expect(page.locator('[data-node-id="changed-core"] .graph-node-label')).toBeVisible();
+  await expect(page.locator("#graph-canvas img")).toHaveCount(0);
+  await expect(page.locator("body img")).toHaveCount(0);
+  await expect(page.locator("#graph-note")).toContainText("42 of");
+
+  const boxes = await nodes.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect();
+      return {
+        left: box.left,
+        right: box.right,
+        top: box.top,
+        bottom: box.bottom
+      };
+    })
+  );
+  for (let left = 0; left < boxes.length; left += 1) {
+    for (let right = left + 1; right < boxes.length; right += 1) {
+      const overlaps = boxes[left].left < boxes[right].right
+        && boxes[left].right > boxes[right].left
+        && boxes[left].top < boxes[right].bottom
+        && boxes[left].bottom > boxes[right].top;
+      expect(overlaps).toBe(false);
+    }
+  }
+});
+
+test("focuses the selected neighborhood and navigates inspector relationships", async ({ page }) => {
+  const changed = page.locator('[data-node-id="changed-core"]');
+  await changed.click();
+
+  await expect(changed).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator('[data-node-id="added-leaf"]')).toHaveClass(/is-neighbor/);
+  await expect(page.locator('[data-node-id="unrelated"]')).toHaveClass(/is-dimmed/);
+  await expect(page.getByRole("heading", { name: "changed-core" })).toBeVisible();
+  await expect(page.locator("#graph-inspector")).toContainText("implementation");
+  await expect(page.locator('#graph-inspector a[href="#source-change-0"]')).toBeVisible();
+  await expect(page.locator('#graph-inspector a[href="#sd1-fixture"]')).toBeVisible();
+
+  await page.locator('[data-neighbor-id="context-api"]').click();
+  await expect(page.locator("#graph-live")).toContainText("Inspecting context-api");
+  await expect(page.getByRole("heading", { name: "context-api" })).toBeVisible();
+  await expect(page.locator("#graph-inspector dt")).toHaveCount(0);
+
+  await page.locator('[data-neighbor-id="changed-core"]').click();
+  await page.locator('[data-neighbor-id="zz-outside-sample"]').click();
+  await expect(page.locator("#graph-live")).toContainText("Inspecting zz-outside-sample");
+  await expect(page.locator("#graph-note")).toContainText("outside the bounded visual sample");
+
+  await page.locator("#graph-canvas svg").click({ position: { x: 4, y: 4 } });
+  await expect(changed).toHaveAttribute("aria-pressed", "false");
+});
+
+test("supports keyboard selection, clearing, and narrow inspector layout", async ({ page }) => {
+  const changed = page.locator('[data-node-id="changed-core"]');
+  await changed.focus();
+  await page.keyboard.press("Enter");
+  await expect(changed).toHaveAttribute("aria-pressed", "true");
+  await page.keyboard.press("Escape");
+  await expect(changed).toHaveAttribute("aria-pressed", "false");
+  await expect(page.locator("#graph-live")).toContainText("Graph selection cleared");
+
+  await page.setViewportSize({ width: 720, height: 900 });
+  const canvas = await page.locator("#graph-canvas").boundingBox();
+  const inspector = await page.locator("#graph-inspector").boundingBox();
+  expect(canvas).not.toBeNull();
+  expect(inspector).not.toBeNull();
+  expect(inspector!.y).toBeGreaterThanOrEqual(canvas!.y + canvas!.height - 1);
+});
+
+test("falls back safely when graph data is unavailable", async ({ page }) => {
+  await page.evaluate(() => {
+    const runtime = globalThis as typeof globalThis & {
+      graphFixture: { destroy(): void };
+      CompassSemanticDiffGraph: {
+        mount(options: Record<string, unknown>): unknown;
+      };
+    };
+    runtime.graphFixture.destroy();
+    const data = document.getElementById("semantic-diff-data")?.textContent || "{}";
+    const report = JSON.parse(data);
+    delete report.graph_delta;
+    runtime.CompassSemanticDiffGraph.mount({
+      report,
+      host: document.getElementById("graph-canvas"),
+      inspector: document.getElementById("graph-inspector"),
+      liveRegion: document.getElementById("graph-live"),
+      note: document.getElementById("graph-note")
+    });
+  });
+
+  await expect(page.locator("#graph-canvas")).toContainText("Interactive graph unavailable.");
+  await expect(page.locator("#graph-note")).toContainText("exhaustive graph-change lists");
+  await expect(page.locator("#exhaustive-list")).toContainText("changed-core");
+});

--- a/tests/viewer/semantic-diff-graph.spec.ts
+++ b/tests/viewer/semantic-diff-graph.spec.ts
@@ -8,6 +8,8 @@ test("renders a bounded collision-free capsule graph safely", async ({ page }) =
   const nodes = page.locator("#graph-canvas [data-node-id]");
   await expect(nodes).toHaveCount(42);
   await expect(page.locator('[data-node-id="changed-core"] .graph-node-label')).toBeVisible();
+  await expect(page.locator('[data-node-id="added-leaf"] .graph-node-label')).toBeVisible();
+  await expect(page.locator('[data-node-id="removed-caller"] .graph-node-label')).toBeVisible();
   await expect(page.locator("#graph-canvas img")).toHaveCount(0);
   await expect(page.locator("body img")).toHaveCount(0);
   await expect(page.locator("#graph-note")).toContainText("42 of");


### PR DESCRIPTION
## What changed

- replace the dense semantic-diff graph with a bounded, collision-free capsule layout
- add a persistent node inspector with incoming/outgoing relationships, related findings, and source-patch navigation
- highlight the selected node and its connected topology while dimming unrelated nodes and edges
- add keyboard controls, responsive stacking, reduced-motion support, and a safe no-JavaScript/runtime fallback
- sample changed, added, and removed nodes fairly so every non-empty change category is visible
- keep exhaustive node/edge lists and embedded JSON as the authoritative complete result

## Why

The previous force-directed visualization produced overlapping labels and was difficult to inspect. Its status-priority truncation could also fill the visual sample with changed and removed nodes before any added nodes were rendered, even when the report contained many additions.

This makes the standalone semantic-diff report practical for understanding code evolution beyond line-level diffs while preserving deterministic, bounded rendering performance.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p compass-cli --all-targets --no-deps -- -D warnings`
- focused semantic-diff renderer and CLI integration tests
- `cargo test --workspace`
- 4 Chromium Playwright interaction tests
- fresh CocoIndex report generated from `9057153` to `71f9cc9`
- real report visual sample verified as 17 added, 16 removed, 9 changed, 42 total
- deterministic semantic-diff JSON verified across repeated runs
- `graphify update .`
