### PR TITLE
Add guided call graph workflow

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -66,6 +66,11 @@ to collapse and expand it.
 
 ### Trace calls from the editor
 
+Choose **Call graph from cursor** under **Workspace > Explore** to open a visual
+guide with the editor steps and working **Show Callers**, **Show Callees**, and
+**Show Both** actions. Compass captures the active source position before the
+guide opens and returns to that exact cursor when an action is selected.
+
 1. Open an indexed source file and place the cursor anywhere inside a function
    or method body.
 2. Right-click in the editor and choose **Compass Call Graph**.

--- a/editors/vscode/esbuild.mjs
+++ b/editors/vscode/esbuild.mjs
@@ -60,6 +60,7 @@ const builds = [
     entryPoints: {
       graph: "src/webviews/graph.tsx",
       callGraph: "src/webviews/callGraph.tsx",
+      callGraphGuide: "src/webviews/callGraphGuide.tsx",
       architecture: "src/webviews/architecture.tsx",
       query: "src/webviews/query.tsx",
       history: "src/webviews/history.tsx",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -90,6 +90,11 @@
         "icon": "$(type-hierarchy)"
       },
       {
+        "command": "compass.openCallGraphGuide",
+        "title": "Compass: Call Graph Guide",
+        "icon": "$(book)"
+      },
+      {
         "command": "compass.openCallers",
         "title": "Compass: Show Callers",
         "icon": "$(references)"

--- a/editors/vscode/scripts/smoke-vsix.mjs
+++ b/editors/vscode/scripts/smoke-vsix.mjs
@@ -17,6 +17,7 @@ for (const required of [
   "extension/dist/webviews/graph.js",
   "extension/dist/webviews/viewer.css",
   "extension/dist/webviews/callGraph.js",
+  "extension/dist/webviews/callGraphGuide.js",
   "extension/dist/webviews/history.js",
   "extension/media/icon.png"
 ]) {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import { CompassProcessManager } from "./cli/processManager";
 import { registerBuildCommands } from "./commands/buildCommands";
 import { GraphPanel } from "./views/graphPanel";
 import { CallGraphPanel } from "./views/callGraphPanel";
+import { openCallGraphGuidePanel } from "./views/callGraphGuidePanel";
 import { openArchitecturePanel } from "./views/architecturePanel";
 import { openQueryPanel } from "./views/queryPanel";
 import { openHistoryPanel } from "./views/historyPanel";
@@ -239,6 +240,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         return;
       }
       await GraphPanel.open(context, session, output);
+    }),
+    vscode.commands.registerCommand("compass.openCallGraphGuide", () => {
+      openCallGraphGuidePanel(context, vscode.window.activeTextEditor);
     }),
     vscode.commands.registerCommand("compass.openCallGraph", () => openCallGraph("both")),
     vscode.commands.registerCommand("compass.openCallers", () => openCallGraph("callers")),

--- a/editors/vscode/src/test/suite/extension.integration.ts
+++ b/editors/vscode/src/test/suite/extension.integration.ts
@@ -18,6 +18,7 @@ suite("Compass extension", () => {
       "compass.stopWatch",
       "compass.openSettings",
       "compass.openGraph",
+      "compass.openCallGraphGuide",
       "compass.openCallGraph",
       "compass.openCallers",
       "compass.openCallees",

--- a/editors/vscode/src/views/callGraphContributions.test.ts
+++ b/editors/vscode/src/views/callGraphContributions.test.ts
@@ -19,6 +19,10 @@ const manifest = JSON.parse(
 
 describe("call graph editor contributions", () => {
   it("contributes one editor submenu with caller, callee, and combined actions", () => {
+    expect(manifest.contributes.commands).toContainEqual(expect.objectContaining({
+      command: "compass.openCallGraphGuide",
+      title: "Compass: Call Graph Guide"
+    }));
     expect(manifest.contributes.submenus).toContainEqual({
       id: "compass.callGraph",
       label: "Compass Call Graph"

--- a/editors/vscode/src/views/callGraphGuidePanel.ts
+++ b/editors/vscode/src/views/callGraphGuidePanel.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+import * as vscode from "vscode";
+import type { CallDirection } from "@compass/viewer/contracts/callGraph";
+
+type CallGraphSource = {
+  uri: vscode.Uri;
+  selection: vscode.Selection;
+  viewColumn: vscode.ViewColumn | undefined;
+  fileLabel: string;
+  languageId: string;
+};
+
+const directionCommands: Record<CallDirection, string> = {
+  callers: "compass.openCallers",
+  callees: "compass.openCallees",
+  both: "compass.openCallersAndCallees"
+};
+
+export function openCallGraphGuidePanel(
+  context: vscode.ExtensionContext,
+  editor: vscode.TextEditor | undefined
+): void {
+  const source = editor ? captureSource(editor) : undefined;
+  const panel = vscode.window.createWebviewPanel(
+    "compass.callGraphGuide",
+    "Compass Call Graph",
+    vscode.ViewColumn.Active,
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist")]
+    }
+  );
+  panel.webview.html = html(context, panel.webview);
+  panel.webview.onDidReceiveMessage(async (message) => {
+    if (message?.type === "ready") {
+      await panel.webview.postMessage({
+        type: "hydrate",
+        source: source
+          ? { fileLabel: source.fileLabel, languageId: source.languageId }
+          : null
+      });
+      return;
+    }
+    if (message?.type === "openWalkthrough") {
+      await vscode.commands.executeCommand(
+        "workbench.action.openWalkthrough",
+        "crabbuild.crabbuild-compass-vscode#compass.getStarted",
+        false
+      );
+      return;
+    }
+    if (message?.type !== "openDirection") {
+      return;
+    }
+    const candidate: unknown = message.direction;
+    if (!isDirection(candidate)) return;
+    const direction: CallDirection = candidate;
+    if (!source) {
+      void vscode.window.showInformationMessage(
+        "Open an indexed source file, place the cursor inside a function, then reopen the call graph guide."
+      );
+      return;
+    }
+    panel.dispose();
+    try {
+      const document = await vscode.workspace.openTextDocument(source.uri);
+      const options: vscode.TextDocumentShowOptions = {
+        preserveFocus: false,
+        preview: false,
+        selection: source.selection
+      };
+      if (source.viewColumn !== undefined) {
+        options.viewColumn = source.viewColumn;
+      }
+      await vscode.window.showTextDocument(document, options);
+      await vscode.commands.executeCommand(directionCommands[direction]);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      void vscode.window.showErrorMessage(
+        `Compass could not restore the source editor: ${detail}`
+      );
+    }
+  });
+}
+
+function captureSource(editor: vscode.TextEditor): CallGraphSource {
+  const relative = vscode.workspace.asRelativePath(editor.document.uri, false);
+  return {
+    uri: editor.document.uri,
+    selection: editor.selection,
+    viewColumn: editor.viewColumn,
+    fileLabel: relative || editor.document.fileName,
+    languageId: editor.document.languageId
+  };
+}
+
+function isDirection(value: unknown): value is CallDirection {
+  return value === "callers" || value === "callees" || value === "both";
+}
+
+function html(context: vscode.ExtensionContext, webview: vscode.Webview): string {
+  const script = webview.asWebviewUri(
+    vscode.Uri.joinPath(context.extensionUri, "dist", "webviews", "callGraphGuide.js")
+  );
+  const styles = webview.asWebviewUri(
+    vscode.Uri.joinPath(context.extensionUri, "dist", "webviews", "viewer.css")
+  );
+  const nonce = randomUUID().replaceAll("-", "");
+  return `<!doctype html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+<link rel="stylesheet" href="${styles}"><title>Compass Call Graph Guide</title>
+</head><body><div id="root"></div>
+<script nonce="${nonce}" src="${script}"></script></body></html>`;
+}

--- a/editors/vscode/src/views/treeModel.test.ts
+++ b/editors/vscode/src/views/treeModel.test.ts
@@ -36,7 +36,7 @@ describe("buildWorkspaceTree", () => {
     expect(nodes[1]?.children?.map((node) => [node.label, node.command])).toEqual([
       ["Code graph", "compass.openGraph"],
       ["Architecture flow", "compass.openArchitecture"],
-      ["Call graph from cursor", "compass.openCallGraph"],
+      ["Call graph from cursor", "compass.openCallGraphGuide"],
       ["Ask codebase", "compass.openQuery"],
       ["Codebase evolution", "compass.openHistory"]
     ]);

--- a/editors/vscode/src/views/treeModel.ts
+++ b/editors/vscode/src/views/treeModel.ts
@@ -125,8 +125,8 @@ export function buildWorkspaceTree(
         "workspace:call-graph",
         "Call graph from cursor",
         "references",
-        "compass.openCallGraph",
-        "Trace callers and callees for the active function"
+        "compass.openCallGraphGuide",
+        "Learn how to trace callers and callees from the editor"
       ),
       actionNode(
         "workspace:query",

--- a/editors/vscode/src/webviews/callGraphGuide.tsx
+++ b/editors/vscode/src/webviews/callGraphGuide.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  ArrowDownToLineIcon,
+  ArrowRightIcon,
+  ArrowUpFromLineIcon,
+  BookOpenIcon,
+  ChevronRightIcon,
+  FileCode2Icon,
+  GitForkIcon,
+  MousePointer2Icon,
+  NetworkIcon
+} from "lucide-react";
+import type { CallDirection } from "@compass/viewer/contracts/callGraph";
+
+declare function acquireVsCodeApi(): { postMessage(message: unknown): void };
+
+type GuideSource = {
+  fileLabel: string;
+  languageId: string;
+};
+
+const vscode = acquireVsCodeApi();
+const element = document.getElementById("root");
+if (!element) throw new Error("Compass call graph guide root is missing");
+
+function CallGraphGuide() {
+  const [source, setSource] = useState<GuideSource | null | undefined>(undefined);
+
+  useEffect(() => {
+    const receive = (event: MessageEvent) => {
+      if (event.data?.type !== "hydrate") return;
+      const next = event.data.source;
+      if (next === null) {
+        setSource(null);
+      } else if (
+        typeof next?.fileLabel === "string"
+        && typeof next?.languageId === "string"
+      ) {
+        setSource(next);
+      }
+    };
+    window.addEventListener("message", receive);
+    vscode.postMessage({ type: "ready" });
+    return () => window.removeEventListener("message", receive);
+  }, []);
+
+  const open = (direction: CallDirection) => {
+    vscode.postMessage({ type: "openDirection", direction });
+  };
+  const ready = source !== null && source !== undefined;
+
+  return (
+    <main className="call-guide-shell">
+      <div className="call-guide-grid" aria-hidden="true" />
+
+      <header className="call-guide-hero">
+        <section className="call-guide-intro">
+          <div className="call-guide-kicker">
+            <NetworkIcon aria-hidden="true" />
+            <span>Compass / Call trace</span>
+          </div>
+          <h1>Trace how this function connects.</h1>
+          <p className="call-guide-lead">
+            Start from the cursor. Follow what calls in, what calls out, or map
+            the full neighborhood in one view.
+          </p>
+          <div
+            className="call-guide-source"
+            data-ready={ready ? "true" : "false"}
+            role="status"
+          >
+            <span className="call-guide-source-light" aria-hidden="true" />
+            <FileCode2Icon aria-hidden="true" />
+            <span>
+              {source === undefined
+                ? "Reading the active editor…"
+                : source
+                  ? source.fileLabel
+                  : "Open a source file to enable trace actions"}
+            </span>
+            {source && <code>{source.languageId}</code>}
+          </div>
+        </section>
+
+        <CallRoute />
+      </header>
+
+      <section className="call-guide-section" aria-labelledby="call-guide-how">
+        <div className="call-guide-heading">
+          <div>
+            <span className="call-guide-overline">Editor workflow</span>
+            <h2 id="call-guide-how">Three moves from code to context</h2>
+          </div>
+          <span className="call-guide-shortcut">
+            Right-click <ArrowRightIcon aria-hidden="true" /> Compass Call Graph
+          </span>
+        </div>
+
+        <ol className="call-guide-steps">
+          <li>
+            <span className="call-guide-step-number">01</span>
+            <MousePointer2Icon aria-hidden="true" />
+            <div>
+              <h3>Place the cursor</h3>
+              <p>Click anywhere inside an indexed function or method body.</p>
+            </div>
+          </li>
+          <li className="call-guide-step-menu">
+            <span className="call-guide-step-number">02</span>
+            <div>
+              <h3>Open Compass Call Graph</h3>
+              <p>Right-click in the editor and open the Compass submenu.</p>
+            </div>
+            <ContextMenuPreview />
+          </li>
+          <li>
+            <span className="call-guide-step-number">03</span>
+            <GitForkIcon aria-hidden="true" />
+            <div>
+              <h3>Choose a direction</h3>
+              <p>Inspect incoming callers, outgoing callees, or both.</p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      <section className="call-guide-section call-guide-actions-section" aria-labelledby="call-guide-actions">
+        <div className="call-guide-heading">
+          <div>
+            <span className="call-guide-overline">Start now</span>
+            <h2 id="call-guide-actions">Trace from the captured cursor</h2>
+          </div>
+          <p>
+            {ready
+              ? "Compass will return to your source before opening the graph."
+              : "Open a source file, then reopen this guide from the side panel."}
+          </p>
+        </div>
+
+        <div className="call-guide-actions">
+          <DirectionAction
+            direction="callers"
+            icon={<ArrowDownToLineIcon aria-hidden="true" />}
+            title="Show Callers"
+            description="Who reaches this function"
+            onOpen={open}
+            disabled={!ready}
+          />
+          <DirectionAction
+            direction="both"
+            icon={<GitForkIcon aria-hidden="true" />}
+            title="Show Both"
+            description="See the full call neighborhood"
+            onOpen={open}
+            disabled={!ready}
+            primary
+          />
+          <DirectionAction
+            direction="callees"
+            icon={<ArrowUpFromLineIcon aria-hidden="true" />}
+            title="Show Callees"
+            description="What this function reaches"
+            onOpen={open}
+            disabled={!ready}
+          />
+        </div>
+      </section>
+
+      <footer className="call-guide-footer">
+        <div className="call-guide-coverage">
+          <span className="call-guide-coverage-badge">Structural graph</span>
+          <p>
+            Works across every call-capable language Compass indexes. Program IR
+            adds exact call evidence when available, and partial coverage is
+            labeled in the graph.
+          </p>
+        </div>
+        <button
+          className="call-guide-walkthrough"
+          type="button"
+          onClick={() => vscode.postMessage({ type: "openWalkthrough" })}
+        >
+          <BookOpenIcon aria-hidden="true" />
+          Open full walkthrough
+          <ChevronRightIcon aria-hidden="true" />
+        </button>
+      </footer>
+    </main>
+  );
+}
+
+function CallRoute() {
+  return (
+    <div
+      className="call-guide-route"
+      role="img"
+      aria-label="A caller flows into the current function, which flows out to callees"
+    >
+      <div className="call-guide-route-label">
+        <span>Live call trace</span>
+        <code>cursor → graph</code>
+      </div>
+      <div className="call-guide-route-stage">
+        <div className="call-guide-route-line call-guide-route-line-in" aria-hidden="true">
+          <i />
+        </div>
+        <div className="call-guide-route-line call-guide-route-line-out" aria-hidden="true">
+          <i />
+        </div>
+        <div className="call-guide-route-node" data-kind="caller">
+          <span>IN</span>
+          <strong>caller()</strong>
+          <small>incoming edge</small>
+        </div>
+        <div className="call-guide-route-node call-guide-route-current" data-kind="current">
+          <MousePointer2Icon aria-hidden="true" />
+          <strong>cursor()</strong>
+          <small>active function</small>
+        </div>
+        <div className="call-guide-route-node" data-kind="callee">
+          <span>OUT</span>
+          <strong>callee()</strong>
+          <small>outgoing edge</small>
+        </div>
+      </div>
+      <div className="call-guide-route-readout" aria-hidden="true">
+        <span>01 locate</span>
+        <span>02 resolve</span>
+        <span>03 render</span>
+      </div>
+    </div>
+  );
+}
+
+function ContextMenuPreview() {
+  return (
+    <div
+      className="call-guide-menu-preview"
+      role="img"
+      aria-label="Compass Call Graph editor context menu with callers, callees, and both"
+    >
+      <div className="call-guide-menu-parent">
+        <NetworkIcon aria-hidden="true" />
+        <span>Compass Call Graph</span>
+        <ChevronRightIcon aria-hidden="true" />
+      </div>
+      <div className="call-guide-submenu">
+        <span><ArrowDownToLineIcon aria-hidden="true" /> Show Callers</span>
+        <span><ArrowUpFromLineIcon aria-hidden="true" /> Show Callees</span>
+        <span className="is-active"><GitForkIcon aria-hidden="true" /> Show Callers &amp; Callees</span>
+      </div>
+    </div>
+  );
+}
+
+function DirectionAction({
+  direction,
+  icon,
+  title,
+  description,
+  onOpen,
+  disabled,
+  primary = false
+}: {
+  direction: CallDirection;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  onOpen(direction: CallDirection): void;
+  disabled: boolean;
+  primary?: boolean;
+}) {
+  return (
+    <button
+      className="call-guide-action"
+      data-primary={primary ? "true" : "false"}
+      type="button"
+      disabled={disabled}
+      onClick={() => onOpen(direction)}
+    >
+      <span className="call-guide-action-icon">{icon}</span>
+      <span>
+        <strong>{title}</strong>
+        <small>{description}</small>
+      </span>
+      <ArrowRightIcon className="call-guide-action-arrow" aria-hidden="true" />
+      {primary && <em>Recommended</em>}
+    </button>
+  );
+}
+
+createRoot(element).render(<CallGraphGuide />);

--- a/packages/compass-viewer/src/theme.css
+++ b/packages/compass-viewer/src/theme.css
@@ -4535,3 +4535,772 @@ body.vscode-high-contrast-light .architecture-call-table {
     max-width: none;
   }
 }
+
+/* Call graph editor guide */
+.call-guide-shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: auto;
+  box-sizing: border-box;
+  padding: clamp(28px, 5vw, 72px) clamp(20px, 5vw, 72px) 40px;
+  background:
+    radial-gradient(
+      circle at 77% 8%,
+      color-mix(in srgb, var(--compass-focus) 9%, transparent),
+      transparent 28rem
+    ),
+    var(--vscode-editor-background, var(--background));
+  isolation: isolate;
+}
+
+.call-guide-grid {
+  position: fixed;
+  z-index: -1;
+  inset: 0;
+  opacity: 0.19;
+  background-image:
+    linear-gradient(var(--compass-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--compass-grid) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(to bottom, black, transparent 68%);
+  pointer-events: none;
+}
+
+.call-guide-hero,
+.call-guide-section,
+.call-guide-footer {
+  width: min(1120px, 100%);
+  margin-inline: auto;
+}
+
+.call-guide-hero {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.9fr) minmax(420px, 1.1fr);
+  align-items: center;
+  gap: clamp(40px, 7vw, 96px);
+  min-height: 330px;
+  padding-bottom: clamp(36px, 5vw, 64px);
+  border-bottom: 1px solid var(--vscode-panel-border, var(--border));
+}
+
+.call-guide-kicker,
+.call-guide-overline,
+.call-guide-route-label,
+.call-guide-route-readout,
+.call-guide-shortcut,
+.call-guide-coverage-badge {
+  font-family: var(--compass-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.call-guide-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.call-guide-kicker svg {
+  width: 14px;
+  height: 14px;
+}
+
+.call-guide-intro h1 {
+  max-width: 650px;
+  margin: 18px 0 0;
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font-size: clamp(34px, 5vw, 62px);
+  font-weight: 620;
+  letter-spacing: -0.052em;
+  line-height: 0.98;
+  text-wrap: balance;
+}
+
+.call-guide-lead {
+  max-width: 580px;
+  margin: 22px 0 0;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: clamp(14px, 1.7vw, 17px);
+  line-height: 1.65;
+}
+
+.call-guide-source {
+  display: inline-flex;
+  max-width: min(100%, 560px);
+  min-height: 34px;
+  align-items: center;
+  gap: 8px;
+  margin-top: 24px;
+  padding: 0 10px;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 4px;
+  background: color-mix(
+    in srgb,
+    var(--vscode-editorWidget-background, var(--card)) 88%,
+    transparent
+  );
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font: 11px/1.3 var(--compass-font-mono);
+}
+
+.call-guide-source > span:not(.call-guide-source-light) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.call-guide-source > svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.call-guide-source code {
+  flex: 0 0 auto;
+  margin-left: 3px;
+  padding-left: 9px;
+  border-left: 1px solid var(--vscode-panel-border, var(--border));
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font: inherit;
+}
+
+.call-guide-source-light {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--vscode-disabledForeground, var(--compass-faint));
+}
+
+.call-guide-source[data-ready="true"] .call-guide-source-light {
+  background: var(--vscode-testing-iconPassed, var(--compass-success));
+  box-shadow: 0 0 9px color-mix(
+    in srgb,
+    var(--vscode-testing-iconPassed, var(--compass-success)) 60%,
+    transparent
+  );
+}
+
+.call-guide-route {
+  position: relative;
+  overflow: hidden;
+  padding: 16px;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 8px;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--vscode-editorWidget-background, var(--card)) 94%, transparent),
+      color-mix(in srgb, var(--vscode-editor-background, var(--background)) 82%, transparent)
+    );
+  box-shadow: 0 24px 70px color-mix(in srgb, #000 22%, transparent);
+}
+
+.call-guide-route::before {
+  content: "";
+  position: absolute;
+  width: 230px;
+  height: 230px;
+  top: 46%;
+  left: 50%;
+  border: 1px solid color-mix(in srgb, var(--compass-focus) 14%, transparent);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow:
+    0 0 0 44px color-mix(in srgb, var(--compass-focus) 3%, transparent),
+    0 0 0 88px color-mix(in srgb, var(--compass-focus) 2%, transparent);
+  pointer-events: none;
+}
+
+.call-guide-route-label,
+.call-guide-route-readout {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  color: var(--vscode-disabledForeground, var(--compass-faint));
+  font-size: 9px;
+}
+
+.call-guide-route-label code {
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font: inherit;
+  text-transform: none;
+}
+
+.call-guide-route-stage {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 13%;
+  min-height: 226px;
+}
+
+.call-guide-route-node {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 5px;
+  background: var(--vscode-editor-background, var(--background));
+  box-shadow: 0 12px 32px color-mix(in srgb, #000 20%, transparent);
+}
+
+.call-guide-route-node > span {
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font: 8px/1 var(--compass-font-mono);
+  letter-spacing: 0.12em;
+}
+
+.call-guide-route-node strong {
+  overflow: hidden;
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font: 600 11px/1.3 var(--compass-font-mono);
+  text-overflow: ellipsis;
+}
+
+.call-guide-route-node small {
+  overflow: hidden;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.call-guide-route-current {
+  align-items: center;
+  padding-block: 17px;
+  border-color: var(--vscode-focusBorder, var(--compass-focus));
+  background: color-mix(
+    in srgb,
+    var(--vscode-focusBorder, var(--compass-focus)) 9%,
+    var(--vscode-editor-background, var(--background))
+  );
+  text-align: center;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--compass-focus) 16%, transparent),
+    0 15px 40px color-mix(in srgb, var(--compass-focus) 14%, transparent);
+}
+
+.call-guide-route-current > svg {
+  width: 17px;
+  height: 17px;
+  margin-bottom: 3px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.call-guide-route-line {
+  position: absolute;
+  z-index: -1;
+  top: 50%;
+  width: 32%;
+  height: 1px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--compass-focus) 44%, var(--border));
+}
+
+.call-guide-route-line-in {
+  left: 18%;
+}
+
+.call-guide-route-line-out {
+  right: 18%;
+}
+
+.call-guide-route-line i {
+  position: absolute;
+  top: -2px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--vscode-focusBorder, var(--compass-focus));
+  box-shadow: 0 0 9px var(--vscode-focusBorder, var(--compass-focus));
+  animation: call-guide-trace 2.2s linear infinite;
+}
+
+.call-guide-route-line-out i {
+  animation-delay: 1.1s;
+}
+
+@keyframes call-guide-trace {
+  from {
+    left: -8px;
+  }
+
+  to {
+    left: calc(100% + 8px);
+  }
+}
+
+.call-guide-route-readout {
+  padding-top: 11px;
+  border-top: 1px solid var(--vscode-panel-border, var(--border));
+  letter-spacing: 0.08em;
+}
+
+.call-guide-section {
+  padding-block: clamp(34px, 5vw, 58px);
+  border-bottom: 1px solid var(--vscode-panel-border, var(--border));
+}
+
+.call-guide-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+  margin-bottom: 24px;
+}
+
+.call-guide-overline {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.call-guide-heading h2 {
+  margin: 0;
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font-size: clamp(19px, 2.4vw, 26px);
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+
+.call-guide-heading > p {
+  max-width: 420px;
+  margin: 0;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.5;
+  text-align: right;
+}
+
+.call-guide-shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.call-guide-shortcut svg {
+  width: 12px;
+  height: 12px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.call-guide-steps {
+  display: grid;
+  grid-template-columns: minmax(170px, 0.8fr) minmax(340px, 1.45fr) minmax(170px, 0.8fr);
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.call-guide-steps > li {
+  position: relative;
+  display: grid;
+  min-height: 168px;
+  align-content: start;
+  gap: 17px;
+  padding: 18px;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 5px;
+  background: color-mix(
+    in srgb,
+    var(--vscode-editorWidget-background, var(--card)) 72%,
+    transparent
+  );
+}
+
+.call-guide-steps > li > svg {
+  width: 22px;
+  height: 22px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.call-guide-step-number {
+  position: absolute;
+  top: 17px;
+  right: 17px;
+  color: var(--vscode-disabledForeground, var(--compass-faint));
+  font: 9px/1 var(--compass-font-mono);
+  letter-spacing: 0.1em;
+}
+
+.call-guide-steps h3 {
+  margin: 0;
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.call-guide-steps p {
+  margin: 6px 0 0;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.call-guide-step-menu {
+  grid-template-columns: minmax(150px, 0.85fr) minmax(195px, 1.15fr);
+  align-items: center;
+}
+
+.call-guide-menu-preview {
+  position: relative;
+  min-width: 0;
+  padding-right: 44%;
+  font-size: 10px;
+}
+
+.call-guide-menu-parent,
+.call-guide-submenu {
+  border: 1px solid var(--vscode-menu-border, var(--border));
+  border-radius: 4px;
+  background: var(--vscode-menu-background, var(--popover));
+  color: var(--vscode-menu-foreground, var(--popover-foreground));
+  box-shadow: 0 12px 30px color-mix(in srgb, #000 25%, transparent);
+}
+
+.call-guide-menu-parent {
+  display: grid;
+  grid-template-columns: 15px 1fr 13px;
+  align-items: center;
+  gap: 7px;
+  min-height: 31px;
+  padding: 0 8px;
+  border-color: var(--vscode-focusBorder, var(--compass-focus));
+  background: var(--vscode-menu-selectionBackground, var(--accent));
+  color: var(--vscode-menu-selectionForeground, var(--accent-foreground));
+}
+
+.call-guide-menu-parent svg,
+.call-guide-submenu svg {
+  width: 13px;
+  height: 13px;
+}
+
+.call-guide-submenu {
+  position: absolute;
+  z-index: 2;
+  top: 22px;
+  right: 0;
+  width: 58%;
+  min-width: 165px;
+  padding: 4px;
+}
+
+.call-guide-submenu span {
+  display: flex;
+  min-height: 26px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 7px;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+
+.call-guide-submenu span.is-active {
+  background: var(--vscode-menu-selectionBackground, var(--accent));
+  color: var(--vscode-menu-selectionForeground, var(--accent-foreground));
+}
+
+.call-guide-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.call-guide-action {
+  position: relative;
+  display: grid;
+  min-height: 104px;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 13px;
+  padding: 18px;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 5px;
+  outline: none;
+  background: var(--vscode-editorWidget-background, var(--card));
+  color: var(--vscode-editor-foreground, var(--foreground));
+  font: inherit;
+  text-align: left;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    transform 140ms ease;
+}
+
+.call-guide-action:not(:disabled):hover {
+  border-color: var(--vscode-focusBorder, var(--compass-focus));
+  background: color-mix(
+    in srgb,
+    var(--vscode-list-hoverBackground, var(--workbench-hover)) 70%,
+    var(--vscode-editorWidget-background, var(--card))
+  );
+  transform: translateY(-2px);
+}
+
+.call-guide-action:focus-visible,
+.call-guide-walkthrough:focus-visible {
+  outline: 2px solid var(--vscode-focusBorder, var(--ring));
+  outline-offset: 2px;
+}
+
+.call-guide-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.call-guide-action[data-primary="true"] {
+  border-color: color-mix(
+    in srgb,
+    var(--vscode-focusBorder, var(--compass-focus)) 72%,
+    var(--border)
+  );
+  background:
+    linear-gradient(
+      130deg,
+      color-mix(in srgb, var(--vscode-focusBorder, var(--compass-focus)) 13%, transparent),
+      transparent 58%
+    ),
+    var(--vscode-editorWidget-background, var(--card));
+}
+
+.call-guide-action-icon {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid var(--vscode-panel-border, var(--border));
+  border-radius: 4px;
+  background: var(--vscode-editor-background, var(--background));
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+}
+
+.call-guide-action-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.call-guide-action strong,
+.call-guide-action small {
+  display: block;
+}
+
+.call-guide-action strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.call-guide-action small {
+  margin-top: 5px;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 10px;
+}
+
+.call-guide-action-arrow {
+  width: 15px;
+  height: 15px;
+  color: var(--vscode-disabledForeground, var(--compass-faint));
+  transition: transform 140ms ease;
+}
+
+.call-guide-action:not(:disabled):hover .call-guide-action-arrow {
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  transform: translateX(3px);
+}
+
+.call-guide-action em {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font: normal 8px/1 var(--compass-font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.call-guide-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  padding-top: 24px;
+}
+
+.call-guide-coverage {
+  display: flex;
+  max-width: 760px;
+  align-items: center;
+  gap: 13px;
+}
+
+.call-guide-coverage-badge {
+  flex: 0 0 auto;
+  padding: 5px 7px;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--vscode-testing-iconPassed, var(--compass-success)) 50%,
+    var(--border)
+  );
+  border-radius: 3px;
+  color: var(--vscode-testing-iconPassed, var(--compass-success));
+  font-size: 8px;
+  font-weight: 700;
+}
+
+.call-guide-coverage p {
+  margin: 0;
+  color: var(--vscode-descriptionForeground, var(--muted-foreground));
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.call-guide-walkthrough {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--vscode-textLink-foreground, var(--compass-focus));
+  font: 11px/1 var(--compass-font-sans);
+}
+
+.call-guide-walkthrough svg {
+  width: 14px;
+  height: 14px;
+}
+
+.call-guide-walkthrough svg:last-child {
+  width: 12px;
+  transition: transform 140ms ease;
+}
+
+.call-guide-walkthrough:hover svg:last-child {
+  transform: translateX(2px);
+}
+
+body.vscode-high-contrast .call-guide-route,
+body.vscode-high-contrast-light .call-guide-route,
+body.vscode-high-contrast .call-guide-steps > li,
+body.vscode-high-contrast-light .call-guide-steps > li,
+body.vscode-high-contrast .call-guide-action,
+body.vscode-high-contrast-light .call-guide-action {
+  border-width: 2px;
+  border-color: var(--vscode-contrastBorder, var(--ring));
+}
+
+@media (max-width: 900px) {
+  .call-guide-hero {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .call-guide-route {
+    width: min(620px, 100%);
+    box-sizing: border-box;
+  }
+
+  .call-guide-steps {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .call-guide-step-menu {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+@media (max-width: 680px) {
+  .call-guide-shell {
+    padding-inline: 16px;
+  }
+
+  .call-guide-heading,
+  .call-guide-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .call-guide-heading > p {
+    text-align: left;
+  }
+
+  .call-guide-shortcut {
+    display: none;
+  }
+
+  .call-guide-steps,
+  .call-guide-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .call-guide-step-menu {
+    grid-column: auto;
+    grid-row: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .call-guide-menu-preview {
+    padding-right: min(42%, 180px);
+  }
+
+  .call-guide-coverage {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 440px) {
+  .call-guide-route-stage {
+    gap: 5%;
+  }
+
+  .call-guide-route-node {
+    padding: 9px 7px;
+  }
+
+  .call-guide-route-node small {
+    display: none;
+  }
+
+  .call-guide-menu-preview {
+    padding: 0;
+  }
+
+  .call-guide-submenu {
+    position: relative;
+    top: auto;
+    width: auto;
+    margin: 6px 0 0 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .call-guide-route-line i {
+    animation: none;
+  }
+
+  .call-guide-action,
+  .call-guide-action-arrow,
+  .call-guide-walkthrough svg:last-child {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

- make **Call graph from cursor** in the Compass side panel open a dedicated visual guide
- show the exact editor right-click workflow and caller/callee direction choices
- provide working **Show Callers**, **Show Both**, and **Show Callees** actions
- preserve and restore the originating source file and cursor before launching the graph
- add a responsive, theme-aware call-trace UI with high-contrast and reduced-motion support
- include the guide bundle in VSIX packaging and smoke validation

## Why

PR #64 added universal call graphs and editor context actions, but the side-panel item still launched the combined graph immediately. Users could not discover the right-click workflow or choose a direction from that entry point.

The guide makes the workflow self-explanatory while retaining a one-click path into each graph direction. Capturing the source location before opening the webview also prevents webview focus from losing the active function.

## User impact

Selecting **Workspace > Explore > Call graph from cursor** now opens an instructional page that:

1. explains where to place the cursor
2. previews the **Compass Call Graph** editor context menu
3. launches callers, callees, or both from the captured cursor
4. explains structural graph and Program IR coverage

## Verification

- VS Code typecheck passed
- VS Code extension: 56 tests passed
- Compass viewer: 72 tests passed
- Playwright viewer suite: 64 scenarios passed
- VS Code extension-host integration test passed
- VSIX packaging and smoke validation passed
- visually inspected the compiled guide at a 1440px editor viewport

## Notes

- This is a follow-up to merged PR #64.
- `graphify update` was intentionally not run per request.
