### PR TITLE
Stream validated versioned graph publication

### DIFF
--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -3,13 +3,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use prolly::{
-    BatchBuilder, Config, KeyBuilder, ManifestStoreScan, NamedRootUpdate, Prolly,
+    Config, KeyBuilder, ManifestStoreScan, NamedRootUpdate, Prolly, SortedBatchBuilder,
     TransactionUpdate, Tree,
 };
 use prolly_store_sqlite::{SqliteStore, SqliteStoreConfig};
 
 use crate::keys::root_name;
-use crate::validate::{RealizationTrees, validate_trees, validate_trees_with_artifacts};
+use crate::validate::{
+    RealizationTrees, validate_publication_partition, validate_trees, validate_trees_with_artifacts,
+};
 use crate::{
     ActivityGuard, CommitId, GraphVersion, HistoryError, MaintenanceGuard, PublishRequest,
     PublishedVersion, RealizationId, Repository, StoredTree, StructuralSharing,
@@ -185,14 +187,16 @@ impl HistoryStore {
             })
         };
 
-        let partitioned = request.artifacts.partition(&request.completion)?;
-        let node_count = count(partitioned.nodes.len())?;
-        let edge_count = count(partitioned.edges.len())?;
-        let hyperedge_count = count(partitioned.hyperedges.len())?;
-        let analysis_count = count(partitioned.analysis.len())?;
-        let metadata_count = count(partitioned.metadata.len())?;
-        let program_fact_count = count(partitioned.program_facts.len())?;
-        let program_summary_count = count(partitioned.program_summaries.len())?;
+        let validated = validate_publication_partition(&request.artifacts, &request.completion)?;
+        let report = validated.report;
+        let partitioned = validated.partitioned;
+        let node_count = report.nodes;
+        let edge_count = report.edges;
+        let hyperedge_count = report.hyperedges;
+        let analysis_count = report.analysis_records;
+        let metadata_count = report.metadata_records;
+        let program_fact_count = report.program_fact_records;
+        let program_summary_count = report.program_summary_records;
         let nodes = self.build_tree(partitioned.nodes)?;
         let edges = self.build_tree(partitioned.edges)?;
         let hyperedges = self.build_tree(partitioned.hyperedges)?;
@@ -228,21 +232,6 @@ impl HistoryStore {
             KeyBuilder::new().push_str("manifest").finish(),
             canonical_json_bytes(&serde_json::to_value(&version)?)?,
         )])?;
-
-        validate_trees(
-            &self.prolly,
-            &id,
-            &version,
-            RealizationTrees {
-                nodes: &nodes,
-                edges: &edges,
-                hyperedges: &hyperedges,
-                analysis: &analysis,
-                metadata: &metadata,
-                program_facts: &program_facts,
-                program_summaries: &program_summaries,
-            },
-        )?;
 
         Ok(PreparedPublication {
             id,
@@ -716,9 +705,9 @@ impl HistoryStore {
     }
 
     fn build_tree(&self, entries: Vec<(Vec<u8>, Vec<u8>)>) -> Result<Tree, HistoryError> {
-        let mut builder = BatchBuilder::new(self.prolly.store().clone(), Config::default());
+        let mut builder = SortedBatchBuilder::new(self.prolly.store().clone(), Config::default());
         for (key, value) in entries {
-            builder.add(key, value);
+            builder.add(key, value)?;
         }
         builder.build().map_err(HistoryError::from)
     }
@@ -944,11 +933,6 @@ pub(crate) fn version_root_name(id: &RealizationId, kind: &[u8]) -> Vec<u8> {
 
 fn preferred_root_name(commit: &CommitId) -> Vec<u8> {
     root_name(&[b"compass", b"v1", b"preferred", commit.as_str().as_bytes()])
-}
-
-fn count(value: usize) -> Result<u64, HistoryError> {
-    u64::try_from(value)
-        .map_err(|_| HistoryError::InvalidArtifacts("record count exceeds u64".to_owned()))
 }
 
 fn hex(bytes: &[u8]) -> String {

--- a/crates/compass-history/src/validate.rs
+++ b/crates/compass-history/src/validate.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 use std::sync::Arc;
 
 use crate::{
-    CompletedGraphArtifacts, GraphVersion, HistoryError, PartitionedGraph, RealizationId,
-    canonical_json_bytes, node_key,
+    CompletedGraphArtifacts, CompletionEvidence, GraphArtifacts, GraphVersion, HistoryError,
+    PartitionedGraph, RealizationId, canonical_json_bytes, node_key,
 };
 
 type Records = Vec<(Vec<u8>, Vec<u8>)>;
@@ -84,6 +84,50 @@ pub(crate) struct RealizationTrees<'a> {
 pub(crate) struct ValidatedTrees {
     pub report: ValidationReport,
     pub artifacts: CompletedGraphArtifacts,
+}
+
+pub(crate) struct ValidatedPartition {
+    pub report: ValidationReport,
+    pub partitioned: PartitionedGraph,
+}
+
+pub(crate) fn validate_publication_partition(
+    artifacts: &GraphArtifacts,
+    completion: &CompletionEvidence,
+) -> Result<ValidatedPartition, HistoryError> {
+    let partitioned = artifacts.partition(completion)?;
+    let mut problems = Vec::new();
+    let mut total_bytes = 0_u64;
+    for (kind, entries) in [
+        ("nodes", partitioned.nodes.as_slice()),
+        ("edges", partitioned.edges.as_slice()),
+        ("hyperedges", partitioned.hyperedges.as_slice()),
+        ("analysis", partitioned.analysis.as_slice()),
+        ("metadata", partitioned.metadata.as_slice()),
+        ("program facts", partitioned.program_facts.as_slice()),
+        (
+            "program summaries",
+            partitioned.program_summaries.as_slice(),
+        ),
+    ] {
+        validate_partition_records(kind, entries, &mut total_bytes, &mut problems)?;
+    }
+    validate_partition_references(&partitioned.nodes, &artifacts.document, &mut problems)?;
+    if !problems.is_empty() {
+        return Err(HistoryError::InvalidRealization(problems));
+    }
+    Ok(ValidatedPartition {
+        report: ValidationReport {
+            nodes: record_count(&partitioned.nodes),
+            edges: record_count(&partitioned.edges),
+            hyperedges: record_count(&partitioned.hyperedges),
+            analysis_records: record_count(&partitioned.analysis),
+            metadata_records: record_count(&partitioned.metadata),
+            program_fact_records: record_count(&partitioned.program_facts),
+            program_summary_records: record_count(&partitioned.program_summaries),
+        },
+        partitioned,
+    })
 }
 
 pub(crate) fn validate_trees(
@@ -208,22 +252,126 @@ pub(crate) fn validate_trees_with_artifacts(
             None
         }
     };
-    if problems.is_empty() {
-        Ok(ValidatedTrees {
-            report: ValidationReport {
-                nodes: version.node_count,
-                edges: version.edge_count,
-                hyperedges: version.hyperedge_count,
-                analysis_records: version.analysis_count,
-                metadata_records: version.metadata_count,
-                program_fact_records: version.program_fact_count,
-                program_summary_records: version.program_summary_count,
-            },
-            artifacts: artifacts.expect("valid reconstruction is present without problems"),
-        })
-    } else {
-        Err(HistoryError::InvalidRealization(problems))
+    if !problems.is_empty() {
+        return Err(HistoryError::InvalidRealization(problems));
     }
+    let Some(artifacts) = artifacts else {
+        return Err(HistoryError::InvalidRealization(vec![
+            ValidationProblem::ArtifactRegistry(
+                "reconstruction was unavailable after successful validation".to_owned(),
+            ),
+        ]));
+    };
+    Ok(ValidatedTrees {
+        report: ValidationReport {
+            nodes: version.node_count,
+            edges: version.edge_count,
+            hyperedges: version.hyperedge_count,
+            analysis_records: version.analysis_count,
+            metadata_records: version.metadata_count,
+            program_fact_records: version.program_fact_count,
+            program_summary_records: version.program_summary_count,
+        },
+        artifacts,
+    })
+}
+
+fn validate_partition_records(
+    kind: &'static str,
+    entries: &[(Vec<u8>, Vec<u8>)],
+    total_bytes: &mut u64,
+    problems: &mut Vec<ValidationProblem>,
+) -> Result<(), HistoryError> {
+    let count = record_count(entries);
+    if exceeds_limit(count, MAX_RECORDS_PER_TREE) {
+        problems.push(ValidationProblem::ResourceLimit {
+            kind: "records per tree",
+            limit: MAX_RECORDS_PER_TREE,
+            actual: count,
+        });
+    }
+    for pair in entries.windows(2) {
+        if pair[0].0 >= pair[1].0 {
+            problems.push(ValidationProblem::KeyMismatch {
+                kind,
+                key: pair[1].0.clone(),
+            });
+        }
+    }
+    for (key, value) in entries {
+        validate_record_limits(kind, key, value, total_bytes, problems)?;
+    }
+    Ok(())
+}
+
+fn validate_record_limits(
+    kind: &'static str,
+    key: &[u8],
+    value: &[u8],
+    total_bytes: &mut u64,
+    problems: &mut Vec<ValidationProblem>,
+) -> Result<(), HistoryError> {
+    if exceeds_limit(key.len() as u64, MAX_KEY_BYTES as u64) {
+        problems.push(ValidationProblem::ResourceLimit {
+            kind: "key bytes",
+            limit: MAX_KEY_BYTES as u64,
+            actual: key.len() as u64,
+        });
+    }
+    if exceeds_limit(value.len() as u64, MAX_RECORD_VALUE_BYTES as u64) {
+        problems.push(ValidationProblem::ResourceLimit {
+            kind: "record value bytes",
+            limit: MAX_RECORD_VALUE_BYTES as u64,
+            actual: value.len() as u64,
+        });
+    }
+    *total_bytes = total_bytes
+        .saturating_add(key.len() as u64)
+        .saturating_add(value.len() as u64);
+    if exceeds_limit(*total_bytes, MAX_AUTHORITATIVE_BYTES) {
+        problems.push(ValidationProblem::ResourceLimit {
+            kind: "authoritative bytes",
+            limit: MAX_AUTHORITATIVE_BYTES,
+            actual: *total_bytes,
+        });
+    }
+    let envelope = match VersionedValue::from_bytes(value) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            problems.push(ValidationProblem::ArtifactRegistry(format!(
+                "{kind} record has an invalid envelope: {error}"
+            )));
+            return Ok(());
+        }
+    };
+    let json = match serde_json::from_slice::<Value>(&envelope.payload) {
+        Ok(json) => json,
+        Err(error) => {
+            problems.push(ValidationProblem::ArtifactRegistry(format!(
+                "{kind} record has invalid JSON: {error}"
+            )));
+            return Ok(());
+        }
+    };
+    let depth = json_depth(&json);
+    if exceeds_limit(depth as u64, MAX_JSON_DEPTH as u64) {
+        problems.push(ValidationProblem::ResourceLimit {
+            kind: "JSON depth",
+            limit: MAX_JSON_DEPTH as u64,
+            actual: depth as u64,
+        });
+    }
+    if canonical_json_bytes(&json)? != envelope.payload {
+        problems.push(ValidationProblem::KeyMismatch {
+            kind,
+            key: key.to_vec(),
+        });
+    }
+    Ok(())
+}
+
+fn record_count(entries: &[(Vec<u8>, Vec<u8>)]) -> u64 {
+    u64::try_from(entries.len()).unwrap_or(u64::MAX)
 }
 
 fn scan_tree(
@@ -236,48 +384,7 @@ fn scan_tree(
     let mut entries = Vec::new();
     for entry in manager.range(tree, &[], None)? {
         let (key, value) = entry?;
-        if exceeds_limit(key.len() as u64, MAX_KEY_BYTES as u64) {
-            problems.push(ValidationProblem::ResourceLimit {
-                kind: "key bytes",
-                limit: MAX_KEY_BYTES as u64,
-                actual: key.len() as u64,
-            });
-        }
-        if exceeds_limit(value.len() as u64, MAX_RECORD_VALUE_BYTES as u64) {
-            problems.push(ValidationProblem::ResourceLimit {
-                kind: "record value bytes",
-                limit: MAX_RECORD_VALUE_BYTES as u64,
-                actual: value.len() as u64,
-            });
-        }
-        *total_bytes = total_bytes
-            .saturating_add(key.len() as u64)
-            .saturating_add(value.len() as u64);
-        if exceeds_limit(*total_bytes, MAX_AUTHORITATIVE_BYTES) {
-            problems.push(ValidationProblem::ResourceLimit {
-                kind: "authoritative bytes",
-                limit: MAX_AUTHORITATIVE_BYTES,
-                actual: *total_bytes,
-            });
-        }
-        if let Ok(envelope) = VersionedValue::from_bytes(&value)
-            && let Ok(json) = serde_json::from_slice::<Value>(&envelope.payload)
-        {
-            let depth = json_depth(&json);
-            if exceeds_limit(depth as u64, MAX_JSON_DEPTH as u64) {
-                problems.push(ValidationProblem::ResourceLimit {
-                    kind: "JSON depth",
-                    limit: MAX_JSON_DEPTH as u64,
-                    actual: depth as u64,
-                });
-            }
-            if canonical_json_bytes(&json)? != envelope.payload {
-                problems.push(ValidationProblem::KeyMismatch {
-                    kind,
-                    key: key.clone(),
-                });
-            }
-        }
+        validate_record_limits(kind, &key, &value, total_bytes, problems)?;
         entries.push((key, value));
         if exceeds_limit(entries.len() as u64, MAX_RECORDS_PER_TREE) {
             problems.push(ValidationProblem::ResourceLimit {
@@ -337,6 +444,60 @@ fn validate_references(
         }
     }
     Ok(())
+}
+
+fn validate_partition_references(
+    nodes: &[(Vec<u8>, Vec<u8>)],
+    document: &GraphDocument,
+    problems: &mut Vec<ValidationProblem>,
+) -> Result<(), HistoryError> {
+    for edge in &document.links {
+        for endpoint in [&edge.source, &edge.target] {
+            if !partition_has_node(nodes, endpoint) {
+                problems.push(ValidationProblem::MissingEdgeEndpoint {
+                    edge: canonical_json_bytes(&serde_json::to_value(edge)?)?,
+                    endpoint: endpoint.clone(),
+                });
+            }
+        }
+    }
+    for value in document
+        .graph
+        .get("hyperedges")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .chain(
+            document
+                .extras
+                .get("hyperedges")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten(),
+        )
+    {
+        for member in ["nodes", "members"]
+            .into_iter()
+            .filter_map(|field| value.get(field).and_then(Value::as_array))
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            if !partition_has_node(nodes, member) {
+                problems.push(ValidationProblem::MissingHyperedgeMember {
+                    hyperedge: canonical_json_bytes(value)?,
+                    member: member.to_owned(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn partition_has_node(nodes: &[(Vec<u8>, Vec<u8>)], node: &str) -> bool {
+    let key = node_key(node);
+    nodes
+        .binary_search_by(|(candidate, _)| candidate.as_slice().cmp(key.as_slice()))
+        .is_ok()
 }
 
 fn json_depth(value: &Value) -> usize {

--- a/crates/compass-history/tests/publication.rs
+++ b/crates/compass-history/tests/publication.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use compass_analysis::{AnalysisBundle, analyze};
 use compass_history::{
-    CommitId, CompletionEvidence, ExtractionFingerprint, GraphArtifacts, HistoryStore,
-    PublishRequest, Repository,
+    CommitId, CompletedGraphArtifacts, CompletionEvidence, ExtractionFingerprint, GraphArtifacts,
+    HistoryStore, PublishRequest, Repository,
 };
 use compass_ir::{ProgramBundle, ProviderDescriptor, ProviderKind, hex_sha256};
 use compass_model::GraphDocument;
@@ -120,6 +120,10 @@ fn publication_is_atomic_reopenable_and_content_idempotent()
     let mut publish = request('a', false)?;
     publish.profile.insert("provider", "none")?;
     let expected_profile = publish.profile.clone();
+    let expected_artifacts = CompletedGraphArtifacts {
+        artifacts: publish.artifacts.clone(),
+        completion: publish.completion.clone(),
+    };
     let first = history.publish(publish.clone())?;
     let second = history.publish(publish)?;
     assert_eq!(first.id, second.id);
@@ -139,6 +143,7 @@ fn publication_is_atomic_reopenable_and_content_idempotent()
         first.id
     );
     assert_eq!(reopened.get(&first.id)?.version, first.version);
+    assert_eq!(reopened.artifacts(&first.id)?, expected_artifacts);
     assert_eq!(reopened.list(None)?.len(), 1);
     Ok(())
 }
@@ -241,6 +246,7 @@ fn validation_rejects_missing_endpoints_before_catalog_publication()
     let fixture = Fixture::new()?;
     let repository = Repository::discover(&fixture.path)?;
     let history = HistoryStore::create(&repository)?;
+    let initial_nodes = history.plan_gc(false)?.candidate_nodes;
     let mut invalid = request('c', true)?;
     invalid.artifacts.document.links[0].target = "missing".to_owned();
     let error = match history.publish(invalid) {
@@ -268,6 +274,11 @@ fn validation_rejects_missing_endpoints_before_catalog_publication()
         Err(error) => error,
     };
     assert!(error.to_string().contains("MissingHyperedgeMember"));
+    assert_eq!(
+        history.plan_gc(false)?.candidate_nodes,
+        initial_nodes,
+        "invalid in-memory partitions must not write orphaned tree nodes"
+    );
 
     let valid = history.publish(request('d', true)?)?;
     let report = history.validate(&valid.id)?;


### PR DESCRIPTION
## What changed

- certify the canonical in-memory graph partition before any tree nodes are written
- validate resource limits, sorted uniqueness, canonical record JSON, and graph references against that partition
- build the already-sorted records with Prolly's memory-bounded `SortedBatchBuilder`
- remove the duplicate persisted-tree scan, reconstruction, and repartition from the normal publication hot path
- retain full persisted-tree reconstruction and canonical round-trip validation for explicit `history verify` and artifact export
- strengthen publication tests to require exact artifact reconstruction and prove invalid partitions create no orphaned Prolly nodes

## Why

Publication was doing the expensive work twice. `GraphArtifacts::partition` already produced canonical sorted records, but `BatchBuilder` retained, sorted, and copied them again. The publication path then reread every persisted tree, accumulated another full set of records, reconstructed all artifacts, and repartitioned them before exposing catalog roots. That dominated arbitrary-commit build time and peak memory.

This hard-cutover path validates the trusted partition once and streams it to canonical Prolly trees. Catalog publication remains atomic, while deep verification stays available explicitly.

## Real repository qualification

Pinned CocoIndex checkout, building arbitrary historical commit `90571539fa291fc6e6b248095bd2c8a2ff68bab4` from working revision `71f9cc9dc693080310181a2d011fb737420f7907`, release binaries, fresh shared clones and empty history stores:

| Build | Wall time | Peak RSS |
|---|---:|---:|
| baseline `e2e9216` | 12.06 s | 2,467,332,096 bytes |
| this branch | 7.61 s | 1,496,285,184 bytes |

That is 36.9% less wall time and 39.4% less peak RSS. Both binaries produced the exact same realization ID: `8a038e8f936dc5a584b88810f8fc45cb0e284cbc23273ab5d12a51893177698b`.

The adjacent revision also built successfully in 7.95 s. Full `history verify` passed for both persisted realizations. Their exact diff streamed 81,179 changes in 2.20 s with 499,826,688-byte peak RSS.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-history --tests --locked` (65 executed tests passed; 1 performance-evidence test intentionally ignored)
- `cargo clippy -p compass-history --lib --tests --locked -- -D warnings`
- real CocoIndex build, two full persisted-tree verifications, and exact diff
- `graphify update .` (no topology changes)

Repository-wide Clippy reaches `compass-history` cleanly, then fails on five pre-existing `needless_borrow` diagnostics in `crates/compass-graph/src/analyze.rs`; those unrelated files are not changed here.
