### PR TITLE
Release Compass 0.1.8 for macOS, Linux, and Windows

### DIFF
--- a/.github/workflows/compass-release.yml
+++ b/.github/workflows/compass-release.yml
@@ -1,4 +1,4 @@
-name: Release Compass for macOS and Linux
+name: Release Compass for macOS, Linux, and Windows
 
 on:
   push:
@@ -34,12 +34,22 @@ jobs:
         include:
           - runner: macos-15-intel
             target: x86_64-apple-darwin
+            binary: compass
           - runner: macos-15
             target: aarch64-apple-darwin
+            binary: compass
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            binary: compass
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            binary: compass
+          - runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            binary: compass.exe
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            binary: compass.exe
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -59,14 +69,16 @@ jobs:
       - name: Test Compass product contract
         run: cargo test -p compass-cli --test compass_product --locked
       - name: Test release scripts
+        shell: bash
         run: sh scripts/test_release_scripts.sh
       - name: Build locked Compass binary
         run: cargo build --release --locked -p compass-cli --bin compass --target ${{ matrix.target }}
       - name: Package release distribution
+        shell: bash
         run: >-
           scripts/package_release.sh
           ${{ matrix.target }}
-          target/${{ matrix.target }}/release/compass
+          target/${{ matrix.target }}/release/${{ matrix.binary }}
           dist
       - name: Verify packaged Compass binary
         shell: bash
@@ -74,12 +86,19 @@ jobs:
           name="compass-${{ matrix.target }}"
           mkdir -p dist/verify
           tar -C dist/verify -xzf "dist/$name.tar.gz"
-          "dist/verify/$name/compass" --version
-          "dist/verify/$name/compass" query --help
+          "dist/verify/$name/${{ matrix.binary }}" --version
+          "dist/verify/$name/${{ matrix.binary }}" query --help
           test -f "dist/verify/$name/LICENSE-MIT"
           test -f "dist/verify/$name/LICENSE-APACHE"
           test -f "dist/verify/$name/THIRD_PARTY_NOTICES.md"
-          (cd dist && shasum -a 256 -c "$name.tar.gz.sha256")
+          (
+            cd dist
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum -c "$name.tar.gz.sha256"
+            else
+              shasum -a 256 -c "$name.tar.gz.sha256"
+            fi
+          )
       - name: Attest release archive
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-model",
  "glob",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-model",
  "regex",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "axum",
  "compass-core",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-model",
  "regex",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ curl --proto '=https' --tlsv1.2 -LsSf \
   https://github.com/crabbuild/compass/releases/latest/download/install.sh | sh
 ```
 
+On Windows, download the x86_64 or ARM64 archive and matching `.sha256`
+file from the [latest release](https://github.com/crabbuild/compass/releases/latest),
+verify the checksum, extract it, and add the directory containing
+`compass.exe` to `PATH`.
+
 Or build from source with the pinned Rust 1.97.1+ toolchain:
 
 ```bash

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -11,7 +11,12 @@ binary=$2
 dist=$3
 case "$target" in
     aarch64-apple-darwin|x86_64-apple-darwin|\
-    aarch64-unknown-linux-gnu|x86_64-unknown-linux-gnu) ;;
+    aarch64-unknown-linux-gnu|x86_64-unknown-linux-gnu)
+        binary_name=compass
+        ;;
+    aarch64-pc-windows-msvc|x86_64-pc-windows-msvc)
+        binary_name=compass.exe
+        ;;
     *)
         echo "error: unsupported release target: $target" >&2
         exit 2
@@ -26,7 +31,8 @@ trap 'rm -rf "$staging"' EXIT HUP INT TERM
 bundle="$staging/$name"
 mkdir -p "$bundle" "$dist"
 
-install -m 0755 "$binary" "$bundle/compass"
+cp "$binary" "$bundle/$binary_name"
+chmod 0755 "$bundle/$binary_name"
 cp "$repo_root/README.md" "$bundle/"
 cp "$repo_root/LICENSE" "$bundle/"
 cp "$repo_root/LICENSE-MIT" "$bundle/"

--- a/scripts/test_release_scripts.sh
+++ b/scripts/test_release_scripts.sh
@@ -15,17 +15,25 @@ chmod +x "$test_root/fake-checksum-bin/shasum"
 
 cat > "$test_root/fake-checksum-bin/sha256sum" <<'EOF'
 #!/bin/sh
+if [ -x /usr/bin/sha256sum ]; then
+    exec /usr/bin/sha256sum "$@"
+fi
 exec /usr/bin/shasum -a 256 "$@"
 EOF
 chmod +x "$test_root/fake-checksum-bin/sha256sum"
 
-for target in \
-    aarch64-apple-darwin \
-    x86_64-apple-darwin \
-    aarch64-unknown-linux-gnu \
-    x86_64-unknown-linux-gnu
+for release_case in \
+    "aarch64-apple-darwin compass" \
+    "x86_64-apple-darwin compass" \
+    "aarch64-unknown-linux-gnu compass" \
+    "x86_64-unknown-linux-gnu compass" \
+    "aarch64-pc-windows-msvc compass.exe" \
+    "x86_64-pc-windows-msvc compass.exe"
 do
-    fake_binary="$test_root/fake-compass-$target"
+    set -- $release_case
+    target=$1
+    binary_name=$2
+    fake_binary="$test_root/fake-$target-$binary_name"
     printf '#!/bin/sh\necho %s\n' "$target" > "$fake_binary"
     chmod +x "$fake_binary"
     dist="$test_root/dist-$target"
@@ -35,9 +43,13 @@ do
     checksum="$archive.sha256"
     test -f "$archive"
     test -f "$checksum"
-    (cd "$dist" && shasum -a 256 -c "$(basename "$checksum")")
-    tar -tzf "$archive" | grep -Eq '(^|/)compass$'
-    test "$(tar -tzf "$archive" | grep -Ec '(^|/)compass$')" -eq 1
+    (
+        cd "$dist"
+        PATH="$test_root/fake-checksum-bin:$PATH" \
+            sha256sum -c "$(basename "$checksum")"
+    )
+    tar -tzf "$archive" | grep -Eq "(^|/)$binary_name$"
+    test "$(tar -tzf "$archive" | grep -Ec "(^|/)$binary_name$")" -eq 1
 done
 
 release_dir="$test_root/release"

--- a/tools/skillgen/mod.rs
+++ b/tools/skillgen/mod.rs
@@ -276,7 +276,7 @@ fn validate_integrations(root: &Path) -> io::Result<()> {
             .unwrap_or_default();
         if DELEGATING_INTEGRATIONS.contains(&name) {
             require(
-                body.starts_with("---\nname: compass\n"),
+                has_canonical_frontmatter(&body),
                 &path,
                 "delegating command must use canonical Compass frontmatter",
             )?;

--- a/tools/skillgen/mod.rs
+++ b/tools/skillgen/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn validate(assets: &Path, cli_source: &Path, help_source: &Path) -> 
     let skill_path = skill_root.join("SKILL.md");
     let skill = read_utf8(&skill_path)?;
     require(
-        skill.starts_with("---\nname: compass\n"),
+        has_canonical_frontmatter(&skill),
         &skill_path,
         "frontmatter must start with the canonical Compass skill name",
     )?;
@@ -350,6 +350,11 @@ fn read_utf8(path: &Path) -> io::Result<String> {
         .map_err(|error| io::Error::new(error.kind(), format!("{}: {error}", path.display())))
 }
 
+fn has_canonical_frontmatter(body: &str) -> bool {
+    let mut lines = body.lines();
+    lines.next() == Some("---") && lines.next() == Some("name: compass")
+}
+
 fn validate_native(path: &Path, body: &str) -> io::Result<()> {
     let lowercase = body.to_ascii_lowercase();
     require(
@@ -381,7 +386,23 @@ fn path_string(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::linked_references;
+    use super::{has_canonical_frontmatter, linked_references};
+
+    #[test]
+    fn canonical_frontmatter_accepts_lf_and_crlf() {
+        assert!(has_canonical_frontmatter(
+            "---\nname: compass\ndescription: test\n"
+        ));
+        assert!(has_canonical_frontmatter(
+            "---\r\nname: compass\r\ndescription: test\r\n"
+        ));
+        assert!(!has_canonical_frontmatter(
+            "---\n\nname: compass\ndescription: test\n"
+        ));
+        assert!(!has_canonical_frontmatter(
+            "---\nname: other\ndescription: test\n"
+        ));
+    }
 
     #[test]
     fn reference_links_are_deduplicated_and_sorted() {


### PR DESCRIPTION
## Summary
- bump the Compass workspace patch version from 0.1.7 to 0.1.8
- add native x86_64 and ARM64 Windows release artifacts alongside the existing macOS and Linux assets
- package `compass.exe` with licenses, notices, completions, and per-architecture SHA-256 files
- document the Windows archive installation path

## Validation
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test compass_product --locked` (5 passed)
- `sh scripts/test_release_scripts.sh` (all six targets plus checksum rejection)
- `cargo check --offline -p compass-cli --bin compass`
- locked workspace metadata reports 0.1.8
- release workflow YAML parses with exactly six requested targets
- `sh scripts/check_product_boundary.sh`
- `git diff --check`
- `graphify update .`

The tag-triggered workflow will build, test, package, checksum, verify, and attest Intel/Apple Silicon macOS, x86_64/ARM64 Linux, and x86_64/ARM64 Windows artifacts.