### PR TITLE
Enhance VS Code community graph diff details

### DIFF
--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -81,6 +81,15 @@ Choose a parent to see structural counts and Compass semantic findings. Queries
 can target the selected available revision; unavailable revisions stay
 disabled and are never materialized implicitly.
 
+The changed-graph tab starts with the bounded community overview. Select a
+changed community and choose **Inspect changes** to load that community from
+both revisions. The detail view provides a searchable affected-symbol list,
+status-aware relationships, and a Before/After table for every modified symbol
+field. **Open before** and **Open after** display read-only source from the
+owning Git commit. If the configured `compass.graphNodeLimit` prevents either
+community export from being complete, Compass keeps the aggregate comparison
+available and marks the detailed counts as partial.
+
 ## Security
 
 The extension is disabled for untrusted workspaces. It starts Compass with

--- a/docs/superpowers/plans/2026-07-26-vscode-community-diff-detail.md
+++ b/docs/superpowers/plans/2026-07-26-vscode-community-diff-detail.md
@@ -1,0 +1,448 @@
+# VS Code Community Diff Detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let developers drill from an aggregate changed community into an exact symbol/relationship delta and inspect every changed field before and after.
+
+**Architecture:** Keep the initial history comparison aggregate and fast. On community activation, the VS Code host loads the parent and current historical community projections in parallel, the webview rejects stale responses and computes a detailed comparison, and shared viewer components render searchable change evidence. Comparison records retain canonical before/after snapshots and field changes while ordinary graphs remain backward compatible.
+
+**Tech Stack:** TypeScript 5.9, React 19, Zod 4, VS Code Webview API, Vitest, Testing Library, Playwright, vis-network.
+
+## Global Constraints
+
+- Follow the user's requested implementation-first sequence: implement each behavior before adding its regression tests; do not use the red/green TDD loop.
+- Preserve ordinary current-graph and single-revision history community behavior.
+- Keep historical detail lazy and bounded by `compass.graphNodeLimit`, default `5000`.
+- Exclude `color`, `change`, and `evidence` from stored-field comparisons.
+- Treat all graph and webview payloads as untrusted and validate them through the existing Zod contracts.
+- Ignore late responses when commit, parent, community, request identifier, or comparison mode no longer matches.
+- Run `graphify update .` after code changes.
+
+---
+
+### Task 1: Explainable graph-record comparisons
+
+**Files:**
+- Modify: `packages/compass-viewer/src/contracts/graph.ts`
+- Create: `packages/compass-viewer/src/history/recordDiff.ts`
+- Modify: `packages/compass-viewer/src/history/ComparisonOverlay.tsx`
+- Modify: `packages/compass-viewer/src/history/ComparisonOverlay.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `GraphFieldChange = { field: string; before?: unknown; after?: unknown }`
+  - `GraphRecordEvidence = { before?: Record<string, unknown>; after?: Record<string, unknown>; fields: GraphFieldChange[] }`
+  - optional `evidence` on `GraphNode` and `GraphEdge`
+  - `compareRecord(before, after): GraphRecordEvidence`
+  - `compareGraphs(parent, current): GraphComparison` with retained evidence and aggregate-mode preservation
+
+- [ ] **Step 1: Add backward-compatible graph evidence contracts**
+
+Add Zod schemas and inferred types in `contracts/graph.ts`:
+
+```ts
+export const GraphFieldChangeSchema = z.object({
+  field: z.string().min(1),
+  before: z.unknown().optional(),
+  after: z.unknown().optional()
+});
+export const GraphRecordEvidenceSchema = z.object({
+  before: z.record(z.string(), z.unknown()).optional(),
+  after: z.record(z.string(), z.unknown()).optional(),
+  fields: z.array(GraphFieldChangeSchema)
+});
+```
+
+Attach `evidence: GraphRecordEvidenceSchema.optional()` to both graph record
+schemas and export their inferred types.
+
+- [ ] **Step 2: Implement canonical record comparison**
+
+Create `recordDiff.ts` with:
+
+```ts
+const PRESENTATION_FIELDS = new Set(["color", "change", "evidence"]);
+export function compareRecord(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined
+): GraphRecordEvidence;
+export function displayFieldValue(value: unknown, maxLength = 240): {
+  text: string;
+  truncated: boolean;
+};
+```
+
+Recursively sort object keys, omit presentation fields at every record root,
+flatten nested object changes using dotted paths such as `source.startLine`,
+treat arrays as atomic values, preserve explicit `undefined` as an absent side,
+and sort field changes lexically.
+
+- [ ] **Step 3: Retain evidence in graph comparisons**
+
+Replace `JSON.stringify` equality in `compareGraphs` with `compareRecord`.
+For a changed node or edge, attach both canonical snapshots and the non-empty
+field list. Added and removed records retain their owning record plus their
+status. Set `stats.aggregated` to
+`parent.stats.aggregated || current.stats.aggregated`; detailed community
+inputs remain non-aggregated.
+
+- [ ] **Step 4: Add regression coverage after implementation**
+
+Extend `ComparisonOverlay.test.tsx` with cases that assert:
+
+```ts
+expect(changedNode.evidence?.fields).toEqual([
+  { field: "signature", before: "old()", after: "new()" },
+  { field: "source.startLine", before: 2, after: 4 }
+]);
+expect(changedNode.evidence?.fields.map((field) => field.field))
+  .not.toContain("color.background");
+expect(comparison.graph.stats.aggregated).toBe(true);
+```
+
+Also cover key-order independence, nested missing values, changed edge
+evidence, and bounded structured display.
+
+- [ ] **Step 5: Verify Task 1**
+
+Run:
+
+```bash
+npm test -w @compass/viewer -- ComparisonOverlay
+npm run typecheck -w @compass/viewer
+```
+
+Expected: all targeted tests pass and TypeScript reports no errors.
+
+---
+
+### Task 2: Detailed symbol and relationship inspector
+
+**Files:**
+- Create: `packages/compass-viewer/src/graph/ChangeEvidence.tsx`
+- Create: `packages/compass-viewer/src/graph/ChangedSymbolList.tsx`
+- Modify: `packages/compass-viewer/src/graph/GraphInspector.tsx`
+- Modify: `packages/compass-viewer/src/graph/CompassGraph.tsx`
+- Modify: `packages/compass-viewer/src/graph/NodeHoverCard.tsx`
+- Modify: `packages/compass-viewer/src/theme.css`
+- Create: `packages/compass-viewer/src/graph/ChangeEvidence.test.tsx`
+
+**Interfaces:**
+- Consumes: optional node/edge `evidence` from Task 1.
+- Produces:
+  - `GraphSourceRevisions = { before: string; after: string }`
+  - `GraphHost.openSource(source, revision?)`
+  - optional `communityDetail.bounded` notice metadata
+  - comparison inspector sections for affected symbols and connected edges
+
+- [ ] **Step 1: Implement changed-symbol discovery**
+
+Create `ChangedSymbolList` that receives:
+
+```ts
+{
+  nodes: GraphNode[];
+  query: string;
+  selectedId?: string;
+  onFocus(nodeId: string): void;
+}
+```
+
+Include nodes whose change is `added`, `removed`, or `changed`; filter by label,
+kind, and source path; sort with `changed`, `added`, `removed` groups then
+locale-aware label order; render status text and a maximum initial window of
+100 rows with a Show all control.
+
+- [ ] **Step 2: Implement before/after evidence**
+
+Create `ChangeEvidence` that receives the selected node, all connected edges,
+a node lookup, source revisions, and callbacks. Render:
+
+- a `What changed` table for `node.evidence.fields`;
+- complete ordinary metadata for added/removed nodes through the existing
+  inspector content;
+- `Open before` and `Open after` actions derived from
+  `evidence.before.source` and `evidence.after.source`;
+- relationship rows containing relation, endpoint, confidence, and status;
+- a nested field table for changed-edge evidence.
+
+Use `displayFieldValue` for every cell, `Not recorded` for absent values, and a
+visible/accessible truncated marker.
+
+- [ ] **Step 3: Wire comparison detail into the graph workspace**
+
+Change the graph host signature to:
+
+```ts
+openSource(source: SourceLocation, revision?: string): void;
+```
+
+Pass connected `GraphEdge[]`, revisions, and evidence callbacks into
+`GraphInspector`. In aggregate comparison mode, label the community action
+`Inspect changes` with `${memberCount} current symbols`; outside comparison
+mode retain `Open community`.
+
+Preserve aggregate-mode activation so double-clicking a changed community calls
+`openCommunity`. Add an optional bounded notice:
+
+```ts
+bounded?: { limit: number; parentMembers: number; currentMembers: number };
+```
+
+The notice must say the visible comparison may be incomplete and name
+`compass.graphNodeLimit`.
+
+- [ ] **Step 4: Style the evidence without widening the inspector**
+
+Add VS Code-token-based styles for the symbol list, Before/After table,
+relationship list, truncation label, bounded notice, focus/hover states, narrow
+inspector wrapping, and high-contrast borders. Do not introduce fixed light
+background colors.
+
+- [ ] **Step 5: Add regression coverage after implementation**
+
+Test changed-field headers and cells, missing values, truncation text,
+relationship status/confidence, changed-edge fields, changed-symbol sorting and
+filtering, revision-aware source callbacks, aggregate `Inspect changes` copy,
+and unchanged ordinary graph copy.
+
+- [ ] **Step 6: Verify Task 2**
+
+Run:
+
+```bash
+npm test -w @compass/viewer -- ChangeEvidence GraphInspector CompassGraph
+npm run typecheck -w @compass/viewer
+```
+
+Expected: all targeted tests pass and TypeScript reports no errors.
+
+---
+
+### Task 3: Dual-revision community protocol and historical source
+
+**Files:**
+- Modify: `editors/vscode/src/history/panelMessages.ts`
+- Modify: `editors/vscode/src/history/panelMessages.test.ts`
+- Modify: `editors/vscode/src/history/revisionStore.ts`
+- Modify: `editors/vscode/src/history/revisionStore.test.ts`
+- Create: `editors/vscode/src/history/historicalSource.ts`
+- Create: `editors/vscode/src/history/historicalSource.test.ts`
+- Modify: `editors/vscode/src/views/historyPanel.ts`
+
+**Interfaces:**
+- Produces:
+  - `compareCommunity` webview request containing request/commit/parent,
+    both identities, community ID, and side-presence flags
+  - `communityComparison` response containing optional current/parent graphs
+    and `nodeLimit`
+  - `communityComparisonError` correlated error response
+  - `HistoricalSourceProvider.open(commit, source)`
+
+- [ ] **Step 1: Add protocol unions and operation mapping**
+
+Define the request:
+
+```ts
+{
+  type: "compareCommunity";
+  requestId: string;
+  commit: string;
+  parent: string;
+  currentIdentity: { realization: string; fingerprint: string };
+  parentIdentity: { realization: string; fingerprint: string };
+  communityId: number;
+  hasCurrent: boolean;
+  hasParent: boolean;
+}
+```
+
+Define success/error host messages with matching correlation fields. Add
+`"Compare community"` to `HistoryOperation` and map the request in
+`historyOperationFor`.
+
+- [ ] **Step 2: Load both community projections in parallel**
+
+In `historyPanel.ts`, validate both commits against the loaded timeline and both
+identities against `historyIdentity(entry)`. Require at least one side. Call
+`RevisionStore.loadCommunity` only for present sides:
+
+```ts
+const [current, parent] = await Promise.all([
+  hasCurrent ? revisions.loadCommunity(commit, communityId, graphNodeLimit, currentIdentity) : undefined,
+  hasParent ? revisions.loadCommunity(parent, communityId, graphNodeLimit, parentIdentity) : undefined
+]);
+```
+
+Post one correlated success response; route errors to
+`communityComparisonError` without replacing the aggregate comparison.
+
+- [ ] **Step 3: Implement exact historical source documents**
+
+Create a panel-scoped `HistoricalSourceProvider` using a unique URI scheme.
+Validate that source paths remain lexically inside the repository, run:
+
+```bash
+git show --no-textconv <commit>:<repo-relative-path>
+```
+
+with `execFile` argument arrays, an 8 MiB output bound, and no shell. Use the
+URI path to preserve the original file extension for VS Code language
+detection. Reveal the recorded line/byte range after opening. Only allow the
+active comparison's current or parent commit. Dispose the provider with the
+history panel.
+
+- [ ] **Step 4: Add protocol and host regression coverage after implementation**
+
+Cover union acceptance, operation mapping, parallel load cache keys, identity
+mismatch, absent-side behavior, correlated errors, path traversal rejection,
+git argument construction, source range selection, and provider disposal.
+
+- [ ] **Step 5: Verify Task 3**
+
+Run:
+
+```bash
+npm test -w editors/vscode -- panelMessages revisionStore historicalSource
+npm run typecheck -w editors/vscode
+```
+
+Expected: all targeted tests pass and TypeScript reports no errors.
+
+---
+
+### Task 4: History webview state and lazy drill-down
+
+**Files:**
+- Modify: `editors/vscode/src/webviews/history.tsx`
+- Modify: `packages/compass-viewer/src/history/HistoryWorkspace.tsx`
+- Modify: `packages/compass-viewer/src/history/HistoryWorkspace.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 1 `compareGraphs`, Task 2 detail/revision props, Task 3 protocol.
+- Produces: stale-safe community comparison state and immediate Back behavior.
+
+- [ ] **Step 1: Retain both comparison identities**
+
+On a `comparison` host message, store:
+
+```ts
+{
+  current: { realization: message.realization, fingerprint: message.fingerprint },
+  parent: { realization: message.parentRealization, fingerprint: message.parentFingerprint }
+}
+```
+
+Add the parent identity fields to the comparison host message emitted in Task
+3. Clear both identities and detail state when commits or comparison mode
+change.
+
+- [ ] **Step 2: Request exact community comparisons**
+
+When aggregate comparison activation occurs, derive side presence and member
+counts from the selected aggregate node's evidence snapshots. Send
+`compareCommunity`, retain its request ID plus commit/parent/community tuple,
+and render loading state without unmounting the aggregate graph.
+
+- [ ] **Step 3: Accept only current responses**
+
+For `communityComparison`, require an exact match on request ID, selected
+commit, comparison parent, and community. Parse optional graph sides. Synthesize
+an empty graph from the present side when one side is intentionally absent,
+then call `compareGraphs(parent, current)`.
+
+Set bounded metadata when either loaded detail node count is less than the
+corresponding aggregate `memberCount`. For a correlated error, keep the
+aggregate graph and expose a retryable error. Back clears only detail/request
+state.
+
+- [ ] **Step 4: Wire revision-aware source opening**
+
+Pass `{ before: comparison.parent, after: selected.commit }` to `CompassGraph`.
+Forward a supplied revision to `HistoryHost.openSource`; otherwise retain the
+selected commit fallback for ordinary historical graphs.
+
+- [ ] **Step 5: Add regression coverage after implementation**
+
+Extend `HistoryWorkspace.test.tsx` to verify `Inspect changes`, loading status,
+detailed summary/filter counts, bounded notice, Back restoration, retry
+behavior, and before/after source commit forwarding.
+
+- [ ] **Step 6: Verify Task 4**
+
+Run:
+
+```bash
+npm test -w @compass/viewer -- HistoryWorkspace
+npm run build -w editors/vscode
+npm run typecheck -w editors/vscode
+```
+
+Expected: component tests, webview bundle, and TypeScript all succeed.
+
+---
+
+### Task 5: Browser coverage, documentation, and release verification
+
+**Files:**
+- Modify: `tests/viewer/fixtures/generate.ts`
+- Modify: `tests/viewer/history.spec.ts`
+- Modify: `editors/vscode/README.md`
+- Modify: `docs/guides/vscode.md`
+- Modify: `docs/superpowers/specs/2026-07-26-vscode-community-diff-detail-design.md`
+
+**Interfaces:**
+- Consumes: completed feature from Tasks 1–4.
+- Produces: end-to-end evidence, user guidance, and current graph metadata.
+
+- [ ] **Step 1: Add a representative browser fixture**
+
+Generate an aggregate comparison with one changed community, then provide
+parent/current detail containing a changed signature/source range, one added
+symbol, one removed symbol, and added/removed relationships.
+
+- [ ] **Step 2: Add the browser workflow regression**
+
+In `history.spec.ts`, open Changed graph, select the community, activate
+`Inspect changes`, assert the symbol list and visible delta, select the changed
+symbol, assert Before/After values and relationship statuses, and return with
+Back.
+
+- [ ] **Step 3: Document the interaction**
+
+Update the extension README and VS Code guide with the lazy drill-down,
+field-level evidence, relationship evidence, historical source actions, and
+the `compass.graphNodeLimit` bounded-results notice. Change the design spec
+status to `Implemented`.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run:
+
+```bash
+npm test -w @compass/viewer
+npm test -w editors/vscode
+npm run typecheck:js
+npm run build:viewer
+npm run build:vscode
+npm run package -w editors/vscode
+npm run smoke:vsix -w editors/vscode
+npm test -w @compass/viewer-tests -- history.spec.ts
+```
+
+Expected: all checks, including the history Playwright workflow, pass without
+new warnings.
+
+- [ ] **Step 5: Refresh the knowledge graph and inspect the final diff**
+
+Run:
+
+```bash
+graphify update .
+git status --short
+git diff --check
+git diff --stat HEAD~1
+```
+
+Expected: the knowledge graph is current, formatting checks pass, and only
+feature-related files are present.

--- a/docs/superpowers/specs/2026-07-26-vscode-community-diff-detail-design.md
+++ b/docs/superpowers/specs/2026-07-26-vscode-community-diff-detail-design.md
@@ -1,0 +1,278 @@
+# VS Code Community Diff Detail Design
+
+**Date:** 2026-07-26  
+**Status:** Interaction approved; awaiting written-spec review
+
+## Problem
+
+The Codebase Evolution changed-graph view compares overview projections. For a
+large graph, each overview node represents a community rather than an individual
+symbol. A changed community therefore appears as a single `Changed` node with
+its current member count.
+
+Opening that community currently loads only the selected revision. The
+comparison context is lost, so developers cannot discover which symbols or
+relationships were added, removed, or changed. A changed symbol also carries
+only a status badge; the inspector does not explain which stored fields differ
+between revisions.
+
+## Goals
+
+The enhanced comparison must let a developer:
+
+1. move from a changed aggregate community to its exact symbol-level delta;
+2. browse and search the affected symbols without relying on the graph layout;
+3. distinguish added, removed, changed, and contextual symbols and
+   relationships;
+4. inspect the exact before and after values for every changed symbol field;
+5. open the appropriate historical source location from either revision;
+6. return to the aggregate comparison without recomputing it; and
+7. retain the lazy-loading and bounded-memory behavior of the existing history
+   view.
+
+## Chosen Approach
+
+Compass will lazily load the selected community from both compared revisions.
+The extension host validates both historical identities and sends the two
+community graph projections to the webview. The webview computes a focused
+community comparison and renders it through the existing comparison-aware graph
+workspace.
+
+This approach is preferred over loading a repository-wide exact symbol diff
+upfront because it preserves fast aggregate comparison startup and bounded
+community detail. It is preferred over tooltip-only enrichment because it
+exposes the evidence instead of merely adding another summary.
+
+## Interaction Design
+
+### Aggregate comparison
+
+The existing changed-community node remains the lightweight entry point.
+Selecting it pins the ordinary inspector, which adds a prominent
+`Inspect changes` action for aggregate nodes in comparison mode. The action
+describes the community as a collection of symbols, not as a count of changed
+symbols, because the existing `memberCount` is the current membership total.
+
+Activating the action, or using the existing community activation gesture,
+starts the two-revision community request. The aggregate graph remains visible
+while the request is running.
+
+### Community comparison
+
+When both community projections arrive, the graph frame shows a focused
+symbol-level delta:
+
+- added symbols and relationships;
+- removed symbols and relationships;
+- changed symbols and relationships; and
+- unchanged endpoint symbols needed to explain changed relationships.
+
+A breadcrumb-style Back action returns to the aggregate changed graph. A
+summary states the exact visible counts for symbol and relationship changes.
+The existing Added, Removed, Changed, and Context filters remain available.
+
+The inspector makes `Changed symbols` the primary comparison section. It
+provides a searchable, keyboard-accessible list ordered by change type and then
+symbol label. Choosing a result focuses the matching graph node. The graph
+remains useful for topology, while the list provides a deterministic way to
+find the evidence in dense communities.
+
+### Symbol evidence
+
+Selecting a changed symbol shows a `What changed` table. It contains only fields
+whose stored values differ, with `Before` and `After` columns. The comparison
+supports at least:
+
+- label;
+- symbol kind;
+- signature;
+- language;
+- community identifier and name;
+- source file;
+- source line or byte range;
+- degree and member count when present;
+- learning status metadata; and
+- additional retained graph-node fields that differ.
+
+Presentation-only metadata such as viewer color, the computed change status,
+and attached diff evidence is excluded.
+
+Missing values are rendered as `Not recorded`. Structured values are rendered
+as bounded, readable JSON rather than as `[object Object]`. If an unknown field
+contains an unusually large value, the inspector truncates its display while
+retaining an accessible indication that the value was shortened.
+
+Added and removed symbols show the complete available metadata from their
+owning revision instead of an artificial two-column comparison.
+
+### Relationship evidence
+
+The selected-symbol inspector receives the connected edges rather than only a
+deduplicated neighbor list. Each relationship row shows:
+
+- relation type;
+- the other endpoint;
+- Added, Removed, Changed, or Context status; and
+- confidence when recorded.
+
+A changed relationship can expose its differing before and after fields using
+the same bounded field-difference representation. This keeps topology evidence
+separate from symbol-property evidence while making both discoverable from the
+selected symbol.
+
+### Source navigation
+
+Source actions carry the revision that owns the displayed location:
+
+- added symbols open the current revision;
+- removed symbols open the parent revision; and
+- changed symbols offer `Open before` and `Open after` when those locations are
+  recorded.
+
+The existing source-navigation safety checks remain authoritative. A missing or
+non-navigable source location remains readable metadata but does not render an
+enabled action.
+
+## Data Model
+
+The comparison result will retain immutable evidence in addition to the
+presentation record:
+
+```ts
+type GraphFieldChange = {
+  field: string;
+  before: unknown;
+  after: unknown;
+};
+
+type GraphRecordEvidence<T> = {
+  before?: T;
+  after?: T;
+  fields: GraphFieldChange[];
+};
+```
+
+Graph nodes and edges in a comparison may carry record evidence. The evidence
+snapshots exclude computed comparison properties to avoid recursive data and
+false differences.
+
+The comparison function will use a canonical comparison projection rather than
+raw `JSON.stringify` ordering. It excludes presentation-only keys, compares
+nested source locations deterministically, and produces field differences from
+the same projection used to assign `Changed`. This guarantees that every
+`Changed` badge has explainable evidence.
+
+The graph contract remains backward compatible: evidence fields are optional,
+and ordinary graph projections do not include them.
+
+## Extension and Webview Protocol
+
+The webview adds a dedicated community-comparison request containing:
+
+- request identifier;
+- current commit and expected realization/fingerprint;
+- parent commit and expected realization/fingerprint; and
+- selected community identifier.
+
+The extension host:
+
+1. validates that the request belongs to the active comparison;
+2. loads both community projections in parallel through `RevisionStore`;
+3. verifies each projection against its expected historical identity; and
+4. returns both projections in one correlated response.
+
+The response includes both commits and the request identifier. The webview
+accepts it only when the selected commit, comparison parent, community, and
+active request still match. Changing commits, leaving comparison mode, opening
+another community, or returning to the overview invalidates the previous
+request.
+
+Ordinary single-revision `openCommunity` messages remain unchanged.
+
+## State and Data Flow
+
+```text
+aggregate changed community
+  -> request current + parent community detail
+  -> RevisionStore loads both projections in parallel
+  -> extension validates both immutable identities
+  -> webview rejects stale or mismatched responses
+  -> compareGraphs retains before/after record evidence
+  -> focused community delta graph
+  -> searchable changed-symbol list
+  -> selected symbol field and relationship evidence
+```
+
+The aggregate comparison remains in webview memory while detail is open, so
+Back is immediate. Community exports continue to use the configured graph node
+limit and the existing bounded LRU caches.
+
+## Loading, Errors, and Limits
+
+During loading, the aggregate graph stays mounted and reports which community
+is being compared. Duplicate activation is ignored while that request is
+active.
+
+If either community cannot be loaded, the user remains on the aggregate
+comparison. The inspector shows a concise error and a retry action. Identity
+mismatch errors instruct the user to refresh the revision comparison.
+
+Compass detects a bounded community by comparing the loaded detail counts with
+the member counts retained on the parent and current aggregate community nodes.
+If either side cannot contain its complete aggregate membership under the
+configured node limit, Compass must not imply that the visible delta is
+complete. The detail view displays a persistent bounded-results notice
+containing the limit and recommends increasing `compass.graphNodeLimit` when
+the complete community is required. Counts are described as visible counts
+while that notice is present.
+
+An absent community on one side is valid. It is represented by an empty
+projection, making all symbols on the other side added or removed. A missing
+community caused by an invalid export is an error, not an empty projection.
+
+## Accessibility
+
+Change state continues to use text in addition to color. The changed-symbol
+list uses buttons with visible labels and status text. The Before/After table
+has explicit column headers, and missing or truncated values have readable
+labels.
+
+Loading and error messages use status and alert semantics. Keyboard users can
+search, select a changed symbol, inspect its fields and relationships, use
+source actions, and return to the aggregate comparison without interacting with
+the canvas.
+
+## Verification
+
+Unit and component tests will cover:
+
+- deterministic field comparison and exclusion of presentation metadata;
+- before/after evidence for changed nodes and edges;
+- complete metadata behavior for added and removed symbols;
+- exact community-level node and relationship counts;
+- empty community handling on either side;
+- community-comparison request and response validation;
+- parallel current/parent loading and historical identity checks;
+- stale response rejection after commit, parent, community, or mode changes;
+- changed-symbol search, ordering, focus, and keyboard behavior;
+- Before/After rendering for missing, nested, and bounded values;
+- relationship status and field evidence;
+- parent/current source-revision selection;
+- loading, retryable error, and bounded-results states;
+- accessibility labels and status semantics; and
+- unchanged behavior in ordinary and aggregate graph views.
+
+Browser coverage will verify the end-to-end drill-down from a changed aggregate
+community into a symbol-level delta, field inspection, source actions, and Back
+navigation. Existing viewer, VS Code build, and VSIX smoke checks remain part of
+the completion gate.
+
+After code changes, `graphify update .` refreshes the project knowledge graph.
+
+## Scope Boundaries
+
+This work does not add source editing, patch application, diff comments,
+cross-community identity remapping, repository-wide eager symbol loading, or a
+new history storage format. It reuses existing historical community exports and
+adds comparison evidence and interaction in the VS Code extension and shared
+viewer.

--- a/docs/superpowers/specs/2026-07-26-vscode-community-diff-detail-design.md
+++ b/docs/superpowers/specs/2026-07-26-vscode-community-diff-detail-design.md
@@ -1,7 +1,7 @@
 # VS Code Community Diff Detail Design
 
 **Date:** 2026-07-26  
-**Status:** Interaction approved; awaiting written-spec review
+**Status:** Implemented and verified
 
 ## Problem
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -94,6 +94,14 @@ Select a commit, then:
    revision graphs are available.
 4. Choose **Query this revision** to run a query against that exact commit.
 
+In a changed graph, select an aggregate community and choose **Inspect
+changes**. Compass lazily compares that community at both revisions and shows
+the exact added, removed, and changed symbols and relationships. Selecting a
+changed symbol reveals a Before/After table containing only modified fields,
+including signatures and source ranges, with source actions for both commits.
+If either community exceeds `compass.graphNodeLimit`, the detail view labels
+its counts as partial and explains how to increase the limit.
+
 Opening Codebase Evolution never builds historical graphs automatically. Revision
 builds are explicit because they can take time and may use a configured semantic
 provider.

--- a/editors/vscode/src/history/historicalSource.test.ts
+++ b/editors/vscode/src/history/historicalSource.test.ts
@@ -24,6 +24,7 @@ vi.mock("vscode", () => ({
 
 import {
   historicalSourceArgs,
+  parseHistoricalSourceLocation,
   repositoryRelativePath
 } from "./historicalSource";
 
@@ -42,5 +43,23 @@ describe("historical source paths", () => {
       "--no-textconv",
       "abc1234:src/core.ts"
     ]);
+  });
+
+  it("rejects malformed source locations at the webview boundary", () => {
+    expect(parseHistoricalSourceLocation({
+      file: "src/core.ts",
+      startLine: 4,
+      metadata: "retained"
+    })).toMatchObject({
+      file: "src/core.ts",
+      startLine: 4,
+      metadata: "retained"
+    });
+    expect(() => parseHistoricalSourceLocation({
+      file: "src/core.ts",
+      startLine: -1
+    })).toThrow("invalid historical source location");
+    expect(() => parseHistoricalSourceLocation({ startLine: 1 }))
+      .toThrow("invalid historical source location");
   });
 });

--- a/editors/vscode/src/history/historicalSource.test.ts
+++ b/editors/vscode/src/history/historicalSource.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+  Position: class Position {
+    constructor(readonly line: number, readonly character: number) {}
+  },
+  Range: class Range {
+    constructor(readonly start: unknown, readonly end: unknown) {}
+  },
+  Selection: class Selection {
+    constructor(readonly start: unknown, readonly end: unknown) {}
+  },
+  TextEditorRevealType: { InCenterIfOutsideViewport: 0 },
+  Uri: {
+    from(value: unknown) { return value; }
+  },
+  workspace: {
+    openTextDocument: vi.fn()
+  },
+  window: {
+    showTextDocument: vi.fn()
+  }
+}));
+
+import {
+  historicalSourceArgs,
+  repositoryRelativePath
+} from "./historicalSource";
+
+describe("historical source paths", () => {
+  it("normalizes repository-relative paths and rejects traversal", () => {
+    expect(repositoryRelativePath("/repo", "src/core.ts")).toBe("src/core.ts");
+    expect(() => repositoryRelativePath("/repo", "../secret.ts"))
+      .toThrow("outside the repository");
+    expect(() => repositoryRelativePath("/repo", "/tmp/secret.ts"))
+      .toThrow("outside the repository");
+  });
+
+  it("reads exact commit content with argument-array git invocation", () => {
+    expect(historicalSourceArgs("abc1234", "src/core.ts")).toEqual([
+      "show",
+      "--no-textconv",
+      "abc1234:src/core.ts"
+    ]);
+  });
+});

--- a/editors/vscode/src/history/historicalSource.ts
+++ b/editors/vscode/src/history/historicalSource.ts
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import * as vscode from "vscode";
+import type { SourceLocation } from "@compass/viewer/contracts/graph";
+
+const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
+
+export type GitSourceReader = (
+  cwd: string,
+  args: readonly string[]
+) => Promise<string>;
+
+export class HistoricalSourceProvider implements vscode.TextDocumentContentProvider {
+  private readonly entries = new Map<string, {
+    commit: string;
+    relativePath: string;
+  }>();
+
+  constructor(
+    readonly scheme: string,
+    private readonly repositoryRoot: string,
+    private readonly readGitSource: GitSourceReader = defaultGitSourceReader
+  ) {}
+
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    const token = new URLSearchParams(uri.query).get("token");
+    const entry = token ? this.entries.get(token) : undefined;
+    if (!entry) throw new Error("This historical source request is no longer available.");
+    return this.readGitSource(
+      this.repositoryRoot,
+      historicalSourceArgs(entry.commit, entry.relativePath)
+    );
+  }
+
+  async open(commit: string, source: SourceLocation): Promise<void> {
+    if (!/^[0-9a-f]{7,64}$/i.test(commit)) {
+      throw new Error("Compass refused an invalid historical revision.");
+    }
+    const relativePath = repositoryRelativePath(this.repositoryRoot, source.file);
+    const token = crypto.randomUUID();
+    this.entries.set(token, { commit, relativePath });
+    const uri = vscode.Uri.from({
+      scheme: this.scheme,
+      path: `/${commit.slice(0, 9)}/${relativePath}`,
+      query: new URLSearchParams({ token }).toString()
+    });
+    const document = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(document, { preview: true });
+    revealSource(editor, document, source);
+  }
+
+  dispose(): void {
+    this.entries.clear();
+  }
+}
+
+export function repositoryRelativePath(root: string, sourceFile: string): string {
+  const resolved = path.resolve(root, sourceFile);
+  const relative = path.relative(path.resolve(root), resolved);
+  if (!relative
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)) {
+    throw new Error("Compass refused to open a path outside the repository.");
+  }
+  return relative.split(path.sep).join("/");
+}
+
+export function historicalSourceArgs(
+  commit: string,
+  relativePath: string
+): string[] {
+  return ["show", "--no-textconv", `${commit}:${relativePath}`];
+}
+
+export function revealSource(
+  editor: vscode.TextEditor,
+  document: vscode.TextDocument,
+  source: SourceLocation
+): void {
+  const start = source.startByte !== undefined
+    ? document.positionAt(source.startByte)
+    : new vscode.Position(Math.max(0, (source.startLine ?? 1) - 1), 0);
+  const recordedEndLine = source.endLine ?? source.startLine;
+  const end = recordedEndLine !== undefined
+    ? document.validatePosition(
+      new vscode.Position(Math.max(start.line, recordedEndLine), 0)
+    )
+    : source.endByte !== undefined
+      ? document.positionAt(source.endByte)
+      : start;
+  const range = new vscode.Range(start, end);
+  editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+  editor.selection = new vscode.Selection(start, end);
+}
+
+function defaultGitSourceReader(
+  cwd: string,
+  args: readonly string[]
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "git",
+      [...args],
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: MAX_SOURCE_BYTES,
+        windowsHide: true
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || error.message));
+        } else {
+          resolve(stdout);
+        }
+      }
+    );
+  });
+}

--- a/editors/vscode/src/history/historicalSource.ts
+++ b/editors/vscode/src/history/historicalSource.ts
@@ -1,7 +1,10 @@
 import { execFile } from "node:child_process";
 import path from "node:path";
 import * as vscode from "vscode";
-import type { SourceLocation } from "@compass/viewer/contracts/graph";
+import {
+  SourceLocationSchema,
+  type SourceLocation
+} from "@compass/viewer/contracts/graph";
 
 const MAX_SOURCE_BYTES = 8 * 1024 * 1024;
 
@@ -71,6 +74,14 @@ export function historicalSourceArgs(
   relativePath: string
 ): string[] {
   return ["show", "--no-textconv", `${commit}:${relativePath}`];
+}
+
+export function parseHistoricalSourceLocation(value: unknown): SourceLocation {
+  const parsed = SourceLocationSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error("Compass refused an invalid historical source location.");
+  }
+  return parsed.data;
 }
 
 export function revealSource(

--- a/editors/vscode/src/history/panelMessages.test.ts
+++ b/editors/vscode/src/history/panelMessages.test.ts
@@ -8,6 +8,7 @@ describe("history panel messages", () => {
     expect(historyOperationFor({ type: "loadMoreTimeline" })).toBe("Load more history");
     expect(historyOperationFor({ type: "enableHistory" })).toBe("Enable history");
     expect(historyOperationFor({ type: "compareCommunity" })).toBe("Compare community");
+    expect(historyOperationFor({ type: "exitComparison" })).toBe("Exit comparison");
   });
 
   it("supports recoverable bootstrap failures", () => {

--- a/editors/vscode/src/history/panelMessages.test.ts
+++ b/editors/vscode/src/history/panelMessages.test.ts
@@ -7,6 +7,7 @@ describe("history panel messages", () => {
     expect(historyOperationFor({ type: "retryTimeline" })).toBe("Load history");
     expect(historyOperationFor({ type: "loadMoreTimeline" })).toBe("Load more history");
     expect(historyOperationFor({ type: "enableHistory" })).toBe("Enable history");
+    expect(historyOperationFor({ type: "compareCommunity" })).toBe("Compare community");
   });
 
   it("supports recoverable bootstrap failures", () => {
@@ -15,5 +16,32 @@ describe("history panel messages", () => {
       message: "Git history is unavailable"
     };
     expect(message.type).toBe("bootstrapError");
+  });
+
+  it("carries correlated dual-revision community comparisons", () => {
+    const message: HistoryHostMessage = {
+      type: "communityComparison",
+      requestId: "request",
+      commit: "current",
+      parent: "parent",
+      communityId: 7,
+      nodeLimit: 5000,
+      currentGraph: {
+        schema: "compass.viewer.graph/1",
+        title: "Current",
+        stats: { nodes: 0, edges: 0, communities: 0, aggregated: false },
+        nodes: [],
+        edges: [],
+        communities: [],
+        hyperedges: []
+      }
+    };
+
+    expect(message).toMatchObject({
+      type: "communityComparison",
+      requestId: "request",
+      parent: "parent",
+      communityId: 7
+    });
   });
 });

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -13,6 +13,7 @@ export type HistoryOperation =
   | "Build graph"
   | "Compare revisions"
   | "Compare community"
+  | "Exit comparison"
   | "Load change counts"
   | "Open community"
   | "Open source"
@@ -26,6 +27,7 @@ export type HistoryWebviewMessage =
   | { type: "loadRevision"; commit: string }
   | { type: "buildRevision"; commit: string }
   | { type: "compare"; commit: string; parent: string }
+  | { type: "exitComparison"; commit: string }
   | {
     type: "compareCommunity";
     requestId: string;
@@ -139,6 +141,7 @@ export function historyOperationFor(message: unknown): HistoryOperation {
     case "buildRevision": return "Build graph";
     case "compare": return "Compare revisions";
     case "compareCommunity": return "Compare community";
+    case "exitComparison": return "Exit comparison";
     case "changeCounts": return "Load change counts";
     case "openCommunity": return "Open community";
     case "openSource": return "Open source";

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -12,6 +12,7 @@ export type HistoryOperation =
   | "Load graph"
   | "Build graph"
   | "Compare revisions"
+  | "Compare community"
   | "Load change counts"
   | "Open community"
   | "Open source"
@@ -25,6 +26,17 @@ export type HistoryWebviewMessage =
   | { type: "loadRevision"; commit: string }
   | { type: "buildRevision"; commit: string }
   | { type: "compare"; commit: string; parent: string }
+  | {
+    type: "compareCommunity";
+    requestId: string;
+    commit: string;
+    parent: string;
+    currentIdentity: { realization: string; fingerprint: string };
+    parentIdentity: { realization: string; fingerprint: string };
+    communityId: number;
+    hasCurrent: boolean;
+    hasParent: boolean;
+  }
   | { type: "queryRevision"; commit: string }
   | { type: "changeCounts"; commit: string }
   | {
@@ -78,10 +90,30 @@ export type HistoryHostMessage =
     parent: string;
     realization: string;
     fingerprint: string;
+    parentRealization: string;
+    parentFingerprint: string;
     currentGraph: GraphViewModel;
     parentGraph: GraphViewModel;
     semanticDiff: unknown;
     counts?: HistoryChangeCounts;
+  }
+  | {
+    type: "communityComparison";
+    requestId: string;
+    commit: string;
+    parent: string;
+    communityId: number;
+    currentGraph?: GraphViewModel;
+    parentGraph?: GraphViewModel;
+    nodeLimit: number;
+  }
+  | {
+    type: "communityComparisonError";
+    requestId: string;
+    commit: string;
+    parent: string;
+    communityId: number;
+    message: string;
   }
   | { type: "changeCounts"; commit: string; counts: HistoryChangeCounts }
   | { type: "buildRunning"; commit: string }
@@ -106,6 +138,7 @@ export function historyOperationFor(message: unknown): HistoryOperation {
     case "loadRevision": return "Load graph";
     case "buildRevision": return "Build graph";
     case "compare": return "Compare revisions";
+    case "compareCommunity": return "Compare community";
     case "changeCounts": return "Load change counts";
     case "openCommunity": return "Open community";
     case "openSource": return "Open source";

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -531,24 +531,31 @@ export async function openHistoryPanel(
           || !sameIdentity(comparisonState.parentIdentity, message.parentIdentity)) {
           throw new Error("This community request no longer matches the active comparison.");
         }
-        const [current, parent] = await Promise.all([
-          message.hasCurrent
-            ? revisions.loadCommunity(
-                message.commit,
-                message.communityId,
-                graphNodeLimit,
-                comparisonState.currentIdentity
-              )
-            : undefined,
-          message.hasParent
-            ? revisions.loadCommunity(
-                message.parent,
-                message.communityId,
-                graphNodeLimit,
-                comparisonState.parentIdentity
-              )
-            : undefined
-        ]);
+        let current: Awaited<ReturnType<RevisionStore["loadCommunity"]>> | undefined;
+        let parent: Awaited<ReturnType<RevisionStore["loadCommunity"]>> | undefined;
+        try {
+          [current, parent] = await Promise.all([
+            message.hasCurrent
+              ? revisions.loadCommunity(
+                  message.commit,
+                  message.communityId,
+                  graphNodeLimit,
+                  comparisonState.currentIdentity
+                )
+              : undefined,
+            message.hasParent
+              ? revisions.loadCommunity(
+                  message.parent,
+                  message.communityId,
+                  graphNodeLimit,
+                  comparisonState.parentIdentity
+                )
+              : undefined
+          ]);
+        } catch (error) {
+          if (generation !== viewGeneration || activeComparison !== comparisonState) return;
+          throw error;
+        }
         if (generation !== viewGeneration || activeComparison !== comparisonState) return;
         await postMessage({
           type: "communityComparison",

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -6,7 +6,10 @@ import { loadSemanticDiff } from "../history/diffClient";
 import { loadChangeCounts } from "../history/changeCountsClient";
 import { RevisionStore } from "../history/revisionStore";
 import { loadTimeline } from "../history/timelineClient";
-import { HistoricalSourceProvider } from "../history/historicalSource";
+import {
+  HistoricalSourceProvider,
+  parseHistoricalSourceLocation
+} from "../history/historicalSource";
 import {
   historyOperationFor,
   type HistoryHostMessage
@@ -53,6 +56,7 @@ export async function openHistoryPanel(
     parentIdentity: { realization: string; fingerprint: string };
   } | undefined;
   let activeSourceCommits = new Set<string>();
+  let viewGeneration = 0;
   const sourceProvider = new HistoricalSourceProvider(
     `compass-history-${randomUUID().replaceAll("-", "")}`,
     session.root
@@ -400,12 +404,15 @@ export async function openHistoryPanel(
       } else if (message?.type === "loadRevision" && typeof message.commit === "string") {
         const entry = timeline?.entries.find((candidate) => candidate.commit === message.commit);
         if (!entry) throw new Error("Reload commit history before opening this revision.");
+        const generation = ++viewGeneration;
+        activeComparison = undefined;
+        activeSourceCommits = new Set();
         const revision = await revisions.load(
           message.commit,
           graphNodeLimit,
           historyIdentity(entry)
         );
-        activeComparison = undefined;
+        if (generation !== viewGeneration) return;
         activeSourceCommits = new Set([message.commit]);
         await postMessage({
           type: "graph",
@@ -454,12 +461,16 @@ export async function openHistoryPanel(
         if (!currentEntry?.presentationAvailable || !parentEntry?.presentationAvailable) {
           throw new Error("Both revisions must have graph available before comparison.");
         }
+        const generation = ++viewGeneration;
+        activeComparison = undefined;
+        activeSourceCommits = new Set([message.commit]);
         const [current, parent, semanticDiff, counts] = await Promise.all([
           revisions.load(message.commit, graphNodeLimit, historyIdentity(currentEntry)),
           revisions.load(message.parent, graphNodeLimit, historyIdentity(parentEntry)),
           loadSemanticDiff(session, message.parent, message.commit),
           loadChangeCounts(session, message.commit, message.parent)
         ]);
+        if (generation !== viewGeneration) return;
         const currentIdentity = {
           realization: current.realization,
           fingerprint: current.fingerprint
@@ -488,6 +499,14 @@ export async function openHistoryPanel(
           semanticDiff,
           counts
         });
+      } else if (message?.type === "exitComparison"
+        && typeof message.commit === "string") {
+        if (!activeComparison || activeComparison.commit !== message.commit) {
+          throw new Error("This comparison is no longer active.");
+        }
+        viewGeneration += 1;
+        activeComparison = undefined;
+        activeSourceCommits = new Set([message.commit]);
       } else if (message?.type === "compareCommunity"
         && typeof message.requestId === "string"
         && typeof message.commit === "string"
@@ -503,11 +522,13 @@ export async function openHistoryPanel(
         if (!message.hasCurrent && !message.hasParent) {
           throw new Error("The selected community is absent from both compared revisions.");
         }
-        if (!activeComparison
-          || activeComparison.commit !== message.commit
-          || activeComparison.parent !== message.parent
-          || !sameIdentity(activeComparison.currentIdentity, message.currentIdentity)
-          || !sameIdentity(activeComparison.parentIdentity, message.parentIdentity)) {
+        const generation = viewGeneration;
+        const comparisonState = activeComparison;
+        if (!comparisonState
+          || comparisonState.commit !== message.commit
+          || comparisonState.parent !== message.parent
+          || !sameIdentity(comparisonState.currentIdentity, message.currentIdentity)
+          || !sameIdentity(comparisonState.parentIdentity, message.parentIdentity)) {
           throw new Error("This community request no longer matches the active comparison.");
         }
         const [current, parent] = await Promise.all([
@@ -516,7 +537,7 @@ export async function openHistoryPanel(
                 message.commit,
                 message.communityId,
                 graphNodeLimit,
-                activeComparison.currentIdentity
+                comparisonState.currentIdentity
               )
             : undefined,
           message.hasParent
@@ -524,10 +545,11 @@ export async function openHistoryPanel(
                 message.parent,
                 message.communityId,
                 graphNodeLimit,
-                activeComparison.parentIdentity
+                comparisonState.parentIdentity
               )
             : undefined
         ]);
+        if (generation !== viewGeneration || activeComparison !== comparisonState) return;
         await postMessage({
           type: "communityComparison",
           requestId: message.requestId,
@@ -558,7 +580,10 @@ export async function openHistoryPanel(
         if (message.repositoryId !== session.id) {
           throw new Error("The source request belongs to another repository.");
         }
-        await sourceProvider.open(message.commit, message.source);
+        await sourceProvider.open(
+          message.commit,
+          parseHistoricalSourceLocation(message.source)
+        );
       }
     } catch (error) {
       if (message?.type === "buildRevision" && typeof message.commit === "string") {

--- a/editors/vscode/src/views/historyPanel.ts
+++ b/editors/vscode/src/views/historyPanel.ts
@@ -6,12 +6,12 @@ import { loadSemanticDiff } from "../history/diffClient";
 import { loadChangeCounts } from "../history/changeCountsClient";
 import { RevisionStore } from "../history/revisionStore";
 import { loadTimeline } from "../history/timelineClient";
+import { HistoricalSourceProvider } from "../history/historicalSource";
 import {
   historyOperationFor,
   type HistoryHostMessage
 } from "../history/panelMessages";
 import type { RepositorySession } from "../workspace/repositorySession";
-import { openGraphSource } from "./sourceNavigation";
 import { openQueryPanel } from "./queryPanel";
 
 const TIMELINE_PAGE_SIZE = 100;
@@ -46,6 +46,21 @@ export async function openHistoryPanel(
     .get("graphNodeLimit", 5000);
   const countCache = new Map<string, Awaited<ReturnType<typeof loadChangeCounts>>>();
   let disposed = false;
+  let activeComparison: {
+    commit: string;
+    parent: string;
+    currentIdentity: { realization: string; fingerprint: string };
+    parentIdentity: { realization: string; fingerprint: string };
+  } | undefined;
+  let activeSourceCommits = new Set<string>();
+  const sourceProvider = new HistoricalSourceProvider(
+    `compass-history-${randomUUID().replaceAll("-", "")}`,
+    session.root
+  );
+  const sourceProviderRegistration = vscode.workspace.registerTextDocumentContentProvider(
+    sourceProvider.scheme,
+    sourceProvider
+  );
   let activePanelBuild: {
     command: ReturnType<RepositorySession["processes"]["startJsonl"]>;
     cancelled: boolean;
@@ -143,6 +158,8 @@ export async function openHistoryPanel(
   };
   panel.onDidDispose(() => {
     disposed = true;
+    sourceProviderRegistration.dispose();
+    sourceProvider.dispose();
     if (activePanelBuild) {
       activePanelBuild.cancelled = true;
       activePanelBuild.command.cancel();
@@ -388,6 +405,8 @@ export async function openHistoryPanel(
           graphNodeLimit,
           historyIdentity(entry)
         );
+        activeComparison = undefined;
+        activeSourceCommits = new Set([message.commit]);
         await postMessage({
           type: "graph",
           commit: message.commit,
@@ -441,16 +460,83 @@ export async function openHistoryPanel(
           loadSemanticDiff(session, message.parent, message.commit),
           loadChangeCounts(session, message.commit, message.parent)
         ]);
+        const currentIdentity = {
+          realization: current.realization,
+          fingerprint: current.fingerprint
+        };
+        const parentIdentity = {
+          realization: parent.realization,
+          fingerprint: parent.fingerprint
+        };
+        activeComparison = {
+          commit: message.commit,
+          parent: message.parent,
+          currentIdentity,
+          parentIdentity
+        };
+        activeSourceCommits = new Set([message.commit, message.parent]);
         await postMessage({
           type: "comparison",
           commit: message.commit,
           parent: message.parent,
-          realization: current.realization,
-          fingerprint: current.fingerprint,
+          realization: currentIdentity.realization,
+          fingerprint: currentIdentity.fingerprint,
+          parentRealization: parentIdentity.realization,
+          parentFingerprint: parentIdentity.fingerprint,
           currentGraph: current.graph,
           parentGraph: parent.graph,
           semanticDiff,
           counts
+        });
+      } else if (message?.type === "compareCommunity"
+        && typeof message.requestId === "string"
+        && typeof message.commit === "string"
+        && typeof message.parent === "string"
+        && typeof message.communityId === "number"
+        && typeof message.hasCurrent === "boolean"
+        && typeof message.hasParent === "boolean") {
+        if (session.capabilities?.features.community_detail !== true) {
+          throw new Error(
+            "The installed Compass CLI does not support historical community details. Upgrade Compass and reload VS Code."
+          );
+        }
+        if (!message.hasCurrent && !message.hasParent) {
+          throw new Error("The selected community is absent from both compared revisions.");
+        }
+        if (!activeComparison
+          || activeComparison.commit !== message.commit
+          || activeComparison.parent !== message.parent
+          || !sameIdentity(activeComparison.currentIdentity, message.currentIdentity)
+          || !sameIdentity(activeComparison.parentIdentity, message.parentIdentity)) {
+          throw new Error("This community request no longer matches the active comparison.");
+        }
+        const [current, parent] = await Promise.all([
+          message.hasCurrent
+            ? revisions.loadCommunity(
+                message.commit,
+                message.communityId,
+                graphNodeLimit,
+                activeComparison.currentIdentity
+              )
+            : undefined,
+          message.hasParent
+            ? revisions.loadCommunity(
+                message.parent,
+                message.communityId,
+                graphNodeLimit,
+                activeComparison.parentIdentity
+              )
+            : undefined
+        ]);
+        await postMessage({
+          type: "communityComparison",
+          requestId: message.requestId,
+          commit: message.commit,
+          parent: message.parent,
+          communityId: message.communityId,
+          ...(current ? { currentGraph: current.graph } : {}),
+          ...(parent ? { parentGraph: parent.graph } : {}),
+          nodeLimit: graphNodeLimit
         });
       } else if (message?.type === "queryRevision" && typeof message.commit === "string") {
         const entry = timeline?.entries.find((candidate) => candidate.commit === message.commit);
@@ -466,7 +552,13 @@ export async function openHistoryPanel(
         }
         await postMessage({ type: "changeCounts", commit: message.commit, counts });
       } else if (message?.type === "openSource") {
-        await openGraphSource(session, message.repositoryId, message.source);
+        if (typeof message.commit !== "string" || !activeSourceCommits.has(message.commit)) {
+          throw new Error("This source request no longer matches the active revision view.");
+        }
+        if (message.repositoryId !== session.id) {
+          throw new Error("The source request belongs to another repository.");
+        }
+        await sourceProvider.open(message.commit, message.source);
       }
     } catch (error) {
       if (message?.type === "buildRevision" && typeof message.commit === "string") {
@@ -486,6 +578,19 @@ export async function openHistoryPanel(
           type: "communityError",
           requestId: message.requestId,
           commit: typeof message.commit === "string" ? message.commit : "",
+          communityId: message.communityId,
+          message: error instanceof Error ? error.message : String(error)
+        });
+        return;
+      }
+      if (message?.type === "compareCommunity"
+        && typeof message.requestId === "string"
+        && typeof message.communityId === "number") {
+        await postMessage({
+          type: "communityComparisonError",
+          requestId: message.requestId,
+          commit: typeof message.commit === "string" ? message.commit : "",
+          parent: typeof message.parent === "string" ? message.parent : "",
           communityId: message.communityId,
           message: error instanceof Error ? error.message : String(error)
         });
@@ -514,6 +619,18 @@ function historyIdentity(
   return entry?.realization && entry.fingerprint
     ? { realization: entry.realization, fingerprint: entry.fingerprint }
     : undefined;
+}
+
+function sameIdentity(
+  left: { realization: string; fingerprint: string },
+  right: unknown
+): boolean {
+  return typeof right === "object"
+    && right !== null
+    && "realization" in right
+    && "fingerprint" in right
+    && right.realization === left.realization
+    && right.fingerprint === left.fingerprint;
 }
 
 function html(context: vscode.ExtensionContext, webview: vscode.Webview): string {

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -8,6 +8,7 @@ import {
   compareGraphs,
   type GraphViewModel,
   type GraphComparison,
+  type CommunityGraphDetail,
   type HistoryBuildState,
   type HistoryChangeCounts,
   type HistoryOperationError,
@@ -28,10 +29,22 @@ let selectedCommit = "";
 let graph: GraphViewModel | undefined;
 let graphCommit: string | undefined;
 let graphIdentity: { realization: string; fingerprint: string } | undefined;
-let communityDetail: { communityId: number; model: GraphViewModel } | undefined;
+let comparisonIdentities: {
+  current: { realization: string; fingerprint: string };
+  parent: { realization: string; fingerprint: string };
+} | undefined;
+let communityDetail: CommunityGraphDetail | undefined;
 let communityLoading: number | null = null;
 let communityError: string | undefined;
 let activeCommunityRequest = "";
+let activeCommunityContext: {
+  requestId: string;
+  commit: string;
+  parent?: string | undefined;
+  communityId: number;
+  parentMembers: number;
+  currentMembers: number;
+} | undefined;
 let semanticDiff: unknown;
 let comparison: (GraphComparison & { parent: string }) | undefined;
 let repositoryId = "";
@@ -53,6 +66,7 @@ function clearRevisionPresentation(): void {
   graph = undefined;
   graphCommit = undefined;
   graphIdentity = undefined;
+  comparisonIdentities = undefined;
   semanticDiff = undefined;
   comparison = undefined;
   changeCounts = undefined;
@@ -60,6 +74,7 @@ function clearRevisionPresentation(): void {
   communityLoading = null;
   communityError = undefined;
   activeCommunityRequest = "";
+  activeCommunityContext = undefined;
   revisionLoadState = "idle";
 }
 
@@ -149,11 +164,18 @@ function render(): void {
         communityLoading = null;
         communityError = undefined;
         activeCommunityRequest = "";
+        activeCommunityContext = undefined;
         render();
       }}
       onExitComparison={() => {
         comparison = undefined;
+        comparisonIdentities = undefined;
         semanticDiff = undefined;
+        communityDetail = undefined;
+        communityLoading = null;
+        communityError = undefined;
+        activeCommunityRequest = "";
+        activeCommunityContext = undefined;
         requestChangeCounts(selectedCommit);
         render();
       }}
@@ -203,6 +225,51 @@ function render(): void {
           communityLoading = communityId;
           communityError = undefined;
           activeCommunityRequest = crypto.randomUUID();
+          const aggregate = comparison?.graph.nodes.find(
+            (node) => node.community === communityId && node.memberCount !== undefined
+          );
+          if (comparison && comparisonIdentities && aggregate) {
+            const hasCurrent = aggregate.change === "unchanged"
+              || aggregate.evidence?.after !== undefined;
+            const hasParent = aggregate.change === "unchanged"
+              || aggregate.evidence?.before !== undefined;
+            const currentMembers = memberCount(
+              aggregate.evidence?.after,
+              hasCurrent ? (aggregate.memberCount ?? 0) : 0
+            );
+            const parentMembers = memberCount(
+              aggregate.evidence?.before,
+              hasParent ? (aggregate.memberCount ?? 0) : 0
+            );
+            activeCommunityContext = {
+              requestId: activeCommunityRequest,
+              commit,
+              parent: comparison.parent,
+              communityId,
+              parentMembers,
+              currentMembers
+            };
+            postMessage({
+              type: "compareCommunity",
+              requestId: activeCommunityRequest,
+              commit,
+              parent: comparison.parent,
+              currentIdentity: comparisonIdentities.current,
+              parentIdentity: comparisonIdentities.parent,
+              communityId,
+              hasCurrent,
+              hasParent
+            });
+            render();
+            return;
+          }
+          activeCommunityContext = {
+            requestId: activeCommunityRequest,
+            commit,
+            communityId,
+            parentMembers: 0,
+            currentMembers: aggregate?.memberCount ?? 0
+          };
           postMessage({
             type: "openCommunity",
             requestId: activeCommunityRequest,
@@ -288,10 +355,12 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
         realization: message.realization,
         fingerprint: message.fingerprint
       };
+      comparisonIdentities = undefined;
       communityDetail = undefined;
       communityLoading = null;
       communityError = undefined;
       activeCommunityRequest = "";
+      activeCommunityContext = undefined;
       operationErrors.delete(message.commit);
       revisionLoadState = "ready";
     }
@@ -329,10 +398,21 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
         realization: message.realization,
         fingerprint: message.fingerprint
       };
+      comparisonIdentities = {
+        current: {
+          realization: message.realization,
+          fingerprint: message.fingerprint
+        },
+        parent: {
+          realization: message.parentRealization,
+          fingerprint: message.parentFingerprint
+        }
+      };
       communityDetail = undefined;
       communityLoading = null;
       communityError = undefined;
       activeCommunityRequest = "";
+      activeCommunityContext = undefined;
       comparison = {
         ...compareGraphs(parent.data, current.data),
         ...(exactCounts
@@ -352,6 +432,70 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       operationErrors.delete(message.commit);
       revisionLoadState = "ready";
     }
+  } else if (message?.type === "communityComparison") {
+    const context = activeCommunityContext;
+    if (!context
+      || message.requestId !== activeCommunityRequest
+      || message.requestId !== context.requestId
+      || message.commit !== selectedCommit
+      || message.commit !== context.commit
+      || message.parent !== comparison?.parent
+      || message.parent !== context.parent
+      || message.communityId !== context.communityId) {
+      return;
+    }
+    const current = message.currentGraph
+      ? GraphViewModelSchema.safeParse(message.currentGraph)
+      : undefined;
+    const parent = message.parentGraph
+      ? GraphViewModelSchema.safeParse(message.parentGraph)
+      : undefined;
+    if ((current && !current.success) || (parent && !parent.success) || (!current && !parent)) {
+      communityLoading = null;
+      communityError = "Compass returned an invalid community comparison.";
+    } else {
+      const reference = current?.success
+        ? current.data
+        : parent?.success
+          ? parent.data
+          : comparison.graph;
+      const currentGraph = current?.success
+        ? current.data
+        : emptyGraph(reference, "Current community");
+      const parentGraph = parent?.success
+        ? parent.data
+        : emptyGraph(reference, "Parent community");
+      const detail = compareGraphs(parentGraph, currentGraph);
+      const bounded = currentGraph.nodes.length < context.currentMembers
+        || parentGraph.nodes.length < context.parentMembers;
+      communityDetail = {
+        communityId: message.communityId,
+        model: detail.graph,
+        ...(bounded
+          ? {
+              bounded: {
+                limit: message.nodeLimit,
+                parentMembers: context.parentMembers,
+                currentMembers: context.currentMembers
+              }
+            }
+          : {})
+      };
+      communityLoading = null;
+      communityError = undefined;
+    }
+  } else if (message?.type === "communityComparisonError") {
+    const context = activeCommunityContext;
+    if (!context
+      || message.requestId !== activeCommunityRequest
+      || message.requestId !== context.requestId
+      || message.commit !== selectedCommit
+      || message.parent !== comparison?.parent
+      || message.communityId !== context.communityId) {
+      return;
+    }
+    communityLoading = null;
+    communityError = message.message;
   } else if (message?.type === "changeCounts") {
     if (!acceptsCommit(message.commit)) return;
     const parsed = HistoryChangeCountsSchema.safeParse(message.counts);
@@ -383,3 +527,28 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
 
 render();
 postMessage({ type: "ready" });
+
+function memberCount(
+  snapshot: Record<string, unknown> | undefined,
+  fallback: number
+): number {
+  return typeof snapshot?.memberCount === "number" ? snapshot.memberCount : fallback;
+}
+
+function emptyGraph(reference: GraphViewModel, title: string): GraphViewModel {
+  return {
+    ...reference,
+    title,
+    stats: {
+      ...reference.stats,
+      nodes: 0,
+      edges: 0,
+      communities: 0,
+      aggregated: false
+    },
+    nodes: [],
+    edges: [],
+    communities: [],
+    hyperedges: []
+  };
+}

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -168,6 +168,7 @@ function render(): void {
         render();
       }}
       onExitComparison={() => {
+        postMessage({ type: "exitComparison", commit: selectedCommit });
         comparison = undefined;
         comparisonIdentities = undefined;
         semanticDiff = undefined;

--- a/packages/compass-viewer/src/contracts/graph.ts
+++ b/packages/compass-viewer/src/contracts/graph.ts
@@ -10,6 +10,18 @@ export const SourceLocationSchema = z.object({
   endByte: z.number().int().nonnegative().optional()
 }).passthrough();
 
+export const GraphFieldChangeSchema = z.object({
+  field: z.string().min(1),
+  before: z.unknown().optional(),
+  after: z.unknown().optional()
+});
+
+export const GraphRecordEvidenceSchema = z.object({
+  before: z.record(z.string(), z.unknown()).optional(),
+  after: z.record(z.string(), z.unknown()).optional(),
+  fields: z.array(GraphFieldChangeSchema)
+});
+
 export const GraphNodeSchema = z.object({
   id: z.string().min(1),
   label: z.string(),
@@ -24,6 +36,7 @@ export const GraphNodeSchema = z.object({
   learningStatus: z.string().optional(),
   learningStale: z.boolean().optional(),
   change: z.enum(["added", "removed", "changed", "unchanged"]).optional(),
+  evidence: GraphRecordEvidenceSchema.optional(),
   source: SourceLocationSchema.optional(),
   color: z.object({
     background: z.string(),
@@ -37,6 +50,7 @@ export const GraphEdgeSchema = z.object({
   target: z.string().min(1),
   relation: z.string(),
   change: z.enum(["added", "removed", "changed", "unchanged"]).optional(),
+  evidence: GraphRecordEvidenceSchema.optional(),
   confidence: z.enum(["extracted", "inferred", "ambiguous"]).optional()
 }).passthrough();
 
@@ -63,6 +77,8 @@ export const GraphViewModelSchema = z.object({
 }).passthrough();
 
 export type SourceLocation = z.infer<typeof SourceLocationSchema>;
+export type GraphFieldChange = z.infer<typeof GraphFieldChangeSchema>;
+export type GraphRecordEvidence = z.infer<typeof GraphRecordEvidenceSchema>;
 export type GraphNode = z.infer<typeof GraphNodeSchema>;
 export type GraphEdge = z.infer<typeof GraphEdgeSchema>;
 export type GraphViewModel = z.infer<typeof GraphViewModelSchema>;

--- a/packages/compass-viewer/src/graph/ChangeEvidence.test.tsx
+++ b/packages/compass-viewer/src/graph/ChangeEvidence.test.tsx
@@ -1,0 +1,137 @@
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { GraphEdge, GraphNode } from "../contracts/graph";
+import { ChangeEvidence } from "./ChangeEvidence";
+import { ChangedSymbolList } from "./ChangedSymbolList";
+
+const changedNode: GraphNode = {
+  id: "changed",
+  label: "render",
+  kind: "function",
+  community: 7,
+  change: "changed",
+  source: { file: "src/render.ts", startLine: 8 },
+  evidence: {
+    before: {
+      source: { file: "src/render.ts", startLine: 3 },
+      signature: "render(oldValue)"
+    },
+    after: {
+      source: { file: "src/render.ts", startLine: 8 },
+      signature: "render(newValue)"
+    },
+    fields: [{
+      field: "signature",
+      before: "render(oldValue)",
+      after: "render(newValue)"
+    }, {
+      field: "source.startLine",
+      before: 3,
+      after: 8
+    }]
+  }
+};
+const neighbor: GraphNode = {
+  id: "caller",
+  label: "main",
+  community: 7,
+  change: "added"
+};
+const edge: GraphEdge = {
+  id: "calls",
+  source: "caller",
+  target: "changed",
+  relation: "calls",
+  confidence: "extracted",
+  change: "changed",
+  evidence: {
+    before: { relation: "references" },
+    after: { relation: "calls" },
+    fields: [{
+      field: "relation",
+      before: "references",
+      after: "calls"
+    }]
+  }
+};
+
+describe("ChangeEvidence", () => {
+  it("shows field and relationship evidence and opens both source revisions", () => {
+    const onOpenSource = vi.fn();
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    flushSync(() => root.render(
+        <ChangeEvidence
+          node={changedNode}
+          edges={[edge]}
+          nodes={new Map([[changedNode.id, changedNode], [neighbor.id, neighbor]])}
+          sourceRevisions={{ before: "parent", after: "current" }}
+          onFocus={vi.fn()}
+          onOpenSource={onOpenSource}
+        />
+      ));
+
+    expect(container.querySelector("h3")?.textContent).toBe("What changed");
+    expect(Array.from(container.querySelectorAll("th")).map((cell) => cell.textContent))
+      .toContain("Before");
+    expect(container.textContent).toContain("render(oldValue)");
+    expect(container.textContent).toContain("render(newValue)");
+    expect(container.textContent).toContain("extracted");
+    expect(container.textContent).toContain("calls");
+
+    const sourceButtons = Array.from(container.querySelectorAll<HTMLButtonElement>("button"));
+    flushSync(() => sourceButtons.find((button) => button.textContent?.includes("Open before"))?.click());
+    flushSync(() => sourceButtons.find((button) => button.textContent?.includes("Open after"))?.click());
+    expect(onOpenSource).toHaveBeenNthCalledWith(
+      1,
+      { file: "src/render.ts", startLine: 3 },
+      "parent"
+    );
+    expect(onOpenSource).toHaveBeenNthCalledWith(
+      2,
+      { file: "src/render.ts", startLine: 8 },
+      "current"
+    );
+    root.unmount();
+  });
+});
+
+describe("ChangedSymbolList", () => {
+  it("orders affected symbols by status and filters by source", () => {
+    const onFocus = vi.fn();
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    flushSync(() => root.render(
+        <ChangedSymbolList
+          nodes={[
+            { ...neighbor, id: "added", label: "Zulu", source: { file: "src/z.ts" } },
+            { ...changedNode, id: "changed-b", label: "Beta" },
+            { ...changedNode, id: "changed-a", label: "Alpha" },
+            { id: "removed", label: "Gone", community: 7, change: "removed" }
+          ]}
+          query=""
+          onFocus={onFocus}
+        />
+      ));
+
+    expect(Array.from(container.querySelectorAll("button")).map((button) => button.textContent))
+      .toEqual([
+      "ChangedAlphasrc/render.ts",
+      "ChangedBetasrc/render.ts",
+      "AddedZulusrc/z.ts",
+      "RemovedGoneGraph symbol"
+    ]);
+
+    flushSync(() => root.render(
+        <ChangedSymbolList
+          nodes={[{ ...neighbor, id: "added", label: "Zulu", source: { file: "src/z.ts" } }]}
+          query="src/z"
+          onFocus={onFocus}
+        />
+      ));
+    flushSync(() => container.querySelector<HTMLButtonElement>("button")?.click());
+    expect(onFocus).toHaveBeenCalledWith("added");
+    root.unmount();
+  });
+});

--- a/packages/compass-viewer/src/graph/ChangeEvidence.test.tsx
+++ b/packages/compass-viewer/src/graph/ChangeEvidence.test.tsx
@@ -95,6 +95,77 @@ describe("ChangeEvidence", () => {
     );
     root.unmount();
   });
+
+  it("shows every retained field for added and removed symbols", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const renderNode = (node: GraphNode) => flushSync(() => root.render(
+      <ChangeEvidence
+        node={node}
+        edges={[]}
+        nodes={new Map([[node.id, node]])}
+        onFocus={vi.fn()}
+        onOpenSource={vi.fn()}
+      />
+    ));
+    const added: GraphNode = {
+      id: "added",
+      label: "Added",
+      community: 7,
+      change: "added",
+      size: 42,
+      learningStatus: "learned",
+      evidence: {
+        after: {
+          id: "added",
+          label: "Added",
+          community: 7,
+          size: 42,
+          learningStatus: "learned"
+        },
+        fields: [
+          { field: "id", after: "added" },
+          { field: "label", after: "Added" },
+          { field: "community", after: 7 },
+          { field: "size", after: 42 },
+          { field: "learningStatus", after: "learned" }
+        ]
+      }
+    };
+
+    renderNode(added);
+    expect(container.querySelector("h3")?.textContent).toBe("Added symbol metadata");
+    expect(container.textContent).toContain("learningStatus");
+    expect(container.textContent).toContain("learned");
+    expect(container.textContent).toContain("size");
+    expect(container.textContent).toContain("42");
+
+    const removed: GraphNode = {
+      ...added,
+      id: "removed",
+      label: "Removed",
+      change: "removed",
+      evidence: {
+        before: {
+          id: "removed",
+          label: "Removed",
+          community: 7,
+          memberCount: 12
+        },
+        fields: [
+          { field: "id", before: "removed" },
+          { field: "label", before: "Removed" },
+          { field: "community", before: 7 },
+          { field: "memberCount", before: 12 }
+        ]
+      }
+    };
+    renderNode(removed);
+    expect(container.querySelector("h3")?.textContent).toBe("Removed symbol metadata");
+    expect(container.textContent).toContain("memberCount");
+    expect(container.textContent).toContain("12");
+    root.unmount();
+  });
 });
 
 describe("ChangedSymbolList", () => {

--- a/packages/compass-viewer/src/graph/ChangeEvidence.tsx
+++ b/packages/compass-viewer/src/graph/ChangeEvidence.tsx
@@ -1,0 +1,158 @@
+import { ExternalLinkIcon } from "lucide-react";
+import {
+  SourceLocationSchema,
+  type GraphEdge,
+  type GraphNode,
+  type SourceLocation
+} from "../contracts/graph";
+import { displayFieldValue } from "../history/recordDiff";
+
+export type GraphSourceRevisions = {
+  before: string;
+  after: string;
+};
+
+export function ChangeEvidence({
+  node,
+  edges,
+  nodes,
+  sourceRevisions,
+  onFocus,
+  onOpenSource
+}: {
+  node: GraphNode;
+  edges: GraphEdge[];
+  nodes: ReadonlyMap<string, GraphNode>;
+  sourceRevisions?: GraphSourceRevisions | undefined;
+  onFocus(nodeId: string): void;
+  onOpenSource(source: SourceLocation, revision?: string): void;
+}) {
+  const beforeSource = evidenceSource(node.evidence?.before);
+  const afterSource = evidenceSource(node.evidence?.after);
+
+  return (
+    <>
+      {node.change === "changed" && node.evidence?.fields.length ? (
+        <section className="compass-record-evidence" aria-labelledby="compass-node-changes-title">
+          <div className="compass-evidence-heading">
+            <h3 id="compass-node-changes-title">What changed</h3>
+            <span>{node.evidence.fields.length} fields</span>
+          </div>
+          <FieldTable fields={node.evidence.fields} />
+          {(beforeSource || afterSource) && (
+            <div className="compass-evidence-source-actions">
+              {beforeSource && (
+                <button
+                  type="button"
+                  onClick={() => onOpenSource(beforeSource, sourceRevisions?.before)}
+                >
+                  <ExternalLinkIcon aria-hidden="true" />
+                  Open before
+                </button>
+              )}
+              {afterSource && (
+                <button
+                  type="button"
+                  onClick={() => onOpenSource(afterSource, sourceRevisions?.after)}
+                >
+                  <ExternalLinkIcon aria-hidden="true" />
+                  Open after
+                </button>
+              )}
+            </div>
+          )}
+        </section>
+      ) : null}
+
+      <section className="compass-relationship-evidence" aria-labelledby="compass-relationships-title">
+        <div className="compass-neighbors-heading">
+          <span id="compass-relationships-title">Relationships</span>
+          <strong>{edges.length}</strong>
+        </div>
+        {edges.length ? (
+          <div className="compass-relationship-list">
+            {edges.map((edge) => {
+              const otherId = edge.source === node.id ? edge.target : edge.source;
+              const other = nodes.get(otherId);
+              return (
+                <details key={edge.id}>
+                  <summary>
+                    <span className="compass-change-badge" data-change={edge.change}>
+                      {changeLabel(edge.change)}
+                    </span>
+                    <span className="compass-relationship-target">
+                      {other?.label ?? otherId}
+                    </span>
+                    <small>{edge.relation}</small>
+                    {edge.confidence && <i>{edge.confidence}</i>}
+                  </summary>
+                  <div className="compass-relationship-detail">
+                    {edge.change === "changed" && edge.evidence?.fields.length ? (
+                      <FieldTable fields={edge.evidence.fields} />
+                    ) : (
+                      <p>
+                        {changeLabel(edge.change)} relationship: {edge.source} → {edge.target}
+                      </p>
+                    )}
+                    <button type="button" onClick={() => onFocus(otherId)}>
+                      Focus {other?.label ?? otherId}
+                    </button>
+                  </div>
+                </details>
+              );
+            })}
+          </div>
+        ) : (
+          <span className="compass-empty">No connected relationships</span>
+        )}
+      </section>
+    </>
+  );
+}
+
+function FieldTable({
+  fields
+}: {
+  fields: NonNullable<GraphNode["evidence"]>["fields"];
+}) {
+  return (
+    <div className="compass-field-table-wrap">
+      <table className="compass-field-table">
+        <thead>
+          <tr><th>Field</th><th>Before</th><th>After</th></tr>
+        </thead>
+        <tbody>
+          {fields.map((field) => (
+            <tr key={field.field}>
+              <th scope="row">{field.field}</th>
+              <FieldValue value={field.before} />
+              <FieldValue value={field.after} />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function FieldValue({ value }: { value: unknown }) {
+  const display = displayFieldValue(value);
+  return (
+    <td>
+      <code>{display.text}</code>
+      {display.truncated && <span className="compass-value-truncated">Value shortened</span>}
+    </td>
+  );
+}
+
+function evidenceSource(
+  snapshot: Record<string, unknown> | undefined
+): SourceLocation | undefined {
+  const parsed = SourceLocationSchema.safeParse(snapshot?.source);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function changeLabel(change: GraphEdge["change"]): string {
+  if (!change || change === "unchanged") return "Context";
+  return `${change[0]?.toLocaleUpperCase()}${change.slice(1)}`;
+}

--- a/packages/compass-viewer/src/graph/ChangeEvidence.tsx
+++ b/packages/compass-viewer/src/graph/ChangeEvidence.tsx
@@ -32,14 +32,14 @@ export function ChangeEvidence({
 
   return (
     <>
-      {node.change === "changed" && node.evidence?.fields.length ? (
+      {node.evidence?.fields.length ? (
         <section className="compass-record-evidence" aria-labelledby="compass-node-changes-title">
           <div className="compass-evidence-heading">
-            <h3 id="compass-node-changes-title">What changed</h3>
+            <h3 id="compass-node-changes-title">{evidenceTitle(node.change)}</h3>
             <span>{node.evidence.fields.length} fields</span>
           </div>
           <FieldTable fields={node.evidence.fields} />
-          {(beforeSource || afterSource) && (
+          {node.change === "changed" && (beforeSource || afterSource) && (
             <div className="compass-evidence-source-actions">
               {beforeSource && (
                 <button
@@ -155,4 +155,10 @@ function evidenceSource(
 function changeLabel(change: GraphEdge["change"]): string {
   if (!change || change === "unchanged") return "Context";
   return `${change[0]?.toLocaleUpperCase()}${change.slice(1)}`;
+}
+
+function evidenceTitle(change: GraphNode["change"]): string {
+  if (change === "added") return "Added symbol metadata";
+  if (change === "removed") return "Removed symbol metadata";
+  return "What changed";
 }

--- a/packages/compass-viewer/src/graph/ChangedSymbolList.tsx
+++ b/packages/compass-viewer/src/graph/ChangedSymbolList.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import type { GraphNode } from "../contracts/graph";
+
+const INITIAL_LIMIT = 100;
+const CHANGE_ORDER: Record<NonNullable<GraphNode["change"]>, number> = {
+  changed: 0,
+  added: 1,
+  removed: 2,
+  unchanged: 3
+};
+
+export function ChangedSymbolList({
+  nodes,
+  query,
+  selectedId,
+  onFocus
+}: {
+  nodes: GraphNode[];
+  query: string;
+  selectedId?: string | undefined;
+  onFocus(nodeId: string): void;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const changed = nodes
+    .filter((node) => node.change && node.change !== "unchanged")
+    .filter((node) => !normalizedQuery
+      || node.label.toLocaleLowerCase().includes(normalizedQuery)
+      || node.kind?.toLocaleLowerCase().includes(normalizedQuery)
+      || node.source?.file.toLocaleLowerCase().includes(normalizedQuery))
+    .sort((left, right) =>
+      CHANGE_ORDER[left.change ?? "unchanged"] - CHANGE_ORDER[right.change ?? "unchanged"]
+      || left.label.localeCompare(right.label)
+      || left.id.localeCompare(right.id));
+  const visible = showAll ? changed : changed.slice(0, INITIAL_LIMIT);
+
+  return (
+    <section className="compass-changed-symbols" aria-labelledby="compass-changed-symbols-title">
+      <div className="compass-section-heading">
+        <h2 id="compass-changed-symbols-title">Changed symbols</h2>
+        <span>{changed.length}</span>
+      </div>
+      {visible.length ? (
+        <div className="compass-changed-symbol-list">
+          {visible.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              aria-pressed={node.id === selectedId}
+              data-change={node.change}
+              onClick={() => onFocus(node.id)}
+            >
+              <span className="compass-changed-symbol-status">{changeLabel(node.change)}</span>
+              <strong>{node.label}</strong>
+              <small>{node.source?.file ?? node.kind ?? "Graph symbol"}</small>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="compass-empty">
+          {normalizedQuery ? "No affected symbols match this search." : "No symbol changes."}
+        </p>
+      )}
+      {!showAll && changed.length > INITIAL_LIMIT && (
+        <button
+          className="compass-changed-symbol-expand"
+          type="button"
+          onClick={() => setShowAll(true)}
+        >
+          Show all {changed.length.toLocaleString()} affected symbols
+        </button>
+      )}
+    </section>
+  );
+}
+
+function changeLabel(change: GraphNode["change"]): string {
+  if (!change || change === "unchanged") return "Context";
+  return `${change[0]?.toLocaleUpperCase()}${change.slice(1)}`;
+}

--- a/packages/compass-viewer/src/graph/CompassGraph.tsx
+++ b/packages/compass-viewer/src/graph/CompassGraph.tsx
@@ -16,6 +16,7 @@ import {
 } from "./inspectorLayout";
 import { graphNodeActivation } from "./nodeActivation";
 import { NodeHoverCard, type GraphHover } from "./NodeHoverCard";
+import type { GraphSourceRevisions } from "./ChangeEvidence";
 import { VisNetworkCanvas, type GraphCanvasHandle } from "./VisNetworkCanvas";
 import {
   graphReducer,
@@ -34,17 +35,28 @@ const CHANGE_TYPES: Array<{
 ];
 
 export type GraphHost = {
-  openSource(source: SourceLocation): void;
+  openSource(source: SourceLocation, revision?: string): void;
   openCommunity?(communityId: number): void;
+};
+
+export type CommunityGraphDetail = {
+  communityId: number;
+  model: GraphViewModel;
+  bounded?: {
+    limit: number;
+    parentMembers: number;
+    currentMembers: number;
+  } | undefined;
 };
 
 export type CompassGraphProps = {
   model: GraphViewModel;
   host: GraphHost;
-  communityDetail?: { communityId: number; model: GraphViewModel } | undefined;
+  communityDetail?: CommunityGraphDetail | undefined;
   communityLoading?: number | null | undefined;
   communityError?: string | undefined;
   onBackToOverview?: (() => void) | undefined;
+  sourceRevisions?: GraphSourceRevisions | undefined;
   initialInspectorLayout?: Partial<InspectorLayout> | undefined;
   onInspectorLayoutChange?: ((layout: InspectorLayout) => void) | undefined;
 };
@@ -56,6 +68,7 @@ export function CompassGraph({
   communityLoading,
   communityError,
   onBackToOverview,
+  sourceRevisions,
   initialInspectorLayout,
   onInspectorLayoutChange
 }: CompassGraphProps) {
@@ -78,6 +91,8 @@ export function CompassGraph({
       communityLoading={communityLoading}
       communityError={communityError}
       onBackToOverview={communityDetail ? onBackToOverview : undefined}
+      bounded={communityDetail?.bounded}
+      sourceRevisions={sourceRevisions}
       inspectorLayout={inspectorLayout}
       onInspectorLayoutChange={updateInspectorLayout}
     />
@@ -91,6 +106,8 @@ function CompassGraphView({
   communityLoading,
   communityError,
   onBackToOverview,
+  bounded,
+  sourceRevisions,
   inspectorLayout,
   onInspectorLayoutChange
 }: {
@@ -100,6 +117,8 @@ function CompassGraphView({
   communityLoading?: number | null | undefined;
   communityError?: string | undefined;
   onBackToOverview?: (() => void) | undefined;
+  bounded?: CommunityGraphDetail["bounded"];
+  sourceRevisions?: GraphSourceRevisions | undefined;
   inspectorLayout: InspectorLayout;
   onInspectorLayoutChange(layout: InspectorLayout): void;
 }) {
@@ -160,8 +179,19 @@ function CompassGraphView({
     if (activation.type === "community") {
       hostRef.current.openCommunity?.(activation.communityId);
     }
-    if (activation.type === "source") hostRef.current.openSource(activation.source);
-  }, [detailCommunityId, model.nodes, model.stats.aggregated]);
+    if (activation.type === "source") {
+      hostRef.current.openSource(
+        activation.source,
+        node.change === "removed" ? sourceRevisions?.before : sourceRevisions?.after
+      );
+    }
+  }, [
+    detailCommunityId,
+    model.nodes,
+    model.stats.aggregated,
+    sourceRevisions?.after,
+    sourceRevisions?.before
+  ]);
   const status = communityLoading !== undefined && communityLoading !== null
     ? `Loading community ${communityLoading}`
     : selected
@@ -243,6 +273,16 @@ function CompassGraphView({
             {communityError}
           </div>
         )}
+        {bounded && (
+          <div className="compass-bounded-notice" role="status">
+            <strong>Partial community comparison</strong>
+            <span>
+              This view is limited to {bounded.limit.toLocaleString()} nodes. Increase{" "}
+              <code>compass.graphNodeLimit</code> to inspect all{" "}
+              {Math.max(bounded.parentMembers, bounded.currentMembers).toLocaleString()} symbols.
+            </span>
+          </div>
+        )}
         {hover && hovered && <NodeHoverCard node={hovered} hover={hover} />}
       </main>
       {!inspectorLayout.collapsed && (
@@ -258,10 +298,14 @@ function CompassGraphView({
         model={model}
         selected={selected}
         neighbors={neighbors}
+        connectedEdges={selected
+          ? model.edges.filter((edge) => edge.source === selected.id || edge.target === selected.id)
+          : []}
         query={state.query}
         matches={matches}
         hiddenCommunities={state.hiddenCommunities}
         comparisonMode={comparisonMode}
+        sourceRevisions={sourceRevisions}
         onQueryChange={(query) => dispatch({ type: "search", query })}
         onFocus={focus}
         onOpenSource={host.openSource}

--- a/packages/compass-viewer/src/graph/GraphInspector.tsx
+++ b/packages/compass-viewer/src/graph/GraphInspector.tsx
@@ -6,7 +6,14 @@ import {
   PanelRightOpenIcon,
   SearchIcon
 } from "lucide-react";
-import type { GraphNode, GraphViewModel, SourceLocation } from "../contracts/graph";
+import type {
+  GraphEdge,
+  GraphNode,
+  GraphViewModel,
+  SourceLocation
+} from "../contracts/graph";
+import { ChangeEvidence, type GraphSourceRevisions } from "./ChangeEvidence";
+import { ChangedSymbolList } from "./ChangedSymbolList";
 import { navigableSource } from "./sourceNavigation";
 
 function lineRange(node: GraphNode): string | undefined {
@@ -61,10 +68,12 @@ export function GraphInspector({
   model,
   selected,
   neighbors,
+  connectedEdges,
   query,
   matches,
   hiddenCommunities,
   comparisonMode,
+  sourceRevisions,
   onQueryChange,
   onFocus,
   onOpenSource,
@@ -77,13 +86,15 @@ export function GraphInspector({
   model: GraphViewModel;
   selected: GraphNode | undefined;
   neighbors: GraphNode[];
+  connectedEdges: GraphEdge[];
   query: string;
   matches: GraphNode[];
   hiddenCommunities: ReadonlySet<number>;
   comparisonMode: boolean;
+  sourceRevisions?: GraphSourceRevisions | undefined;
   onQueryChange(query: string): void;
   onFocus(nodeId: string): void;
-  onOpenSource(source: SourceLocation): void;
+  onOpenSource(source: SourceLocation, revision?: string): void;
   onOpenCommunity?: ((communityId: number) => void) | undefined;
   onToggleCommunity(communityId: number): void;
   onSetAllVisible(visible: boolean): void;
@@ -102,6 +113,10 @@ export function GraphInspector({
     return counts;
   }, [model.nodes]);
   const allVisible = hiddenCommunities.size === 0;
+  const nodeLookup = useMemo(
+    () => new Map(model.nodes.map((node) => [node.id, node])),
+    [model.nodes]
+  );
 
   const choose = (node: GraphNode) => {
     onFocus(node.id);
@@ -265,7 +280,12 @@ export function GraphInspector({
                         type="button"
                         aria-label={sourceActionLabel(selected, source)}
                         title={sourceActionLabel(selected, source)}
-                        onClick={() => onOpenSource(source)}
+                        onClick={() => onOpenSource(
+                          source,
+                          selected.change === "removed"
+                            ? sourceRevisions?.before
+                            : sourceRevisions?.after
+                        )}
                       >
                         <span className="compass-source-copy">
                           <span className="compass-source-eyebrow" aria-hidden="true">
@@ -303,39 +323,64 @@ export function GraphInspector({
                   type="button"
                   onClick={() => onOpenCommunity(selected.community)}
                 >
-                  Open community
-                  <span>{selected.memberCount.toLocaleString()} members</span>
+                  {comparisonMode ? "Inspect changes" : "Open community"}
+                  <span>
+                    {selected.memberCount.toLocaleString()}{" "}
+                    {comparisonMode ? "current symbols" : "members"}
+                  </span>
                 </button>
               )}
-            <div className="compass-neighbors-heading">
-              <span>Connected nodes</span>
-              <strong>{neighbors.length}</strong>
-            </div>
-            <div className="compass-neighbors-list">
-              {neighbors.length ? neighbors.map((neighbor) => (
-                <button
-                  key={neighbor.id}
-                  type="button"
-                  className="compass-neighbor-link"
-                  title={neighbor.label}
-                  onClick={() => onFocus(neighbor.id)}
-                >
-                  <span
-                    className="compass-neighbor-dot"
-                    aria-hidden="true"
-                    style={{ background: neighbor.color?.background
-                      ?? model.communities.find((item) => item.id === neighbor.community)?.color
-                      ?? "var(--border)" }}
-                  />
-                  <span className="compass-neighbor-label">{neighbor.label}</span>
-                </button>
-              )) : <span className="compass-empty">No connected nodes</span>}
-            </div>
+            {comparisonMode ? (
+              <ChangeEvidence
+                node={selected}
+                edges={connectedEdges}
+                nodes={nodeLookup}
+                sourceRevisions={sourceRevisions}
+                onFocus={onFocus}
+                onOpenSource={onOpenSource}
+              />
+            ) : (
+              <>
+                <div className="compass-neighbors-heading">
+                  <span>Connected nodes</span>
+                  <strong>{neighbors.length}</strong>
+                </div>
+                <div className="compass-neighbors-list">
+                  {neighbors.length ? neighbors.map((neighbor) => (
+                    <button
+                      key={neighbor.id}
+                      type="button"
+                      className="compass-neighbor-link"
+                      title={neighbor.label}
+                      onClick={() => onFocus(neighbor.id)}
+                    >
+                      <span
+                        className="compass-neighbor-dot"
+                        aria-hidden="true"
+                        style={{ background: neighbor.color?.background
+                          ?? model.communities.find((item) => item.id === neighbor.community)?.color
+                          ?? "var(--border)" }}
+                      />
+                      <span className="compass-neighbor-label">{neighbor.label}</span>
+                    </button>
+                  )) : <span className="compass-empty">No connected nodes</span>}
+                </div>
+              </>
+            )}
           </div>
         ) : (
           <p className="compass-empty">Select a node to inspect its relationships.</p>
         )}
       </section>
+
+      {comparisonMode && !model.stats.aggregated && (
+        <ChangedSymbolList
+          nodes={model.nodes}
+          query={query}
+          selectedId={selected?.id}
+          onFocus={onFocus}
+        />
+      )}
 
       <section
         className="compass-community-panel"

--- a/packages/compass-viewer/src/graph/NodeHoverCard.tsx
+++ b/packages/compass-viewer/src/graph/NodeHoverCard.tsx
@@ -40,7 +40,12 @@ export function NodeHoverCard({
         </span>
       )}
       {node.memberCount !== undefined ? (
-        <p>{node.memberCount.toLocaleString()} symbols</p>
+        <>
+          <p>{node.memberCount.toLocaleString()} symbols</p>
+          {node.change && node.change !== "unchanged" && (
+            <p className="compass-hover-hint">Select to inspect exact changes</p>
+          )}
+        </>
       ) : (
         <>
           {node.language && <p>Language: {node.language}</p>}

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -159,6 +159,75 @@ describe("compareGraphs", () => {
       fields: [{ field: "memberCount", before: 5, after: 6 }]
     });
   });
+
+  it("matches production edges when inserted relationships shift generated IDs", () => {
+    const nodes = [
+      { id: "a", label: "A", community: 0 },
+      { id: "b", label: "B", community: 0 },
+      { id: "c", label: "C", community: 0 },
+      { id: "d", label: "D", community: 0 }
+    ];
+    const parent = graph(nodes, [
+      { id: "edge-0-b-c", source: "b", target: "c", relation: "calls" },
+      { id: "edge-1-c-d", source: "c", target: "d", relation: "uses" }
+    ]);
+    const current = graph(nodes, [
+      { id: "edge-0-a-b", source: "a", target: "b", relation: "calls" },
+      { id: "edge-1-b-c", source: "b", target: "c", relation: "calls" },
+      { id: "edge-2-c-d", source: "c", target: "d", relation: "uses" }
+    ]);
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison).toMatchObject({
+      addedEdges: 1,
+      removedEdges: 0,
+      changedEdges: 0
+    });
+    expect(comparison.graph.edges).toMatchObject([
+      { id: "edge-0-a-b", source: "a", target: "b", change: "added" }
+    ]);
+  });
+
+  it("retains field evidence when a shifted generated edge changes", () => {
+    const nodes = [
+      { id: "a", label: "A", community: 0 },
+      { id: "b", label: "B", community: 0 },
+      { id: "c", label: "C", community: 0 }
+    ];
+    const parent = graph(nodes, [
+      {
+        id: "edge-0-b-c",
+        source: "b",
+        target: "c",
+        relation: "calls",
+        confidence: "inferred"
+      }
+    ]);
+    const current = graph(nodes, [
+      { id: "edge-0-a-b", source: "a", target: "b", relation: "calls" },
+      {
+        id: "edge-1-b-c",
+        source: "b",
+        target: "c",
+        relation: "uses",
+        confidence: "extracted"
+      }
+    ]);
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison).toMatchObject({
+      addedEdges: 1,
+      removedEdges: 0,
+      changedEdges: 1
+    });
+    expect(comparison.graph.edges.find((edge) => edge.change === "changed")?.evidence?.fields)
+      .toEqual([
+        { field: "confidence", before: "inferred", after: "extracted" },
+        { field: "relation", before: "calls", after: "uses" }
+      ]);
+  });
 });
 
 describe("record diff presentation", () => {

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { GraphViewModel } from "../contracts/graph";
 import { compareGraphs } from "./ComparisonOverlay";
+import { compareRecord, displayFieldValue } from "./recordDiff";
 
 function graph(
   nodes: GraphViewModel["nodes"],
@@ -83,5 +84,100 @@ describe("compareGraphs", () => {
     expect(comparison.graph.nodes).toEqual([]);
     expect(comparison.graph.edges).toEqual([]);
     expect(comparison.graph.stats).toMatchObject({ nodes: 0, edges: 0 });
+  });
+
+  it("retains exact before and after fields without presentation metadata", () => {
+    const parent = graph(
+      [{
+        id: "shared",
+        label: "Shared",
+        community: 0,
+        signature: "old()",
+        source: { file: "src/core.ts", startLine: 2 },
+        color: { background: "#111111", border: "#222222" }
+      }],
+      [{
+        id: "edge",
+        source: "shared",
+        target: "shared",
+        relation: "calls",
+        confidence: "inferred"
+      }]
+    );
+    const current = graph(
+      [{
+        id: "shared",
+        label: "Shared",
+        community: 0,
+        signature: "new()",
+        source: { file: "src/core.ts", startLine: 4 },
+        color: { background: "#eeeeee", border: "#dddddd" }
+      }],
+      [{
+        id: "edge",
+        source: "shared",
+        target: "shared",
+        relation: "invokes",
+        confidence: "extracted"
+      }]
+    );
+
+    const comparison = compareGraphs(parent, current);
+    const changedNode = comparison.graph.nodes[0];
+    const changedEdge = comparison.graph.edges[0];
+
+    expect(changedNode?.evidence?.fields).toEqual([
+      { field: "signature", before: "old()", after: "new()" },
+      { field: "source.startLine", before: 2, after: 4 }
+    ]);
+    expect(changedNode?.evidence?.fields.map((field) => field.field))
+      .not.toContain("color.background");
+    expect(changedEdge?.evidence?.fields).toEqual([
+      { field: "confidence", before: "inferred", after: "extracted" },
+      { field: "relation", before: "calls", after: "invokes" }
+    ]);
+  });
+
+  it("preserves aggregate comparison mode for community drill-down", () => {
+    const parent = graph(
+      [{ id: "community-0", label: "Core", community: 0, memberCount: 5 }],
+      []
+    );
+    const current = graph(
+      [{ id: "community-0", label: "Core", community: 0, memberCount: 6 }],
+      []
+    );
+    parent.stats.aggregated = true;
+    current.stats.aggregated = true;
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison.graph.stats.aggregated).toBe(true);
+    expect(comparison.graph.nodes[0]?.evidence).toMatchObject({
+      before: { memberCount: 5 },
+      after: { memberCount: 6 },
+      fields: [{ field: "memberCount", before: 5, after: 6 }]
+    });
+  });
+});
+
+describe("record diff presentation", () => {
+  it("is independent of object key order and reports missing nested values", () => {
+    const evidence = compareRecord(
+      { source: { startLine: 2, file: "src/core.ts" }, signature: "same()" },
+      { signature: "same()", source: { file: "src/core.ts", endLine: 8 } }
+    );
+
+    expect(evidence.fields).toEqual([
+      { field: "source.endLine", after: 8 },
+      { field: "source.startLine", before: 2 }
+    ]);
+  });
+
+  it("bounds structured values and marks them as shortened", () => {
+    expect(displayFieldValue({ detail: "x".repeat(100) }, 32)).toEqual({
+      text: expect.stringMatching(/…$/),
+      truncated: true
+    });
   });
 });

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -228,6 +228,42 @@ describe("compareGraphs", () => {
         { field: "relation", before: "calls", after: "uses" }
       ]);
   });
+
+  it("keeps stable custom edge IDs authoritative when parallel records swap", () => {
+    const nodes = [
+      { id: "a", label: "A", community: 0 },
+      { id: "b", label: "B", community: 0 }
+    ];
+    const parent = graph(nodes, [
+      { id: "primary", source: "a", target: "b", relation: "calls" },
+      { id: "secondary", source: "a", target: "b", relation: "uses" }
+    ]);
+    const current = graph(nodes, [
+      { id: "primary", source: "a", target: "b", relation: "uses" },
+      { id: "secondary", source: "a", target: "b", relation: "calls" }
+    ]);
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison).toMatchObject({
+      addedEdges: 0,
+      removedEdges: 0,
+      changedEdges: 2
+    });
+    expect(comparison.graph.edges.map((edge) => ({
+      id: edge.id,
+      fields: edge.evidence?.fields
+    }))).toEqual([
+      {
+        id: "primary",
+        fields: [{ field: "relation", before: "calls", after: "uses" }]
+      },
+      {
+        id: "secondary",
+        fields: [{ field: "relation", before: "uses", after: "calls" }]
+      }
+    ]);
+  });
 });
 
 describe("record diff presentation", () => {

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -90,8 +90,6 @@ export function compareGraphs(
 ): GraphComparison {
   const parentNodes = new Map(parent.nodes.map((node) => [node.id, node]));
   const currentNodes = new Map(current.nodes.map((node) => [node.id, node]));
-  const parentEdges = new Map(parent.edges.map((edge) => [edge.id, edge]));
-  const currentEdges = new Map(current.edges.map((edge) => [edge.id, edge]));
   const nodes = new Map<string, GraphNode>();
   const edges: GraphEdge[] = [];
   const addedNodeIds = difference(currentNodes, parentNodes);
@@ -103,15 +101,14 @@ export function compareGraphs(
   const changedNodeIds = [...nodeEvidence.entries()]
     .filter(([, evidence]) => evidence.fields.length > 0)
     .map(([id]) => id);
-  const addedEdgeIds = difference(currentEdges, parentEdges);
-  const removedEdgeIds = difference(parentEdges, currentEdges);
-  const edgeEvidence = new Map(intersection(currentEdges, parentEdges).map((id) => [
-    id,
-    compareRecord(parentEdges.get(id), currentEdges.get(id))
-  ]));
-  const changedEdgeIds = [...edgeEvidence.entries()]
-    .filter(([, evidence]) => evidence.fields.length > 0)
-    .map(([id]) => id);
+  const edgeMatches = matchEdges(parent.edges, current.edges);
+  const changedEdgeMatches = edgeMatches.matched
+    .map(({ before, after }) => ({
+      before,
+      after,
+      evidence: compareMatchedEdges(before, after)
+    }))
+    .filter(({ evidence }) => evidence.fields.length > 0);
 
   for (const id of addedNodeIds) {
     addNode(
@@ -132,26 +129,29 @@ export function compareGraphs(
   for (const id of changedNodeIds) {
     addNode(nodes, currentNodes.get(id), "changed", nodeEvidence.get(id));
   }
-  for (const [ids, source, change] of [
-    [addedEdgeIds, currentEdges, "added"],
-    [removedEdgeIds, parentEdges, "removed"],
-    [changedEdgeIds, currentEdges, "changed"]
-  ] as const) {
-    for (const id of ids) {
-      const edge = source.get(id);
-      if (!edge) continue;
-      const evidence = change === "added"
-        ? compareRecord(undefined, edge)
-        : change === "removed"
-          ? compareRecord(edge, undefined)
-          : edgeEvidence.get(id);
-      edges.push({ ...edge, change, ...(evidence ? { evidence } : {}) });
-      addContextNode(nodes, edge.source, parentNodes, currentNodes);
-      addContextNode(nodes, edge.target, parentNodes, currentNodes);
-    }
+  for (const edge of edgeMatches.added) {
+    edges.push({
+      ...edge,
+      change: "added",
+      evidence: compareRecord(undefined, edge)
+    });
+    addEdgeContext(nodes, edge, parentNodes, currentNodes);
+  }
+  for (const edge of edgeMatches.removed) {
+    edges.push({
+      ...edge,
+      change: "removed",
+      evidence: compareRecord(edge, undefined)
+    });
+    addEdgeContext(nodes, edge, parentNodes, currentNodes);
+  }
+  for (const { after, evidence } of changedEdgeMatches) {
+    edges.push({ ...after, change: "changed", evidence });
+    addEdgeContext(nodes, after, parentNodes, currentNodes);
   }
   const orderedNodes = [...nodes.values()].sort((left, right) => left.id.localeCompare(right.id));
   edges.sort((left, right) => left.id.localeCompare(right.id));
+  const orderedEdges = uniqueEdgeIds(edges);
   const communityIds = new Set(orderedNodes.map((node) => node.community));
   const communities = [
     ...current.communities,
@@ -162,21 +162,21 @@ export function compareGraphs(
     addedNodes: addedNodeIds.length,
     removedNodes: removedNodeIds.length,
     changedNodes: changedNodeIds.length,
-    addedEdges: addedEdgeIds.length,
-    removedEdges: removedEdgeIds.length,
-    changedEdges: changedEdgeIds.length,
+    addedEdges: edgeMatches.added.length,
+    removedEdges: edgeMatches.removed.length,
+    changedEdges: changedEdgeMatches.length,
     graph: {
       ...current,
       title: `Graph delta · ${current.title}`,
       stats: {
         ...current.stats,
         nodes: orderedNodes.length,
-        edges: edges.length,
+        edges: orderedEdges.length,
         communities: communities.length,
         aggregated: parent.stats.aggregated || current.stats.aggregated
       },
       nodes: orderedNodes,
-      edges,
+      edges: orderedEdges,
       communities,
       hyperedges: []
     }
@@ -215,5 +215,139 @@ function addContextNode(
   if (node) nodes.set(id, {
     ...node,
     change: "unchanged"
+  });
+}
+
+function addEdgeContext(
+  nodes: Map<string, GraphNode>,
+  edge: GraphEdge,
+  parent: ReadonlyMap<string, GraphNode>,
+  current: ReadonlyMap<string, GraphNode>
+): void {
+  addContextNode(nodes, edge.source, parent, current);
+  addContextNode(nodes, edge.target, parent, current);
+}
+
+function compareMatchedEdges(
+  before: GraphEdge,
+  after: GraphEdge
+): GraphRecordEvidence {
+  return compareRecord(
+    { ...before, id: after.id },
+    after
+  );
+}
+
+function matchEdges(
+  parent: GraphEdge[],
+  current: GraphEdge[]
+): {
+  matched: Array<{ before: GraphEdge; after: GraphEdge }>;
+  added: GraphEdge[];
+  removed: GraphEdge[];
+} {
+  const parentUsed = new Set<number>();
+  const currentUsed = new Set<number>();
+  const matched: Array<{ before: GraphEdge; after: GraphEdge }> = [];
+  const pair = (parentIndex: number, currentIndex: number): void => {
+    parentUsed.add(parentIndex);
+    currentUsed.add(currentIndex);
+    matched.push({
+      before: parent[parentIndex]!,
+      after: current[currentIndex]!
+    });
+  };
+
+  pairEdgesByKey(parent, current, parentUsed, currentUsed, pair, edgeSemanticKey);
+  pairEdgesByKey(
+    parent,
+    current,
+    parentUsed,
+    currentUsed,
+    pair,
+    (edge) => isGeneratedEdgeId(edge.id) ? undefined : edge.id
+  );
+
+  const endpointGroups = new Map<string, { parent: number[]; current: number[] }>();
+  parent.forEach((edge, index) => {
+    if (parentUsed.has(index)) return;
+    const group = endpointGroups.get(edgeEndpointKey(edge)) ?? { parent: [], current: [] };
+    group.parent.push(index);
+    endpointGroups.set(edgeEndpointKey(edge), group);
+  });
+  current.forEach((edge, index) => {
+    if (currentUsed.has(index)) return;
+    const group = endpointGroups.get(edgeEndpointKey(edge)) ?? { parent: [], current: [] };
+    group.current.push(index);
+    endpointGroups.set(edgeEndpointKey(edge), group);
+  });
+  for (const group of endpointGroups.values()) {
+    group.parent.sort((left, right) => compareEdgeOrder(parent[left]!, parent[right]!));
+    group.current.sort((left, right) => compareEdgeOrder(current[left]!, current[right]!));
+    const pairCount = Math.min(group.parent.length, group.current.length);
+    for (let index = 0; index < pairCount; index += 1) {
+      pair(group.parent[index]!, group.current[index]!);
+    }
+  }
+
+  return {
+    matched,
+    added: current.filter((_, index) => !currentUsed.has(index)),
+    removed: parent.filter((_, index) => !parentUsed.has(index))
+  };
+}
+
+function pairEdgesByKey(
+  parent: GraphEdge[],
+  current: GraphEdge[],
+  parentUsed: ReadonlySet<number>,
+  currentUsed: ReadonlySet<number>,
+  pair: (parentIndex: number, currentIndex: number) => void,
+  keyFor: (edge: GraphEdge) => string | undefined
+): void {
+  const currentByKey = new Map<string, number[]>();
+  current.forEach((edge, index) => {
+    if (currentUsed.has(index)) return;
+    const key = keyFor(edge);
+    if (key === undefined) return;
+    const indexes = currentByKey.get(key) ?? [];
+    indexes.push(index);
+    currentByKey.set(key, indexes);
+  });
+  parent.forEach((edge, parentIndex) => {
+    if (parentUsed.has(parentIndex)) return;
+    const key = keyFor(edge);
+    if (key === undefined) return;
+    const candidates = currentByKey.get(key);
+    const currentIndex = candidates?.shift();
+    if (currentIndex !== undefined) pair(parentIndex, currentIndex);
+  });
+}
+
+function edgeSemanticKey(edge: GraphEdge): string {
+  const record: Record<string, unknown> = { ...edge };
+  delete record.id;
+  return JSON.stringify(compareRecord(undefined, record).after);
+}
+
+function edgeEndpointKey(edge: GraphEdge): string {
+  return JSON.stringify([edge.source, edge.target]);
+}
+
+function compareEdgeOrder(left: GraphEdge, right: GraphEdge): number {
+  return edgeSemanticKey(left).localeCompare(edgeSemanticKey(right))
+    || left.id.localeCompare(right.id);
+}
+
+function isGeneratedEdgeId(id: string): boolean {
+  return /^edge-\d+-/.test(id);
+}
+
+function uniqueEdgeIds(edges: GraphEdge[]): GraphEdge[] {
+  const counts = new Map<string, number>();
+  return edges.map((edge) => {
+    const count = counts.get(edge.id) ?? 0;
+    counts.set(edge.id, count + 1);
+    return count === 0 ? edge : { ...edge, id: `${edge.id}::${edge.change}-${count}` };
   });
 }

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -2,8 +2,10 @@ import { GitCompareIcon, XIcon } from "lucide-react";
 import type {
   GraphEdge,
   GraphNode,
+  GraphRecordEvidence,
   GraphViewModel
 } from "../contracts/graph";
+import { compareRecord } from "./recordDiff";
 
 export type GraphComparison = {
   addedNodes: number;
@@ -94,16 +96,42 @@ export function compareGraphs(
   const edges: GraphEdge[] = [];
   const addedNodeIds = difference(currentNodes, parentNodes);
   const removedNodeIds = difference(parentNodes, currentNodes);
-  const changedNodeIds = intersection(currentNodes, parentNodes)
-    .filter((id) => !sameRecord(currentNodes.get(id), parentNodes.get(id)));
+  const nodeEvidence = new Map(intersection(currentNodes, parentNodes).map((id) => [
+    id,
+    compareRecord(parentNodes.get(id), currentNodes.get(id))
+  ]));
+  const changedNodeIds = [...nodeEvidence.entries()]
+    .filter(([, evidence]) => evidence.fields.length > 0)
+    .map(([id]) => id);
   const addedEdgeIds = difference(currentEdges, parentEdges);
   const removedEdgeIds = difference(parentEdges, currentEdges);
-  const changedEdgeIds = intersection(currentEdges, parentEdges)
-    .filter((id) => !sameRecord(currentEdges.get(id), parentEdges.get(id)));
+  const edgeEvidence = new Map(intersection(currentEdges, parentEdges).map((id) => [
+    id,
+    compareRecord(parentEdges.get(id), currentEdges.get(id))
+  ]));
+  const changedEdgeIds = [...edgeEvidence.entries()]
+    .filter(([, evidence]) => evidence.fields.length > 0)
+    .map(([id]) => id);
 
-  for (const id of addedNodeIds) addNode(nodes, currentNodes.get(id), "added");
-  for (const id of removedNodeIds) addNode(nodes, parentNodes.get(id), "removed");
-  for (const id of changedNodeIds) addNode(nodes, currentNodes.get(id), "changed");
+  for (const id of addedNodeIds) {
+    addNode(
+      nodes,
+      currentNodes.get(id),
+      "added",
+      compareRecord(undefined, currentNodes.get(id))
+    );
+  }
+  for (const id of removedNodeIds) {
+    addNode(
+      nodes,
+      parentNodes.get(id),
+      "removed",
+      compareRecord(parentNodes.get(id), undefined)
+    );
+  }
+  for (const id of changedNodeIds) {
+    addNode(nodes, currentNodes.get(id), "changed", nodeEvidence.get(id));
+  }
   for (const [ids, source, change] of [
     [addedEdgeIds, currentEdges, "added"],
     [removedEdgeIds, parentEdges, "removed"],
@@ -112,7 +140,12 @@ export function compareGraphs(
     for (const id of ids) {
       const edge = source.get(id);
       if (!edge) continue;
-      edges.push({ ...edge, change });
+      const evidence = change === "added"
+        ? compareRecord(undefined, edge)
+        : change === "removed"
+          ? compareRecord(edge, undefined)
+          : edgeEvidence.get(id);
+      edges.push({ ...edge, change, ...(evidence ? { evidence } : {}) });
       addContextNode(nodes, edge.source, parentNodes, currentNodes);
       addContextNode(nodes, edge.target, parentNodes, currentNodes);
     }
@@ -140,7 +173,7 @@ export function compareGraphs(
         nodes: orderedNodes.length,
         edges: edges.length,
         communities: communities.length,
-        aggregated: false
+        aggregated: parent.stats.aggregated || current.stats.aggregated
       },
       nodes: orderedNodes,
       edges,
@@ -158,16 +191,17 @@ function intersection<T>(left: ReadonlyMap<string, T>, right: ReadonlyMap<string
   return [...left.keys()].filter((id) => right.has(id));
 }
 
-function sameRecord(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
-}
-
 function addNode(
   nodes: Map<string, GraphNode>,
   node: GraphNode | undefined,
-  change: "added" | "removed" | "changed"
+  change: "added" | "removed" | "changed",
+  evidence: GraphRecordEvidence | undefined
 ): void {
-  if (node) nodes.set(node.id, { ...node, change });
+  if (node) nodes.set(node.id, {
+    ...node,
+    change,
+    ...(evidence ? { evidence } : {})
+  });
 }
 
 function addContextNode(

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -258,7 +258,6 @@ function matchEdges(
     });
   };
 
-  pairEdgesByKey(parent, current, parentUsed, currentUsed, pair, edgeSemanticKey);
   pairEdgesByKey(
     parent,
     current,
@@ -267,16 +266,24 @@ function matchEdges(
     pair,
     (edge) => isGeneratedEdgeId(edge.id) ? undefined : edge.id
   );
+  pairEdgesByKey(
+    parent,
+    current,
+    parentUsed,
+    currentUsed,
+    pair,
+    (edge) => isGeneratedEdgeId(edge.id) ? edgeSemanticKey(edge) : undefined
+  );
 
   const endpointGroups = new Map<string, { parent: number[]; current: number[] }>();
   parent.forEach((edge, index) => {
-    if (parentUsed.has(index)) return;
+    if (parentUsed.has(index) || !isGeneratedEdgeId(edge.id)) return;
     const group = endpointGroups.get(edgeEndpointKey(edge)) ?? { parent: [], current: [] };
     group.parent.push(index);
     endpointGroups.set(edgeEndpointKey(edge), group);
   });
   current.forEach((edge, index) => {
-    if (currentUsed.has(index)) return;
+    if (currentUsed.has(index) || !isGeneratedEdgeId(edge.id)) return;
     const group = endpointGroups.get(edgeEndpointKey(edge)) ?? { parent: [], current: [] };
     group.current.push(index);
     endpointGroups.set(edgeEndpointKey(edge), group);

--- a/packages/compass-viewer/src/history/HistoryWorkspace.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.tsx
@@ -12,7 +12,10 @@ import {
   SparklesIcon
 } from "lucide-react";
 import { WorkspaceState } from "../components/workbench/WorkspaceState";
-import { CompassGraph } from "../graph/CompassGraph";
+import {
+  CompassGraph,
+  type CommunityGraphDetail
+} from "../graph/CompassGraph";
 import type { GraphViewModel, SourceLocation } from "../contracts/graph";
 import type {
   HistoryBuildState,
@@ -71,7 +74,7 @@ export function HistoryWorkspace({
   semanticDiff?: unknown;
   changeCounts?: HistoryChangeCounts | undefined;
   graphCommit?: string | undefined;
-  communityDetail?: { communityId: number; model: GraphViewModel } | undefined;
+  communityDetail?: CommunityGraphDetail | undefined;
   communityLoading?: number | null | undefined;
   communityError?: string | undefined;
   onBackToOverview?: (() => void) | undefined;
@@ -322,7 +325,9 @@ export function HistoryWorkspace({
                       ) : (
                         <div className="history-graph-ready">
                           <div className="history-graph-status" role="status">
-                            Viewing changed subgraph for{" "}
+                            {communityDetail
+                              ? `Viewing exact changes in community ${communityDetail.communityId} for `
+                              : "Viewing changed subgraph for "}
                             <span>{selected.commit.slice(0, 9)}</span>
                           </div>
                           <div className="history-graph-canvas">
@@ -332,9 +337,13 @@ export function HistoryWorkspace({
                               communityLoading={communityLoading}
                               communityError={communityError}
                               onBackToOverview={onBackToOverview}
+                              sourceRevisions={{
+                                before: comparison.parent,
+                                after: selected.commit
+                              }}
                               host={{
-                                openSource(source) {
-                                  host.openSource(selected.commit, source);
+                                openSource(source, revision) {
+                                  host.openSource(revision ?? selected.commit, source);
                                 },
                                 openCommunity(communityId) {
                                   if (graphCommit) host.openCommunity(graphCommit, communityId);
@@ -375,8 +384,8 @@ export function HistoryWorkspace({
                           communityError={communityError}
                           onBackToOverview={onBackToOverview}
                           host={{
-                            openSource(source) {
-                              host.openSource(selected.commit, source);
+                            openSource(source, revision) {
+                              host.openSource(revision ?? selected.commit, source);
                             },
                             openCommunity(communityId) {
                               if (graphCommit) host.openCommunity(graphCommit, communityId);

--- a/packages/compass-viewer/src/history/recordDiff.ts
+++ b/packages/compass-viewer/src/history/recordDiff.ts
@@ -1,0 +1,89 @@
+import type { GraphRecordEvidence } from "../contracts/graph";
+
+const PRESENTATION_FIELDS = new Set(["color", "change", "evidence"]);
+
+export function compareRecord(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined
+): GraphRecordEvidence {
+  const canonicalBefore = canonicalRecord(before);
+  const canonicalAfter = canonicalRecord(after);
+  return {
+    ...(canonicalBefore ? { before: canonicalBefore } : {}),
+    ...(canonicalAfter ? { after: canonicalAfter } : {}),
+    fields: collectChanges(canonicalBefore, canonicalAfter)
+  };
+}
+
+export function displayFieldValue(
+  value: unknown,
+  maxLength = 240
+): { text: string; truncated: boolean } {
+  const complete = value === undefined
+    ? "Not recorded"
+    : typeof value === "string"
+      ? value
+      : JSON.stringify(value, null, isStructured(value) ? 2 : undefined) ?? String(value);
+  if (complete.length <= maxLength) return { text: complete, truncated: false };
+  return {
+    text: `${complete.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`,
+    truncated: true
+  };
+}
+
+function canonicalRecord(
+  record: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+  return canonicalObject(record);
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (isStructured(value)) return canonicalObject(value);
+  return value;
+}
+
+function canonicalObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.keys(value)
+      .filter((key) => !PRESENTATION_FIELDS.has(key))
+      .sort((left, right) => left.localeCompare(right))
+      .map((key) => [key, canonicalValue(value[key])])
+  );
+}
+
+function collectChanges(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined,
+  prefix = ""
+): GraphRecordEvidence["fields"] {
+  const keys = new Set([
+    ...Object.keys(before ?? {}),
+    ...Object.keys(after ?? {})
+  ]);
+  const changes: GraphRecordEvidence["fields"] = [];
+  for (const key of [...keys].sort((left, right) => left.localeCompare(right))) {
+    const field = prefix ? `${prefix}.${key}` : key;
+    const previous = before?.[key];
+    const next = after?.[key];
+    if (isStructured(previous) && isStructured(next)) {
+      changes.push(...collectChanges(previous, next, field));
+    } else if (!sameValue(previous, next)) {
+      changes.push({
+        field,
+        ...(previous !== undefined ? { before: previous } : {}),
+        ...(next !== undefined ? { after: next } : {})
+      });
+    }
+  }
+  return changes;
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(canonicalValue(left)) === JSON.stringify(canonicalValue(right));
+}
+
+function isStructured(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -904,6 +904,13 @@ button:not(:disabled),
   outline-offset: 2px;
 }
 
+.compass-changed-symbols button:focus-visible,
+.compass-evidence-source-actions button:focus-visible,
+.compass-relationship-detail > button:focus-visible {
+  outline: 2px solid var(--compass-focus);
+  outline-offset: 2px;
+}
+
 .compass-change-legend {
   position: absolute;
   z-index: 4;
@@ -1218,6 +1225,273 @@ button:not(:disabled),
   overflow-y: auto;
   padding: 18px 16px;
   border-bottom: 1px solid var(--compass-line);
+}
+
+.compass-changed-symbols {
+  max-height: 30%;
+  overflow-y: auto;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--compass-line);
+}
+
+.compass-changed-symbol-list {
+  display: grid;
+  gap: 4px;
+}
+
+.compass-changed-symbol-list > button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 2px 8px;
+  width: 100%;
+  padding: 7px 8px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--foreground);
+  text-align: left;
+}
+
+.compass-changed-symbol-list > button:hover,
+.compass-changed-symbol-list > button[aria-pressed="true"] {
+  border-color: var(--compass-line);
+  background: var(--vscode-list-activeSelectionBackground, var(--compass-focus-soft));
+}
+
+.compass-changed-symbol-list strong,
+.compass-changed-symbol-list small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compass-changed-symbol-list small {
+  grid-column: 2;
+  color: var(--compass-faint);
+  font: 9px/1.35 var(--compass-font-mono);
+}
+
+.compass-changed-symbol-status {
+  grid-row: 1 / span 2;
+  align-self: center;
+  color: var(--vscode-descriptionForeground);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.compass-changed-symbol-list > button[data-change="added"] .compass-changed-symbol-status {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #2ea043);
+}
+
+.compass-changed-symbol-list > button[data-change="removed"] .compass-changed-symbol-status {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.compass-changed-symbol-list > button[data-change="changed"] .compass-changed-symbol-status {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}
+
+.compass-changed-symbol-expand {
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--compass-line);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.compass-record-evidence,
+.compass-relationship-evidence {
+  margin-top: 16px;
+}
+
+.compass-evidence-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 7px;
+}
+
+.compass-evidence-heading h3 {
+  color: var(--foreground);
+  font-size: 11px;
+}
+
+.compass-evidence-heading span {
+  color: var(--compass-faint);
+  font-size: 9px;
+}
+
+.compass-field-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--compass-line);
+  border-radius: 3px;
+}
+
+.compass-field-table {
+  width: 100%;
+  min-width: 360px;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.compass-field-table th,
+.compass-field-table td {
+  padding: 6px 7px;
+  border-right: 1px solid var(--compass-line);
+  border-bottom: 1px solid var(--compass-line);
+  vertical-align: top;
+  text-align: left;
+}
+
+.compass-field-table tr:last-child > * {
+  border-bottom: 0;
+}
+
+.compass-field-table tr > *:last-child {
+  border-right: 0;
+}
+
+.compass-field-table thead th {
+  background: var(--vscode-editorWidget-background, var(--background));
+  color: var(--compass-faint);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.compass-field-table tbody th {
+  width: 27%;
+  color: var(--foreground);
+  font: 9px/1.4 var(--compass-font-mono);
+  overflow-wrap: anywhere;
+}
+
+.compass-field-table code {
+  color: var(--foreground);
+  font: 9px/1.4 var(--compass-font-mono);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.compass-value-truncated {
+  display: block;
+  margin-top: 4px;
+  color: var(--vscode-editorWarning-foreground, #d29922);
+  font-size: 8px;
+}
+
+.compass-evidence-source-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.compass-evidence-source-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 7px;
+  border: 1px solid var(--compass-line);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.compass-evidence-source-actions svg {
+  width: 12px;
+  height: 12px;
+}
+
+.compass-relationship-list {
+  display: grid;
+  gap: 5px;
+  margin-top: 7px;
+}
+
+.compass-relationship-list details {
+  padding: 6px 7px;
+  border: 1px solid var(--compass-line);
+  border-radius: 3px;
+  background: var(--vscode-editorWidget-background, var(--background));
+}
+
+.compass-relationship-list summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px 7px;
+  cursor: pointer;
+}
+
+.compass-relationship-target {
+  overflow: hidden;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compass-relationship-list summary small {
+  grid-column: 2;
+  color: var(--foreground);
+  font: 9px/1.3 var(--compass-font-mono);
+}
+
+.compass-relationship-list summary i {
+  grid-column: 3;
+  grid-row: 2;
+  color: var(--compass-faint);
+  font-size: 8px;
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.compass-relationship-detail {
+  margin-top: 7px;
+}
+
+.compass-relationship-detail > p {
+  margin: 7px 0 0;
+  color: var(--compass-faint);
+  font: 9px/1.4 var(--compass-font-mono);
+}
+
+.compass-relationship-detail > button {
+  margin-top: 7px;
+  padding: 4px 7px;
+  border: 1px solid var(--compass-line);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.compass-bounded-notice {
+  position: absolute;
+  z-index: 4;
+  right: 12px;
+  bottom: 12px;
+  display: grid;
+  max-width: min(420px, calc(100% - 24px));
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-editorWarning-foreground, #d29922);
+  border-radius: 3px;
+  background: var(--vscode-editorWidget-background, var(--compass-panel));
+  color: var(--foreground);
+  font-size: 10px;
+}
+
+.compass-bounded-notice span {
+  color: var(--muted-foreground);
+}
+
+.compass-hover-hint {
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font-weight: 600;
 }
 
 .compass-section-heading,

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -204,6 +204,52 @@ export default async function generate(): Promise<void> {
     ...historyOverviewB,
     title: "Revision C graph"
   };
+  const historyCommunityA = {
+    ...communityDetail,
+    title: "Core detail at revision A",
+    stats: { nodes: 3, edges: 1, communities: 1, aggregated: false },
+    nodes: [
+      {
+        id: "run", label: "run", kind: "function", community: 0, degree: 1,
+        language: "rust", signature: "pub fn run(old_value: usize)",
+        source: { file: "src/lib.rs", startLine: 1, endLine: 3 }
+      },
+      {
+        id: "shared", label: "shared", kind: "function", community: 0, degree: 1,
+        language: "rust", signature: "fn shared()",
+        source: { file: "src/shared.rs", startLine: 4, endLine: 6 }
+      },
+      {
+        id: "removed", label: "removed_symbol", kind: "function", community: 0,
+        source: { file: "src/removed.rs", startLine: 1 }
+      }
+    ],
+    edges: [{
+      id: "run-shared", source: "run", target: "shared", relation: "calls",
+      confidence: "inferred"
+    }],
+    communities: communityOverview.communities.slice(0, 1)
+  };
+  const historyCommunityB = {
+    ...historyCommunityA,
+    title: "Core detail at revision B",
+    nodes: [
+      {
+        id: "run", label: "run", kind: "function", community: 0, degree: 1,
+        language: "rust", signature: "pub fn run(new_value: usize)",
+        source: { file: "src/lib.rs", startLine: 8, endLine: 11 }
+      },
+      historyCommunityA.nodes[1],
+      {
+        id: "added", label: "added_symbol", kind: "function", community: 0,
+        source: { file: "src/added.rs", startLine: 1 }
+      }
+    ],
+    edges: [{
+      id: "run-shared", source: "run", target: "shared", relation: "uses",
+      confidence: "extracted"
+    }]
+  };
   await writeFile(path.join(output, "architecture.html"), architectureHarness(architecture));
   await writeFile(path.join(output, "calls.html"), callGraphHarness(calls));
   await writeFile(
@@ -215,7 +261,11 @@ export default async function generate(): Promise<void> {
         [commitB]: historyOverviewB,
         [commitC]: historyOverviewC
       },
-      communityDetail
+      {
+        [commitA]: historyCommunityA,
+        [commitB]: historyCommunityB,
+        [commitC]: historyCommunityB
+      }
     )
   );
   await writeFile(path.join(output, "query.html"), queryHarness());
@@ -560,10 +610,13 @@ window.acquireVsCodeApi=()=>({postMessage(message){
   progress(40,1,3,"src/commands/init.ts");
   progress(440,2,3,"src/core/index.ts");
   progress(840,3,3,"src/views/graph.ts");
-  window.initializationTimers.push(setTimeout(
-    ()=>window.postMessage({type:"succeeded",message:"compass is indexed and ready for graph exploration."},"*"),
-    1240
-  ));
+  window.completeInitialization=()=>window.postMessage({
+    type:"succeeded",
+    message:"compass is indexed and ready for graph exploration."
+  },"*");
+  if(!new URLSearchParams(window.location.search).has("manualSuccess")) {
+    window.initializationTimers.push(setTimeout(window.completeInitialization,1240));
+  }
 }})</script><script src="/initialize.js"></script></body></html>`;
 }
 
@@ -591,11 +644,12 @@ window.acquireVsCodeApi=()=>({getState(){return window.webviewState},setState(st
 function historyHarness(
   timeline: { entries: Array<{ commit: string }> },
   graphs: Record<string, unknown>,
-  detail: unknown
+  details: Record<string, unknown>
 ): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Compass history fixture</title><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; style-src-attr 'unsafe-inline'; script-src 'self' 'unsafe-inline';"><link rel="stylesheet" href="/viewer.css"></head><body><div id="root"></div><script>
 window.fixtureTimeline=${JSON.stringify(timeline)};
 window.historyGraphs=${JSON.stringify(graphs)};
+window.historyCommunityGraphs=${JSON.stringify(details)};
 window.historyHostMessages=[];
 window.historyBootstrapAttempts=0;
 window.historyGeneration=0;
@@ -670,7 +724,7 @@ window.acquireVsCodeApi=()=>({postMessage(message){
     },"*"),20);
   } else if(message.type==="openCommunity") {
     window.openedHistoricalCommunity=message.communityId;
-    setTimeout(()=>window.postMessage({type:"communityGraph",requestId:message.requestId,commit:message.commit,communityId:message.communityId,graph:${JSON.stringify(detail)}},"*"),0);
+    setTimeout(()=>window.postMessage({type:"communityGraph",requestId:message.requestId,commit:message.commit,communityId:message.communityId,graph:window.historyCommunityGraphs[message.commit]},"*"),0);
   } else if(message.type==="compare") {
     setTimeout(()=>window.postMessage({
       type:"comparison",
@@ -678,6 +732,8 @@ window.acquireVsCodeApi=()=>({postMessage(message){
       parent:message.parent,
       realization:"r-"+message.commit.slice(0,1),
       fingerprint:"f-"+message.commit.slice(0,1),
+      parentRealization:"r-"+message.parent.slice(0,1),
+      parentFingerprint:"f-"+message.parent.slice(0,1),
       currentGraph:window.historyGraphs[message.commit],
       parentGraph:window.historyGraphs[message.parent],
       counts:{
@@ -699,6 +755,17 @@ window.acquireVsCodeApi=()=>({postMessage(message){
         }],
         findings:[{summary:"Fixture comparison"}]
       }
+    },"*"),0);
+  } else if(message.type==="compareCommunity") {
+    setTimeout(()=>window.postMessage({
+      type:"communityComparison",
+      requestId:message.requestId,
+      commit:message.commit,
+      parent:message.parent,
+      communityId:message.communityId,
+      currentGraph:message.hasCurrent ? window.historyCommunityGraphs[message.commit] : undefined,
+      parentGraph:message.hasParent ? window.historyCommunityGraphs[message.parent] : undefined,
+      nodeLimit:5000
     },"*"),0);
   } else if(message.type==="buildRevision") {
     const scenario=new URLSearchParams(window.location.search).get("build") || "cancel";

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -160,6 +160,32 @@ test("comparison replaces the full graph with a readable focused delta", async (
   await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
   await expect(page.getByLabel("Graph change filters")).toContainText("Changed2");
 
+  const graphSearch = page.getByRole("combobox", { name: "Search graph nodes" });
+  await graphSearch.fill("Core B");
+  await page.getByRole("option", { name: /Core B/i }).click();
+  await page.getByRole("button", { name: /Inspect changes/i }).click();
+
+  await expect(page.getByText(/Viewing exact changes in community 0/)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Changed symbols" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Changed run/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Added added_symbol/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Removed removed_symbol/i })).toBeVisible();
+
+  await page.getByRole("button", { name: /Changed run/i }).click();
+  await expect(page.getByRole("heading", { name: "What changed" })).toBeVisible();
+  const fieldEvidence = page.locator(".compass-record-evidence");
+  await expect(fieldEvidence.getByText("pub fn run(old_value: usize)")).toBeVisible();
+  await expect(fieldEvidence.getByText("pub fn run(new_value: usize)")).toBeVisible();
+  const relationshipEvidence = page.locator(".compass-relationship-evidence");
+  await relationshipEvidence.locator("summary").click();
+  await expect(relationshipEvidence.getByText("inferred")).toBeVisible();
+  await expect(relationshipEvidence.locator("summary i")).toHaveText("extracted");
+  await expect(page.getByRole("button", { name: "Open before" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Open after" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Back to community overview" }).click();
+  await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
+
   await page.getByRole("tab", { name: /Semantic findings/ }).click();
   await expect(page.getByText("Fixture comparison", { exact: true })).toBeVisible();
 

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -192,6 +192,15 @@ test("comparison replaces the full graph with a readable focused delta", async (
   await page.getByRole("button", { name: "Exit comparison" }).click();
   await expect(page.getByText("Comparison mode")).toHaveCount(0);
   await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+  await expect.poll(() => page.evaluate(() => {
+    const messages = (window as typeof window & {
+      historyHostMessages: Array<Record<string, unknown>>;
+    }).historyHostMessages;
+    return messages.find((message) => message.type === "exitComparison");
+  })).toMatchObject({
+    type: "exitComparison",
+    commit: "b".repeat(40)
+  });
 });
 
 test("unavailable comparison explains how to recover", async ({ page }) => {

--- a/tests/viewer/initialize.spec.ts
+++ b/tests/viewer/initialize.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("initialization reviews scope before starting file-level progress", async ({ page }) => {
-  await page.goto("/initialize.html");
+  await page.goto("/initialize.html?manualSuccess=true");
 
   await expect(page.getByRole("heading", { name: "Build a map of compass" })).toBeVisible();
   await page.getByRole("radio", { name: /custom scope/i }).click();
@@ -16,6 +16,10 @@ test("initialization reviews scope before starting file-level progress", async (
   await expect(page.getByText("src/commands/init.ts")).toBeVisible();
   await expect(page.getByText("3 of 3 files")).toBeVisible();
   await expect(page.getByText("src/views/graph.ts")).toBeVisible();
+  await page.evaluate(() => {
+    (window as typeof window & { completeInitialization: () => void })
+      .completeInitialization();
+  });
   await expect(page.getByRole("heading", { name: "Your Compass index is ready" })).toBeVisible();
   await expect.poll(() => page.evaluate(() => {
     const messages = (window as typeof window & {

--- a/tests/viewer/theme.spec.ts
+++ b/tests/viewer/theme.spec.ts
@@ -87,6 +87,7 @@ test("history comparison and source diffs follow the light VS Code theme", async
     .toHaveCSS("background-color", "rgb(244, 244, 244)");
   await expect(page.getByRole("button", { name: "Split" }))
     .toHaveCSS("color", "rgb(32, 32, 32)");
+  await page.getByRole("tab", { name: /Changed graph/ }).click();
   await expect(page.locator(".compass-graph-stage"))
     .toHaveAttribute("data-comparison", "true");
   await expect(page.locator(".compass-graph-stage"))


### PR DESCRIPTION
## Summary

Enhance the VS Code Codebase Evolution graph so a changed aggregate community can be drilled into an exact symbol- and relationship-level diff.

- retain canonical before/after evidence for changed graph records
- add a searchable Added / Removed / Changed symbol list and field-level inspector
- show relationship status, confidence, and before/after fields
- lazily load the selected community from both compared revisions with stale-response and node-limit guards
- open exact read-only historical source for before and after revisions
- reconcile Compass generated edge IDs without overriding stable custom edge identities

## Motivation

The versioned graph previously showed a changed community and its symbol count, but it did not identify which symbols or relationships changed. Developers could not inspect signature, kind, source path/line, confidence, or other stored-field differences from the graph.

This change preserves the fast aggregate overview while making its Changed state explainable on demand.

## Verification

```text
npm run test:js
  @compass/viewer: 54 tests passed
  editors/vscode: 51 tests passed
npm test -w @compass/viewer-tests
  62 Playwright tests passed
npm run typecheck:js
  both TypeScript workspaces passed
npm run package -w editors/vscode
  packaged crabbuild-compass-vscode-0.1.2.vsix (4.92 MB)
npm run smoke:vsix -w editors/vscode
  VSIX smoke check passed
graphify update .
  graph refreshed successfully
```

An independent read-only review found no remaining critical or important issues.

## Compatibility and documentation

The graph evidence fields are optional, so existing graph payloads and ordinary current-graph views remain compatible. Community detail stays lazy and bounded by `compass.graphNodeLimit`; the inspector warns when the exact view is partial. Historical source content is read with argument-array Git invocation, repository path validation, bounded output, and runtime source-location validation.

Updated `editors/vscode/README.md` and `docs/guides/vscode.md` with the new workflow and behavior.

## Checklist

- [x] The change is focused and excludes unrelated formatting or generated files
- [x] Tests cover changed behavior, or this pull request changes documentation only
- [x] User-facing commands, flags, limits, and examples are documented
- [x] Compatibility or migration effects are described
- [x] No credentials, private source code, or sensitive report details are included
- [x] I agree to license my contribution under `MIT OR Apache-2.0`
- [x] I followed the [Compass code of conduct](https://github.com/crabbuild/compass/blob/main/CODE_OF_CONDUCT.md)
