### PR TITLE
Harden v1 producer resolution and publication safety

### DIFF
--- a/.github/workflows/compass-ci.yml
+++ b/.github/workflows/compass-ci.yml
@@ -122,6 +122,7 @@ jobs:
           sh -n scripts/install.sh
           sh -n scripts/package_release.sh
           sh -n scripts/test_release_scripts.sh
+          bash -n scripts/qualify_code_graph_v1.sh
           sh scripts/test_release_scripts.sh
           bash -n completions/compass.bash
           python -c "import ast,pathlib; ast.parse(pathlib.Path('scripts/measure_process.py').read_text())"

--- a/.github/workflows/compass-release.yml
+++ b/.github/workflows/compass-release.yml
@@ -25,9 +25,28 @@ jobs:
           test "$(printf '%s\n' "$versions" | wc -l | tr -d ' ')" = "1"
           test "$GITHUB_REF_NAME" = "compass-v$versions"
 
+  code-graph-qualification:
+    needs: metadata
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.97.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          key: release-code-graph-qualification
+      - name: Qualify pinned enterprise repository
+        shell: bash
+        run: >-
+          ./scripts/qualify_code_graph_v1.sh
+          --repositories tests/qualification/code-graph-v1-repositories.toml
+
   build:
     name: Build ${{ matrix.target }}
-    needs: metadata
+    needs: [metadata, code-graph-qualification]
     strategy:
       fail-fast: false
       matrix:

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1152,6 +1152,26 @@ fn build_graph_inner(
     if document.nodes.is_empty() {
         return Err(CoreError::EmptyGraph);
     }
+    let commit = options.built_at_commit.clone().or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|directory| git_commit(&directory))
+    });
+    let preflight_started = Instant::now();
+    normalize_document_v1_with_inventory(
+        &document,
+        &root,
+        graph_configuration_digest(options, &output_dir)?,
+        commit.as_deref(),
+        detection_inventory(
+            &detection,
+            semantic,
+            &extraction_failures,
+            &extraction_partials,
+            &root,
+        ),
+    )?;
+    profile_internal_duration("graph.json v1 preflight", preflight_started.elapsed());
 
     let unchanged_artifacts_complete = match options.purpose {
         BuildPurpose::Update => update_artifacts_complete(&output_dir),
@@ -1266,11 +1286,6 @@ fn build_graph_inner(
     stage_started = Instant::now();
     let labels = label_communities_by_hub(&document, &communities);
     profile_internal("community labeling", &mut internal_started);
-    let commit = options.built_at_commit.clone().or_else(|| {
-        std::env::current_dir()
-            .ok()
-            .and_then(|directory| git_commit(&directory))
-    });
 
     let graph_output = || -> Result<Duration, CoreError> {
         let started = Instant::now();
@@ -3911,13 +3926,19 @@ mod tests {
             .filter(|node| node.label() == "[]")
             .collect::<Vec<_>>();
         assert!(
-            !punctuation_symbols.is_empty(),
-            "fixture must exercise the punctuation-symbol identity collision"
+            punctuation_symbols.is_empty(),
+            "generic punctuation symbols must not be guessed into the typed graph"
         );
         assert!(
-            punctuation_symbols
-                .iter()
-                .all(|node| node.id.starts_with("sha256:"))
+            first_graph.graph.diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == "unresolved_node_kind"
+                    && diagnostic
+                        .anchor
+                        .as_ref()
+                        .is_some_and(|anchor| anchor.file == "src/Page.astro")
+            }),
+            "omitted generic symbols must remain visible as anchored diagnostics: {:#?}",
+            first_graph.graph.diagnostics
         );
         Ok(())
     }

--- a/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
+++ b/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 use std::path::Path;
 
-use compass_core::{BuildOptions, build_local_graph};
+use compass_core::{BuildOptions, build_graph_with_layers, build_local_graph};
 use compass_files::{Cache, CacheOptions};
 use compass_languages::{Extraction, Registry};
 use compass_model::code_graph::{CoverageStatus, ExtractionStatus, GraphDocument};
@@ -26,6 +26,70 @@ fn write(root: &Path, relative: &str, source: &str) -> Result<(), Box<dyn Error>
         fs::create_dir_all(parent)?;
     }
     fs::write(path, source)?;
+    Ok(())
+}
+
+#[test]
+fn failed_topology_preflight_preserves_the_last_known_good_generation() -> Result<(), Box<dyn Error>>
+{
+    let directory = tempfile::tempdir()?;
+    write(directory.path(), "src/main.rs", "pub fn healthy() {}\n")?;
+    let mut options = BuildOptions::new(directory.path());
+    options.no_viz = true;
+    options.built_at_commit = Some("0123456789012345678901234567890123456789".to_owned());
+    let first = build_local_graph(&options)?;
+    let graph_before = fs::read(first.output_dir.join("graph.json"))?;
+    let pointer = directory
+        .path()
+        .join("compass-out/.compass-active-generation");
+    let active_before = fs::read_to_string(&pointer)?;
+
+    options.force = true;
+    let invalid_layer = serde_json::json!({
+        "nodes": [
+            {
+                "id": "invalid_owner",
+                "label": "owner",
+                "symbol_kind": "variable",
+                "file_type": "code",
+                "source_file": "src/main.rs",
+                "source_location": "L1",
+                "language": "rust",
+                "extractor": "test.invalid"
+            },
+            {
+                "id": "invalid_method",
+                "label": ".method()",
+                "symbol_kind": "method",
+                "file_type": "code",
+                "source_file": "src/main.rs",
+                "source_location": "L1",
+                "language": "rust",
+                "extractor": "test.invalid"
+            }
+        ],
+        "edges": [{
+            "source": "invalid_owner",
+            "target": "invalid_method",
+            "relation": "method",
+            "source_file": "src/main.rs",
+            "source_location": "L1",
+            "confidence": "EXTRACTED",
+            "extractor": "test.invalid"
+        }]
+    });
+    let error = match build_graph_with_layers(&options, None, &[invalid_layer]) {
+        Ok(_) => return Err("invalid endpoint topology passed publication preflight".into()),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("contains")
+            && error.to_string().contains("variable")
+            && error.to_string().contains("method"),
+        "unexpected preflight error: {error}"
+    );
+    assert_eq!(fs::read_to_string(&pointer)?, active_before);
+    assert_eq!(fs::read(first.output_dir.join("graph.json"))?, graph_before);
     Ok(())
 }
 

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -433,6 +433,13 @@ pub fn normalize_v1(
     split_sourceless_placeholders(&mut extraction, &evidence.repository_root, &file_facts)?;
     let stub_wiring_sites =
         collect_stub_wiring_sites(&extraction.edges, &evidence.repository_root, &file_facts)?;
+    resolve_or_drop_generic_symbols(
+        &mut extraction,
+        &mut evidence.diagnostics,
+        &evidence.repository_root,
+        &file_facts,
+        &stub_wiring_sites,
+    )?;
 
     let mut id_remap = HashMap::with_capacity(extraction.nodes.len());
     let mut nodes = BTreeMap::new();
@@ -1147,8 +1154,136 @@ fn inferred_external_target_kind(attributes: &Map<String, Value>) -> Option<&'st
     match optional_string(attributes, "relation").as_deref() {
         Some("implements" | "scip_impl" | "mixes_in") => Some("interface"),
         Some("extends" | "inherits") => Some("class"),
+        Some("calls" | "indirect_call") => Some("function"),
+        Some("type_of" | "returns" | "scip_typed") => Some("type_alias"),
+        Some("references")
+            if matches!(
+                optional_string(attributes, "context").as_deref(),
+                Some(
+                    "field"
+                        | "generic_arg"
+                        | "parameter_type"
+                        | "return_type"
+                        | "type"
+                        | "type_annotation"
+                )
+            ) =>
+        {
+            Some("type_alias")
+        }
         _ => None,
     }
+}
+
+fn resolve_or_drop_generic_symbols(
+    extraction: &mut Extraction,
+    diagnostics: &mut Vec<GraphDiagnostic>,
+    root: &Path,
+    file_facts: &HashMap<String, PublishedFileFacts>,
+    wiring_sites: &HashMap<String, SourceAnchor>,
+) -> Result<(), GraphError> {
+    let generic_ids = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.attributes.get(TRUSTED_NODE_RECORD).is_none()
+                && node
+                    .attributes
+                    .get("file_type")
+                    .and_then(Value::as_str)
+                    .unwrap_or("code")
+                    == "code"
+                && node
+                    .attributes
+                    .get("symbol_kind")
+                    .or_else(|| node.attributes.get("type"))
+                    .and_then(Value::as_str)
+                    .is_none_or(|kind| kind == "symbol")
+        })
+        .map(|node| node.id.clone())
+        .collect::<BTreeSet<_>>();
+    if generic_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut inferred = HashMap::<String, BTreeSet<&'static str>>::new();
+    for edge in &extraction.edges {
+        if generic_ids.contains(&edge.target)
+            && let Some(kind) = inferred_external_target_kind(&edge.attributes)
+        {
+            inferred
+                .entry(edge.target.clone())
+                .or_default()
+                .insert(kind);
+        }
+    }
+
+    for node in &mut extraction.nodes {
+        let Some(kinds) = inferred.get(&node.id).filter(|kinds| kinds.len() == 1) else {
+            continue;
+        };
+        if let Some(kind) = kinds.first() {
+            node.attributes
+                .insert("symbol_kind".to_owned(), Value::String((*kind).to_owned()));
+        }
+    }
+
+    let dropped = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            generic_ids.contains(&node.id)
+                && node
+                    .attributes
+                    .get("symbol_kind")
+                    .or_else(|| node.attributes.get("type"))
+                    .and_then(Value::as_str)
+                    .is_none_or(|kind| kind == "symbol")
+        })
+        .map(|node| node.id.clone())
+        .collect::<BTreeSet<_>>();
+    if dropped.is_empty() {
+        return Ok(());
+    }
+
+    for node in extraction
+        .nodes
+        .iter()
+        .filter(|node| dropped.contains(&node.id))
+    {
+        let incident_count = extraction
+            .edges
+            .iter()
+            .filter(|edge| edge.source == node.id || edge.target == node.id)
+            .count();
+        let anchor = raw_anchor(&node.attributes, root, file_facts)?
+            .or(raw_origin_anchor(&node.attributes, root, file_facts)?)
+            .or_else(|| wiring_sites.get(&node.id).cloned());
+        if anchor.is_none()
+            && optional_string(&node.attributes, "extractor").as_deref()
+                == Some("compass.graph.external-placeholder")
+        {
+            return Err(raw_error(
+                &node.id,
+                "unresolved external placeholder requires an exact wiring site",
+            ));
+        }
+        diagnostics.push(GraphDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: "unresolved_node_kind".to_owned(),
+            message: format!(
+                "omitted generic symbol {} and {incident_count} incident relationships because no exact node kind could be inferred",
+                node.id
+            ),
+            anchor,
+            related_ids: Vec::new(),
+        });
+    }
+    extraction.nodes.retain(|node| !dropped.contains(&node.id));
+    extraction
+        .edges
+        .retain(|edge| !dropped.contains(&edge.source) && !dropped.contains(&edge.target));
+    Ok(())
 }
 
 fn mark_external_placeholder(
@@ -2502,7 +2637,7 @@ fn map_node_kind(
         "constructor" => NodeKind::Constructor,
         "property" => NodeKind::Property,
         "field" => NodeKind::Field,
-        "variable" | "symbol" => NodeKind::Variable,
+        "variable" => NodeKind::Variable,
         "constant" => NodeKind::Constant,
         "parameter" => NodeKind::Parameter,
         "import" => NodeKind::Import,

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -919,18 +919,55 @@ fn normalization_treats_blank_external_source_paths_as_unanchored()
     graph.edges.clear();
 
     let document = normalize_v1(graph, build_evidence(root)?)?;
+    assert!(
+        document.nodes.iter().all(|node| node.name != "callee"),
+        "a generic symbol without structural kind evidence must not be guessed as a variable"
+    );
+    assert!(document.graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unresolved_node_kind"
+            && diagnostic.message.contains("raw:b")
+            && diagnostic.anchor.is_some()
+    }));
+    Ok(())
+}
+
+#[test]
+fn normalization_infers_an_external_call_target_as_a_function()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let graph = Extraction {
+        nodes: vec![
+            raw_node(root, "raw:caller", "caller", 10),
+            raw_external_node("raw:external", "external"),
+        ],
+        edges: vec![RawEdgeRecord {
+            source: "raw:caller".to_owned(),
+            target: "raw:external".to_owned(),
+            attributes: Map::from_iter([
+                ("relation".to_owned(), json!("calls")),
+                ("confidence".to_owned(), json!("INFERRED")),
+                ("extractor".to_owned(), json!("test.rust")),
+                ("source_anchor".to_owned(), anchor(root, 50)),
+            ]),
+        }],
+        ..Extraction::default()
+    };
+
+    let document = normalize_v1(graph, build_evidence(root)?)?;
     let external = document
         .nodes
         .iter()
-        .find(|node| node.name == "callee")
-        .ok_or("missing external node")?;
-    assert_eq!(external.source, None);
-    assert_eq!(external.kind, NodeKind::Variable);
-    assert_eq!(
-        external.evidence[0].rule.as_deref(),
-        Some("external-symbol-placeholder")
-    );
-    assert!(external.evidence[0].wiring_site.is_some());
+        .find(|node| node.name == "external")
+        .ok_or("missing inferred external function")?;
+    assert_eq!(external.kind, NodeKind::Function);
+    assert!(external.source.is_none());
+    assert!(external.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unresolved_external_symbol" && diagnostic.anchor.is_some()
+    }));
+    assert!(document.links.iter().any(|edge| {
+        edge.kind == EdgeKind::Calls && edge.target == external.id && edge.deferred
+    }));
     Ok(())
 }
 
@@ -1215,10 +1252,16 @@ fn authoritative_incident_scope_separates_precoalesced_java_and_typescript_place
     global_entity
         .attributes
         .insert("origin_file".to_owned(), json!("src/typeorm.ts"));
+    global_entity
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("type_alias"));
     let mut duplicate_typescript_entity = raw_external_node("raw:entity-ts", "Entity");
     duplicate_typescript_entity
         .attributes
         .insert("language".to_owned(), json!("java"));
+    duplicate_typescript_entity
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("type_alias"));
     duplicate_typescript_entity.attributes.insert(
         "declaring_scope".to_owned(),
         json!("stale-typescript-owner"),

--- a/crates/compass-languages/src/go.rs
+++ b/crates/compass-languages/src/go.rs
@@ -37,6 +37,13 @@ pub(crate) fn extract(path: &Path, source: &[u8], root: Node<'_>) -> Extraction 
     GoState::new(path, source).run(root)
 }
 
+#[derive(Clone)]
+struct LexicalBinding {
+    name: String,
+    active_from: usize,
+    active_until: usize,
+}
+
 struct GoState<'source, 'tree> {
     source: &'source [u8],
     source_file: String,
@@ -45,7 +52,7 @@ struct GoState<'source, 'tree> {
     file_id: String,
     extraction: Extraction,
     seen: HashSet<String>,
-    function_bodies: Vec<(String, Node<'tree>)>,
+    function_bodies: Vec<(String, Node<'tree>, Vec<LexicalBinding>)>,
     imported_packages: HashSet<String>,
 }
 
@@ -105,7 +112,8 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                     self.add_edge(&self.file_id.clone(), &id, "contains", at, None);
                     self.add_function_references(node, &id, at);
                     if let Some(body) = node.child_by_field_name("body") {
-                        self.function_bodies.push((id, body));
+                        self.function_bodies
+                            .push((id, body, lexical_bindings(node, self.source)));
                     }
                 }
                 return;
@@ -160,7 +168,8 @@ impl<'source, 'tree> GoState<'source, 'tree> {
         };
         self.add_function_references(node, &id, at);
         if let Some(body) = node.child_by_field_name("body") {
-            self.function_bodies.push((id, body));
+            self.function_bodies
+                .push((id, body, lexical_bindings(node, self.source)));
         }
     }
 
@@ -365,8 +374,8 @@ impl<'source, 'tree> GoState<'source, 'tree> {
             );
         }
         let mut seen_pairs = HashSet::new();
-        for (caller, body) in self.function_bodies.clone() {
-            self.walk_calls_in(body, &caller, &labels, &mut seen_pairs);
+        for (caller, body, bindings) in self.function_bodies.clone() {
+            self.walk_calls_in(body, &caller, &labels, &bindings, &mut seen_pairs);
         }
     }
 
@@ -375,6 +384,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
         node: Node<'tree>,
         caller: &str,
         labels: &HashMap<String, String>,
+        lexical_bindings: &[LexicalBinding],
         seen_pairs: &mut HashSet<(String, String, usize, usize)>,
     ) {
         if matches!(node.kind(), "function_declaration" | "method_declaration") {
@@ -398,7 +408,16 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                 (None, false)
             };
             if let Some(callee) = callee {
-                if let Some(target) = labels.get(&callee).filter(|target| *target != caller) {
+                let is_lexically_bound = function.kind() == "identifier"
+                    && lexical_bindings.iter().any(|binding| {
+                        binding.name == callee
+                            && binding.active_from <= function.start_byte()
+                            && function.start_byte() < binding.active_until
+                    });
+                if is_lexically_bound {
+                    // A local callback or function value shadows repository-level symbols.
+                } else if let Some(target) = labels.get(&callee).filter(|target| *target != caller)
+                {
                     let pair = (
                         caller.to_owned(),
                         target.clone(),
@@ -426,7 +445,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.walk_calls_in(child, caller, labels, seen_pairs);
+            self.walk_calls_in(child, caller, labels, lexical_bindings, seen_pairs);
         }
     }
 
@@ -502,6 +521,123 @@ impl<'source, 'tree> GoState<'source, 'tree> {
     fn text(&self, node: Node<'_>) -> String {
         node.utf8_text(self.source).unwrap_or_default().to_owned()
     }
+}
+
+fn lexical_bindings(callable: Node<'_>, source: &[u8]) -> Vec<LexicalBinding> {
+    fn collect_binding_identifiers(node: Node<'_>, source: &[u8], names: &mut Vec<String>) {
+        if node.kind() == "identifier"
+            && let Ok(name) = node.utf8_text(source)
+            && !name.is_empty()
+        {
+            names.push(name.to_owned());
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+            collect_binding_identifiers(child, source, names);
+        }
+    }
+
+    fn push_bindings(
+        names_node: Node<'_>,
+        source: &[u8],
+        active_from: usize,
+        active_until: usize,
+        bindings: &mut Vec<LexicalBinding>,
+    ) {
+        let mut names = Vec::new();
+        collect_binding_identifiers(names_node, source, &mut names);
+        names.sort();
+        names.dedup();
+        bindings.extend(names.into_iter().map(|name| LexicalBinding {
+            name,
+            active_from,
+            active_until,
+        }));
+    }
+
+    fn walk(node: Node<'_>, source: &[u8], scope_end: usize, bindings: &mut Vec<LexicalBinding>) {
+        if node.kind() == "func_literal"
+            && let Some(body) = node.child_by_field_name("body")
+        {
+            if let Some(parameters) = node.child_by_field_name("parameters") {
+                push_bindings(
+                    parameters,
+                    source,
+                    body.start_byte(),
+                    body.end_byte(),
+                    bindings,
+                );
+            }
+            walk(body, source, body.end_byte(), bindings);
+            return;
+        }
+        let scope_end = if node.kind() == "block" {
+            node.end_byte()
+        } else {
+            scope_end
+        };
+        match node.kind() {
+            "var_spec" => {
+                let type_node = node.child_by_field_name("type");
+                let value_node = node.child_by_field_name("value");
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor).filter(|child| {
+                    child.is_named() && Some(*child) != type_node && Some(*child) != value_node
+                }) {
+                    if child.kind() == "identifier" {
+                        push_bindings(child, source, node.end_byte(), scope_end, bindings);
+                    }
+                }
+            }
+            "short_var_declaration" => {
+                if let Some(left) = node.child_by_field_name("left") {
+                    push_bindings(left, source, node.end_byte(), scope_end, bindings);
+                }
+            }
+            "for_statement" => {
+                let body = node.child_by_field_name("body");
+                let mut cursor = node.walk();
+                if let Some(range) = node
+                    .children(&mut cursor)
+                    .find(|child| child.kind() == "range_clause")
+                    && range.utf8_text(source).unwrap_or_default().contains(":=")
+                    && let Some(left) = range.child_by_field_name("left")
+                {
+                    push_bindings(
+                        left,
+                        source,
+                        range.end_byte(),
+                        body.map_or(node.end_byte(), |body| body.end_byte()),
+                        bindings,
+                    );
+                }
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+            walk(child, source, scope_end, bindings);
+        }
+    }
+
+    let Some(body) = callable.child_by_field_name("body") else {
+        return Vec::new();
+    };
+    let mut bindings = Vec::new();
+    for field in ["receiver", "parameters"] {
+        if let Some(parameters) = callable.child_by_field_name(field) {
+            push_bindings(
+                parameters,
+                source,
+                body.start_byte(),
+                body.end_byte(),
+                &mut bindings,
+            );
+        }
+    }
+    walk(body, source, body.end_byte(), &mut bindings);
+    bindings
 }
 
 fn collect_type_refs(

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -225,6 +225,8 @@ fn finish_resolution(
     profile_internal("resolver JavaScript re-exports", &mut profile_started);
     canonicalize_import_targets(&mut merged);
     profile_internal("resolver import canonicalization", &mut profile_started);
+    canonicalize_go_receiver_owners(&mut merged);
+    profile_internal("resolver Go receiver ownership", &mut profile_started);
     let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     disambiguate_colliding_node_ids_with_calls(
         &mut merged,
@@ -856,6 +858,73 @@ fn is_type_like_definition(node: &NodeRecord) -> bool {
     !label.is_empty() && !label.ends_with(')') && !label.starts_with('.') && !label.contains('.')
 }
 
+fn canonicalize_go_receiver_owners(extraction: &mut Extraction) {
+    let mut groups = HashMap::<&str, Vec<usize>>::new();
+    for (index, node) in extraction.nodes.iter().enumerate() {
+        if !node.id.is_empty() && string_attribute(node, "language") == "go" {
+            groups.entry(&node.id).or_default().push(index);
+        }
+    }
+
+    let mut dropped = HashSet::new();
+    for (id, indexes) in groups {
+        if indexes.len() < 2 {
+            continue;
+        }
+        let definitions = indexes
+            .iter()
+            .copied()
+            .filter(|index| {
+                matches!(
+                    string_attribute(&extraction.nodes[*index], "symbol_kind").as_str(),
+                    "class" | "struct" | "interface" | "type_alias"
+                )
+            })
+            .collect::<Vec<_>>();
+        if definitions.len() != 1 {
+            continue;
+        }
+        let definition = &extraction.nodes[definitions[0]];
+        let definition_scope = repository_scope(&string_attribute(definition, "source_file"));
+        let definition_label = definition.label();
+        if definition_scope.is_empty() || definition_label.is_empty() {
+            continue;
+        }
+
+        for index in indexes {
+            if index == definitions[0] {
+                continue;
+            }
+            let candidate = &extraction.nodes[index];
+            let candidate_source = string_attribute(candidate, "source_file");
+            if string_attribute(candidate, "symbol_kind") != "symbol"
+                || candidate.label() != definition_label
+                || repository_scope(&candidate_source) != definition_scope
+            {
+                continue;
+            }
+            let owns_method_in_source = extraction.edges.iter().any(|edge| {
+                edge.source == id
+                    && relation(edge) == "method"
+                    && edge.string("source_file") == candidate_source
+            });
+            if owns_method_in_source {
+                dropped.insert(index);
+            }
+        }
+    }
+
+    if dropped.is_empty() {
+        return;
+    }
+    let mut index = 0_usize;
+    extraction.nodes.retain(|_| {
+        let keep = !dropped.contains(&index);
+        index += 1;
+        keep
+    });
+}
+
 #[cfg(test)]
 fn disambiguate_colliding_node_ids(extraction: &mut Extraction, root: &Path) {
     let mut raw_calls = extraction.raw_calls.take();
@@ -1082,9 +1151,7 @@ fn resolve_cross_file_calls_with_root_calls(
                 .entry(source.clone())
                 .or_insert_with(|| node.id.clone());
         }
-        if string_attribute(node, "file_type") == "rationale"
-            || string_attribute(node, "type") == "namespace"
-        {
+        if !is_generic_call_target(node) {
             continue;
         }
         let label = node
@@ -2586,6 +2653,21 @@ fn is_file_node(node: &NodeRecord, source: &str) -> bool {
             .file_name()
             .and_then(|value| value.to_str())
             == Some(node.label())
+}
+
+fn is_generic_call_target(node: &NodeRecord) -> bool {
+    if node.attributes.get("_callable").and_then(Value::as_bool) == Some(true) {
+        return true;
+    }
+    let kind = string_attribute(node, "symbol_kind");
+    let legacy_kind = string_attribute(node, "type");
+    matches!(
+        kind.as_str(),
+        "function" | "method" | "constructor" | "database_procedure"
+    ) || matches!(
+        legacy_kind.as_str(),
+        "function" | "method" | "constructor" | "database_procedure"
+    )
 }
 
 fn relation(edge: &EdgeRecord) -> &str {

--- a/crates/compass-resolve/tests/go_resolution.rs
+++ b/crates/compass-resolve/tests/go_resolution.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+use compass_languages::{Engine, RawNodeRecord};
+use serde_json::{Map, Value};
+
+#[test]
+fn cross_file_go_receiver_methods_use_the_declared_type_owner() -> Result<(), Box<dyn Error>> {
+    let declaration_path = Path::new("cmd/agent/vogon.go");
+    let declaration_source = b"package agent\n\ntype Agent struct{}\n";
+    let methods_path = Path::new("cmd/agent/hooks.go");
+    let methods_source = br#"package agent
+
+func (a *Agent) Prepare() {}
+func (a *Agent) Finish() {}
+"#;
+
+    let mut engine = Engine::default();
+    let declaration = engine.extract_source(declaration_path, declaration_source)?;
+    let methods = engine.extract_source(methods_path, methods_source)?;
+    let sources = HashMap::from([
+        (
+            declaration_path.to_string_lossy().into_owned(),
+            String::from_utf8(declaration_source.to_vec())?,
+        ),
+        (
+            methods_path.to_string_lossy().into_owned(),
+            String::from_utf8(methods_source.to_vec())?,
+        ),
+    ]);
+
+    let resolved =
+        compass_resolve::resolve_with_root(&[declaration, methods], &sources, Path::new("."));
+    let owners = resolved
+        .nodes
+        .iter()
+        .filter(|node| node.label() == "Agent")
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        owners.len(),
+        1,
+        "receiver placeholders must be rebound before source-ID disambiguation: {:?}",
+        resolved.nodes
+    );
+    let owner_id = &owners[0].id;
+    let method_edges = resolved
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "method")
+        .collect::<Vec<_>>();
+    assert_eq!(method_edges.len(), 2, "edges={:?}", resolved.edges);
+    assert!(
+        method_edges.iter().all(|edge| &edge.source == owner_id),
+        "every receiver method must be owned by the declared type: {method_edges:?}"
+    );
+    assert_eq!(
+        owners[0].string("source_file"),
+        declaration_path.to_string_lossy()
+    );
+    Ok(())
+}
+
+#[test]
+fn go_local_callback_is_not_exported_for_cross_file_resolution() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("internal/pushqueue/pushqueue.go");
+    let source = br#"package pushqueue
+
+func acquire() (func(), error) { return func() {}, nil }
+
+func enqueue() {
+    release, err := acquire()
+    _ = err
+    defer release()
+}
+"#;
+
+    let extracted = Engine::default().extract_source(path, source)?;
+    let raw_calls = extracted.raw_calls.as_deref().unwrap_or_default();
+    assert!(
+        raw_calls.iter().all(|call| call.callee != "release"),
+        "lexically bound callbacks must stay within their callable scope: {raw_calls:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn go_local_binding_only_shadows_calls_after_its_declaration() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("internal/pushqueue/shadow.go");
+    let source = br#"package pushqueue
+
+func release() {}
+func enqueue() {
+    release()
+    release := func() {}
+    release()
+}
+"#;
+
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let release_calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && resolved.nodes.iter().any(|node| {
+                    node.id == edge.target
+                        && node.label() == "release()"
+                        && node.string("source_file") == path.to_string_lossy()
+                })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        release_calls.len(),
+        1,
+        "only the call before the short declaration targets the package function: {:?}",
+        resolved.edges
+    );
+    assert_eq!(release_calls[0].string("source_location"), "L5");
+    Ok(())
+}
+
+#[test]
+fn generic_call_resolution_never_targets_file_nodes() -> Result<(), Box<dyn Error>> {
+    let caller_path = Path::new("internal/pushqueue/pushqueue.go");
+    let caller_source = b"package pushqueue\n\nfunc enqueue() { release() }\n";
+    let mut extracted = Engine::default().extract_source(caller_path, caller_source)?;
+    extracted.nodes.push(RawNodeRecord {
+        id: "mise_tasks_release_file".to_owned(),
+        attributes: Map::from_iter([
+            ("label".to_owned(), Value::String("release".to_owned())),
+            (
+                "source_file".to_owned(),
+                Value::String("mise-tasks/release".to_owned()),
+            ),
+            ("file_type".to_owned(), Value::String("code".to_owned())),
+            ("symbol_kind".to_owned(), Value::String("file".to_owned())),
+        ]),
+    });
+    let sources = HashMap::from([(
+        caller_path.to_string_lossy().into_owned(),
+        String::from_utf8(caller_source.to_vec())?,
+    )]);
+
+    let resolved = compass_resolve::resolve_with_root(&[extracted], &sources, Path::new("."));
+    assert!(
+        resolved.edges.iter().all(|edge| {
+            edge.string("relation") != "calls" || edge.target != "mise_tasks_release_file"
+        }),
+        "file nodes must never be selected as callable targets: {:?}",
+        resolved.edges
+    );
+    Ok(())
+}

--- a/docs/design/code-graph-v1-qualification.md
+++ b/docs/design/code-graph-v1-qualification.md
@@ -36,6 +36,27 @@ Run the complete offline fixture gate from the repository root:
 ./scripts/qualify_code_graph_v1.sh --fixtures-only
 ```
 
+Run the pinned release corpus gate:
+
+```bash
+./scripts/qualify_code_graph_v1.sh \
+  --repositories tests/qualification/code-graph-v1-repositories.toml
+```
+
+For a clean local checkout at the pinned commit, avoid a second clone with:
+
+```bash
+./scripts/qualify_code_graph_v1.sh \
+  --repositories tests/qualification/code-graph-v1-repositories.toml \
+  --local-repository /Volumes/Workspace/Github/Entire
+```
+
+The release-corpus mode verifies the manifest pin, requires a clean source
+checkout, builds through the production CLI, strictly reloads the published
+`compass.graph/1` artifact, and fails unless the graph contains exactly zero
+error-severity validation diagnostics. The release workflow must pass this
+gate before platform binaries are packaged.
+
 The script:
 
 1. validates both manifests before building;

--- a/scripts/qualify_code_graph_v1.sh
+++ b/scripts/qualify_code_graph_v1.sh
@@ -6,12 +6,37 @@ QUALIFY_TMP="$(mktemp -d "${TMPDIR:-/tmp}/compass-code-graph-v1.XXXXXX")"
 trap 'chmod -R u+w "$QUALIFY_TMP" 2>/dev/null || true; rm -rf -- "$QUALIFY_TMP"' EXIT
 
 usage() {
-  echo "usage: $0 --fixtures-only" >&2
+  cat >&2 <<EOF
+usage:
+  $0 --fixtures-only
+  $0 --repositories <manifest> [--local-repository <path>]
+EOF
   exit 2
 }
 
-[[ "${1:-}" == "--fixtures-only" ]] || usage
-shift
+MODE=
+REPOSITORIES_MANIFEST=
+LOCAL_REPOSITORY=
+case "${1:-}" in
+  --fixtures-only)
+    MODE=fixtures
+    shift
+    ;;
+  --repositories)
+    MODE=repositories
+    REPOSITORIES_MANIFEST="${2:-}"
+    [[ -n "$REPOSITORIES_MANIFEST" ]] || usage
+    shift 2
+    if [[ "${1:-}" == "--local-repository" ]]; then
+      LOCAL_REPOSITORY="${2:-}"
+      [[ -n "$LOCAL_REPOSITORY" ]] || usage
+      shift 2
+    fi
+    ;;
+  *)
+    usage
+    ;;
+esac
 [[ "$#" -eq 0 ]] || usage
 
 cd "$QUALIFY_ROOT"
@@ -19,6 +44,159 @@ MANIFEST="$QUALIFY_ROOT/tests/qualification/code-graph-v1-semantic.json"
 CORPUS_MANIFEST="$QUALIFY_ROOT/tests/qualification/code-graph-v1-corpus.json"
 CORPUS="$QUALIFY_TMP/corpus"
 OUTPUT_PARENT="$QUALIFY_TMP/output"
+
+active_graph() {
+  python3 - "$1" <<'PY'
+import pathlib
+import sys
+
+output = pathlib.Path(sys.argv[1]) / "compass-out"
+pointer = output / ".compass-active-generation"
+generation = pointer.read_text().strip()
+if not generation.startswith("generation-") or "/" in generation or "\\" in generation:
+    raise SystemExit(f"invalid active generation {generation!r}")
+active = output / ".compass-generations" / generation
+if not active.is_dir() or (active / ".compass-build-incomplete").exists():
+    raise SystemExit(f"incomplete active generation {active}")
+print(active / "graph.json")
+PY
+}
+
+echo "[code-graph-v1] build qualifying production binary once"
+cargo build --locked -p compass-cli --bin compass
+COMPASS_BIN="$QUALIFY_ROOT/target/debug/compass"
+
+if [[ "$MODE" == repositories ]]; then
+  [[ -f "$REPOSITORIES_MANIFEST" ]] || {
+    echo "repository manifest not found: $REPOSITORIES_MANIFEST" >&2
+    exit 1
+  }
+  RELEASE_REPOSITORIES="$QUALIFY_TMP/release-repositories.tsv"
+  python3 - "$REPOSITORIES_MANIFEST" >"$RELEASE_REPOSITORIES" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+path = pathlib.Path(sys.argv[1])
+manifest = tomllib.loads(path.read_text())
+if manifest.get("schema") != "compass.code-graph-qualification/1":
+    raise SystemExit(f"unsupported repository manifest schema in {path}")
+repositories = [
+    repository
+    for repository in manifest.get("repository", [])
+    if repository.get("release_gate") is True
+]
+if not repositories:
+    raise SystemExit(f"no release-gate repositories declared in {path}")
+for repository in repositories:
+    required = {
+        "name",
+        "url",
+        "commit",
+        "size_class",
+        "language_family",
+        "release_gate",
+        "required_validation_errors",
+    }
+    missing = required - repository.keys()
+    if missing:
+        raise SystemExit(
+            f"repository {repository.get('name', '<unknown>')} missing {sorted(missing)}"
+        )
+    if repository["required_validation_errors"] != 0:
+        raise SystemExit(
+            f"repository {repository['name']} must require zero validation errors"
+        )
+    print(
+        "\t".join(
+            [
+                repository["name"],
+                repository["url"],
+                repository["commit"],
+                str(repository["required_validation_errors"]),
+            ]
+        )
+    )
+PY
+  repository_count="$(wc -l <"$RELEASE_REPOSITORIES" | tr -d ' ')"
+  if [[ -n "$LOCAL_REPOSITORY" && "$repository_count" -ne 1 ]]; then
+    echo "--local-repository requires exactly one release-gate repository" >&2
+    exit 1
+  fi
+
+  while IFS=$'\t' read -r repository_name repository_url repository_commit required_errors; do
+    repository="$QUALIFY_TMP/repositories/$repository_name"
+    if [[ -n "$LOCAL_REPOSITORY" ]]; then
+      repository="$(cd "$LOCAL_REPOSITORY" && pwd)"
+    else
+      git clone --quiet --no-checkout "$repository_url" "$repository"
+      git -C "$repository" checkout --quiet --detach "$repository_commit"
+    fi
+    [[ "$(git -C "$repository" rev-parse HEAD)" == "$repository_commit" ]] || {
+      echo "$repository_name is not at pinned commit $repository_commit" >&2
+      exit 1
+    }
+    status_before="$(git -C "$repository" status --porcelain=v1 --untracked-files=all)"
+    [[ -z "$status_before" ]] || {
+      echo "$repository_name qualification repository must be clean" >&2
+      exit 1
+    }
+
+    repository_output="$QUALIFY_TMP/repository-output/$repository_name"
+    echo "[code-graph-v1] qualify pinned repository $repository_name@$repository_commit"
+    "$COMPASS_BIN" update "$repository" \
+      --out "$repository_output" --no-cluster --no-viz \
+      >"$QUALIFY_TMP/$repository_name.log"
+    repository_graph="$(active_graph "$repository_output")"
+    "$COMPASS_BIN" benchmark "$repository_graph" \
+      >"$QUALIFY_TMP/$repository_name.benchmark.json"
+    python3 - "$repository_graph" "$repository_name" "$repository_commit" "$required_errors" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+name = sys.argv[2]
+commit = sys.argv[3]
+required_errors = int(sys.argv[4])
+graph_bytes = path.read_bytes()
+graph = json.loads(graph_bytes)
+metadata = graph.get("graph", {})
+if metadata.get("schema") != "compass.graph/1":
+    raise SystemExit(f"{name}: unexpected graph schema {metadata.get('schema')!r}")
+diagnostics = metadata.get("diagnostics", [])
+validation_errors = sum(
+    diagnostic.get("severity") == "error" for diagnostic in diagnostics
+)
+if validation_errors != required_errors:
+    raise SystemExit(
+        f"{name}: expected {required_errors} validation errors, found {validation_errors}"
+    )
+print(
+    json.dumps(
+        {
+            "schema": "compass.code-graph-repository-qualification/1",
+            "repository": name,
+            "commit": commit,
+            "graphSha256": hashlib.sha256(graph_bytes).hexdigest(),
+            "nodes": len(graph.get("nodes", [])),
+            "edges": len(graph.get("links", [])),
+            "validationErrors": validation_errors,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+)
+PY
+    status_after="$(git -C "$repository" status --porcelain=v1 --untracked-files=all)"
+    [[ "$status_after" == "$status_before" ]] || {
+      echo "$repository_name source repository changed during qualification" >&2
+      exit 1
+    }
+  done <"$RELEASE_REPOSITORIES"
+  exit 0
+fi
 
 echo "[code-graph-v1] validate strict manifests"
 python3 scripts/check_code_graph_v1_coverage.py \
@@ -39,10 +217,6 @@ cargo test --locked -p compass-query --test code_query_scale \
 cargo test --locked -p compass-resolve --test framework_resolution_scale \
   shared_production_framework_resolution_stays_within_enterprise_ceiling
 
-echo "[code-graph-v1] build qualifying production binary once"
-cargo build --locked -p compass-cli --bin compass
-COMPASS_BIN="$QUALIFY_ROOT/target/debug/compass"
-
 mkdir -p "$CORPUS/fixtures/code-graph"
 cp -R "$QUALIFY_ROOT/fixtures/code-graph/." "$CORPUS/fixtures/code-graph/"
 python3 - "$CORPUS_MANIFEST" "$CORPUS" <<'PY'
@@ -57,23 +231,6 @@ for fixture in manifest["files"]:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(fixture["contents"].encode("utf-8"))
 PY
-
-active_graph() {
-  python3 - "$1" <<'PY'
-import pathlib
-import sys
-
-output = pathlib.Path(sys.argv[1]) / "compass-out"
-pointer = output / ".compass-active-generation"
-generation = pointer.read_text().strip()
-if not generation.startswith("generation-") or "/" in generation or "\\" in generation:
-    raise SystemExit(f"invalid active generation {generation!r}")
-active = output / ".compass-generations" / generation
-if not active.is_dir() or (active / ".compass-build-incomplete").exists():
-    raise SystemExit(f"incomplete active generation {active}")
-print(active / "graph.json")
-PY
-}
 
 fixture_digest() {
   python3 - "$QUALIFY_ROOT/fixtures/code-graph" <<'PY'

--- a/tests/qualification/code-graph-v1-repositories.toml
+++ b/tests/qualification/code-graph-v1-repositories.toml
@@ -380,3 +380,13 @@ framework = "astro"
 name = "Astro dynamic page"
 query = "slug"
 source = "fixtures/code-graph/routes/typescript/astro/src/pages/blog/[slug].astro"
+
+[[repository]]
+name = "entire-cli"
+url = "https://github.com/entireio/cli.git"
+commit = "683a10d3773ee4830ee791f39d76d8092ef1b0cf"
+size_class = "large"
+language_family = "go"
+frameworks = []
+release_gate = true
+required_validation_errors = 0


### PR DESCRIPTION
## Summary

Hardens Compass v1 graph production without weakening the v1 validator:

- canonicalizes Go receiver ownership before source-ID disambiguation
- resolves calls with lexical scope and callable-kind constraints so file nodes cannot become call targets
- replaces the generic `symbol` → `variable` fallback with structural kind inference or an anchored diagnostic
- validates the normalized v1 graph before clustering and publication
- preserves the last-known-good generation when a new build fails validation
- adds a pinned, zero-validation-error repository qualification gate to release CI

## Motivation

Strict v1 validation exposed producer defects that could create duplicate Go receiver owners, resolve local callbacks across files, target file nodes from call edges, or publish guessed variable kinds. These failures prevented otherwise supported repositories from completing a graph build after the v1 cutover.

This change repairs the producer and resolution stages at their source. Ambiguous generic nodes now fail closed with actionable diagnostics, and invalid graphs are rejected before expensive clustering or any generation-pointer update.

## Verification

```text
cargo test --workspace --lib --bins --locked
# passed; 0 failed; 2 pre-existing ignored parser-pack tests

cargo clippy --locked -p compass-languages -p compass-resolve -p compass-graph -p compass-core --all-targets -- -D warnings
# passed

cargo fmt --all -- --check
git diff --check
bash -n scripts/qualify_code_graph_v1.sh
# passed

./scripts/qualify_code_graph_v1.sh --repositories tests/qualification/code-graph-v1-repositories.toml --local-repository /Volumes/Workspace/Github/Entire
# schema: compass.code-graph-repository-qualification/1
# nodes: 22,294; edges: 72,199; validationErrors: 0
```

Additional production-corpus checks confirmed:

- `contains variable -> method`: 0
- `calls -> file`: 0
- generic symbol kinds: 0
- the Go `Agent` receiver resolves to one canonical class owner with 22 contained methods
- v1 preflight completes before clustering
- a failed build leaves the active generation and graph bytes unchanged

## Compatibility and documentation

The public `compass.graph/1` contract and strict validator remain unchanged. Producer behavior is stricter: unresolved ambiguous generic symbols are omitted with anchored `unresolved_node_kind` diagnostics instead of being guessed as variables.

The repository qualification workflow and local invocation are documented in `docs/design/code-graph-v1-qualification.md`.

## Checklist

- [x] The change is focused and excludes unrelated formatting or generated files
- [x] Tests cover changed behavior, or this pull request changes documentation only
- [x] User-facing commands, flags, limits, and examples are documented
- [x] Compatibility or migration effects are described
- [x] No credentials, private source code, or sensitive report details are included
- [x] I agree to license my contribution under `MIT OR Apache-2.0`
- [x] I followed the [Compass code of conduct](https://github.com/crabbuild/compass/blob/main/CODE_OF_CONDUCT.md)
