### PR TITLE
Release Compass 0.1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-model",
  "regex",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "glob",
  "md-5 0.10.6",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-files",
  "compass-transcribe",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "axum",
  "compass-core",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-model",
  "regex",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-cypher",
  "compass-graphdb",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "compass-whisper",
  "rubato",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump the Compass workspace version to 0.1.10
- refresh workspace package versions in Cargo.lock
- retain the six-architecture macOS, Linux, and Windows release matrix

## Verification
- `sh scripts/check_product_boundary.sh`
- `sh scripts/test_release_scripts.sh`
- `cargo test -p compass-cli --test compass_product --locked`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test --workspace --lib --bins --locked`
- `graphify update .`