### PR TITLE
Publish strict-valid partial code graphs

### DIFF
--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -898,7 +898,17 @@ fn write_watch_status_mode(
                 "[compass watch] graph artifacts updated in {}",
                 result.output_dir.display()
             );
+            if result.partial_graph {
+                let _result = native_line!(
+                    stderr,
+                    "[compass watch] warning: partial graph published after omitting {} nodes and {} edges; {} identity collisions quarantined",
+                    result.omitted_nodes,
+                    result.omitted_edges,
+                    result.identity_collisions
+                );
+            }
             let _result = stdout.flush();
+            let _result = stderr.flush();
         }
         WatchStatus::UpToDate { reason } => {
             if frontend == Frontend::Compass {
@@ -2046,8 +2056,14 @@ fn command_build_with_validation_inner(
                 output.push_str(&notes.join("\n"));
             }
             let mut outcome = Outcome::success(output);
-            if let Some(warning) = global_warning {
+            if let Some(warning) = format_partial_graph_warning(&result) {
                 outcome.stderr = warning;
+            }
+            if let Some(warning) = global_warning {
+                if !outcome.stderr.is_empty() {
+                    outcome.stderr.push('\n');
+                }
+                outcome.stderr.push_str(&warning);
             }
             if timing {
                 if !outcome.stderr.is_empty() {
@@ -3767,6 +3783,15 @@ fn format_program_analysis(result: &BuildResult) -> String {
     )
 }
 
+fn format_partial_graph_warning(result: &BuildResult) -> Option<String> {
+    result.partial_graph.then(|| {
+        format!(
+            "warning: Compass published a partial graph after omitting {} nodes and {} edges; {} identity collisions quarantined.",
+            result.omitted_nodes, result.omitted_edges, result.identity_collisions
+        )
+    })
+}
+
 #[cfg(test)]
 mod mcp_option_tests {
     use super::*;
@@ -3797,6 +3822,10 @@ mod mcp_option_tests {
             nodes: 3,
             edges: 2,
             communities: 1,
+            omitted_nodes: 0,
+            omitted_edges: 0,
+            identity_collisions: 0,
+            partial_graph: false,
             html_written,
             outputs_changed,
             program_modules: 0,
@@ -3810,6 +3839,22 @@ mod mcp_option_tests {
             program_conflicts: 0,
             timings: BuildTimings::default(),
         }
+    }
+
+    #[test]
+    fn partial_graph_warning_discloses_exact_omission_counts() {
+        let mut result = sample_build_result(true, false);
+        result.partial_graph = true;
+        result.omitted_nodes = 3;
+        result.omitted_edges = 5;
+        result.identity_collisions = 2;
+
+        assert_eq!(
+            format_partial_graph_warning(&result).as_deref(),
+            Some(
+                "warning: Compass published a partial graph after omitting 3 nodes and 5 edges; 2 identity collisions quarantined."
+            )
+        );
     }
 
     #[test]

--- a/crates/compass-core/src/build_state.rs
+++ b/crates/compass-core/src/build_state.rs
@@ -106,6 +106,12 @@ pub(crate) struct SavedStats {
     pub nodes: usize,
     pub edges: usize,
     pub communities: usize,
+    #[serde(default)]
+    pub omitted_nodes: usize,
+    #[serde(default)]
+    pub omitted_edges: usize,
+    #[serde(default)]
+    pub identity_collisions: usize,
     pub program_modules: usize,
     pub program_summaries: usize,
     pub program_providers: usize,

--- a/crates/compass-core/src/diagnostics.rs
+++ b/crates/compass-core/src/diagnostics.rs
@@ -141,7 +141,7 @@ fn enforce_graph_size_cap(path: &Path) -> Result<(), CoreError> {
 }
 
 fn graph_size_cap() -> u128 {
-    const DEFAULT: u128 = 512 * 1024 * 1024;
+    const DEFAULT: u128 = compass_model::DEFAULT_GRAPH_SIZE_CAP_BYTES as u128;
     let Ok(raw) = std::env::var("COMPASS_MAX_GRAPH_BYTES") else {
         return DEFAULT;
     };

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -11,10 +11,10 @@ use compass_files::{
 };
 use compass_graph::{
     ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION, InventoryEvidence,
-    build_owned_with_tiebreaker as build_document, canonical_edge_kind, canonical_raw_edge_sites,
-    cluster, dedupe_edges, dedupe_nodes, extraction_from_v1, graph_insights,
-    label_communities_by_hub, normalize_document_v1_with_inventory, remap_communities_to_previous,
-    score_communities,
+    PublicationOmissions, PublicationOutcome, build_owned_with_tiebreaker as build_document,
+    canonical_edge_kind, canonical_raw_edge_sites, cluster, dedupe_nodes, extraction_from_v1,
+    graph_insights, label_communities_by_hub, normalize_document_v1_with_inventory_best_effort,
+    remap_communities_to_previous, score_communities,
 };
 use compass_languages::{
     EXTRACTION_QUALITY_EXTENSION, EXTRACTION_QUALITY_PARTIAL, EXTRACTION_QUALITY_REASON_EXTENSION,
@@ -123,6 +123,23 @@ struct OutputStats {
     edges: usize,
     communities: usize,
     clustered: bool,
+    #[serde(default)]
+    omitted_nodes: usize,
+    #[serde(default)]
+    omitted_edges: usize,
+    #[serde(default)]
+    identity_collisions: usize,
+}
+
+impl OutputStats {
+    const fn omissions(&self) -> PublicationOmissions {
+        PublicationOmissions {
+            nodes: self.omitted_nodes,
+            edges: self.omitted_edges,
+            identity_collisions: self.identity_collisions,
+            examples_omitted: 0,
+        }
+    }
 }
 
 impl BuildOptions {
@@ -178,6 +195,10 @@ pub struct BuildResult {
     pub nodes: usize,
     pub edges: usize,
     pub communities: usize,
+    pub omitted_nodes: usize,
+    pub omitted_edges: usize,
+    pub identity_collisions: usize,
+    pub partial_graph: bool,
     pub html_written: bool,
     pub outputs_changed: bool,
     pub program_modules: usize,
@@ -516,6 +537,12 @@ fn build_graph_inner(
                 nodes: state.stats.nodes,
                 edges: state.stats.edges,
                 communities: state.stats.communities,
+                omitted_nodes: state.stats.omitted_nodes,
+                omitted_edges: state.stats.omitted_edges,
+                identity_collisions: state.stats.identity_collisions,
+                partial_graph: state.stats.omitted_nodes > 0
+                    || state.stats.omitted_edges > 0
+                    || state.stats.identity_collisions > 0,
                 html_written: output_dir.join("graph.html").is_file(),
                 outputs_changed: false,
                 program_modules: state.stats.program_modules,
@@ -563,6 +590,7 @@ fn build_graph_inner(
             stats.nodes,
             stats.edges,
             stats.communities,
+            stats.omissions(),
             unchanged_program.as_ref(),
         )?;
         let published_output_dir = commit_generation(guard, &output_container)?;
@@ -577,6 +605,10 @@ fn build_graph_inner(
             nodes: stats.nodes,
             edges: stats.edges,
             communities: stats.communities,
+            omitted_nodes: stats.omitted_nodes,
+            omitted_edges: stats.omitted_edges,
+            identity_collisions: stats.identity_collisions,
+            partial_graph: stats.omissions().is_partial(),
             html_written: output_dir.join("graph.html").is_file(),
             outputs_changed: false,
             program_modules: program_modules(unchanged_program.as_ref()),
@@ -1003,6 +1035,7 @@ fn build_graph_inner(
         && semantic.is_some_and(semantic_layer_is_empty)
         && let Ok(document) = GraphDocument::load(&output_dir.join("graph.json"))
     {
+        let omissions = saved_publication_omissions(&output_dir);
         let mut manifest = prior_manifest;
         save_build_manifest(
             &mut manifest,
@@ -1019,6 +1052,7 @@ fn build_graph_inner(
             document.nodes.len(),
             document.links.len(),
             0,
+            omissions,
             program.as_ref(),
         )?;
         let published_output_dir = commit_generation(guard, &output_container)?;
@@ -1033,6 +1067,10 @@ fn build_graph_inner(
             nodes: document.nodes.len(),
             edges: document.links.len(),
             communities: 0,
+            omitted_nodes: omissions.nodes,
+            omitted_edges: omissions.edges,
+            identity_collisions: omissions.identity_collisions,
+            partial_graph: omissions.is_partial(),
             html_written: false,
             outputs_changed: false,
             program_modules: program_modules(program.as_ref()),
@@ -1058,7 +1096,7 @@ fn build_graph_inner(
         });
     }
     if options.no_cluster {
-        let (nodes, edges) = (dedupe_nodes(&resolved.nodes), dedupe_edges(&resolved.edges));
+        let nodes = dedupe_nodes(&resolved.nodes);
         enforce_incomplete_raw_guard(semantic, &output_dir.join("graph.json"), &root, nodes.len())?;
         let document = build_document(resolved, true, true, Some(&root), tiebreaker)?;
         let configuration_digest = graph_configuration_digest(options, &output_dir)?;
@@ -1066,7 +1104,7 @@ fn build_graph_inner(
             .built_at_commit
             .clone()
             .or_else(|| git_commit(&root));
-        let published = normalize_document_v1_with_inventory(
+        let published = normalize_document_v1_with_inventory_best_effort(
             &document,
             &root,
             configuration_digest,
@@ -1079,9 +1117,22 @@ fn build_graph_inner(
                 &root,
             ),
         )?;
-        write_json_atomic(output_dir.join("graph.json"), &published, false)?;
+        if published.document.nodes.is_empty() {
+            return Err(CoreError::EmptyGraph);
+        }
+        let omissions = published.omissions;
+        let published_nodes = published.document.nodes.len();
+        let published_edges = published.document.links.len();
+        write_json_atomic(output_dir.join("graph.json"), &published.document, false)?;
         remove_if_exists(&output_dir.join(GRAPH_OVERVIEW_FILE))?;
-        save_output_stats(&output_dir, nodes.len(), edges.len(), 0, false)?;
+        save_output_stats(
+            &output_dir,
+            published_nodes,
+            published_edges,
+            0,
+            false,
+            omissions,
+        )?;
         write_semantic_marker(&output_dir, semantic)?;
         if options.purpose == BuildPurpose::Update {
             write_text_atomic(
@@ -1103,9 +1154,10 @@ fn build_graph_inner(
             &output_dir,
             &manifest_path,
             sources.len(),
-            nodes.len(),
-            edges.len(),
+            published_nodes,
+            published_edges,
             0,
+            omissions,
             program.as_ref(),
         )?;
         let published_output_dir = commit_generation(guard, &output_container)?;
@@ -1118,9 +1170,13 @@ fn build_graph_inner(
             files_extracted: missing.len(),
             files_cached: sources.len().saturating_sub(missing.len()),
             empty_files,
-            nodes: nodes.len(),
-            edges: edges.len(),
+            nodes: published_nodes,
+            edges: published_edges,
             communities: 0,
+            omitted_nodes: omissions.nodes,
+            omitted_edges: omissions.edges,
+            identity_collisions: omissions.identity_collisions,
+            partial_graph: omissions.is_partial(),
             html_written: false,
             outputs_changed: true,
             program_modules: program_modules(program.as_ref()),
@@ -1158,7 +1214,7 @@ fn build_graph_inner(
             .and_then(|directory| git_commit(&directory))
     });
     let preflight_started = Instant::now();
-    normalize_document_v1_with_inventory(
+    let preflight = normalize_document_v1_with_inventory_best_effort(
         &document,
         &root,
         graph_configuration_digest(options, &output_dir)?,
@@ -1171,6 +1227,9 @@ fn build_graph_inner(
             &root,
         ),
     )?;
+    if preflight.document.nodes.is_empty() {
+        return Err(CoreError::EmptyGraph);
+    }
     profile_internal_duration("graph.json v1 preflight", preflight_started.elapsed());
 
     let unchanged_artifacts_complete = match options.purpose {
@@ -1183,7 +1242,8 @@ fn build_graph_inner(
     let unchanged_layers = semantic.is_none()
         || (options.purpose == BuildPurpose::Extract
             && semantic.is_some_and(semantic_layer_is_empty));
-    if unchanged_layers
+    if !preflight.omissions.is_partial()
+        && unchanged_layers
         && supplemental.is_empty()
         && !options.force
         && unchanged_artifacts_complete
@@ -1212,6 +1272,7 @@ fn build_graph_inner(
             document.nodes.len(),
             document.links.len(),
             communities,
+            PublicationOmissions::default(),
             program.as_ref(),
         )?;
         let published_output_dir = commit_generation(guard, &output_container)?;
@@ -1226,6 +1287,10 @@ fn build_graph_inner(
             nodes: document.nodes.len(),
             edges: document.links.len(),
             communities,
+            omitted_nodes: 0,
+            omitted_edges: 0,
+            identity_collisions: 0,
+            partial_graph: false,
             html_written: output_dir.join("graph.html").is_file(),
             outputs_changed: false,
             program_modules: program_modules(program.as_ref()),
@@ -1287,7 +1352,7 @@ fn build_graph_inner(
     let labels = label_communities_by_hub(&document, &communities);
     profile_internal("community labeling", &mut internal_started);
 
-    let graph_output = || -> Result<Duration, CoreError> {
+    let graph_output = || -> Result<(Duration, PublicationOmissions, usize, usize), CoreError> {
         let started = Instant::now();
         let mut output_profile_started = Instant::now();
         let configuration_digest = graph_configuration_digest(options, &output_dir)?;
@@ -1305,7 +1370,12 @@ fn build_graph_inner(
             configuration_digest,
             commit.as_deref(),
         )?;
-        write_json_atomic(output_dir.join("graph.json"), &published, false)?;
+        if published.document.nodes.is_empty() {
+            return Err(CoreError::EmptyGraph);
+        }
+        let published_nodes = published.document.nodes.len();
+        let published_edges = published.document.links.len();
+        write_json_atomic(output_dir.join("graph.json"), &published.document, false)?;
         profile_internal("graph.json v1 publication", &mut output_profile_started);
         if options.purpose == BuildPurpose::Update {
             write_text_atomic(
@@ -1318,7 +1388,12 @@ fn build_graph_inner(
                 &mut output_profile_started,
             );
         }
-        Ok(started.elapsed())
+        Ok((
+            started.elapsed(),
+            published.omissions,
+            published_nodes,
+            published_edges,
+        ))
     };
     let graph_analyses = || -> Result<(bool, Duration), CoreError> {
         let started = Instant::now();
@@ -1424,7 +1499,7 @@ fn build_graph_inner(
         Ok((html_written, started.elapsed()))
     };
     let (graph_output_elapsed, analysis_result) = rayon::join(graph_output, graph_analyses);
-    let graph_output_elapsed = graph_output_elapsed?;
+    let (graph_output_elapsed, omissions, published_nodes, published_edges) = graph_output_elapsed?;
     let (html_written, analysis_elapsed) = analysis_result?;
     profile_internal_duration("graph and overview publication", graph_output_elapsed);
     profile_internal_duration(
@@ -1451,19 +1526,21 @@ fn build_graph_inner(
     }
     save_output_stats(
         &output_dir,
-        document.nodes.len(),
-        document.links.len(),
+        published_nodes,
+        published_edges,
         communities.len(),
         true,
+        omissions,
     )?;
     publish_build_state(
         options,
         &output_dir,
         &manifest_path,
         sources.len(),
-        document.nodes.len(),
-        document.links.len(),
+        published_nodes,
+        published_edges,
         communities.len(),
+        omissions,
         program.as_ref(),
     )?;
     profile_internal("Program output and build seals", &mut internal_started);
@@ -1476,9 +1553,13 @@ fn build_graph_inner(
         files_extracted: missing.len(),
         files_cached: sources.len().saturating_sub(missing.len()),
         empty_files,
-        nodes: document.nodes.len(),
-        edges: document.links.len(),
+        nodes: published_nodes,
+        edges: published_edges,
         communities: communities.len(),
+        omitted_nodes: omissions.nodes,
+        omitted_edges: omissions.edges,
+        identity_collisions: omissions.identity_collisions,
+        partial_graph: omissions.is_partial(),
         html_written,
         outputs_changed: true,
         program_modules: program_modules(program.as_ref()),
@@ -1565,6 +1646,7 @@ fn publish_build_state(
     nodes: usize,
     edges: usize,
     communities: usize,
+    omissions: PublicationOmissions,
     program: Option<&ProgramBuild>,
 ) -> Result<(), CoreError> {
     let mut required = vec![output_dir.join(OUTPUT_STATS_FILE)];
@@ -1601,6 +1683,9 @@ fn publish_build_state(
             nodes,
             edges,
             communities,
+            omitted_nodes: omissions.nodes,
+            omitted_edges: omissions.edges,
+            identity_collisions: omissions.identity_collisions,
             program_modules: program_modules(program),
             program_summaries: program_summaries(program),
             program_providers: program_providers(program),
@@ -3159,7 +3244,7 @@ fn published_v1_document(
     evidence: PublicationEvidence<'_>,
     configuration_digest: String,
     source_commit: Option<&str>,
-) -> Result<compass_model::code_graph::GraphDocument, CoreError> {
+) -> Result<PublicationOutcome, CoreError> {
     let mut publication_source = document.clone();
     let node_communities = communities
         .iter()
@@ -3184,7 +3269,7 @@ fn published_v1_document(
             );
         }
     }
-    Ok(normalize_document_v1_with_inventory(
+    Ok(normalize_document_v1_with_inventory_best_effort(
         &publication_source,
         root,
         configuration_digest,
@@ -3486,6 +3571,9 @@ fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<O
             edges: document.links.len(),
             communities: 0,
             clustered: false,
+            omitted_nodes: 0,
+            omitted_edges: 0,
+            identity_collisions: 0,
         };
         let _ = write_json_atomic(output_dir.join(OUTPUT_STATS_FILE), &stats, true);
         return Some(stats);
@@ -3511,9 +3599,19 @@ fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<O
             .collect::<HashSet<_>>()
             .len(),
         clustered: true,
+        omitted_nodes: 0,
+        omitted_edges: 0,
+        identity_collisions: 0,
     };
     let _ = write_json_atomic(output_dir.join(OUTPUT_STATS_FILE), &stats, true);
     Some(stats)
+}
+
+fn saved_publication_omissions(output_dir: &Path) -> PublicationOmissions {
+    fs::read(output_dir.join(OUTPUT_STATS_FILE))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<OutputStats>(&bytes).ok())
+        .map_or_else(PublicationOmissions::default, |stats| stats.omissions())
 }
 
 fn save_output_stats(
@@ -3522,6 +3620,7 @@ fn save_output_stats(
     edges: usize,
     communities: usize,
     clustered: bool,
+    omissions: PublicationOmissions,
 ) -> Result<(), CoreError> {
     let graph_bytes = fs::metadata(output_dir.join("graph.json"))
         .map_err(|source| compass_files::FileError::Io {
@@ -3537,6 +3636,9 @@ fn save_output_stats(
             edges,
             communities,
             clustered,
+            omitted_nodes: omissions.nodes,
+            omitted_edges: omissions.edges,
+            identity_collisions: omissions.identity_collisions,
         },
         true,
     )?;

--- a/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
+++ b/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
@@ -8,6 +8,7 @@ use compass_files::{Cache, CacheOptions};
 use compass_languages::{Extraction, Registry};
 use compass_model::code_graph::{CoverageStatus, ExtractionStatus, GraphDocument};
 use compass_model::provenance::EvidenceOrigin;
+use compass_model::validate_code_graph;
 use sha2::{Digest, Sha256};
 
 fn build(root: &Path) -> Result<GraphDocument, Box<dyn Error>> {
@@ -30,15 +31,14 @@ fn write(root: &Path, relative: &str, source: &str) -> Result<(), Box<dyn Error>
 }
 
 #[test]
-fn failed_topology_preflight_preserves_the_last_known_good_generation() -> Result<(), Box<dyn Error>>
+fn invalid_topology_is_quarantined_and_the_valid_graph_is_published() -> Result<(), Box<dyn Error>>
 {
     let directory = tempfile::tempdir()?;
     write(directory.path(), "src/main.rs", "pub fn healthy() {}\n")?;
     let mut options = BuildOptions::new(directory.path());
     options.no_viz = true;
     options.built_at_commit = Some("0123456789012345678901234567890123456789".to_owned());
-    let first = build_local_graph(&options)?;
-    let graph_before = fs::read(first.output_dir.join("graph.json"))?;
+    let _first = build_local_graph(&options)?;
     let pointer = directory
         .path()
         .join("compass-out/.compass-active-generation");
@@ -78,18 +78,39 @@ fn failed_topology_preflight_preserves_the_last_known_good_generation() -> Resul
             "extractor": "test.invalid"
         }]
     });
-    let error = match build_graph_with_layers(&options, None, &[invalid_layer]) {
-        Ok(_) => return Err("invalid endpoint topology passed publication preflight".into()),
-        Err(error) => error,
-    };
-    assert!(
-        error.to_string().contains("contains")
-            && error.to_string().contains("variable")
-            && error.to_string().contains("method"),
-        "unexpected preflight error: {error}"
-    );
-    assert_eq!(fs::read_to_string(&pointer)?, active_before);
-    assert_eq!(fs::read(first.output_dir.join("graph.json"))?, graph_before);
+    let result = build_graph_with_layers(&options, None, &[invalid_layer])?;
+    assert!(result.partial_graph);
+    assert_eq!(result.omitted_nodes, 0);
+    assert_eq!(result.omitted_edges, 1);
+    assert_eq!(result.identity_collisions, 0);
+    assert_ne!(fs::read_to_string(&pointer)?, active_before);
+
+    let graph = GraphDocument::load(&result.output_dir.join("graph.json"))?;
+    validate_code_graph(&graph)?;
+    let owner = graph
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name == "owner")
+        .ok_or("missing retained owner")?;
+    let method = graph
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name == ".method()")
+        .ok_or("missing retained method")?;
+    assert!(graph.links.iter().all(|edge| {
+        !(edge.source == owner.id && edge.target == method.id && edge.kind.as_str() == "contains")
+    }));
+    assert!(graph.graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "publication_omission_summary"
+            && diagnostic.message.contains("0 nodes and 1 edges")
+    }));
+
+    let stats: serde_json::Value = serde_json::from_slice(&fs::read(
+        result.output_dir.join(".compass_output_stats.json"),
+    )?)?;
+    assert_eq!(stats["omitted_nodes"], 0);
+    assert_eq!(stats["omitted_edges"], 1);
+    assert_eq!(stats["identity_collisions"], 0);
     Ok(())
 }
 

--- a/crates/compass-global/src/lib.rs
+++ b/crates/compass-global/src/lib.rs
@@ -9,12 +9,11 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use compass_files::{FileError, write_json_atomic, write_text_atomic};
-use compass_model::{EdgeRecord, GraphDocument, GraphError};
+use compass_model::{DEFAULT_GRAPH_SIZE_CAP_BYTES, EdgeRecord, GraphDocument, GraphError};
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 
-const MAX_GRAPH_BYTES: u64 = 512 * 1024 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
@@ -371,7 +370,7 @@ fn effective_graph_cap() -> u64 {
     let raw = env::var("COMPASS_MAX_GRAPH_BYTES").unwrap_or_default();
     let text = raw.trim().to_ascii_uppercase();
     if text.is_empty() {
-        return MAX_GRAPH_BYTES;
+        return DEFAULT_GRAPH_SIZE_CAP_BYTES;
     }
     let (number, multiplier) = if let Some(number) = text.strip_suffix("GB") {
         (number.trim(), 1024_u64 * 1024 * 1024)
@@ -385,7 +384,7 @@ fn effective_graph_cap() -> u64 {
         .ok()
         .filter(|value| *value > 0)
         .and_then(|value| value.checked_mul(multiplier))
-        .unwrap_or(MAX_GRAPH_BYTES)
+        .unwrap_or(DEFAULT_GRAPH_SIZE_CAP_BYTES)
 }
 
 fn save_global_graph(paths: &GlobalPaths, graph: &GraphDocument) -> Result<(), GlobalError> {

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -3,6 +3,7 @@
 mod analyze;
 mod cluster;
 mod dedup;
+mod quarantine;
 mod v1;
 
 pub use analyze::{
@@ -20,10 +21,11 @@ pub use dedup::{
     AmbiguousPair, DedupError, DedupResult, DedupStats, EntityTiebreaker, deduplicate_entities,
     deduplicate_entities_with_tiebreaker,
 };
+pub use quarantine::{MAX_QUARANTINE_EXAMPLES, PublicationOmissions, PublicationOutcome};
 pub use v1::{
     BuildEvidence, InventoryEvidence, V1_PUBLICATION_SEMANTICS_VERSION, canonical_edge_kind,
     canonical_raw_edge_sites, extraction_from_v1, normalize_document_v1,
-    normalize_document_v1_with_inventory, normalize_v1,
+    normalize_document_v1_with_inventory, normalize_v1, normalize_v1_best_effort,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -25,7 +25,8 @@ pub use quarantine::{MAX_QUARANTINE_EXAMPLES, PublicationOmissions, PublicationO
 pub use v1::{
     BuildEvidence, InventoryEvidence, V1_PUBLICATION_SEMANTICS_VERSION, canonical_edge_kind,
     canonical_raw_edge_sites, extraction_from_v1, normalize_document_v1,
-    normalize_document_v1_with_inventory, normalize_v1, normalize_v1_best_effort,
+    normalize_document_v1_with_inventory, normalize_document_v1_with_inventory_best_effort,
+    normalize_v1, normalize_v1_best_effort,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/compass-graph/src/quarantine.rs
+++ b/crates/compass-graph/src/quarantine.rs
@@ -1,0 +1,110 @@
+use compass_model::code_graph::{DiagnosticSeverity, GraphDiagnostic, GraphDocument};
+use compass_model::provenance::SourceAnchor;
+
+pub const MAX_QUARANTINE_EXAMPLES: usize = 100;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PublicationOmissions {
+    pub nodes: usize,
+    pub edges: usize,
+    pub identity_collisions: usize,
+    pub examples_omitted: usize,
+}
+
+impl PublicationOmissions {
+    #[must_use]
+    pub const fn is_partial(self) -> bool {
+        self.nodes > 0 || self.edges > 0 || self.identity_collisions > 0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PublicationOutcome {
+    pub document: GraphDocument,
+    pub omissions: PublicationOmissions,
+}
+
+#[derive(Default)]
+pub(crate) struct QuarantineCollector {
+    omissions: PublicationOmissions,
+    diagnostics: Vec<GraphDiagnostic>,
+    node_examples: usize,
+    edge_examples: usize,
+    collision_examples: usize,
+}
+
+impl QuarantineCollector {
+    pub(crate) fn omit_node(&mut self, identity: &str, reason: &str, anchor: Option<SourceAnchor>) {
+        self.omissions.nodes = self.omissions.nodes.saturating_add(1);
+        if self.node_examples < MAX_QUARANTINE_EXAMPLES {
+            self.node_examples += 1;
+            self.diagnostics.push(GraphDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "publication_omitted_node".to_owned(),
+                message: format!("omitted node {identity}: {reason}"),
+                anchor,
+                related_ids: Vec::new(),
+            });
+        } else {
+            self.omissions.examples_omitted = self.omissions.examples_omitted.saturating_add(1);
+        }
+    }
+
+    pub(crate) fn omit_edge(&mut self, identity: &str, reason: &str, anchor: Option<SourceAnchor>) {
+        self.omissions.edges = self.omissions.edges.saturating_add(1);
+        if self.edge_examples < MAX_QUARANTINE_EXAMPLES {
+            self.edge_examples += 1;
+            self.diagnostics.push(GraphDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "publication_omitted_edge".to_owned(),
+                message: format!("omitted edge {identity}: {reason}"),
+                anchor,
+                related_ids: Vec::new(),
+            });
+        } else {
+            self.omissions.examples_omitted = self.omissions.examples_omitted.saturating_add(1);
+        }
+    }
+
+    pub(crate) fn identity_collision(
+        &mut self,
+        identity: &str,
+        reason: &str,
+        anchor: Option<SourceAnchor>,
+    ) {
+        self.omissions.nodes = self.omissions.nodes.saturating_add(1);
+        self.omissions.identity_collisions = self.omissions.identity_collisions.saturating_add(1);
+        if self.collision_examples < MAX_QUARANTINE_EXAMPLES {
+            self.collision_examples += 1;
+            self.diagnostics.push(GraphDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "publication_identity_collision".to_owned(),
+                message: format!("omitted conflicting node {identity}: {reason}"),
+                anchor,
+                related_ids: Vec::new(),
+            });
+        } else {
+            self.omissions.examples_omitted = self.omissions.examples_omitted.saturating_add(1);
+        }
+    }
+
+    pub(crate) fn finish(mut self, diagnostics: &mut Vec<GraphDiagnostic>) -> PublicationOmissions {
+        if self.omissions.is_partial() {
+            self.diagnostics.push(GraphDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: "publication_omission_summary".to_owned(),
+                message: format!(
+                    "partial graph published after quarantining {} nodes and {} edges with {} identity collisions; {} examples omitted by the diagnostic cap",
+                    self.omissions.nodes,
+                    self.omissions.edges,
+                    self.omissions.identity_collisions,
+                    self.omissions.examples_omitted
+                ),
+                anchor: None,
+                related_ids: Vec::new(),
+            });
+        }
+        diagnostics.append(&mut self.diagnostics);
+        self.omissions
+    }
+}

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -22,9 +22,13 @@ use compass_model::provenance::{
     SEMANTIC_LAYER_EXTRACTOR, SourceAnchor, TRUSTED_EDGE_RECORD_ATTRIBUTE,
     TRUSTED_NODE_RECORD_ATTRIBUTE,
 };
-use compass_model::{GraphError, validate_code_graph};
+use compass_model::{
+    CodeGraphValidationError, GraphError, validate_code_graph, validate_code_graph_records,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+
+use crate::quarantine::{PublicationOutcome, QuarantineCollector};
 
 /// Version of the normalization and publication contract behind graph schema v1.
 pub const V1_PUBLICATION_SEMANTICS_VERSION: &str = "compass.graph.publication/2";
@@ -36,6 +40,12 @@ const TRUSTED_GRAPH_COVERAGE: &str = "_compass_v1_graph_coverage";
 const TRUSTED_GRAPH_DIAGNOSTICS: &str = "_compass_v1_graph_diagnostics";
 const COALESCED_EDGE_EVIDENCE: &str = "_coalesced_edge_evidence";
 const MAX_EXTERNAL_REFERENCE_DIAGNOSTICS: usize = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PublicationMode {
+    Strict,
+    BestEffort,
+}
 
 #[derive(Clone, Debug)]
 pub struct BuildEvidence {
@@ -413,9 +423,27 @@ fn coverage_file_id(
 
 /// Publish resolved raw facts as a validated, deterministic Compass graph v1 document.
 pub fn normalize_v1(
+    extraction: Extraction,
+    evidence: BuildEvidence,
+) -> Result<GraphDocument, GraphError> {
+    normalize_v1_with_mode(extraction, evidence, PublicationMode::Strict)
+        .map(|outcome| outcome.document)
+}
+
+/// Publish the largest strict-valid graph after quarantining invalid records.
+pub fn normalize_v1_best_effort(
+    extraction: Extraction,
+    evidence: BuildEvidence,
+) -> Result<PublicationOutcome, GraphError> {
+    normalize_v1_with_mode(extraction, evidence, PublicationMode::BestEffort)
+}
+
+fn normalize_v1_with_mode(
     mut extraction: Extraction,
     mut evidence: BuildEvidence,
-) -> Result<GraphDocument, GraphError> {
+    mode: PublicationMode,
+) -> Result<PublicationOutcome, GraphError> {
+    let mut quarantine = QuarantineCollector::default();
     if let Some(value) = extraction.extensions.remove(TRUSTED_GRAPH_COVERAGE) {
         let mut coverage = serde_json::from_value::<Vec<CoverageRecord>>(value)
             .map_err(|error| raw_error("graph.coverage", &error.to_string()))?;
@@ -439,33 +467,69 @@ pub fn normalize_v1(
         &evidence.repository_root,
         &file_facts,
         &stub_wiring_sites,
+        mode,
+        &mut quarantine,
     )?;
 
+    if mode == PublicationMode::BestEffort {
+        extraction.nodes.sort_by_cached_key(raw_node_sort_key);
+        extraction.edges.sort_by_cached_key(raw_edge_sort_key);
+    }
     let mut id_remap = HashMap::with_capacity(extraction.nodes.len());
-    let mut nodes = BTreeMap::new();
+    let mut nodes = BTreeMap::<String, NodeRecord>::new();
     for raw in extraction.nodes {
-        if id_remap.contains_key(&raw.id) {
-            return Err(raw_error(
-                &raw.id,
+        let raw_id = raw.id.clone();
+        let diagnostic_anchor =
+            best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts);
+        if id_remap.contains_key(&raw_id) {
+            let error = raw_error(
+                &raw_id,
                 "duplicate raw node ID cannot be resolved deterministically",
-            ));
+            );
+            if mode == PublicationMode::Strict {
+                return Err(error);
+            }
+            id_remap.remove(&raw_id);
+            quarantine.omit_node(&raw_id, &error.to_string(), diagnostic_anchor);
+            continue;
         }
-        let node = match raw.attributes.get(TRUSTED_NODE_RECORD) {
+        let normalized = match raw.attributes.get(TRUSTED_NODE_RECORD) {
             Some(value) => serde_json::from_value::<NodeRecord>(value.clone())
-                .map_err(|error| raw_error(&raw.id, &error.to_string()))?,
+                .map_err(|error| raw_error(&raw_id, &error.to_string())),
             None => normalize_node(
                 raw.clone(),
                 &evidence.repository_root,
                 &file_facts,
-                stub_wiring_sites.get(&raw.id),
-            )?,
+                stub_wiring_sites.get(&raw_id),
+            ),
         };
-        id_remap.insert(raw.id, node.id.clone());
+        let node = match normalized {
+            Ok(node) => node,
+            Err(error) if mode == PublicationMode::BestEffort => {
+                quarantine.omit_node(&raw_id, &error.to_string(), diagnostic_anchor);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let published_id = node.id.clone();
         if let Some(existing) = nodes.get_mut(&node.id) {
-            merge_normalized_node(existing, node)?;
+            let mut merged = existing.clone();
+            if let Err(error) = merge_normalized_node(&mut merged, node) {
+                if mode == PublicationMode::Strict {
+                    return Err(error);
+                }
+                quarantine.identity_collision(
+                    &raw_id,
+                    &error.to_string(),
+                    diagnostic_anchor.or_else(|| best_effort_node_anchor(existing)),
+                );
+                continue;
+            }
+            *existing = merged;
         } else {
             nodes.insert(node.id.clone(), node);
         }
+        id_remap.insert(raw_id, published_id);
     }
     for node in nodes.values_mut() {
         remap_provenance_candidates(&mut node.evidence, &id_remap);
@@ -487,39 +551,72 @@ pub fn normalize_v1(
         recompute_route_resolution(details);
     }
 
-    let mut links = BTreeMap::new();
+    let mut links = BTreeMap::<String, EdgeRecord>::new();
     for (index, raw) in extraction.edges.into_iter().enumerate() {
-        let source = id_remap.get(&raw.source).ok_or_else(|| {
-            raw_error(
-                &format!("edge[{index}]"),
-                &format!("source {} does not match a raw node", raw.source),
-            )
-        })?;
-        let target = id_remap.get(&raw.target).ok_or_else(|| {
-            raw_error(
-                &format!("edge[{index}]"),
-                &format!("target {} does not match a raw node", raw.target),
-            )
-        })?;
+        let raw_identity = raw_edge_identity(&raw, index);
+        let diagnostic_anchor =
+            best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts);
+        let source = match id_remap.get(&raw.source) {
+            Some(source) => source.clone(),
+            None if mode == PublicationMode::BestEffort => {
+                quarantine.omit_edge(
+                    &raw_identity,
+                    &format!("source {} does not match a retained raw node", raw.source),
+                    diagnostic_anchor,
+                );
+                continue;
+            }
+            None => {
+                return Err(raw_error(
+                    &format!("edge[{index}]"),
+                    &format!("source {} does not match a raw node", raw.source),
+                ));
+            }
+        };
+        let target = match id_remap.get(&raw.target) {
+            Some(target) => target.clone(),
+            None if mode == PublicationMode::BestEffort => {
+                quarantine.omit_edge(
+                    &raw_identity,
+                    &format!("target {} does not match a retained raw node", raw.target),
+                    diagnostic_anchor,
+                );
+                continue;
+            }
+            None => {
+                return Err(raw_error(
+                    &format!("edge[{index}]"),
+                    &format!("target {} does not match a raw node", raw.target),
+                ));
+            }
+        };
         let trusted_edge = raw.attributes.contains_key(TRUSTED_EDGE_RECORD);
-        let mut edge = match raw.attributes.get(TRUSTED_EDGE_RECORD).cloned() {
+        let normalized = match raw.attributes.get(TRUSTED_EDGE_RECORD).cloned() {
             Some(value) => normalize_trusted_edge(
                 raw,
                 value,
-                source,
-                target,
+                &source,
+                &target,
                 index,
                 &evidence.repository_root,
                 &file_facts,
-            )?,
+            ),
             None => normalize_edge(
                 raw,
-                source,
-                target,
+                &source,
+                &target,
                 index,
                 &evidence.repository_root,
                 &file_facts,
-            )?,
+            ),
+        };
+        let mut edge = match normalized {
+            Ok(edge) => edge,
+            Err(error) if mode == PublicationMode::BestEffort => {
+                quarantine.omit_edge(&raw_identity, &error.to_string(), diagnostic_anchor);
+                continue;
+            }
+            Err(error) => return Err(error),
         };
         remap_provenance_candidates(&mut edge.evidence, &id_remap);
         if !trusted_edge
@@ -627,6 +724,13 @@ pub fn normalize_v1(
             });
         }
         if edge.source == edge.target && edge.kind != EdgeKind::Calls {
+            if mode == PublicationMode::BestEffort {
+                quarantine.omit_edge(
+                    &edge.id,
+                    &format!("unsupported {} self-loop", edge.kind.as_str()),
+                    edge.relationship_site.clone(),
+                );
+            }
             evidence.diagnostics.push(GraphDiagnostic {
                 severity: DiagnosticSeverity::Warning,
                 code: "dropped_non_recursive_self_loop".to_owned(),
@@ -651,6 +755,18 @@ pub fn normalize_v1(
                     _ => false,
                 };
             if !valid {
+                if mode == PublicationMode::BestEffort {
+                    quarantine.omit_edge(
+                        &edge.id,
+                        &format!(
+                            "invalid {} endpoints {} -> {}",
+                            edge.kind.as_str(),
+                            source_kind.as_str(),
+                            target_kind.as_str()
+                        ),
+                        edge.relationship_site.clone(),
+                    );
+                }
                 evidence.diagnostics.push(GraphDiagnostic {
                     severity: DiagnosticSeverity::Warning,
                     code: "dropped_invalid_inheritance_target".to_owned(),
@@ -667,7 +783,19 @@ pub fn normalize_v1(
             }
         }
         if let Some(existing) = links.get_mut(&edge.id) {
-            merge_normalized_edge(existing, edge)?;
+            let mut merged = existing.clone();
+            if let Err(error) = merge_normalized_edge(&mut merged, edge) {
+                if mode == PublicationMode::Strict {
+                    return Err(error);
+                }
+                quarantine.omit_edge(
+                    &existing.id,
+                    &error.to_string(),
+                    existing.relationship_site.clone(),
+                );
+                continue;
+            }
+            *existing = merged;
         } else {
             links.insert(edge.id.clone(), edge);
         }
@@ -783,7 +911,7 @@ pub fn normalize_v1(
             .cmp(&(right.code.as_str(), right.message.as_str()))
     });
 
-    let document = GraphDocument {
+    let mut document = GraphDocument {
         directed: true,
         multigraph: true,
         graph: GraphMetadata {
@@ -796,8 +924,246 @@ pub fn normalize_v1(
         nodes,
         links,
     };
+    if mode == PublicationMode::BestEffort {
+        sanitize_document(&mut document, &mut quarantine)?;
+    }
+    let omissions = quarantine.finish(&mut document.graph.diagnostics);
+    sort_dedup_serialized(&mut document.graph.diagnostics);
+    document.graph.diagnostics.sort_by(|left, right| {
+        (left.code.as_str(), left.message.as_str())
+            .cmp(&(right.code.as_str(), right.message.as_str()))
+    });
     validate_code_graph(&document)?;
-    Ok(document)
+    Ok(PublicationOutcome {
+        document,
+        omissions,
+    })
+}
+
+fn sanitize_document(
+    document: &mut GraphDocument,
+    quarantine: &mut QuarantineCollector,
+) -> Result<(), GraphError> {
+    let report = validate_code_graph_records(document);
+    if !report.document_errors.is_empty() {
+        return Err(CodeGraphValidationError {
+            errors: report.document_errors,
+        }
+        .into());
+    }
+
+    let invalid_nodes = report
+        .node_errors
+        .iter()
+        .map(|record| record.id.as_str())
+        .collect::<HashSet<_>>();
+    for record in &report.node_errors {
+        quarantine.omit_node(&record.id, &record.errors.join("; "), None);
+    }
+
+    let incident_edges = document
+        .links
+        .iter()
+        .filter(|edge| {
+            invalid_nodes.contains(edge.source.as_str())
+                || invalid_nodes.contains(edge.target.as_str())
+        })
+        .map(|edge| edge.id.clone())
+        .collect::<BTreeSet<_>>();
+    for edge in document
+        .links
+        .iter()
+        .filter(|edge| incident_edges.contains(&edge.id))
+    {
+        quarantine.omit_edge(
+            &edge.id,
+            "an endpoint node was quarantined",
+            edge.relationship_site.clone(),
+        );
+    }
+
+    let invalid_edges = report
+        .edge_errors
+        .iter()
+        .filter(|record| !incident_edges.contains(&record.id))
+        .map(|record| record.id.clone())
+        .collect::<BTreeSet<_>>();
+    for record in report
+        .edge_errors
+        .iter()
+        .filter(|record| invalid_edges.contains(&record.id))
+    {
+        let anchor = document
+            .links
+            .iter()
+            .find(|edge| edge.id == record.id)
+            .and_then(|edge| edge.relationship_site.clone());
+        quarantine.omit_edge(&record.id, &record.errors.join("; "), anchor);
+    }
+
+    document
+        .nodes
+        .retain(|node| !invalid_nodes.contains(node.id.as_str()));
+    document
+        .links
+        .retain(|edge| !incident_edges.contains(&edge.id) && !invalid_edges.contains(&edge.id));
+    repair_route_topology(document);
+    Ok(())
+}
+
+fn repair_route_topology(document: &mut GraphDocument) {
+    let retained_nodes = document
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<HashSet<_>>();
+    let retained_stages = document
+        .links
+        .iter()
+        .filter_map(|edge| {
+            let EdgeDetails::Route(details) = edge.details.as_ref()? else {
+                return None;
+            };
+            Some((
+                edge.source.clone(),
+                details.stage,
+                details.position,
+                edge.target.clone(),
+            ))
+        })
+        .collect::<HashSet<_>>();
+
+    for node in &mut document.nodes {
+        for evidence in &mut node.evidence {
+            evidence
+                .candidates
+                .retain(|candidate| retained_nodes.contains(candidate.node_id.as_str()));
+        }
+        let Some(NodeDetails::Route(details)) = node.details.as_mut() else {
+            continue;
+        };
+        for stage in &mut details.stages {
+            stage
+                .candidates
+                .retain(|candidate| retained_nodes.contains(candidate.node_id.as_str()));
+            let retained = stage.target.as_ref().is_some_and(|target| {
+                retained_stages.contains(&(
+                    node.id.clone(),
+                    stage.stage,
+                    Some(stage.position),
+                    target.clone(),
+                ))
+            });
+            if !retained {
+                stage.target = None;
+                stage.resolution = if stage.candidates.len() > 1 {
+                    ResolutionState::Ambiguous
+                } else {
+                    ResolutionState::Unresolved
+                };
+            }
+        }
+        recompute_route_resolution(details);
+    }
+    for edge in &mut document.links {
+        for evidence in &mut edge.evidence {
+            evidence
+                .candidates
+                .retain(|candidate| retained_nodes.contains(candidate.node_id.as_str()));
+        }
+    }
+}
+
+fn raw_node_sort_key(raw: &RawNodeRecord) -> String {
+    let trusted = raw
+        .attributes
+        .get(TRUSTED_NODE_RECORD)
+        .and_then(|value| serde_json::from_value::<NodeRecord>(value.clone()).ok());
+    let rank = trusted.as_ref().map_or_else(
+        || {
+            let has_source = optional_source_path(&raw.attributes, "source_file").is_some();
+            let exact = optional_string(&raw.attributes, "confidence")
+                .is_some_and(|confidence| matches!(confidence.as_str(), "EXACT" | "EXTRACTED"));
+            let ast = optional_string(&raw.attributes, "origin")
+                .is_some_and(|origin| origin.eq_ignore_ascii_case("ast"));
+            match (ast, exact, has_source) {
+                (true, _, true) => 0,
+                (_, true, true) => 1,
+                (_, _, true) => 2,
+                _ => 4,
+            }
+        },
+        |node| {
+            let exact_ast = node.evidence.iter().any(|evidence| {
+                evidence.origin == EvidenceOrigin::Ast
+                    && evidence.confidence == EvidenceConfidence::Exact
+            });
+            let exact_source = node.source.is_some()
+                && node
+                    .evidence
+                    .iter()
+                    .any(|evidence| evidence.confidence == EvidenceConfidence::Exact);
+            let inferred_source = node.source.is_some();
+            let exact_wiring = node.evidence.iter().any(|evidence| {
+                evidence.wiring_site.is_some() && evidence.confidence == EvidenceConfidence::Exact
+            });
+            if exact_ast {
+                0
+            } else if exact_source {
+                1
+            } else if inferred_source {
+                2
+            } else if exact_wiring {
+                3
+            } else {
+                4
+            }
+        },
+    );
+    format!(
+        "{rank}\u{1f}{}\u{1f}{}",
+        raw.id,
+        serialized(&raw.attributes)
+    )
+}
+
+fn raw_edge_sort_key(raw: &RawEdgeRecord) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        raw.source,
+        optional_string(&raw.attributes, "relation").unwrap_or_default(),
+        raw.target,
+        serialized(&raw.attributes)
+    )
+}
+
+fn raw_edge_identity(raw: &RawEdgeRecord, index: usize) -> String {
+    let relation =
+        optional_string(&raw.attributes, "relation").unwrap_or_else(|| "<missing>".to_owned());
+    format!(
+        "edge[{index}] {} -[{relation}]-> {}",
+        raw.source, raw.target
+    )
+}
+
+fn best_effort_raw_anchor(
+    attributes: &Map<String, Value>,
+    root: &Path,
+    file_facts: &HashMap<String, PublishedFileFacts>,
+) -> Option<SourceAnchor> {
+    raw_anchor(attributes, root, file_facts).ok().flatten()
+}
+
+fn best_effort_node_anchor(node: &NodeRecord) -> Option<SourceAnchor> {
+    node.source.clone().or_else(|| {
+        node.evidence.iter().find_map(|evidence| {
+            evidence
+                .anchors
+                .first()
+                .cloned()
+                .or_else(|| evidence.wiring_site.clone())
+        })
+    })
 }
 
 fn remap_diagnostic_ids(diagnostic: &mut GraphDiagnostic, id_remap: &HashMap<String, String>) {
@@ -1185,6 +1551,8 @@ fn resolve_or_drop_generic_symbols(
     root: &Path,
     file_facts: &HashMap<String, PublishedFileFacts>,
     wiring_sites: &HashMap<String, SourceAnchor>,
+    mode: PublicationMode,
+    quarantine: &mut QuarantineCollector,
 ) -> Result<(), GraphError> {
     let generic_ids = extraction
         .nodes
@@ -1266,11 +1634,19 @@ fn resolve_or_drop_generic_symbols(
         if anchor.is_none()
             && optional_string(&node.attributes, "extractor").as_deref()
                 == Some("compass.graph.external-placeholder")
+            && mode == PublicationMode::Strict
         {
             return Err(raw_error(
                 &node.id,
                 "unresolved external placeholder requires an exact wiring site",
             ));
+        }
+        if mode == PublicationMode::BestEffort {
+            quarantine.omit_node(
+                &node.id,
+                "no exact node kind or wiring site could be inferred",
+                anchor.clone(),
+            );
         }
         diagnostics.push(GraphDiagnostic {
             severity: DiagnosticSeverity::Warning,
@@ -1282,6 +1658,19 @@ fn resolve_or_drop_generic_symbols(
             anchor,
             related_ids: Vec::new(),
         });
+    }
+    if mode == PublicationMode::BestEffort {
+        for edge in extraction
+            .edges
+            .iter()
+            .filter(|edge| dropped.contains(&edge.source) || dropped.contains(&edge.target))
+        {
+            quarantine.omit_edge(
+                &raw_edge_identity(edge, 0),
+                "an endpoint node was quarantined",
+                best_effort_raw_anchor(&edge.attributes, root, file_facts),
+            );
+        }
     }
     extraction.nodes.retain(|node| !dropped.contains(&node.id));
     extraction

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1962,6 +1962,40 @@ pub fn normalize_document_v1_with_inventory(
     source_commit: Option<&str>,
     inventory: Vec<InventoryEvidence>,
 ) -> Result<GraphDocument, GraphError> {
+    let (extraction, evidence) = document_publication_input(
+        document,
+        repository_root,
+        configuration_digest,
+        source_commit,
+        inventory,
+    )?;
+    normalize_v1(extraction, evidence)
+}
+
+pub fn normalize_document_v1_with_inventory_best_effort(
+    document: &compass_model::GraphDocument,
+    repository_root: &Path,
+    configuration_digest: impl Into<String>,
+    source_commit: Option<&str>,
+    inventory: Vec<InventoryEvidence>,
+) -> Result<PublicationOutcome, GraphError> {
+    let (extraction, evidence) = document_publication_input(
+        document,
+        repository_root,
+        configuration_digest,
+        source_commit,
+        inventory,
+    )?;
+    normalize_v1_best_effort(extraction, evidence)
+}
+
+fn document_publication_input(
+    document: &compass_model::GraphDocument,
+    repository_root: &Path,
+    configuration_digest: impl Into<String>,
+    source_commit: Option<&str>,
+    inventory: Vec<InventoryEvidence>,
+) -> Result<(Extraction, BuildEvidence), GraphError> {
     let mut extensions = Map::new();
     if let Some(diagnostics) = document.graph.get(TRUSTED_GRAPH_DIAGNOSTICS) {
         extensions.insert(TRUSTED_GRAPH_DIAGNOSTICS.to_owned(), diagnostics.clone());
@@ -1991,7 +2025,7 @@ pub fn normalize_document_v1_with_inventory(
         BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?;
     evidence.include_inventory(inventory)?;
     evidence.build.source_commit = source_commit.map(str::to_owned);
-    normalize_v1(extraction, evidence)
+    Ok((extraction, evidence))
 }
 
 /// Project trusted v1 records back into flexible facts for incremental recomposition.

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use compass_graph::{
     BuildEvidence, InventoryEvidence, build_from_extraction, extraction_from_v1,
-    normalize_document_v1, normalize_v1,
+    normalize_document_v1, normalize_v1, normalize_v1_best_effort,
 };
 use compass_languages::{Extraction, RawEdgeRecord, RawNodeRecord};
 use compass_model::code_graph::{
@@ -15,6 +15,7 @@ use compass_model::provenance::{
     EndpointRewriteEvidence, EndpointRewriteRule, EvidenceConfidence, EvidenceOrigin,
     SEMANTIC_LAYER_EXTRACTOR, TRUSTED_EDGE_RECORD_ATTRIBUTE, append_endpoint_rewrite_evidence,
 };
+use compass_model::validate_code_graph;
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
@@ -1016,6 +1017,244 @@ fn normalization_rejects_unknown_aliases_and_missing_wiring_sites() {
     missing_site.edges[0].attributes.remove("source_anchor");
     let evidence = build_evidence(root).unwrap_or_else(|_| std::process::abort());
     assert!(normalize_v1(missing_site, evidence).is_err());
+}
+
+#[test]
+fn best_effort_normalization_omits_an_unknown_relation() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut source = extraction(root);
+    source.edges[0]
+        .attributes
+        .insert("relation".to_owned(), json!("bound_to"));
+
+    let outcome = normalize_v1_best_effort(source, build_evidence(root)?)?;
+
+    assert_eq!(outcome.document.nodes.len(), 2);
+    assert!(outcome.document.links.is_empty());
+    assert_eq!(outcome.omissions.edges, 1);
+    assert_eq!(outcome.omissions.nodes, 0);
+    assert!(outcome.document.graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "publication_omitted_edge"
+            && diagnostic.message.contains("unknown raw relation")
+    }));
+    assert!(validate_code_graph(&outcome.document).is_ok());
+    Ok(())
+}
+
+#[test]
+fn best_effort_normalization_quarantines_unwired_placeholders()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let source = Extraction {
+        nodes: vec![
+            raw_node(root, "raw:valid", "valid", 10),
+            raw_external_node("raw:model", "ExternalModel"),
+        ],
+        edges: vec![RawEdgeRecord {
+            source: "raw:valid".to_owned(),
+            target: "raw:model".to_owned(),
+            attributes: Map::from_iter([
+                ("relation".to_owned(), json!("references")),
+                ("extractor".to_owned(), json!("test.rust")),
+            ]),
+        }],
+        ..Extraction::default()
+    };
+
+    let outcome = normalize_v1_best_effort(source, build_evidence(root)?)?;
+
+    assert_eq!(outcome.document.nodes.len(), 1);
+    assert!(outcome.document.links.is_empty());
+    assert_eq!(outcome.omissions.nodes, 1);
+    assert_eq!(outcome.omissions.edges, 1);
+    assert!(validate_code_graph(&outcome.document).is_ok());
+    Ok(())
+}
+
+#[test]
+fn best_effort_stable_identity_collision_is_order_independent()
+-> Result<(), Box<dyn std::error::Error>> {
+    let left_directory = tempfile::tempdir()?;
+    let right_directory = tempfile::tempdir()?;
+    let left_root = left_directory.path();
+    let right_root = right_directory.path();
+    let source_at = |root: &Path| Extraction {
+        nodes: vec![
+            raw_node(root, "raw:first", "repeated", 10),
+            raw_node(root, "raw:second", "repeated", 30),
+        ],
+        ..Extraction::default()
+    };
+
+    let left = normalize_v1_best_effort(source_at(left_root), build_evidence(left_root)?)?;
+    let mut reversed = source_at(right_root);
+    reversed.nodes.reverse();
+    let right = normalize_v1_best_effort(reversed, build_evidence(right_root)?)?;
+
+    assert_eq!(left.document, right.document);
+    assert_eq!(left.omissions, right.omissions);
+    assert_eq!(left.document.nodes.len(), 1);
+    assert_eq!(left.omissions.nodes, 1);
+    assert_eq!(left.omissions.identity_collisions, 1);
+    assert!(validate_code_graph(&left.document).is_ok());
+    Ok(())
+}
+
+#[test]
+fn best_effort_typed_validation_omits_invalid_endpoint_edges()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut source = extraction(root);
+    source.nodes[0]
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("method"));
+    source.nodes[1]
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("module"));
+    source.edges[0]
+        .attributes
+        .insert("relation".to_owned(), json!("calls"));
+    source.edges[0]
+        .attributes
+        .insert("_origin".to_owned(), json!("ast"));
+    source.edges[0]
+        .attributes
+        .insert("confidence".to_owned(), json!("EXTRACTED"));
+
+    let outcome = normalize_v1_best_effort(source, build_evidence(root)?)?;
+
+    assert_eq!(outcome.document.nodes.len(), 2);
+    assert!(outcome.document.links.is_empty());
+    assert_eq!(outcome.omissions.edges, 1);
+    assert!(outcome.document.graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "publication_omitted_edge"
+            && diagnostic
+                .message
+                .contains("invalid calls endpoints method -> module")
+    }));
+    assert!(validate_code_graph(&outcome.document).is_ok());
+    Ok(())
+}
+
+#[test]
+fn best_effort_route_stage_becomes_unresolved_when_handler_edge_is_quarantined()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut route = raw_node(root, "raw:route", "GET /items", 10);
+    route
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("route"));
+    route
+        .attributes
+        .insert("framework".to_owned(), json!("express"));
+    route
+        .attributes
+        .insert("operation".to_owned(), json!("GET"));
+    route.attributes.insert("path".to_owned(), json!("/items"));
+    route
+        .attributes
+        .insert("declaring_scope".to_owned(), json!("router"));
+    route.attributes.insert(
+        "stages".to_owned(),
+        json!([{
+            "stage": "handler",
+            "position": 0,
+            "reference": "handlers.listItems",
+            "resolution": "exact",
+            "target": "raw:handler",
+            "candidates": []
+        }]),
+    );
+    let mut invalid_handler = raw_node(root, "raw:handler", "handlers", 30);
+    invalid_handler
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("module"));
+    let outcome = normalize_v1_best_effort(
+        Extraction {
+            nodes: vec![route, invalid_handler],
+            edges: vec![RawEdgeRecord {
+                source: "raw:route".to_owned(),
+                target: "raw:handler".to_owned(),
+                attributes: Map::from_iter([
+                    ("relation".to_owned(), json!("routes_to")),
+                    ("stage".to_owned(), json!("handler")),
+                    ("position".to_owned(), json!(0)),
+                    ("operation".to_owned(), json!("GET")),
+                    ("extractor".to_owned(), json!("test.routes")),
+                    ("source_anchor".to_owned(), anchor(root, 10)),
+                ]),
+            }],
+            ..Extraction::default()
+        },
+        build_evidence(root)?,
+    )?;
+
+    assert!(outcome.document.links.is_empty());
+    let route = outcome
+        .document
+        .nodes
+        .iter()
+        .find(|node| node.kind == NodeKind::Route)
+        .ok_or("missing route")?;
+    let compass_model::code_graph::NodeDetails::Route(details) =
+        route.details.as_ref().ok_or("missing route details")?
+    else {
+        return Err("wrong route details".into());
+    };
+    assert_eq!(
+        details.resolution,
+        compass_model::provenance::ResolutionState::Unresolved
+    );
+    assert_eq!(
+        details.stages[0].resolution,
+        compass_model::provenance::ResolutionState::Unresolved
+    );
+    assert!(details.stages[0].target.is_none());
+    assert!(validate_code_graph(&outcome.document).is_ok());
+    Ok(())
+}
+
+#[test]
+fn best_effort_diagnostic_examples_are_bounded_with_exact_counts()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut source = extraction(root);
+    source.edges = (0..110)
+        .map(|index| RawEdgeRecord {
+            source: "raw:a".to_owned(),
+            target: "raw:b".to_owned(),
+            attributes: Map::from_iter([
+                ("relation".to_owned(), json!(format!("unknown_{index}"))),
+                ("source_anchor".to_owned(), anchor(root, 50)),
+            ]),
+        })
+        .collect();
+
+    let outcome = normalize_v1_best_effort(source, build_evidence(root)?)?;
+
+    assert_eq!(outcome.omissions.edges, 110);
+    assert_eq!(outcome.omissions.examples_omitted, 10);
+    assert_eq!(
+        outcome
+            .document
+            .graph
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "publication_omitted_edge")
+            .count(),
+        100
+    );
+    assert!(outcome.document.graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "publication_omission_summary"
+            && diagnostic.message.contains("110 edges")
+            && diagnostic.message.contains("10 examples")
+    }));
+    Ok(())
 }
 
 #[test]

--- a/crates/compass-model/src/graph.rs
+++ b/crates/compass-model/src/graph.rs
@@ -23,7 +23,7 @@ pub struct Graph {
 }
 
 impl Graph {
-    /// Load a graph file with the same default 512 MiB safety cap as Python.
+    /// Load a graph file with the default bounded enterprise graph size cap.
     ///
     /// # Errors
     ///
@@ -313,7 +313,7 @@ fn ensure_endpoint(id: &str, nodes: &mut Vec<NodeRecord>, ids: &mut HashMap<Stri
 }
 
 pub(crate) fn graph_size_cap() -> u64 {
-    const DEFAULT: u64 = 512 * 1024 * 1024;
+    const DEFAULT: u64 = crate::DEFAULT_GRAPH_SIZE_CAP_BYTES;
     let Ok(raw) = std::env::var("COMPASS_MAX_GRAPH_BYTES") else {
         return DEFAULT;
     };

--- a/crates/compass-model/src/lib.rs
+++ b/crates/compass-model/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::GraphError;
 pub use graph::{EdgeIndex, Graph, NodeIndex};
 pub use query_index::{QueryIndex, SchemaFingerprint, cypher_node_label, cypher_relationship_type};
 pub use validation::{
-    CodeGraphValidationError, ExtractionValidationError, assert_valid_extraction,
-    validate_code_graph, validate_extraction,
+    CodeGraphValidationError, CodeGraphValidationReport, ExtractionValidationError,
+    RecordValidationErrors, assert_valid_extraction, validate_code_graph,
+    validate_code_graph_records, validate_extraction,
 };

--- a/crates/compass-model/src/lib.rs
+++ b/crates/compass-model/src/lib.rs
@@ -1,5 +1,8 @@
 //! Typed model for Compass node-link graphs.
 
+/// Default bounded size accepted by current graph readers.
+pub const DEFAULT_GRAPH_SIZE_CAP_BYTES: u64 = 1024 * 1024 * 1024;
+
 pub mod code_graph;
 mod document;
 mod error;

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -173,17 +173,59 @@ impl std::fmt::Display for ExtractionValidationError {
 
 impl std::error::Error for ExtractionValidationError {}
 
-/// Validate all cross-record invariants of a strict `compass.graph/1` document.
-pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraphValidationError> {
-    let mut errors = Vec::new();
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RecordValidationErrors {
+    pub id: String,
+    pub errors: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CodeGraphValidationReport {
+    pub document_errors: Vec<String>,
+    pub node_errors: Vec<RecordValidationErrors>,
+    pub edge_errors: Vec<RecordValidationErrors>,
+}
+
+impl CodeGraphValidationReport {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.document_errors.is_empty()
+            && self.node_errors.is_empty()
+            && self.edge_errors.is_empty()
+    }
+
+    fn into_errors(self) -> Vec<String> {
+        let mut errors = self.document_errors;
+        errors.extend(
+            self.node_errors
+                .into_iter()
+                .flat_map(|record| record.errors),
+        );
+        errors.extend(
+            self.edge_errors
+                .into_iter()
+                .flat_map(|record| record.errors),
+        );
+        errors
+    }
+}
+
+/// Classify strict `compass.graph/1` validation failures by owning record.
+#[must_use]
+pub fn validate_code_graph_records(document: &CodeGraphDocument) -> CodeGraphValidationReport {
+    let mut report = CodeGraphValidationReport::default();
     if !document.directed {
-        errors.push("directed must be true".to_owned());
+        report
+            .document_errors
+            .push("directed must be true".to_owned());
     }
     if !document.multigraph {
-        errors.push("multigraph must be true".to_owned());
+        report
+            .document_errors
+            .push("multigraph must be true".to_owned());
     }
     if document.graph.schema != CODE_GRAPH_SCHEMA_V1 {
-        errors.push(format!(
+        report.document_errors.push(format!(
             "graph.schema must be {CODE_GRAPH_SCHEMA_V1}, got {}",
             document.graph.schema
         ));
@@ -192,22 +234,26 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
     let mut files = HashMap::new();
     for file in &document.graph.files {
         if file.id.trim().is_empty() {
-            errors.push("file ID must not be empty".to_owned());
+            report
+                .document_errors
+                .push("file ID must not be empty".to_owned());
         }
         if file.path.is_empty()
             || std::path::Path::new(&file.path).is_absolute()
             || file.path.contains('\\')
         {
-            errors.push(format!(
+            report.document_errors.push(format!(
                 "file {} has a non-portable repository path",
                 file.id
             ));
         }
         if files.insert(file.path.as_str(), file.byte_size).is_some() {
-            errors.push(format!("duplicate file path {}", file.path));
+            report
+                .document_errors
+                .push(format!("duplicate file path {}", file.path));
         }
         if file.id != file_id(&file.path) {
-            errors.push(format!(
+            report.document_errors.push(format!(
                 "file {} does not match its deterministic path identity",
                 file.path
             ));
@@ -216,6 +262,7 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
 
     let mut nodes = HashMap::new();
     for node in &document.nodes {
+        let mut errors = Vec::new();
         if node.id.trim().is_empty() {
             errors.push("node ID must not be empty".to_owned());
         }
@@ -242,10 +289,17 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
                 node.kind.as_str()
             ));
         }
+        if !errors.is_empty() {
+            report.node_errors.push(RecordValidationErrors {
+                id: node.id.clone(),
+                errors,
+            });
+        }
     }
 
     let mut edge_ids = HashSet::new();
     for edge in &document.links {
+        let mut errors = Vec::new();
         if edge
             .occurrence_rule
             .as_ref()
@@ -290,6 +344,10 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
                 "edge {} source {} does not match a node",
                 edge.id, edge.source
             ));
+            report.edge_errors.push(RecordValidationErrors {
+                id: edge.id.clone(),
+                errors,
+            });
             continue;
         };
         let Some(target) = nodes.get(edge.target.as_str()) else {
@@ -297,6 +355,10 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
                 "edge {} target {} does not match a node",
                 edge.id, edge.target
             ));
+            report.edge_errors.push(RecordValidationErrors {
+                id: edge.id.clone(),
+                errors,
+            });
             continue;
         };
         if edge.source == edge.target && edge.kind != EdgeKind::Calls {
@@ -330,8 +392,24 @@ pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraph
                 site
             ));
         }
+        if !errors.is_empty() {
+            report.edge_errors.push(RecordValidationErrors {
+                id: edge.id.clone(),
+                errors,
+            });
+        }
     }
 
+    report
+}
+
+/// Validate all cross-record invariants of a strict `compass.graph/1` document.
+pub fn validate_code_graph(document: &CodeGraphDocument) -> Result<(), CodeGraphValidationError> {
+    let report = validate_code_graph_records(document);
+    if report.is_valid() {
+        return Ok(());
+    }
+    let errors = report.into_errors();
     if errors.is_empty() {
         Ok(())
     } else {

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -6,7 +6,7 @@ use compass_model::provenance::{
     EvidenceConfidence, EvidenceOrigin, OccurrenceRule, Provenance, ResolutionCandidate,
     SourceAnchor,
 };
-use compass_model::validate_code_graph;
+use compass_model::{validate_code_graph, validate_code_graph_records};
 
 const CLOSED_ENDPOINT_REWRITE_RULES: [&str; 12] = [
     "csharp-namespace-canonicalization",
@@ -119,6 +119,72 @@ fn document() -> GraphDocument {
 #[test]
 fn whole_document_validation_accepts_the_supported_route_shape() {
     assert!(validate_code_graph(&document()).is_ok());
+}
+
+#[test]
+fn structured_validation_classifies_document_node_and_edge_failures() {
+    let mut graph = document();
+    graph.directed = false;
+    graph.nodes[0].source.as_mut().unwrap().end_byte = 101;
+    graph.nodes[1].kind = NodeKind::Route;
+
+    let report = validate_code_graph_records(&graph);
+
+    assert_eq!(report.document_errors, vec!["directed must be true"]);
+    assert_eq!(report.node_errors.len(), 1);
+    assert_eq!(report.node_errors[0].id, "route");
+    assert!(
+        report.node_errors[0]
+            .errors
+            .iter()
+            .any(|error| error.contains("source anchor exceeds"))
+    );
+    assert_eq!(report.edge_errors.len(), 1);
+    assert_eq!(report.edge_errors[0].id, graph.links[0].id);
+    assert!(
+        report.edge_errors[0]
+            .errors
+            .iter()
+            .any(|error| error.contains("invalid routes_to"))
+    );
+}
+
+#[test]
+fn structured_validation_preserves_strict_error_order() {
+    let mut graph = document();
+    graph.multigraph = false;
+    graph.nodes[0].name.clear();
+    graph.nodes[1].kind = NodeKind::Route;
+
+    let report = validate_code_graph_records(&graph);
+    let mut expected = report.document_errors.clone();
+    expected.extend(
+        report
+            .node_errors
+            .iter()
+            .flat_map(|record| record.errors.iter().cloned()),
+    );
+    expected.extend(
+        report
+            .edge_errors
+            .iter()
+            .flat_map(|record| record.errors.iter().cloned()),
+    );
+
+    assert_eq!(
+        validate_code_graph(&graph).unwrap_err().errors,
+        expected,
+        "strict validation must remain an ordered projection of the report"
+    );
+}
+
+#[test]
+fn structured_validation_is_empty_for_a_valid_document() {
+    let report = validate_code_graph_records(&document());
+    assert!(report.is_valid());
+    assert!(report.document_errors.is_empty());
+    assert!(report.node_errors.is_empty());
+    assert!(report.edge_errors.is_empty());
 }
 
 #[test]

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -122,10 +122,15 @@ fn whole_document_validation_accepts_the_supported_route_shape() {
 }
 
 #[test]
-fn structured_validation_classifies_document_node_and_edge_failures() {
+fn structured_validation_classifies_document_node_and_edge_failures() -> Result<(), Box<dyn Error>>
+{
     let mut graph = document();
     graph.directed = false;
-    graph.nodes[0].source.as_mut().unwrap().end_byte = 101;
+    let source = graph.nodes[0]
+        .source
+        .as_mut()
+        .ok_or("fixture node must remain source-backed")?;
+    source.end_byte = 101;
     graph.nodes[1].kind = NodeKind::Route;
 
     let report = validate_code_graph_records(&graph);
@@ -147,10 +152,11 @@ fn structured_validation_classifies_document_node_and_edge_failures() {
             .iter()
             .any(|error| error.contains("invalid routes_to"))
     );
+    Ok(())
 }
 
 #[test]
-fn structured_validation_preserves_strict_error_order() {
+fn structured_validation_preserves_strict_error_order() -> Result<(), Box<dyn Error>> {
     let mut graph = document();
     graph.multigraph = false;
     graph.nodes[0].name.clear();
@@ -171,11 +177,15 @@ fn structured_validation_preserves_strict_error_order() {
             .flat_map(|record| record.errors.iter().cloned()),
     );
 
+    let errors = validate_code_graph(&graph)
+        .err()
+        .ok_or("invalid fixture unexpectedly passed strict validation")?
+        .errors;
     assert_eq!(
-        validate_code_graph(&graph).unwrap_err().errors,
-        expected,
+        errors, expected,
         "strict validation must remain an ordered projection of the report"
     );
+    Ok(())
 }
 
 #[test]
@@ -640,3 +650,4 @@ fn unknown_rewrite_like_names_remain_valid_open_ended_producer_rules() {
     graph.links[0].evidence[0].rule = Some("future-endpoint-remap".to_owned());
     assert!(validate_code_graph(&graph).is_ok());
 }
+use std::error::Error;

--- a/crates/compass-model/tests/contracts_coverage.rs
+++ b/crates/compass-model/tests/contracts_coverage.rs
@@ -146,6 +146,30 @@ fn graph_size_cap_units_and_fallbacks_are_accepted_without_global_side_effects()
 }
 
 #[test]
+fn default_graph_size_cap_accepts_heavy_artifacts_but_remains_bounded() -> Result<(), Box<dyn Error>>
+{
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("graph.json");
+    let file = fs::File::create(&path)?;
+
+    file.set_len(768 * 1024 * 1024)?;
+    assert!(
+        compass_model::code_graph::GraphDocument::size_cap_exceeded(&path).is_none(),
+        "the default cap must accept qualified enterprise artifacts"
+    );
+
+    file.set_len(compass_model::DEFAULT_GRAPH_SIZE_CAP_BYTES + 1)?;
+    assert_eq!(
+        compass_model::code_graph::GraphDocument::size_cap_exceeded(&path),
+        Some((
+            compass_model::DEFAULT_GRAPH_SIZE_CAP_BYTES + 1,
+            compass_model::DEFAULT_GRAPH_SIZE_CAP_BYTES,
+        ))
+    );
+    Ok(())
+}
+
+#[test]
 fn graph_size_cap_child() -> Result<(), Box<dyn Error>> {
     let Some(path) = std::env::var_os("COMPASS_GRAPH_CAP_FIXTURE") else {
         return Ok(());

--- a/crates/compass-output/src/json.rs
+++ b/crates/compass-output/src/json.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use compass_files::write_json_ascii_atomic;
 use compass_graph::Communities;
-use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
+use compass_model::{DEFAULT_GRAPH_SIZE_CAP_BYTES, EdgeRecord, GraphDocument, NodeRecord};
 use rayon::prelude::*;
 use serde::ser::{SerializeMap, SerializeSeq};
 use serde::{Serialize, Serializer};
@@ -15,8 +15,6 @@ use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 use ahash::AHashMap;
 
 use crate::OutputError;
-
-const DEFAULT_GRAPH_SIZE_CAP: u64 = 512 * 1024 * 1024;
 
 #[derive(Clone, Debug, Default)]
 pub struct JsonExportOptions<'a> {
@@ -411,11 +409,11 @@ fn enforce_shrink_guard(path: &Path, new_count: usize, force: bool) -> Result<()
 
 fn graph_size_cap() -> u64 {
     let Ok(raw) = std::env::var("COMPASS_MAX_GRAPH_BYTES") else {
-        return DEFAULT_GRAPH_SIZE_CAP;
+        return DEFAULT_GRAPH_SIZE_CAP_BYTES;
     };
     let text = raw.trim().to_uppercase();
     if text.is_empty() {
-        return DEFAULT_GRAPH_SIZE_CAP;
+        return DEFAULT_GRAPH_SIZE_CAP_BYTES;
     }
     let (number, multiplier) = if let Some(number) = text.strip_suffix("GB") {
         (number, 1024_u64 * 1024 * 1024)
@@ -430,7 +428,7 @@ fn graph_size_cap() -> u64 {
         .ok()
         .and_then(|value| value.checked_mul(multiplier))
         .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_GRAPH_SIZE_CAP)
+        .unwrap_or(DEFAULT_GRAPH_SIZE_CAP_BYTES)
 }
 
 pub(crate) fn escape_non_ascii(value: &str) -> String {

--- a/crates/compass-query/src/code_query.rs
+++ b/crates/compass-query/src/code_query.rs
@@ -81,6 +81,7 @@ pub struct CodeQueryEngine {
     pub(crate) index_path: PathBuf,
     pub(crate) adjacency: CodeAdjacencyIndex,
     pub(crate) lookup: CodeLookupIndex,
+    pub(crate) partial_graph_message: Option<String>,
 }
 
 pub(crate) struct CodeLookupIndex {
@@ -310,7 +311,7 @@ impl CodeQueryEngine {
                 node_id: None,
                 path: None,
             });
-            return Ok(response);
+            return self.finish_response(&mut response);
         }
         let mut statement = self
             .connection
@@ -400,13 +401,7 @@ impl CodeQueryEngine {
                 path: None,
             });
         }
-        if self.program.is_some() {
-            join_program_evidence(&mut response, self.program.as_ref());
-        } else {
-            response.sort_stable();
-        }
-        enforce_response_size(&mut response)?;
-        Ok(response)
+        self.finish_response(&mut response)
     }
 
     pub fn callers(&self, request: CallRequest) -> Result<CodeQueryResponse, QueryError> {
@@ -430,7 +425,7 @@ impl CodeQueryEngine {
         };
         let mut response = CodeQueryResponse::empty(operation, request.limits.clone());
         let Some(seed) = self.resolve_symbol(&request.symbol, &mut response) else {
-            return Ok(response);
+            return self.finish_response(&mut response);
         };
         let kinds: &[EdgeKind] = if inbound {
             &[EdgeKind::Calls, EdgeKind::RoutesTo]
@@ -461,7 +456,7 @@ impl CodeQueryEngine {
         let mut response =
             CodeQueryResponse::empty(CodeQueryOperation::Impact, request.limits.clone());
         let Some(seed) = self.resolve_symbol(&request.symbol, &mut response) else {
-            return Ok(response);
+            return self.finish_response(&mut response);
         };
         let max_depth = usize::try_from(request.limits.max_depth).unwrap_or(usize::MAX);
         let max_nodes = usize::try_from(request.limits.max_nodes).unwrap_or(usize::MAX);
@@ -580,10 +575,10 @@ impl CodeQueryEngine {
         let mut response =
             CodeQueryResponse::empty(CodeQueryOperation::NodeTrail, request.limits.clone());
         let Some(source) = self.resolve_symbol(&request.source, &mut response) else {
-            return Ok(response);
+            return self.finish_response(&mut response);
         };
         let Some(target) = self.resolve_symbol(&request.target, &mut response) else {
-            return Ok(response);
+            return self.finish_response(&mut response);
         };
         let mut budget = TraversalBudget::new(&request.limits);
         let (path, truncated) = self.shortest_path(
@@ -604,7 +599,7 @@ impl CodeQueryEngine {
                 node_id: Some(source),
                 path: None,
             });
-            return Ok(response);
+            return self.finish_response(&mut response);
         };
         let ids = nodes.iter().cloned().collect::<HashSet<_>>();
         self.add_nodes(&ids, &mut response);
@@ -842,6 +837,14 @@ impl CodeQueryEngine {
             response.diagnostics.push(QueryDiagnostic {
                 code: QueryDiagnosticCode::BoundedTruncation,
                 message: "One or more query bounds truncated the response".to_owned(),
+                node_id: None,
+                path: None,
+            });
+        }
+        if let Some(message) = &self.partial_graph_message {
+            response.diagnostics.push(QueryDiagnostic {
+                code: QueryDiagnosticCode::IncompleteCoverage,
+                message: message.clone(),
                 node_id: None,
                 path: None,
             });

--- a/crates/compass-query/src/index.rs
+++ b/crates/compass-query/src/index.rs
@@ -68,6 +68,17 @@ pub fn open(
         .map_err(sql_error)?;
     let adjacency = crate::code_query::CodeAdjacencyIndex::build(&graph);
     let lookup = crate::code_query::CodeLookupIndex::build(&graph);
+    let partial_graph_message = graph
+        .graph
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "publication_omission_summary")
+        .map(|diagnostic| {
+            format!(
+                "Published graph coverage is incomplete: {}",
+                diagnostic.message
+            )
+        });
     Ok(CodeQueryEngine {
         graph,
         program,
@@ -76,6 +87,7 @@ pub fn open(
         index_path,
         adjacency,
         lookup,
+        partial_graph_message,
     })
 }
 

--- a/crates/compass-query/tests/code_search.rs
+++ b/crates/compass-query/tests/code_search.rs
@@ -1,6 +1,10 @@
 mod support;
 
 use compass_model::query_contract::{CodeQueryLimits, SearchRequest};
+use compass_model::{
+    code_graph::{DiagnosticSeverity, GraphDiagnostic, GraphDocument},
+    query_contract::QueryDiagnosticCode,
+};
 use compass_query::open;
 
 #[test]
@@ -78,5 +82,34 @@ fn search_limits_are_enforced_before_sqlite_work() -> Result<(), Box<dyn std::er
             })
             .is_err()
     );
+    Ok(())
+}
+
+#[test]
+fn search_discloses_partial_publication_coverage() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    let mut graph = GraphDocument::load(&graph_path)?;
+    graph.graph.diagnostics.push(GraphDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: "publication_omission_summary".to_owned(),
+        message:
+            "partial graph published after quarantining 2 nodes and 3 edges with 1 identity collisions; 0 examples omitted by the diagnostic cap"
+                .to_owned(),
+        anchor: None,
+        related_ids: Vec::new(),
+    });
+    std::fs::write(&graph_path, serde_json::to_vec(&graph)?)?;
+
+    let engine = open(&graph_path, None, &directory.path().join("cache"))?;
+    let response = engine.search(SearchRequest {
+        query: "list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    })?;
+    assert!(response.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == QueryDiagnosticCode::IncompleteCoverage
+            && diagnostic.message.contains("2 nodes and 3 edges")
+    }));
     Ok(())
 }

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -732,6 +732,7 @@ fn rewire_unique_stub_nodes(extraction: &mut Extraction) {
     let mut stub_families = HashMap::<String, HashSet<&'static str>>::new();
     let mut stub_scopes = HashMap::<String, HashSet<String>>::new();
     let mut stub_consumers = HashMap::<String, HashSet<String>>::new();
+    let mut stub_source_files = HashMap::<String, HashSet<String>>::new();
     let mut imports = HashMap::<String, HashSet<String>>::new();
     let mut imports_by_file = HashMap::<String, HashSet<String>>::new();
     for edge in &extraction.edges {
@@ -758,6 +759,10 @@ fn rewire_unique_stub_nodes(extraction: &mut Extraction) {
                     .entry(endpoint.clone())
                     .or_default()
                     .insert(repository_scope(&edge.string("source_file")));
+                stub_source_files
+                    .entry(endpoint.clone())
+                    .or_default()
+                    .insert(edge.string("source_file"));
                 let counterpart = if endpoint == &edge.source {
                     &edge.target
                 } else {
@@ -775,6 +780,7 @@ fn rewire_unique_stub_nodes(extraction: &mut Extraction) {
         let families = stub_families.get(&stub);
         let scopes = stub_scopes.get(&stub);
         let consumers = stub_consumers.get(&stub);
+        let source_files = stub_source_files.get(&stub);
         let compatible_unique = |items: Option<&Vec<String>>| {
             let compatible = items?
                 .iter()
@@ -796,12 +802,11 @@ fn rewire_unique_stub_nodes(extraction: &mut Extraction) {
                                 .get(consumer)
                                 .is_some_and(|targets| targets.contains(*candidate))
                         })
-                    }) || scopes.is_some_and(|_| {
-                        extraction.edges.iter().any(|edge| {
-                            (edge.source == stub || edge.target == stub)
-                                && imports_by_file
-                                    .get(&edge.string("source_file"))
-                                    .is_some_and(|targets| targets.contains(*candidate))
+                    }) || source_files.is_some_and(|files| {
+                        files.iter().any(|source_file| {
+                            imports_by_file
+                                .get(source_file)
+                                .is_some_and(|targets| targets.contains(*candidate))
                         })
                     });
                     family_compatible && (scope_compatible || explicitly_imported)
@@ -3619,6 +3624,54 @@ mod tests {
             edges: vec![
                 edge(
                     "package-a-child",
+                    "package-b-base",
+                    "imports",
+                    "packages/a/src/Child.java",
+                ),
+                edge(
+                    "package-a-child",
+                    "base",
+                    "extends",
+                    "packages/a/src/Child.java",
+                ),
+            ],
+            ..Extraction::default()
+        };
+
+        rewire_unique_family_stubs(&mut extraction);
+        rewire_unique_stub_nodes(&mut extraction);
+
+        assert_eq!(extraction.edges[1].target, "package-b-base");
+        assert!(extraction.nodes.iter().all(|node| node.id != "base"));
+    }
+
+    #[test]
+    fn file_scoped_import_evidence_allows_cross_scope_stub_rewiring() {
+        let mut extraction = Extraction {
+            nodes: vec![
+                node(
+                    "package-b-base",
+                    "Base",
+                    "packages/b/src/Base.java",
+                    "class",
+                ),
+                node("base", "Base", "", "stub"),
+                node(
+                    "package-a-child",
+                    "Child",
+                    "packages/a/src/Child.java",
+                    "class",
+                ),
+                node(
+                    "package-a-import",
+                    "BaseImport",
+                    "packages/a/src/Child.java",
+                    "import",
+                ),
+            ],
+            edges: vec![
+                edge(
+                    "package-a-import",
                     "package-b-base",
                     "imports",
                     "packages/a/src/Child.java",

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -195,6 +195,29 @@ Graph loading is guarded by:
 This protects query commands from treating arbitrary, oversized, or stale
 cache content as a valid graph.
 
+## Partial publication and quarantine
+
+Compass publishes only records that satisfy the closed graph vocabulary and
+endpoint rules. If one extracted node or edge is invalid, the normal build
+quarantines that record instead of weakening validation for the artifact:
+
+- an invalid node is omitted with all incident edges;
+- an invalid edge is omitted without inventing a generic relationship;
+- a conflicting stable identity keeps one deterministic survivor;
+- a route whose handler edge is omitted becomes unresolved;
+- the remaining `compass.graph/1` document passes the full strict validator.
+
+The graph records bounded examples in `graph.diagnostics` and an exact
+`publication_omission_summary`. Build output reports retained counts and warns
+when the artifact is partial. Search, callers, callees, impact, explore, and
+node-trail responses surface the same condition as `incomplete_coverage`.
+Missing topology in such a response may reflect quarantine, so it is not proof
+that no relationship exists in source.
+
+Invalid document metadata, unsafe file inventory, an empty usable graph, and
+publication I/O failures remain hard failures. Atomic publication preserves the
+last known good generation when one of those failures occurs.
+
 ## Provenance and confidence
 
 Relationships can carry:

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -232,15 +232,18 @@ include:
 
 | Artifact | Responsibility |
 | --- | --- |
-| `graph.json` | Complete machine-readable node-link graph |
+| `graph.json` | Strictly valid machine-readable node-link graph |
 | `GRAPH_REPORT.md` | Human-readable orientation and diagnostics |
 | `graph.html` | Optional interactive visualization |
 | `manifest.json` | Incremental build state |
 
-The build pipeline treats output as a set. A failed semantic provider,
-validation error, or incomplete build must not publish a graph as if it were a
-complete successful result. Write paths use temporary or staged artifacts and
-atomic replacement where the contract requires it.
+The build pipeline treats output as a set. Invalid individual node and edge
+records are deterministically quarantined and reported before the remaining
+graph passes strict validation. A partial graph is published with an explicit
+warning and exact omission summary. Document-level validation errors or an
+empty usable graph remain failures and cannot replace the active generation.
+Write paths use temporary or staged artifacts and atomic replacement where the
+contract requires it.
 
 Consumers should still avoid reading files while a writer is replacing an
 artifact set. A long-lived integration can either watch for completion, invoke

--- a/docs/cookbook/troubleshooting.md
+++ b/docs/cookbook/troubleshooting.md
@@ -55,6 +55,7 @@ Record:
 | provider requested unexpectedly | semantic sources present | inspect command and file classes | configure intentionally or use code-only |
 | graph changed on no-op | config/version/input changed | compare manifest/version/options | clean qualification and investigate fingerprint |
 | `graph.html` missing | disabled or graph too large | inspect command/report | query JSON; HTML is optional |
+| partial graph warning | invalid records were quarantined | inspect `publication_omission_summary` and bounded examples in `graph.json` | fix the named producer/source shape; do not weaken the validator |
 
 ## Query
 
@@ -64,6 +65,7 @@ Record:
 | graph must be JSON | wrong input/export | inspect suffix/content | use canonical graph JSON |
 | node not found | label mismatch/duplicates | broad query by file/domain | use stable ID or more context |
 | path not found | wrong endpoint/direction/missing edge | explain both endpoints | verify graph coverage and relation |
+| `incomplete_coverage` | the published graph omitted invalid records | inspect the publication summary and relevant source | treat absence as uncertain until the producer issue is fixed |
 | too many results | generic phrase/hub | inspect anchors | add behavior/domain terms or CompassQL |
 | limit/timeout | query expansion too broad | run `EXPLAIN`, reduce path/labels | narrow query; approved budget only |
 | JSON consumer breaks | schema mismatch or parsed human text | inspect version tag | consume documented JSON/JSONL and reject unknown major |

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -85,6 +85,19 @@ compass update .
 
 That separates watcher/event problems from extraction problems.
 
+### Operate partial graph warnings
+
+A warning that a partial graph was published is a successful, atomic build,
+not a retryable watcher failure. Compass has omitted invalid individual records
+while keeping the remaining artifact strictly valid.
+
+Record the exact omitted counts, inspect `publication_omission_summary` and its
+bounded examples in `graph.json`, and prioritize repeated producer or
+framework-specific reasons. Queries add `incomplete_coverage`; downstream
+automation must not interpret a missing path as proof of absence while that
+diagnostic is present. Escalate a sudden increase in omissions even when the
+command exits successfully.
+
 ## MCP service
 
 Start by inspecting:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -94,6 +94,14 @@ compass extract [PATH]
 
 Use `--code-only` for an explicit fully local structural profile.
 
+`update`, `extract`, and watch rebuilds may succeed with a warning that Compass
+published a partial graph. The warning reports exact omitted node, omitted
+edge, and identity-collision counts. The retained `graph.json` remains strictly
+valid and queryable; record examples and the exact summary are in
+`graph.diagnostics`. Document-level corruption, an unsafe inventory, no usable
+nodes, serialization failure, and atomic publication failure still return a
+nonzero exit.
+
 ### `watch`
 
 ```text

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -104,6 +104,25 @@ promotion.
 - use canonical/semantic equivalence for graph comparisons;
 - validate file size and JSON at your trust boundary.
 
+### Partial publication diagnostics
+
+A successful build can publish a strictly valid partial graph after
+quarantining invalid individual records. The durable warning codes are:
+
+- `publication_omitted_node`
+- `publication_omitted_edge`
+- `publication_identity_collision`
+- `publication_omission_summary`
+
+The first three provide bounded examples. The summary contains exact omitted
+node, omitted edge, identity-collision, and capped-example counts. At most 100
+examples of each record category are stored.
+
+The private `.compass_output_stats.json` and sealed build state retain the same
+counts so no-op and watch results preserve the partial status. They are
+operational state, not an alternative graph schema. Consumers should use graph
+diagnostics or typed query `incomplete_coverage` diagnostics.
+
 ## `GRAPH_REPORT.md`
 
 The report can include:

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -104,6 +104,12 @@ promotion.
 - use canonical/semantic equivalence for graph comparisons;
 - validate file size and JSON at your trust boundary.
 
+Compass readers use a bounded 1 GiB default graph-size cap. This accommodates
+qualified enterprise artifacts while preventing unbounded input reads.
+Operators can set `COMPASS_MAX_GRAPH_BYTES` to an explicit byte count or
+`<N>MB`/`<N>GB`; raising it also raises the memory exposure of JSON decoding
+and indexing.
+
 ### Partial publication diagnostics
 
 A successful build can publish a strictly valid partial graph after

--- a/docs/superpowers/plans/2026-07-30-best-effort-code-graph-publication.md
+++ b/docs/superpowers/plans/2026-07-30-best-effort-code-graph-publication.md
@@ -1,0 +1,673 @@
+# Best-effort code graph publication implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task by task. Execute inline in the existing isolated worktree. Do not delegate tasks unless the user explicitly authorizes subagents.
+
+**Goal:** Publish a strictly queryable `compass.graph/1` artifact after deterministically quarantining invalid individual nodes and edges.
+
+**Architecture:** Keep the current strict normalizer and full validator as qualification APIs. Add an explicit best-effort normalizer that catches record-level failures, tracks exact bounded omission diagnostics, sanitizes typed records, and runs the unchanged strict validator before publication. Normal builds use the best-effort path, while queries disclose partial coverage through the existing `incomplete_coverage` diagnostic.
+
+**Tech stack:** Rust 2024, Serde, `compass-model`, `compass-graph`, `compass-core`, `compass-query`, `compass-cli`, Cargo workspace tests, official heavyweight framework repositories
+
+## Global constraints
+
+- Use implementation-first sequencing. Add focused tests after each implementation slice; do not use a red-green TDD sequence.
+- Preserve `normalize_v1` and `normalize_document_v1_with_inventory` as strict APIs.
+- Every published graph must pass the existing full `validate_code_graph` function.
+- Record-level failures may remove records but may not invent node kinds, edge kinds, endpoint identities, provenance, source anchors, or wiring sites.
+- Document-level failures remain fatal: invalid envelope, invalid file inventory, unsafe paths, unreadable authoritative input, empty usable graph, serialization failure, and atomic publication failure.
+- Best-effort output and diagnostics must be byte-deterministic under reordered raw input.
+- Keep at most 100 node examples, 100 edge examples, and 100 identity-collision examples while preserving exact total counts.
+- Preserve last-known-good generation behavior.
+- Do not add a second durable graph artifact or schema.
+- Do not mention retired products in code, documentation, commits, or pull-request text.
+
+## File map
+
+- `crates/compass-model/src/validation.rs`: Structured document, node, and edge validation report plus the unchanged strict aggregate validator
+- `crates/compass-model/src/lib.rs`: Public validation report exports
+- `crates/compass-model/tests/code_graph_validation.rs`: Structured validation and strict compatibility tests
+- `crates/compass-graph/src/quarantine.rs`: Omission counters, bounded diagnostic collection, and publication outcome types
+- `crates/compass-graph/src/v1.rs`: Strict and best-effort normalization modes, deterministic raw-record ordering, record quarantine, route repair, and final validation
+- `crates/compass-graph/src/lib.rs`: Best-effort publication API exports
+- `crates/compass-graph/tests/graph_v1_normalization.rs`: Best-effort normalization, determinism, collision, endpoint, and route tests
+- `crates/compass-core/src/pipeline.rs`: Default best-effort publication, build statistics, output statistics, and atomic pipeline integration
+- `crates/compass-core/src/build_state.rs`: Backward-compatible persisted omission statistics
+- `crates/compass-core/tests/loading_coverage.rs`: Pipeline partial-publication and last-known-good coverage
+- `crates/compass-query/src/code_query.rs`: Partial graph detection and query diagnostic injection
+- `crates/compass-query/tests/code_search.rs`: Search disclosure coverage
+- `crates/compass-query/tests/code_calls.rs`: Callers and callees disclosure coverage
+- `crates/compass-cli/src/lib.rs`: Human-readable partial-publication warning
+- `docs/concepts/graph-model.md`: Partial graph and quarantine semantics
+- `docs/reference/outputs.md`: Durable diagnostic contract
+- `docs/reference/commands.md`: Build success warning
+- `docs/guides/operations.md`: Operational interpretation
+- `docs/cookbook/troubleshooting.md`: Partial graph remediation
+- `docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md`: Design amendment
+
+## Task 1: Add structured graph validation
+
+**Files:**
+
+- Modify: `crates/compass-model/src/validation.rs`
+- Modify: `crates/compass-model/src/lib.rs`
+- Modify: `crates/compass-model/tests/code_graph_validation.rs`
+
+**Interfaces:**
+
+- Produces: `CodeGraphValidationReport`
+- Produces: `RecordValidationErrors`
+- Produces: `validate_code_graph_records(&CodeGraphDocument) -> CodeGraphValidationReport`
+- Preserves: `validate_code_graph(&CodeGraphDocument) -> Result<(), CodeGraphValidationError>`
+
+- [ ] **Step 1: Implement typed validation reporting**
+
+Add ordered public report types:
+
+```rust
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RecordValidationErrors {
+    pub id: String,
+    pub errors: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CodeGraphValidationReport {
+    pub document_errors: Vec<String>,
+    pub node_errors: Vec<RecordValidationErrors>,
+    pub edge_errors: Vec<RecordValidationErrors>,
+}
+
+impl CodeGraphValidationReport {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.document_errors.is_empty()
+            && self.node_errors.is_empty()
+            && self.edge_errors.is_empty()
+    }
+}
+```
+
+Refactor the current validation loop so document and file-inventory failures enter `document_errors`, node failures enter the matching node record, and edge failures enter the matching edge record. Keep traversal order stable.
+
+- [ ] **Step 2: Preserve strict error text and ordering**
+
+Implement `validate_code_graph` by flattening the structured report in the current order. Keep `CodeGraphValidationError.errors` and its display format unchanged so existing strict tests and callers retain compatible behavior.
+
+- [ ] **Step 3: Export the report API**
+
+Export the new types and `validate_code_graph_records` from `crates/compass-model/src/lib.rs`.
+
+- [ ] **Step 4: Format and compile the model crate**
+
+Run:
+
+```bash
+cargo fmt --all
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo check -p compass-model --locked
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Add focused tests**
+
+Add tests proving:
+
+- invalid metadata appears only in `document_errors`
+- an invalid source anchor appears under its node ID
+- an invalid endpoint-kind pair appears under its edge ID
+- the strict aggregate error list remains identical to the expected ordering
+- a valid document produces an empty report
+
+- [ ] **Step 6: Run model validation tests**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-model --test code_graph_validation --locked
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/compass-model/src/validation.rs crates/compass-model/src/lib.rs crates/compass-model/tests/code_graph_validation.rs
+git commit -m "feat(graph): expose structured validation results"
+```
+
+## Task 2: Implement bounded quarantine accounting
+
+**Files:**
+
+- Create: `crates/compass-graph/src/quarantine.rs`
+- Modify: `crates/compass-graph/src/lib.rs`
+- Modify: `crates/compass-graph/src/v1.rs`
+- Modify: `crates/compass-graph/tests/graph_v1_normalization.rs`
+
+**Interfaces:**
+
+- Consumes: `CodeGraphValidationReport`
+- Produces: `PublicationOutcome`
+- Produces: `PublicationOmissions`
+- Produces: `normalize_v1_best_effort(Extraction, BuildEvidence) -> Result<PublicationOutcome, GraphError>`
+
+- [ ] **Step 1: Add publication outcome types**
+
+Create `quarantine.rs` with:
+
+```rust
+pub const MAX_QUARANTINE_EXAMPLES: usize = 100;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PublicationOmissions {
+    pub nodes: usize,
+    pub edges: usize,
+    pub identity_collisions: usize,
+    pub examples_omitted: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct PublicationOutcome {
+    pub document: GraphDocument,
+    pub omissions: PublicationOmissions,
+}
+
+impl PublicationOmissions {
+    #[must_use]
+    pub const fn is_partial(self) -> bool {
+        self.nodes > 0 || self.edges > 0 || self.identity_collisions > 0
+    }
+}
+```
+
+Add a crate-private collector that records exact counters and at most 100 diagnostics per record category. Use warning codes `publication_omitted_node`, `publication_omitted_edge`, and `publication_identity_collision`. Add one `publication_omission_summary` diagnostic when any counter is nonzero.
+
+- [ ] **Step 2: Add explicit strict and best-effort modes**
+
+Refactor `normalize_v1` through:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PublicationMode {
+    Strict,
+    BestEffort,
+}
+
+fn normalize_v1_with_mode(
+    extraction: Extraction,
+    evidence: BuildEvidence,
+    mode: PublicationMode,
+) -> Result<PublicationOutcome, GraphError>
+```
+
+`normalize_v1` calls strict mode and returns `outcome.document`. `normalize_v1_best_effort` returns the complete outcome.
+
+- [ ] **Step 3: Deterministically normalize or quarantine raw nodes**
+
+In best-effort mode, sort raw nodes with a canonical key derived from raw ID, declared kind, qualified name, portable source data, and serialized attributes.
+
+For each node:
+
+- quarantine normalization failures
+- quarantine duplicate raw IDs after the deterministic first record
+- merge compatible stable identities
+- select a deterministic survivor for incompatible stable-identity collisions
+- leave quarantined raw IDs absent from `id_remap`
+
+Use the design ranking: exact AST evidence, exact source-backed evidence, inferred source-backed evidence, exact wiring-site evidence, then canonical serialized order.
+
+- [ ] **Step 4: Deterministically normalize or quarantine raw edges**
+
+In best-effort mode, sort raw edges by raw source, relation, raw target, source site, occurrence rule, and serialized attributes.
+
+For each edge:
+
+- quarantine it if either endpoint lacks an `id_remap` entry
+- quarantine `normalize_edge` or `normalize_trusted_edge` failures
+- merge compatible duplicates
+- quarantine conflicting duplicate edge identities
+
+Do not alias an unknown relation to `references`.
+
+- [ ] **Step 5: Handle unwired generic external placeholders**
+
+Change `resolve_or_drop_generic_symbols` to accept publication mode and a quarantine collector. Strict mode keeps the current error. Best-effort mode omits an unwired placeholder and its incident edges with `publication_omitted_node`.
+
+- [ ] **Step 6: Format and compile the graph crate**
+
+Run:
+
+```bash
+cargo fmt --all
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo check -p compass-graph --locked
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Add raw-record quarantine tests**
+
+Add tests for:
+
+- unknown relation omits one edge and retains both nodes
+- missing wiring site omits the placeholder and its incident edge
+- invalid raw node kind omits its node and incident edge
+- duplicate raw ID retains one deterministic record
+- Razor-style method collision retains one method
+- Rust-style repeated module collision retains one module
+- reversing node and edge input produces identical serialized output
+- strict `normalize_v1` still returns the original errors
+
+- [ ] **Step 8: Run graph normalization tests**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-graph --test graph_v1_normalization --locked
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/compass-graph/src/quarantine.rs crates/compass-graph/src/lib.rs crates/compass-graph/src/v1.rs crates/compass-graph/tests/graph_v1_normalization.rs
+git commit -m "feat(graph): quarantine invalid raw records"
+```
+
+## Task 3: Sanitize typed records and repair framework topology
+
+**Files:**
+
+- Modify: `crates/compass-graph/src/v1.rs`
+- Modify: `crates/compass-graph/tests/graph_v1_normalization.rs`
+
+**Interfaces:**
+
+- Consumes: `validate_code_graph_records`
+- Produces: `sanitize_document(&mut GraphDocument, &mut QuarantineCollector) -> Result<(), GraphError>`
+- Preserves: final `validate_code_graph(&document)` gate
+
+- [ ] **Step 1: Implement typed sanitization**
+
+After constructing the typed document:
+
+1. Call `validate_code_graph_records`.
+2. Return `InvalidCodeGraph` when `document_errors` is nonempty.
+3. Quarantine every node in `node_errors`.
+4. Remove every edge incident to a quarantined node.
+5. Quarantine every remaining edge in `edge_errors`.
+6. Append bounded diagnostics and the exact summary.
+7. Run the existing strict validator.
+
+Use ID sets for linear filtering. Do not repeatedly clone the complete graph.
+
+- [ ] **Step 2: Repair route stages after edge removal**
+
+Build the set of retained `routes_to` stage tuples `(route_id, stage, position, target_id)`. For every route:
+
+- clear a stage target when no retained tuple matches it
+- remove candidates that reference quarantined nodes
+- set the stage to `unresolved` when no target remains
+- call the current `recompute_route_resolution`
+
+The route node and its framework evidence remain when only its handler edge fails.
+
+- [ ] **Step 3: Repair provenance candidates and diagnostics**
+
+Remove candidate IDs that do not correspond to retained nodes from node evidence, edge evidence, and route stages. Remove related IDs that reference quarantined records from new quarantine diagnostics.
+
+- [ ] **Step 4: Add typed sanitization tests**
+
+Add tests proving:
+
+- `calls` from method to module is omitted
+- invalid `contains` from class to module is omitted
+- all incident edges disappear when a node fails typed validation
+- a route becomes unresolved when its `routes_to` edge is omitted
+- every best-effort result passes `validate_code_graph`
+- diagnostic caps retain exact summary counts
+
+- [ ] **Step 5: Run graph tests and Clippy**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-graph --locked
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo clippy -p compass-graph --all-targets --locked -- -D warnings
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/compass-graph/src/v1.rs crates/compass-graph/tests/graph_v1_normalization.rs
+git commit -m "feat(graph): sanitize partial graph topology"
+```
+
+## Task 4: Use best-effort publication in the build pipeline
+
+**Files:**
+
+- Modify: `crates/compass-graph/src/v1.rs`
+- Modify: `crates/compass-graph/src/lib.rs`
+- Modify: `crates/compass-core/src/pipeline.rs`
+- Modify: `crates/compass-core/src/build_state.rs`
+- Modify: `crates/compass-core/tests/loading_coverage.rs`
+- Modify: `crates/compass-cli/src/lib.rs`
+
+**Interfaces:**
+
+- Produces: `normalize_document_v1_with_inventory_best_effort(...) -> Result<PublicationOutcome, GraphError>`
+- Extends: `BuildResult` with `omitted_nodes`, `omitted_edges`, `identity_collisions`, and `partial_graph`
+- Extends persisted stats with backward-compatible `#[serde(default)]` fields
+
+- [ ] **Step 1: Add the document-level best-effort adapter**
+
+Add `normalize_document_v1_with_inventory_best_effort` beside the strict adapter. It constructs `Extraction` and `BuildEvidence` through the same code path, then calls `normalize_v1_best_effort`.
+
+- [ ] **Step 2: Switch normal pipeline publication**
+
+Use the best-effort adapter in no-cluster preflight, clustered preflight, and final publication. Write `outcome.document` only after successful final strict validation.
+
+Keep semantic raw guards, generation staging, artifact sealing, and pointer swap unchanged.
+
+- [ ] **Step 3: Extend build and persisted statistics**
+
+Add these fields with zero defaults:
+
+```rust
+pub omitted_nodes: usize,
+pub omitted_edges: usize,
+pub identity_collisions: usize,
+pub partial_graph: bool,
+```
+
+Persist them in `OutputStats` and `SavedStats`. Populate unchanged-build results from the saved statistics so cached builds report the same partial status.
+
+- [ ] **Step 4: Report partial success in the CLI**
+
+When `result.partial_graph` is true, append to stderr:
+
+```text
+Compass published a partial graph: N nodes and M edges omitted; C identity collisions quarantined.
+```
+
+Do not mention `compass diagnose publication` until that command exists.
+
+- [ ] **Step 5: Add pipeline and CLI tests**
+
+Add coverage for:
+
+- extract succeeds with one invalid relation
+- update succeeds with invalid endpoint-kind edges
+- output `graph.json` passes strict load validation
+- omission stats persist through an unchanged build
+- a document-level failure preserves the active generation
+- CLI stdout reports indexing success and stderr reports partial publication
+- complete builds leave stderr unchanged
+
+- [ ] **Step 6: Run affected tests**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-core --test loading_coverage --locked
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-cli --lib --locked
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/compass-graph/src/v1.rs crates/compass-graph/src/lib.rs crates/compass-core/src/pipeline.rs crates/compass-core/src/build_state.rs crates/compass-core/tests/loading_coverage.rs crates/compass-cli/src/lib.rs
+git commit -m "feat(core): publish usable partial graphs"
+```
+
+## Task 5: Disclose partial coverage in typed queries
+
+**Files:**
+
+- Modify: `crates/compass-query/src/code_query.rs`
+- Modify: `crates/compass-query/tests/code_search.rs`
+- Modify: `crates/compass-query/tests/code_calls.rs`
+
+**Interfaces:**
+
+- Consumes: `publication_omission_summary` graph diagnostic
+- Produces: one `QueryDiagnosticCode::IncompleteCoverage` per typed response
+
+- [ ] **Step 1: Parse the omission summary once**
+
+When `CodeQueryEngine` opens the graph, derive an optional concise message from `graph.graph.diagnostics`. Store it on the engine:
+
+```rust
+partial_graph_message: Option<String>,
+```
+
+Use the summary diagnostic rather than scanning every omission example per query.
+
+- [ ] **Step 2: Inject query disclosure**
+
+At the beginning of `finish_response`, append one diagnostic when `partial_graph_message` is present:
+
+```rust
+QueryDiagnostic {
+    code: QueryDiagnosticCode::IncompleteCoverage,
+    message: message.clone(),
+    node_id: None,
+    path: None,
+}
+```
+
+Also call the same helper on early successful returns caused by no match or ambiguity so every typed operation discloses partial coverage.
+
+- [ ] **Step 3: Add search and call tests**
+
+Test complete and partial graphs across search, callers, callees, impact, explore, and node trail. Assert one disclosure diagnostic, stable response ordering, and unchanged query nodes and edges.
+
+- [ ] **Step 4: Run query tests and Clippy**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test -p compass-query --locked
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo clippy -p compass-query --all-targets --locked -- -D warnings
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/compass-query/src/code_query.rs crates/compass-query/tests/code_search.rs crates/compass-query/tests/code_calls.rs
+git commit -m "feat(query): disclose partial graph coverage"
+```
+
+## Task 6: Update the product documentation
+
+**Files:**
+
+- Modify: `docs/concepts/graph-model.md`
+- Modify: `docs/reference/outputs.md`
+- Modify: `docs/reference/commands.md`
+- Modify: `docs/guides/operations.md`
+- Modify: `docs/cookbook/troubleshooting.md`
+- Modify: `docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md`
+
+**Interfaces:**
+
+- Documents: default best-effort publication
+- Documents: strict durable graph validation
+- Documents: omission diagnostics and query disclosure
+
+- [ ] **Step 1: Amend the original v1 design**
+
+Add a dated amendment under validation and failure handling. State that record-level failures are quarantined before final validation, while document-level failures remain fatal.
+
+- [ ] **Step 2: Update graph and output references**
+
+Define partial graph, quarantine, diagnostic codes, exact summary counts, and the 100-example cap. Explain that unknown relations never enter `links`.
+
+- [ ] **Step 3: Update command and operations guidance**
+
+Document the CLI partial-success warning and tell operators to inspect graph diagnostics before interpreting absent topology.
+
+- [ ] **Step 4: Update troubleshooting guidance**
+
+Add remedies for high omission counts, repeated identity collisions, unknown producer relations, and unresolved framework handlers.
+
+- [ ] **Step 5: Check documentation**
+
+Run:
+
+```bash
+rg -n 'T[B]D|TO[D]O|FIX[M]E|compass diagnose publication' docs/concepts/graph-model.md docs/reference/outputs.md docs/reference/commands.md docs/guides/operations.md docs/cookbook/troubleshooting.md docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md
+git diff --check
+```
+
+Expected: no placeholders, no nonexistent diagnostic command, and no whitespace errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/concepts/graph-model.md docs/reference/outputs.md docs/reference/commands.md docs/guides/operations.md docs/cookbook/troubleshooting.md docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md
+git commit -m "docs(graph): explain best-effort publication"
+```
+
+## Task 7: Run workspace qualification
+
+**Files:**
+
+- Modify only files required to fix failures directly caused by Tasks 1 through 6
+
+**Interfaces:**
+
+- Verifies: strict API compatibility
+- Verifies: best-effort publication behavior
+- Verifies: query disclosure
+
+- [ ] **Step 1: Run formatting and the full workspace test suite**
+
+Run:
+
+```bash
+cargo fmt --all --check
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo test --workspace --lib --bins --tests --locked
+```
+
+Expected: formatting passes and all non-ignored tests pass.
+
+- [ ] **Step 2: Run affected workspace Clippy**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo clippy -p compass-model -p compass-graph -p compass-core -p compass-query -p compass-cli --all-targets --locked -- -D warnings
+```
+
+Expected: exit 0 with no warnings.
+
+- [ ] **Step 3: Run semantic qualification**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target bash scripts/qualify_code_graph_v1.sh --fixtures-only
+```
+
+Expected: the production binary builds and every fixture, invariant, framework flow, and deterministic comparison passes. Record the complete qualification summary in the handoff.
+
+- [ ] **Step 4: Verify deterministic fixtures**
+
+Run clean, warm-cache, forced, and reordered fixture builds. Hash each `graph.json` and assert byte identity when source and configuration are equal.
+
+- [ ] **Step 5: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, only intended files, and scoped commits.
+
+## Task 8: Requalify heavyweight frameworks
+
+**Files:**
+
+- No repository source modifications
+- Write benchmark logs under `/Volumes/Workspace/compass-heavy-framework-best-effort-20260730/`
+
+**Interfaces:**
+
+- Verifies: real framework publication
+- Verifies: query usability
+- Verifies: strict validity after quarantine
+
+- [ ] **Step 1: Build the exact release binary**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/compass-v1-remediation-target cargo build --release --locked -p compass-cli --bin compass
+shasum -a 256 /Volumes/Workspace/compass-v1-remediation-target/release/compass
+```
+
+Record the commit and binary hash.
+
+- [ ] **Step 2: Run pinned cold builds sequentially**
+
+Use the pinned checkouts from the design:
+
+- Django `274a1d494d11d87a1b767340d1f398f197810f93`
+- Spring Framework `317eae88d0746534974bf75487042e007b53f681`
+- Angular `1a2bcb2295c8b4e3a398c8ecbd92cce0affaff1d`
+- ASP.NET Core `2e05e269f599be5615cea4fcd2d27f7080f6e54f`
+- Rails `0f36bbf72cc8b814bf1ad05c896c9c427b18217f`
+- Laravel Framework `7e5b3aff7dcc0843758cc0ad83c383aab84596b8`
+- Bevy `25368b78ce5e9b15dc770cdf2af4595602cc8a7b`
+
+Run each with:
+
+```bash
+/usr/bin/time -l compass extract repository_path --code-only --out output_path --no-cluster --no-viz --max-workers 8
+```
+
+Apply a 10-minute observation ceiling per repository and run sequentially to avoid resource contention.
+
+- [ ] **Step 3: Validate every published graph**
+
+For every successful build, record:
+
+- schema
+- retained nodes and edges
+- omitted nodes and edges
+- identity collisions
+- validation errors
+- graph size
+- wall time
+- peak resident memory
+- graph SHA-256
+- route and `routes_to` counts
+
+Spring Framework, ASP.NET Core, Rails, Laravel Framework, and Bevy must publish a graph with zero strict validation errors.
+
+- [ ] **Step 4: Run real queries**
+
+Run at least one symbol search and one callers or callees query against every published graph. Assert a typed `compass.query/1` response, bounded results, and `incomplete_coverage` when the graph is partial.
+
+- [ ] **Step 5: Recheck determinism on a failing corpus**
+
+Choose the corpus with the largest omission count. Run cold and forced builds and compare `graph.json` SHA-256 hashes.
+
+- [ ] **Step 6: Record remaining performance blockers**
+
+Report Angular separately if it exceeds 10 minutes. Do not classify a performance timeout as successful validation remediation.
+
+- [ ] **Step 7: Commit any qualification fixtures or scripts**
+
+Commit only reusable repository-owned qualification fixtures or scripts. Keep downloaded repositories, generated graphs, and raw benchmark logs outside Git.

--- a/docs/superpowers/reviews/2026-07-30-best-effort-heavy-framework-qualification.md
+++ b/docs/superpowers/reviews/2026-07-30-best-effort-heavy-framework-qualification.md
@@ -1,0 +1,204 @@
+# Best-Effort Code Graph Heavy-Framework Qualification
+
+Date: 2026-07-30
+
+## Decision
+
+The best-effort publication path is available and queryable on all eight
+heavyweight repositories in this qualification. Every completed build emitted
+the closed `compass.graph/1` vocabulary, passed the strict reader used by the
+query commands, and disclosed quarantined records through
+`publication_omission_summary` and `incomplete_coverage`.
+
+One production-scale defect was found and fixed during qualification. Angular
+spent more than 12 minutes in generic stub rewiring because the resolver scanned
+the complete edge collection inside each stub/candidate comparison. Commit
+`0af6326` replaces the repeated scan with a precomputed stub-to-source-file
+index. The same full Angular checkout then completed in 49.39 seconds. The
+affected resolver stage completed in 6.22 seconds, while preserving file-scoped
+import resolution behavior under a regression test.
+
+This result qualifies availability and typed-artifact integrity. It does not
+claim complete semantic coverage: Spring's quarantine rate is material and
+requires producer improvement, even though the graph remains productive and
+truthfully reports the missing coverage.
+
+## Method
+
+The runs used the release binary, the full pinned repository checkout, forced
+structural extraction, Program IR analysis, disabled clustering, and disabled
+HTML generation:
+
+```text
+compass update <repository> --out <output> --no-cluster --no-viz --force --timing
+```
+
+`/usr/bin/time -l` measured wall time and peak resident memory. A symbol search
+with a dedicated query cache then exercised the normal strict graph reader and
+`compass.query/1` response contract. No source subsets, fixture reductions, or
+generated miniature applications were used.
+
+Host:
+
+- Apple M2 Max, 12 logical CPUs
+- 32 GiB memory
+- macOS 26.5.2
+
+The source checkouts and generated evidence are retained under:
+
+```text
+/Volumes/Workspace/compass-heavy-framework-perf-20260729/repos
+/Volumes/Workspace/compass-heavy-framework-best-effort-20260730
+```
+
+## Build Results
+
+| Repository | Pinned commit | Tracked files | Wall time | Peak RSS | Graph size | Published nodes | Published edges |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Django | `274a1d494d11` | 7,074 | 17.22 s | 4.98 GiB | 239.4 MB | 52,904 | 206,205 |
+| Spring Framework | `317eae88d074` | 11,384 | 139.15 s | 6.41 GiB | 547.6 MB | 152,496 | 305,894 |
+| Rails | `0f36bbf72cc8` | 4,973 | 44.64 s | 2.36 GiB | 147.0 MB | 59,504 | 96,958 |
+| Laravel | `7e5b3aff7dcc` | 3,333 | 8.16 s | 1.98 GiB | 129.0 MB | 41,623 | 86,169 |
+| Bevy | `25368b78ce5e` | 2,969 | 75.76 s | 5.64 GiB | 285.3 MB | 117,061 | 187,221 |
+| ASP.NET Core | `2e05e269f599` | 17,281 | 487.67 s | 8.97 GiB | 795.5 MB | 306,282 | 468,897 |
+| Angular | `1a2bcb2295c8` | 10,670 | 49.39 s | 7.92 GiB | 362.2 MB | 187,878 | 231,890 |
+| Entire | `683a10d3773e` | 2,657 | 5.39 s | 1.32 GiB | 88.6 MB | 22,294 | 72,199 |
+
+ASP.NET Core is the largest published artifact and slowest build in this
+corpus. It also verified the production default graph-size cap: the 795.5 MB
+artifact opens without a `COMPASS_MAX_GRAPH_BYTES` override after the default
+was raised to 1 GiB.
+
+## Query Results
+
+Every graph completed a real symbol search and returned `compass.query/1`.
+Every partial graph included an `incomplete_coverage` diagnostic. The observed
+search timings include graph loading, strict validation, index preparation or
+reuse, execution, and response construction.
+
+| Repository | Observed search wall time | Peak RSS | Result |
+| --- | ---: | ---: | --- |
+| Django | 24.03 s | 0.65 GiB | Passed |
+| Spring Framework | 30.97 s | 4.23 GiB | Passed |
+| Rails | 9.78 s | 1.26 GiB | Passed |
+| Laravel | 9.20 s | 1.11 GiB | Passed |
+| Bevy | 23.47 s | 2.50 GiB | Passed |
+| ASP.NET Core | 58.19 s | 6.63 GiB | Passed with the production default size cap |
+| Angular | 25.67 s | 3.26 GiB | Passed |
+| Entire | 6.01 s | 0.78 GiB | Passed |
+
+These measurements show that the query path is usable but still expensive for
+the largest artifacts. They are qualification observations, not a declared
+latency service-level objective.
+
+## Framework Topology
+
+Framework-specific entities use the same closed graph contract as ordinary
+symbols. Route declarations become `route` nodes and resolved handlers are
+connected with explicit `routes_to` edges. Framework detectors contribute
+facts; the central resolver performs bounded target resolution; the v1
+normalizer validates both endpoints before publication.
+
+| Repository | `route` nodes | `routes_to` edges |
+| --- | ---: | ---: |
+| Django | 578 | 352 |
+| Spring Framework | 645 | 300 |
+| Rails | 124 | 45 |
+| Laravel | 27 | 34 |
+| Bevy | 0 | 0 |
+| ASP.NET Core | 691 | 623 |
+| Angular | 7 | 14 |
+
+Zero routes in a framework source tree is not itself an extraction failure:
+Bevy is not a web-routing framework, and this qualification does not infer
+routes where the repository contains no supported route declaration shape.
+The Angular checkout is the framework implementation rather than a large
+Angular application, so it is primarily a TypeScript-scale and resolver test.
+
+## Quarantine and Coverage
+
+Rates below use `omitted / (published + omitted)`. Identity collisions are
+reported separately.
+
+| Repository | Omitted nodes | Node rate | Omitted edges | Edge rate | Identity collisions |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Django | 316 | 0.59% | 348 | 0.17% | 0 |
+| Spring Framework | 32,064 | 17.37% | 87,078 | 22.16% | 0 |
+| Rails | 1 | <0.01% | 1,457 | 1.48% | 0 |
+| Laravel | 1,191 | 2.78% | 1,443 | 1.65% | 0 |
+| Bevy | 1,064 | 0.90% | 356 | 0.19% | 10 |
+| ASP.NET Core | 1,828 | 0.59% | 5,048 | 1.07% | 6 |
+| Angular | 2,580 | 1.35% | 8,233 | 3.43% | 0 |
+| Entire | 59 | 0.26% | 182 | 0.25% | 0 |
+
+Sampled diagnostics show four recurring producer-quality categories:
+
+- unresolved placeholders without an exact node kind or wiring site;
+- incident edges removed after their endpoint was quarantined;
+- invalid inheritance endpoints, especially Rails class-to-module relations;
+- stable same-identity conflicts in Bevy modules and ASP.NET method/namespace
+  symbols.
+
+Spring is the only corpus member where quarantine removes roughly one fifth of
+the candidate topology. The artifact is strict-valid and queryable, but agents
+must treat its `incomplete_coverage` diagnostic as material. The next
+producer-quality priority is to infer or resolve Spring placeholders before
+publication rather than broadening the validator.
+
+## Angular Performance Defect
+
+Before the fix, all early stages completed quickly:
+
+- combined tree-sitter extraction: 3.45 seconds;
+- declaration merge: 0.14 seconds;
+- Program syntax cache publication: 3.94 seconds;
+- family stub rewiring: 0.18 seconds.
+
+The next stage, unique stub rewiring, had not completed after more than 12
+minutes. A 10-second process sample showed the main thread continuously sorting
+and comparing while worker threads were idle. Inspection identified this
+effective shape:
+
+```text
+for each stub
+  for each same-name candidate
+    scan every edge to recover incident source files
+```
+
+The resolver already performs one complete edge pass to collect stub families,
+scopes, consumers, and imports. The fix records incident source files during
+that pass and performs indexed file/import lookups in the candidate loop. The
+resolution conditions and endpoint rewrite provenance remain unchanged.
+
+After the fix:
+
+- unique stub rewiring: 6.22 seconds;
+- complete cross-file resolution: 11.03 seconds;
+- Compass-reported update time: 43.77 seconds;
+- externally measured wall time: 49.39 seconds;
+- published topology: 187,878 nodes and 231,890 edges;
+- strict query: passed with 500 returned symbols and explicit incomplete
+  coverage.
+
+## Release Assessment
+
+The branch now meets the intended best-effort contract on real heavyweight
+repositories:
+
+- invalid records are quarantined rather than weakening v1 invariants;
+- a valid non-empty generation is atomically published;
+- omitted counts and bounded examples remain visible to CLI and query clients;
+- graphs larger than 512 MiB remain readable under the production default;
+- all eight full repositories build and answer a typed search;
+- the Angular superlinear resolver defect is covered and removed.
+
+Remaining production work is quality and efficiency hardening rather than an
+artifact-integrity failure:
+
+1. Reduce Spring placeholder and incident-edge quarantine.
+2. Reduce peak build memory for ASP.NET Core and Angular.
+3. Avoid loading and validating the complete graph for each fresh query.
+4. Add this pinned corpus, or an equivalently sized internal mirror, to
+   scheduled release qualification with wall-time, memory, validity, and
+   omission-rate regression thresholds.
+

--- a/docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md
+++ b/docs/superpowers/specs/2026-07-27-compass-code-graph-v1-design.md
@@ -789,20 +789,26 @@ resolution, or provenance classification.
 
 Graph publication fails for:
 
-- unknown node, role, or edge values;
-- invalid endpoint-kind combinations;
-- duplicate stable IDs with conflicting content;
-- dangling endpoints;
-- missing provenance;
-- heuristic relationships without a rule or wiring site;
-- invalid source anchors;
+- invalid envelope or build metadata;
+- invalid or repository-escaping file inventory;
+- no usable nodes after record quarantine;
 - repository-escaping paths;
 - mismatched graph, Program IR, manifest, or build fingerprints.
+
+Unknown node, role, or edge values, invalid endpoint-kind combinations,
+conflicting stable identities, dangling endpoints, missing record provenance,
+heuristic relationships without a rule or wiring site, and invalid record
+anchors quarantine the affected node or edge in normal builds. The remaining
+document is still validated by the unchanged strict validator. Strict
+normalization APIs continue to reject those producer defects for qualification
+and tests.
 
 ### Partial extraction
 
 An unsupported or unparsable file is represented by failed or indeterminate
-coverage and a diagnostic. It does not silently disappear.
+coverage and a diagnostic. An invalid individual graph record is represented by
+a bounded quarantine diagnostic and exact publication omission summary. Neither
+silently disappears.
 
 The default developer build may publish a partial graph when all structural
 invariants remain valid. Strict mode fails publication when required coverage

--- a/docs/superpowers/specs/2026-07-30-best-effort-code-graph-publication-design.md
+++ b/docs/superpowers/specs/2026-07-30-best-effort-code-graph-publication-design.md
@@ -1,0 +1,309 @@
+# Publish a usable code graph when individual records are invalid
+
+**Status:** Approved by product direction, pending written review
+**Date:** 2026-07-30
+**Product:** Compass
+**Schemas:** `compass.graph/1`, `compass.query/1`
+**Content type:** Conceptual
+
+## Summary
+
+Compass will publish the largest structurally valid code graph it can derive from a repository. A malformed node, edge, producer relation, identity collision, or endpoint-kind combination will no longer abort the complete build. Compass will quarantine the invalid record, remove topology that depends on it, record bounded diagnostics, and validate the remaining graph before atomic publication.
+
+The durable `compass.graph/1` contract remains strict. Query consumers will never need to handle dangling endpoints, unknown kinds, malformed provenance, or invalid source paths. Compass moves tolerance to the producer-to-publication boundary instead of weakening the artifact consumed by the command-line interface (CLI), Model Context Protocol (MCP) server, Visual Studio Code extension, and coding agents.
+
+## Product decision
+
+The primary product outcome is a queryable graph that helps a coding agent navigate a real repository. Complete graph rejection is worse than a disclosed omission when most symbols and relationships remain usable.
+
+Compass therefore distinguishes two failure classes:
+
+- **Record-level failure:** Quarantine the node or edge, record the omission, and continue
+- **Document-level failure:** Abort publication because no safe query artifact can be produced
+
+Default developer builds use best-effort publication. The existing strict normalizer and validator remain available to unit tests, producer qualification, and diagnostic tooling.
+
+## Goals
+
+1. Publish a queryable graph when individual producer records are invalid.
+2. Preserve the strict `compass.graph/1` invariant set for every published artifact.
+3. Maximize retained nodes and edges without fabricating replacement semantics.
+4. Tell agents and operators that the graph is partial.
+5. Make every quarantine decision deterministic across clean, cached, forced, and reordered builds.
+6. Preserve atomic generation publication and the last-known-good graph.
+7. Bound diagnostic volume on repositories that produce hundreds or thousands of invalid records.
+
+## Non-goals
+
+- Publishing dangling edges or unknown node and edge kinds
+- Converting every unknown relation to `references`
+- Guessing a replacement node kind solely to satisfy validation
+- Treating a partial graph as complete
+- Hiding producer defects from qualification reports
+- Solving extraction and query latency in the same change
+- Adding a second durable graph schema or a second graph artifact
+
+## Terms
+
+**Quarantine** means omitting an invalid raw or normalized record from the published graph and recording why Compass omitted it.
+
+**Record-level failure** means a failure attributable to one raw node, normalized node, raw edge, or normalized edge. Incident edges also become record-level omissions when their endpoint is quarantined.
+
+**Document-level failure** means a failure that prevents Compass from producing or publishing a structurally safe artifact. Examples include an unsupported schema, unsafe repository path, unreadable authoritative input, invalid file inventory, empty usable graph, serialization failure, and atomic publication failure.
+
+**Partial graph** means a strictly valid graph that includes one or more quarantine diagnostics.
+
+## Chosen architecture
+
+Compass will add a best-effort publication path beside the existing strict path:
+
+```text
+resolved raw extraction
+        |
+        v
+best-effort node normalization
+  keep valid nodes
+  quarantine invalid nodes and conflicting duplicates
+        |
+        v
+best-effort edge normalization
+  drop edges with quarantined endpoints
+  quarantine malformed or unknown relations
+        |
+        v
+typed record sanitization
+  quarantine invalid normalized nodes
+  cascade incident-edge removal
+  quarantine invalid normalized edges
+        |
+        v
+existing strict graph validator
+        |
+        v
+atomic compass.graph/1 publication
+```
+
+`compass-model` continues to own strict validation. `compass-graph` owns quarantine and diagnostic accounting. `compass-core` uses the best-effort path for normal builds and reports the omission summary. `compass-query` converts partial-publication diagnostics into `incomplete_coverage` query diagnostics.
+
+## Public and internal interfaces
+
+The existing `normalize_v1` and `normalize_document_v1_with_inventory` functions keep their strict behavior. Existing strict tests and callers do not silently change semantics.
+
+`compass-graph` will add best-effort variants that return a typed publication outcome:
+
+```rust
+pub struct PublicationOutcome {
+    pub document: GraphDocument,
+    pub omissions: PublicationOmissions,
+}
+
+pub struct PublicationOmissions {
+    pub nodes: usize,
+    pub edges: usize,
+    pub identity_collisions: usize,
+    pub examples_omitted: usize,
+}
+```
+
+The concrete function names may follow existing crate naming conventions, but the strict and best-effort boundaries must remain explicit in the Rust API.
+
+Normal `compass extract`, `compass update`, watch rebuilds, and history materialization will use best-effort publication. Producer-focused tests can continue to call the strict path.
+
+## Deterministic quarantine algorithm
+
+### Normalize nodes
+
+Compass sorts raw nodes by a stable record key before normalization. The key includes raw identity, declared kind, qualified name, portable source path, source range, and canonical serialized attributes.
+
+For each raw node:
+
+1. Normalize the node with the current typed normalizer.
+2. If normalization fails, quarantine the raw node and mark its raw identity unavailable for edge remapping.
+3. If normalization succeeds with a new stable identity, retain it.
+4. If the stable identity already exists and the records are compatible, merge them with the current evidence-preserving merge.
+5. If the stable identity already exists and the records conflict, choose one deterministic survivor and quarantine the other raw record.
+
+The survivor ranking is:
+
+1. Exact Abstract Syntax Tree (AST) evidence
+2. Other exact source-backed evidence
+3. Inferred source-backed evidence
+4. Sourceless evidence with an exact wiring site
+5. Canonical serialized record order as the final tie-breaker
+
+Compass does not remap edges from a quarantined conflicting raw record to the survivor. Those edges are omitted because their intended semantic owner is ambiguous.
+
+### Normalize edges
+
+Compass sorts raw edges by source identity, raw relation, target identity, relationship site, occurrence rule, and canonical serialized attributes.
+
+For each raw edge:
+
+1. Omit the edge if either raw endpoint was quarantined.
+2. Omit the edge if an endpoint has no normalized identity.
+3. Normalize the relation, provenance, source anchor, and stable edge identity.
+4. Quarantine the edge if normalization fails, including unknown raw relations such as an unregistered producer-specific relation.
+5. Merge compatible duplicate edges with the current evidence-preserving merge.
+6. Quarantine conflicting duplicate edges instead of aborting the graph.
+
+Compass will not map an unknown relation to a generic edge kind. A missing edge conveys less false information than an invented relationship.
+
+### Sanitize typed records
+
+The model layer will expose structured record validation helpers. The publication path must not parse validator error strings.
+
+Sanitization proceeds in this order:
+
+1. Validate document metadata and file inventory. Any failure remains fatal.
+2. Validate each normalized node independently.
+3. Quarantine invalid nodes.
+4. Remove every edge incident to a quarantined node.
+5. Validate each remaining edge against its endpoints.
+6. Quarantine invalid edges.
+7. Recompute route resolution when a quarantined edge was a route stage.
+8. Run the existing full strict validator.
+
+If the final validator still fails, publication aborts. This catches implementation defects in the sanitizer rather than exposing an invalid artifact.
+
+### Preserve a usable minimum
+
+Best-effort publication has no percentage-based omission threshold. A repository can contain unsupported or malformed regions while retaining a valuable graph elsewhere.
+
+Publication still fails when no usable symbol, file, route, component, domain, or database node remains. Existing last-known-good generation behavior remains authoritative when that failure occurs.
+
+## Diagnostics
+
+Compass records quarantine outcomes in `graph.diagnostics` with warning severity:
+
+- `publication_omitted_node`
+- `publication_omitted_edge`
+- `publication_identity_collision`
+- `publication_omission_summary`
+
+Each example includes the original failure reason, raw or stable identity, portable source or wiring site when available, and related retained identities when applicable.
+
+Compass stores at most 100 node examples, 100 edge examples, and 100 collision examples. The summary records total omitted nodes, omitted edges, identity collisions, and examples excluded by the diagnostic cap. Counts remain exact even when examples are bounded.
+
+The CLI prints one concise success warning:
+
+```text
+Compass published a partial graph: 2 nodes and 801 edges omitted.
+Run `compass diagnose publication` for details.
+```
+
+The first implementation may expose the details through existing graph diagnostics before adding a dedicated `diagnose publication` command. The CLI must not advertise that command until it exists.
+
+## Query behavior
+
+Every query continues to operate on a strictly valid graph. Traversal code does not add malformed-record branches.
+
+When graph diagnostics contain a publication omission summary, search, callers, callees, impact, explore, node trail, and call graph responses include one `incomplete_coverage` diagnostic. The message reports omission counts and states that absent topology may reflect quarantine.
+
+Queries do not append every record-level diagnostic. Agents can inspect graph diagnostics or a diagnostic command when they need examples.
+
+## Framework-specific behavior
+
+Framework routes, handlers, middleware, events, jobs, schemas, and database facts follow the same policy:
+
+- A valid route node remains queryable when an unrelated route fails.
+- A route edge with an invalid handler endpoint is omitted.
+- The route stage becomes unresolved after its edge is omitted.
+- The route node retains framework evidence and its relationship site.
+- A malformed domain relationship does not remove valid domain entities.
+
+Compass must recompute route resolution after quarantine so route details never claim exact resolution without a retained `routes_to` edge.
+
+## Atomic publication and history
+
+Best-effort normalization finishes before Compass writes the candidate generation. Graph JSON, Program intermediate representation (IR), manifest, build state, and generation pointer retain their current atomic publication boundary.
+
+A valid partial graph may replace the active generation. A document-level failure cannot replace it. History builds record the same deterministic omission diagnostics for the same source revision and configuration.
+
+## Observability
+
+Build statistics will expose:
+
+- retained node count
+- retained edge count
+- omitted node count
+- omitted edge count
+- identity collision count
+- partial graph status
+
+Profiling will measure node normalization, edge normalization, typed sanitization, strict final validation, and diagnostic serialization separately. Quarantine must not require repeatedly cloning the complete graph.
+
+## Test strategy
+
+### Model tests
+
+- Validate nodes and edges independently through structured helpers.
+- Keep the full strict validator behavior unchanged.
+- Prove invalid endpoint kinds remain invalid in durable artifacts.
+
+### Graph normalization tests
+
+- Strict normalization still rejects unknown relations and missing wiring sites.
+- Best-effort normalization omits one unknown edge and publishes the remaining graph.
+- Best-effort normalization omits one invalid node and every incident edge.
+- Stable identity collisions retain the same survivor under reversed input order.
+- Invalid endpoint-kind edges become bounded diagnostics.
+- Route resolution becomes unresolved when quarantine removes `routes_to`.
+- Sanitized output passes the existing strict validator.
+- Repeated and reordered builds serialize to identical bytes.
+
+### Pipeline tests
+
+- Normal extract and update publish partial graphs successfully.
+- The CLI reports omission counts without reporting a failed build.
+- An empty usable graph remains a failure.
+- A failed document-level publication preserves the active generation.
+- Cached and forced builds produce identical partial graphs.
+
+### Query tests
+
+- Every typed operation includes one `incomplete_coverage` diagnostic for a partial graph.
+- Query results remain usable and bounded.
+- Complete graphs do not receive a partial-graph diagnostic.
+
+## Heavy-framework qualification
+
+Compass will rerun the pinned official repositories used in the 2026-07-29 qualification:
+
+| Repository | Expected outcome after this change |
+|---|---|
+| Django | Publishes the same valid topology plus deterministic diagnostics |
+| Spring Framework | Quarantines the unwired placeholder and publishes the remaining graph |
+| Angular | Publishes within the existing 10-minute observation ceiling or remains a separately reported performance blocker |
+| ASP.NET Core | Quarantines the conflicting Razor record and publishes the remaining graph |
+| Rails | Omits invalid endpoint-kind edges and publishes the remaining graph |
+| Laravel Framework | Omits the unknown `bound_to` edge and publishes the remaining graph |
+| Bevy | Quarantines the conflicting Rust module record and publishes the remaining graph |
+
+For each successful publication, qualification records wall time, peak resident memory, retained and omitted record counts, validation errors, graph hash, route counts, and a real search or callers query.
+
+This change is complete only when Spring Framework, ASP.NET Core, Rails, Laravel Framework, and Bevy publish queryable strict-valid graphs. Angular performance remains in scope for the broader production-readiness goal but is not disguised as a validation failure.
+
+## Documentation changes
+
+Update the graph model, output reference, command reference, operations guide, and troubleshooting guide:
+
+- Explain that default publication is best-effort.
+- Define partial graph and quarantine.
+- List document-level hard failures.
+- Explain diagnostic caps and exact summary counts.
+- Tell agents to verify critical paths in source when coverage is incomplete.
+
+The original Code Graph v1 design will receive a short amendment that replaces whole-build failure for record-level defects with this approved quarantine contract. Historical text remains otherwise intact.
+
+## Acceptance criteria
+
+1. Default builds quarantine record-level failures and continue.
+2. Every published graph passes the unchanged strict validator.
+3. Invalid nodes never leave dangling edges.
+4. Unknown relations never enter the durable edge vocabulary.
+5. Identity collision survivors and omission diagnostics are deterministic.
+6. Query responses disclose partial publication.
+7. Diagnostic examples are bounded and summary counts are exact.
+8. Last-known-good publication behavior remains intact for document-level failures.
+9. The five heavyweight repositories that previously failed validation publish queryable graphs.
+10. Existing strict normalization APIs and tests remain available for producer qualification.

--- a/scripts/qualify_code_graph_v1.sh
+++ b/scripts/qualify_code_graph_v1.sh
@@ -64,7 +64,9 @@ PY
 
 echo "[code-graph-v1] build qualifying production binary once"
 cargo build --locked -p compass-cli --bin compass
-COMPASS_BIN="$QUALIFY_ROOT/target/debug/compass"
+QUALIFY_TARGET="$(cargo metadata --format-version 1 --no-deps | python3 -c \
+  'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
+COMPASS_BIN="$QUALIFY_TARGET/debug/compass"
 
 if [[ "$MODE" == repositories ]]; then
   [[ -f "$REPOSITORIES_MANIFEST" ]] || {


### PR DESCRIPTION
## Summary

- keep the closed v1 validator strict while quarantining invalid nodes, incident edges, and identity collisions
- atomically publish a valid non-empty partial graph and disclose exact omission counts through CLI and compass.query/1
- raise the shared production graph reader cap to 1 GiB for qualified enterprise artifacts
- remove the superlinear unique-stub resolver scan found on the full Angular repository
- document heavyweight qualification across Django, Spring Framework, Rails, Laravel, Bevy, ASP.NET Core, Angular, and Entire

## Verification

- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- cargo test --workspace --locked --no-run
- scripts/qualify_code_graph_v1.sh --fixtures-only
- full release builds and typed searches on all eight pinned heavyweight repositories

The v1 qualification covers 57 languages, 45 node kinds, 28 edge kinds, 24 flows, 23 negative cases, 500k-edge scale, and byte-identical clean, warm, forced, restored, and alternate-checkout builds. Angular now completes in 49.39 seconds after previously exceeding 12 minutes.

## Known quality gap

Spring Framework publishes a strict-valid and queryable partial graph, but its incomplete_coverage diagnostic is material: 17.37% of candidate nodes and 22.16% of candidate edges are quarantined. This PR keeps that limitation explicit; producer resolution should be improved separately without weakening the v1 contract.