### PR TITLE
Harden exact versioned graph diffs

### DIFF
--- a/crates/compass-cli/assets/compass-skill/references/history.md
+++ b/crates/compass-cli/assets/compass-skill/references/history.md
@@ -51,10 +51,16 @@ compass diff v1.2.0 HEAD
 compass diff HEAD~1 HEAD --all
 compass diff HEAD~1 HEAD --format json
 compass diff HEAD~1 HEAD --explain sd1-...
+compass history diff HEAD~1 HEAD --format jsonl
+compass history diff HEAD~1 HEAD --root nodes --root edges --output exact.jsonl
 compass history list HEAD --format json
 compass history show HEAD
 compass history export HEAD --format compass-out --output historical-output
 ```
+
+Use `compass diff` for a ranked semantic review. Use `compass history diff`
+when the user needs an exhaustive, deterministic record-level comparison of
+immutable graph roots.
 
 Semantic realizations with different extraction fingerprints are not silently
 treated as equivalent. Use `history list`, `show`, and `prefer` to inspect or

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 use compass_core::LoadedGraph;
 use compass_core::{
     MaterializeError, MaterializeObserver, MaterializeRequest, MaterializeStage,
@@ -7,8 +10,10 @@ use compass_history::{
     ArtifactClass, BuildProfile, ChangeKind, ChangeSink, ClaimedJob, CommitId,
     DerivedCacheNamespace, ExtractionFingerprint, GitTargetLimitation, GraphChange, HistoryConfig,
     HistoryError, HistoryQueue, HistoryStore, JobRequest, JobState, PublishedVersion,
-    RealizationId, Repository,
+    RealizationId, RecordKind, Repository, canonical_json_bytes,
 };
+use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::history_build::{HistoryBuildOptions, parse_build_command, parse_enable_options};
 use crate::{Frontend, Outcome};
@@ -16,7 +21,7 @@ use crate::{Frontend, Outcome};
 pub(crate) fn help(_frontend: Frontend) -> String {
     let prefix = "compass";
     format!(
-        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  status [REV] [--format text|json]\n  verify REV|REALIZATION [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  cache status [--format text|json]\n  cache gc [--max-bytes N] [--max-age-days N] [--yes] [--format text|json]\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
+        "Usage: {prefix} history <command>\n\nCommands:\n  enable [build-profile options]\n  disable\n  timeline [--rev REV] [--limit N [--after CURSOR]] --format json\n  change-counts REV [--parent REV] --format json\n  diff OLD NEW [--root NAME] [--output PATH] --format jsonl\n  status [REV] [--format text|json]\n  verify REV|REALIZATION [--format text|json]\n  build REV [--all [--first-parent]] [build-profile options|--profile-from REV|REALIZATION] [--format text|json]\n  rebuild REV [build-profile options] [--replace-corrupt] [--format text|json]\n  list [REV] [--format text|json]\n  show REALIZATION [--format text|json]\n  prefer REV REALIZATION [--format text|json]\n  export REV --format graph-json|json|compass-out [--community ID] [--node-limit N] --output PATH\n  cache status [--format text|json]\n  cache gc [--max-bytes N] [--max-age-days N] [--yes] [--format text|json]\n  gc [--prune-non-preferred] [--yes] [--format text|json]\n\nExact diff roots:\n  nodes, edges, hyperedges, analysis, metadata, program-facts, program-summaries\n\nBuild options:\n  --all                    Build every commit reachable from REV\n  --first-parent           With --all, build only the first-parent lineage\n\nBuild-profile options:\n  --code-only              Build a complete local AST/inferred realization without model credentials\n  --backend NAME           Build a semantic realization with the selected provider\n  --model NAME             Select the provider model\n  --exclude PATTERN        Exclude a committed path pattern (repeatable)\n  --cargo                   Include Cargo package metadata"
     )
 }
 
@@ -232,6 +237,14 @@ pub(crate) fn resolve_comparable_pair(
             (history, old, new)
         }
     };
+    let old_engine = engine_compatibility_digest(&old.version.build_profile)?;
+    let new_engine = engine_compatibility_digest(&new.version.build_profile)?;
+    if old_engine != new_engine {
+        return Err(format!(
+            "realizations were produced by incompatible graph engines\n\nOLD {} ({}) engine: {}\nNEW {} ({}) engine: {}\n\nRebuild one revision with `compass history build REV --profile-from OTHER`",
+            old.version.git_commit, old.id, old_engine, new.version.git_commit, new.id, new_engine,
+        ));
+    }
     if old.version.build_profile != new.version.build_profile {
         return Err(format!(
             "realizations are not semantically comparable\n\nOLD {} ({}) profile: {}\nNEW {} ({}) profile: {}\n\nBuild a comparable realization:\n  compass history build {} --profile-from {}",
@@ -246,6 +259,37 @@ pub(crate) fn resolve_comparable_pair(
         ));
     }
     Ok(ResolvedDiff { history, old, new })
+}
+
+fn engine_compatibility_digest(profile: &BuildProfile) -> Result<String, String> {
+    const ENGINE_FIELDS: [&str; 13] = [
+        "compass_version",
+        "graph_schema",
+        "extractor_version",
+        "resolver_version",
+        "pipeline_version",
+        "program_provider_policy",
+        "program_ir_schema",
+        "program_merger_version",
+        "program_analysis_schema",
+        "program_analyzer_version",
+        "enabled_features",
+        "direction",
+        "semantic_prompt_sha256",
+    ];
+    let values = ENGINE_FIELDS
+        .into_iter()
+        .map(|field| {
+            profile
+                .value(field)
+                .map(|value| (field, value))
+                .ok_or_else(|| format!("build profile has no engine field {field}"))
+        })
+        .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?;
+    let bytes =
+        canonical_json_bytes(&serde_json::to_value(values).map_err(|error| error.to_string())?)
+            .map_err(|error| error.to_string())?;
+    Ok(format!("{:x}", Sha256::digest(bytes)))
 }
 
 fn select_existing(
@@ -291,6 +335,9 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
     }
     if args[0] == "change-counts" {
         return execute_change_counts(&repository, &args[1..]);
+    }
+    if args[0] == "diff" {
+        return execute_exact_diff(&repository, &args[1..]);
     }
     if args[0] == "verify" {
         return execute_verify(&repository, &args[1..]);
@@ -702,6 +749,250 @@ fn execute(frontend: Frontend, args: &[String]) -> Result<String, CommandFailure
         }
         other => Err(usage(format!("unknown history command {other}"))),
     }
+}
+
+const MAX_STDOUT_EXACT_DIFF_BYTES: u64 = 128 * 1024 * 1024;
+
+fn execute_exact_diff(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {
+    let mut revisions = Vec::new();
+    let mut roots = Vec::new();
+    let mut output = None;
+    let mut format = "jsonl";
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--root" => {
+                index += 1;
+                roots.push(
+                    args.get(index)
+                        .ok_or_else(|| usage("--root requires a root name"))?
+                        .clone(),
+                );
+            }
+            value if value.starts_with("--root=") => roots.push(value[7..].to_owned()),
+            "--output" => {
+                index += 1;
+                let path = args
+                    .get(index)
+                    .ok_or_else(|| usage("--output requires a path"))?;
+                if output.replace(PathBuf::from(path)).is_some() {
+                    return Err(usage("duplicate --output"));
+                }
+            }
+            value if value.starts_with("--output=") => {
+                if output.replace(PathBuf::from(&value[9..])).is_some() {
+                    return Err(usage("duplicate --output"));
+                }
+            }
+            "--format" => {
+                index += 1;
+                format = args
+                    .get(index)
+                    .map(String::as_str)
+                    .ok_or_else(|| usage("--format requires jsonl"))?;
+            }
+            value if value.starts_with("--format=") => format = &value[9..],
+            value if value.starts_with('-') => {
+                return Err(usage(format!("unknown history diff option {value}")));
+            }
+            value => revisions.push(value.to_owned()),
+        }
+        index += 1;
+    }
+    exact(&revisions, 2, "history diff requires OLD NEW")?;
+    if format != "jsonl" {
+        return Err(usage("history diff --format must be jsonl"));
+    }
+    if output
+        .as_ref()
+        .is_some_and(|path| path.as_os_str().is_empty())
+    {
+        return Err(usage("--output requires a non-empty path"));
+    }
+    let records = if roots.is_empty() {
+        exact_diff_roots().to_vec()
+    } else {
+        let mut selected = Vec::new();
+        for root in roots {
+            let record = parse_exact_diff_root(&root)?;
+            if !selected.contains(&record) {
+                selected.push(record);
+            }
+        }
+        selected
+    };
+    let old_commit = repository.resolve(&revisions[0]).map_err(runtime)?;
+    let new_commit = repository.resolve(&revisions[1]).map_err(runtime)?;
+    let resolved =
+        resolve_comparable_pair(repository, old_commit, new_commit, None).map_err(runtime)?;
+    let old_reader = resolved.history.reader(&resolved.old.id).map_err(runtime)?;
+    let new_reader = resolved.history.reader(&resolved.new.id).map_err(runtime)?;
+    let header = serde_json::json!({
+        "type": "header",
+        "schema": "compass.history.exact_diff/1",
+        "old": {
+            "commit": resolved.old.version.git_commit,
+            "realization": resolved.old.id,
+        },
+        "new": {
+            "commit": resolved.new.version.git_commit,
+            "realization": resolved.new.id,
+        },
+        "engine_compatibility": engine_compatibility_digest(&resolved.old.version.build_profile)
+            .map_err(runtime)?,
+        "profile_digest": resolved.old.version.profile_digest,
+        "roots": records.iter().map(|record| exact_diff_root_name(*record)).collect::<Vec<_>>(),
+    });
+    if let Some(output) = output {
+        if output.exists() {
+            return Err(runtime(format!(
+                "history diff output already exists: {}",
+                output.display()
+            )));
+        }
+        let parent = output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(runtime)?;
+        let counts = write_exact_diff(
+            &old_reader,
+            &new_reader,
+            &records,
+            &header,
+            temporary.as_file_mut(),
+            None,
+        )
+        .map_err(runtime)?;
+        temporary.as_file_mut().flush().map_err(runtime)?;
+        temporary.as_file().sync_all().map_err(runtime)?;
+        temporary.persist_noclobber(&output).map_err(runtime)?;
+        Ok(format!(
+            "wrote {} exact changes to {}",
+            counts.total,
+            output.display()
+        ))
+    } else {
+        let mut bytes = Vec::new();
+        write_exact_diff(
+            &old_reader,
+            &new_reader,
+            &records,
+            &header,
+            &mut bytes,
+            Some(MAX_STDOUT_EXACT_DIFF_BYTES),
+        )
+        .map_err(runtime)?;
+        if bytes.last() == Some(&b'\n') {
+            bytes.pop();
+        }
+        String::from_utf8(bytes).map_err(runtime)
+    }
+}
+
+fn exact_diff_roots() -> &'static [RecordKind] {
+    &[
+        RecordKind::Node,
+        RecordKind::Edge,
+        RecordKind::Hyperedge,
+        RecordKind::Analysis,
+        RecordKind::Metadata,
+        RecordKind::ProgramFact,
+        RecordKind::ProgramSummary,
+    ]
+}
+
+fn parse_exact_diff_root(value: &str) -> Result<RecordKind, CommandFailure> {
+    match value {
+        "nodes" => Ok(RecordKind::Node),
+        "edges" => Ok(RecordKind::Edge),
+        "hyperedges" => Ok(RecordKind::Hyperedge),
+        "analysis" => Ok(RecordKind::Analysis),
+        "metadata" => Ok(RecordKind::Metadata),
+        "program-facts" => Ok(RecordKind::ProgramFact),
+        "program-summaries" => Ok(RecordKind::ProgramSummary),
+        _ => Err(usage(format!("unknown history diff root {value:?}"))),
+    }
+}
+
+fn exact_diff_root_name(record: RecordKind) -> &'static str {
+    match record {
+        RecordKind::Node => "nodes",
+        RecordKind::Edge => "edges",
+        RecordKind::Hyperedge => "hyperedges",
+        RecordKind::Analysis => "analysis",
+        RecordKind::Metadata => "metadata",
+        RecordKind::ProgramFact => "program-facts",
+        RecordKind::ProgramSummary => "program-summaries",
+    }
+}
+
+#[derive(Default, Serialize)]
+struct ExactDiffCounts {
+    total: u64,
+    added: u64,
+    removed: u64,
+    changed: u64,
+}
+
+struct ExactDiffWriter<'writer, W> {
+    writer: &'writer mut W,
+    written: u64,
+    max_bytes: Option<u64>,
+    counts: ExactDiffCounts,
+}
+
+impl<W: Write> ExactDiffWriter<'_, W> {
+    fn line(&mut self, value: &serde_json::Value) -> Result<(), HistoryError> {
+        let mut bytes = canonical_json_bytes(value)?;
+        bytes.push(b'\n');
+        let next = self
+            .written
+            .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
+        if self.max_bytes.is_some_and(|limit| next > limit) {
+            return Err(HistoryError::OperationalState(
+                "exact diff exceeds stdout limit; use --output PATH".to_owned(),
+            ));
+        }
+        self.writer
+            .write_all(&bytes)
+            .map_err(|error| HistoryError::OperationalState(error.to_string()))?;
+        self.written = next;
+        Ok(())
+    }
+}
+
+impl<W: Write> ChangeSink for ExactDiffWriter<'_, W> {
+    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
+        self.counts.total = self.counts.total.saturating_add(1);
+        match change.change {
+            ChangeKind::Added => self.counts.added = self.counts.added.saturating_add(1),
+            ChangeKind::Removed => self.counts.removed = self.counts.removed.saturating_add(1),
+            ChangeKind::Changed => self.counts.changed = self.counts.changed.saturating_add(1),
+        }
+        self.line(&serde_json::json!({"type":"change", "change":change}))
+    }
+}
+
+fn write_exact_diff<W: Write>(
+    old: &compass_history::RealizationReader<'_>,
+    new: &compass_history::RealizationReader<'_>,
+    records: &[RecordKind],
+    header: &serde_json::Value,
+    writer: &mut W,
+    max_bytes: Option<u64>,
+) -> Result<ExactDiffCounts, HistoryError> {
+    let mut sink = ExactDiffWriter {
+        writer,
+        written: 0,
+        max_bytes,
+        counts: ExactDiffCounts::default(),
+    };
+    sink.line(header)?;
+    old.diff_records(new, records, &mut sink)?;
+    let summary = serde_json::to_value(&sink.counts)?;
+    sink.line(&serde_json::json!({"type":"summary", "counts":summary}))?;
+    Ok(sink.counts)
 }
 
 #[derive(Default, serde::Serialize)]

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -38,7 +38,23 @@ fn run(
 fn current_history_profile() -> Result<compass_history::BuildProfile, compass_history::HistoryError>
 {
     let mut profile = compass_history::BuildProfile::default();
-    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
+    for (key, value) in [
+        ("compass_version", env!("CARGO_PKG_VERSION")),
+        ("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA),
+        ("extractor_version", "compass-languages/v1"),
+        ("resolver_version", "compass-resolve/v1"),
+        ("pipeline_version", "compass-core/v1"),
+        ("program_provider_policy", "offline-artifacts-first"),
+        ("program_ir_schema", "1"),
+        ("program_merger_version", "1"),
+        ("program_analysis_schema", "1"),
+        ("program_analyzer_version", "1"),
+        ("enabled_features", "workspace-default"),
+        ("direction", "native-source-semantics"),
+        ("semantic_prompt_sha256", "fixture-prompt"),
+    ] {
+        profile.insert(key, value)?;
+    }
     Ok(profile)
 }
 
@@ -1184,6 +1200,93 @@ fn diff_emits_semantic_text_json_html_and_rejects_removed_flags()
     drop(history);
 
     let compass = env!("CARGO_BIN_EXE_compass");
+    let exact_output = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "diff",
+            "HEAD~1",
+            "HEAD",
+            "--root",
+            "nodes",
+            "--root=edges",
+            "--format=jsonl",
+        ],
+    )?;
+    assert!(
+        exact_output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&exact_output.stderr)
+    );
+    let exact_lines = String::from_utf8(exact_output.stdout)?
+        .lines()
+        .map(serde_json::from_str::<serde_json::Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        exact_lines.first().ok_or("missing exact diff header")?["type"],
+        "header"
+    );
+    assert_eq!(
+        exact_lines.first().ok_or("missing exact diff header")?["schema"],
+        "compass.history.exact_diff/1"
+    );
+    assert_eq!(
+        exact_lines.first().ok_or("missing exact diff header")?["roots"],
+        json!(["nodes", "edges"])
+    );
+    let exact_changes = exact_lines
+        .iter()
+        .filter(|line| line["type"] == "change")
+        .collect::<Vec<_>>();
+    assert!(!exact_changes.is_empty());
+    assert!(
+        exact_changes
+            .iter()
+            .all(|line| { matches!(line["change"]["record"].as_str(), Some("node" | "edge")) })
+    );
+    let exact_summary = exact_lines.last().ok_or("missing exact diff summary")?;
+    assert_eq!(exact_summary["type"], "summary");
+    assert_eq!(
+        exact_summary["counts"]["total"],
+        u64::try_from(exact_changes.len())?
+    );
+
+    let exact_path = directory.path().join("exact-diff.jsonl");
+    let exact_file = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "diff",
+            "HEAD~1",
+            "HEAD",
+            "--root=nodes",
+            "--output",
+            exact_path.to_str().ok_or("exact path")?,
+        ],
+    )?;
+    assert!(
+        exact_file.status.success(),
+        "{}",
+        String::from_utf8_lossy(&exact_file.stderr)
+    );
+    assert!(exact_path.is_file());
+    let no_overwrite = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "diff",
+            "HEAD~1",
+            "HEAD",
+            "--output",
+            exact_path.to_str().ok_or("exact path")?,
+        ],
+    )?;
+    assert_eq!(no_overwrite.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&no_overwrite.stderr).contains("already exists"));
+
     let summary = run(compass, directory.path(), &["diff", "HEAD~1", "HEAD"])?;
     assert!(
         summary.status.success(),
@@ -1327,7 +1430,7 @@ fn diff_emits_semantic_text_json_html_and_rejects_removed_flags()
     drop(history);
     let mismatch = run(compass, directory.path(), &["diff", "HEAD~1", "HEAD"])?;
     assert_eq!(mismatch.status.code(), Some(1));
-    assert!(String::from_utf8_lossy(&mismatch.stderr).contains("not semantically comparable"));
+    assert!(String::from_utf8_lossy(&mismatch.stderr).contains("incompatible graph engines"));
     Ok(())
 }
 

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -289,7 +289,7 @@ fn run_promoted_materialization(
     request: &MaterializeRequest,
     observer: &mut dyn MaterializeObserver,
     activity: &compass_history::ActivityGuard,
-    completed: CompletedGraphArtifacts,
+    mut completed: CompletedGraphArtifacts,
 ) -> Result<PublishedVersion, MaterializeError> {
     let providers = completed
         .artifacts
@@ -302,7 +302,12 @@ fn run_promoted_materialization(
     observer.resolved(&fingerprint)?;
     observer.entered(MaterializeStage::Building)?;
     observer.entered(MaterializeStage::Validating)?;
-    validate_promoted(&completed, &request.commit)?;
+    validate_promoted(
+        &mut completed,
+        &request.repository,
+        &request.commit,
+        &request.profile,
+    )?;
     observer.entered(MaterializeStage::Publishing)?;
     let prepared = store.prepare_publish_with_activity(
         PublishRequest {
@@ -334,9 +339,15 @@ fn run_materialization(
     let fingerprint = resolve_fingerprint(&request.profile, worktree.path())?;
     observer.resolved(&fingerprint)?;
     observer.entered(MaterializeStage::Building)?;
-    let completed = builder.build(worktree.path(), worktree.output_root())?;
+    let mut completed = builder.build(worktree.path(), worktree.output_root())?;
     observer.entered(MaterializeStage::Validating)?;
-    validate_completed(&completed, &request.commit, &request.profile, worktree)?;
+    validate_completed(
+        &mut completed,
+        &request.repository,
+        &request.commit,
+        &request.profile,
+        worktree,
+    )?;
     let default_viewer = builder
         .default_viewer_projection(&completed, request.repository.root(), &request.commit)
         .ok()
@@ -562,7 +573,8 @@ fn collect_configuration_files(
 }
 
 fn validate_completed(
-    completed: &CompletedGraphArtifacts,
+    completed: &mut CompletedGraphArtifacts,
+    repository: &Repository,
     commit: &CommitId,
     profile: &BuildProfile,
     worktree: &WorktreeGuard,
@@ -638,12 +650,22 @@ fn validate_completed(
             }
         }
     }
+    attach_source_inventory(
+        completed,
+        repository,
+        commit,
+        profile,
+        worktree.path(),
+        &detection.files,
+    )?;
     Ok(())
 }
 
 fn validate_promoted(
-    completed: &CompletedGraphArtifacts,
+    completed: &mut CompletedGraphArtifacts,
+    repository: &Repository,
     commit: &CommitId,
+    profile: &BuildProfile,
 ) -> Result<(), MaterializeError> {
     let built_at = completed
         .artifacts
@@ -657,7 +679,146 @@ fn validate_promoted(
             built_at
         )));
     }
+    let detection = detect(
+        repository.root(),
+        &DetectOptions {
+            gitignore: profile_gitignore(profile),
+            ignore_policy: IgnorePolicy::HistoricalCommit,
+            extra_excludes: profile_excludes(profile),
+            ..DetectOptions::default()
+        },
+    )?;
+    attach_source_inventory(
+        completed,
+        repository,
+        commit,
+        profile,
+        repository.root(),
+        &detection.files,
+    )?;
     Ok(())
+}
+
+fn attach_source_inventory(
+    completed: &mut CompletedGraphArtifacts,
+    repository: &Repository,
+    commit: &CommitId,
+    profile: &BuildProfile,
+    checkout: &Path,
+    detected: &BTreeMap<String, Vec<String>>,
+) -> Result<(), MaterializeError> {
+    const INVENTORY_PATH: &str = ".compass_source_inventory.json";
+    if completed
+        .artifacts
+        .authoritative_sidecars
+        .contains_key(INVENTORY_PATH)
+    {
+        return Err(MaterializeError::Incomplete(format!(
+            "graph builder attempted to provide reserved artifact {INVENTORY_PATH}"
+        )));
+    }
+    let manifest = completed
+        .artifacts
+        .manifest
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            MaterializeError::Incomplete(
+                "exact extraction requires an object-shaped source manifest".to_owned(),
+            )
+        })?;
+    let blobs = repository.committed_blob_ids(commit)?;
+    let mut record_counts = BTreeMap::<String, u64>::new();
+    for attributes in completed
+        .artifacts
+        .document
+        .nodes
+        .iter()
+        .map(|node| &node.attributes)
+        .chain(
+            completed
+                .artifacts
+                .document
+                .links
+                .iter()
+                .map(|edge| &edge.attributes),
+        )
+    {
+        let mut attributed = BTreeSet::new();
+        for field in ["source_file", "origin_file"] {
+            if let Some(source) = attributes
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .and_then(|source| repository_relative_source(source, checkout))
+            {
+                attributed.insert(source);
+            }
+        }
+        for source in attributed {
+            *record_counts.entry(source).or_default() += 1;
+        }
+    }
+    let mut entries = BTreeMap::new();
+    for file in detected.get("code").into_iter().flatten() {
+        let path = Path::new(file);
+        let relative = path.strip_prefix(checkout).map_err(|_| {
+            MaterializeError::Incomplete(format!(
+                "detected code source escaped exact checkout: {}",
+                path.display()
+            ))
+        })?;
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        let blob = blobs.get(&relative).ok_or_else(|| {
+            MaterializeError::Incomplete(format!(
+                "detected code source is absent from exact Git tree: {relative}"
+            ))
+        })?;
+        let ast_hash = manifest
+            .get(&relative)
+            .and_then(serde_json::Value::as_object)
+            .and_then(|entry| entry.get("ast_hash"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|hash| !hash.is_empty())
+            .ok_or_else(|| {
+                MaterializeError::Incomplete(format!(
+                    "extraction manifest has no AST completion stamp for {relative}"
+                ))
+            })?;
+        let record_count = record_counts.get(&relative).copied().unwrap_or_default();
+        entries.insert(
+            relative.clone(),
+            json!({
+                "git_object": blob,
+                "ast_hash": ast_hash,
+                "extension": relative.rsplit_once('.').map(|(_, extension)| extension).unwrap_or(""),
+                "status": if record_count == 0 { "no_graph_records" } else { "extracted" },
+                "graph_record_count": record_count,
+            }),
+        );
+    }
+    let inventory = json!({
+        "schema": "compass.history.source_inventory/1",
+        "commit": commit,
+        "profile_digest": format!("{:x}", Sha256::digest(profile.canonical_bytes()?)),
+        "code_files": entries,
+    });
+    completed.artifacts.authoritative_sidecars.insert(
+        INVENTORY_PATH.to_owned(),
+        compass_history::canonical_json_bytes(&inventory)?,
+    );
+    Ok(())
+}
+
+fn repository_relative_source(source: &str, checkout: &Path) -> Option<String> {
+    let path = Path::new(source);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(checkout).ok()?
+    } else {
+        path
+    };
+    let normalized = relative.to_string_lossy().replace('\\', "/");
+    let normalized = normalized.strip_prefix("./").unwrap_or(&normalized);
+    (!normalized.is_empty() && !normalized.starts_with("../")).then(|| normalized.to_owned())
 }
 
 fn profile_gitignore(profile: &BuildProfile) -> bool {

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -108,7 +108,11 @@ impl CompleteGraphBuilder for RecordingBuilder {
                 program: None,
                 analysis: None,
                 labels: None,
-                manifest: Some(json!({"service.rs":{"ast_hash":"fixture"}})),
+                manifest: Some(json!({
+                    "service.rs":{"ast_hash":"fixture"},
+                    "settings.toml":{"ast_hash":"fixture"},
+                    "config/tsconfig.json":{"ast_hash":"fixture"}
+                })),
                 authoritative_sidecars: Default::default(),
             },
             completion: CompletionEvidence {
@@ -149,7 +153,52 @@ fn current_snapshot_is_published_without_invoking_the_exact_builder()
     assert!(builder.builds()? == 0, "exact builder unexpectedly ran");
     let artifacts = history.artifacts(&published.id)?;
     assert_eq!(artifacts.artifacts.document.nodes[0].id, "promoted");
+    let inventory: serde_json::Value = serde_json::from_slice(
+        artifacts
+            .artifacts
+            .authoritative_sidecars
+            .get(".compass_source_inventory.json")
+            .ok_or("source inventory was not published")?,
+    )?;
+    assert_eq!(inventory["schema"], "compass.history.source_inventory/1");
+    assert_eq!(inventory["code_files"]["service.rs"]["status"], "extracted");
+    assert!(
+        inventory["code_files"]["service.rs"]["git_object"]
+            .as_str()
+            .is_some_and(|object| object.len() >= 40)
+    );
     assert_eq!(published.version.git_commit, commit.to_string());
+    Ok(())
+}
+
+#[test]
+fn exact_materialization_rejects_a_code_file_without_an_ast_completion_stamp()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("service.rs"), "fn service() {}\n")?;
+    std::fs::write(directory.path().join("omitted.py"), "def omitted(): pass\n")?;
+    git(directory.path(), &["add", "."])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "sources"])?;
+    let repository = Repository::discover(directory.path())?;
+    let commit = repository.resolve("HEAD")?;
+    let history = HistoryStore::create(&repository)?;
+
+    let error = materialize_history(
+        &history,
+        &RecordingBuilder::default(),
+        request(&repository, commit.clone(), false)?,
+    )
+    .err()
+    .ok_or("materialization unexpectedly accepted an omitted code source")?;
+
+    assert!(error.to_string().contains("omitted.py"));
+    assert!(history.preferred(&commit)?.is_none());
     Ok(())
 }
 

--- a/crates/compass-history/src/diff.rs
+++ b/crates/compass-history/src/diff.rs
@@ -134,11 +134,7 @@ impl RealizationReader<'_> {
         if old == new {
             return Ok(());
         }
-        for difference in self
-            .store
-            .prolly
-            .stream_diff(&old.to_tree(), &new.to_tree())?
-        {
+        for difference in self.prolly.stream_diff(&self.tree(old), &self.tree(new))? {
             let difference = difference?;
             let (change, key, old, new) = match difference {
                 Diff::Added { key, val } => {

--- a/crates/compass-history/src/git.rs
+++ b/crates/compass-history/src/git.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -195,6 +196,55 @@ impl Repository {
         attach_hunks(&patch, &mut deltas)?;
         deltas.sort();
         Ok(deltas)
+    }
+
+    /// Return the exact Git object identity for every ordinary blob in a commit.
+    ///
+    /// Paths are repository-relative and use Git's `/` separator. Gitlinks are
+    /// deliberately excluded because they are reported separately as target
+    /// limitations and cannot contribute ordinary source records.
+    pub fn committed_blob_ids(
+        &self,
+        commit: &CommitId,
+    ) -> Result<BTreeMap<String, String>, HistoryError> {
+        let listing = git_output(
+            &self.root,
+            &["ls-tree", "-r", "-z", "--full-tree", commit.as_str()],
+        )?;
+        let mut blobs = BTreeMap::new();
+        for entry in listing
+            .split(|byte| *byte == 0)
+            .filter(|entry| !entry.is_empty())
+        {
+            let tab = entry
+                .iter()
+                .position(|byte| *byte == b'\t')
+                .ok_or_else(|| {
+                    HistoryError::Git("Git returned malformed tree inventory".to_owned())
+                })?;
+            let metadata = std::str::from_utf8(&entry[..tab]).map_err(|error| {
+                HistoryError::Git(format!("Git returned non-UTF-8 tree metadata: {error}"))
+            })?;
+            let fields = metadata.split_ascii_whitespace().collect::<Vec<_>>();
+            if fields.len() != 3 || fields.get(1) != Some(&"blob") {
+                continue;
+            }
+            let object = fields[2];
+            if object.len() < 40 || !object.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err(HistoryError::Git(format!(
+                    "Git returned invalid blob identity {object:?}"
+                )));
+            }
+            let path = String::from_utf8(entry[tab + 1..].to_vec()).map_err(|error| {
+                HistoryError::Git(format!("Git returned non-UTF-8 tree path: {error}"))
+            })?;
+            if blobs.insert(path.clone(), object.to_owned()).is_some() {
+                return Err(HistoryError::Git(format!(
+                    "Git returned duplicate tree path {path:?}"
+                )));
+            }
+        }
+        Ok(blobs)
     }
 
     /// Return every commit reachable from `tip` in parent-before-child order.

--- a/crates/compass-history/src/reader.rs
+++ b/crates/compass-history/src/reader.rs
@@ -1,12 +1,18 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use prolly::Tree;
+use prolly::{Prolly, RuntimeConfig, Tree};
+use prolly_store_sqlite::SqliteStore;
 
 use crate::{
     ActivityGuard, HistoryError, HistoryRecord, HistoryRecordKey, HistoryStore, PublishedVersion,
-    RealizationId,
+    RealizationId, StoredTree,
 };
+
+const READER_NODE_CACHE_MAX_NODES: usize = 16_384;
+const READER_NODE_CACHE_MAX_BYTES: usize = 128 * 1024 * 1024;
+const READER_READ_PARALLELISM: usize = 16;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 enum OwnedHistoryRecordKey {
@@ -34,6 +40,7 @@ pub struct RealizationReader<'store> {
     pub(crate) store: &'store HistoryStore,
     _activity: ActivityGuard,
     pub(crate) published: PublishedVersion,
+    pub(crate) prolly: Prolly<Arc<SqliteStore>>,
     roots: RefCell<HashMap<&'static str, Tree>>,
     records: RefCell<HashMap<OwnedHistoryRecordKey, Option<HistoryRecord>>>,
 }
@@ -45,10 +52,17 @@ impl HistoryStore {
     ) -> Result<RealizationReader<'_>, HistoryError> {
         let activity = self.activity()?;
         let published = self.get_with_activity(realization, &activity)?;
+        let mut config = self.prolly.config().clone();
+        config.runtime = RuntimeConfig {
+            node_cache_max_nodes: Some(READER_NODE_CACHE_MAX_NODES),
+            node_cache_max_bytes: Some(READER_NODE_CACHE_MAX_BYTES),
+            read_parallelism: READER_READ_PARALLELISM,
+        };
         Ok(RealizationReader {
             store: self,
             _activity: activity,
             published,
+            prolly: Prolly::new(self.prolly.store().clone(), config),
             roots: RefCell::new(HashMap::new()),
             records: RefCell::new(HashMap::new()),
         })
@@ -69,31 +83,31 @@ impl RealizationReader<'_> {
         let (root_name, tree, encoded_key, schema) = match &owned {
             OwnedHistoryRecordKey::Node(id) => (
                 "nodes",
-                self.published.version.nodes_root.to_tree(),
+                self.tree(&self.published.version.nodes_root),
                 crate::node_key(id),
                 "compass.node",
             ),
             OwnedHistoryRecordKey::ProgramModule(source_file) => (
                 "program-facts",
-                self.published.version.program_facts_root.to_tree(),
+                self.tree(&self.published.version.program_facts_root),
                 crate::artifacts::program_key("module", source_file),
                 "compass.program.module",
             ),
             OwnedHistoryRecordKey::ProgramFunction(symbol_id) => (
                 "program-facts",
-                self.published.version.program_facts_root.to_tree(),
+                self.tree(&self.published.version.program_facts_root),
                 crate::artifacts::program_key("function", symbol_id),
                 "compass.program.function",
             ),
             OwnedHistoryRecordKey::ProgramSummary(symbol_id) => (
                 "program-summaries",
-                self.published.version.program_summaries_root.to_tree(),
+                self.tree(&self.published.version.program_summaries_root),
                 crate::artifacts::program_key("summary", symbol_id),
                 "compass.program.summary",
             ),
             OwnedHistoryRecordKey::ReverseCallers(symbol_id) => (
                 "program-summaries",
-                self.published.version.program_summaries_root.to_tree(),
+                self.tree(&self.published.version.program_summaries_root),
                 crate::artifacts::program_key("reverse-call", symbol_id),
                 "compass.program.reverse-call",
             ),
@@ -104,7 +118,7 @@ impl RealizationReader<'_> {
             .entry(root_name)
             .or_insert(tree)
             .clone();
-        let value = match self.store.prolly.get(&tree, &encoded_key)? {
+        let value = match self.prolly.get(&tree, &encoded_key)? {
             None => None,
             Some(bytes) => {
                 if bytes.len() > crate::MAX_RECORD_VALUE_BYTES {
@@ -140,5 +154,9 @@ impl RealizationReader<'_> {
         keys: impl IntoIterator<Item = HistoryRecordKey<'key>>,
     ) -> Result<Vec<Option<HistoryRecord>>, HistoryError> {
         keys.into_iter().map(|key| self.read(key)).collect()
+    }
+
+    pub(crate) fn tree(&self, stored: &StoredTree) -> Tree {
+        stored.to_tree()
     }
 }

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -9,6 +9,8 @@ use compass_history::{
 };
 use compass_ir::{ProgramBundle, ProviderDescriptor, ProviderKind, hex_sha256};
 use compass_model::GraphDocument;
+use prolly::{VersionedValue, decode_segments};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use serde_json::{Value, json};
 
 #[derive(Default)]
@@ -105,6 +107,98 @@ fn program(input: &[u8]) -> Result<AnalysisBundle, compass_analysis::AnalysisErr
         evidence: Vec::new(),
         modules: Vec::new(),
     })
+}
+
+fn naive_changes(
+    record: RecordKind,
+    old: &[(Vec<u8>, Vec<u8>)],
+    new: &[(Vec<u8>, Vec<u8>)],
+) -> Result<Vec<GraphChange>, Box<dyn std::error::Error>> {
+    let old = old.iter().cloned().collect::<BTreeMap<_, _>>();
+    let new = new.iter().cloned().collect::<BTreeMap<_, _>>();
+    let keys = old
+        .keys()
+        .chain(new.keys())
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let decode = |bytes: &[u8]| -> Result<Value, Box<dyn std::error::Error>> {
+        let envelope = VersionedValue::from_bytes(bytes)?;
+        Ok(serde_json::from_slice(&envelope.payload)?)
+    };
+    let display = |key: &[u8]| -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let mut segments = decode_segments(key)?;
+        segments.drain(..2);
+        Ok(segments
+            .into_iter()
+            .map(|segment| {
+                if segment
+                    .iter()
+                    .all(|byte| byte.is_ascii_graphic() || *byte == b' ')
+                {
+                    String::from_utf8(segment)
+                        .unwrap_or_else(|bytes| format!("invalid-utf8:{:?}", bytes.as_bytes()))
+                } else {
+                    segment.iter().fold(String::from("0x"), |mut output, byte| {
+                        use std::fmt::Write;
+                        let _ = write!(output, "{byte:02x}");
+                        output
+                    })
+                }
+            })
+            .collect())
+    };
+    let mut changes = Vec::new();
+    for key in keys {
+        let left = old.get(&key);
+        let right = new.get(&key);
+        let change = match (left, right) {
+            (Some(left), Some(right)) if left == right => None,
+            (Some(left), Some(right)) => Some(GraphChange {
+                record,
+                change: ChangeKind::Changed,
+                key: display(&key)?,
+                old: Some(decode(left)?),
+                new: Some(decode(right)?),
+            }),
+            (Some(left), None) => Some(GraphChange {
+                record,
+                change: ChangeKind::Removed,
+                key: display(&key)?,
+                old: Some(decode(left)?),
+                new: None,
+            }),
+            (None, Some(right)) => Some(GraphChange {
+                record,
+                change: ChangeKind::Added,
+                key: display(&key)?,
+                old: None,
+                new: Some(decode(right)?),
+            }),
+            (None, None) => None,
+        };
+        if let Some(change) = change {
+            changes.push(change);
+        }
+    }
+    Ok(changes)
+}
+
+fn sort_changes(changes: &mut [GraphChange]) -> Result<(), compass_history::HistoryError> {
+    let mut keyed = changes
+        .iter()
+        .cloned()
+        .map(|change| {
+            Ok((
+                compass_history::canonical_json_bytes(&serde_json::to_value(&change)?)?,
+                change,
+            ))
+        })
+        .collect::<Result<Vec<_>, compass_history::HistoryError>>()?;
+    keyed.sort_by(|left, right| left.0.cmp(&right.0));
+    for (target, (_, change)) in changes.iter_mut().zip(keyed) {
+        *target = change;
+    }
+    Ok(())
 }
 
 #[test]
@@ -245,5 +339,77 @@ fn full_diff_includes_program_facts_while_topology_diff_skips_them()
         &mut topology,
     )?;
     assert!(topology.0.is_empty());
+    Ok(())
+}
+
+#[test]
+fn streamed_topology_diff_matches_naive_map_oracle_across_random_graphs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    for seed in 0..64_u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let graph = |rng: &mut StdRng| {
+            let mut nodes = Vec::new();
+            for index in 0..16 {
+                if rng.gen_bool(0.65) {
+                    nodes.push(json!({
+                        "id": format!("node-{index:02}"),
+                        "kind": if rng.gen_bool(0.5) { "function" } else { "class" },
+                        "revision": rng.gen_range(0..4),
+                    }));
+                }
+            }
+            if nodes.is_empty() {
+                nodes.push(json!({"id":"node-00","kind":"function","revision":0}));
+            }
+            let ids = nodes
+                .iter()
+                .filter_map(|node| node.get("id").and_then(Value::as_str))
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+            let mut links = Vec::new();
+            for index in 0..24 {
+                if rng.gen_bool(0.55) {
+                    let source = &ids[rng.gen_range(0..ids.len())];
+                    let target = &ids[rng.gen_range(0..ids.len())];
+                    links.push(json!({
+                        "source": source,
+                        "target": target,
+                        "relation": if rng.gen_bool(0.5) { "calls" } else { "imports" },
+                        "key": format!("edge-{index:02}"),
+                        "weight": rng.gen_range(0..5),
+                    }));
+                }
+            }
+            (nodes, links)
+        };
+        let (old_nodes, old_links) = graph(&mut rng);
+        let (new_nodes, new_links) = graph(&mut rng);
+        let old_request = request('a', old_nodes, old_links, Vec::new(), rng.gen_range(0..8))?;
+        let new_request = request('b', new_nodes, new_links, Vec::new(), rng.gen_range(0..8))?;
+        let old_partition = old_request.artifacts.partition(&old_request.completion)?;
+        let new_partition = new_request.artifacts.partition(&new_request.completion)?;
+        let old = history.publish(old_request)?;
+        let new = history.publish(new_request)?;
+        let old_reader = history.reader(&old.id)?;
+        let new_reader = history.reader(&new.id)?;
+        let mut actual = VecSink::default();
+        old_reader.diff_records(
+            &new_reader,
+            &[RecordKind::Node, RecordKind::Edge],
+            &mut actual,
+        )?;
+        let mut expected =
+            naive_changes(RecordKind::Node, &old_partition.nodes, &new_partition.nodes)?;
+        expected.extend(naive_changes(
+            RecordKind::Edge,
+            &old_partition.edges,
+            &new_partition.edges,
+        )?);
+        sort_changes(&mut actual.0)?;
+        sort_changes(&mut expected)?;
+        assert_eq!(actual.0, expected, "streaming diff diverged at seed {seed}");
+    }
     Ok(())
 }

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -30,6 +30,7 @@ commit SHA + extraction fingerprint
                 +-- hyperedges
                 +-- analysis and communities
                 +-- reconstruction metadata
+                +-- committed source inventory
                 `-- authoritative sidecars
 ```
 
@@ -41,6 +42,12 @@ History graph schema `networkx-node-link/v1` records automatic multigraph
 promotion. This release is a hard cutover for caches and operational state:
 Compass starts the new `cache/v1` namespace empty and never imports or reads
 legacy cache entries. The immutable realization schema itself is unchanged.
+
+Before publication, Compass binds every detected code file to its exact Git
+blob ID and requires an AST completion stamp in the extraction manifest. The
+canonical `.compass_source_inventory.json` sidecar records that proof and
+distinguishes files that legitimately produced no graph records. A missing
+stamp fails closed instead of publishing an apparently complete graph.
 
 ## 1. Inspect the command contract
 
@@ -55,7 +62,8 @@ History commands include:
 
 ```text
 enable   disable   status   verify  build   rebuild
-list     show      prefer   export  cache   gc
+timeline change-counts diff list    show    prefer
+export   cache         gc
 ```
 
 Text output is for people. Commands that support `--format json` expose stable
@@ -245,6 +253,29 @@ Machine-readable output:
 compass diff v1.2.0 HEAD --format json
 ```
 
+For an exhaustive record-level diff rather than a ranked semantic review, use
+the history subcommand:
+
+```bash
+compass history diff v1.2.0 HEAD --format jsonl
+```
+
+It streams deterministic `header`, `change`, and `summary` records using schema
+`compass.history.exact_diff/1`. Select roots when an integration only needs
+part of the realization:
+
+```bash
+compass history diff v1.2.0 HEAD \
+  --root nodes \
+  --root edges \
+  --output exact-topology-diff.jsonl
+```
+
+Available roots are `nodes`, `edges`, `hyperedges`, `analysis`, `metadata`,
+`program-facts`, and `program-summaries`. Omitted roots are not opened. Output
+files are written atomically and never overwritten. Stdout is bounded; use
+`--output` for a very large exact diff.
+
 Self-contained interactive reviewer report:
 
 ```bash
@@ -305,7 +336,8 @@ compass history build NEW_REV --profile-from OLD_REV_OR_REALIZATION
 ```
 
 There is no profile-mismatch override: unlike profiles do not produce a
-semantic report.
+semantic or exact report. Compass checks graph-engine compatibility explicitly
+before comparing the complete build profiles.
 
 ## 7. Export a realization
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -613,6 +613,7 @@ compass program call-graph (--symbol SYMBOL | --source FILE --byte BYTE)
   [--direction callers|callees|both] [--depth N] --format json
 compass history timeline [--rev REV] [--limit N [--after CURSOR]] --format json
 compass history change-counts REV [--parent REV] --format json
+compass history diff OLD NEW [--root NAME] [--output PATH] --format jsonl
 compass history export REV --format json [--community ID] [--node-limit N] --output PATH
 ```
 
@@ -622,7 +623,12 @@ the preceding page's opaque `nextCursor`. A cursor rejects local-ref changes
 instead of silently mixing snapshots. Responses include `hasMore`,
 `nextCursor`, and `totalEntries` once the final page establishes the exact
 count. `history change-counts` requires existing preferred realizations for
-both revisions and never builds them. Guided writers accept `--events jsonl`; stdout then contains
+both revisions and never builds them. `history diff` streams an exhaustive,
+deterministic record-level diff for selected immutable roots. It may lazily
+materialize a missing revision, requires identical complete build profiles and
+compatible graph engines, refuses to overwrite `--output`, and bounds stdout
+for safety. This is distinct from the ranked `compass diff` semantic-review
+report. Guided writers accept `--events jsonl`; stdout then contains
 `compass.ide.progress/1` events and human diagnostics move to stderr.
 
 `json` is the canonical versioned graph-presentation export. `viewer-json`


### PR DESCRIPTION
## Summary

- bind every detected code file to its exact Git blob and require an AST completion stamp before publishing a realization
- add `compass history diff OLD NEW --format jsonl` for exhaustive, deterministic, root-selective record diffs with atomic output
- reject incompatible graph engines explicitly and isolate historical readers behind a finite 128 MiB Prolly cache
- document the exact-versus-semantic diff contract and hard-cutover behavior

## Correctness

- randomized streamed-diff oracle compares Prolly output with a naive map diff across 64 generated graph pairs
- missing code-file AST stamps fail closed and never create a preferred realization
- source-inventory proof is canonical, content-addressed, and sealed as an authoritative sidecar
- exact output contains canonical header/change/summary records and refuses output overwrite

This materially hardens correctness but is not a formal mathematical proof of every extractor semantic. It guarantees exact comparison of the sealed records that passed the publication inventory and profile/engine checks.

## Verification

- `cargo test --release -p compass-history --test diff` — 4 passed
- `cargo test --release -p compass-core --test history_materialize` — 8 passed
- `cargo test --release -p compass-cli --test history_cli` — 23 passed before rebase
- focused CLI exact/semantic diff test passed after rebase onto Compass 0.1.8
- `graphify update .` completed: 39,749 nodes / 86,148 edges

## Real-repository qualification

Podman commits `d8380c9` and `7ac3e83` were materialized code-only with the new source inventory, producing 119,293/119,289 nodes and 262,724/254,690 edges.

Exact node+edge diff:

- 20,932 changes, 14.1 MB canonical JSONL
- first measured run after release rebuild: 4.48s, 561 MB peak RSS
- immediate repeat: 0.86s, 561 MB peak RSS
- byte-identical SHA-256 on every run: `2e70da34f66d02ebef3e26c354d797176b9fe09ccf79a9ba099f7d51533852d7`
- finite-cache RSS is about 11.2% below the 631.8 MB unbounded-manager measurement

## Next slice

The highest-value follow-up is fused streaming publication and validation: emit canonical graph partitions directly into Prolly builders while computing the completion certificate, eliminating the current full in-memory artifact reconstruction and duplicate validation scan. That targets the remaining 5.7 GB build RSS and multi-minute publication cost observed on Podman.