### PR TITLE
Harden cross-language graph production

### DIFF
--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -557,6 +557,10 @@ pub fn normalize_v1(
             .get(&edge.target)
             .map(|node| node.kind)
             .unwrap_or(NodeKind::Variable);
+        let target_is_constructible = nodes.get(&edge.target).is_some_and(|node| {
+            node.kind.is_constructible()
+                || (node.kind == NodeKind::EnumMember && node.language.as_deref() == Some("rust"))
+        });
         let unresolved_wiring_site = [&edge.source, &edge.target]
             .into_iter()
             .filter_map(|id| nodes.get(id))
@@ -598,7 +602,7 @@ pub fn normalize_v1(
             edge.id.clone_from(&id);
             edge.key = id;
         }
-        if !trusted_edge && edge.kind == EdgeKind::Calls && target_kind.is_constructible() {
+        if !trusted_edge && edge.kind == EdgeKind::Calls && target_is_constructible {
             edge.kind = EdgeKind::Instantiates;
             edge.details = None;
             let id = edge_id(
@@ -1420,7 +1424,14 @@ fn merge_normalized_node(
     }
     let current_ast_is_authoritative =
         existing_has_ast != duplicate_has_ast && (existing_has_ast || duplicate_has_ast);
+    let compatible_route_registration = existing.kind == NodeKind::Route
+        && duplicate.kind == NodeKind::Route
+        && existing.name == duplicate.name
+        && existing.qualified_name == duplicate.qualified_name
+        && existing.language == duplicate.language
+        && existing.framework == duplicate.framework;
     if !current_ast_is_authoritative
+        && !compatible_route_registration
         && (existing.kind != duplicate.kind
             || existing.name != duplicate.name
             || existing.qualified_name != duplicate.qualified_name
@@ -1460,6 +1471,9 @@ fn merge_normalized_node(
     existing.diagnostics.append(&mut duplicate.diagnostics);
     sort_dedup_serialized(&mut existing.diagnostics);
     if !current_ast_is_authoritative {
+        if compatible_route_registration {
+            existing.source = deterministic_option(existing.source.take(), duplicate.source.take());
+        }
         existing.details = deterministic_option(existing.details.take(), duplicate.details);
     }
     existing.community = deterministic_option(existing.community.take(), duplicate.community);
@@ -2964,6 +2978,39 @@ fn node_identity(
                 &database.logical_database,
                 database.database_schema.as_deref().unwrap_or_default(),
                 qualified_name,
+            )
+        }
+        NodeKind::Resource
+            if matches!(
+                details,
+                Some(NodeDetails::Resource(ResourceNodeDetails {
+                    resource_kind: ResourceKind::Rationale,
+                    ..
+                }))
+            ) =>
+        {
+            let positional_name = identity_site.map_or_else(
+                || qualified_name.to_owned(),
+                |site| format!("{qualified_name}@{}:{}", site.start_byte, site.end_byte),
+            );
+            domain_id(kind, source_path, &positional_name)
+        }
+        NodeKind::Import | NodeKind::Export => {
+            let binding = match details {
+                Some(NodeDetails::ImportExport(details)) => format!(
+                    "{}:{}:{}",
+                    details.imported_name.as_deref().unwrap_or_default(),
+                    details.local_name.as_deref().unwrap_or_default(),
+                    details.type_only
+                ),
+                _ => String::new(),
+            };
+            symbol_id(
+                language.unwrap_or("unknown"),
+                source_path,
+                kind,
+                qualified_name,
+                &binding,
             )
         }
         NodeKind::Job

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -641,6 +641,143 @@ fn route_identity_uses_handler_reference_instead_of_extractor_local_target()
 }
 
 #[test]
+fn duplicate_route_registrations_coalesce_without_losing_relationship_sites()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let route = |id: &str, start: u64| {
+        let mut route = raw_node(root, id, "GET /items", start);
+        route
+            .attributes
+            .insert("symbol_kind".to_owned(), json!("route"));
+        route
+            .attributes
+            .insert("framework".to_owned(), json!("express"));
+        route
+            .attributes
+            .insert("operation".to_owned(), json!("GET"));
+        route.attributes.insert("path".to_owned(), json!("/items"));
+        route
+            .attributes
+            .insert("declaring_scope".to_owned(), json!("router"));
+        route.attributes.insert(
+            "stages".to_owned(),
+            json!([{
+                "stage": "handler",
+                "position": 0,
+                "reference": "handlers.listItems",
+                "resolution": "exact",
+                "target": "raw:handler",
+                "candidates": []
+            }]),
+        );
+        route
+    };
+    let route_edge = |source: &str, start: u64| RawEdgeRecord {
+        source: source.to_owned(),
+        target: "raw:handler".to_owned(),
+        attributes: Map::from_iter([
+            ("relation".to_owned(), json!("routes_to")),
+            ("stage".to_owned(), json!("handler")),
+            ("position".to_owned(), json!(0)),
+            ("operation".to_owned(), json!("GET")),
+            ("extractor".to_owned(), json!("test.routes")),
+            ("source_anchor".to_owned(), anchor(root, start)),
+        ]),
+    };
+    let mut route_with_middleware = route("raw:route-b", 100);
+    route_with_middleware.attributes.insert(
+        "stages".to_owned(),
+        json!([
+            {
+                "stage": "middleware",
+                "position": 0,
+                "reference": "authenticate",
+                "resolution": "unresolved",
+                "candidates": []
+            },
+            {
+                "stage": "handler",
+                "position": 1,
+                "reference": "handlers.listItems",
+                "resolution": "exact",
+                "target": "raw:handler",
+                "candidates": []
+            }
+        ]),
+    );
+    let document = normalize_v1(
+        Extraction {
+            nodes: vec![
+                route("raw:route-a", 10),
+                route_with_middleware,
+                raw_node(root, "raw:handler", "listItems", 200),
+            ],
+            edges: vec![
+                route_edge("raw:route-a", 10),
+                route_edge("raw:route-b", 100),
+            ],
+            ..Extraction::default()
+        },
+        build_evidence(root)?,
+    )?;
+
+    let routes = document
+        .nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::Route)
+        .collect::<Vec<_>>();
+    assert_eq!(routes.len(), 1, "nodes={:#?}", document.nodes);
+    let route_edges = document
+        .links
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::RoutesTo && edge.source == routes[0].id)
+        .collect::<Vec<_>>();
+    assert_eq!(route_edges.len(), 2, "edges={:#?}", document.links);
+    assert_ne!(
+        route_edges[0].relationship_site,
+        route_edges[1].relationship_site
+    );
+    Ok(())
+}
+
+#[test]
+fn rust_enum_variant_calls_normalize_to_instantiations() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let caller = raw_node(root, "raw:caller", "poll", 10);
+    let mut variant = raw_node(root, "raw:variant", "Ready", 30);
+    variant
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("enum_member"));
+    let document = normalize_v1(
+        Extraction {
+            nodes: vec![caller, variant],
+            edges: vec![RawEdgeRecord {
+                source: "raw:caller".to_owned(),
+                target: "raw:variant".to_owned(),
+                attributes: Map::from_iter([
+                    ("relation".to_owned(), json!("calls")),
+                    ("extractor".to_owned(), json!("test.rust")),
+                    ("source_anchor".to_owned(), anchor(root, 50)),
+                ]),
+            }],
+            ..Extraction::default()
+        },
+        build_evidence(root)?,
+    )?;
+    assert!(
+        document
+            .links
+            .iter()
+            .any(|edge| edge.kind == EdgeKind::Instantiates),
+        "edges={:#?}",
+        document.links
+    );
+    Ok(())
+}
+
+#[test]
 fn route_stage_becomes_ambiguous_when_multiple_edges_bind_after_remap()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-graph/tests/import_alias_identity.rs
+++ b/crates/compass-graph/tests/import_alias_identity.rs
@@ -1,0 +1,50 @@
+use std::error::Error;
+use std::fs;
+
+use compass_graph::{build_from_extraction, normalize_document_v1};
+use compass_languages::Engine;
+use compass_model::code_graph::{NodeDetails, NodeKind};
+
+#[test]
+fn namespace_imports_from_one_module_keep_distinct_local_alias_identities()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let path = root.join("module.js");
+    fs::write(
+        &path,
+        r#"
+import * as NewModule from "./module_test.js";
+import * as m from "./module_test.js";
+import * as m from "./module_test.js";
+"#,
+    )?;
+
+    let extraction = Engine::default().extract(&path)?;
+    let flexible = build_from_extraction(&extraction, true, Some(root));
+    let graph = normalize_document_v1(&flexible, root, "sha256:test", None)?;
+
+    let mut imports = graph
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            if node.kind != NodeKind::Import {
+                return None;
+            }
+            let Some(NodeDetails::ImportExport(details)) = &node.details else {
+                return None;
+            };
+            Some((
+                details.local_name.as_deref().unwrap_or_default(),
+                node.id.as_str(),
+            ))
+        })
+        .collect::<Vec<_>>();
+    imports.sort_unstable();
+    assert_eq!(
+        imports.iter().map(|(name, _)| *name).collect::<Vec<_>>(),
+        ["NewModule", "m"]
+    );
+    assert_ne!(imports[0].1, imports[1].1);
+    Ok(())
+}

--- a/crates/compass-graph/tests/rationale_identity.rs
+++ b/crates/compass-graph/tests/rationale_identity.rs
@@ -1,0 +1,57 @@
+use std::error::Error;
+use std::fs;
+
+use compass_graph::{build_from_extraction, normalize_document_v1};
+use compass_languages::Engine;
+use compass_model::code_graph::{EdgeKind, NodeDetails, NodeKind, ResourceKind};
+
+#[test]
+fn repeated_python_rationales_at_distinct_sites_keep_distinct_v1_identities()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let path = root.join("service.py");
+    fs::write(
+        &path,
+        r#"
+def first():
+    """Explain the shared compatibility behavior in enough detail to become a rationale resource."""
+
+def second():
+    """Explain the shared compatibility behavior in enough detail to become a rationale resource."""
+"#,
+    )?;
+
+    let extraction = Engine::default().extract(&path)?;
+    let flexible = build_from_extraction(&extraction, true, Some(root));
+    let graph = normalize_document_v1(&flexible, root, "sha256:test", None)?;
+
+    let rationales = graph
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.kind == NodeKind::Resource
+                && matches!(
+                    node.details,
+                    Some(NodeDetails::Resource(ref details))
+                        if details.resource_kind == ResourceKind::Rationale
+                )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(rationales.len(), 2, "nodes={:#?}", graph.nodes);
+    assert_ne!(rationales[0].id, rationales[1].id);
+    assert_ne!(rationales[0].source, rationales[1].source);
+
+    let documents = graph
+        .links
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::Documents)
+        .collect::<Vec<_>>();
+    assert_eq!(documents.len(), 2, "edges={:#?}", graph.links);
+    assert!(
+        rationales
+            .iter()
+            .all(|rationale| { documents.iter().any(|edge| edge.source == rationale.id) })
+    );
+    Ok(())
+}

--- a/crates/compass-languages/src/dart.rs
+++ b/crates/compass-languages/src/dart.rs
@@ -616,7 +616,31 @@ impl<'a> State<'a> {
             for package in packages {
                 let target = make_id(&[&package]);
                 self.add_node(&target, &package, "code", None);
+                if let Some(resource) = self
+                    .extraction
+                    .nodes
+                    .iter_mut()
+                    .find(|resource| resource.id == target)
+                {
+                    resource.attributes.insert(
+                        "symbol_kind".to_owned(),
+                        Value::String("resource".to_owned()),
+                    );
+                }
                 self.add_edge(&self.file_id.clone(), &target, relation, None);
+                if !package.contains(':')
+                    && !Path::new(&package).is_absolute()
+                    && let Some(edge) = self.extraction.edges.last_mut()
+                {
+                    let target_file = Path::new(&self.source_file)
+                        .parent()
+                        .unwrap_or_else(|| Path::new("."))
+                        .join(&package);
+                    edge.attributes.insert(
+                        "target_file".to_owned(),
+                        Value::String(target_file.to_string_lossy().replace('\\', "/")),
+                    );
+                }
             }
         }
     }

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -1989,6 +1989,18 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                 "object" | "array" | "as_expression" | "call_expression" | "new_expression"
             ) {
                 self.add_node(&id, &name, line(declaration), false, None);
+                if name_node.kind() == "identifier"
+                    && let Some(binding) = self
+                        .extraction
+                        .nodes
+                        .iter_mut()
+                        .find(|binding| binding.id == id)
+                {
+                    binding.attributes.insert(
+                        "symbol_kind".to_owned(),
+                        Value::String("variable".to_owned()),
+                    );
+                }
                 self.add_edge(
                     &self.file_id.clone(),
                     &id,

--- a/crates/compass-languages/src/frameworks/java.rs
+++ b/crates/compass-languages/src/frameworks/java.rs
@@ -30,9 +30,12 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     let Ok(class) = Regex::new(r"\b(?:class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)") else {
         return Vec::new();
     };
-    let Ok(method) = Regex::new(
+    let Ok(java_method) = Regex::new(
         r"\b(?:public|protected|private|static|final|synchronized|abstract|native|\s)+[A-Za-z0-9_<>,.?\[\]\s]+\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(",
     ) else {
+        return Vec::new();
+    };
+    let Ok(kotlin_method) = Regex::new(r"\bfun\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(") else {
         return Vec::new();
     };
 
@@ -72,8 +75,9 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
             offset = offset.saturating_add(line.len());
             continue;
         };
-        let Some(method_name) = method
+        let Some(method_name) = java_method
             .captures(line)
+            .or_else(|| kotlin_method.captures(line))
             .and_then(|capture| capture.get(1))
             .map(|value| value.as_str())
         else {

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -35,7 +35,7 @@ pub(crate) fn detect(
         "python" => python::detect(path, source, root),
         "php" => php::detect(path, source, root),
         "ruby" => ruby::detect(path, source, root),
-        "java" => java::detect(path, source, root),
+        "java" | "kotlin" => java::detect(path, source, root),
         "go" => go::detect(path, source, root),
         "rust" => rust::detect(path, source, root),
         "csharp" => csharp::detect(path, source, root),

--- a/crates/compass-languages/src/rust_lang.rs
+++ b/crates/compass-languages/src/rust_lang.rs
@@ -462,7 +462,11 @@ impl<'source, 'tree> RustState<'source, 'tree> {
                 _ => (None, false, false),
             };
             if let Some(callee) = callee {
-                if let Some(target) = labels.get(&callee).filter(|target| *target != caller) {
+                if let Some(target) = (!scoped)
+                    .then(|| labels.get(&callee))
+                    .flatten()
+                    .filter(|target| *target != caller)
+                {
                     let pair = (
                         caller.to_owned(),
                         target.clone(),

--- a/crates/compass-languages/src/xaml.rs
+++ b/crates/compass-languages/src/xaml.rs
@@ -878,7 +878,10 @@ fn community_toolkit_members(
         let mut attributes = Map::new();
         attributes.insert("label".to_owned(), Value::String(label.clone()));
         attributes.insert("file_type".to_owned(), Value::String("code".to_owned()));
-        attributes.insert("symbol_kind".to_owned(), Value::String(kind.to_owned()));
+        attributes.insert(
+            "symbol_kind".to_owned(),
+            Value::String("property".to_owned()),
+        );
         attributes.insert("source_file".to_owned(), Value::String(source_file.clone()));
         attributes.insert(
             "source_location".to_owned(),

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -255,6 +255,51 @@ fn repeated_rust_calls_keep_exact_sites_and_known_producer_metadata() -> Result<
 }
 
 #[test]
+fn rust_scoped_calls_do_not_bind_terminal_names_to_unrelated_symbols() -> Result<(), Box<dyn Error>>
+{
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("scoped.rs");
+    fs::write(
+        &path,
+        b"
+trait Error {}
+enum RejectionReason { Error(String) }
+fn reject(message: String) {
+    let _ = RejectionReason::Error(message);
+}
+",
+    )?;
+
+    let extraction = Engine::default().extract(&path)?;
+    let error_trait = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("symbol_kind") == "trait" && node.string("qualified_name").contains("Error")
+        })
+        .ok_or("missing Error trait")?;
+    let reject = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            matches!(node.string("symbol_kind").as_str(), "function" | "method")
+                && node.string("qualified_name").contains("reject")
+        })
+        .ok_or("missing reject function")?;
+
+    assert!(
+        !extraction.edges.iter().any(|edge| {
+            edge.string("relation") == "calls"
+                && edge.source == reject.id
+                && edge.target == error_trait.id
+        }),
+        "scoped enum construction bound to unrelated trait: {:?}",
+        extraction.edges
+    );
+    Ok(())
+}
+
+#[test]
 fn repeated_generic_calls_keep_each_ast_range() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let path = directory.path().join("repeated.py");
@@ -851,6 +896,63 @@ fn javascript_modules_reexports_require_and_decorators_keep_compass_contracts()
             .edges
             .iter()
             .any(|edge| edge.string("relation") == "imports")
+    );
+    Ok(())
+}
+
+#[test]
+fn javascript_module_object_bindings_have_explicit_variable_kind() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("app.ts");
+    fs::write(
+        &path,
+        r#"
+import express from "express";
+const app = express();
+const settings = { enabled: true };
+app.get("/health", health);
+function health() { return "ok"; }
+"#,
+    )?;
+
+    let extraction = Engine::default().extract(&path)?;
+    for name in ["app", "settings"] {
+        let binding = extraction
+            .nodes
+            .iter()
+            .find(|node| node.label() == name)
+            .ok_or_else(|| format!("missing {name} binding"))?;
+        assert_eq!(
+            binding.string("symbol_kind"),
+            "variable",
+            "binding={binding:#?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn dart_exports_have_explicit_resource_targets() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("exports.dart");
+    fs::write(&path, "export 'rich.dart';\n")?;
+
+    let extraction = Engine::default().extract(&path)?;
+    let export = extraction
+        .edges
+        .iter()
+        .find(|edge| edge.string("relation") == "exports")
+        .ok_or("missing Dart export")?;
+    let target = extraction
+        .nodes
+        .iter()
+        .find(|node| node.id == export.target)
+        .ok_or("missing Dart export target")?;
+
+    assert_eq!(target.string("symbol_kind"), "resource");
+    assert_eq!(
+        export.string("target_file"),
+        directory.path().join("rich.dart").to_string_lossy()
     );
     Ok(())
 }

--- a/crates/compass-languages/tests/xaml_coverage.rs
+++ b/crates/compass-languages/tests/xaml_coverage.rs
@@ -77,6 +77,17 @@ public partial class MainWindowViewModel {
             .and_then(serde_json::Value::as_str)
             == Some("communitytoolkit_observable_property")
     }));
+    for command in ["SaveCommand", "CancelCommand"] {
+        assert_eq!(
+            extraction
+                .nodes
+                .iter()
+                .find(|node| node.label() == command)
+                .map(|node| node.string("symbol_kind")),
+            Some("property".to_owned()),
+            "CommunityToolkit generates an ICommand property for {command}"
+        );
+    }
     assert!(extraction.edges.iter().any(|edge| {
         edge.attributes
             .get("context")

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -310,12 +310,24 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
             validate_anchor(&edge.id, anchor, &files, &mut errors);
         }
         if !endpoint_kinds_are_valid(source, edge.kind, target) {
+            let site = edge.relationship_site.as_ref().map_or_else(
+                || "<none>".to_owned(),
+                |anchor| {
+                    format!(
+                        "{}:{}:{}",
+                        anchor.file, anchor.start_line, anchor.start_column
+                    )
+                },
+            );
             errors.push(format!(
-                "edge {} has invalid {} endpoints {} -> {}",
+                "edge {} has invalid {} endpoints {} -> {}; source={} target={} site={}",
                 edge.id,
                 edge.kind.as_str(),
                 source.kind.as_str(),
-                target.kind.as_str()
+                target.kind.as_str(),
+                source.qualified_name,
+                target.qualified_name,
+                site
             ));
         }
     }
@@ -476,10 +488,10 @@ fn endpoint_kinds_are_valid(
         EdgeKind::TypeOf => is_typed_value(source.kind) && target.kind.is_type(),
         EdgeKind::Returns => source.kind.is_callable() && is_return_target(target.kind),
         EdgeKind::Instantiates => {
-            (source.kind.is_callable()
-                || source.kind.is_type()
-                || source.kind == NodeKind::Variable)
-                && target.kind.is_constructible()
+            is_call_source(source.kind)
+                && (target.kind.is_constructible()
+                    || (target.kind == NodeKind::EnumMember
+                        && target.language.as_deref() == Some("rust")))
         }
         EdgeKind::Overrides => source.kind.is_callable() && target.kind.is_callable(),
         EdgeKind::Decorates => {
@@ -833,6 +845,7 @@ const fn is_import_target(kind: NodeKind) -> bool {
                 | NodeKind::TypeAlias
                 | NodeKind::Variable
                 | NodeKind::Constant
+                | NodeKind::EnumMember
                 | NodeKind::Resource
                 | NodeKind::ConfigKey
         )
@@ -930,6 +943,8 @@ const fn is_reference_target(kind: NodeKind) -> bool {
                 | NodeKind::Field
                 | NodeKind::Variable
                 | NodeKind::Constant
+                | NodeKind::EnumMember
+                | NodeKind::Parameter
                 | NodeKind::Import
                 | NodeKind::Export
                 | NodeKind::TypeAlias

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -210,6 +210,28 @@ fn whole_document_validation_rejects_an_invalid_endpoint_kind_pair() {
 }
 
 #[test]
+fn invalid_endpoint_diagnostics_name_both_symbols_and_the_relationship_site() {
+    let mut graph = document();
+    graph.nodes[0].kind = NodeKind::Method;
+    graph.nodes[1].kind = NodeKind::Interface;
+    graph.links[0].kind = EdgeKind::Calls;
+    let id = edge_id("route", EdgeKind::Calls, "handler", Some(&anchor()), None);
+    graph.links[0].id.clone_from(&id);
+    graph.links[0].key = id;
+
+    let errors = validate_code_graph(&graph)
+        .err()
+        .map(|error| error.errors)
+        .unwrap_or_default();
+    assert!(errors.iter().any(|error| {
+        error.contains("invalid calls endpoints method -> interface")
+            && error.contains("source=route")
+            && error.contains("target=handler")
+            && error.contains("site=src/lib.rs:1:0")
+    }));
+}
+
+#[test]
 fn top_level_calls_accept_file_and_module_sources_but_require_callable_targets() {
     for source_kind in [NodeKind::File, NodeKind::Module] {
         let mut graph = document();
@@ -235,6 +257,55 @@ fn top_level_calls_accept_file_and_module_sources_but_require_callable_targets()
         validate_code_graph(&graph).is_err(),
         "top-level calls must still target a callable node"
     );
+}
+
+#[test]
+fn top_level_instantiations_accept_file_and_module_sources() {
+    for source_kind in [NodeKind::File, NodeKind::Module] {
+        let mut graph = document();
+        graph.nodes[0].kind = source_kind;
+        graph.nodes[1].kind = NodeKind::Class;
+        graph.links[0].kind = EdgeKind::Instantiates;
+        let id = edge_id(
+            "route",
+            EdgeKind::Instantiates,
+            "handler",
+            Some(&anchor()),
+            None,
+        );
+        graph.links[0].id.clone_from(&id);
+        graph.links[0].key = id;
+        assert!(
+            validate_code_graph(&graph).is_ok(),
+            "rejected intentional {source_kind:?} -> class top-level instantiation"
+        );
+    }
+}
+
+#[test]
+fn rust_enum_members_are_importable_referenceable_and_constructible() {
+    for (kind, source_kind, target_kind) in [
+        (EdgeKind::Imports, NodeKind::File, NodeKind::EnumMember),
+        (EdgeKind::References, NodeKind::Method, NodeKind::EnumMember),
+        (EdgeKind::References, NodeKind::Struct, NodeKind::Parameter),
+        (
+            EdgeKind::Instantiates,
+            NodeKind::Method,
+            NodeKind::EnumMember,
+        ),
+    ] {
+        let mut graph = document();
+        graph.nodes[0].kind = source_kind;
+        graph.nodes[1].kind = target_kind;
+        graph.links[0].kind = kind;
+        let id = edge_id("route", kind, "handler", Some(&anchor()), None);
+        graph.links[0].id.clone_from(&id);
+        graph.links[0].key = id;
+        assert!(
+            validate_code_graph(&graph).is_ok(),
+            "rejected Rust {kind:?} {source_kind:?} -> {target_kind:?}"
+        );
+    }
 }
 
 #[test]
@@ -293,7 +364,6 @@ fn endpoint_matrix_rejects_invalid_pairs_across_relationship_families() {
         (EdgeKind::Extends, NodeKind::Class, NodeKind::Function),
         (EdgeKind::Implements, NodeKind::Class, NodeKind::Class),
         (EdgeKind::TypeOf, NodeKind::Variable, NodeKind::Function),
-        (EdgeKind::Instantiates, NodeKind::File, NodeKind::Class),
         (EdgeKind::Reads, NodeKind::Route, NodeKind::Class),
         (EdgeKind::Handles, NodeKind::Variable, NodeKind::Event),
         (EdgeKind::Publishes, NodeKind::Variable, NodeKind::Message),

--- a/crates/compass-resolve/src/frameworks/typescript.rs
+++ b/crates/compass-resolve/src/frameworks/typescript.rs
@@ -53,25 +53,159 @@ pub(super) fn import_alias_map(
             continue;
         };
         let source_file = source_file.replace('\\', "/");
-        let key = (source_file.clone(), local.to_owned());
-        let is_new = !aliases.contains_key(&key);
-        aliases.insert(
-            key,
+        insert_alias(
+            &mut aliases,
+            &mut aliases_per_file,
+            limits,
+            source_file,
+            local,
             ImportAlias {
                 module: module.to_owned(),
                 imported: imported.to_owned(),
             },
-        );
-        let aliases_in_file = aliases_per_file.entry(source_file).or_insert(0_usize);
-        if is_new {
-            *aliases_in_file += 1;
+        )?;
+    }
+    let nodes_by_id = extraction
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<HashMap<_, _>>();
+    for edge in &extraction.edges {
+        if edge.attributes.get("language").and_then(Value::as_str) != Some("python") {
+            continue;
         }
-        if *aliases_in_file > limits.max_alias_expansions {
-            return Err(FrameworkResolutionError::AliasLimit {
-                observed: *aliases_in_file,
-                maximum: limits.max_alias_expansions,
-            });
+        let Some(source_file) = edge
+            .attributes
+            .get("source_file")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let Some(local) = edge
+            .attributes
+            .get("local_name")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let Some(imported) = edge
+            .attributes
+            .get("imported_name")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let context = edge
+            .attributes
+            .get("context")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let raw_module = edge
+            .attributes
+            .get("module")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let module = if context == "submodule_import" {
+            let Some(target_source) = nodes_by_id
+                .get(edge.target.as_str())
+                .and_then(|node| node.attributes.get("source_file"))
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+            else {
+                continue;
+            };
+            let Some(stem) = std::path::Path::new(target_source)
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .filter(|value| !value.is_empty())
+            else {
+                continue;
+            };
+            format!("./{stem}")
+        } else {
+            if raw_module.is_empty() {
+                continue;
+            }
+            python_module_path(raw_module)
+        };
+        let source_file = source_file.replace('\\', "/");
+        insert_alias(
+            &mut aliases,
+            &mut aliases_per_file,
+            limits,
+            source_file.clone(),
+            local,
+            ImportAlias {
+                module: module.clone(),
+                imported: if context == "submodule_import" {
+                    "*".to_owned()
+                } else {
+                    imported.to_owned()
+                },
+            },
+        )?;
+        if context == "import"
+            && let Some(namespace) = raw_module
+                .trim_start_matches('.')
+                .rsplit('.')
+                .next()
+                .filter(|value| !value.is_empty())
+        {
+            insert_alias(
+                &mut aliases,
+                &mut aliases_per_file,
+                limits,
+                source_file,
+                namespace,
+                ImportAlias {
+                    module,
+                    imported: "*".to_owned(),
+                },
+            )?;
         }
     }
     Ok(aliases)
+}
+
+fn insert_alias(
+    aliases: &mut ImportAliases,
+    aliases_per_file: &mut HashMap<String, usize>,
+    limits: FrameworkLimits,
+    source_file: String,
+    local: &str,
+    alias: ImportAlias,
+) -> Result<(), FrameworkResolutionError> {
+    let key = (source_file.clone(), local.to_owned());
+    let is_new = !aliases.contains_key(&key);
+    aliases.insert(key, alias);
+    let aliases_in_file = aliases_per_file.entry(source_file).or_insert(0_usize);
+    if is_new {
+        *aliases_in_file += 1;
+    }
+    if *aliases_in_file > limits.max_alias_expansions {
+        return Err(FrameworkResolutionError::AliasLimit {
+            observed: *aliases_in_file,
+            maximum: limits.max_alias_expansions,
+        });
+    }
+    Ok(())
+}
+
+fn python_module_path(module: &str) -> String {
+    let depth = module
+        .len()
+        .saturating_sub(module.trim_start_matches('.').len());
+    let bare = module.trim_start_matches('.').replace('.', "/");
+    if depth == 0 {
+        return bare;
+    }
+    let prefix = if depth == 1 {
+        "./".to_owned()
+    } else {
+        "../".repeat(depth - 1)
+    };
+    format!("{prefix}{bare}")
 }

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -669,8 +669,10 @@ fn canonicalize_import_targets(extraction: &mut Extraction) {
         })
         .collect::<HashMap<_, _>>();
     for edge in &mut extraction.edges {
-        if matches!(relation(edge), "imports" | "imports_from" | "re_exports")
-            && let Some(target) = aliases.get(&edge.target)
+        if matches!(
+            relation(edge),
+            "imports" | "imports_from" | "exports" | "re_exports"
+        ) && let Some(target) = aliases.get(&edge.target)
         {
             edge.target.clone_from(target);
             stamp_endpoint_rewrite(edge, EndpointRewriteRule::CanonicalImportTarget, 1.0);
@@ -1034,7 +1036,10 @@ fn disambiguate_colliding_node_ids_with_calls(
             .remove("target_file")
             .and_then(|value| value.as_str().map(str::to_owned));
         let relation = relation(edge);
-        let target_key = if matches!(relation, "imports" | "imports_from" | "re_exports") {
+        let target_key = if matches!(
+            relation,
+            "imports" | "imports_from" | "exports" | "re_exports"
+        ) {
             target_file
                 .as_deref()
                 .map_or(edge_key, |path| source_key(path, root))
@@ -1648,6 +1653,15 @@ fn python_import_edge(
         (
             OCCURRENCE_RULE_ATTRIBUTE.to_owned(),
             Value::String(python_import_occurrence_rule(resolution, imported)),
+        ),
+        ("module".to_owned(), Value::String(imported.module.clone())),
+        (
+            "imported_name".to_owned(),
+            Value::String(imported.imported.clone()),
+        ),
+        (
+            "local_name".to_owned(),
+            Value::String(imported.local.clone()),
         ),
         ("weight".to_owned(), Value::from(1.0)),
     ]);

--- a/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
+++ b/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
@@ -137,6 +137,39 @@ fn spring_composes_class_and_method_mappings_without_custom_annotation_matches()
 }
 
 #[test]
+fn spring_kotlin_controllers_publish_exact_routes() -> Result<(), Box<dyn Error>> {
+    let source = br#"
+package example
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api")
+class KotlinController {
+    @GetMapping("/users/{id}")
+    fun show(id: Long): String = id.toString()
+}
+"#;
+    let mut engine = Engine::default();
+    let mut extraction = engine.extract_source(Path::new("src/KotlinController.kt"), source)?;
+    let resolved =
+        resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+
+    assert!(
+        resolved.iter().any(|route| {
+            route.route.operation == "GET"
+                && route.route.normalized_path == "/api/users/{id}"
+                && route.route.handler_reference == "KotlinController.show"
+                && route.state == ResolutionState::Exact
+        }),
+        "routes={resolved:#?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn play_config_routes_resolve_java_scala_and_injected_controllers() -> Result<(), Box<dyn Error>> {
     let route_path = fixture("jvm/play/conf/routes");
     let spec = Registry::resolve(&route_path).ok_or("Play routes are not registered")?;

--- a/crates/compass-resolve/tests/python_routes.rs
+++ b/crates/compass-resolve/tests/python_routes.rs
@@ -138,6 +138,97 @@ urlpatterns = [path("users/<int:user_id>/", detail)]
 }
 
 #[test]
+fn django_relative_module_import_resolves_class_based_view_route()
+-> Result<(), Box<dyn std::error::Error>> {
+    let urls_source = br#"
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("profile/", views.ProfileView.as_view()),
+]
+"#;
+    let views_source = br#"
+class ProfileView:
+    pass
+"#;
+    let mut engine = Engine::default();
+    let urls = engine.extract_source(Path::new("accounts/urls.py"), urls_source)?;
+    let views = engine.extract_source(Path::new("accounts/views.py"), views_source)?;
+    let sources = HashMap::from([
+        (
+            "accounts/urls.py".to_owned(),
+            String::from_utf8(urls_source.to_vec())?,
+        ),
+        (
+            "accounts/views.py".to_owned(),
+            String::from_utf8(views_source.to_vec())?,
+        ),
+    ]);
+
+    let extraction = resolve(&[urls, views], &sources);
+    let route = resolve_routes(&extraction, FrameworkLimits::default())?
+        .into_iter()
+        .find(|route| route.route.handler_reference.contains("ProfileView"))
+        .ok_or("missing profile route")?;
+
+    assert_eq!(route.state, ResolutionState::Exact, "{route:#?}");
+    let target = route
+        .candidates
+        .first()
+        .and_then(|candidate| {
+            extraction
+                .nodes
+                .iter()
+                .find(|node| node.id == candidate.node_id)
+        })
+        .ok_or("missing route target")?;
+    assert_eq!(target.string("symbol_kind"), "class");
+    assert_eq!(target.label(), "ProfileView");
+    Ok(())
+}
+
+#[test]
+fn django_relative_symbol_import_resolves_class_based_view_route()
+-> Result<(), Box<dyn std::error::Error>> {
+    let urls_source = br#"
+from django.urls import path
+from .views import ProfileView
+
+urlpatterns = [
+    path("profile/", ProfileView.as_view()),
+]
+"#;
+    let views_source = br#"
+class ProfileView:
+    pass
+"#;
+    let mut engine = Engine::default();
+    let urls = engine.extract_source(Path::new("accounts/urls.py"), urls_source)?;
+    let views = engine.extract_source(Path::new("accounts/views.py"), views_source)?;
+    let sources = HashMap::from([
+        (
+            "accounts/urls.py".to_owned(),
+            String::from_utf8(urls_source.to_vec())?,
+        ),
+        (
+            "accounts/views.py".to_owned(),
+            String::from_utf8(views_source.to_vec())?,
+        ),
+    ]);
+
+    let extraction = resolve(&[urls, views], &sources);
+    let route = resolve_routes(&extraction, FrameworkLimits::default())?
+        .into_iter()
+        .find(|route| route.route.handler_reference.contains("ProfileView"))
+        .ok_or("missing profile route")?;
+
+    assert_eq!(route.state, ResolutionState::Exact, "{route:#?}");
+    assert_eq!(route.candidates.len(), 1, "{route:#?}");
+    Ok(())
+}
+
+#[test]
 fn django_include_cycles_stop_and_depth_overflow_fails_explicitly()
 -> Result<(), Box<dyn std::error::Error>> {
     let source = |target: &str| {


### PR DESCRIPTION
## Summary

Hardens Compass graph production across Python/Django, Rust, Java/Kotlin, TypeScript/JavaScript, PHP, C#, C++, Ruby, and Dart without relaxing the strict `compass.graph/1` validator.

- makes repeated rationale, import/export alias, and route identities collision-safe
- preserves distinct route relationship sites while coalescing repeated semantic route registrations
- resolves Django class-based views through exact Python import provenance
- detects Spring routes in Kotlin controllers as well as Java controllers
- prevents Rust scoped calls from binding terminal names to unrelated traits and normalizes proven enum-variant construction
- emits canonical C# CommunityToolkit generated properties
- gives JavaScript module bindings and Dart export resources explicit kinds instead of relying on generic-symbol fallback
- improves invalid endpoint diagnostics with both qualified endpoints and the exact relationship site

## Root causes

Real repositories exposed producer assumptions that small fixtures did not:

1. positional resources and aliased imports could share stable identities despite distinct source declarations;
2. semantic route identity excluded registration sites, but publication rejected repeated registrations when middleware details differed;
3. Django route resolution ignored resolved Python submodule/symbol-import evidence;
4. Rust scoped calls were resolved by terminal name and could target an unrelated `Error` trait;
5. generated C# command members used a non-vocabulary raw kind;
6. Kotlin Spring annotations were not dispatched to the JVM route detector;
7. JavaScript module bindings and Dart export targets still depended on the generic-symbol fallback.

## Impact

Compass now completes strict v1 publication with zero validation errors on the audited real-project matrix. Framework topology is qualified separately from language topology so a successful language parse is not treated as proof of route resolution.

| Project | Language/framework | Nodes | Edges | Routes | `routes_to` | Validation errors |
|---|---|---:|---:|---:|---:|---:|
| django/django `5e32c82` | Python / Django | 52,894 | 206,182 | 578 | 352 | 0 |
| tokio-rs/axum `3f06ead` | Rust / Axum | 9,193 | 13,386 | 182 | 104 | 0 |
| spring-petclinic `f182358` | Java / Spring | 718 | 1,070 | 18 | 17 | 0 |
| spring-petclinic-kotlin `49f13fc` | Kotlin / Spring | 533 | 659 | 20 | 18 | 0 |
| expressjs/express `a371447` | JavaScript / Express | 542 | 351 | 106 | 14 | 0 |
| nestjs/typescript-starter `c4d9330` | TypeScript / NestJS | 189 | 249 | 1 | 1 | 0 |
| dotnet/eShop `9b4f943` | C# | 7,731 | 8,923 | — | — | 0 |
| fmtlib/fmt `758d39e` | C++ | 3,705 | 866 | — | — | 0 |
| heartcombo/devise `372b295` | Ruby / Rails | 1,428 | 1,650 | 14 | 11 | 0 |
| laravel/laravel `ff031db` | PHP | 208 | 227 | — | — | 0 |

Laravel and ASP.NET framework semantics remain covered by their controller/action fixture flows; the audited Laravel skeleton uses a closure-only welcome route, and eShop uses minimal APIs rather than attribute controllers.

## Verification

```text
cargo test --workspace --lib --bins --locked
# status 0; all workspace library/binary tests passed (2 ignored)

cargo clippy -p compass-model -p compass-languages -p compass-resolve -p compass-graph --tests --locked -- -D warnings
cargo fmt --all -- --check
git diff --check
# passed
```

The production qualification corpus also passed clean/warm/forced/alternate-checkout byte equality and all semantic assertions:

- 45 node kinds
- 28 edge kinds
- 57 languages
- 24 framework flows
- 1,213 invariants
- 68 exact route resolutions

## Compatibility

The public v1 schema and endpoint validator stay strict. The change is producer-side: proven shapes receive explicit canonical kinds and exact provenance; ambiguous shapes remain omitted or unresolved rather than being guessed.

## Checklist

- [x] Changes are limited to graph producers, resolution, validation diagnostics, and regression coverage
- [x] Real repositories publish zero-validation-error v1 graphs
- [x] Deterministic clean, warm, forced, and alternate-checkout graphs are byte-identical
- [x] Framework route topology is distinguished from language topology
- [x] No credentials or private source details are included
- [x] I agree to license my contribution under `MIT OR Apache-2.0`
- [x] I followed the [Compass code of conduct](https://github.com/crabbuild/compass/blob/main/CODE_OF_CONDUCT.md)
