### PR TITLE
perf: harden interactive call graph resolution

### DIFF
--- a/crates/compass-analysis/src/universal_call_graph.rs
+++ b/crates/compass-analysis/src/universal_call_graph.rs
@@ -214,8 +214,8 @@ pub fn build_universal_call_graph(
         .collect::<Vec<_>>();
     if edges.len() > request.max_edges {
         for edge in &edges[request.max_edges..] {
-            continuations.insert(edge.source.clone());
-            continuations.insert(edge.target.clone());
+            insert_continuation(&mut continuations, edge.source.clone(), request.max_nodes);
+            insert_continuation(&mut continuations, edge.target.clone(), request.max_nodes);
         }
         edges.truncate(request.max_edges);
         truncated = true;
@@ -226,6 +226,7 @@ pub fn build_universal_call_graph(
         .collect::<Vec<_>>();
     let continuation_records = continuations
         .into_iter()
+        .take(request.max_nodes)
         .filter(|symbol| symbol != &root)
         .map(|symbol| UniversalCallContinuation {
             symbol,
@@ -489,15 +490,34 @@ fn traverse(
     edges: &[UniversalCallEdge],
     request: &UniversalCallGraphRequest,
 ) -> (BTreeSet<String>, BTreeSet<String>) {
+    let mut adjacency = BTreeMap::<&str, Vec<usize>>::new();
+    for (index, edge) in edges.iter().enumerate() {
+        match request.direction {
+            CallGraphDirection::Callers => {
+                adjacency.entry(&edge.target).or_default().push(index);
+            }
+            CallGraphDirection::Callees => {
+                adjacency.entry(&edge.source).or_default().push(index);
+            }
+            CallGraphDirection::Both => {
+                adjacency.entry(&edge.source).or_default().push(index);
+                if edge.target != edge.source {
+                    adjacency.entry(&edge.target).or_default().push(index);
+                }
+            }
+        }
+    }
+
     let mut selected = BTreeSet::from([root.to_owned()]);
     let mut queue = VecDeque::from([(root.to_owned(), 0_u32)]);
     let mut continuations = BTreeSet::new();
     while let Some((symbol, level)) = queue.pop_front() {
-        for edge in edges.iter().filter(|edge| match request.direction {
-            CallGraphDirection::Callers => edge.target == symbol,
-            CallGraphDirection::Callees => edge.source == symbol,
-            CallGraphDirection::Both => edge.source == symbol || edge.target == symbol,
-        }) {
+        for edge in adjacency
+            .get(symbol.as_str())
+            .into_iter()
+            .flatten()
+            .map(|index| &edges[*index])
+        {
             let next = if edge.source == symbol {
                 &edge.target
             } else {
@@ -505,8 +525,15 @@ fn traverse(
             };
             if level >= request.depth {
                 if nodes.contains_key(next) {
-                    continuations.insert(next.clone());
+                    insert_continuation(&mut continuations, next.clone(), request.max_nodes);
                 }
+                continue;
+            }
+            if selected.contains(next) {
+                continue;
+            }
+            if selected.len() >= request.max_nodes {
+                insert_continuation(&mut continuations, next.clone(), request.max_nodes);
                 continue;
             }
             if selected.insert(next.clone()) {
@@ -515,6 +542,12 @@ fn traverse(
         }
     }
     (selected, continuations)
+}
+
+fn insert_continuation(continuations: &mut BTreeSet<String>, symbol: String, limit: usize) {
+    if continuations.len() < limit {
+        continuations.insert(symbol);
+    }
 }
 
 fn coverage(

--- a/crates/compass-analysis/tests/universal_call_graph.rs
+++ b/crates/compass-analysis/tests/universal_call_graph.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
 
 use compass_analysis::{
     AnalysisBundle, CallGraphDirection, CallResolution, UNIVERSAL_CALL_GRAPH_SCHEMA,
@@ -218,6 +219,62 @@ fn program_ir_enriches_structural_edges_and_retains_unresolved_calls()
             .edges
             .iter()
             .any(|edge| edge.resolution == CallResolution::Unresolved)
+    );
+    Ok(())
+}
+
+#[test]
+fn high_fanout_traversal_stays_within_the_interactive_latency_budget()
+-> Result<(), Box<dyn std::error::Error>> {
+    const FANOUT: usize = 16_000;
+    let file = "src/hot_path.rs";
+    let mut graph = GraphDocument {
+        directed: true,
+        multigraph: true,
+        graph: Map::new(),
+        nodes: Vec::with_capacity(FANOUT + 1),
+        links: Vec::with_capacity(FANOUT),
+        extras: BTreeMap::new(),
+    };
+    graph
+        .nodes
+        .push(node("root", "root()", file, "function", 1, 3));
+    for index in 0..FANOUT {
+        let id = format!("callee-{index:05}");
+        graph.nodes.push(node(
+            &id,
+            &format!("callee_{index}()"),
+            file,
+            "function",
+            5,
+            7,
+        ));
+        graph.links.push(edge("root", &id, "L2", "EXTRACTED"));
+    }
+
+    let started = Instant::now();
+    let response = build_universal_call_graph(
+        &graph,
+        None,
+        &UniversalCallGraphRequest {
+            root: UniversalCallGraphRoot::Symbol {
+                symbol: "root".to_owned(),
+            },
+            direction: CallGraphDirection::Callees,
+            depth: 2,
+            max_nodes: 128,
+            max_edges: 256,
+        },
+    )?;
+    let elapsed = started.elapsed();
+
+    assert!(response.nodes.len() <= 128);
+    assert!(response.edges.len() <= 256);
+    assert!(response.continuations.len() <= 128);
+    assert!(response.truncated);
+    assert!(
+        elapsed < Duration::from_millis(1_500),
+        "bounded call-graph traversal took {elapsed:?}"
     );
     Ok(())
 }

--- a/editors/vscode/src/views/callGraphArguments.test.ts
+++ b/editors/vscode/src/views/callGraphArguments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  callGraphCommandArguments,
   callGraphExpansionArguments,
   callGraphRootArguments
 } from "./callGraphArguments";
@@ -32,6 +33,29 @@ describe("Compass call graph arguments", () => {
       "callers",
       "--depth",
       "3"
+    ]);
+  });
+
+  it("keeps interactive resolution on the structural graph without loading Program IR", () => {
+    expect(callGraphCommandArguments(
+      ["--symbol", "go:auth.Resolve", "--direction", "both", "--depth", "2"],
+      "/repo/compass-out/graph.json"
+    )).toEqual([
+      "call-graph",
+      "--symbol",
+      "go:auth.Resolve",
+      "--direction",
+      "both",
+      "--depth",
+      "2",
+      "--max-nodes",
+      "500",
+      "--max-edges",
+      "1000",
+      "--graph",
+      "/repo/compass-out/graph.json",
+      "--format",
+      "json"
     ]);
   });
 });

--- a/editors/vscode/src/views/callGraphArguments.ts
+++ b/editors/vscode/src/views/callGraphArguments.ts
@@ -6,6 +6,27 @@ type CallGraphRoot = {
   line: number;
 };
 
+export function callGraphCommandArguments(
+  request: readonly string[],
+  graphPath: string
+): string[] {
+  // Keep the editor interaction on the required structural graph. Program IR
+  // remains an explicit CLI enrichment because reparsing it on every reveal
+  // can be much more expensive than resolving the requested neighborhood.
+  return [
+    "call-graph",
+    ...request,
+    "--max-nodes",
+    "500",
+    "--max-edges",
+    "1000",
+    "--graph",
+    graphPath,
+    "--format",
+    "json"
+  ];
+}
+
 export function callGraphRootArguments(
   root: CallGraphRoot,
   direction: CallDirection,

--- a/editors/vscode/src/views/callGraphPanel.ts
+++ b/editors/vscode/src/views/callGraphPanel.ts
@@ -5,6 +5,7 @@ import { CallGraphResponseSchema } from "@compass/viewer/contracts/callGraph";
 import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 import type { RepositorySession } from "../workspace/repositorySession";
 import {
+  callGraphCommandArguments,
   callGraphExpansionArguments,
   callGraphRootArguments
 } from "./callGraphArguments";
@@ -27,7 +28,6 @@ export class CallGraphPanel {
     }
     const byte = utf8ByteAt(editor.document, editor.selection.active);
     const line = editor.selection.active.line + 1;
-    const hasProgram = await fileExists(session.programPath);
     const panel = vscode.window.createWebviewPanel(
       "compass.callGraph",
       `Compass Calls — ${path.basename(relative)}`,
@@ -91,15 +91,7 @@ export class CallGraphPanel {
       const abort = () => controller.abort();
       panelController.signal.addEventListener("abort", abort, { once: true });
       try {
-        const graphArgs = [
-          "call-graph",
-          ...rootArgs,
-          "--max-nodes", "500",
-          "--max-edges", "1000",
-          "--graph", session.graphPath,
-          ...(hasProgram ? ["--program", session.programPath] : []),
-          "--format", "json"
-        ];
+        const graphArgs = callGraphCommandArguments(rootArgs, session.graphPath);
         const graph = await session.processes.runJson(
           session.root,
           graphArgs,
@@ -131,15 +123,6 @@ export class CallGraphPanel {
 
 function isDirection(value: unknown): value is CallDirection {
   return value === "callers" || value === "callees" || value === "both";
-}
-
-async function fileExists(file: string): Promise<boolean> {
-  try {
-    const stat = await vscode.workspace.fs.stat(vscode.Uri.file(file));
-    return (stat.type & vscode.FileType.File) !== 0;
-  } catch {
-    return false;
-  }
 }
 
 function userFacingError(message: string): string {


### PR DESCRIPTION
## Summary

- keep interactive VS Code call-graph resolution on the structural graph instead of reparsing optional Program IR for every reveal
- index caller/callee adjacency once per request instead of rescanning every edge for each visited node
- enforce node, edge, and continuation bounds during traversal
- add high-fanout latency coverage and an extension command-boundary regression

## Root cause

The VS Code panel eagerly passed `program.json` whenever it existed, so every initial load, direction change, and expansion reparsed and validated a potentially very large optional artifact. Traversal then filtered the complete call-edge list once for every reached node and only applied request bounds after exploring the reachable graph.

## Impact

Interactive callers/callees now resolve from the required structural graph while explicit CLI callers can still opt into Program IR enrichment. Traversal work and response continuation metadata stay bounded for dense or high-fanout graphs.

On the repository's 26,567-node / 63,204-edge artifact, warm graph-only resolution measured about 0.20 seconds. The 16,000-edge high-fanout regression completes in roughly 0.3–0.5 seconds in an unoptimized test build.

## Validation

- `cargo test -p compass-analysis`
- `cargo test -p compass-cli --test call_graph_cli`
- `cargo clippy -p compass-analysis --tests -- -D warnings`
- `npm test --workspace editors/vscode` (62 tests)
- `npm run typecheck --workspace editors/vscode`
- `npm run build --workspace editors/vscode`
- `cargo build --release -p compass-cli`
