### PR TITLE
Release Compass 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-model",
  "regex",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "axum",
  "compass-core",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-model",
  "regex",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the Compass workspace version from 0.1.8 to 0.1.9
- refresh Compass workspace package versions in Cargo.lock
- publish the existing macOS, Linux, and Windows release matrix after merge

## Verification

- `sh scripts/check_product_boundary.sh`
- `sh scripts/test_release_scripts.sh`
- `cargo test -p compass-cli --test compass_product --locked`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test --workspace --lib --bins --locked`
- `cargo check --offline -p compass-cli --bin compass`
- `graphify update .`