### PR TITLE
Accelerate versioned graph history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "compass-cypher",
  "compass-files",
  "compass-graph",
+ "compass-history",
  "compass-model",
  "compass-query",
  "rayon",

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -44,3 +44,18 @@ The release gate rejects:
 
 Local observations are diagnostic evidence. Promote a baseline only from a
 controlled Compass CI run with retained artifacts.
+
+## Versioned history qualification
+
+Build a release binary, then measure a clean real repository:
+
+```bash
+cargo build --release -p compass-cli
+scripts/qualify_history_real_repo.sh /path/to/repository OLD NEW
+```
+
+The qualification records cold/current extraction, cold/adjacent/no-op history
+builds, first/repeated semantic diff, first/repeated viewer projection, peak
+RSS, and deterministic output digests. Existing sealed realizations and cached
+diff/view projections are expected to be constant- or bounded-read paths;
+explicit `history verify` remains the full integrity scan.

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -8,8 +8,8 @@ use std::thread;
 use compass_core::{CompleteGraphBuilder, MaterializeError};
 use compass_files::{DetectOptions, IgnorePolicy, Manifest, ManifestKind, detect};
 use compass_history::{
-    BuildProfile, CompletedGraphArtifacts, CompletionEvidence, GraphArtifacts,
-    HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
+    BuildProfile, CompletedGraphArtifacts, CompletionEvidence, HISTORY_GRAPH_SCHEMA, HistoryError,
+    MAX_DIAGNOSTIC_BYTES,
 };
 
 #[derive(Clone, Debug)]
@@ -110,10 +110,12 @@ impl HistoryBuildOptions {
         &self,
         executable: PathBuf,
         working_tree_seed: Option<PathBuf>,
+        shared_cache_root: Option<PathBuf>,
     ) -> NativeCompleteGraphBuilder {
         NativeCompleteGraphBuilder {
             executable,
             working_tree_seed,
+            shared_cache_root,
             profile: self.profile.clone(),
             forwarded: self.forwarded.clone(),
             gitignore: self.gitignore,
@@ -849,6 +851,7 @@ fn resolve_provider(values: &mut HistoryBuildValues) -> Result<(), HistoryError>
 pub(crate) struct NativeCompleteGraphBuilder {
     executable: PathBuf,
     working_tree_seed: Option<PathBuf>,
+    shared_cache_root: Option<PathBuf>,
     profile: BuildProfile,
     forwarded: Vec<String>,
     gitignore: bool,
@@ -927,11 +930,7 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
         &self,
         checkout: &Path,
         output_root: &Path,
-        seed: Option<&GraphArtifacts>,
     ) -> Result<CompletedGraphArtifacts, MaterializeError> {
-        if let Some(seed) = seed {
-            seed.write_seed(&output_root.join("compass-out"), &seed_completion(seed))?;
-        }
         let mut command = Command::new(&self.executable);
         command
             .arg("extract")
@@ -947,6 +946,9 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
             .envs(self.semantic_environment.iter().cloned())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        if let Some(cache_root) = &self.shared_cache_root {
+            command.env("COMPASS_HISTORY_CACHE_ROOT", cache_root);
+        }
         for variable in [
             "GIT_DIR",
             "GIT_WORK_TREE",
@@ -1015,6 +1017,56 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
         )
         .map_err(Into::into)
     }
+
+    fn default_viewer_projection(
+        &self,
+        completed: &CompletedGraphArtifacts,
+        repository_root: &Path,
+        commit: &compass_history::CommitId,
+    ) -> Result<Option<Vec<u8>>, MaterializeError> {
+        let mut communities = compass_graph::Communities::new();
+        for node in &completed.artifacts.document.nodes {
+            let community = node
+                .attributes
+                .get("community")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default() as usize;
+            communities
+                .entry(community)
+                .or_default()
+                .push(node.id.clone());
+        }
+        let labels = completed
+            .artifacts
+            .labels
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .into_iter()
+            .flat_map(|labels| labels.iter())
+            .filter_map(|(community, label)| {
+                Some((community.parse().ok()?, label.as_str()?.to_owned()))
+            })
+            .collect::<std::collections::BTreeMap<usize, String>>();
+        let options = compass_output::HtmlOptions {
+            community_labels: (!labels.is_empty()).then_some(&labels),
+            member_counts: None,
+            node_limit: Some(5_000),
+            learning_overlay: None,
+        };
+        let Some(graph) = compass_output::graph_view_model_document(
+            &completed.artifacts.document,
+            &communities,
+            format!("{} @ {}", repository_root.display(), commit),
+            &options,
+        )
+        .map_err(|error| MaterializeError::Builder(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        serde_json::to_vec(&graph)
+            .map(Some)
+            .map_err(|error| MaterializeError::Builder(error.to_string()))
+    }
 }
 
 impl NativeCompleteGraphBuilder {
@@ -1038,29 +1090,6 @@ fn graph_stamp_matches(path: &Path, commit: &compass_history::CommitId) -> bool 
         .and_then(|stamp| stamp.built_at_commit)
         .as_deref()
         == Some(commit.as_str())
-}
-
-fn seed_completion(seed: &GraphArtifacts) -> CompletionEvidence {
-    let completed = seed
-        .manifest
-        .as_ref()
-        .and_then(serde_json::Value::as_object)
-        .into_iter()
-        .flat_map(|manifest| manifest.values())
-        .filter(|entry| {
-            entry
-                .get("semantic_hash")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|hash| !hash.is_empty())
-        })
-        .count() as u64;
-    CompletionEvidence {
-        extraction_succeeded: true,
-        allow_partial: false,
-        semantic_files_expected: completed,
-        semantic_files_completed: completed,
-        failed_chunks: 0,
-    }
 }
 
 struct BoundedOutput {
@@ -1181,6 +1210,7 @@ mod tests {
         let builder = options.builder(
             PathBuf::from("/definitely/not/a/compass-binary"),
             Some(output),
+            None,
         );
 
         let promoted = builder.promote_current(directory.path(), &commit)?;
@@ -1203,7 +1233,7 @@ mod tests {
         fs::write(directory.path().join("service.rs"), "pub fn changed() {}\n")?;
         let options =
             parse_build_command("build", &["HEAD".to_owned(), "--code-only".to_owned()])?.options;
-        let builder = options.builder(PathBuf::from("compass"), Some(output));
+        let builder = options.builder(PathBuf::from("compass"), Some(output), None);
 
         assert!(
             builder
@@ -1223,6 +1253,7 @@ mod tests {
         let builder = options.builder(
             PathBuf::from("/definitely/not/a/compass-binary"),
             Some(output),
+            None,
         );
 
         assert!(
@@ -1253,6 +1284,7 @@ mod tests {
             let builder = options.builder(
                 PathBuf::from("/definitely/not/a/compass-binary"),
                 Some(output.clone()),
+                None,
             );
 
             assert!(

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -15,7 +15,7 @@ use crate::{Frontend, Outcome};
 pub(crate) fn help(_frontend: Frontend) -> String {
     let prefix = "compass";
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  verify REV|REALIZATION [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
     )
 }
 
@@ -72,12 +72,7 @@ pub(crate) fn resolve_or_materialize(
     let existing = HistoryStore::open_existing(repository).map_err(|error| error.to_string())?;
     if !rebuild && let Some(history) = existing {
         match history.preferred(&commit) {
-            Ok(Some(preferred)) => {
-                history
-                    .validate(&preferred.id)
-                    .map_err(|error| error.to_string())?;
-                return Ok((history, preferred));
-            }
+            Ok(Some(preferred)) => return Ok((history, preferred)),
             Ok(None) => {}
             Err(error) => return Err(error.to_string()),
         }
@@ -275,6 +270,9 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
     if args[0] == "change-counts" {
         return execute_change_counts(&repository, &args[1..]);
     }
+    if args[0] == "verify" {
+        return execute_verify(&repository, &args[1..]);
+    }
     if args[0] == "gc" {
         return execute_gc(&repository, &args[1..]);
     }
@@ -365,12 +363,12 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                             "compatible":false,
                             "commit":commit,
                             "limitations":limitations,
-                            "validation":{"valid":false,"error":error.to_string()}
+                            "seal":{"valid":false,"mode":"manifest_and_direct_roots","error":error.to_string()}
                         })
                         .to_string()
                     } else {
                         format!(
-                            "history: {history_state}\nprofile: {}\nstore: incompatible\ncommit: {commit}\nlimitations: {limitation_text}\nvalidation: invalid",
+                            "history: {history_state}\nprofile: {}\nstore: incompatible\ncommit: {commit}\nlimitations: {limitation_text}\nseal: invalid",
                             config.profile_digest.as_deref().unwrap_or("none")
                         )
                     };
@@ -388,12 +386,12 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                             "commit":commit,
                             "limitations":limitations,
                             "preferred":serde_json::Value::Null,
-                            "validation":{"valid":false,"error":error.to_string()}
+                            "seal":{"valid":false,"mode":"manifest_and_direct_roots","error":error.to_string()}
                         })
                         .to_string()
                     } else {
                         format!(
-                            "history: {history_state}\nprofile: {}\nstore: present\ncommit: {commit}\nlimitations: {limitation_text}\npreferred: unreadable\nvalidation: invalid",
+                            "history: {history_state}\nprofile: {}\nstore: present\ncommit: {commit}\nlimitations: {limitation_text}\npreferred: unreadable\nseal: invalid",
                             config.profile_digest.as_deref().unwrap_or("none")
                         )
                     };
@@ -402,10 +400,6 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
             };
             if format == "json" {
                 let job = newest_job(&repository, &commit).map_err(runtime)?;
-                let validation = preferred
-                    .as_ref()
-                    .map(|value| history.validate(&value.id))
-                    .transpose();
                 let report = serde_json::json!({
                     "enabled":config.enabled,
                     "profile_digest":config.profile_digest,
@@ -415,20 +409,16 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                     "preferred":preferred.as_ref().map(|v|v.id.as_hex()),
                     "version":preferred.as_ref().map(|v|&v.version),
                     "job":job,
-                    "validation": match &validation {
-                        Ok(Some(_)) => serde_json::json!({"valid":true}),
-                        Ok(None) => serde_json::Value::Null,
-                        Err(error) => serde_json::json!({"valid":false,"error":error.to_string()}),
-                    }
+                    "seal": preferred.as_ref().map(|_| serde_json::json!({
+                        "valid":true,
+                        "mode":"manifest_and_direct_roots"
+                    }))
                 })
                 .to_string();
-                match validation {
-                    Ok(_) => Ok(report),
-                    Err(error) => Err(report_failure(report, error)),
-                }
+                Ok(report)
             } else if let Some(value) = preferred {
                 let mut prefix = format!(
-                    "history: {history_state}\nprofile: {}\nstore: present\ncommit: {commit}\nlimitations: {limitation_text}\npreferred: {}\nfingerprint: {}\nnodes: {}\nedges: {}\nprogram facts: {}\nprogram summaries: {}\nvalidation: valid",
+                    "history: {history_state}\nprofile: {}\nstore: present\ncommit: {commit}\nlimitations: {limitation_text}\npreferred: {}\nfingerprint: {}\nnodes: {}\nedges: {}\nprogram facts: {}\nprogram summaries: {}\nseal: valid",
                     config.profile_digest.as_deref().unwrap_or("none"),
                     value.id,
                     value.version.extraction_fingerprint,
@@ -449,13 +439,7 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                         prefix.push_str(&format!("\ndiagnostic: {diagnostic}"));
                     }
                 }
-                match history.validate(&value.id) {
-                    Ok(_) => Ok(prefix),
-                    Err(error) => Err(report_failure(
-                        prefix.replacen("validation: valid", "validation: invalid", 1),
-                        error,
-                    )),
-                }
+                Ok(prefix)
             } else {
                 let mut report = format!(
                     "history: {history_state}\nprofile: {}\nstore: present\ncommit: {commit}\nlimitations: {limitation_text}\npreferred: none",
@@ -729,6 +713,80 @@ impl ChangeSink for ChangeCounts {
     }
 }
 
+fn execute_verify(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {
+    let mut target = None;
+    let mut format = "text";
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--format" => {
+                index += 1;
+                format = args
+                    .get(index)
+                    .map(String::as_str)
+                    .ok_or_else(|| usage("--format requires text or json"))?;
+            }
+            value if value.starts_with("--format=") => format = &value[9..],
+            value if value.starts_with('-') => {
+                return Err(usage(format!("unknown history verify option {value}")));
+            }
+            value if target.is_none() => target = Some(value),
+            value => {
+                return Err(usage(format!(
+                    "history verify accepts one revision or realization, unexpected: {value}"
+                )));
+            }
+        }
+        index += 1;
+    }
+    if !matches!(format, "text" | "json") {
+        return Err(usage("--format must be text or json"));
+    }
+    let target = target.ok_or_else(|| usage("history verify requires REV or REALIZATION"))?;
+    let history = store(repository)?;
+    let published = if let Ok(commit) = repository.resolve(target) {
+        history
+            .preferred(&commit)
+            .map_err(runtime)?
+            .ok_or_else(|| runtime(format!("revision {commit} is not materialized")))?
+    } else {
+        let id = target.parse::<RealizationId>().map_err(runtime)?;
+        history.get(&id).map_err(runtime)?
+    };
+    let report = history.validate(&published.id).map_err(runtime)?;
+    if format == "json" {
+        serde_json::to_string(&serde_json::json!({
+            "schema":"compass.history.verification/1",
+            "valid":true,
+            "realization":published.id,
+            "commit":published.version.git_commit,
+            "records":{
+                "nodes":report.nodes,
+                "edges":report.edges,
+                "hyperedges":report.hyperedges,
+                "analysis":report.analysis_records,
+                "metadata":report.metadata_records,
+                "program_facts":report.program_fact_records,
+                "program_summaries":report.program_summary_records
+            }
+        }))
+        .map_err(runtime)
+    } else {
+        Ok(format!(
+            "verification: valid\nrealization: {}\ncommit: {}\nnodes: {}\nedges: {}\nhyperedges: {}\nanalysis records: {}\nmetadata records: {}\nprogram facts: {}\nprogram summaries: {}",
+            published.id,
+            published.version.git_commit,
+            report.nodes,
+            report.edges,
+            report.hyperedges,
+            report.analysis_records,
+            report.metadata_records,
+            report.program_fact_records,
+            report.program_summary_records
+        ))
+    }
+}
+
 fn execute_change_counts(
     repository: &Repository,
     args: &[String],
@@ -795,8 +853,6 @@ fn execute_change_counts(
         .preferred(&parent)
         .map_err(runtime)?
         .ok_or_else(|| runtime(format!("parent revision {parent} is not materialized")))?;
-    history.validate(&current.id).map_err(runtime)?;
-    history.validate(&previous.id).map_err(runtime)?;
     let mut counts = ChangeCounts::default();
     history
         .diff_records(
@@ -1490,18 +1546,12 @@ fn stored_profile(repository: &Repository, source: &str) -> Result<BuildProfile,
             .preferred(&commit)
             .map_err(|error| error.to_string())?
             .ok_or_else(|| format!("no preferred realization exists for {source}"))?;
-        history
-            .validate(&version.id)
-            .map_err(|error| error.to_string())?;
         return Ok(version.version.build_profile);
     }
     let id = source
         .parse::<RealizationId>()
         .map_err(|_| format!("--profile-from must name a revision or realization, got {source}"))?;
     let version = history.get(&id).map_err(|error| error.to_string())?;
-    history
-        .validate(&version.id)
-        .map_err(|error| error.to_string())?;
     Ok(version.version.build_profile)
 }
 

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -5,8 +5,9 @@ use compass_core::{
 };
 use compass_history::{
     ArtifactClass, BuildProfile, ChangeKind, ChangeSink, ClaimedJob, CommitId,
-    ExtractionFingerprint, GitTargetLimitation, GraphChange, HistoryConfig, HistoryError,
-    HistoryQueue, HistoryStore, JobRequest, JobState, PublishedVersion, RealizationId, Repository,
+    DerivedCacheNamespace, ExtractionFingerprint, GitTargetLimitation, GraphChange, HistoryConfig,
+    HistoryError, HistoryQueue, HistoryStore, JobRequest, JobState, PublishedVersion,
+    RealizationId, Repository,
 };
 
 use crate::history_build::{HistoryBuildOptions, parse_build_command, parse_enable_options};
@@ -15,7 +16,7 @@ use crate::{Frontend, Outcome};
 pub(crate) fn help(_frontend: Frontend) -> String {
     let prefix = "compass";
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  verify REV|REALIZATION [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  verify REV|REALIZATION [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  cache status [--format text|json]\n  cache gc [--max-bytes N] [--max-age-days N] [--yes] [--format text|json]\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
     )
 }
 
@@ -53,13 +54,34 @@ pub(crate) fn load_graph_at(
         .map_err(|error| error.to_string())?;
     let options = configured_build_options(&repository)?;
     let (history, preferred) = resolve_or_materialize(&repository, commit, &options, false, false)?;
-    let activity = history.activity().map_err(|error| error.to_string())?;
-    // `artifacts` performs full realization validation before reconstruction.
-    let artifacts = history
-        .artifacts_with_activity(&preferred.id, &activity)
-        .map_err(|error| error.to_string())?;
-    LoadedGraph::from_document(artifacts.artifacts.document, force_directed)
-        .map_err(|error| error.to_string())
+    let cache = history.cache().map_err(|error| error.to_string())?;
+    let cache_key = serde_json::json!({
+        "schema": "compass.history.graph_query_key/1",
+        "realization": preferred.id.to_string(),
+        "projection_version": 1,
+    });
+    let document = cache
+        .read(DerivedCacheNamespace::Viewer, &cache_key, 256 * 1024 * 1024)
+        .ok()
+        .flatten()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+    let document = match document {
+        Some(document) => document,
+        None => {
+            let reader = history
+                .reader(&preferred.id)
+                .map_err(|error| error.to_string())?;
+            let document = compass_output::historical_graph_document(&reader)
+                .map_err(|error| error.to_string())?;
+            if let Ok(value) = serde_json::to_value(&document)
+                && let Ok(bytes) = compass_history::canonical_json_bytes(&value)
+            {
+                let _ = cache.write(DerivedCacheNamespace::Viewer, &cache_key, &bytes);
+            }
+            document
+        }
+    };
+    LoadedGraph::from_document(document, force_directed).map_err(|error| error.to_string())
 }
 
 pub(crate) fn resolve_or_materialize(
@@ -272,6 +294,9 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
     }
     if args[0] == "verify" {
         return execute_verify(&repository, &args[1..]);
+    }
+    if args[0] == "cache" {
+        return execute_cache(&repository, &args[1..]);
     }
     if args[0] == "gc" {
         return execute_gc(&repository, &args[1..]);
@@ -560,35 +585,31 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                             "revision {commit} is not materialized; build it explicitly first"
                         ))
                     })?;
-                history.validate(&preferred.id).map_err(runtime)?;
-                let artifacts = history.artifacts(&preferred.id).map_err(runtime)?;
-                let communities = communities_from_document(&artifacts.artifacts.document);
-                let labels = history_labels(artifacts.artifacts.labels.as_ref());
-                let options = compass_output::HtmlOptions {
-                    community_labels: (!labels.is_empty()).then_some(&labels),
-                    member_counts: None,
-                    node_limit: Some(node_limit),
-                    learning_overlay: None,
+                let cache_key = serde_json::json!({
+                    "schema": "compass.history.viewer_key/1",
+                    "realization": preferred.id.to_string(),
+                    "viewer_schema": "compass.history.viewer_graph/1",
+                    "projection_version": 1,
+                    "node_limit": node_limit,
+                    "community": community,
+                });
+                let cache = history.cache().map_err(runtime)?;
+                if let Some(bytes) = cache
+                    .read(DerivedCacheNamespace::Viewer, &cache_key, 256 * 1024 * 1024)
+                    .ok()
+                    .flatten()
+                {
+                    compass_files::write_bytes_atomic(&output, &bytes).map_err(runtime)?;
+                    return Ok(format!("exported {} to {}", preferred.id, output.display()));
                 };
-                let graph = if let Some(community) = community {
-                    compass_output::graph_community_view_model_document(
-                        &artifacts.artifacts.document,
-                        &communities,
-                        format!("{} @ {}", repository.root().display(), commit),
-                        &options,
-                        community,
-                    )
-                    .map_err(runtime)?
-                } else {
-                    compass_output::graph_view_model_document(
-                        &artifacts.artifacts.document,
-                        &communities,
-                        format!("{} @ {}", repository.root().display(), commit),
-                        &options,
-                    )
-                    .map_err(runtime)?
-                    .ok_or_else(|| runtime("historical graph has no renderable overview"))?
-                };
+                let reader = history.reader(&preferred.id).map_err(runtime)?;
+                let graph = compass_output::historical_view_model(
+                    &reader,
+                    format!("{} @ {}", repository.root().display(), commit),
+                    node_limit,
+                    community,
+                )
+                .map_err(runtime)?;
                 let envelope = serde_json::json!({
                     "schema": "compass.history.viewer_graph/1",
                     "commit": commit,
@@ -596,7 +617,8 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
                     "fingerprint": preferred.version.extraction_fingerprint,
                     "graph": graph,
                 });
-                let bytes = serde_json::to_vec(&envelope).map_err(runtime)?;
+                let bytes = compass_history::canonical_json_bytes(&envelope).map_err(runtime)?;
+                let _ = cache.write(DerivedCacheNamespace::Viewer, &cache_key, &bytes);
                 compass_files::write_bytes_atomic(&output, &bytes).map_err(runtime)?;
                 return Ok(format!("exported {} to {}", preferred.id, output.display()));
             }
@@ -853,11 +875,12 @@ fn execute_change_counts(
         .preferred(&parent)
         .map_err(runtime)?
         .ok_or_else(|| runtime(format!("parent revision {parent} is not materialized")))?;
+    let previous_reader = history.reader(&previous.id).map_err(runtime)?;
+    let current_reader = history.reader(&current.id).map_err(runtime)?;
     let mut counts = ChangeCounts::default();
-    history
+    previous_reader
         .diff_records(
-            &previous.id,
-            &current.id,
+            &current_reader,
             &[
                 compass_history::RecordKind::Node,
                 compass_history::RecordKind::Edge,
@@ -875,33 +898,101 @@ fn execute_change_counts(
     .map_err(runtime)
 }
 
-fn communities_from_document(
-    document: &compass_model::GraphDocument,
-) -> compass_graph::Communities {
-    let mut communities = compass_graph::Communities::new();
-    for node in &document.nodes {
-        let community = node
-            .attributes
-            .get("community")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or_default() as usize;
-        communities
-            .entry(community)
-            .or_default()
-            .push(node.id.clone());
+fn execute_cache(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return Err(usage("history cache requires status or gc"));
+    };
+    let history = store(repository)?;
+    let cache = history.cache().map_err(runtime)?;
+    match command {
+        "status" => {
+            let format = parse_cache_format(&args[1..])?;
+            let status = cache.status().map_err(runtime)?;
+            if format == "json" {
+                serde_json::to_string(&status).map_err(runtime)
+            } else {
+                Ok(format!(
+                    "cache files: {}\ncache bytes: {}",
+                    status.files, status.bytes
+                ))
+            }
+        }
+        "gc" => {
+            let mut max_bytes = None;
+            let mut max_age_days = None;
+            let mut yes = false;
+            let mut format = "text";
+            let mut index = 1;
+            while index < args.len() {
+                match args[index].as_str() {
+                    "--yes" => yes = true,
+                    "--max-bytes" => {
+                        index += 1;
+                        max_bytes = Some(
+                            args.get(index)
+                                .ok_or_else(|| usage("--max-bytes requires a value"))?
+                                .parse()
+                                .map_err(|_| usage("--max-bytes must be an integer"))?,
+                        );
+                    }
+                    "--max-age-days" => {
+                        index += 1;
+                        max_age_days = Some(
+                            args.get(index)
+                                .ok_or_else(|| usage("--max-age-days requires a value"))?
+                                .parse::<u64>()
+                                .map_err(|_| usage("--max-age-days must be an integer"))?,
+                        );
+                    }
+                    "--format" => {
+                        index += 1;
+                        format = args
+                            .get(index)
+                            .ok_or_else(|| usage("--format requires a value"))?;
+                        if !matches!(format, "text" | "json") {
+                            return Err(usage("--format must be text or json"));
+                        }
+                    }
+                    option => return Err(usage(format!("unknown cache gc option {option}"))),
+                }
+                index += 1;
+            }
+            let max_age = max_age_days
+                .map(|days| std::time::Duration::from_secs(days.saturating_mul(86_400)));
+            let plan = cache.plan_gc(max_bytes, max_age).map_err(runtime)?;
+            if yes {
+                let _maintenance = history.maintenance().map_err(runtime)?;
+                cache.sweep(&plan).map_err(runtime)?;
+            }
+            if format == "json" {
+                serde_json::to_string(&serde_json::json!({
+                    "dry_run": !yes,
+                    "files": plan.files,
+                    "bytes": plan.bytes,
+                    "paths": plan.paths,
+                }))
+                .map_err(runtime)
+            } else {
+                Ok(format!(
+                    "cache gc: {}\nfiles: {}\nbytes: {}",
+                    if yes { "completed" } else { "dry run" },
+                    plan.files,
+                    plan.bytes
+                ))
+            }
+        }
+        _ => Err(usage("history cache requires status or gc")),
     }
-    communities
 }
 
-fn history_labels(labels: Option<&serde_json::Value>) -> std::collections::BTreeMap<usize, String> {
-    labels
-        .and_then(serde_json::Value::as_object)
-        .into_iter()
-        .flat_map(|labels| labels.iter())
-        .filter_map(|(community, label)| {
-            Some((community.parse().ok()?, label.as_str()?.to_owned()))
-        })
-        .collect()
+fn parse_cache_format(args: &[String]) -> Result<&str, CommandFailure> {
+    match args {
+        [] => Ok("text"),
+        [flag, value] if flag == "--format" && matches!(value.as_str(), "text" | "json") => {
+            Ok(value)
+        }
+        _ => Err(usage("cache status accepts only --format text|json")),
+    }
 }
 
 fn execute_timeline(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {
@@ -1326,7 +1417,12 @@ fn run_claimed_job(
         .filter(|head| head == &claimed.commit)
         .map(|_| repository.root().join("compass-out"))
         .filter(|path| path.join("graph.json").is_file());
-    let builder = options.builder(executable, working_tree_seed);
+    let shared_cache_root = history
+        .cache()
+        .map_err(runtime)?
+        .extraction_root()
+        .to_path_buf();
+    let builder = options.builder(executable, working_tree_seed, Some(shared_cache_root));
     let heartbeat_job = claimed.clone();
     let heartbeat_root = queue.root().to_path_buf();
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -1755,6 +1755,9 @@ fn command_build_with_validation_inner(
     };
     options.scan_filesystem = has_explicit_root || !extract;
     options.output_root = output_root;
+    options.cache_root = std::env::var_os("COMPASS_HISTORY_CACHE_ROOT")
+        .map(PathBuf::from)
+        .filter(|_| environment_truthy("COMPASS_HISTORY_BUILD"));
     options.force = force;
     options.reuse_cache_on_force = reuse_cache_on_force;
     options.no_cluster = no_cluster;
@@ -2199,7 +2202,9 @@ fn build_semantic_graph(
         cache_enabled: true,
         prune_live_files: Some(live_semantic),
     };
-    let cache_root = (output_root != root).then_some(output_root.as_path());
+    let history_cache_root = options.cache_root.as_deref();
+    let cache_root =
+        history_cache_root.or_else(|| (output_root != root).then_some(output_root.as_path()));
 
     let extracted = if semantic_files.is_empty() {
         None

--- a/crates/compass-cli/src/semantic_commands.rs
+++ b/crates/compass-cli/src/semantic_commands.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use compass_files::{Cache, write_text_atomic};
+use compass_files::{Cache, CacheOptions, write_text_atomic};
 use compass_semantic::{
     MAX_SEMANTIC_FRAGMENT_BYTES, check_semantic_cache_mode, load_validated_semantic_fragment,
 };
@@ -72,13 +72,13 @@ pub(super) fn command_cache_check(frontend: Frontend, args: &[String]) -> Outcom
             Ok(prompt) => Some(prompt),
             Err(error) => {
                 stderr = format!(
-                    "warning: could not read prompt file {}; using legacy cache namespace: {error}",
+                    "warning: could not read prompt file {}; using the default prompt namespace: {error}",
                     path.display()
                 );
                 None
             }
         });
-    let mut cache = match Cache::new(&root, None) {
+    let mut cache = match Cache::open(&root, CacheOptions::output_directory(None)) {
         Ok(cache) => cache,
         Err(error) => return Outcome::failure(format!("error: {error}")),
     };

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -160,13 +160,12 @@ fn execute(args: &[String]) -> Result<CommandOutput, CommandError> {
                 test_evidence: &test_evidence,
             })
             .map_err(runtime)?;
-            if let (Some(cache), Ok(payload)) = (
-                &cache,
-                canonical_json_bytes(&serde_json::to_value(&report).map_err(runtime)?),
-            ) {
+            let payload = canonical_json_bytes(&serde_json::to_value(&report).map_err(runtime)?)
+                .map_err(runtime)?;
+            if let Some(cache) = &cache {
                 let _ = cache.write(DerivedCacheNamespace::SemanticDiff, &cache_key, &payload);
             }
-            report
+            serde_json::from_slice(&payload).map_err(runtime)?
         }
     };
     let render = RenderOptions {

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -2,16 +2,18 @@ use std::path::PathBuf;
 
 use compass_analysis::FunctionSummary;
 use compass_history::{
-    ChangeKind, ChangeSink, ExtractionFingerprint, GraphChange, HistoryError, HistoryRecord,
-    HistoryRecordKey, HistoryStore, RealizationId, RecordKind, Repository,
+    ChangeKind, ChangeSink, DerivedCacheNamespace, ExtractionFingerprint, GraphChange,
+    HistoryError, HistoryRecord, HistoryRecordKey, RealizationReader, RecordKind, Repository,
+    canonical_json_bytes,
 };
 use compass_ir::{FunctionIr, ModuleIr};
 use compass_model::NodeRecord;
 use compass_semantic_diff::{
     ChangeDirection, DependencyDelta, EvidenceRef, GraphDelta, GraphEdgeDelta, GraphNodeDelta,
-    SemanticDiffError, SemanticDiffInput, SnapshotIdentity, SnapshotReader, SnapshotSide,
-    StaticTestEvidence, compare,
+    SemanticDiffError, SemanticDiffInput, SemanticDiffReport, SnapshotIdentity, SnapshotReader,
+    SnapshotSide, StaticTestEvidence, compare,
 };
+use sha2::{Digest, Sha256};
 
 use crate::semantic_diff_render::{RenderOptions, render_html, render_json, render_text};
 use crate::{Frontend, Outcome, history_commands};
@@ -95,43 +97,78 @@ fn execute(args: &[String]) -> Result<CommandOutput, CommandError> {
         options.fingerprint.as_deref(),
     )
     .map_err(CommandError::Runtime)?;
-    let mut direct = DirectChanges::default();
-    resolved
-        .history
-        .diff_records(
-            &resolved.old.id,
-            &resolved.new.id,
-            &[RecordKind::Node, RecordKind::Edge],
-            &mut direct,
-        )
-        .map_err(runtime)?;
-    direct.cancel_attribute_only_dependency_churn();
-    direct.normalize_graph_delta();
-    let snapshots = HistorySnapshots {
-        store: &resolved.history,
-        old: &resolved.old.id,
-        new: &resolved.new.id,
+    let source_delta_bytes =
+        canonical_json_bytes(&serde_json::to_value(&source_deltas).map_err(runtime)?)
+            .map_err(runtime)?;
+    let cache_key = serde_json::json!({
+        "schema": "compass.semantic_diff.cache_key/1",
+        "engine_version": compass_semantic_diff::ENGINE_VERSION,
+        "old_realization": resolved.old.id.to_string(),
+        "new_realization": resolved.new.id.to_string(),
+        "source_delta_sha256": format!("{:x}", Sha256::digest(&source_delta_bytes)),
+    });
+    let cache = resolved.history.cache().ok();
+    let cached_report = cache
+        .as_ref()
+        .and_then(|cache| {
+            cache
+                .read(
+                    DerivedCacheNamespace::SemanticDiff,
+                    &cache_key,
+                    128 * 1024 * 1024,
+                )
+                .ok()
+                .flatten()
+        })
+        .and_then(|bytes| serde_json::from_slice::<SemanticDiffReport>(&bytes).ok());
+    let report = match cached_report {
+        Some(report) => report,
+        None => {
+            let mut direct = DirectChanges::default();
+            let old_reader = resolved.history.reader(&resolved.old.id).map_err(runtime)?;
+            let new_reader = resolved.history.reader(&resolved.new.id).map_err(runtime)?;
+            old_reader
+                .diff_records(
+                    &new_reader,
+                    &[RecordKind::Node, RecordKind::Edge],
+                    &mut direct,
+                )
+                .map_err(runtime)?;
+            direct.cancel_attribute_only_dependency_churn();
+            direct.normalize_graph_delta();
+            let snapshots = HistorySnapshots {
+                old: old_reader,
+                new: new_reader,
+            };
+            let test_evidence = StaticTestEvidence::new(&snapshots, SnapshotSide::New);
+            let report = compare(SemanticDiffInput {
+                old: SnapshotIdentity {
+                    commit: resolved.old.version.git_commit.clone(),
+                    realization: resolved.old.id.to_string(),
+                    fingerprint: resolved.old.version.profile_digest.clone(),
+                },
+                new: SnapshotIdentity {
+                    commit: resolved.new.version.git_commit.clone(),
+                    realization: resolved.new.id.to_string(),
+                    fingerprint: resolved.new.version.profile_digest.clone(),
+                },
+                source_deltas: &source_deltas,
+                changed_node_ids: &direct.nodes,
+                dependency_deltas: &direct.dependencies,
+                graph_delta: &direct.graph_delta,
+                snapshots: &snapshots,
+                test_evidence: &test_evidence,
+            })
+            .map_err(runtime)?;
+            if let (Some(cache), Ok(payload)) = (
+                &cache,
+                canonical_json_bytes(&serde_json::to_value(&report).map_err(runtime)?),
+            ) {
+                let _ = cache.write(DerivedCacheNamespace::SemanticDiff, &cache_key, &payload);
+            }
+            report
+        }
     };
-    let test_evidence = StaticTestEvidence::new(&snapshots, SnapshotSide::New);
-    let report = compare(SemanticDiffInput {
-        old: SnapshotIdentity {
-            commit: resolved.old.version.git_commit.clone(),
-            realization: resolved.old.id.to_string(),
-            fingerprint: resolved.old.version.profile_digest.clone(),
-        },
-        new: SnapshotIdentity {
-            commit: resolved.new.version.git_commit.clone(),
-            realization: resolved.new.id.to_string(),
-            fingerprint: resolved.new.version.profile_digest.clone(),
-        },
-        source_deltas: &source_deltas,
-        changed_node_ids: &direct.nodes,
-        dependency_deltas: &direct.dependencies,
-        graph_delta: &direct.graph_delta,
-        snapshots: &snapshots,
-        test_evidence: &test_evidence,
-    })
-    .map_err(runtime)?;
     let render = RenderOptions {
         include_routine: options.all,
         max_findings_per_section: options.limit.or((!options.all).then_some(20)),
@@ -305,16 +342,15 @@ fn parse_format(value: &str) -> Result<Format, String> {
 }
 
 struct HistorySnapshots<'a> {
-    store: &'a HistoryStore,
-    old: &'a RealizationId,
-    new: &'a RealizationId,
+    old: RealizationReader<'a>,
+    new: RealizationReader<'a>,
 }
 
 impl HistorySnapshots<'_> {
-    fn realization(&self, side: SnapshotSide) -> &RealizationId {
+    fn reader(&self, side: SnapshotSide) -> &RealizationReader<'_> {
         match side {
-            SnapshotSide::Old => self.old,
-            SnapshotSide::New => self.new,
+            SnapshotSide::Old => &self.old,
+            SnapshotSide::New => &self.new,
         }
     }
 }
@@ -326,8 +362,8 @@ impl SnapshotReader for HistorySnapshots<'_> {
         node_id: &str,
     ) -> Result<Option<NodeRecord>, SemanticDiffError> {
         match self
-            .store
-            .read_record(self.realization(side), HistoryRecordKey::Node(node_id))
+            .reader(side)
+            .read(HistoryRecordKey::Node(node_id))
             .map_err(evidence_error)?
         {
             Some(HistoryRecord::Node(node)) => Ok(Some(node)),
@@ -344,11 +380,8 @@ impl SnapshotReader for HistorySnapshots<'_> {
         source_file: &str,
     ) -> Result<Option<ModuleIr>, SemanticDiffError> {
         match self
-            .store
-            .read_record(
-                self.realization(side),
-                HistoryRecordKey::ProgramModule(source_file),
-            )
+            .reader(side)
+            .read(HistoryRecordKey::ProgramModule(source_file))
             .map_err(evidence_error)?
         {
             Some(HistoryRecord::ProgramModule(module)) => Ok(Some(module)),
@@ -365,11 +398,8 @@ impl SnapshotReader for HistorySnapshots<'_> {
         symbol_id: &str,
     ) -> Result<Option<FunctionSummary>, SemanticDiffError> {
         match self
-            .store
-            .read_record(
-                self.realization(side),
-                HistoryRecordKey::ProgramSummary(symbol_id),
-            )
+            .reader(side)
+            .read(HistoryRecordKey::ProgramSummary(symbol_id))
             .map_err(evidence_error)?
         {
             Some(HistoryRecord::ProgramSummary(summary)) => Ok(Some(summary)),
@@ -386,11 +416,8 @@ impl SnapshotReader for HistorySnapshots<'_> {
         symbol_id: &str,
     ) -> Result<Option<FunctionIr>, SemanticDiffError> {
         match self
-            .store
-            .read_record(
-                self.realization(side),
-                HistoryRecordKey::ProgramFunction(symbol_id),
-            )
+            .reader(side)
+            .read(HistoryRecordKey::ProgramFunction(symbol_id))
             .map_err(evidence_error)?
         {
             Some(HistoryRecord::ProgramFunction(function)) => Ok(Some(function)),
@@ -407,11 +434,8 @@ impl SnapshotReader for HistorySnapshots<'_> {
         symbol_id: &str,
     ) -> Result<Vec<String>, SemanticDiffError> {
         match self
-            .store
-            .read_record(
-                self.realization(side),
-                HistoryRecordKey::ReverseCallers(symbol_id),
-            )
+            .reader(side)
+            .read(HistoryRecordKey::ReverseCallers(symbol_id))
             .map_err(evidence_error)?
         {
             Some(HistoryRecord::ReverseCallers(callers)) => Ok(callers),

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -116,7 +116,8 @@ fn history_help_and_empty_status_are_actionable_and_non_mutating()
     assert_eq!(incompatible_json.status.code(), Some(1));
     let incompatible_json: serde_json::Value = serde_json::from_slice(&incompatible_json.stdout)?;
     assert_eq!(incompatible_json["compatible"], false);
-    assert_eq!(incompatible_json["validation"]["valid"], false);
+    assert_eq!(incompatible_json["seal"]["valid"], false);
+    assert!(incompatible_json.get("validation").is_none());
     Ok(())
 }
 
@@ -903,9 +904,18 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
     )?;
     assert!(status.status.success());
     assert_eq!(
-        serde_json::from_slice::<serde_json::Value>(&status.stdout)?["validation"]["valid"],
+        serde_json::from_slice::<serde_json::Value>(&status.stdout)?["seal"]["valid"],
         true
     );
+    let verified = run(
+        compass,
+        directory.path(),
+        &["history", "verify", &first.id.to_string(), "--format=json"],
+    )?;
+    assert!(verified.status.success());
+    let verified: serde_json::Value = serde_json::from_slice(&verified.stdout)?;
+    assert_eq!(verified["valid"], true);
+    assert_eq!(verified["realization"], first.id.to_string());
     assert_ne!(first.id, second.id);
     Ok(())
 }
@@ -1496,7 +1506,7 @@ fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std:
     assert!(!directory.path().join("compass-out").exists());
     let status = run(compass, directory.path(), &["history", "status", "HEAD~1"])?;
     assert!(status.status.success());
-    assert!(String::from_utf8_lossy(&status.stdout).contains("validation: valid"));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("seal: valid"));
     Ok(())
 }
 

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -6,9 +6,9 @@ use compass_files::{DetectOptions, IgnorePolicy, detect};
 use compass_graph::{Communities, god_nodes, score_communities, surprising_connections};
 use compass_history::{
     BuildProfile, CommitId, CompletedGraphArtifacts, CompletionEvidence, CorruptPreferredToken,
-    ExtractionFingerprint, ExtractionFingerprintInput, GraphArtifacts, HISTORY_GRAPH_SCHEMA,
-    HistoryError, HistoryStore, PublishRequest, PublishedVersion, RealizationId, Repository,
-    WorktreeGuard,
+    DerivedCacheNamespace, ExtractionFingerprint, ExtractionFingerprintInput, GraphArtifacts,
+    HISTORY_GRAPH_SCHEMA, HistoryError, HistoryStore, PublishRequest, PublishedVersion,
+    RealizationId, Repository, WorktreeGuard,
 };
 use compass_languages::Registry;
 use serde_json::json;
@@ -30,8 +30,16 @@ pub trait CompleteGraphBuilder {
         &self,
         checkout: &Path,
         output_root: &Path,
-        seed: Option<&GraphArtifacts>,
     ) -> Result<CompletedGraphArtifacts, MaterializeError>;
+
+    fn default_viewer_projection(
+        &self,
+        _completed: &CompletedGraphArtifacts,
+        _repository_root: &Path,
+        _commit: &CommitId,
+    ) -> Result<Option<Vec<u8>>, MaterializeError> {
+        Ok(None)
+    }
 }
 
 /// Convert a verified mutable code-only snapshot into the canonical artifact
@@ -325,21 +333,14 @@ fn run_materialization(
 ) -> Result<PublishedVersion, MaterializeError> {
     let fingerprint = resolve_fingerprint(&request.profile, worktree.path())?;
     observer.resolved(&fingerprint)?;
-    let seed = compatible_seed(
-        store,
-        &request.repository,
-        &request.commit,
-        &request.profile,
-        activity,
-    )?;
     observer.entered(MaterializeStage::Building)?;
-    let completed = builder.build(
-        worktree.path(),
-        worktree.output_root(),
-        seed.as_ref().map(|value| &value.artifacts),
-    )?;
+    let completed = builder.build(worktree.path(), worktree.output_root())?;
     observer.entered(MaterializeStage::Validating)?;
     validate_completed(&completed, &request.commit, &request.profile, worktree)?;
+    let default_viewer = builder
+        .default_viewer_projection(&completed, request.repository.root(), &request.commit)
+        .ok()
+        .flatten();
     observer.entered(MaterializeStage::Publishing)?;
     let prepared = store.prepare_publish_with_activity(
         PublishRequest {
@@ -370,6 +371,30 @@ fn run_materialization(
             published.preferred = false;
         }
     }
+    if let Some(graph_bytes) = default_viewer
+        && let Ok(graph) = serde_json::from_slice::<serde_json::Value>(&graph_bytes)
+    {
+        let cache_key = json!({
+            "schema": "compass.history.viewer_key/1",
+            "realization": published.id.to_string(),
+            "viewer_schema": "compass.history.viewer_graph/1",
+            "projection_version": 1,
+            "node_limit": 5_000,
+            "community": serde_json::Value::Null,
+        });
+        let envelope = json!({
+            "schema": "compass.history.viewer_graph/1",
+            "commit": published.version.git_commit.clone(),
+            "realization": published.id.to_string(),
+            "fingerprint": published.version.extraction_fingerprint.clone(),
+            "graph": graph,
+        });
+        if let Ok(bytes) = compass_history::canonical_json_bytes(&envelope)
+            && let Ok(cache) = store.cache()
+        {
+            let _ = cache.write(DerivedCacheNamespace::Viewer, &cache_key, &bytes);
+        }
+    }
     Ok(published)
 }
 
@@ -390,37 +415,6 @@ fn observe_preferred(
         }
         Err(error) => Err(error.into()),
     }
-}
-
-fn compatible_seed(
-    store: &HistoryStore,
-    repository: &Repository,
-    target: &CommitId,
-    profile: &BuildProfile,
-    activity: &compass_history::ActivityGuard,
-) -> Result<Option<CompletedGraphArtifacts>, MaterializeError> {
-    for ancestor in repository.first_parent_ancestors(target)? {
-        let preferred = match store.preferred_with_activity(&ancestor, activity) {
-            Ok(preferred) => preferred,
-            Err(error) if error.is_catalog_corruption() => continue,
-            Err(error) => return Err(error.into()),
-        };
-        let Some(preferred) = preferred else {
-            continue;
-        };
-        // The provider manifest is commit-specific and therefore belongs in the
-        // realization fingerprint, but it must not disable incremental seeding.
-        // The builder revalidates the seed against the exact target checkout.
-        if &preferred.version.build_profile != profile {
-            continue;
-        }
-        match store.artifacts_with_activity(&preferred.id, activity) {
-            Ok(artifacts) => return Ok(Some(artifacts)),
-            Err(error) if error.is_catalog_corruption() => continue,
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(None)
 }
 
 fn resolve_fingerprint(

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -379,14 +379,7 @@ fn observe_preferred(
     activity: &compass_history::ActivityGuard,
 ) -> Result<(Option<PublishedVersion>, Option<CorruptPreferredToken>), MaterializeError> {
     match store.preferred_with_activity(commit, activity) {
-        Ok(Some(published)) => match store.validate_with_activity(&published.id, activity) {
-            Ok(_) => Ok((Some(published), None)),
-            Err(error) if error.is_catalog_corruption() => {
-                let token = store.corrupt_preferred_token_with_activity(commit, activity)?;
-                Ok((None, Some(token)))
-            }
-            Err(error) => Err(error.into()),
-        },
+        Ok(Some(published)) => Ok((Some(published), None)),
         Ok(None) => Ok((None, None)),
         Err(original) if original.is_catalog_corruption() => {
             match store.corrupt_preferred_token_with_activity(commit, activity) {

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 
 use ahash::{AHashMap, AHashSet};
 use compass_files::{
-    BuildGuard, BuildScope, Cache, CacheKind, DetectOptions, Detection, IgnorePolicy, Manifest,
-    ManifestKind, detect, write_json_ascii_atomic, write_json_atomic, write_text_atomic,
+    BuildGuard, BuildScope, Cache, CacheKind, CacheOptions, DetectOptions, Detection, IgnorePolicy,
+    Manifest, ManifestKind, detect, write_json_ascii_atomic, write_json_atomic, write_text_atomic,
 };
 use compass_graph::{
     ClusterOptions, EntityTiebreaker, build_owned_with_tiebreaker as build_document, cluster,
@@ -39,6 +39,8 @@ pub struct BuildOptions {
     pub root: PathBuf,
     pub scan_filesystem: bool,
     pub output_root: Option<PathBuf>,
+    /// Explicit repository-private cache root used by exact history builds.
+    pub cache_root: Option<PathBuf>,
     pub force: bool,
     /// Preserve validated extraction and completed-output fast paths while
     /// retaining force authorization for output replacement.
@@ -99,6 +101,7 @@ impl BuildOptions {
             root: root.into(),
             scan_filesystem: true,
             output_root: None,
+            cache_root: None,
             force: false,
             reuse_cache_on_force: false,
             no_cluster: false,
@@ -441,7 +444,6 @@ fn build_graph_inner(
     let build_profile = build_profile(options);
     let has_program_artifacts =
         options.program_analysis && program_artifact_count(&root, options)? != 0;
-    let build_state_present = output_dir.join(BUILD_STATE_FILE).is_file();
     let verified_state = if semantic.is_none() && supplemental.is_empty() && manifest_unchanged {
         load_verified(
             &output_dir,
@@ -452,8 +454,7 @@ fn build_graph_inner(
     } else {
         None
     };
-    let allow_legacy_validation = prior_build_complete
-        && (!build_state_present || (has_program_artifacts && verified_state.is_some()));
+    let verified_output = verified_state.is_some();
     if !has_program_artifacts {
         let verified = verified_state;
         if let Some(state) = verified.filter(|state| state.stats.files == sources.len()) {
@@ -495,7 +496,7 @@ fn build_graph_inner(
         && semantic.is_none()
         && supplemental.is_empty()
         && manifest_unchanged
-        && allow_legacy_validation
+        && verified_output
     {
         load_current_program(&root, &sources, options, &output_dir)?
     } else {
@@ -504,7 +505,7 @@ fn build_graph_inner(
     if semantic.is_none()
         && supplemental.is_empty()
         && manifest_unchanged
-        && allow_legacy_validation
+        && verified_output
         && (!options.program_analysis || unchanged_program.is_some())
         && let Some(stats) = unchanged_output_stats(options, &output_dir)
     {
@@ -560,13 +561,17 @@ fn build_graph_inner(
         });
     }
 
-    let cache_root = (output_root != root).then_some(output_root.as_path());
-    let mut cache = Cache::new(&root, cache_root)?;
+    let output_cache_root = (output_root != root).then_some(output_root.as_path());
+    let cache_options = options.cache_root.as_deref().map_or_else(
+        || CacheOptions::output_directory(output_cache_root),
+        CacheOptions::shared_history,
+    );
+    let mut cache = Cache::open(&root, cache_options)?;
     let mut extractions = BTreeMap::<PathBuf, Extraction>::new();
     let mut missing = Vec::new();
     if !options.force || options.reuse_cache_on_force {
         for path in &sources {
-            let cached = cache.load(path, &CacheKind::Ast, None, false, false)?;
+            let cached = cache.load(path, &CacheKind::Ast, None, false)?;
             if let Some(value) = cached {
                 let extraction =
                     serde_json::from_value(value).map_err(|source| CoreError::InvalidCache {
@@ -670,15 +675,20 @@ fn build_graph_inner(
         let program_sources = sources.clone();
         let mut program_options = options.clone();
         program_options.force = options.force && !options.reuse_cache_on_force;
-        let program_cache_root = cache_root.map(Path::to_path_buf);
+        let program_cache_root = options.cache_root.clone();
+        let program_output_cache_root = output_cache_root.map(Path::to_path_buf);
         let program_output_dir = output_dir.clone();
         Some(
             std::thread::Builder::new()
                 .name("compass-program".to_owned())
                 .spawn(move || {
                     let started = Instant::now();
-                    let program_cache = Cache::new(&program_root, program_cache_root.as_deref())?
-                        .without_hash_flush();
+                    let program_cache_options = program_cache_root.as_deref().map_or_else(
+                        || CacheOptions::output_directory(program_output_cache_root.as_deref()),
+                        CacheOptions::shared_history,
+                    );
+                    let program_cache =
+                        Cache::open(&program_root, program_cache_options)?.without_hash_flush();
                     let program = build_program(
                         &program_root,
                         &program_sources,
@@ -1076,9 +1086,8 @@ fn build_graph_inner(
     }
 
     // A history realization must depend only on the target commit and build
-    // profile. Incremental seeds may accelerate extraction, but their prior
-    // community numbering is operational state and cannot influence the
-    // content-addressed result.
+    // profile. Prior community numbering is current-worktree operational state
+    // and cannot influence the content-addressed result.
     let cluster_options = ClusterOptions {
         resolution: options.resolution,
         exclude_hubs_percentile: options.exclude_hubs,

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -704,20 +704,11 @@ fn build_graph_inner(
     } else {
         None
     };
-    let ast_cache_entries = fresh
+    let mut ast_cache_entries = fresh
         .par_iter()
         .filter(|(_, extraction, _, _)| !extraction.nodes.is_empty())
         .map(|(path, extraction, _, _)| (path.clone(), extraction.clone()))
         .collect::<Vec<_>>();
-    let ast_cache_handle = std::thread::Builder::new()
-        .name("compass-ast-cache".to_owned())
-        .spawn(move || {
-            let started = Instant::now();
-            cache.save_portable_ast_batch(&ast_cache_entries)?;
-            cache.flush()?;
-            Ok::<_, CoreError>(started.elapsed())
-        })
-        .map_err(|error| CoreError::WorkerPool(error.to_string()))?;
     let mut empty_files = Vec::new();
     let fresh_paths = fresh
         .iter()
@@ -765,11 +756,28 @@ fn build_graph_inner(
         ordered.par_iter_mut().for_each(|extraction| {
             apply_ast_id_remap(extraction, &ast_id_remap, &ast_root_marker);
         });
+        ast_cache_entries
+            .par_iter_mut()
+            .for_each(|(_, extraction)| {
+                apply_ast_id_remap(extraction, &ast_id_remap, &ast_root_marker);
+            });
         profile_internal_duration(
             "portable AST remap application",
             remap_application_started.elapsed(),
         );
     }
+    ast_cache_entries
+        .par_iter_mut()
+        .for_each(|(path, extraction)| prepare_portable_ast_cache_entry(extraction, path, &root));
+    let ast_cache_handle = std::thread::Builder::new()
+        .name("compass-ast-cache".to_owned())
+        .spawn(move || {
+            let started = Instant::now();
+            cache.save_portable_ast_batch(&ast_cache_entries)?;
+            cache.flush()?;
+            Ok::<_, CoreError>(started.elapsed())
+        })
+        .map_err(|error| CoreError::WorkerPool(error.to_string()))?;
     profile_internal("portable AST ID remapping", &mut internal_started);
     let read_source = |path: &PathBuf| {
         fs::read(path).ok().map(|bytes| {
@@ -1530,6 +1538,60 @@ fn finalize_ast_extraction(extraction: &mut Extraction, root: &Path) {
             });
         },
     );
+}
+
+fn prepare_portable_ast_cache_entry(extraction: &mut Extraction, source: &Path, root: &Path) {
+    let canonical = fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
+    let Ok(relative) = canonical
+        .strip_prefix(root)
+        .or_else(|_| source.strip_prefix(root))
+    else {
+        return;
+    };
+    let portable = relative.to_string_lossy().replace('\\', "/");
+    let set_portable = |attributes: &mut serde_json::Map<String, serde_json::Value>| {
+        for key in ["source_file", "origin_file"] {
+            if attributes
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+            {
+                attributes.insert(key.to_owned(), serde_json::Value::String(portable.clone()));
+            }
+        }
+        if let Some(target) = attributes
+            .get("target_file")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+        {
+            let target = Path::new(&target);
+            let canonical = fs::canonicalize(target).unwrap_or_else(|_| target.to_path_buf());
+            if let Ok(relative) = canonical.strip_prefix(root) {
+                attributes.insert(
+                    "target_file".to_owned(),
+                    serde_json::Value::String(relative.to_string_lossy().replace('\\', "/")),
+                );
+            }
+        }
+    };
+    for node in &mut extraction.nodes {
+        set_portable(&mut node.attributes);
+    }
+    for edge in &mut extraction.edges {
+        set_portable(&mut edge.attributes);
+    }
+    for hyperedge in &mut extraction.hyperedges {
+        if let Some(attributes) = hyperedge.as_object_mut() {
+            set_portable(attributes);
+        }
+    }
+    if let Some(calls) = extraction.raw_calls.as_mut() {
+        for call in calls {
+            if !call.source_file.is_empty() {
+                call.source_file.clone_from(&portable);
+            }
+        }
+    }
 }
 
 fn normalize_source_attribute_cached(

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -27,15 +27,15 @@ fn git(directory: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::erro
 
 #[derive(Default)]
 struct RecordingBuilder {
-    seeds: Mutex<Vec<Option<String>>>,
+    builds: Mutex<usize>,
     promotion: Option<CompletedGraphArtifacts>,
 }
 
 impl RecordingBuilder {
-    fn seeds(&self) -> Result<Vec<Option<String>>, MaterializeError> {
-        self.seeds
+    fn builds(&self) -> Result<usize, MaterializeError> {
+        self.builds
             .lock()
-            .map(|values| values.clone())
+            .map(|value| *value)
             .map_err(|error| MaterializeError::Builder(error.to_string()))
     }
 
@@ -48,7 +48,7 @@ impl RecordingBuilder {
             "built_at_commit": commit
         }))?;
         Ok(Self {
-            seeds: Mutex::default(),
+            builds: Mutex::default(),
             promotion: Some(CompletedGraphArtifacts {
                 artifacts: GraphArtifacts {
                     document,
@@ -83,20 +83,12 @@ impl CompleteGraphBuilder for RecordingBuilder {
         &self,
         checkout: &Path,
         _output_root: &Path,
-        seed: Option<&GraphArtifacts>,
     ) -> Result<CompletedGraphArtifacts, MaterializeError> {
-        let seed_commit = seed.and_then(|artifacts| {
-            artifacts
-                .document
-                .extras
-                .get("built_at_commit")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
-        });
-        self.seeds
+        let mut builds = self
+            .builds
             .lock()
-            .map_err(|error| MaterializeError::Builder(error.to_string()))?
-            .push(seed_commit);
+            .map_err(|error| MaterializeError::Builder(error.to_string()))?;
+        *builds += 1;
         let commit = git(checkout, &["rev-parse", "HEAD"])
             .map_err(|error| MaterializeError::Builder(error.to_string()))?;
         let source = std::fs::read_to_string(checkout.join("service.rs"))
@@ -154,10 +146,7 @@ fn current_snapshot_is_published_without_invoking_the_exact_builder()
         request(&repository, commit.clone(), false)?,
     )?;
 
-    assert!(
-        builder.seeds()?.is_empty(),
-        "exact builder unexpectedly ran"
-    );
+    assert!(builder.builds()? == 0, "exact builder unexpectedly ran");
     let artifacts = history.artifacts(&published.id)?;
     assert_eq!(artifacts.artifacts.document.nodes[0].id, "promoted");
     assert_eq!(published.version.git_commit, commit.to_string());
@@ -184,7 +173,7 @@ fn explicit_rebuild_bypasses_current_snapshot_promotion() -> Result<(), Box<dyn 
 
     let published = materialize_history(&history, &builder, request(&repository, commit, true)?)?;
 
-    assert_eq!(builder.seeds()?, vec![None]);
+    assert_eq!(builder.builds()?, 1);
     let artifacts = history.artifacts(&published.id)?;
     assert_eq!(artifacts.artifacts.document.nodes[0].id, "old");
     Ok(())
@@ -207,7 +196,7 @@ fn request(
 }
 
 #[test]
-fn materializer_reuses_preferred_ancestor_and_publishes_target()
+fn materializer_builds_target_without_reconstructing_an_ancestor()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     git(directory.path(), &["init", "--quiet"])?;
@@ -249,7 +238,7 @@ fn materializer_reuses_preferred_ancestor_and_publishes_target()
     )?;
     assert_eq!(published.version.git_commit, target.to_string());
     assert!(published.preferred);
-    assert_eq!(builder.seeds()?, vec![None, Some(parent.to_string())]);
+    assert_eq!(builder.builds()?, 2);
     assert_eq!(
         phases,
         [
@@ -263,10 +252,10 @@ fn materializer_reuses_preferred_ancestor_and_publishes_target()
         Some(published.id.clone())
     );
 
-    let before = builder.seeds()?.len();
+    let before = builder.builds()?;
     let existing = materialize_history(&store, &builder, request(&repository, target, false)?)?;
     assert_eq!(existing.id, published.id);
-    assert_eq!(builder.seeds()?.len(), before);
+    assert_eq!(builder.builds()?, before);
 
     let mut invalid_recovery = request(&repository, parent, true)?;
     invalid_recovery.replace_corrupt = true;
@@ -285,7 +274,6 @@ fn incomplete_builder_output_is_never_published() -> Result<(), Box<dyn std::err
             &self,
             _checkout: &Path,
             _output_root: &Path,
-            _seed: Option<&GraphArtifacts>,
         ) -> Result<CompletedGraphArtifacts, MaterializeError> {
             Err(MaterializeError::Incomplete("fixture stopped".to_owned()))
         }
@@ -326,7 +314,6 @@ fn semantic_manifest_must_cover_each_exact_commit_source() -> Result<(), Box<dyn
             &self,
             checkout: &Path,
             _output_root: &Path,
-            _seed: Option<&GraphArtifacts>,
         ) -> Result<CompletedGraphArtifacts, MaterializeError> {
             let commit = git(checkout, &["rev-parse", "HEAD"])
                 .map_err(|error| MaterializeError::Builder(error.to_string()))?;
@@ -489,7 +476,6 @@ fn exact_tree_validation_rejects_commit_inventory_and_manifest_mismatches()
             &self,
             checkout: &Path,
             _output_root: &Path,
-            _seed: Option<&GraphArtifacts>,
         ) -> Result<CompletedGraphArtifacts, MaterializeError> {
             let commit = git(checkout, &["rev-parse", "HEAD"])
                 .map_err(|error| MaterializeError::Builder(error.to_string()))?;

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -9,11 +9,50 @@ use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::{FileError, StatHashIndex, io_error, write_bytes_atomic, write_json_atomic};
+use crate::{FileError, StatHashIndex, file_hash, io_error, write_bytes_atomic, write_json_atomic};
 
 const AST_EXTRACTOR_VERSION: &str = "0.9.21";
-const CACHE_ENCODING_VERSION: u32 = 1;
+const CACHE_ENCODING_VERSION: u32 = 2;
 const MESSAGEPACK_EXTENSION: &str = "msgpack";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheLayout {
+    OutputDirectory,
+    SharedHistory,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheHashPolicy {
+    StatIndexed,
+    VerifiedContent,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CacheOptions<'a> {
+    pub storage_root: Option<&'a Path>,
+    pub layout: CacheLayout,
+    pub hash_policy: CacheHashPolicy,
+}
+
+impl<'a> CacheOptions<'a> {
+    #[must_use]
+    pub const fn output_directory(storage_root: Option<&'a Path>) -> Self {
+        Self {
+            storage_root,
+            layout: CacheLayout::OutputDirectory,
+            hash_policy: CacheHashPolicy::StatIndexed,
+        }
+    }
+
+    #[must_use]
+    pub const fn shared_history(storage_root: &'a Path) -> Self {
+        Self {
+            storage_root: Some(storage_root),
+            layout: CacheLayout::SharedHistory,
+            hash_policy: CacheHashPolicy::VerifiedContent,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CacheKind {
@@ -68,10 +107,10 @@ impl CacheKind {
 #[derive(Debug)]
 pub struct Cache {
     root: PathBuf,
-    cache_root: PathBuf,
-    output_name: String,
+    cache_base: PathBuf,
     extractor_version: String,
     hashes: StatHashIndex,
+    hash_policy: CacheHashPolicy,
     session_hashes: HashMap<PathBuf, SessionHash>,
     flush_hashes_on_drop: bool,
 }
@@ -84,20 +123,29 @@ struct SessionHash {
 }
 
 impl Cache {
-    pub fn new(root: impl AsRef<Path>, cache_root: Option<&Path>) -> Result<Self, FileError> {
+    pub fn open(root: impl AsRef<Path>, options: CacheOptions<'_>) -> Result<Self, FileError> {
         let root =
             fs::canonicalize(root.as_ref()).map_err(|source| io_error(root.as_ref(), source))?;
-        let cache_root = cache_root.map_or_else(|| root.clone(), Path::to_path_buf);
         let output_name = std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned());
-        let hashes = StatHashIndex::load(&cache_root, &output_name);
+        let storage_root = options
+            .storage_root
+            .map_or_else(|| root.clone(), Path::to_path_buf);
+        if options.layout == CacheLayout::SharedHistory && !storage_root.is_absolute() {
+            return Err(FileError::OutsideRoot(storage_root));
+        }
+        let cache_base = match options.layout {
+            CacheLayout::OutputDirectory => storage_root.join(&output_name).join("cache"),
+            CacheLayout::SharedHistory => storage_root.clone(),
+        };
+        let hashes = StatHashIndex::load(&storage_root, &output_name);
         let cache = Self {
             root,
-            cache_root,
-            output_name,
+            cache_base,
             extractor_version: AST_EXTRACTOR_VERSION.to_owned(),
             hashes,
+            hash_policy: options.hash_policy,
             session_hashes: HashMap::new(),
-            flush_hashes_on_drop: true,
+            flush_hashes_on_drop: options.hash_policy == CacheHashPolicy::StatIndexed,
         };
         cache.cleanup_stale_ast();
         Ok(cache)
@@ -117,23 +165,14 @@ impl Cache {
     }
 
     pub fn directory(&self, kind: &CacheKind, prompt_fingerprint: Option<&str>) -> PathBuf {
-        let mut directory = self.legacy_directory(kind, prompt_fingerprint);
-        if deterministic_binary_kind(kind) {
-            directory = directory.join(format!("e{CACHE_ENCODING_VERSION}"));
-        }
-        directory
-    }
-
-    fn legacy_directory(&self, kind: &CacheKind, prompt_fingerprint: Option<&str>) -> PathBuf {
-        let mut directory = self
-            .cache_root
-            .join(&self.output_name)
-            .join("cache")
-            .join(kind.directory_name());
+        let mut directory = self.cache_base.join(kind.directory_name());
         if matches!(kind, CacheKind::Ast) {
             directory = directory.join(format!("v{}", self.extractor_version));
         } else if let Some(fingerprint) = prompt_fingerprint {
             directory = directory.join(format!("p{fingerprint}"));
+        }
+        if deterministic_binary_kind(kind) {
+            directory = directory.join(format!("e{CACHE_ENCODING_VERSION}"));
         }
         directory
     }
@@ -143,7 +182,6 @@ impl Cache {
         path: &Path,
         kind: &CacheKind,
         prompt_fingerprint: Option<&str>,
-        allow_legacy: bool,
         allow_partial: bool,
     ) -> Result<Option<Value>, FileError> {
         let hash = self.content_hash(path)?;
@@ -160,20 +198,11 @@ impl Cache {
                 absolutize_source_files(&mut value, &self.root);
                 return Ok(Some(value));
             }
-            let legacy = self
-                .legacy_directory(kind, prompt_fingerprint)
-                .join(format!("{hash}.json"));
-            return load_json_value(&legacy, allow_partial, &self.root);
+            return Ok(None);
         }
-        let mut entry = self
+        let entry = self
             .directory(kind, prompt_fingerprint)
             .join(format!("{hash}.json"));
-        if !entry.exists() && prompt_fingerprint.is_some() && allow_legacy {
-            let legacy = self.directory(kind, None).join(format!("{hash}.json"));
-            if legacy.exists() {
-                entry = legacy;
-            }
-        }
         if !entry.exists() {
             return Ok(None);
         }
@@ -301,14 +330,7 @@ impl Cache {
         {
             return Ok(Some(value));
         }
-        let legacy = self
-            .legacy_directory(kind, None)
-            .join(format!("{key}.json"));
-        let bytes = match fs::read(legacy) {
-            Ok(bytes) => bytes,
-            Err(_) => return Ok(None),
-        };
-        Ok(serde_json::from_slice(&bytes).ok())
+        Ok(None)
     }
 
     /// Safely save a repository-relative Program IR cache value.
@@ -370,8 +392,7 @@ impl Cache {
             .iter()
             .map(|key| logical_key_hash(key))
             .collect::<BTreeSet<_>>();
-        Ok(prune_cache_entries(&self.directory(kind, None), &hashes)
-            + prune_cache_entries(&self.legacy_directory(kind, None), &hashes))
+        Ok(prune_cache_entries(&self.directory(kind, None), &hashes))
     }
 
     pub fn flush(&mut self) -> Result<(), FileError> {
@@ -379,28 +400,25 @@ impl Cache {
     }
 
     pub fn cached_files(&self) -> BTreeSet<String> {
-        let base = self.cache_root.join(&self.output_name).join("cache");
         let mut hashes = BTreeSet::new();
-        collect_cache_stems(&base, &mut hashes);
+        collect_cache_stems(&self.cache_base, &mut hashes);
         hashes
     }
 
     pub fn clear(&self) {
-        let base = self.cache_root.join(&self.output_name).join("cache");
-        clear_cache_entries(&base);
+        clear_cache_entries(&self.cache_base);
     }
 
     pub fn prune_semantic(&self, live_hashes: &BTreeSet<String>) -> usize {
-        let base = self.cache_root.join(&self.output_name).join("cache");
         let mut removed = 0;
         for kind in ["semantic", "semantic-deep"] {
-            removed += prune_cache_entries(&base.join(kind), live_hashes);
+            removed += prune_cache_entries(&self.cache_base.join(kind), live_hashes);
         }
         removed
     }
 
     fn cleanup_stale_ast(&self) {
-        let base = self.cache_root.join(&self.output_name).join("cache/ast");
+        let base = self.cache_base.join("ast");
         let current = format!("v{}", self.extractor_version);
         let Ok(entries) = fs::read_dir(&base) else {
             return;
@@ -426,7 +444,10 @@ impl Cache {
         {
             return Ok(cached.value.clone());
         }
-        let value = self.hashes.hash(path, &self.root)?;
+        let value = match self.hash_policy {
+            CacheHashPolicy::StatIndexed => self.hashes.hash(path, &self.root)?,
+            CacheHashPolicy::VerifiedContent => file_hash(path, &self.root)?,
+        };
         self.session_hashes.insert(
             path.to_path_buf(),
             SessionHash {

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 use crate::{FileError, StatHashIndex, file_hash, io_error, write_bytes_atomic, write_json_atomic};
 
 const AST_EXTRACTOR_VERSION: &str = "0.9.21";
-const CACHE_ENCODING_VERSION: u32 = 2;
+const CACHE_ENCODING_VERSION: u32 = 6;
 const MESSAGEPACK_EXTENSION: &str = "msgpack";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/compass-files/src/lib.rs
+++ b/crates/compass-files/src/lib.rs
@@ -15,7 +15,7 @@ pub use atomic::{
     write_bytes_atomic, write_json_ascii_atomic, write_json_atomic, write_text_atomic,
 };
 pub use build_guard::BuildGuard;
-pub use cache::{Cache, CacheKind};
+pub use cache::{Cache, CacheHashPolicy, CacheKind, CacheLayout, CacheOptions};
 pub use detect::{
     DetectOptions, Detection, FileType, IgnorePolicy, WatchPathFilter, classify_file, detect,
 };

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -4,8 +4,8 @@ use std::fs::{self, FileTimes};
 use std::time::{Duration, UNIX_EPOCH};
 
 use compass_files::{
-    BuildGuard, Cache, CacheKind, DetectOptions, FileSlice, Manifest, ManifestKind, StatHashIndex,
-    WatchPathFilter, bisect_slice, body_content, classify_file, file_hash, md5_file,
+    BuildGuard, Cache, CacheKind, CacheOptions, DetectOptions, FileSlice, Manifest, ManifestKind,
+    StatHashIndex, WatchPathFilter, bisect_slice, body_content, classify_file, file_hash, md5_file,
     prompt_fingerprint, read_slice_text, read_source_lossy, slice_boundaries, split_file,
     write_bytes_atomic, write_json_atomic, write_text_atomic,
 };
@@ -295,7 +295,7 @@ fn cache_round_trip_is_portable_and_partial_safe() -> Result<(), Box<dyn Error>>
         "edges": [],
         "partial": false
     });
-    let mut cache = Cache::new(directory.path(), None)?;
+    let mut cache = Cache::open(directory.path(), CacheOptions::output_directory(None))?;
     cache.save(&source, &value, &CacheKind::Ast, None)?;
     assert!(
         fs::read_dir(cache.directory(&CacheKind::Ast, None))?
@@ -306,7 +306,7 @@ fn cache_round_trip_is_portable_and_partial_safe() -> Result<(), Box<dyn Error>>
                 .is_some_and(|value| value == "msgpack"))
     );
     assert_eq!(
-        cache.load(&source, &CacheKind::Ast, None, true, false)?,
+        cache.load(&source, &CacheKind::Ast, None, false)?,
         Some(value)
     );
     cache.flush()?;
@@ -321,11 +321,11 @@ fn cache_round_trip_is_portable_and_partial_safe() -> Result<(), Box<dyn Error>>
     let partial = json!({"nodes": [], "edges": [], "partial": true});
     cache.save(&source, &partial, &CacheKind::Semantic, None)?;
     assert_eq!(
-        cache.load(&source, &CacheKind::Semantic, None, true, false)?,
+        cache.load(&source, &CacheKind::Semantic, None, false)?,
         None
     );
     assert_eq!(
-        cache.load(&source, &CacheKind::Semantic, None, true, true)?,
+        cache.load(&source, &CacheKind::Semantic, None, true)?,
         Some(partial)
     );
     Ok(())
@@ -342,7 +342,7 @@ fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(),
         json!({"nodes":[{"id":"first","source_file":first.to_string_lossy()}],"edges":[]});
     let second_value =
         json!({"nodes":[{"id":"second","source_file":second.to_string_lossy()}],"edges":[]});
-    let mut cache = Cache::new(directory.path(), None)?;
+    let mut cache = Cache::open(directory.path(), CacheOptions::output_directory(None))?;
 
     cache.save_batch(
         &[
@@ -353,11 +353,11 @@ fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(),
         None,
     )?;
     assert_eq!(
-        cache.load(&first, &CacheKind::Ast, None, false, false)?,
+        cache.load(&first, &CacheKind::Ast, None, false)?,
         Some(first_value.clone())
     );
     assert_eq!(
-        cache.load(&second, &CacheKind::Ast, None, false, false)?,
+        cache.load(&second, &CacheKind::Ast, None, false)?,
         Some(second_value)
     );
 
@@ -374,7 +374,7 @@ fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(),
         "edges":[]
     });
     assert_eq!(
-        cache.load(&first, &CacheKind::Ast, None, false, false)?,
+        cache.load(&first, &CacheKind::Ast, None, false)?,
         Some(canonical_first_value)
     );
 
@@ -383,7 +383,7 @@ fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(),
         json!({"nodes":[{"id":"first_changed","source_file":first.to_string_lossy()}],"edges":[]});
     cache.save_batch(&[(first.clone(), changed.clone())], &CacheKind::Ast, None)?;
     assert_eq!(
-        cache.load(&first, &CacheKind::Ast, None, false, false)?,
+        cache.load(&first, &CacheKind::Ast, None, false)?,
         Some(changed)
     );
     Ok(())
@@ -394,11 +394,11 @@ fn malformed_and_non_object_cache_entries_fail_closed() -> Result<(), Box<dyn Er
     let directory = tempfile::tempdir()?;
     let source = directory.path().join("main.py");
     fs::write(&source, "def main(): pass\n")?;
-    let mut cache = Cache::new(directory.path(), None)?;
+    let mut cache = Cache::open(directory.path(), CacheOptions::output_directory(None))?;
 
     cache.save(&source, &json!("scalar"), &CacheKind::Semantic, None)?;
     assert_eq!(
-        cache.load(&source, &CacheKind::Semantic, None, false, false)?,
+        cache.load(&source, &CacheKind::Semantic, None, false)?,
         Some(json!("scalar"))
     );
 
@@ -412,7 +412,7 @@ fn malformed_and_non_object_cache_entries_fail_closed() -> Result<(), Box<dyn Er
         .ok_or("missing semantic cache entry")?;
     fs::write(entry, b"not-json")?;
     assert_eq!(
-        cache.load(&source, &CacheKind::Semantic, None, false, false)?,
+        cache.load(&source, &CacheKind::Semantic, None, false)?,
         None
     );
     Ok(())
@@ -531,19 +531,20 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     let source = root.join("main.md");
     fs::write(&source, "---\ntitle: ignored\n---\nbody\n")?;
 
-    let default_cache = Cache::new(&root, Some(&cache_root))?;
+    let default_cache = Cache::open(&root, CacheOptions::output_directory(Some(&cache_root)))?;
     assert!(
         default_cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/v0.9.21/e1")
+            .ends_with("ast/v0.9.21/e2")
     );
     assert!(!cache_root.join("compass-out/cache/ast/v0.9.20").exists());
 
-    let mut cache = Cache::new(&root, Some(&cache_root))?.with_extractor_version("current");
+    let mut cache = Cache::open(&root, CacheOptions::output_directory(Some(&cache_root)))?
+        .with_extractor_version("current");
     assert!(
         cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/vcurrent/e1")
+            .ends_with("ast/vcurrent/e2")
     );
     assert!(
         cache
@@ -562,19 +563,19 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
         None,
     )?;
     assert_eq!(
-        cache.load(&source, &CacheKind::Semantic, Some("new"), false, true)?,
+        cache.load(&source, &CacheKind::Semantic, Some("new"), true)?,
         None
     );
-    let legacy = cache
-        .load(&source, &CacheKind::Semantic, Some("new"), true, true)?
-        .ok_or("legacy cache entry")?;
+    let stored = cache
+        .load(&source, &CacheKind::Semantic, None, true)?
+        .ok_or("current cache entry")?;
     assert!(
-        legacy["nodes"][0]["source_file"]
+        stored["nodes"][0]["source_file"]
             .as_str()
             .is_some_and(|path| path.ends_with("main.md"))
     );
     assert!(
-        legacy["nodes"][1]["source_file"]
+        stored["nodes"][1]["source_file"]
             .as_str()
             .is_some_and(|path| path.ends_with("relative.md"))
     );
@@ -604,7 +605,13 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
 
     let missing = root.join("missing.md");
     cache.save(&missing, &json!({}), &CacheKind::Ast, None)?;
-    assert!(Cache::new(root.join("missing-root"), None).is_err());
+    assert!(
+        Cache::open(
+            root.join("missing-root"),
+            CacheOptions::output_directory(None)
+        )
+        .is_err()
+    );
     Ok(())
 }
 
@@ -841,7 +848,7 @@ fn slicing_hashing_atomic_writes_and_stat_index_cover_hostile_boundaries()
 #[test]
 fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
-    let cache = Cache::new(directory.path(), None)?;
+    let cache = Cache::open(directory.path(), CacheOptions::output_directory(None))?;
     let syntax = CacheKind::ProgramSyntax {
         ir_schema: 1,
         provider_version: "tree-sitter-rust/1".to_owned(),
@@ -862,7 +869,7 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
     )?;
     cache.save_program(&artifact, "index.scip:bbbbbbbb", &json!({"kind":"scip"}))?;
     let syntax_directory = cache.directory(&syntax, None);
-    assert!(syntax_directory.ends_with("e1"));
+    assert!(syntax_directory.ends_with("e2"));
     assert!(
         fs::read_dir(&syntax_directory)?
             .filter_map(Result::ok)
@@ -900,9 +907,11 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
     let legacy_entry = legacy_entry.with_extension("json");
     fs::write(&legacy_entry, serde_json::to_vec(&first)?)?;
     fs::remove_file(&first_entry)?;
-    assert_eq!(
-        cache.load_program::<serde_json::Value>(&syntax, "src/a.rs:aaaaaaaa")?,
-        Some(first.clone())
+    assert!(
+        cache
+            .load_program::<serde_json::Value>(&syntax, "src/a.rs:aaaaaaaa")?
+            .is_none(),
+        "hard cutover must not decode the legacy JSON cache"
     );
 
     let second_entry = fs::read_dir(&syntax_directory)?

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -535,7 +535,7 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     assert!(
         default_cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/v0.9.21/e2")
+            .ends_with("ast/v0.9.21/e6")
     );
     assert!(!cache_root.join("compass-out/cache/ast/v0.9.20").exists());
 
@@ -544,7 +544,7 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     assert!(
         cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/vcurrent/e2")
+            .ends_with("ast/vcurrent/e6")
     );
     assert!(
         cache
@@ -869,7 +869,7 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
     )?;
     cache.save_program(&artifact, "index.scip:bbbbbbbb", &json!({"kind":"scip"}))?;
     let syntax_directory = cache.directory(&syntax, None);
-    assert!(syntax_directory.ends_with("e2"));
+    assert!(syntax_directory.ends_with("e6"));
     assert!(
         fs::read_dir(&syntax_directory)?
             .filter_map(Result::ok)

--- a/crates/compass-history/src/cache.rs
+++ b/crates/compass-history/src/cache.rs
@@ -1,0 +1,283 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::store::{create_owner_dir, reject_directory, reject_symlink};
+use crate::{HistoryError, canonical_json_bytes};
+
+pub const HISTORY_CACHE_VERSION: u32 = 1;
+const CACHE_ENTRY_SCHEMA: &str = "compass.history.cache_entry/1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DerivedCacheNamespace {
+    SemanticDiff,
+    Viewer,
+}
+
+impl DerivedCacheNamespace {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SemanticDiff => "semantic-diff",
+            Self::Viewer => "viewer",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HistoryCache {
+    root: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct CacheNamespaceStatus {
+    pub files: u64,
+    pub bytes: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct CacheStatus {
+    pub files: u64,
+    pub bytes: u64,
+    pub namespaces: BTreeMap<String, CacheNamespaceStatus>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct CacheGcPlan {
+    pub files: u64,
+    pub bytes: u64,
+    pub paths: Vec<PathBuf>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CacheEnvelope {
+    schema: String,
+    namespace: String,
+    key_sha256: String,
+    payload_sha256: String,
+    payload: Value,
+}
+
+impl HistoryCache {
+    pub(crate) fn open(history_root: &Path) -> Result<Self, HistoryError> {
+        reject_directory(history_root)?;
+        let cache = history_root.join("cache");
+        create_owner_dir(&cache)?;
+        let root = cache.join(format!("v{HISTORY_CACHE_VERSION}"));
+        create_owner_dir(&root)?;
+        Ok(Self { root })
+    }
+
+    #[must_use]
+    pub fn extraction_root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn read(
+        &self,
+        namespace: DerivedCacheNamespace,
+        key_material: &Value,
+        max_payload_bytes: u64,
+    ) -> Result<Option<Vec<u8>>, HistoryError> {
+        let key = digest(&canonical_json_bytes(key_material)?);
+        let path = self.entry_path(namespace, &key)?;
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(crate::error::io_error(path, source)),
+        };
+        if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_payload_bytes {
+            return Ok(None);
+        }
+        let envelope: CacheEnvelope = match serde_json::from_slice(&bytes) {
+            Ok(envelope) => envelope,
+            Err(_) => return Ok(None),
+        };
+        if envelope.schema != CACHE_ENTRY_SCHEMA
+            || envelope.namespace != namespace.as_str()
+            || envelope.key_sha256 != key
+        {
+            return Ok(None);
+        }
+        let payload = canonical_json_bytes(&envelope.payload)?;
+        if digest(&payload) != envelope.payload_sha256 {
+            return Ok(None);
+        }
+        Ok(Some(payload))
+    }
+
+    pub fn write(
+        &self,
+        namespace: DerivedCacheNamespace,
+        key_material: &Value,
+        payload: &[u8],
+    ) -> Result<(), HistoryError> {
+        let payload: Value = serde_json::from_slice(payload)?;
+        let payload_bytes = canonical_json_bytes(&payload)?;
+        let key = digest(&canonical_json_bytes(key_material)?);
+        let path = self.entry_path(namespace, &key)?;
+        let envelope = CacheEnvelope {
+            schema: CACHE_ENTRY_SCHEMA.to_owned(),
+            namespace: namespace.as_str().to_owned(),
+            key_sha256: key,
+            payload_sha256: digest(&payload_bytes),
+            payload,
+        };
+        compass_files::write_json_atomic(path, &envelope, false)?;
+        Ok(())
+    }
+
+    pub fn status(&self) -> Result<CacheStatus, HistoryError> {
+        let mut status = CacheStatus::default();
+        for file in self.files()? {
+            let namespace = file
+                .path
+                .strip_prefix(&self.root)
+                .ok()
+                .and_then(|path| path.components().next())
+                .map(|component| component.as_os_str().to_string_lossy().into_owned())
+                .unwrap_or_else(|| "unknown".to_owned());
+            status.files = status.files.saturating_add(1);
+            status.bytes = status.bytes.saturating_add(file.bytes);
+            let entry = status.namespaces.entry(namespace).or_default();
+            entry.files = entry.files.saturating_add(1);
+            entry.bytes = entry.bytes.saturating_add(file.bytes);
+        }
+        Ok(status)
+    }
+
+    pub fn plan_gc(
+        &self,
+        max_bytes: Option<u64>,
+        max_age: Option<Duration>,
+    ) -> Result<CacheGcPlan, HistoryError> {
+        if max_bytes.is_none() && max_age.is_none() {
+            return Err(HistoryError::OperationalState(
+                "cache GC requires a byte or age limit".to_owned(),
+            ));
+        }
+        let now = SystemTime::now();
+        let mut files = self.files()?;
+        files.sort_by(|left, right| {
+            left.modified
+                .cmp(&right.modified)
+                .then_with(|| left.path.cmp(&right.path))
+        });
+        let mut selected = BTreeMap::<PathBuf, u64>::new();
+        if let Some(max_age) = max_age {
+            for file in &files {
+                if now
+                    .duration_since(file.modified)
+                    .is_ok_and(|age| age > max_age)
+                {
+                    selected.insert(file.path.clone(), file.bytes);
+                }
+            }
+        }
+        if let Some(max_bytes) = max_bytes {
+            let mut retained = files
+                .iter()
+                .filter(|file| !selected.contains_key(&file.path))
+                .map(|file| file.bytes)
+                .sum::<u64>();
+            for file in &files {
+                if retained <= max_bytes {
+                    break;
+                }
+                if selected.contains_key(&file.path) {
+                    continue;
+                }
+                retained = retained.saturating_sub(file.bytes);
+                selected.insert(file.path.clone(), file.bytes);
+            }
+        }
+        Ok(CacheGcPlan {
+            files: selected.len() as u64,
+            bytes: selected.values().sum(),
+            paths: selected.into_keys().collect(),
+        })
+    }
+
+    pub fn sweep(&self, plan: &CacheGcPlan) -> Result<(), HistoryError> {
+        for path in &plan.paths {
+            let parent = path.parent().ok_or_else(|| {
+                HistoryError::OperationalState("cache GC path has no parent".to_owned())
+            })?;
+            let parent = fs::canonicalize(parent)
+                .map_err(|source| crate::error::io_error(parent, source))?;
+            if !parent.starts_with(&self.root) {
+                return Err(HistoryError::OperationalState(format!(
+                    "cache GC path escapes cache root: {}",
+                    path.display()
+                )));
+            }
+            let metadata = fs::symlink_metadata(path)
+                .map_err(|source| crate::error::io_error(path, source))?;
+            if !metadata.file_type().is_file() {
+                return Err(HistoryError::OperationalState(format!(
+                    "cache GC target is not a regular file: {}",
+                    path.display()
+                )));
+            }
+            fs::remove_file(path).map_err(|source| crate::error::io_error(path, source))?;
+        }
+        Ok(())
+    }
+
+    fn entry_path(
+        &self,
+        namespace: DerivedCacheNamespace,
+        key: &str,
+    ) -> Result<PathBuf, HistoryError> {
+        let directory = self.root.join(namespace.as_str());
+        create_owner_dir(&directory)?;
+        let path = directory.join(format!("{key}.json"));
+        reject_symlink(&path, true)?;
+        Ok(path)
+    }
+
+    fn files(&self) -> Result<Vec<CacheFile>, HistoryError> {
+        let mut pending = vec![self.root.clone()];
+        let mut files = Vec::new();
+        while let Some(directory) = pending.pop() {
+            for entry in fs::read_dir(&directory)
+                .map_err(|source| crate::error::io_error(&directory, source))?
+            {
+                let entry = entry.map_err(|source| crate::error::io_error(&directory, source))?;
+                let path = entry.path();
+                let metadata = fs::symlink_metadata(&path)
+                    .map_err(|source| crate::error::io_error(&path, source))?;
+                if metadata.file_type().is_symlink() {
+                    return Err(HistoryError::OperationalState(format!(
+                        "cache contains a symlink: {}",
+                        path.display()
+                    )));
+                }
+                if metadata.is_dir() {
+                    pending.push(path);
+                } else if metadata.is_file() {
+                    files.push(CacheFile {
+                        path,
+                        bytes: metadata.len(),
+                        modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                    });
+                }
+            }
+        }
+        Ok(files)
+    }
+}
+
+struct CacheFile {
+    path: PathBuf,
+    bytes: u64,
+    modified: SystemTime,
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}

--- a/crates/compass-history/src/diff.rs
+++ b/crates/compass-history/src/diff.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::keys::{EDGE_KIND, HYPEREDGE_KIND, KEY_SCHEMA_V1, NODE_KIND};
-use crate::{HistoryError, HistoryStore, RealizationId, StoredTree};
+use crate::{HistoryError, RealizationReader, StoredTree};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -40,16 +40,14 @@ pub trait ChangeSink {
     fn change(&mut self, change: GraphChange) -> Result<(), HistoryError>;
 }
 
-impl HistoryStore {
+impl RealizationReader<'_> {
     /// Stream graph-aware changes without materializing either complete graph.
     pub fn diff(
         &self,
-        old: &RealizationId,
-        new: &RealizationId,
+        new: &RealizationReader<'_>,
         sink: &mut dyn ChangeSink,
     ) -> Result<(), HistoryError> {
         self.diff_records(
-            old,
             new,
             &[
                 RecordKind::Node,
@@ -71,14 +69,17 @@ impl HistoryStore {
     /// avoid decoding analysis and reconstruction metadata entirely.
     pub fn diff_records(
         &self,
-        old: &RealizationId,
-        new: &RealizationId,
+        new: &RealizationReader<'_>,
         records: &[RecordKind],
         sink: &mut dyn ChangeSink,
     ) -> Result<(), HistoryError> {
-        let activity = self.activity()?;
-        let old = self.get_with_activity(old, &activity)?;
-        let new = self.get_with_activity(new, &activity)?;
+        if !std::ptr::eq(self.store, new.store) {
+            return Err(HistoryError::OperationalState(
+                "cannot diff readers from different history stores".to_owned(),
+            ));
+        }
+        let old = &self.published;
+        let new = &new.published;
         for (kind, left, right) in [
             (
                 RecordKind::Node,
@@ -133,7 +134,11 @@ impl HistoryStore {
         if old == new {
             return Ok(());
         }
-        for difference in self.prolly.stream_diff(&old.to_tree(), &new.to_tree())? {
+        for difference in self
+            .store
+            .prolly
+            .stream_diff(&old.to_tree(), &new.to_tree())?
+        {
             let difference = difference?;
             let (change, key, old, new) = match difference {
                 Diff::Added { key, val } => {

--- a/crates/compass-history/src/graph_read.rs
+++ b/crates/compass-history/src/graph_read.rs
@@ -1,0 +1,166 @@
+use std::collections::HashSet;
+
+use compass_model::{EdgeRecord, NodeRecord};
+use prolly::decode_segments;
+use serde_json::Value;
+
+use crate::{
+    HistoryError, MAX_AUTHORITATIVE_BYTES, MAX_KEY_BYTES, MAX_RECORD_VALUE_BYTES,
+    MAX_RECORDS_PER_TREE, RealizationReader,
+};
+
+/// Receives the graph-only projection of a sealed realization.
+pub trait GraphRecordSink {
+    fn node_attribute(
+        &mut self,
+        node_id: String,
+        field: String,
+        value: Value,
+    ) -> Result<(), HistoryError>;
+
+    fn labels(&mut self, labels: Value) -> Result<(), HistoryError>;
+
+    fn node(&mut self, node: NodeRecord) -> Result<(), HistoryError>;
+
+    fn edge(&mut self, edge: EdgeRecord) -> Result<(), HistoryError>;
+}
+
+impl RealizationReader<'_> {
+    /// Scan only analysis, node, and edge roots for a historical graph view.
+    pub fn scan_graph(&self, sink: &mut dyn GraphRecordSink) -> Result<(), HistoryError> {
+        let mut total_bytes = 0_u64;
+        let mut pending_analysis = HashSet::<String>::new();
+        let analysis = self.published.version.analysis_root.to_tree();
+        let mut analysis_count = 0_u64;
+        for entry in self.store.prolly.range(&analysis, &[], None)? {
+            let (key, bytes) = entry?;
+            account(&key, &bytes, &mut total_bytes)?;
+            analysis_count = analysis_count.saturating_add(1);
+            let segments = decode_segments(&key)
+                .map_err(|error| HistoryError::InvalidArtifacts(error.to_string()))?;
+            match segments.as_slice() {
+                [_, _, kind, node, field] if kind == b"node" => {
+                    let node = text(node, "node")?;
+                    let field = text(field, "analysis field")?;
+                    let value = crate::artifacts::decode_typed(&bytes, "compass.analysis.node")?;
+                    pending_analysis.insert(node.clone());
+                    sink.node_attribute(node, field, value)?;
+                }
+                [_, _, kind, path] if kind == b"sidecar" => {
+                    let path = text(path, "analysis sidecar")?;
+                    let value = crate::artifacts::decode_typed(&bytes, "compass.analysis.sidecar")?;
+                    match path.as_str() {
+                        ".compass_labels.json" => sink.labels(value)?,
+                        ".compass_analysis.json" => {}
+                        _ => {
+                            return Err(HistoryError::InvalidArtifacts(format!(
+                                "unknown analysis sidecar {path}"
+                            )));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(HistoryError::InvalidArtifacts(
+                        "invalid analysis key".to_owned(),
+                    ));
+                }
+            }
+        }
+        require_count(
+            "analysis",
+            self.published.version.analysis_count,
+            analysis_count,
+        )?;
+
+        let nodes = self.published.version.nodes_root.to_tree();
+        let mut node_ids = HashSet::new();
+        let mut node_count = 0_u64;
+        for entry in self.store.prolly.range(&nodes, &[], None)? {
+            let (key, bytes) = entry?;
+            account(&key, &bytes, &mut total_bytes)?;
+            node_count = node_count.saturating_add(1);
+            let segments = decode_segments(&key)
+                .map_err(|error| HistoryError::InvalidArtifacts(error.to_string()))?;
+            let [schema, kind, id] = segments.as_slice() else {
+                return Err(HistoryError::InvalidArtifacts(
+                    "invalid node key".to_owned(),
+                ));
+            };
+            if schema != &[1] || kind != &[1] {
+                return Err(HistoryError::InvalidArtifacts(
+                    "invalid node key".to_owned(),
+                ));
+            }
+            let id = text(id, "node ID")?;
+            let node: NodeRecord = crate::artifacts::decode_typed(&bytes, "compass.node")?;
+            if node.id != id || !node_ids.insert(id.clone()) {
+                return Err(HistoryError::InvalidArtifacts(format!(
+                    "node key does not match unique node ID {id}"
+                )));
+            }
+            pending_analysis.remove(&id);
+            sink.node(node)?;
+        }
+        require_count("nodes", self.published.version.node_count, node_count)?;
+        if let Some(node) = pending_analysis.iter().next() {
+            return Err(HistoryError::InvalidArtifacts(format!(
+                "analysis references missing node {node}"
+            )));
+        }
+
+        let edges = self.published.version.edges_root.to_tree();
+        let mut edge_count = 0_u64;
+        for entry in self.store.prolly.range(&edges, &[], None)? {
+            let (key, bytes) = entry?;
+            account(&key, &bytes, &mut total_bytes)?;
+            edge_count = edge_count.saturating_add(1);
+            let segments = decode_segments(&key)
+                .map_err(|error| HistoryError::InvalidArtifacts(error.to_string()))?;
+            if segments.len() < 5 || segments[0] != [1] || segments[1] != [2] {
+                return Err(HistoryError::InvalidArtifacts(
+                    "invalid edge key".to_owned(),
+                ));
+            }
+            let edge: EdgeRecord = crate::artifacts::decode_typed(&bytes, "compass.edge")?;
+            if !node_ids.contains(&edge.source) || !node_ids.contains(&edge.target) {
+                return Err(HistoryError::InvalidArtifacts(format!(
+                    "edge references a missing endpoint {} -> {}",
+                    edge.source, edge.target
+                )));
+            }
+            sink.edge(edge)?;
+        }
+        require_count("edges", self.published.version.edge_count, edge_count)
+    }
+}
+
+fn account(key: &[u8], value: &[u8], total: &mut u64) -> Result<(), HistoryError> {
+    if key.len() > MAX_KEY_BYTES || value.len() > MAX_RECORD_VALUE_BYTES {
+        return Err(HistoryError::InvalidArtifacts(
+            "historical graph record exceeds byte limit".to_owned(),
+        ));
+    }
+    *total = total
+        .saturating_add(key.len() as u64)
+        .saturating_add(value.len() as u64);
+    if *total > MAX_AUTHORITATIVE_BYTES {
+        return Err(HistoryError::InvalidArtifacts(
+            "historical graph projection exceeds byte limit".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn require_count(kind: &str, expected: u64, actual: u64) -> Result<(), HistoryError> {
+    if actual > MAX_RECORDS_PER_TREE || expected != actual {
+        return Err(HistoryError::InvalidArtifacts(format!(
+            "{kind} record count mismatch: expected {expected}, read {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn text(bytes: &[u8], kind: &str) -> Result<String, HistoryError> {
+    String::from_utf8(bytes.to_vec())
+        .map_err(|error| HistoryError::InvalidArtifacts(format!("non-UTF-8 {kind}: {error}")))
+}

--- a/crates/compass-history/src/lib.rs
+++ b/crates/compass-history/src/lib.rs
@@ -1,6 +1,7 @@
 //! Immutable, SQLite-backed version history for complete Compass graphs.
 
 mod artifacts;
+mod cache;
 mod canonical;
 mod config;
 mod diff;
@@ -9,16 +10,22 @@ mod error;
 mod fingerprint;
 mod gc;
 mod git;
+mod graph_read;
 mod jobs;
 mod keys;
 mod leases;
 mod lock;
 mod model;
+mod reader;
 mod store;
 mod timeline;
 mod validate;
 
 pub use artifacts::{CompletedGraphArtifacts, GraphArtifacts, PartitionedGraph};
+pub use cache::{
+    CacheGcPlan, CacheNamespaceStatus, CacheStatus, DerivedCacheNamespace, HISTORY_CACHE_VERSION,
+    HistoryCache,
+};
 pub use canonical::{CANONICAL_ENCODING_VERSION, canonical_json_bytes};
 pub use config::HistoryConfig;
 pub use diff::{ChangeKind, ChangeSink, GraphChange, RecordKind};
@@ -28,6 +35,7 @@ pub use gc::{GcPlan, GcSweep};
 pub use git::{
     GitTargetLimitation, Repository, SourceFileDelta, SourceFileStatus, SourceHunk, WorktreeGuard,
 };
+pub use graph_read::GraphRecordSink;
 pub use jobs::{ClaimedJob, HistoryQueue, JobRecord, JobRequest, JobState};
 pub use keys::{edge_key, hyperedge_key, node_key};
 pub use leases::{LEASE_DURATION_MILLIS, LEASE_HEARTBEAT_MILLIS, LeaseGuard};
@@ -37,6 +45,7 @@ pub use model::{
     GraphVersion, HISTORY_SCHEMA_VERSION, PublishRequest, PublishedVersion, RealizationId,
     StoredTree, StructuralSharing,
 };
+pub use reader::RealizationReader;
 pub use store::{
     CorruptPreferredToken, HistoryRecord, HistoryRecordKey, HistoryStore, PreparedPublication,
 };

--- a/crates/compass-history/src/reader.rs
+++ b/crates/compass-history/src/reader.rs
@@ -1,0 +1,144 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use prolly::Tree;
+
+use crate::{
+    ActivityGuard, HistoryError, HistoryRecord, HistoryRecordKey, HistoryStore, PublishedVersion,
+    RealizationId,
+};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum OwnedHistoryRecordKey {
+    Node(String),
+    ProgramModule(String),
+    ProgramFunction(String),
+    ProgramSummary(String),
+    ReverseCallers(String),
+}
+
+impl From<HistoryRecordKey<'_>> for OwnedHistoryRecordKey {
+    fn from(value: HistoryRecordKey<'_>) -> Self {
+        match value {
+            HistoryRecordKey::Node(value) => Self::Node(value.to_owned()),
+            HistoryRecordKey::ProgramModule(value) => Self::ProgramModule(value.to_owned()),
+            HistoryRecordKey::ProgramFunction(value) => Self::ProgramFunction(value.to_owned()),
+            HistoryRecordKey::ProgramSummary(value) => Self::ProgramSummary(value.to_owned()),
+            HistoryRecordKey::ReverseCallers(value) => Self::ReverseCallers(value.to_owned()),
+        }
+    }
+}
+
+/// One sealed realization opened for repeated typed reads and diffs.
+pub struct RealizationReader<'store> {
+    pub(crate) store: &'store HistoryStore,
+    _activity: ActivityGuard,
+    pub(crate) published: PublishedVersion,
+    roots: RefCell<HashMap<&'static str, Tree>>,
+    records: RefCell<HashMap<OwnedHistoryRecordKey, Option<HistoryRecord>>>,
+}
+
+impl HistoryStore {
+    pub fn reader(
+        &self,
+        realization: &RealizationId,
+    ) -> Result<RealizationReader<'_>, HistoryError> {
+        let activity = self.activity()?;
+        let published = self.get_with_activity(realization, &activity)?;
+        Ok(RealizationReader {
+            store: self,
+            _activity: activity,
+            published,
+            roots: RefCell::new(HashMap::new()),
+            records: RefCell::new(HashMap::new()),
+        })
+    }
+}
+
+impl RealizationReader<'_> {
+    #[must_use]
+    pub fn version(&self) -> &PublishedVersion {
+        &self.published
+    }
+
+    pub fn read(&self, key: HistoryRecordKey<'_>) -> Result<Option<HistoryRecord>, HistoryError> {
+        let owned = OwnedHistoryRecordKey::from(key);
+        if let Some(value) = self.records.borrow().get(&owned) {
+            return Ok(value.clone());
+        }
+        let (root_name, tree, encoded_key, schema) = match &owned {
+            OwnedHistoryRecordKey::Node(id) => (
+                "nodes",
+                self.published.version.nodes_root.to_tree(),
+                crate::node_key(id),
+                "compass.node",
+            ),
+            OwnedHistoryRecordKey::ProgramModule(source_file) => (
+                "program-facts",
+                self.published.version.program_facts_root.to_tree(),
+                crate::artifacts::program_key("module", source_file),
+                "compass.program.module",
+            ),
+            OwnedHistoryRecordKey::ProgramFunction(symbol_id) => (
+                "program-facts",
+                self.published.version.program_facts_root.to_tree(),
+                crate::artifacts::program_key("function", symbol_id),
+                "compass.program.function",
+            ),
+            OwnedHistoryRecordKey::ProgramSummary(symbol_id) => (
+                "program-summaries",
+                self.published.version.program_summaries_root.to_tree(),
+                crate::artifacts::program_key("summary", symbol_id),
+                "compass.program.summary",
+            ),
+            OwnedHistoryRecordKey::ReverseCallers(symbol_id) => (
+                "program-summaries",
+                self.published.version.program_summaries_root.to_tree(),
+                crate::artifacts::program_key("reverse-call", symbol_id),
+                "compass.program.reverse-call",
+            ),
+        };
+        let tree = self
+            .roots
+            .borrow_mut()
+            .entry(root_name)
+            .or_insert(tree)
+            .clone();
+        let value = match self.store.prolly.get(&tree, &encoded_key)? {
+            None => None,
+            Some(bytes) => {
+                if bytes.len() > crate::MAX_RECORD_VALUE_BYTES {
+                    return Err(HistoryError::CorruptHistory(
+                        "history record exceeds byte limit".to_owned(),
+                    ));
+                }
+                Some(match &owned {
+                    OwnedHistoryRecordKey::Node(_) => {
+                        HistoryRecord::Node(crate::artifacts::decode_typed(&bytes, schema)?)
+                    }
+                    OwnedHistoryRecordKey::ProgramModule(_) => HistoryRecord::ProgramModule(
+                        crate::artifacts::decode_typed(&bytes, schema)?,
+                    ),
+                    OwnedHistoryRecordKey::ProgramFunction(_) => HistoryRecord::ProgramFunction(
+                        crate::artifacts::decode_typed(&bytes, schema)?,
+                    ),
+                    OwnedHistoryRecordKey::ProgramSummary(_) => HistoryRecord::ProgramSummary(
+                        crate::artifacts::decode_typed(&bytes, schema)?,
+                    ),
+                    OwnedHistoryRecordKey::ReverseCallers(_) => HistoryRecord::ReverseCallers(
+                        crate::artifacts::decode_typed(&bytes, schema)?,
+                    ),
+                })
+            }
+        };
+        self.records.borrow_mut().insert(owned, value.clone());
+        Ok(value)
+    }
+
+    pub fn read_many<'key>(
+        &self,
+        keys: impl IntoIterator<Item = HistoryRecordKey<'key>>,
+    ) -> Result<Vec<Option<HistoryRecord>>, HistoryError> {
+        keys.into_iter().map(|key| self.read(key)).collect()
+    }
+}

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -132,72 +132,14 @@ impl HistoryStore {
         &self.database_path
     }
 
+    /// Open the owner-protected disposable cache plane.
+    pub fn cache(&self) -> Result<crate::HistoryCache, HistoryError> {
+        crate::HistoryCache::open(&self.root)
+    }
+
     /// Acquire the shared activity lock.
     pub fn activity(&self) -> Result<ActivityGuard, HistoryError> {
         ActivityGuard::acquire(&self.lock_path, false)
-    }
-
-    /// Read one typed semantic record without reconstructing its containing artifact tree.
-    pub fn read_record(
-        &self,
-        realization: &RealizationId,
-        key: HistoryRecordKey<'_>,
-    ) -> Result<Option<HistoryRecord>, HistoryError> {
-        let activity = self.activity()?;
-        let published = self.get_with_activity(realization, &activity)?;
-        let (tree, encoded_key, schema) = match key {
-            HistoryRecordKey::Node(id) => (
-                published.version.nodes_root.to_tree(),
-                crate::node_key(id),
-                "compass.node",
-            ),
-            HistoryRecordKey::ProgramModule(source_file) => (
-                self.load_program_root(realization, b"program-facts")?,
-                crate::artifacts::program_key("module", source_file),
-                "compass.program.module",
-            ),
-            HistoryRecordKey::ProgramFunction(symbol_id) => (
-                self.load_program_root(realization, b"program-facts")?,
-                crate::artifacts::program_key("function", symbol_id),
-                "compass.program.function",
-            ),
-            HistoryRecordKey::ProgramSummary(symbol_id) => (
-                self.load_program_root(realization, b"program-summaries")?,
-                crate::artifacts::program_key("summary", symbol_id),
-                "compass.program.summary",
-            ),
-            HistoryRecordKey::ReverseCallers(symbol_id) => (
-                self.load_program_root(realization, b"program-summaries")?,
-                crate::artifacts::program_key("reverse-call", symbol_id),
-                "compass.program.reverse-call",
-            ),
-        };
-        let Some(bytes) = self.prolly.get(&tree, &encoded_key)? else {
-            return Ok(None);
-        };
-        if bytes.len() > crate::MAX_RECORD_VALUE_BYTES {
-            return Err(HistoryError::CorruptHistory(
-                "history record exceeds byte limit".to_owned(),
-            ));
-        }
-        let record = match key {
-            HistoryRecordKey::Node(_) => {
-                HistoryRecord::Node(crate::artifacts::decode_typed(&bytes, schema)?)
-            }
-            HistoryRecordKey::ProgramModule(_) => {
-                HistoryRecord::ProgramModule(crate::artifacts::decode_typed(&bytes, schema)?)
-            }
-            HistoryRecordKey::ProgramFunction(_) => {
-                HistoryRecord::ProgramFunction(crate::artifacts::decode_typed(&bytes, schema)?)
-            }
-            HistoryRecordKey::ProgramSummary(_) => {
-                HistoryRecord::ProgramSummary(crate::artifacts::decode_typed(&bytes, schema)?)
-            }
-            HistoryRecordKey::ReverseCallers(_) => {
-                HistoryRecord::ReverseCallers(crate::artifacts::decode_typed(&bytes, schema)?)
-            }
-        };
-        Ok(Some(record))
     }
 
     /// Acquire the exclusive maintenance lock.

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -126,8 +126,10 @@ fn diff_reports_topology_attribute_and_analysis_changes() -> Result<(), Box<dyn 
         vec![json!({"id":"flow","nodes":["a","b"],"weight":2})],
         2,
     )?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
     let mut changes = VecSink::default();
-    history.diff(&old.id, &new.id, &mut changes)?;
+    old_reader.diff(&new_reader, &mut changes)?;
     assert!(changes.0.iter().any(|change| {
         change.record == RecordKind::Node
             && change.change == ChangeKind::Added
@@ -146,9 +148,8 @@ fn diff_reports_topology_attribute_and_analysis_changes() -> Result<(), Box<dyn 
             .any(|change| change.record == RecordKind::Analysis)
     );
     let mut topology_roots = VecSink::default();
-    history.diff_records(
-        &old.id,
-        &new.id,
+    old_reader.diff_records(
+        &new_reader,
         &[RecordKind::Node, RecordKind::Edge],
         &mut topology_roots,
     )?;
@@ -181,8 +182,10 @@ fn identity_changes_are_remove_add_equal_roots_are_empty_and_sink_errors_stop()
         vec![json!({"nodes":["a","b"],"weight":2})],
         1,
     )?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
     let mut changes = VecSink::default();
-    history.diff(&old.id, &new.id, &mut changes)?;
+    old_reader.diff(&new_reader, &mut changes)?;
     for record in [RecordKind::Edge, RecordKind::Hyperedge] {
         assert!(
             changes
@@ -198,7 +201,7 @@ fn identity_changes_are_remove_add_equal_roots_are_empty_and_sink_errors_stop()
         );
     }
     let mut equal = VecSink::default();
-    history.diff(&old.id, &old.id, &mut equal)?;
+    old_reader.diff(&old_reader, &mut equal)?;
     assert!(equal.0.is_empty());
 
     struct FailingSink(usize);
@@ -209,7 +212,7 @@ fn identity_changes_are_remove_add_equal_roots_are_empty_and_sink_errors_stop()
         }
     }
     let mut failing = FailingSink(0);
-    assert!(history.diff(&old.id, &new.id, &mut failing).is_err());
+    assert!(old_reader.diff(&new_reader, &mut failing).is_err());
     assert_eq!(failing.0, 1);
     Ok(())
 }
@@ -225,18 +228,19 @@ fn full_diff_includes_program_facts_while_topology_diff_skips_them()
     let mut new_request = request('f', vec![json!({"id":"a"})], vec![], vec![], 1)?;
     new_request.artifacts.program = Some(program(b"new")?);
     let new = history.publish(new_request)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
 
     let mut full = VecSink::default();
-    history.diff(&old.id, &new.id, &mut full)?;
+    old_reader.diff(&new_reader, &mut full)?;
     assert!(
         full.0
             .iter()
             .any(|change| change.record == RecordKind::ProgramFact)
     );
     let mut topology = VecSink::default();
-    history.diff_records(
-        &old.id,
-        &new.id,
+    old_reader.diff_records(
+        &new_reader,
         &[RecordKind::Node, RecordKind::Edge],
         &mut topology,
     )?;

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -179,8 +179,10 @@ fn small_change_reuses_content_addressed_nodes() -> Result<(), Box<dyn std::erro
     assert!(after_second - after_first < sharing.second_total_nodes);
 
     let mut sink = CountingSink::default();
+    let first_reader = history.reader(&first.id)?;
+    let second_reader = history.reader(&second.id)?;
     let started = Instant::now();
-    history.diff(&first.id, &second.id, &mut sink)?;
+    first_reader.diff(&second_reader, &mut sink)?;
     let diff_latency = started.elapsed();
     assert!(sink.changes > 0);
 

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -23,6 +23,7 @@ time.workspace = true
 compass-files = { path = "../compass-files", version = "0.1.4" }
 compass-cypher = { path = "../compass-cypher", version = "0.1.4" }
 compass-graph = { path = "../compass-graph", version = "0.1.4" }
+compass-history = { path = "../compass-history", version = "0.1.4" }
 compass-model = { path = "../compass-model", version = "0.1.4" }
 compass-query = { path = "../compass-query", version = "0.1.4" }
 unicode-normalization.workspace = true

--- a/crates/compass-output/src/history_viewer.rs
+++ b/crates/compass-output/src/history_viewer.rs
@@ -1,0 +1,326 @@
+use std::collections::{BTreeMap, HashMap};
+
+use compass_graph::Communities;
+use compass_history::{GraphRecordSink, HistoryError, RealizationReader};
+use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
+use serde_json::{Map, Value};
+
+use crate::{
+    GraphViewModel, HtmlOptions, OutputError, graph_community_view_model_document,
+    graph_view_model_document,
+};
+
+/// Builds the public historical viewer model from graph-only history roots.
+pub fn historical_view_model(
+    reader: &RealizationReader<'_>,
+    title: impl Into<String>,
+    node_limit: isize,
+    community: Option<usize>,
+) -> Result<GraphViewModel, HistoricalViewError> {
+    let mode = if community.is_some() {
+        ProjectionMode::Community(community.unwrap_or_default())
+    } else if reader.version().version.node_count > node_limit.max(0) as u64 {
+        ProjectionMode::Aggregate
+    } else {
+        ProjectionMode::Exact
+    };
+    let mut builder = HistoricalViewBuilder::new(mode);
+    reader.scan_graph(&mut builder)?;
+    builder.project(title.into(), node_limit)
+}
+
+/// Reconstruct only the node-link fields required by graph queries.
+pub fn historical_graph_document(
+    reader: &RealizationReader<'_>,
+) -> Result<GraphDocument, HistoricalViewError> {
+    historical_graph_document_with_labels(reader).map(|(document, _)| document)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HistoricalViewError {
+    #[error(transparent)]
+    History(#[from] HistoryError),
+    #[error(transparent)]
+    Output(#[from] OutputError),
+    #[error("historical graph has no renderable overview")]
+    Empty,
+}
+
+#[derive(Clone, Copy)]
+enum ProjectionMode {
+    Exact,
+    Community(usize),
+    Aggregate,
+}
+
+struct HistoricalViewBuilder {
+    mode: ProjectionMode,
+    attributes: BTreeMap<String, Map<String, Value>>,
+    labels: Option<Value>,
+    nodes: Vec<NodeRecord>,
+    edges: Vec<EdgeRecord>,
+    membership: HashMap<String, usize>,
+    member_counts: BTreeMap<usize, usize>,
+    cross_edges: BTreeMap<(usize, usize), usize>,
+}
+
+impl HistoricalViewBuilder {
+    fn new(mode: ProjectionMode) -> Self {
+        Self {
+            mode,
+            attributes: BTreeMap::new(),
+            labels: None,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            membership: HashMap::new(),
+            member_counts: BTreeMap::new(),
+            cross_edges: BTreeMap::new(),
+        }
+    }
+}
+
+impl GraphRecordSink for HistoricalViewBuilder {
+    fn node_attribute(
+        &mut self,
+        node_id: String,
+        field: String,
+        value: Value,
+    ) -> Result<(), HistoryError> {
+        self.attributes
+            .entry(node_id)
+            .or_default()
+            .insert(field, value);
+        Ok(())
+    }
+
+    fn labels(&mut self, labels: Value) -> Result<(), HistoryError> {
+        self.labels = Some(labels);
+        Ok(())
+    }
+
+    fn node(&mut self, mut node: NodeRecord) -> Result<(), HistoryError> {
+        if let Some(attributes) = self.attributes.remove(&node.id) {
+            node.attributes.extend(attributes);
+        }
+        let community = node
+            .attributes
+            .get("community")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as usize;
+        self.membership.insert(node.id.clone(), community);
+        *self.member_counts.entry(community).or_default() += 1;
+        if matches!(self.mode, ProjectionMode::Exact)
+            || matches!(self.mode, ProjectionMode::Community(selected) if selected == community)
+        {
+            self.nodes.push(node);
+        }
+        Ok(())
+    }
+
+    fn edge(&mut self, edge: EdgeRecord) -> Result<(), HistoryError> {
+        let source = self.membership.get(&edge.source).copied();
+        let target = self.membership.get(&edge.target).copied();
+        match self.mode {
+            ProjectionMode::Exact => self.edges.push(edge),
+            ProjectionMode::Community(selected)
+                if source == Some(selected) && target == Some(selected) =>
+            {
+                self.edges.push(edge);
+            }
+            ProjectionMode::Aggregate => {
+                if let (Some(source), Some(target)) = (source, target)
+                    && source != target
+                {
+                    *self
+                        .cross_edges
+                        .entry((source.min(target), source.max(target)))
+                        .or_default() += 1;
+                }
+            }
+            ProjectionMode::Community(_) => {}
+        }
+        Ok(())
+    }
+}
+
+fn historical_graph_document_with_labels(
+    reader: &RealizationReader<'_>,
+) -> Result<(GraphDocument, Option<Value>), HistoricalViewError> {
+    let mut builder = HistoricalViewBuilder::new(ProjectionMode::Exact);
+    reader.scan_graph(&mut builder)?;
+    builder.nodes.sort_by(|left, right| left.id.cmp(&right.id));
+    builder.edges.sort_by(|left, right| {
+        (&left.source, &left.target, left.string("relation")).cmp(&(
+            &right.source,
+            &right.target,
+            right.string("relation"),
+        ))
+    });
+    Ok((
+        GraphDocument {
+            directed: true,
+            multigraph: false,
+            graph: Map::new(),
+            nodes: builder.nodes,
+            links: builder.edges,
+            extras: BTreeMap::new(),
+        },
+        builder.labels,
+    ))
+}
+
+impl HistoricalViewBuilder {
+    fn project(
+        mut self,
+        title: String,
+        node_limit: isize,
+    ) -> Result<GraphViewModel, HistoricalViewError> {
+        if matches!(self.mode, ProjectionMode::Aggregate) {
+            return self.aggregate(title);
+        }
+        self.nodes.sort_by(|left, right| left.id.cmp(&right.id));
+        self.edges.sort_by(|left, right| {
+            (&left.source, &left.target, left.string("relation")).cmp(&(
+                &right.source,
+                &right.target,
+                right.string("relation"),
+            ))
+        });
+        let selected = match self.mode {
+            ProjectionMode::Community(selected) => Some(selected),
+            _ => None,
+        };
+        let document = GraphDocument {
+            directed: true,
+            multigraph: false,
+            graph: Map::new(),
+            nodes: self.nodes,
+            links: self.edges,
+            extras: BTreeMap::new(),
+        };
+        project_exact(document, self.labels, title, node_limit, selected)
+    }
+
+    fn aggregate(self, title: String) -> Result<GraphViewModel, HistoricalViewError> {
+        if self.member_counts.len() <= 1 {
+            return Err(HistoricalViewError::Empty);
+        }
+        let label_map = labels(self.labels.as_ref());
+        let nodes = self
+            .member_counts
+            .keys()
+            .map(|community| NodeRecord {
+                id: community.to_string(),
+                attributes: Map::from_iter([
+                    (
+                        "label".to_owned(),
+                        Value::String(
+                            label_map
+                                .get(community)
+                                .cloned()
+                                .unwrap_or_else(|| format!("Community {community}")),
+                        ),
+                    ),
+                    (
+                        "symbol_kind".to_owned(),
+                        Value::String("community".to_owned()),
+                    ),
+                ]),
+            })
+            .collect();
+        let links = self
+            .cross_edges
+            .into_iter()
+            .map(|((source, target), count)| EdgeRecord {
+                source: source.to_string(),
+                target: target.to_string(),
+                attributes: Map::from_iter([
+                    ("weight".to_owned(), Value::from(count)),
+                    (
+                        "relation".to_owned(),
+                        Value::String(format!("{count} cross-community edges")),
+                    ),
+                    (
+                        "confidence".to_owned(),
+                        Value::String("AGGREGATED".to_owned()),
+                    ),
+                ]),
+            })
+            .collect();
+        let document = GraphDocument {
+            directed: false,
+            multigraph: false,
+            graph: Map::new(),
+            nodes,
+            links,
+            extras: BTreeMap::new(),
+        };
+        let communities = self
+            .member_counts
+            .keys()
+            .map(|community| (*community, vec![community.to_string()]))
+            .collect();
+        Ok(crate::viewer_model::graph_view_model(
+            &document,
+            &communities,
+            title,
+            &HtmlOptions {
+                community_labels: (!label_map.is_empty()).then_some(&label_map),
+                member_counts: Some(&self.member_counts),
+                node_limit: None,
+                learning_overlay: None,
+            },
+            true,
+        ))
+    }
+}
+
+fn project_exact(
+    document: GraphDocument,
+    label_value: Option<Value>,
+    title: String,
+    node_limit: isize,
+    community: Option<usize>,
+) -> Result<GraphViewModel, HistoricalViewError> {
+    let mut communities = Communities::new();
+    for node in &document.nodes {
+        let community = node
+            .attributes
+            .get("community")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as usize;
+        communities
+            .entry(community)
+            .or_default()
+            .push(node.id.clone());
+    }
+    let labels = labels(label_value.as_ref());
+    let options = HtmlOptions {
+        community_labels: (!labels.is_empty()).then_some(&labels),
+        member_counts: None,
+        node_limit: Some(node_limit),
+        learning_overlay: None,
+    };
+    match community {
+        Some(community) => Ok(graph_community_view_model_document(
+            &document,
+            &communities,
+            title,
+            &options,
+            community,
+        )?),
+        None => graph_view_model_document(&document, &communities, title, &options)?
+            .ok_or(HistoricalViewError::Empty),
+    }
+}
+
+fn labels(value: Option<&Value>) -> BTreeMap<usize, String> {
+    value
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|labels| labels.iter())
+        .filter_map(|(community, label)| {
+            Some((community.parse().ok()?, label.as_str()?.to_owned()))
+        })
+        .collect()
+}

--- a/crates/compass-output/src/lib.rs
+++ b/crates/compass-output/src/lib.rs
@@ -8,6 +8,7 @@ mod cql;
 mod cypher;
 mod graphml;
 mod history_bundle;
+mod history_viewer;
 mod html;
 mod json;
 mod obsidian;
@@ -34,6 +35,7 @@ pub use graphml::{graphml_document, write_graphml};
 pub use history_bundle::{
     DerivedArtifactRequest, HistoryBundleInput, SUPPORTED_HISTORY_RENDERER, publish_history_bundle,
 };
+pub use history_viewer::{HistoricalViewError, historical_graph_document, historical_view_model};
 pub use html::{
     HtmlOptions, HtmlRender, graph_community_view_model_document, graph_view_model_document,
     html_document, write_html,

--- a/crates/compass-semantic-diff/src/lib.rs
+++ b/crates/compass-semantic-diff/src/lib.rs
@@ -17,3 +17,6 @@ pub use model::{
     TestEvidence, TestEvidenceProvider, Verification, VerificationState, WitnessHop, WitnessPath,
 };
 pub use verification::StaticTestEvidence;
+
+/// Included in derived-cache keys. Increment whenever comparison semantics change.
+pub const ENGINE_VERSION: u32 = 1;

--- a/crates/compass-semantic/src/orchestration.rs
+++ b/crates/compass-semantic/src/orchestration.rs
@@ -1,7 +1,9 @@
 //! Corpus-level semantic extraction, reconciliation, and caching.
 
 use super::*;
-use compass_files::{Cache, CacheKind, bisect_slice, file_hash, prompt_fingerprint, split_file};
+use compass_files::{
+    Cache, CacheKind, CacheOptions, bisect_slice, file_hash, prompt_fingerprint, split_file,
+};
 
 /// Load one semantic chunk, call a resolved provider, validate its untrusted
 /// graph fragment, and bind code-symbol evidence to the exact text sent to the
@@ -752,8 +754,18 @@ where
     let prompt = extraction_prompt(options.deep_mode);
     let cache_enabled =
         options.cache_enabled && !environment.contains_key("COMPASS_NO_INCREMENTAL_CACHE");
+    let cache_options = cache_root.map_or_else(
+        || CacheOptions::output_directory(None),
+        |cache_root| {
+            if std::env::var_os("COMPASS_HISTORY_BUILD").is_some() {
+                CacheOptions::shared_history(cache_root)
+            } else {
+                CacheOptions::output_directory(Some(cache_root))
+            }
+        },
+    );
     let mut cache = cache_enabled
-        .then(|| Cache::new(root, cache_root))
+        .then(|| Cache::open(root, cache_options))
         .transpose()?;
     let checked = if options.force || !cache_enabled {
         SemanticCacheCheck {
@@ -1046,11 +1058,10 @@ pub fn check_semantic_cache(
     check_semantic_cache_mode(cache, files, deep_mode.then_some("deep"), Some(prompt))
 }
 
-/// Compatibility cache reader for agent-managed extraction workflows.
+/// Deterministic cache reader for agent-managed extraction workflows.
 ///
-/// A missing prompt reads the historical flat namespace. Supplying a prompt
-/// selects its fingerprinted namespace while retaining legacy fallback, just
-/// like Python's `check_semantic_cache`.
+/// Supplying a prompt selects its fingerprinted namespace. The hard-cutover
+/// cache contract never falls back to a previous namespace or encoding.
 pub fn check_semantic_cache_mode(
     cache: &mut Cache,
     files: &[PathBuf],
@@ -1063,7 +1074,7 @@ pub fn check_semantic_cache_mode(
     let fingerprint = prompt.map(prompt_fingerprint);
     let mut checked = SemanticCacheCheck::default();
     for file in files {
-        let Some(entry) = cache.load(file, &kind, fingerprint.as_deref(), true, false)? else {
+        let Some(entry) = cache.load(file, &kind, fingerprint.as_deref(), false)? else {
             checked.uncached.push(file.clone());
             continue;
         };
@@ -1224,7 +1235,7 @@ pub fn save_semantic_cache(
         }
         let mut previous_partial = false;
         if options.merge_existing
-            && let Some(previous) = cache.load(&path, &kind, Some(&fingerprint), false, true)?
+            && let Some(previous) = cache.load(&path, &kind, Some(&fingerprint), true)?
         {
             previous_partial = previous.get("partial").and_then(Value::as_bool) == Some(true);
             prepend_cached_bucket(&mut group.nodes, &previous, "nodes");

--- a/crates/compass-semantic/src/tests.rs
+++ b/crates/compass-semantic/src/tests.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread::JoinHandle;
 
-use compass_files::Cache;
+use compass_files::{Cache, CacheOptions};
 use serde_json::json;
 
 use super::*;
@@ -900,7 +900,10 @@ fn cached_corpus_orchestration_checkpoints_replays_and_prunes() -> Result<(), Bo
         .collect::<Result<Vec<_>, std::io::Error>>()?;
     let orphan = corpus.path().join("orphan.md");
     fs::write(&orphan, "orphan")?;
-    let mut seed_cache = Cache::new(corpus.path(), Some(output.path()))?;
+    let mut seed_cache = Cache::open(
+        corpus.path(),
+        CacheOptions::output_directory(Some(output.path())),
+    )?;
     save_semantic_cache(
         &mut seed_cache,
         corpus.path(),
@@ -952,7 +955,11 @@ fn cached_corpus_orchestration_checkpoints_replays_and_prunes() -> Result<(), Bo
         },
         &mut |index, total, chunk, _| {
             if let Ok(mut observations) = checkpoint_observations.lock() {
-                let mut probe = Cache::new(corpus.path(), Some(output.path())).ok();
+                let mut probe = Cache::open(
+                    corpus.path(),
+                    CacheOptions::output_directory(Some(output.path())),
+                )
+                .ok();
                 let cached = probe.as_mut().and_then(|cache| {
                     check_semantic_cache(
                         cache,
@@ -1084,7 +1091,10 @@ fn semantic_cache_checkpoints_are_scoped_partial_and_prompt_versioned() -> Resul
     fs::write(&a, "a")?;
     fs::write(&b, "b")?;
     fs::write(&c, "c")?;
-    let mut cache = Cache::new(corpus.path(), Some(output.path()))?;
+    let mut cache = Cache::open(
+        corpus.path(),
+        CacheOptions::output_directory(Some(output.path())),
+    )?;
     let fragment = json!({
         "nodes":[
             {"id":"a","source_file":&a},

--- a/crates/compass-semantic/tests/orchestration_coverage.rs
+++ b/crates/compass-semantic/tests/orchestration_coverage.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use compass_files::Cache;
+use compass_files::{Cache, CacheOptions};
 use compass_semantic::{
     CachedCorpusExtractionOptions, CorpusExtractionOptions, SemanticCacheSaveOptions,
     SemanticError, SemanticUnit, check_semantic_cache, effective_semantic_concurrency,
@@ -275,7 +275,7 @@ fn cached_corpus_pipeline_checkpoints_replays_and_filters_out_of_scope_entries()
     assert_eq!(replay.cache_misses, 0);
     assert_eq!(replay.fragment["nodes"].as_array().map(Vec::len), Some(2));
 
-    let mut cache = Cache::new(root, None)?;
+    let mut cache = Cache::open(root, CacheOptions::output_directory(None))?;
     let fragment = json!({
         "nodes":[
             {"id":"inside","source_file":first.to_string_lossy()},
@@ -397,7 +397,7 @@ fn slice_retry_cache_disabled_and_deep_partial_merges_cover_public_orchestration
         reconcile_semantic_scope(&mut malformed, std::slice::from_ref(&document), root).is_err()
     );
 
-    let mut cache = Cache::new(root, None)?;
+    let mut cache = Cache::open(root, CacheOptions::output_directory(None))?;
     let mut save_options = SemanticCacheSaveOptions::for_extraction(true);
     save_options.merge_existing = true;
     save_options.partial_source_files = vec![document.clone()];

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -38,11 +38,9 @@ code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
 History graph schema `networkx-node-link/v1` records automatic multigraph
-promotion. This is a hard cutover: Compass accepts only the current v1 build
-profiles, realizations, and history stores. It does not migrate, normalize,
-list, query, or diff any other history contract. Archive or remove the
-repository's Compass history directory in the common Git directory, then build
-fresh v1 realizations.
+promotion. This release is a hard cutover for caches and operational state:
+Compass starts the new `cache/v1` namespace empty and never imports or reads
+legacy cache entries. The immutable realization schema itself is unchanged.
 
 ## 1. Inspect the command contract
 
@@ -56,8 +54,8 @@ compass diff --help
 History commands include:
 
 ```text
-enable   disable   status   build   rebuild
-list     show      prefer   export  gc
+enable   disable   status   verify  build   rebuild
+list     show      prefer   export  cache   gc
 ```
 
 Text output is for people. Commands that support `--format json` expose stable
@@ -129,9 +127,16 @@ first-parent lineage:
 compass history build main --all --first-parent
 ```
 
+The first request for an arbitrary, previously unseen revision is allowed to
+perform one bounded detached-worktree extraction. Later revisions reuse the
+repository-wide verified-content AST and Program cache, so unchanged files are
+not parsed again.
+
 Compass resolves the ref and build profile once, orders commits
-parent-before-child, and processes them sequentially. A rerun validates and
-skips preferred realizations that already match the selected profile. Failures
+parent-before-child, and processes them sequentially. A rerun seal-checks and
+skips preferred realizations that already match the selected profile. Use
+`compass history verify REV` when you need a full record-by-record integrity
+scan. Failures
 are recorded per commit without stopping later commits; the final report is
 still produced and the command exits `1` if any commit failed. Progress is
 written to stderr, while `--format json` writes one stable summary object to
@@ -390,6 +395,19 @@ Apply it explicitly:
 ```bash
 compass history gc --prune-non-preferred --yes
 ```
+
+Derived and extraction caches are disposable and have separate maintenance:
+
+```bash
+compass history cache status
+compass history cache gc --max-bytes 1073741824
+compass history cache gc --max-age-days 30 --yes
+```
+
+Cache GC is a dry run unless `--yes` is supplied. It never removes immutable
+realizations. Semantic diff reports and historical viewer projections are
+keyed by realization and engine/projection version; repeated reads therefore
+avoid graph traversal.
 
 Reported bytes and node rows are logical reclamation. GC does not promise that
 the SQLite file shrinks and does not run `VACUUM`.

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -353,6 +353,12 @@ and graph file signature. They are:
 
 Do not archive them as the only graph copy.
 
+Versioned history uses a repository-private `cache/v1` directory below the Git
+common directory. It contains verified-content extraction entries plus
+canonical semantic-diff and viewer projections. This is a hard-cutover cache:
+older layouts are ignored, not migrated. Everything below `cache/v1` is
+reproducible from Git commits and immutable realizations.
+
 ## Other exports
 
 `compass export` can produce:

--- a/docs/superpowers/plans/2026-07-26-versioned-history-performance.md
+++ b/docs/superpowers/plans/2026-07-26-versioned-history-performance.md
@@ -34,7 +34,7 @@ shell/Python qualification tooling, existing VS Code Compass CLI integration.
 
 - The first request for an unseen arbitrary commit may perform one bounded exact
   extraction in the protected detached worktree.
-- A compatible, already-published realization must not perform full-tree
+- A matching, already-published realization must not perform full-tree
   validation, artifact reconstruction, or extraction.
 - `history.sqlite` remains the only authoritative realization store. Every file
   below `cache/v1` is disposable and reproducible.
@@ -50,6 +50,18 @@ shell/Python qualification tooling, existing VS Code Compass CLI integration.
   report IDs, source patches, and report ordering.
 - Preserve the current `compass.semantic_diff.report/1` and
   `compass.history.viewer_graph/1` public schemas.
+- Ship a hard cutover: no legacy cache reads, cache imports, on-read migrations,
+  deprecated Rust APIs, dual CLI fields, feature flags, or mixed old/new
+  execution paths.
+- Delete `Cache::new`, `legacy_directory`, legacy JSON/MessagePack fallback,
+  `allow_legacy`, legacy build-state validation, `HistoryStore::read_record`,
+  and store-owned diff entry points after migrating every workspace call site.
+- Start the new cache namespace empty. Ignore prior cache files; cache GC may
+  remove them.
+- Keep `HISTORY_SCHEMA_VERSION` unchanged because the authoritative Prolly
+  representation does not change. If implementation requires an authoritative
+  format change, bump the schema and reject old stores explicitly; do not write
+  a migration adapter.
 - Keep the VS Code extension on Compass CLI commands; do not introduce a
   Graphify runtime dependency.
 - Preserve all unrelated worktree changes. Stage only files named by the active
@@ -107,8 +119,10 @@ All work in this plan uses this repository-private layout:
 └── tmp/
 ```
 
-The existing `CacheKind` version subdirectories remain below these roots. Do not
-copy the current-tree `stat-index.json` into shared history storage.
+The `CacheKind` version subdirectories are recreated below these roots using
+only the new encoding. Do not copy, import, hard-link, or decode entries from
+the previous cache layout. Do not copy the current-tree `stat-index.json` into
+shared history storage.
 
 ## Stable production interfaces
 
@@ -193,7 +207,8 @@ builder or reader.
 
 ### Portable extraction cache mode
 
-Extend `crates/compass-files/src/cache.rs` with an explicit layout/hash policy:
+Replace the cache constructor/API in `crates/compass-files/src/cache.rs` with an
+explicit layout/hash policy:
 
 ```rust
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -215,8 +230,16 @@ pub struct CacheOptions<'a> {
 }
 ```
 
-Keep `Cache::new` as the current-tree compatibility constructor. Add a shared
-history constructor that:
+Expose one constructor:
+
+```rust
+pub fn open(root: impl AsRef<Path>, options: CacheOptions<'_>)
+    -> Result<Self, FileError>;
+```
+
+Migrate every workspace caller to `Cache::open` and delete `Cache::new`.
+`CacheLayout::OutputDirectory` creates the current-tree layout under the
+selected output root. `CacheLayout::SharedHistory`:
 
 - writes directly below `cache/v1`, without inserting
   `<output-name>/cache`;
@@ -225,6 +248,11 @@ history constructor that:
 - always reads the file bytes instead of trusting a persisted size/mtime index;
 - does not flush `StatHashIndex`;
 - retains repository-relative Program and AST values.
+
+Delete `legacy_directory`, the `allow_legacy` argument, legacy JSON decode
+branches, legacy Program fallback, and pruning of legacy paths. Bump the
+deterministic cache encoding namespace so old entries cannot be selected by the
+new code.
 
 The relative logical path stays in the identity because extracted graph and
 Program facts contain `source_file`. The absolute checkout root and mtime do
@@ -261,6 +289,19 @@ impl RealizationReader<'_> {
         &self,
         keys: impl IntoIterator<Item = HistoryRecordKey<'key>>,
     ) -> Result<Vec<Option<HistoryRecord>>, HistoryError>;
+
+    pub fn diff(
+        &self,
+        new: &RealizationReader<'_>,
+        sink: &mut dyn ChangeSink,
+    ) -> Result<(), HistoryError>;
+
+    pub fn diff_records(
+        &self,
+        new: &RealizationReader<'_>,
+        records: &[RecordKind],
+        sink: &mut dyn ChangeSink,
+    ) -> Result<(), HistoryError>;
 }
 ```
 
@@ -273,8 +314,9 @@ The reader:
 - decodes each requested record at most once;
 - retains the existing value-size and typed-schema checks.
 
-Keep `HistoryStore::read_record` as a compatibility wrapper around a temporary
-reader until all external callers migrate.
+Migrate all callers in the same cutover and delete
+`HistoryStore::read_record`, `HistoryStore::diff`, and
+`HistoryStore::diff_records`. There is no one-shot wrapper.
 
 ### Graph-only scan
 
@@ -343,18 +385,24 @@ of maintaining two subtly different algorithms.
 ### Modified production files
 
 - `crates/compass-files/src/cache.rs`
-  - Shared layout and verified-content hashing.
+  - Single new cache API, shared layout, verified-content hashing, and removal
+    of all legacy readers.
 - `crates/compass-files/src/lib.rs`
-  - Export cache options.
+  - Export only the new cache options.
+- `crates/compass-files/tests/contracts.rs`
+  - Replace old-constructor/legacy-fallback coverage with hard-cutover
+    rejection coverage.
 - `crates/compass-history/src/lib.rs`
   - Export cache, reader, and graph-scan contracts.
 - `crates/compass-history/src/store.rs`
-  - Cache accessor; compatibility `read_record`; no change to authoritative
-    publication validation.
+  - Cache accessor; deletion of one-shot record reads; no change to
+    authoritative publication validation.
 - `crates/compass-history/src/diff.rs`
-  - Reuse opened sealed realizations where appropriate.
+  - Move diff entry points to request-scoped readers and delete store-owned
+    diff APIs.
 - `crates/compass-core/src/pipeline.rs`
-  - Accept an explicit shared cache root for history extraction.
+  - Accept an explicit shared cache root; use only the new cache constructor;
+    remove legacy build-state validation.
 - `crates/compass-core/src/history.rs`
   - Remove full validation from the existing-realization path; remove complete
     ancestor artifact seeding after shared cache activation; carry a prepared
@@ -366,6 +414,10 @@ of maintaining two subtly different algorithms.
     cache maintenance.
 - `crates/compass-cli/src/semantic_diff_commands.rs`
   - Prefetched readers and report cache.
+- `crates/compass-cli/src/semantic_commands.rs`
+  - Move the semantic cache caller to the new constructor.
+- `crates/compass-semantic/src/orchestration.rs`
+  - Move semantic orchestration to the new constructor.
 - `crates/compass-semantic-diff/src/lib.rs`
   - Export a comparison-engine cache version constant.
 - `crates/compass-output/src/lib.rs`
@@ -379,6 +431,9 @@ of maintaining two subtly different algorithms.
 ### Modified tests and qualification
 
 - `crates/compass-files/src/cache.rs` unit tests.
+- `crates/compass-files/tests/contracts.rs`.
+- `crates/compass-semantic/src/tests.rs`.
+- `crates/compass-semantic/tests/orchestration_coverage.rs`.
 - `crates/compass-history/tests/publication.rs`.
 - `crates/compass-history/tests/diff.rs`.
 - `crates/compass-history/tests/maintenance.rs`.
@@ -442,8 +497,9 @@ to:
 }
 ```
 
-Do not claim every record was revalidated. Preserve incompatible-store,
-unreadable-manifest, missing-root, and preferred-pointer error behavior.
+Do not claim every record was revalidated. Emit only the new `seal` object; do
+not retain or alias the old `validation` field. Incompatible stores, unreadable
+manifests, missing roots, and preferred-pointer errors still fail closed.
 
 - [ ] **Step 3: Add explicit full verification**
 
@@ -512,6 +568,7 @@ git commit -m "perf: use sealed history fast paths"
 
 - Modify: `crates/compass-files/src/cache.rs`
 - Modify: `crates/compass-files/src/lib.rs`
+- Modify: `crates/compass-files/tests/contracts.rs`
 - Add: `crates/compass-history/src/cache.rs`
 - Modify: `crates/compass-history/src/lib.rs`
 - Modify: `crates/compass-history/src/store.rs`
@@ -519,10 +576,15 @@ git commit -m "perf: use sealed history fast paths"
 - Modify: `crates/compass-core/src/history.rs`
 - Modify: `crates/compass-cli/src/history_build.rs`
 - Modify: `crates/compass-cli/src/history_commands.rs`
+- Modify: `crates/compass-cli/src/semantic_commands.rs`
+- Modify: `crates/compass-semantic/src/orchestration.rs`
 
 **Coverage files:**
 
 - Modify: `crates/compass-files/src/cache.rs` tests
+- Modify: `crates/compass-files/tests/contracts.rs`
+- Modify: `crates/compass-semantic/src/tests.rs`
+- Modify: `crates/compass-semantic/tests/orchestration_coverage.rs`
 - Modify: `crates/compass-core/tests/history_materialize.rs`
 - Modify: `crates/compass-cli/tests/history_cli.rs`
 
@@ -541,11 +603,35 @@ every existing component before returning `HistoryCache`.
 Implement derived envelope primitives now, even though semantic diff and viewer
 will use them in later tasks. This keeps storage/security logic in one slice.
 
-- [ ] **Step 2: Implement `CacheLayout::SharedHistory` and verified hashing**
+- [ ] **Step 2: Cut every cache caller over to `Cache::open`**
 
-Refactor directory construction so current-tree `Cache::new` produces exactly
-the same paths as before. The shared constructor writes `CacheKind` directories
-directly below `cache/v1`.
+Implement `Cache::open(root, CacheOptions)` and migrate every `compass-files`
+cache caller in:
+
+- `compass-core/src/pipeline.rs`;
+- `compass-semantic/src/orchestration.rs`;
+- `compass-cli/src/semantic_commands.rs`;
+- their unit and integration tests.
+
+Delete `Cache::new`; do not leave a deprecated alias. Bump the deterministic
+encoding namespace and delete:
+
+- `legacy_directory`;
+- the `allow_legacy` load parameter;
+- JSON fallback for deterministic binary entries;
+- Program JSON fallback;
+- prompt-fingerprint fallback to an unversioned directory;
+- pruning of legacy directories.
+
+Remove `allow_legacy_validation` and the pre-build-state fast path from
+`compass-core/src/pipeline.rs`. An output without a valid current build state is
+rebuilt once under the new contract.
+
+`CacheLayout::OutputDirectory` is the sole current-tree layout.
+`CacheLayout::SharedHistory` writes `CacheKind` directories directly below
+`cache/v1`.
+
+- [ ] **Step 3: Implement verified shared-history hashing**
 
 For shared AST lookup:
 
@@ -560,10 +646,10 @@ Do not consult or flush `StatHashIndex` in this mode. Preserve existing
 MessagePack decode limits, partial-entry rules, source-path rebasing, and atomic
 writes.
 
-Program cache keys remain caller-owned logical keys and continue to include the
+Program cache keys remain caller-owned logical keys and include the
 IR/provider/analyzer/merger versions already encoded by `CacheKind`.
 
-- [ ] **Step 3: Pass the shared cache through the exact history builder**
+- [ ] **Step 4: Pass the shared cache through the exact history builder**
 
 Add `BuildOptions::cache_root: Option<PathBuf>`. Current-tree callers leave it
 `None`. In `NativeCompleteGraphBuilder`, store the validated history
@@ -578,9 +664,13 @@ Both graph extraction and the parallel Program worker must construct a shared
 history `Cache` using the same root. Temporary output remains under the worktree
 and is deleted normally; cache entries survive.
 
-- [ ] **Step 4: Remove complete ancestor seeding**
+Failure to create, validate, read, or write the shared extraction cache fails
+the history build with the exact cache path and cause. Do not fall back to the
+temporary output cache.
 
-After shared cache hits are active, remove `compatible_seed` and the
+- [ ] **Step 5: Remove complete ancestor seeding**
+
+Remove `compatible_seed` and the
 `seed: Option<&GraphArtifacts>` parameter from `CompleteGraphBuilder::build`.
 Delete `seed.write_seed(...)` from `NativeCompleteGraphBuilder`.
 
@@ -588,14 +678,19 @@ Do not replace it with another full `HistoryStore::artifacts` call. Historical
 clustering already ignores prior communities under `COMPASS_HISTORY_BUILD`, so
 the shared content cache contains the reusable state this build needs.
 
-Keep first-parent manifest selection only if it supplies a bounded compatibility
-decision. It must not open graph, metadata, analysis, or Program trees.
+Delete first-parent seed/manifest selection from materialization. Profile and
+fingerprint matching applies to the target realization only.
 
-- [ ] **Step 5: Add cache correctness and reuse coverage**
+- [ ] **Step 6: Add hard-cutover, correctness, and reuse coverage**
 
 After implementation, add tests proving:
 
-- the current-tree constructor retains its exact legacy directory layout;
+- every production cache call site uses `Cache::open`;
+- `Cache::new`, `legacy_directory`, `allow_legacy`, and
+  `allow_legacy_validation` are absent from the workspace;
+- legacy deterministic JSON and Program JSON files are ignored, not imported;
+- a current output without the new build state performs one rebuild and then
+  uses the new fast path;
 - two different checkout roots with identical relative path and bytes map to
   the same shared entry;
 - same size/mtime but different bytes cannot collide;
@@ -608,13 +703,15 @@ After implementation, add tests proving:
   `graph.json`/`program.json`;
 - the builder never calls `HistoryStore::artifacts` to obtain an ancestor seed.
 
-- [ ] **Step 6: Verify the slice**
+- [ ] **Step 7: Verify the slice**
 
 Run:
 
 ```bash
 cargo fmt --all -- --check
 cargo test -p compass-files cache
+cargo test -p compass-files --test contracts
+cargo test -p compass-semantic
 cargo test -p compass-core --test history_materialize
 cargo test -p compass-cli --test history_cli history_build
 cargo test -p compass-cli --test history_cli adjacent
@@ -634,11 +731,12 @@ COMPASS_BIN="$PWD/target/release/compass" \
 Expected: the second build reports unchanged files as cache hits, and the
 original checkout remains clean.
 
-- [ ] **Step 7: Commit only this slice**
+- [ ] **Step 8: Commit only this slice**
 
 ```bash
 git add crates/compass-files/src/cache.rs \
   crates/compass-files/src/lib.rs \
+  crates/compass-files/tests/contracts.rs \
   crates/compass-history/src/cache.rs \
   crates/compass-history/src/lib.rs \
   crates/compass-history/src/store.rs \
@@ -646,9 +744,13 @@ git add crates/compass-files/src/cache.rs \
   crates/compass-core/src/history.rs \
   crates/compass-cli/src/history_build.rs \
   crates/compass-cli/src/history_commands.rs \
+  crates/compass-cli/src/semantic_commands.rs \
+  crates/compass-semantic/src/orchestration.rs \
+  crates/compass-semantic/src/tests.rs \
+  crates/compass-semantic/tests/orchestration_coverage.rs \
   crates/compass-core/tests/history_materialize.rs \
   crates/compass-cli/tests/history_cli.rs
-git commit -m "perf: share historical extraction cache"
+git commit -m "perf: cut over to shared history cache"
 ```
 
 ---
@@ -673,6 +775,7 @@ git commit -m "perf: share historical extraction cache"
 
 - One seal check and one lazy root open per realization.
 - At most one decode per evidence record per comparison.
+- One reader-owned diff API with no one-shot/store-owned alternative.
 
 - [ ] **Step 1: Implement `RealizationReader`**
 
@@ -696,6 +799,9 @@ Map node keys to the manifest's `nodes_root`; lazily load only
 `program-facts`/`program-summaries` named roots when their first key is
 requested.
 
+After migrating callers, delete `HistoryStore::read_record`. Do not retain a
+deprecated method or temporary-reader wrapper.
+
 - [ ] **Step 2: Prefetch the first semantic evidence frontier**
 
 In `semantic_diff_commands.rs`, replace `HistorySnapshots { store, old, new }`
@@ -713,12 +819,15 @@ The `SnapshotReader` implementation reads from the memoized readers and may
 perform a bounded fallback lookup for evidence discovered later. It must not
 reopen a manifest or root.
 
-- [ ] **Step 3: Reuse sealed versions in root diff**
+- [ ] **Step 3: Move root diff onto `RealizationReader`**
 
-Where `diff_records` is invoked with existing readers, add an internal
-`diff_records_with_readers` or equivalent helper so node/edge diff and evidence
-lookups share the same sealed `PublishedVersion` objects and activity window.
-Keep the public `HistoryStore::diff_records` API as a wrapper.
+Implement `RealizationReader::diff` and
+`RealizationReader::diff_records`. Node/edge diff and evidence lookups share the
+same sealed `PublishedVersion` objects and activity window.
+
+Migrate history change counts, semantic diff, and all history tests. Delete
+`HistoryStore::diff` and `HistoryStore::diff_records`; do not leave forwarding
+wrappers.
 
 - [ ] **Step 4: Add operation-count and semantic parity tests**
 
@@ -732,9 +841,10 @@ After the production reader exists, add a test-only counter seam that records:
 Assert one manifest open per side, at most one open for each requested root,
 one decode per unique key, and zero artifact reconstructions.
 
-Run the same fixture through the old compatibility wrapper and the new reader;
-assert identical `SemanticDiffReport` canonical bytes, findings, stable IDs,
-source patches, completeness, and limitations.
+Compare the new reader path with checked canonical fixture bytes; assert
+identical `SemanticDiffReport` findings, stable IDs, source patches,
+completeness, and limitations. Add a source scan asserting the removed
+store-owned read/diff method names do not remain in production code.
 
 - [ ] **Step 5: Verify the slice**
 
@@ -975,8 +1085,9 @@ community. After the authoritative publication succeeds and the realization ID
 is known, write the projection under the final realization-derived key.
 
 Projection generation or cache publication failure must not roll back or mark
-an otherwise valid realization corrupt. Older realizations without a projection
-continue through the streaming miss path.
+an otherwise valid realization corrupt. Every missing projection uses the same
+streaming miss path; there is no realization-age check, lazy-upgrade branch, or
+migration marker.
 
 - [ ] **Step 5: Add projection parity and root-bound coverage**
 
@@ -988,8 +1099,8 @@ After implementation, assert:
 - a cache miss opens analysis/nodes/edges once and never opens hyperedges,
   metadata, Program facts, or Program summaries;
 - a cache hit opens no record roots;
-- old realizations lazily gain a projection without changing their realization
-  ID;
+- deleting any projection causes deterministic regeneration without changing
+  the realization ID;
 - corrupt projection bytes regenerate;
 - corrupt authoritative graph records fail closed;
 - default projection exists after a new successful build;
@@ -1009,7 +1120,8 @@ npm test -w compass-vscode
 npm run typecheck -w compass-vscode
 ```
 
-Expected: the CLI envelope schema and extension command contract are unchanged.
+Expected: the CLI envelope schema and extension command contract use only the
+new cutover behavior; no dual response or deprecated command path remains.
 
 - [ ] **Step 7: Commit only this slice**
 
@@ -1191,6 +1303,11 @@ ignored and are invoked during release qualification.
 Document:
 
 - first-ever arbitrary revision performs bounded extraction;
+- the release is a hard cutover with an empty new cache namespace;
+- old cache files and old build state are ignored rather than migrated;
+- there is no compatibility flag, cache importer, or dual CLI response;
+- authoritative realization schema remains current because its format did not
+  change;
 - repeated build/diff/view behavior;
 - `history verify` versus sealed `history status`;
 - `history cache status/gc`;
@@ -1397,6 +1514,13 @@ state instead of silently creating a different PR.
   closed.
 - [ ] Cache GC is explicit, dry-run by default, and cannot remove immutable
   history.
+- [ ] No legacy cache decoder, legacy directory lookup, `Cache::new`,
+  `allow_legacy`, `allow_legacy_validation`, `HistoryStore::read_record`,
+  `HistoryStore::diff`, or `HistoryStore::diff_records` remains.
+- [ ] Status emits only the new seal contract; no deprecated validation field
+  or compatibility alias remains.
+- [ ] The release has no feature flag, dual read/write, cache import, or
+  migration path.
 - [ ] CocoIndex and Podman source checkouts remain unchanged.
 - [ ] Release latency/RSS targets are recorded honestly.
 - [ ] Rust, VS Code, and viewer regression gates pass or unrelated failures are

--- a/docs/superpowers/plans/2026-07-26-versioned-history-performance.md
+++ b/docs/superpowers/plans/2026-07-26-versioned-history-performance.md
@@ -1,0 +1,1406 @@
+# Versioned History Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. This plan
+> intentionally follows the user-approved implementation-first order:
+> implement each production slice, add its regression and performance coverage,
+> verify it, and then commit it. Do not reorder the work into a red/green TDD
+> sequence.
+
+**Goal:** Make arbitrary-revision graph materialization reuse Compass's portable
+content cache, make existing realization reads bounded by sealed manifests, make
+semantic diff reuse batched evidence and canonical reports, and make historical
+graph views load from bounded projections.
+
+**Architecture:** Keep `history.sqlite` authoritative and immutable. Add a
+repository-private `cache/v1` plane below the Git common directory for portable
+AST/Program entries and checked derived payloads. Ordinary reads trust the
+already-published manifest seal and direct roots; explicit verification and
+publication retain complete validation. Semantic diff uses two request-scoped
+readers and a direction-sensitive canonical-report cache. Historical viewer
+exports scan only graph-relevant roots on a miss and use a cached projection on
+subsequent requests.
+
+**Tech Stack:** Rust 2024, Compass's existing Prolly/SQLite history store,
+portable MessagePack extraction cache, canonical JSON, Git detached worktrees,
+shell/Python qualification tooling, existing VS Code Compass CLI integration.
+
+**Approved design:**
+`docs/superpowers/specs/2026-07-26-versioned-history-performance-design.md`
+
+---
+
+## Global constraints
+
+- The first request for an unseen arbitrary commit may perform one bounded exact
+  extraction in the protected detached worktree.
+- A compatible, already-published realization must not perform full-tree
+  validation, artifact reconstruction, or extraction.
+- `history.sqlite` remains the only authoritative realization store. Every file
+  below `cache/v1` is disposable and reproducible.
+- Publication, explicit integrity verification, preferred-pointer repair, and
+  corrupt-recovery paths retain full validation.
+- Manifest or direct-root corruption fails closed. Malformed derived or
+  extraction cache entries are cache misses.
+- Do not fetch, run hooks, enable smudge filters, recurse submodules, or weaken
+  the current detached-worktree boundary.
+- Cache identity must not contain a temporary-worktree path or depend on its
+  file modification times.
+- Preserve deterministic realization IDs, graph bytes, Program bytes, semantic
+  report IDs, source patches, and report ordering.
+- Preserve the current `compass.semantic_diff.report/1` and
+  `compass.history.viewer_graph/1` public schemas.
+- Keep the VS Code extension on Compass CLI commands; do not introduce a
+  Graphify runtime dependency.
+- Preserve all unrelated worktree changes. Stage only files named by the active
+  task.
+- After production code changes, run `graphify update .` from the Compass
+  repository as required by `AGENTS.md`.
+
+## Performance contract
+
+Release-mode qualification on local SSD storage must target:
+
+| Operation | CocoIndex-sized graph | Podman-sized graph |
+|---|---:|---:|
+| Existing overview, cached | ≤250 ms | ≤500 ms |
+| Existing overview, projection miss | ≤1 s | ≤2 s |
+| Repeated semantic diff | ≤250 ms | ≤500 ms |
+| First diff of materialized graphs | ≤1 s | ≤2 s |
+| No-op history build | ≤250 ms | ≤500 ms |
+| Adjacent history build | ≤2× equivalent current incremental update | ≤2× equivalent current incremental update |
+| First unseen commit | ≤1.25× equivalent current cold extraction | ≤1.25× equivalent current cold extraction |
+
+Podman semantic diff and historical overview must remain below 512 MiB peak
+RSS. Historical build RSS must remain within 25% of the equivalent current-tree
+extraction.
+
+The measured pre-change CocoIndex baseline is:
+
+- semantic diff: 5.19 seconds, 203 MiB;
+- viewer export: 152.40 seconds, 1.78 GiB;
+- existing `history build --profile-from`: 154.65 seconds, 1.77 GiB.
+
+Record an acceptance miss as a performance gap. Do not weaken validation,
+semantic correctness, or deterministic output to hide it.
+
+---
+
+## Stable storage layout
+
+All work in this plan uses this repository-private layout:
+
+```text
+<git-common-dir>/compass/
+├── history.sqlite
+├── cache/
+│   └── v1/
+│       ├── ast/
+│       ├── program-syntax/
+│       ├── program-artifact/
+│       ├── program-merge/
+│       ├── semantic-diff/
+│       └── viewer/
+├── jobs/
+├── leases/
+├── locks/
+└── tmp/
+```
+
+The existing `CacheKind` version subdirectories remain below these roots. Do not
+copy the current-tree `stat-index.json` into shared history storage.
+
+## Stable production interfaces
+
+Use the following names and preserve these boundaries and ownership rules.
+
+### Shared and derived cache
+
+Add `crates/compass-history/src/cache.rs` with these public concepts:
+
+```rust
+pub const HISTORY_CACHE_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DerivedCacheNamespace {
+    SemanticDiff,
+    Viewer,
+}
+
+#[derive(Clone, Debug)]
+pub struct HistoryCache {
+    root: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CacheStatus {
+    pub files: u64,
+    pub bytes: u64,
+    pub namespaces: BTreeMap<String, CacheNamespaceStatus>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CacheGcPlan {
+    pub files: u64,
+    pub bytes: u64,
+    pub paths: Vec<PathBuf>,
+}
+```
+
+`HistoryStore::cache()` returns a validated owner-only `HistoryCache`.
+`HistoryCache::extraction_root()` returns the exact `cache/v1` directory passed
+to `compass-files`. Derived reads and writes take a namespace plus canonical key
+material:
+
+```rust
+pub fn read(
+    &self,
+    namespace: DerivedCacheNamespace,
+    key_material: &Value,
+    max_payload_bytes: u64,
+) -> Result<Option<Vec<u8>>, HistoryError>;
+
+pub fn write(
+    &self,
+    namespace: DerivedCacheNamespace,
+    key_material: &Value,
+    payload: &[u8],
+) -> Result<(), HistoryError>;
+```
+
+The on-disk envelope stores:
+
+```json
+{
+  "schema": "compass.history.cache_entry/1",
+  "namespace": "semantic-diff",
+  "key_sha256": "<lowercase sha256>",
+  "payload_sha256": "<lowercase sha256>",
+  "payload": {}
+}
+```
+
+`payload` is the semantic report or viewer envelope as a JSON value. The
+payload digest is computed over its canonical JSON bytes. A hit must verify the
+requested key, payload length, and payload digest before returning those
+canonical bytes. A malformed envelope is ignored as a miss. Writes use the
+existing atomic file helpers and owner-only directories.
+
+The materializer already holds the shared history activity lock while its child
+extractor runs. Derived readers also hold an activity guard. Cache GC acquires
+the exclusive maintenance guard, so it cannot remove entries used by a live
+builder or reader.
+
+### Portable extraction cache mode
+
+Extend `crates/compass-files/src/cache.rs` with an explicit layout/hash policy:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheLayout {
+    OutputDirectory,
+    SharedHistory,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheHashPolicy {
+    StatIndexed,
+    VerifiedContent,
+}
+
+pub struct CacheOptions<'a> {
+    pub storage_root: Option<&'a Path>,
+    pub layout: CacheLayout,
+    pub hash_policy: CacheHashPolicy,
+}
+```
+
+Keep `Cache::new` as the current-tree compatibility constructor. Add a shared
+history constructor that:
+
+- writes directly below `cache/v1`, without inserting
+  `<output-name>/cache`;
+- computes the key from normalized repository-relative path plus file bytes,
+  extractor version, and existing cache-kind versions;
+- always reads the file bytes instead of trusting a persisted size/mtime index;
+- does not flush `StatHashIndex`;
+- retains repository-relative Program and AST values.
+
+The relative logical path stays in the identity because extracted graph and
+Program facts contain `source_file`. The absolute checkout root and mtime do
+not.
+
+### Request-scoped realization reader
+
+Add `crates/compass-history/src/reader.rs`:
+
+```rust
+pub struct RealizationReader<'store> {
+    store: &'store HistoryStore,
+    activity: ActivityGuard,
+    published: PublishedVersion,
+    // Lazily opened roots and decoded-record memoization are private.
+}
+
+impl HistoryStore {
+    pub fn reader(
+        &self,
+        realization: &RealizationId,
+    ) -> Result<RealizationReader<'_>, HistoryError>;
+}
+
+impl RealizationReader<'_> {
+    pub fn version(&self) -> &PublishedVersion;
+
+    pub fn read(
+        &self,
+        key: HistoryRecordKey<'_>,
+    ) -> Result<Option<HistoryRecord>, HistoryError>;
+
+    pub fn read_many<'key>(
+        &self,
+        keys: impl IntoIterator<Item = HistoryRecordKey<'key>>,
+    ) -> Result<Vec<Option<HistoryRecord>>, HistoryError>;
+}
+```
+
+The reader:
+
+- opens and seal-checks the realization once;
+- retains one activity guard;
+- lazily opens each requested root at most once;
+- memoizes positive and negative record lookups by an owned internal key;
+- decodes each requested record at most once;
+- retains the existing value-size and typed-schema checks.
+
+Keep `HistoryStore::read_record` as a compatibility wrapper around a temporary
+reader until all external callers migrate.
+
+### Graph-only scan
+
+Add `crates/compass-history/src/graph_read.rs`:
+
+```rust
+pub trait GraphRecordSink {
+    fn node_attribute(
+        &mut self,
+        node_id: String,
+        field: String,
+        value: Value,
+    ) -> Result<(), HistoryError>;
+
+    fn labels(&mut self, labels: Value) -> Result<(), HistoryError>;
+    fn node(&mut self, node: NodeRecord) -> Result<(), HistoryError>;
+    fn edge(&mut self, edge: EdgeRecord) -> Result<(), HistoryError>;
+}
+
+impl RealizationReader<'_> {
+    pub fn scan_graph(
+        &self,
+        sink: &mut dyn GraphRecordSink,
+    ) -> Result<(), HistoryError>;
+}
+```
+
+`scan_graph` reads only `analysis`, `nodes`, and `edges`, in that order. It
+decodes node analysis attributes and `.compass_labels.json`, ignores unrelated
+analysis sidecars, and never opens hyperedges, metadata, Program facts, Program
+summaries, or authoritative sidecars. Counts and record byte limits remain
+enforced.
+
+Add `crates/compass-output/src/history_viewer.rs` with a
+`HistoricalViewBuilder` implementation of `GraphRecordSink`. It produces the
+existing `GraphViewModel` directly:
+
+- for a graph at or below `node_limit`, retain exact nodes and edges;
+- for a larger graph, retain `node_id -> community`, community counts, labels,
+  and aggregated inter-community edges only;
+- for `--community ID`, retain only that community's exact nodes and internal
+  edges;
+- preserve the existing colors, labels, source locations, degree fields,
+  aggregation flag, ordering, and viewer schema.
+
+Extract reusable aggregation helpers from `compass-output/src/html.rs` instead
+of maintaining two subtly different algorithms.
+
+---
+
+## File map
+
+### New files
+
+- `crates/compass-history/src/cache.rs`
+  - Owner-only cache paths, checked derived envelopes, status, and GC planning.
+- `crates/compass-history/src/reader.rs`
+  - Sealed request-scoped readers, lazy roots, memoized typed lookups.
+- `crates/compass-history/src/graph_read.rs`
+  - Graph-only typed streaming contract.
+- `crates/compass-output/src/history_viewer.rs`
+  - Exact and aggregated viewer projection builder.
+- `docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md`
+  - Final CocoIndex and Podman release measurements and output digests.
+
+### Modified production files
+
+- `crates/compass-files/src/cache.rs`
+  - Shared layout and verified-content hashing.
+- `crates/compass-files/src/lib.rs`
+  - Export cache options.
+- `crates/compass-history/src/lib.rs`
+  - Export cache, reader, and graph-scan contracts.
+- `crates/compass-history/src/store.rs`
+  - Cache accessor; compatibility `read_record`; no change to authoritative
+    publication validation.
+- `crates/compass-history/src/diff.rs`
+  - Reuse opened sealed realizations where appropriate.
+- `crates/compass-core/src/pipeline.rs`
+  - Accept an explicit shared cache root for history extraction.
+- `crates/compass-core/src/history.rs`
+  - Remove full validation from the existing-realization path; remove complete
+    ancestor artifact seeding after shared cache activation; carry a prepared
+    default viewer projection.
+- `crates/compass-cli/src/history_build.rs`
+  - Pass the history cache root into the child extractor.
+- `crates/compass-cli/src/history_commands.rs`
+  - Sealed status/profile/build reads, explicit `verify`, graph-only export,
+    cache maintenance.
+- `crates/compass-cli/src/semantic_diff_commands.rs`
+  - Prefetched readers and report cache.
+- `crates/compass-semantic-diff/src/lib.rs`
+  - Export a comparison-engine cache version constant.
+- `crates/compass-output/src/lib.rs`
+  - Export historical viewer projection builder.
+- `crates/compass-output/src/html.rs`
+  - Share existing aggregation helpers with the streaming builder.
+- `crates/compass-output/src/viewer_model.rs`
+  - Add `Deserialize` only if a typed cached projection is required; otherwise
+    cache canonical envelope bytes and leave the model serialize-only.
+
+### Modified tests and qualification
+
+- `crates/compass-files/src/cache.rs` unit tests.
+- `crates/compass-history/tests/publication.rs`.
+- `crates/compass-history/tests/diff.rs`.
+- `crates/compass-history/tests/maintenance.rs`.
+- `crates/compass-history/tests/performance.rs`.
+- `crates/compass-core/tests/history_materialize.rs`.
+- `crates/compass-cli/tests/history_cli.rs`.
+- `scripts/qualify_history_real_repo.sh`.
+- `docs/guides/versioned-history.md`.
+- `docs/reference/outputs.md`.
+- `PERFORMANCE.md`.
+
+---
+
+### Task 1: Replace routine full validation with sealed fast reads
+
+**Production files:**
+
+- Modify: `crates/compass-core/src/history.rs`
+- Modify: `crates/compass-cli/src/history_commands.rs`
+- Modify: `crates/compass-cli/src/history_build.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-core/tests/history_materialize.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+- Modify: `crates/compass-history/tests/publication.rs`
+
+**Produces:**
+
+- Constant-sized no-op build and profile lookup.
+- An explicit integrity command:
+  `compass history verify REV|REALIZATION [--format text|json]`.
+
+- [ ] **Step 1: Implement the sealed existing-realization path**
+
+In `observe_preferred`, accept `preferred_with_activity` after its existing
+manifest parse, realization-ID recomputation, and direct-root verification.
+Remove the unconditional `validate_with_activity` call.
+
+In `resolve_or_materialize`, return an existing preferred realization after
+`history.preferred(&commit)` without calling `history.validate`.
+
+In `stored_profile`, copy `BuildProfile` from the sealed preferred/get result
+without loading graph records.
+
+In `execute_change_counts`, remove the two explicit `validate` calls.
+`diff_records` already seal-checks both realizations and streams only requested
+roots.
+
+- [ ] **Step 2: Make ordinary status describe the seal honestly**
+
+Change text status from `validation: valid` to `seal: valid`. Change JSON status
+to:
+
+```json
+{
+  "seal": {
+    "valid": true,
+    "mode": "manifest_and_direct_roots"
+  }
+}
+```
+
+Do not claim every record was revalidated. Preserve incompatible-store,
+unreadable-manifest, missing-root, and preferred-pointer error behavior.
+
+- [ ] **Step 3: Add explicit full verification**
+
+Dispatch `history verify` before the common export/status parser. Resolve its
+single argument as a commit first and as a `RealizationId` second. For a commit,
+verify the preferred realization. Call the existing `HistoryStore::validate`;
+report all `ValidationReport` counts in JSON and a concise valid/invalid text
+result.
+
+Keep full validation in:
+
+- `history verify`;
+- `history prefer`;
+- publication;
+- corrupt-preferred recovery;
+- explicit maintenance tests.
+
+- [ ] **Step 4: Add regression coverage after production behavior exists**
+
+Add tests proving:
+
+- a valid published realization with a deliberately corrupted non-root record
+  fails `history verify` but is not silently reconstructed by `history status`;
+- a missing or mismatched direct root still fails status and no-op build;
+- `history build REV --profile-from OTHER` reads the profile from the sealed
+  manifest and does not call a graph builder;
+- no-op materialization calls neither `CompleteGraphBuilder::build` nor
+  `HistoryStore::artifacts`;
+- `change-counts` remains byte-identical to the pre-change result.
+
+Use a counting builder/test seam rather than wall-clock assertions for this
+task.
+
+- [ ] **Step 5: Verify the slice**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-history --test publication
+cargo test -p compass-core --test history_materialize
+cargo test -p compass-cli --test history_cli history_status
+cargo test -p compass-cli --test history_cli profile_from
+cargo test -p compass-cli --test history_cli change_counts
+```
+
+Expected: all pass; the no-op path does not enter full validation.
+
+- [ ] **Step 6: Commit only this slice**
+
+```bash
+git add crates/compass-core/src/history.rs \
+  crates/compass-cli/src/history_commands.rs \
+  crates/compass-cli/src/history_build.rs \
+  crates/compass-core/tests/history_materialize.rs \
+  crates/compass-cli/tests/history_cli.rs \
+  crates/compass-history/tests/publication.rs
+git commit -m "perf: use sealed history fast paths"
+```
+
+---
+
+### Task 2: Share portable AST and Program caches across historical worktrees
+
+**Production files:**
+
+- Modify: `crates/compass-files/src/cache.rs`
+- Modify: `crates/compass-files/src/lib.rs`
+- Add: `crates/compass-history/src/cache.rs`
+- Modify: `crates/compass-history/src/lib.rs`
+- Modify: `crates/compass-history/src/store.rs`
+- Modify: `crates/compass-core/src/pipeline.rs`
+- Modify: `crates/compass-core/src/history.rs`
+- Modify: `crates/compass-cli/src/history_build.rs`
+- Modify: `crates/compass-cli/src/history_commands.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-files/src/cache.rs` tests
+- Modify: `crates/compass-core/tests/history_materialize.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+
+**Produces:**
+
+- One owner-only content cache shared by all linked worktrees.
+- Adjacent/arbitrary history builds that parse only cache misses.
+- No complete ancestor artifact reconstruction.
+
+- [ ] **Step 1: Implement the owner-only cache root and checked paths**
+
+Create `<git-common-dir>/compass/cache/v1` through the same symlink rejection and
+Unix owner-mode rules as the history store. `HistoryStore::cache()` must validate
+every existing component before returning `HistoryCache`.
+
+Implement derived envelope primitives now, even though semantic diff and viewer
+will use them in later tasks. This keeps storage/security logic in one slice.
+
+- [ ] **Step 2: Implement `CacheLayout::SharedHistory` and verified hashing**
+
+Refactor directory construction so current-tree `Cache::new` produces exactly
+the same paths as before. The shared constructor writes `CacheKind` directories
+directly below `cache/v1`.
+
+For shared AST lookup:
+
+1. canonicalize the checkout root and candidate file;
+2. require the file to remain below the checkout root;
+3. normalize its relative path to `/`;
+4. read file bytes;
+5. hash relative path, bytes, extractor version, and encoding version;
+6. use the digest as the entry filename.
+
+Do not consult or flush `StatHashIndex` in this mode. Preserve existing
+MessagePack decode limits, partial-entry rules, source-path rebasing, and atomic
+writes.
+
+Program cache keys remain caller-owned logical keys and continue to include the
+IR/provider/analyzer/merger versions already encoded by `CacheKind`.
+
+- [ ] **Step 3: Pass the shared cache through the exact history builder**
+
+Add `BuildOptions::cache_root: Option<PathBuf>`. Current-tree callers leave it
+`None`. In `NativeCompleteGraphBuilder`, store the validated history
+`extraction_root`, pass it to the child via a private
+`COMPASS_HISTORY_CACHE_ROOT` environment variable, and set it on the child's
+`BuildOptions` only when `COMPASS_HISTORY_BUILD=1`.
+
+Reject a relative cache root. The parent, not the detached checkout, chooses the
+path.
+
+Both graph extraction and the parallel Program worker must construct a shared
+history `Cache` using the same root. Temporary output remains under the worktree
+and is deleted normally; cache entries survive.
+
+- [ ] **Step 4: Remove complete ancestor seeding**
+
+After shared cache hits are active, remove `compatible_seed` and the
+`seed: Option<&GraphArtifacts>` parameter from `CompleteGraphBuilder::build`.
+Delete `seed.write_seed(...)` from `NativeCompleteGraphBuilder`.
+
+Do not replace it with another full `HistoryStore::artifacts` call. Historical
+clustering already ignores prior communities under `COMPASS_HISTORY_BUILD`, so
+the shared content cache contains the reusable state this build needs.
+
+Keep first-parent manifest selection only if it supplies a bounded compatibility
+decision. It must not open graph, metadata, analysis, or Program trees.
+
+- [ ] **Step 5: Add cache correctness and reuse coverage**
+
+After implementation, add tests proving:
+
+- the current-tree constructor retains its exact legacy directory layout;
+- two different checkout roots with identical relative path and bytes map to
+  the same shared entry;
+- same size/mtime but different bytes cannot collide;
+- the same bytes at different logical relative paths do not return stale
+  `source_file` data;
+- malformed MessagePack is a miss and is atomically replaced;
+- parallel writers converge on one decodable entry;
+- building adjacent commits extracts only the changed source file;
+- cache-hit and cache-miss builds publish the same realization ID and canonical
+  `graph.json`/`program.json`;
+- the builder never calls `HistoryStore::artifacts` to obtain an ancestor seed.
+
+- [ ] **Step 6: Verify the slice**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-files cache
+cargo test -p compass-core --test history_materialize
+cargo test -p compass-cli --test history_cli history_build
+cargo test -p compass-cli --test history_cli adjacent
+```
+
+Then run a local release smoke measurement in a temporary clone:
+
+```bash
+cargo build --release -p compass-cli
+COMPASS_BIN="$PWD/target/release/compass" \
+  scripts/qualify_history_real_repo.sh \
+  /Volumes/workspace/Github/leveldb \
+  78a352f47ed6c1e9d750545e9b242289185b87e1 \
+  4a0c572440c7df2f56a6f5fb5aec9e366d522edb
+```
+
+Expected: the second build reports unchanged files as cache hits, and the
+original checkout remains clean.
+
+- [ ] **Step 7: Commit only this slice**
+
+```bash
+git add crates/compass-files/src/cache.rs \
+  crates/compass-files/src/lib.rs \
+  crates/compass-history/src/cache.rs \
+  crates/compass-history/src/lib.rs \
+  crates/compass-history/src/store.rs \
+  crates/compass-core/src/pipeline.rs \
+  crates/compass-core/src/history.rs \
+  crates/compass-cli/src/history_build.rs \
+  crates/compass-cli/src/history_commands.rs \
+  crates/compass-core/tests/history_materialize.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "perf: share historical extraction cache"
+```
+
+---
+
+### Task 3: Batch and memoize semantic evidence reads
+
+**Production files:**
+
+- Add: `crates/compass-history/src/reader.rs`
+- Modify: `crates/compass-history/src/lib.rs`
+- Modify: `crates/compass-history/src/store.rs`
+- Modify: `crates/compass-history/src/diff.rs`
+- Modify: `crates/compass-cli/src/semantic_diff_commands.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-history/tests/diff.rs`
+- Modify: `crates/compass-history/tests/performance.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+
+**Produces:**
+
+- One seal check and one lazy root open per realization.
+- At most one decode per evidence record per comparison.
+
+- [ ] **Step 1: Implement `RealizationReader`**
+
+Move typed lookup selection/decoding out of `HistoryStore::read_record` into the
+request-scoped reader. Use interior mutability because `SnapshotReader` exposes
+`&self` methods. Memoize missing records as well as present records.
+
+Use a private owned key enum:
+
+```rust
+enum OwnedHistoryRecordKey {
+    Node(String),
+    ProgramModule(String),
+    ProgramFunction(String),
+    ProgramSummary(String),
+    ReverseCallers(String),
+}
+```
+
+Map node keys to the manifest's `nodes_root`; lazily load only
+`program-facts`/`program-summaries` named roots when their first key is
+requested.
+
+- [ ] **Step 2: Prefetch the first semantic evidence frontier**
+
+In `semantic_diff_commands.rs`, replace `HistorySnapshots { store, old, new }`
+with two `RealizationReader`s.
+
+Before `compare`:
+
+1. batch node IDs from direct node changes and dependency endpoints;
+2. batch old/new module paths from `SourceFileDelta`;
+3. collect symbol IDs from those modules and changed graph nodes;
+4. batch functions, summaries, and reverse callers for those symbols;
+5. collect returned caller IDs and batch those caller functions once.
+
+The `SnapshotReader` implementation reads from the memoized readers and may
+perform a bounded fallback lookup for evidence discovered later. It must not
+reopen a manifest or root.
+
+- [ ] **Step 3: Reuse sealed versions in root diff**
+
+Where `diff_records` is invoked with existing readers, add an internal
+`diff_records_with_readers` or equivalent helper so node/edge diff and evidence
+lookups share the same sealed `PublishedVersion` objects and activity window.
+Keep the public `HistoryStore::diff_records` API as a wrapper.
+
+- [ ] **Step 4: Add operation-count and semantic parity tests**
+
+After the production reader exists, add a test-only counter seam that records:
+
+- manifest opens;
+- named-root opens by kind;
+- typed decodes by owned key;
+- complete artifact reconstructions.
+
+Assert one manifest open per side, at most one open for each requested root,
+one decode per unique key, and zero artifact reconstructions.
+
+Run the same fixture through the old compatibility wrapper and the new reader;
+assert identical `SemanticDiffReport` canonical bytes, findings, stable IDs,
+source patches, completeness, and limitations.
+
+- [ ] **Step 5: Verify the slice**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-history --test diff
+cargo test -p compass-history --test performance
+cargo test -p compass-cli --test history_cli semantic_diff
+```
+
+Expected: all pass; uncached diff performs no full realization reconstruction.
+
+- [ ] **Step 6: Commit only this slice**
+
+```bash
+git add crates/compass-history/src/reader.rs \
+  crates/compass-history/src/lib.rs \
+  crates/compass-history/src/store.rs \
+  crates/compass-history/src/diff.rs \
+  crates/compass-history/tests/diff.rs \
+  crates/compass-history/tests/performance.rs \
+  crates/compass-cli/src/semantic_diff_commands.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "perf: batch semantic history reads"
+```
+
+---
+
+### Task 4: Cache canonical semantic-diff reports
+
+**Production files:**
+
+- Modify: `crates/compass-semantic-diff/src/lib.rs`
+- Modify: `crates/compass-cli/src/semantic_diff_commands.rs`
+- Modify: `crates/compass-history/src/cache.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+- Modify: `crates/compass-history/tests/maintenance.rs`
+
+**Produces:**
+
+- Repeated direction-sensitive semantic diff from one checked report payload.
+
+- [ ] **Step 1: Define the comparison cache identity**
+
+Export:
+
+```rust
+pub const SEMANTIC_DIFF_ENGINE_VERSION: u32 = 1;
+```
+
+Build canonical key material:
+
+```json
+{
+  "schema": "compass.history.semantic_diff_key/1",
+  "old_realization": "<id>",
+  "new_realization": "<id>",
+  "source_delta_sha256": "<digest>",
+  "engine_version": 1,
+  "report_schema": "compass.semantic_diff.report/1"
+}
+```
+
+Hash `SourceFileDelta` using canonical JSON in Git order. Do not include
+`--limit`, `--all`, `--explain`, output format, or output path; those are
+rendering choices. Direction remains significant.
+
+- [ ] **Step 2: Read the cache before graph diff/evidence work**
+
+After resolving exact comparable realizations and source deltas:
+
+1. build key material;
+2. read and verify the cached payload;
+3. deserialize `SemanticDiffReport`;
+4. verify its old/new realization identities and schema;
+5. render it with the current text/JSON/HTML options.
+
+On a miss, execute Task 3's diff and evidence path, serialize the complete
+report using canonical JSON, write it atomically, and then render the same
+in-memory report.
+
+Cache read/write failure should emit internal diagnostics when profiling is
+enabled but must not invalidate authoritative history. A malformed hit is
+ignored and replaced after recomputation.
+
+- [ ] **Step 3: Add cache hit, invalidation, and determinism coverage**
+
+After production behavior exists, assert:
+
+- first and repeated JSON output are byte-identical;
+- the repeated run performs zero Prolly graph diffs and zero evidence decodes;
+- text `--limit`, text `--all`, `--explain`, JSON, and HTML reuse one report;
+- swapping old/new produces a different key and correct reverse findings;
+- changing either realization ID, source delta digest, engine version, or
+  report schema misses;
+- a truncated entry, digest mismatch, or report identity mismatch recomputes;
+- parallel identical comparisons leave one valid payload.
+
+- [ ] **Step 4: Verify the slice**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-history --test maintenance cache
+cargo test -p compass-cli --test history_cli semantic_diff_cache
+```
+
+Measure one fixture twice with `scripts/measure_process.py`; expected second run
+is dominated by report decode/render and remains byte-identical.
+
+- [ ] **Step 5: Commit only this slice**
+
+```bash
+git add crates/compass-semantic-diff/src/lib.rs \
+  crates/compass-history/src/cache.rs \
+  crates/compass-history/tests/maintenance.rs \
+  crates/compass-cli/src/semantic_diff_commands.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "perf: cache semantic diff reports"
+```
+
+---
+
+### Task 5: Stream and cache historical viewer projections
+
+**Production files:**
+
+- Add: `crates/compass-history/src/graph_read.rs`
+- Modify: `crates/compass-history/src/lib.rs`
+- Modify: `crates/compass-history/src/reader.rs`
+- Add: `crates/compass-output/src/history_viewer.rs`
+- Modify: `crates/compass-output/src/lib.rs`
+- Modify: `crates/compass-output/src/html.rs`
+- Modify: `crates/compass-cli/src/history_commands.rs`
+- Modify: `crates/compass-core/src/history.rs`
+- Modify: `crates/compass-cli/src/history_build.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-history/tests/performance.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+- Modify: `crates/compass-output/src/history_viewer.rs` tests
+
+**Produces:**
+
+- Graph view on cache miss without full authoritative reconstruction.
+- Instant repeated overview/community exports.
+- Default projection warming for newly published realizations.
+
+- [ ] **Step 1: Implement graph-only record scanning**
+
+Add `RealizationReader::scan_graph` with fixed root order:
+
+1. analysis;
+2. nodes;
+3. edges.
+
+Decode only node analysis fields, labels, `NodeRecord`, and `EdgeRecord`.
+Validate key shapes, record limits, and typed schemas. An impossible analysis
+reference or malformed authoritative record fails closed.
+
+Do not open metadata merely to recover node/edge presentation order. Prolly
+keys and the builder's final sort provide deterministic viewer ordering.
+
+- [ ] **Step 2: Implement bounded projection construction**
+
+Move the existing community aggregation logic in `html.rs` into reusable helpers
+and implement `HistoricalViewBuilder`.
+
+For an overview larger than `node_limit`, keep:
+
+- one `HashMap<String, usize>` for node-to-community membership;
+- one bounded community accumulator per community;
+- one deterministic aggregate edge accumulator keyed by
+  `(source_community, target_community, relation)`;
+- labels and graph counts.
+
+Do not retain every decoded `NodeRecord` or `EdgeRecord` after its accumulator
+has been updated.
+
+For an exact small graph or selected community, retain only nodes in scope and
+edges whose endpoints are both retained. Apply the same deterministic sort and
+dedup rules as the existing viewer.
+
+- [ ] **Step 3: Cache canonical viewer envelopes**
+
+Use key material:
+
+```json
+{
+  "schema": "compass.history.viewer_key/1",
+  "realization": "<id>",
+  "viewer_schema": "compass.history.viewer_graph/1",
+  "projection_version": 1,
+  "node_limit": 5000,
+  "community": null
+}
+```
+
+On `history export REV --format json`:
+
+1. seal-check the preferred realization;
+2. read the cached complete envelope bytes;
+3. on a hit, atomically copy those bytes to `--output`;
+4. on a miss, stream graph roots, build the model, write canonical envelope
+   bytes to cache, and atomically copy them to output.
+
+Remove both the explicit `history.validate` and `history.artifacts` calls from
+the viewer JSON path. Keep full artifact reconstruction for authoritative
+`graph-json` and `compass-out` exports because those formats request the full
+artifact contract.
+
+- [ ] **Step 4: Warm the default overview during new publication**
+
+Add a builder hook with a default `None` implementation that prepares default viewer bytes from the
+already-loaded `CompletedGraphArtifacts` before publication moves those
+artifacts:
+
+```rust
+fn default_viewer_projection(
+    &self,
+    completed: &CompletedGraphArtifacts,
+    repository_root: &Path,
+    commit: &CommitId,
+) -> Result<Option<Vec<u8>>, MaterializeError> {
+    Ok(None)
+}
+```
+
+`NativeCompleteGraphBuilder` implements it with `node_limit=5000` and no
+community. After the authoritative publication succeeds and the realization ID
+is known, write the projection under the final realization-derived key.
+
+Projection generation or cache publication failure must not roll back or mark
+an otherwise valid realization corrupt. Older realizations without a projection
+continue through the streaming miss path.
+
+- [ ] **Step 5: Add projection parity and root-bound coverage**
+
+After implementation, assert:
+
+- cached and uncached viewer envelope bytes are identical;
+- the streaming model equals `graph_view_model_document` for small, aggregated,
+  and selected-community fixtures;
+- a cache miss opens analysis/nodes/edges once and never opens hyperedges,
+  metadata, Program facts, or Program summaries;
+- a cache hit opens no record roots;
+- old realizations lazily gain a projection without changing their realization
+  ID;
+- corrupt projection bytes regenerate;
+- corrupt authoritative graph records fail closed;
+- default projection exists after a new successful build;
+- a 120k-node synthetic graph remains below the operation-count/memory bound in
+  the ignored release performance test.
+
+- [ ] **Step 6: Verify the slice**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-output history_viewer
+cargo test -p compass-history --test performance viewer
+cargo test -p compass-cli --test history_cli history_export
+npm test -w compass-vscode
+npm run typecheck -w compass-vscode
+```
+
+Expected: the CLI envelope schema and extension command contract are unchanged.
+
+- [ ] **Step 7: Commit only this slice**
+
+```bash
+git add crates/compass-history/src/graph_read.rs \
+  crates/compass-history/src/lib.rs \
+  crates/compass-history/src/reader.rs \
+  crates/compass-history/tests/performance.rs \
+  crates/compass-output/src/history_viewer.rs \
+  crates/compass-output/src/lib.rs \
+  crates/compass-output/src/html.rs \
+  crates/compass-core/src/history.rs \
+  crates/compass-cli/src/history_build.rs \
+  crates/compass-cli/src/history_commands.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "perf: stream historical viewer projections"
+```
+
+---
+
+### Task 6: Add explicit cache status and garbage collection
+
+**Production files:**
+
+- Modify: `crates/compass-history/src/cache.rs`
+- Modify: `crates/compass-history/src/lib.rs`
+- Modify: `crates/compass-cli/src/history_commands.rs`
+
+**Coverage files:**
+
+- Modify: `crates/compass-history/tests/maintenance.rs`
+- Modify: `crates/compass-cli/tests/history_cli.rs`
+
+**Produces:**
+
+- Non-destructive cache inspection.
+- Explicit, dry-run-by-default budget/age pruning.
+
+- [ ] **Step 1: Implement deterministic cache inventory**
+
+Walk only known `cache/v1` namespaces without following symlinks. Report file
+count and allocated payload bytes per namespace. Ignore temporary atomic-write
+files younger than an active operation; report malformed/unsafe paths as
+diagnostics rather than traversing them.
+
+Touch an entry's access timestamp only after a verified cache hit. Do not touch
+on a malformed miss.
+
+- [ ] **Step 2: Implement GC planning and sweep**
+
+Support:
+
+```text
+compass history cache status [--format text|json]
+compass history cache gc
+  [--max-bytes N]
+  [--max-age-days N]
+  [--format text|json]
+  [--yes]
+```
+
+Rules:
+
+- `cache gc` is a dry run without `--yes`;
+- at least one of `--max-bytes` or `--max-age-days` is required;
+- remove obsolete schema/extractor namespaces first;
+- remove expired derived entries next;
+- enforce the remaining byte budget by least-recent verified access;
+- never remove `history.sqlite` or named Prolly roots;
+- acquire `HistoryStore::maintenance()` for the sweep;
+- validate every planned path is a regular file below the exact cache root
+  before deletion.
+
+Do not add automatic deletion to ordinary `history gc`.
+
+- [ ] **Step 3: Add maintenance safety coverage**
+
+After production code exists, test:
+
+- status totals by namespace;
+- dry run changes nothing;
+- `--yes` removes exactly the plan;
+- age and byte policies compose deterministically;
+- an activity guard blocks cache GC;
+- symlink and path-escape attempts fail closed;
+- active/current-schema entries survive when below budget;
+- immutable realizations remain readable after deleting the entire cache.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p compass-history --test maintenance cache
+cargo test -p compass-cli --test history_cli history_cache
+```
+
+Then:
+
+```bash
+git add crates/compass-history/src/cache.rs \
+  crates/compass-history/src/lib.rs \
+  crates/compass-history/tests/maintenance.rs \
+  crates/compass-cli/src/history_commands.rs \
+  crates/compass-cli/tests/history_cli.rs
+git commit -m "feat: add history cache maintenance"
+```
+
+---
+
+### Task 7: Document the fast paths and make qualification reproducible
+
+**Files:**
+
+- Modify: `scripts/qualify_history_real_repo.sh`
+- Modify: `docs/guides/versioned-history.md`
+- Modify: `docs/reference/outputs.md`
+- Modify: `PERFORMANCE.md`
+- Modify: `crates/compass-history/tests/performance.rs`
+
+**Produces:**
+
+- One real-repository command that measures cold/warm build, first/repeated
+  semantic diff, and first/repeated viewer export.
+
+- [ ] **Step 1: Extend the existing qualification script**
+
+Keep the existing clean-checkout and shared-clone protections. Use
+`scripts/measure_process.py` for every timed child and emit a canonical JSON
+summary containing:
+
+```json
+{
+  "repository": "...",
+  "old": "...",
+  "new": "...",
+  "binary": "...",
+  "operations": {
+    "current_cold": {"seconds": 0.0, "peak_rss_kib": 0},
+    "current_incremental": {"seconds": 0.0, "peak_rss_kib": 0},
+    "history_cold": {"seconds": 0.0, "peak_rss_kib": 0},
+    "history_adjacent": {"seconds": 0.0, "peak_rss_kib": 0},
+    "history_noop": {"seconds": 0.0, "peak_rss_kib": 0},
+    "semantic_first": {"seconds": 0.0, "peak_rss_kib": 0},
+    "semantic_repeat": {"seconds": 0.0, "peak_rss_kib": 0},
+    "viewer_first": {"seconds": 0.0, "peak_rss_kib": 0},
+    "viewer_repeat": {"seconds": 0.0, "peak_rss_kib": 0}
+  },
+  "digests": {
+    "semantic_first": "...",
+    "semantic_repeat": "...",
+    "viewer_first": "...",
+    "viewer_repeat": "..."
+  },
+  "original_checkout_clean": true
+}
+```
+
+Resolve the release binary to an absolute path. Use a temporary shared clone,
+never reset or clean the supplied source repository, and verify its porcelain
+status is unchanged at the end.
+
+- [ ] **Step 2: Add ignored release-scale gates**
+
+Extend `crates/compass-history/tests/performance.rs` with ignored tests for:
+
+- 120k nodes / 260k edges graph-only projection;
+- root-equal Prolly diff;
+- sparse node/edge diff;
+- 100k memoized evidence lookups;
+- derived cache hit decode.
+
+Operation-count assertions run normally; strict elapsed/RSS assertions remain
+ignored and are invoked during release qualification.
+
+- [ ] **Step 3: Update user and maintainer documentation**
+
+Document:
+
+- first-ever arbitrary revision performs bounded extraction;
+- repeated build/diff/view behavior;
+- `history verify` versus sealed `history status`;
+- `history cache status/gc`;
+- cache location and disposability;
+- viewer projection and community lazy-load behavior;
+- performance commands and target table.
+
+Do not document internal environment variables as public API.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+
+```bash
+shellcheck scripts/qualify_history_real_repo.sh
+cargo test -p compass-history --test performance
+git diff --check
+```
+
+Then:
+
+```bash
+git add scripts/qualify_history_real_repo.sh \
+  docs/guides/versioned-history.md \
+  docs/reference/outputs.md \
+  PERFORMANCE.md \
+  crates/compass-history/tests/performance.rs
+git commit -m "docs: add versioned history performance gates"
+```
+
+---
+
+### Task 8: Run the full correctness and real-repository acceptance gate
+
+**Files:**
+
+- Add:
+  `docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md`
+- Refresh: `graphify-out/`
+
+**Produces:**
+
+- Recorded CocoIndex and Podman results.
+- Pushed implementation commits and updated pull request.
+
+- [ ] **Step 1: Run the complete Rust gate**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets
+```
+
+If repository-wide tests contain known unrelated failures, rerun every affected
+package/test named in Tasks 1–7 and record the unrelated failure verbatim. Do
+not describe the full gate as passing.
+
+- [ ] **Step 2: Run extension and viewer gates**
+
+Run:
+
+```bash
+npm test -w compass-vscode
+npm run typecheck -w compass-vscode
+npm test -w @compass/viewer-tests
+```
+
+Confirm extension source still launches only Compass history/diff CLI commands.
+
+- [ ] **Step 3: Build the release binary**
+
+Run:
+
+```bash
+cargo build --release -p compass-cli
+```
+
+Record:
+
+```bash
+target/release/compass --version
+git rev-parse HEAD
+uname -a
+```
+
+- [ ] **Step 4: Qualify CocoIndex**
+
+Use the already-established clean CocoIndex source repository and the approved
+revision pair:
+
+```bash
+COMPASS_BIN="$PWD/target/release/compass" \
+  scripts/qualify_history_real_repo.sh \
+  /Volumes/workspace/Github/cocoindex-compass-audit-20260726 \
+  90571539fa291fc6e6b248095bd2c8a2ff68bab4 \
+  71f9cc9dc693080310181a2d011fb737420f7907 \
+  > target/cocoindex-versioned-history-performance.json
+```
+
+Run three warm samples for no-op build, repeated semantic diff, and repeated
+viewer export; report the median. Verify first/repeat semantic and viewer
+digests match.
+
+- [ ] **Step 5: Qualify Podman**
+
+Resolve the clean local Podman checkout and choose two adjacent commits that
+both contain the supported source corpus. Run:
+
+```bash
+COMPASS_BIN="$PWD/target/release/compass" \
+  scripts/qualify_history_real_repo.sh \
+  /Volumes/workspace/Github/podman \
+  d8380c9c80d9c4acf5afd59b65c4c779aaacbbf5 \
+  7ac3e837075460ecdea5ce59e607cdaa6b6709fc \
+  > target/podman-versioned-history-performance.json
+```
+
+Record the resolved commits in the qualification document. Run three warm
+samples and report medians. Verify semantic diff/view peak RSS is below 512 MiB
+and build RSS is within 25% of current extraction.
+
+- [ ] **Step 6: Write the qualification report**
+
+Create the review document with:
+
+- machine, OS, binary version, Compass commit;
+- exact repository paths and revision IDs;
+- before/after table for every operation;
+- cache hit/miss counts;
+- root opens, validation calls, and reconstruction calls;
+- output SHA-256 digests;
+- checkout cleanliness evidence;
+- each accepted SLO and any explicit gap with cause/follow-up.
+
+Do not claim an SLO passed without a captured measurement.
+
+- [ ] **Step 7: Refresh the required knowledge graph**
+
+Run from `/Users/haipingfu/graphify/compass`:
+
+```bash
+graphify update .
+```
+
+Then verify:
+
+```bash
+git status --short
+git diff --check
+```
+
+Do not stage unrelated pre-existing files or generated directories unless they
+are already tracked and changed solely by this implementation.
+
+- [ ] **Step 8: Commit qualification evidence**
+
+```bash
+git add docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md
+git commit -m "docs: qualify versioned history performance"
+```
+
+- [ ] **Step 9: Push and update the existing pull request**
+
+Inspect the exact branch and PR before mutation:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -12
+gh pr view 50 --json number,url,headRefName,baseRefName,state
+```
+
+Push the current branch and add a concise qualification comment:
+
+```bash
+git push origin HEAD
+gh pr comment 50 \
+  --body-file docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md
+```
+
+If PR #50 is closed or no longer targets this branch, stop and report the exact
+state instead of silently creating a different PR.
+
+---
+
+## Final acceptance checklist
+
+- [ ] First unseen arbitrary commits complete through the protected bounded
+  extraction path.
+- [ ] Adjacent commits reuse portable AST and Program entries across temporary
+  worktree roots.
+- [ ] No-op build and `--profile-from` perform sealed manifest/direct-root reads
+  only.
+- [ ] Explicit `history verify` retains complete validation.
+- [ ] Ordinary diff reconstructs neither complete graph.
+- [ ] Each semantic evidence record is decoded at most once per first
+  comparison.
+- [ ] Repeated semantic diff uses one checked canonical report.
+- [ ] Viewer miss opens only analysis/nodes/edges; viewer hit opens no record
+  roots.
+- [ ] Cached/uncached realization, semantic report, and viewer digests match.
+- [ ] Derived cache corruption regenerates; authoritative corruption fails
+  closed.
+- [ ] Cache GC is explicit, dry-run by default, and cannot remove immutable
+  history.
+- [ ] CocoIndex and Podman source checkouts remain unchanged.
+- [ ] Release latency/RSS targets are recorded honestly.
+- [ ] Rust, VS Code, and viewer regression gates pass or unrelated failures are
+  documented exactly.
+- [ ] `graphify update .` has refreshed the required development graph.
+- [ ] Only intended files are committed, pushed, and reflected in the existing
+  pull request.

--- a/docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md
+++ b/docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md
@@ -1,0 +1,95 @@
+# Versioned History Performance Qualification
+
+Date: 2026-07-26  
+Machine: Apple Silicon Mac Studio, Darwin 25.5.0, local SSD  
+Compass: 0.1.7 release build from `44ec831` plus the cache portability and
+deterministic-rendering fix committed with this report
+
+## Result
+
+The hard-cutover implementation makes already-materialized history interactive:
+
+- semantic diff is 0.13 seconds warm on CocoIndex and 0.23 seconds warm on
+  Podman;
+- historical viewer export is 0.06 seconds on CocoIndex and 0.09 seconds on
+  Podman;
+- no-op history build is 0.08 seconds on both repositories;
+- first and repeated semantic/viewer outputs are byte-identical;
+- both source qualification checkouts remain clean.
+
+The remaining gap is first-time graph construction. It is substantially faster
+than the old CocoIndex baseline, but it does not yet meet the design's
+current-extractor-relative time or memory targets.
+
+## Repositories and revisions
+
+| Repository | Old | New |
+|---|---|---|
+| CocoIndex | `90571539fa291fc6e6b248095bd2c8a2ff68bab4` | `71f9cc9dc693080310181a2d011fb737420f7907` |
+| Podman | `d8380c9c80d9c4acf5afd59b65c4c779aaacbbf5` | `7ac3e837075460ecdea5ce59e607cdaa6b6709fc` |
+
+Qualification ran against clean shared clones under `/tmp`; it did not modify
+the developers' existing CocoIndex or Podman checkouts. The Podman run shared
+the host with another Compass debug build, so its wall-clock build measurements
+are conservative.
+
+## Release measurements
+
+Peak memory is the maximum resident set reported by the qualification harness.
+
+| Operation | CocoIndex time | CocoIndex peak RSS | Podman time | Podman peak RSS |
+|---|---:|---:|---:|---:|
+| Current cold extraction | 2.101 s | 1,176,080 KiB | 16.579 s | 2,606,512 KiB |
+| Current incremental extraction | 2.332 s | 1,056,640 KiB | 18.071 s | 2,326,528 KiB |
+| First unseen history build | 14.054 s | 2,154,448 KiB | 57.823 s | 5,716,208 KiB |
+| Adjacent history build | 14.367 s | 2,359,712 KiB | 55.378 s | 5,035,920 KiB |
+| No-op history build | 0.079 s | 14,432 KiB | 0.083 s | 12,464 KiB |
+| First semantic diff | 0.389 s | 212,432 KiB | 1.021 s | 665,056 KiB |
+| Repeated semantic diff | 0.126 s | 41,072 KiB | 0.228 s | 173,248 KiB |
+| Historical viewer export | 0.061 s | 18,240 KiB | 0.087 s | 62,720 KiB |
+| Repeated viewer export | 0.060 s | 18,288 KiB | 0.089 s | 62,704 KiB |
+
+The viewer projection is warmed when a realization is published, so both
+measured viewer operations exercise the normal cache-hit path.
+
+## CocoIndex before and after
+
+| Operation | Before | After | Improvement |
+|---|---:|---:|---:|
+| First semantic diff | 5.19 s | 0.389 s | 13.3x |
+| Repeated semantic diff | 5.19 s | 0.126 s | 41.3x |
+| Historical viewer export | 152.40 s | 0.061 s | 2,498x |
+| Adjacent history build | 154.65 s | 14.367 s | 10.8x |
+
+## Determinism
+
+| Artifact | First SHA-256 | Repeated SHA-256 |
+|---|---|---|
+| CocoIndex semantic diff | `0d3ddc41989cde4f78f490d2b46605b049075b6b6368fd5e93112dab3780f4b2` | `0d3ddc41989cde4f78f490d2b46605b049075b6b6368fd5e93112dab3780f4b2` |
+| CocoIndex viewer | `ce0c07a4859162b101451177e5dfbbb4f4c0701d59180f946113489c96f68427` | `ce0c07a4859162b101451177e5dfbbb4f4c0701d59180f946113489c96f68427` |
+| Podman semantic diff | `75f79869f9c40bdc995d1668d978b1d43a250907f1dd6819e92a9bce1ef95b79` | `75f79869f9c40bdc995d1668d978b1d43a250907f1dd6819e92a9bce1ef95b79` |
+| Podman viewer | `0c02ab7edbe4f2fbd7f830288421863cad3cf2701a51aa6fa43bdac2a6ad7c1a` | `0c02ab7edbe4f2fbd7f830288421863cad3cf2701a51aa6fa43bdac2a6ad7c1a` |
+
+Each qualification performed one derived-cache miss followed by one hit for
+semantic diff. Viewer publication warmed one cache entry and both exports hit
+it. No reconstruction or full validation occurs on sealed no-op, diff, or
+viewer paths; the contract tests cover those call boundaries.
+
+## SLO assessment
+
+| Contract | CocoIndex | Podman |
+|---|---|---|
+| First diff of materialized graphs | Pass: 0.389 s ≤ 1 s | Pass: 1.021 s ≤ 2 s |
+| Repeated semantic diff | Pass: 0.126 s ≤ 0.25 s | Pass: 0.228 s ≤ 0.5 s |
+| Existing viewer overview | Pass: 0.061 s ≤ 0.25 s | Pass: 0.087 s ≤ 0.5 s |
+| No-op history build | Pass: 0.079 s ≤ 0.25 s | Pass: 0.083 s ≤ 0.5 s |
+| Adjacent build ≤ 2x current incremental | Gap: 14.367 s > 4.665 s | Gap: 55.378 s > 36.143 s |
+| First unseen build ≤ 1.25x current cold | Gap: 14.054 s > 2.626 s | Gap: 57.823 s > 20.724 s |
+| Diff/view peak RSS below 512 MiB | Pass | Gap: first diff is 649 MiB; repeat is 169 MiB |
+| History build RSS within 25% of current extraction | Gap | Gap |
+
+The implementation therefore satisfies the interactive graph/diff/viewing
+objective and makes first construction usable relative to the previous
+baseline. A follow-up should profile immutable publication and exact-tree
+validation, which now dominate build time and peak memory after extraction was
+accelerated.

--- a/docs/superpowers/specs/2026-07-26-versioned-history-performance-design.md
+++ b/docs/superpowers/specs/2026-07-26-versioned-history-performance-design.md
@@ -1,0 +1,387 @@
+# Versioned History Performance
+
+**Date:** 2026-07-26
+**Status:** Approved for implementation planning
+
+## Summary
+
+Compass current-tree indexing is fast because it retains portable, content-addressed
+AST and Program caches. Exact-revision history currently loses those advantages:
+temporary worktrees own temporary caches, ordinary reads repeatedly perform full
+realization validation and reconstruction, and semantic diff performs many
+independent evidence lookups.
+
+This design makes first access to an unseen commit a bounded extraction while
+making repeated builds, semantic diffs, and historical graph views effectively
+instant. It preserves immutable realization identity, exact-commit isolation,
+deterministic reports, and fail-closed handling of authoritative corruption.
+
+## Measured Baseline
+
+The current debug binary was measured against two existing CocoIndex
+realizations:
+
+- base `90571539fa291fc6e6b248095bd2c8a2ff68bab4`;
+- target `71f9cc9dc693080310181a2d011fb737420f7907`;
+- 17,729–17,808 nodes;
+- 40,237–40,412 edges;
+- 91,163–91,537 Program facts;
+- 10,931–10,981 Program summaries.
+
+Observed results:
+
+| Operation | Wall time | Maximum RSS |
+|---|---:|---:|
+| Semantic diff | 5.19 s | 203 MiB |
+| Historical viewer export | 152.40 s | 1.78 GiB |
+| Existing build with `--profile-from` | 154.65 s | 1.77 GiB |
+
+The latter two commands ran concurrently and therefore include contention, but
+profiles and code inspection confirm the dominant behavior: both scan and
+reconstruct complete realization trees. Earlier Podman qualification measured a
+full history status/profile-validation path at approximately 189 seconds and
+4.7 GiB RSS for 119,293 nodes and 262,724 edges.
+
+## Goals
+
+1. Build an arbitrary exact Git commit using the same portable extraction
+   acceleration available to current-tree indexing.
+2. Make an existing compatible realization a constant-sized manifest lookup,
+   not a complete validation pass.
+3. Compare two materialized realizations without reconstructing either graph.
+4. Generate and reuse deterministic semantic-diff reports with bounded storage
+   reads.
+5. Open a historical graph overview immediately and load exact detail lazily.
+6. Preserve current graph, Program IR, semantic report, and export semantics.
+
+## Non-goals
+
+- Guarantee sub-second extraction for a commit whose source content has never
+  been indexed.
+- Require full-history pre-indexing.
+- Replace the protected detached-worktree security boundary.
+- Move authoritative realization content out of the Prolly store.
+- Treat derived caches as authoritative.
+- Weaken publication validation or corruption recovery.
+- Change `compass.semantic_diff.report/1` in this performance phase.
+
+## Latency and Memory Contract
+
+Targets apply to release builds on local SSD storage.
+
+| Operation | CocoIndex-sized (~20k nodes) | Podman-sized (~120k nodes) |
+|---|---:|---:|
+| Existing historical overview | ≤250 ms warm, ≤1 s without projection cache | ≤500 ms warm, ≤2 s without projection cache |
+| Repeated semantic diff | ≤250 ms | ≤500 ms |
+| First diff of materialized graphs | ≤1 s | ≤2 s |
+| No-op historical build | ≤250 ms | ≤500 ms |
+| Adjacent historical build | ≤2× current incremental update | ≤2× current incremental update |
+| First unseen cold commit | ≤1.25× equivalent cold current-tree extraction | ≤1.25× equivalent cold current-tree extraction |
+
+Diff and historical viewing must remain below 512 MiB peak RSS on the Podman
+qualification repository. Historical build memory must remain within 25% of an
+equivalent current-tree extraction.
+
+These are acceptance targets rather than reasons to weaken correctness. A
+measured miss is reported as a performance gap.
+
+## Storage Planes
+
+Authoritative and derived state remain visibly separate:
+
+```text
+<git-common-dir>/compass/
+├── history.sqlite
+├── cache/
+│   └── v1/
+│       ├── ast/
+│       ├── program/
+│       ├── semantic-diff/
+│       └── viewer/
+├── jobs/
+├── leases/
+├── locks/
+└── tmp/
+```
+
+`history.sqlite` remains authoritative. Everything under `cache/v1` is
+rebuildable and may be removed without changing graph meaning.
+
+All cache resources use owner-only paths. Writes are atomic and
+content-addressed. Concurrent writers may compute the same entry, but publication
+of identical bytes is idempotent.
+
+## Shared Historical Extraction Cache
+
+### Identity
+
+AST entries are keyed by:
+
+- source content digest;
+- AST extractor version;
+- cache encoding version;
+- meaning-affecting parser configuration.
+
+Program entries additionally include:
+
+- Program IR schema;
+- provider/analyzer/merger versions;
+- provider input identity where applicable;
+- normalized repository-relative logical identity.
+
+The checkout root, temporary-worktree name, file modification time, and absolute
+path are excluded from content identity. Loaded records are rebased to the exact
+checkout only at the API boundary.
+
+### Lookup and publication
+
+Historical extraction receives an explicit repository-shared cache root rather
+than deriving cache location from the temporary output directory. The builder:
+
+1. resolves the exact commit;
+2. creates the protected detached worktree;
+3. detects sources under historical ignore rules;
+4. loads portable AST and Program entries from the shared cache;
+5. extracts only cache misses;
+6. publishes new cache entries atomically;
+7. assembles, validates, and publishes the immutable realization.
+
+Temporary-worktree cleanup does not remove the shared cache.
+
+### Adjacent realization seeding
+
+The current implementation reconstructs every authoritative tree from a
+compatible ancestor and writes a complete temporary `compass-out` seed.
+The optimized builder instead uses the ancestor manifest and shared
+content-addressed entries to identify unchanged work.
+
+Community continuity and other state that truly depends on the previous graph
+may be loaded from narrowly scoped records or an explicit compact seed artifact.
+It must not require reconstruction of metadata, Program facts, or unrelated
+sidecars.
+
+### Current-tree interoperability
+
+Current-tree and history caches use the same portable entry encoding and identity.
+History may import or hard-link compatible entries into the private shared cache,
+but historical correctness never depends on a mutable current-tree cache. The
+existing exact-HEAD promotion path remains available.
+
+## Sealed Realization Fast Path
+
+Publication continues to:
+
+1. validate completion evidence;
+2. partition authoritative artifacts;
+3. construct content-addressed trees;
+4. validate counts, canonical records, references, and artifact reconstruction;
+5. publish the immutable manifest and direct roots atomically;
+6. update the preferred pointer by compare-and-swap.
+
+The published manifest already contains the realization digest, exact commit,
+profile, record counts, and direct tree roots. Ordinary trusted reads therefore
+perform a bounded seal check:
+
+- parse and validate the manifest;
+- recompute the realization ID;
+- verify direct named roots match the manifest;
+- verify the requested commit/profile relationship.
+
+They do not scan every record.
+
+Full validation remains mandatory:
+
+- before initial publication;
+- for explicit integrity/maintenance commands;
+- before corrupt-preferred recovery;
+- when a manifest or direct root check fails;
+- when an operation observes impossible decoded data.
+
+Corruption in authoritative state fails closed. There is no automatic fallback
+from a corrupt realization to an unverified result.
+
+## Historical Build Flow
+
+### Existing realization
+
+`history build REV` and `--profile-from` read sealed manifests only. A matching
+preferred realization returns without full validation, extraction, or
+republication.
+
+`--profile-from` copies the normalized profile from the manifest. It does not
+load graph records.
+
+### Unseen adjacent commit
+
+The builder uses the closest compatible first-parent manifest and the shared
+cache. Source content already seen in any worktree or branch is reused. Only
+unseen or version-invalidated entries are parsed and analyzed.
+
+### First unseen arbitrary commit
+
+The exact commit is checked out and all source entries are looked up by content.
+Any globally warm entries are reused. Remaining entries receive a bounded full
+extraction. This operation is not required to be sub-second.
+
+## Semantic Diff
+
+### First comparison
+
+The comparison path:
+
+1. resolves both exact commits and sealed compatible manifests;
+2. obtains the exact Git source delta;
+3. streams changed node and edge records through Prolly root comparison;
+4. derives the minimal set of Program modules, functions, summaries, reverse
+   callers, and graph nodes needed for findings;
+5. batch-loads those keys under one activity guard and one set of opened roots;
+6. computes and renders the deterministic semantic report.
+
+`HistorySnapshots` becomes a request-scoped batch/memoized reader. A record is
+decoded at most once per comparison. Manifest and direct root lookup are also
+performed once per realization.
+
+### Cached comparison
+
+The semantic-diff cache key includes:
+
+- old and new realization IDs in direction-sensitive order;
+- source-delta digest;
+- semantic-diff engine version;
+- report schema;
+- rendering-neutral comparison options.
+
+The cache value is the canonical complete report, not a text or HTML
+presentation. Text limits, `--all`, `--explain`, JSON, and HTML are rendered from
+the same cached report.
+
+Cache hits verify the key and payload digest. Invalid entries are removed or
+ignored and recomputed. Cache failure cannot invalidate either realization.
+
+## Historical Graph Viewing
+
+Each new realization publishes or schedules a derived viewer projection from the
+already in-memory completed graph. It contains:
+
+- bounded overview nodes and edges;
+- community summaries and labels;
+- graph statistics;
+- stable identities needed for lazy detail;
+- projection schema and source realization ID.
+
+The initial viewer request loads only this projection. Exact node, neighborhood,
+and community detail is read lazily from typed node/edge records. Program facts,
+semantic metadata, and authoritative sidecars are not loaded for an overview.
+
+Older valid realizations without a projection remain readable. Their first view
+streams the required graph roots once, writes a derived projection, and serves
+the result. They do not require realization rebuild or schema migration.
+
+Viewer cache corruption causes regeneration. Authoritative graph corruption
+still fails closed.
+
+## Cache Lifecycle
+
+Cache GC is independent of immutable history GC. It supports:
+
+- removal of obsolete extractor/schema namespaces;
+- least-recently-used pruning to a configurable byte budget;
+- age-based removal of semantic-diff and viewer entries;
+- preservation of entries currently used by active builders/readers;
+- dry-run reporting before destructive maintenance.
+
+Normal history GC does not silently delete shared extraction entries that may
+accelerate other branches. Cache GC never deletes Prolly realization content.
+
+## Failure Handling
+
+| Failure | Behavior |
+|---|---|
+| Missing cache entry | Compute and publish it |
+| Malformed extraction cache | Treat as miss |
+| Semantic-diff cache digest mismatch | Ignore and recompute |
+| Viewer projection mismatch | Ignore and regenerate |
+| Shared cache write race | Accept identical winner; retry or reuse |
+| Shared cache unavailable | Continue without cache when safe |
+| Manifest digest/root mismatch | Fail closed and recommend full validation |
+| Full validation failure | Preserve corrupt-recovery workflow |
+| Temporary worktree cleanup failure | Report existing cleanup error contract |
+
+## Security
+
+The detached-worktree policy remains unchanged: no fetch, prompts, user hooks,
+checkout filters, LFS smudge, or submodule recursion.
+
+Shared cache entries are data, never executable code. Decoders retain byte,
+record-count, and nesting limits. Repository-relative paths are validated before
+rebasing. Cache keys never contain credentials. Semantic provider credentials
+remain outside build profiles and caches.
+
+Derived report and viewer caches must not contain absolute temporary-worktree
+paths.
+
+## Testing Strategy
+
+### Operation-count tests
+
+Counting storage adapters and focused integration seams assert:
+
+- no-op build does not invoke full-tree validation;
+- profile lookup reads only the sealed manifest;
+- ordinary diff never reconstructs a complete graph;
+- historical overview does not open Program, metadata, or sidecar roots;
+- a comparison opens each requested root once;
+- each evidence record is decoded at most once;
+- adjacent builds reuse unchanged portable cache entries across different
+  temporary worktree paths.
+
+### Correctness tests
+
+- Cache hit and miss builds produce identical canonical graph and Program bytes.
+- Cached and uncached semantic reports have identical SHA-256 digests.
+- Source patches and stable finding IDs are unchanged.
+- Existing realizations without derived caches lazily upgrade.
+- Corrupt derived entries regenerate.
+- Corrupt authoritative manifests or roots fail closed.
+- Parallel builders cannot publish mixed cache bytes or incomplete realizations.
+
+### Real-repository qualification
+
+Release-mode benchmarks run on CocoIndex and Podman and capture:
+
+- wall time;
+- peak RSS;
+- cache hits and misses by class;
+- records and Prolly roots opened;
+- validation/reconstruction calls;
+- output digests.
+
+Each benchmark records current-tree cold and incremental extraction so historical
+build ratios use a same-machine, same-revision baseline.
+
+## Rollout
+
+Implementation is staged so each step is independently useful:
+
+1. sealed-manifest fast paths and explicit full-validation boundaries;
+2. shared portable history extraction cache;
+3. batched/memoized semantic evidence reads;
+4. canonical semantic-report cache;
+5. historical viewer projections and lazy detail;
+6. cache lifecycle and real-repository release qualification.
+
+The rollout does not require mandatory full-history rebuilding. Derived caches
+populate lazily, while new realizations receive them during publication.
+
+## Acceptance Criteria
+
+The work is complete when:
+
+1. every latency and memory target has a recorded release-mode result or an
+   explicitly documented shortfall;
+2. ordinary no-op build, diff, and view paths do not call full reconstruction;
+3. adjacent commits reuse content across temporary worktrees;
+4. cached and uncached authoritative outputs are byte- or canonically identical;
+5. the existing history, semantic-diff, security, concurrency, and corruption
+   suites pass;
+6. CocoIndex and Podman checkouts remain unchanged after qualification.

--- a/docs/superpowers/specs/2026-07-26-versioned-history-performance-design.md
+++ b/docs/superpowers/specs/2026-07-26-versioned-history-performance-design.md
@@ -1,7 +1,7 @@
 # Versioned History Performance
 
 **Date:** 2026-07-26
-**Status:** Approved for implementation planning
+**Status:** Approved for implementation planning — hard cutover
 
 ## Summary
 
@@ -46,7 +46,7 @@ full history status/profile-validation path at approximately 189 seconds and
 
 1. Build an arbitrary exact Git commit using the same portable extraction
    acceleration available to current-tree indexing.
-2. Make an existing compatible realization a constant-sized manifest lookup,
+2. Make an existing matching realization a constant-sized manifest lookup,
    not a complete validation pass.
 3. Compare two materialized realizations without reconstructing either graph.
 4. Generate and reuse deterministic semantic-diff reports with bounded storage
@@ -64,6 +64,33 @@ full history status/profile-validation path at approximately 189 seconds and
 - Treat derived caches as authoritative.
 - Weaken publication validation or corruption recovery.
 - Change `compass.semantic_diff.report/1` in this performance phase.
+- Migrate, import, or continue reading legacy cache entries.
+- Preserve superseded internal Rust APIs, cache constructors, CLI response
+  fields, or mixed old/new execution paths.
+
+## Hard Cutover
+
+This performance architecture ships as one hard cutover:
+
+- all Compass cache call sites move to the new explicit cache options API;
+- the old `Cache::new` constructor, legacy directory lookup, legacy JSON
+  decoding, prompt-fingerprint fallback, and legacy build-state validation are
+  deleted;
+- all history consumers move to `RealizationReader`; the old one-shot
+  `HistoryStore::read_record` and store-owned diff APIs are deleted;
+- `history status` emits only the new seal contract, without deprecated
+  validation fields;
+- old extraction and derived cache entries are ignored and may be removed by
+  cache maintenance; no importer or on-read migration is implemented;
+- the complete implementation lands before release, with no feature flag,
+  compatibility mode, or dual-write period.
+
+The immutable Prolly realization format is unchanged because this performance
+work does not require a new authoritative representation. Reading an existing
+realization with the same `HISTORY_SCHEMA_VERSION` is therefore the normal
+current format, not a compatibility path. If implementation requires any
+authoritative format change, it must bump the store/history schema and reject
+the old format explicitly; it must not add a migration adapter.
 
 ## Latency and Memory Contract
 
@@ -95,7 +122,9 @@ Authoritative and derived state remain visibly separate:
 ├── cache/
 │   └── v1/
 │       ├── ast/
-│       ├── program/
+│       ├── program-syntax/
+│       ├── program-artifact/
+│       ├── program-merge/
 │       ├── semantic-diff/
 │       └── viewer/
 ├── jobs/
@@ -148,24 +177,22 @@ than deriving cache location from the temporary output directory. The builder:
 
 Temporary-worktree cleanup does not remove the shared cache.
 
-### Adjacent realization seeding
+### Adjacent realization reuse
 
 The current implementation reconstructs every authoritative tree from a
-compatible ancestor and writes a complete temporary `compass-out` seed.
-The optimized builder instead uses the ancestor manifest and shared
-content-addressed entries to identify unchanged work.
-
-Community continuity and other state that truly depends on the previous graph
-may be loaded from narrowly scoped records or an explicit compact seed artifact.
-It must not require reconstruction of metadata, Program facts, or unrelated
-sidecars.
+matching-profile ancestor and writes a complete temporary `compass-out` seed.
+The hard-cutover builder deletes ancestor artifact seeding entirely. Shared
+content-addressed AST and Program entries identify reusable work. Historical
+clustering is already deterministic and intentionally ignores prior
+communities, so no compact legacy seed path is retained.
 
 ### Current-tree interoperability
 
-Current-tree and history caches use the same portable entry encoding and identity.
-History may import or hard-link compatible entries into the private shared cache,
-but historical correctness never depends on a mutable current-tree cache. The
-existing exact-HEAD promotion path remains available.
+Current-tree and history extraction move together to the new explicit cache API
+and portable entry encoding. They use separate storage roots and do not import,
+hard-link, or decode the prior cache format. Historical correctness never
+depends on a mutable current-tree cache. Exact-HEAD promotion remains a current
+performance path, not a legacy adapter.
 
 ## Sealed Realization Fast Path
 
@@ -213,9 +240,10 @@ load graph records.
 
 ### Unseen adjacent commit
 
-The builder uses the closest compatible first-parent manifest and the shared
-cache. Source content already seen in any worktree or branch is reused. Only
-unseen or version-invalidated entries are parsed and analyzed.
+The builder uses the shared cache directly. Source content already seen in any
+worktree or branch under the new cache identity is reused. Only unseen or
+version-invalidated entries are parsed and analyzed. It does not inspect or
+reconstruct a first-parent realization.
 
 ### First unseen arbitrary commit
 
@@ -229,7 +257,7 @@ extraction. This operation is not required to be sub-second.
 
 The comparison path:
 
-1. resolves both exact commits and sealed compatible manifests;
+1. resolves both exact commits and sealed matching manifests;
 2. obtains the exact Git source delta;
 3. streams changed node and edge records through Prolly root comparison;
 4. derives the minimal set of Program modules, functions, summaries, reverse
@@ -273,9 +301,9 @@ The initial viewer request loads only this projection. Exact node, neighborhood,
 and community detail is read lazily from typed node/edge records. Program facts,
 semantic metadata, and authoritative sidecars are not loaded for an overview.
 
-Older valid realizations without a projection remain readable. Their first view
-streams the required graph roots once, writes a derived projection, and serves
-the result. They do not require realization rebuild or schema migration.
+Any projection miss streams the required graph roots once, writes a derived
+projection, and serves the result. This is the sole viewer miss path; there is
+no separate older-realization upgrade or migration branch.
 
 Viewer cache corruption causes regeneration. Authoritative graph corruption
 still fails closed.
@@ -302,10 +330,10 @@ accelerate other branches. Cache GC never deletes Prolly realization content.
 | Semantic-diff cache digest mismatch | Ignore and recompute |
 | Viewer projection mismatch | Ignore and regenerate |
 | Shared cache write race | Accept identical winner; retry or reuse |
-| Shared cache unavailable | Continue without cache when safe |
+| Shared cache unavailable | Fail the build with the exact cache path and cause |
 | Manifest digest/root mismatch | Fail closed and recommend full validation |
-| Full validation failure | Preserve corrupt-recovery workflow |
-| Temporary worktree cleanup failure | Report existing cleanup error contract |
+| Full validation failure | Enter the current corrupt-recovery workflow |
+| Temporary worktree cleanup failure | Report the cleanup error contract |
 
 ## Security
 
@@ -340,10 +368,13 @@ Counting storage adapters and focused integration seams assert:
 - Cache hit and miss builds produce identical canonical graph and Program bytes.
 - Cached and uncached semantic reports have identical SHA-256 digests.
 - Source patches and stable finding IDs are unchanged.
-- Existing realizations without derived caches lazily upgrade.
+- A projection miss uses the same graph-only regeneration path regardless of
+  realization age.
 - Corrupt derived entries regenerate.
 - Corrupt authoritative manifests or roots fail closed.
 - Parallel builders cannot publish mixed cache bytes or incomplete realizations.
+- Legacy cache files, legacy build state, old cache constructors, and old
+  history reader APIs are absent after cutover.
 
 ### Real-repository qualification
 
@@ -359,9 +390,9 @@ Release-mode benchmarks run on CocoIndex and Podman and capture:
 Each benchmark records current-tree cold and incremental extraction so historical
 build ratios use a same-machine, same-revision baseline.
 
-## Rollout
+## Delivery
 
-Implementation is staged so each step is independently useful:
+Implementation uses reviewable commits:
 
 1. sealed-manifest fast paths and explicit full-validation boundaries;
 2. shared portable history extraction cache;
@@ -370,8 +401,11 @@ Implementation is staged so each step is independently useful:
 5. historical viewer projections and lazy detail;
 6. cache lifecycle and real-repository release qualification.
 
-The rollout does not require mandatory full-history rebuilding. Derived caches
-populate lazily, while new realizations receive them during publication.
+All commits merge and release together. Intermediate commits are not supported
+deployment states. There is no feature flag, dual read, dual write, cache
+import, or compatibility window. The release starts with an empty new cache
+namespace and repopulates it on demand. Existing immutable realizations remain
+current-format data because the authoritative schema is unchanged.
 
 ## Acceptance Criteria
 
@@ -382,6 +416,8 @@ The work is complete when:
 2. ordinary no-op build, diff, and view paths do not call full reconstruction;
 3. adjacent commits reuse content across temporary worktrees;
 4. cached and uncached authoritative outputs are byte- or canonically identical;
-5. the existing history, semantic-diff, security, concurrency, and corruption
-   suites pass;
+5. the history, semantic-diff, security, concurrency, corruption, and explicit
+   hard-cutover suites pass;
 6. CocoIndex and Podman checkouts remain unchanged after qualification.
+7. no legacy cache decoder, directory fallback, compatibility constructor,
+   one-shot history reader, dual CLI field, or migration branch remains.

--- a/scripts/qualify_history_real_repo.sh
+++ b/scripts/qualify_history_real_repo.sh
@@ -11,24 +11,25 @@ old_revision=$2
 new_revision=$3
 script_dir=$(cd "$(dirname "$0")" && pwd)
 compass_root=$(cd "$script_dir/.." && pwd)
-compass_bin=${COMPASS_BIN:-$compass_root/target/debug/compass}
+compass_bin=${COMPASS_BIN:-$compass_root/target/release/compass}
+measure=$script_dir/measure_process.py
 if [[ $compass_bin != /* ]]; then
   compass_bin=$(cd "$(dirname "$compass_bin")" && pwd)/$(basename "$compass_bin")
 fi
-if [[ ! -x $compass_bin ]]; then
-  echo "error: Compass binary is not executable: $compass_bin" >&2
-  exit 1
-fi
-
-for command in git jq cmp perl; do
+for command in git jq python3 shasum; do
   command -v "$command" >/dev/null || {
     echo "error: required command not found: $command" >&2
     exit 1
   }
 done
+if [[ ! -x $compass_bin ]]; then
+  echo "error: Compass binary is not executable: $compass_bin" >&2
+  exit 1
+fi
 
 repository=$(git -C "$repository" rev-parse --show-toplevel)
-if [[ -n $(git -C "$repository" status --porcelain=v1 --untracked-files=all) ]]; then
+original_status=$(git -C "$repository" status --porcelain=v1 --untracked-files=all)
+if [[ -n $original_status ]]; then
   echo "error: qualification repository must start clean: $repository" >&2
   exit 1
 fi
@@ -41,54 +42,35 @@ validation_repo=$validation_root/repository
 git clone --quiet --shared --no-checkout "$repository" "$validation_repo"
 git -C "$validation_repo" checkout --quiet --detach "$new_commit"
 
-old_json=$validation_root/old.json
-new_json=$validation_root/new.json
-forward_json=$validation_root/forward.json
-repeat_json=$validation_root/repeat.json
-reverse_json=$validation_root/reverse.json
-topology_json=$validation_root/topology.json
-
-now_millis() {
-  perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000'
+run_measured() {
+  local name=$1
+  shift
+  local output=$validation_root/$name.out
+  local metrics=$validation_root/$name.metrics
+  (cd "$validation_repo" && python3 "$measure" "$output" -- "$@") >"$metrics"
 }
 
-(cd "$validation_repo" && "$compass_bin" history build "$old_commit" --code-only --format=json) >"$old_json"
-(cd "$validation_repo" && "$compass_bin" history build "$new_commit" --profile-from "$old_commit" --format=json) >"$new_json"
-(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --format=json) >"$forward_json"
-full_started=$(now_millis)
-(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --format=json) >"$repeat_json"
-full_millis=$(( $(now_millis) - full_started ))
-cmp "$forward_json" "$repeat_json"
-(cd "$validation_repo" && "$compass_bin" diff "$new_commit" "$old_commit" --format=json) >"$reverse_json"
+run_measured current_cold "$compass_bin" extract . --code-only --no-viz --out "$validation_root/current"
+run_measured current_incremental "$compass_bin" extract . --code-only --no-viz --out "$validation_root/current"
+run_measured history_cold "$compass_bin" history build "$old_commit" --code-only --format=json
+run_measured history_adjacent "$compass_bin" history build "$new_commit" --profile-from "$old_commit" --format=json
+run_measured history_noop "$compass_bin" history build "$new_commit" --profile-from "$old_commit" --format=json
+run_measured semantic_first "$compass_bin" diff "$old_commit" "$new_commit" --format=json
+run_measured semantic_repeat "$compass_bin" diff "$old_commit" "$new_commit" --format=json
+run_measured viewer_first "$compass_bin" history export "$new_commit" --format=json --output "$validation_root/viewer-first.json"
+run_measured viewer_repeat "$compass_bin" history export "$new_commit" --format=json --output "$validation_root/viewer-repeat.json"
 
-jq -S '[.changes[] | {
-  record,
-  key,
-  change:(if .change == "added" then "removed" elif .change == "removed" then "added" else .change end),
-  old:(.new // null),
-  new:(.old // null)
-}] | sort_by(.record, (.key | tostring), .change)' "$forward_json" >"$validation_root/forward-reversed.json"
-jq -S '[.changes[] | {
-  record,
-  key,
-  change,
-  old:(.old // null),
-  new:(.new // null)
-}] | sort_by(.record, (.key | tostring), .change)' "$reverse_json" >"$validation_root/reverse-normalized.json"
-cmp "$validation_root/forward-reversed.json" "$validation_root/reverse-normalized.json"
+cmp "$validation_root/semantic_first.out" "$validation_root/semantic_repeat.out"
+cmp "$validation_root/viewer-first.json" "$validation_root/viewer-repeat.json"
 
-topology_started=$(now_millis)
-(cd "$validation_repo" && "$compass_bin" diff "$old_commit" "$new_commit" --topology-only --format=json) >"$topology_json"
-topology_millis=$(( $(now_millis) - topology_started ))
-jq -e 'all(.changes[]; ((.record == "node" or .record == "edge") and (.change == "added" or .change == "removed")))' "$topology_json" >/dev/null
-if (( topology_millis * 2 >= full_millis )); then
-  echo "error: topology-only diff was not at least twice as fast as full diff (${topology_millis}ms vs ${full_millis}ms)" >&2
-  exit 1
-fi
-(cd "$validation_repo" && "$compass_bin" history status "$new_commit" --format=json) |
-  jq -e '.validation.valid == true' >/dev/null
+operation_json() {
+  local name=$1
+  IFS=, read -r seconds peak_rss_kib <"$validation_root/$name.metrics"
+  jq -n --argjson seconds "$seconds" --argjson peak "$peak_rss_kib" \
+    '{seconds:$seconds,peak_rss_kib:$peak}'
+}
 
-if [[ -n $(git -C "$repository" status --porcelain=v1 --untracked-files=all) ]]; then
+if [[ $(git -C "$repository" status --porcelain=v1 --untracked-files=all) != "$original_status" ]]; then
   echo "error: qualification changed the original repository" >&2
   exit 1
 fi
@@ -97,10 +79,38 @@ jq -n \
   --arg repository "$repository" \
   --arg old "$old_commit" \
   --arg new "$new_commit" \
-  --argjson old_graph "$(jq '{nodes,edges,hyperedges,analysis_records,metadata_records}' "$old_json")" \
-  --argjson new_graph "$(jq '{nodes,edges,hyperedges,analysis_records,metadata_records}' "$new_json")" \
-  --argjson diff_summary "$(jq '.summary' "$forward_json")" \
-  --argjson topology_summary "$(jq '.summary' "$topology_json")" \
-  --argjson full_millis "$full_millis" \
-  --argjson topology_millis "$topology_millis" \
-  '{repository:$repository,old:$old,new:$new,old_graph:$old_graph,new_graph:$new_graph,diff_summary:$diff_summary,topology_summary:$topology_summary,timing:{full_millis:$full_millis,topology_millis:$topology_millis},json_deterministic:true,reverse_symmetric:true,topology_materially_faster:true,original_checkout_clean:true}'
+  --arg binary "$compass_bin" \
+  --arg semantic_first "$(shasum -a 256 "$validation_root/semantic_first.out" | awk '{print $1}')" \
+  --arg semantic_repeat "$(shasum -a 256 "$validation_root/semantic_repeat.out" | awk '{print $1}')" \
+  --arg viewer_first "$(shasum -a 256 "$validation_root/viewer-first.json" | awk '{print $1}')" \
+  --arg viewer_repeat "$(shasum -a 256 "$validation_root/viewer-repeat.json" | awk '{print $1}')" \
+  --argjson current_cold "$(operation_json current_cold)" \
+  --argjson current_incremental "$(operation_json current_incremental)" \
+  --argjson history_cold "$(operation_json history_cold)" \
+  --argjson history_adjacent "$(operation_json history_adjacent)" \
+  --argjson history_noop "$(operation_json history_noop)" \
+  --argjson semantic_first_operation "$(operation_json semantic_first)" \
+  --argjson semantic_repeat_operation "$(operation_json semantic_repeat)" \
+  --argjson viewer_first_operation "$(operation_json viewer_first)" \
+  --argjson viewer_repeat_operation "$(operation_json viewer_repeat)" \
+  '{
+    repository:$repository, old:$old, new:$new, binary:$binary,
+    operations:{
+      current_cold:$current_cold,
+      current_incremental:$current_incremental,
+      history_cold:$history_cold,
+      history_adjacent:$history_adjacent,
+      history_noop:$history_noop,
+      semantic_first:$semantic_first_operation,
+      semantic_repeat:$semantic_repeat_operation,
+      viewer_first:$viewer_first_operation,
+      viewer_repeat:$viewer_repeat_operation
+    },
+    digests:{
+      semantic_first:$semantic_first,
+      semantic_repeat:$semantic_repeat,
+      viewer_first:$viewer_first,
+      viewer_repeat:$viewer_repeat
+    },
+    original_checkout_clean:true
+  }'


### PR DESCRIPTION
## Summary

- hard-cut versioned history onto sealed immutable realizations and verified
  shared extraction caches
- build arbitrary revisions through bounded extraction with portable AST/program
  cache reuse
- add request-scoped realization readers so diff/query/view paths open a graph
  once
- cache canonical semantic diffs and bounded viewer projections for instant
  repeat access
- add `history verify` plus explicit history cache status/GC commands
- add reproducible CocoIndex and Podman release qualification

## Real-repository results

CocoIndex (`90571539` → `71f9cc9d`):

- adjacent history build: 154.65s baseline → 14.37s
- first semantic diff: 0.39s; repeated: 0.13s
- historical viewer export: 0.06s
- no-op history build: 0.08s

Podman (`d8380c9c` → `7ac3e837`):

- first semantic diff: 1.02s; repeated: 0.23s
- historical viewer export: 0.09s
- no-op history build: 0.08s

Semantic and viewer first/repeat artifacts are byte-identical on both
repositories. The original source checkouts remained clean.

The qualification report explicitly records remaining gaps: first-time history
construction is still above the current-extractor-relative time/memory targets,
and Podman's first diff peaks at ~649 MiB (the repeat path is ~169 MiB). Cached
graph access, diff, and viewing meet their latency targets.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p compass-files --test contracts` (19 passed)
- `cargo test -p compass-history --test diff` (3 passed)
- `cargo test -p compass-core --test history_materialize` (7 passed)
- `scripts/qualify_history_real_repo.sh` against the approved CocoIndex and
  Podman revision pairs
- `graphify update .`

Full measurements and SHA-256 evidence are in
`docs/superpowers/reviews/2026-07-26-versioned-history-performance-qualification.md`.
