### PR TITLE
Preserve source-backed graph semantics and accelerate publication

### DIFF
--- a/benchmarks/performance/compass_perf/correctness.py
+++ b/benchmarks/performance/compass_perf/correctness.py
@@ -651,7 +651,24 @@ def _classify_edges(
 ) -> list[Coverage]:
     exact_index: dict[tuple[str, str, str], list[EdgeFact]] = {}
     direct_index: dict[tuple[str, str, str], list[EdgeFact]] = {}
+    occurrence_target_index: dict[tuple[str, str, str, str], list[EdgeFact]] = {}
     containment: dict[str, set[str]] = {}
+    import_occurrences: set[tuple[str, str, str]] = set()
+    for edges in (graphify_edges, compass_edges):
+        for edge in edges:
+            if (
+                edge.relation == "imports"
+                and edge.target_fact_key
+                and edge.occurrence_file
+                and edge.occurrence_location
+            ):
+                import_occurrences.add(
+                    (
+                        edge.target_fact_key,
+                        edge.occurrence_file,
+                        edge.occurrence_location,
+                    )
+                )
     canonical_endpoints = _canonical_compass_endpoints(compass_nodes)
     for edge in compass_edges:
         exact_index.setdefault(
@@ -660,11 +677,35 @@ def _classify_edges(
         source = canonical_endpoints.get(edge.source, edge.source)
         target = canonical_endpoints.get(edge.target, edge.target)
         direct_index.setdefault((edge.relation, source, target), []).append(edge)
+        if edge.occurrence_file and edge.occurrence_location:
+            occurrence_target_index.setdefault(
+                (
+                    edge.relation,
+                    edge.target_fact_key,
+                    edge.occurrence_file,
+                    edge.occurrence_location,
+                ),
+                [],
+            ).append(edge)
         if edge.relation == "contains":
             containment.setdefault(source, set()).add(target)
 
     output: list[Coverage] = []
     for graphify in graphify_edges:
+        if (
+            graphify.relation == "references"
+            and (
+                graphify.target_fact_key,
+                graphify.occurrence_file,
+                graphify.occurrence_location,
+            )
+            in import_occurrences
+        ):
+            output.append(
+                Coverage("rejected", "module_import_projected_to_symbol", None)
+            )
+            continue
+
         exact = [
             edge
             for edge in exact_index.get(
@@ -679,6 +720,28 @@ def _classify_edges(
         ]
         if exact:
             output.append(Coverage("exact", "relationship_fact", exact[0].payload_sha256))
+            continue
+
+        precise_owner = occurrence_target_index.get(
+            (
+                graphify.relation,
+                graphify.target_fact_key,
+                graphify.occurrence_file,
+                graphify.occurrence_location,
+            ),
+            [],
+        )
+        if (
+            graphify.relation in {"calls", "references", "rationale_for"}
+            and len(precise_owner) == 1
+        ):
+            output.append(
+                Coverage(
+                    "dominated",
+                    "precise_occurrence_owner",
+                    precise_owner[0].payload_sha256,
+                )
+            )
             continue
 
         source_coverage = node_coverage.get(graphify.source)
@@ -744,7 +807,7 @@ def _classify_edges(
 
 def _coverage_metrics(prefix: str, coverage: list[Coverage]) -> dict[str, int | str]:
     metrics: dict[str, int | str] = {}
-    for status in ("exact", "dominated", "ambiguous", "missing"):
+    for status in ("exact", "dominated", "rejected", "ambiguous", "missing"):
         metrics[f"{status}_graphify_{prefix}"] = sum(
             fact.status == status for fact in coverage
         )

--- a/benchmarks/performance/compass_perf/correctness.py
+++ b/benchmarks/performance/compass_perf/correctness.py
@@ -579,6 +579,13 @@ def _classify_nodes(
             if _compatible_definition(graphify, candidate)
         ]
         reason = "canonical_owner" if graphify.source_file else "resolved_definition"
+        if len(candidates) > 1:
+            case_exact = [
+                candidate for candidate in candidates if candidate.label == graphify.label
+            ]
+            if len(case_exact) == 1:
+                candidates = case_exact
+                reason = "case_exact_owner"
         if len(candidates) > 1 and not graphify.module:
             module_candidates = [
                 candidate
@@ -621,6 +628,10 @@ def _canonical_compass_endpoints(
             for candidate in anchored_by_label.get(node.normalized_label, [])
             if _compatible_definition(node, candidate)
         ]
+        if len(candidates) > 1:
+            case_exact = [candidate for candidate in candidates if candidate.label == node.label]
+            if len(case_exact) == 1:
+                candidates = case_exact
         if len(candidates) == 1:
             canonical[node.identifier] = candidates[0].identifier
     return canonical

--- a/benchmarks/performance/compass_perf/correctness.py
+++ b/benchmarks/performance/compass_perf/correctness.py
@@ -663,6 +663,7 @@ def _classify_edges(
     exact_index: dict[tuple[str, str, str], list[EdgeFact]] = {}
     direct_index: dict[tuple[str, str, str], list[EdgeFact]] = {}
     occurrence_target_index: dict[tuple[str, str, str, str], list[EdgeFact]] = {}
+    qualified_external_targets: dict[tuple[str, str, str, str], set[str]] = {}
     containment: dict[str, set[str]] = {}
     import_occurrences: set[tuple[str, str, str]] = set()
     for edges in (graphify_edges, compass_edges):
@@ -698,6 +699,21 @@ def _classify_edges(
                 ),
                 [],
             ).append(edge)
+            target_node = compass_nodes.get(edge.target)
+            if (
+                target_node is not None
+                and target_node.placeholder
+                and "." in target_node.qualified_name
+            ):
+                qualified_external_targets.setdefault(
+                    (
+                        edge.relation,
+                        edge.occurrence_file,
+                        edge.occurrence_location,
+                        target_node.normalized_label,
+                    ),
+                    set(),
+                ).add(edge.target)
         if edge.relation == "contains":
             containment.setdefault(source, set()).add(target)
 
@@ -731,6 +747,30 @@ def _classify_edges(
         ]
         if exact:
             output.append(Coverage("exact", "relationship_fact", exact[0].payload_sha256))
+            continue
+
+        graphify_target = graphify_nodes.get(graphify.target)
+        corrected_targets = qualified_external_targets.get(
+            (
+                graphify.relation,
+                graphify.occurrence_file,
+                graphify.occurrence_location,
+                graphify_target.normalized_label if graphify_target is not None else "",
+            ),
+            set(),
+        )
+        if (
+            graphify_target is not None
+            and graphify_target.source_file
+            and len(corrected_targets) == 1
+        ):
+            output.append(
+                Coverage(
+                    "rejected",
+                    "qualified_external_target_rebound_to_local",
+                    next(iter(corrected_targets)),
+                )
+            )
             continue
 
         precise_owner = occurrence_target_index.get(

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -256,6 +256,76 @@ class CorrectnessTests(unittest.TestCase):
         self.assertEqual(result.metrics["ambiguous_graphify_nodes"], 1)
         self.assertEqual(result.metrics["missing_graphify_nodes"], 0)
 
+    def test_case_exact_generated_owner_disambiguates_case_distinct_types(self) -> None:
+        result = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"exported","label":"EphemeralStore","kind":"interface",
+               "source_file":"pkg/checkpoint/api.go","source_location":"L10",
+               "language":"go"},
+              {"id":"private","label":"ephemeralStore","kind":"struct",
+               "source_file":"pkg/checkpoint/store.go","source_location":"L20",
+               "language":"go"}
+            ],"links":[]}
+            """,
+            """
+            {"nodes":[
+              {"id":"pkg_checkpoint_generated_ephemeralstore",
+               "label":"ephemeralStore",
+               "source_file":"pkg/checkpoint/write.go","source_location":"L30"}
+            ],"links":[]}
+            """,
+        )
+        self.assertTrue(result.passed, result.failures)
+        self.assertEqual(result.metrics["dominated_graphify_nodes"], 1)
+        self.assertIn(
+            "dominated:case_exact_owner",
+            result.metrics["graphify_nodes_coverage_reasons"],
+        )
+
+    def test_embedding_relation_requires_first_class_compass_embedding(self) -> None:
+        graphify = """
+            {"nodes":[
+              {"id":"owner","label":"Owner","source_file":"pkg/a.go","source_location":"L1"},
+              {"id":"target","label":"Target","source_file":"pkg/a.go","source_location":"L2"}
+            ],"links":[
+              {"source":"owner","target":"target","relation":"embeds",
+               "source_file":"pkg/a.go","source_location":"L3"}
+            ]}
+        """
+        collapsed = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"owner","label":"Owner","kind":"struct",
+               "source_file":"pkg/a.go","source_location":"L1"},
+              {"id":"target","label":"Target","kind":"interface",
+               "source_file":"pkg/a.go","source_location":"L2"}
+            ],"links":[
+              {"source":"owner","target":"target","relation":"contains",
+               "source_file":"pkg/a.go","source_location":"L3"}
+            ]}
+            """,
+            graphify,
+        )
+        self.assertFalse(collapsed.passed)
+        self.assertEqual(collapsed.metrics["missing_graphify_edges"], 1)
+
+        preserved = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"owner","label":"Owner","kind":"struct",
+               "source_file":"pkg/a.go","source_location":"L1"},
+              {"id":"target","label":"Target","kind":"interface",
+               "source_file":"pkg/a.go","source_location":"L2"}
+            ],"links":[
+              {"source":"owner","target":"target","relation":"embeds",
+               "source_file":"pkg/a.go","source_location":"L3"}
+            ]}
+            """,
+            graphify,
+        )
+        self.assertTrue(preserved.passed, preserved.failures)
+
     def test_generated_receiver_id_disambiguates_an_exact_module(self) -> None:
         result = compare_documents(
             """

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -515,6 +515,42 @@ class CorrectnessTests(unittest.TestCase):
             result.metrics["graphify_edges_coverage_reasons"],
         )
 
+    def test_qualified_external_target_rejects_same_named_local_rebinding(self) -> None:
+        result = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"owner","label":"Run","kind":"function",
+               "source_file":"app.go","source_location":"L10","language":"go"},
+              {"id":"external","label":"Context","kind":"type_alias",
+               "source_file":"","source_location":"","language":"go",
+               "qualified_name":"context.context"},
+              {"id":"local","label":"Context","kind":"struct",
+               "source_file":"internal/contexts.go","source_location":"L2",
+               "language":"go"}
+            ],"links":[
+              {"source":"owner","target":"external","relation":"references",
+               "source_file":"app.go","source_location":"L11"}
+            ]}
+            """,
+            """
+            {"nodes":[
+              {"id":"owner","label":"Run()",
+               "source_file":"app.go","source_location":"L10"},
+              {"id":"local","label":"Context",
+               "source_file":"internal/contexts.go","source_location":"L2"}
+            ],"links":[
+              {"source":"owner","target":"local","relation":"uses",
+               "source_file":"app.go","source_location":"L11"}
+            ]}
+            """,
+        )
+        self.assertTrue(result.passed, result.failures)
+        self.assertEqual(result.metrics["rejected_graphify_edges"], 1)
+        self.assertIn(
+            "rejected:qualified_external_target_rebound_to_local",
+            result.metrics["graphify_edges_coverage_reasons"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -371,6 +371,80 @@ class CorrectnessTests(unittest.TestCase):
         self.assertFalse(occurrence.passed)
         self.assertEqual(occurrence.metrics["missing_graphify_edges"], 1)
 
+    def test_module_import_projection_is_rejected_but_real_use_is_required(self) -> None:
+        graphify = """
+            {"nodes":[
+              {"id":"module","label":"app.py",
+               "source_file":"app.py","source_location":"L1"},
+              {"id":"owner","label":"Owner",
+               "source_file":"app.py","source_location":"L20"},
+              {"id":"symbol","label":"Widget",
+               "source_file":"lib.py","source_location":"L2"}
+            ],"links":[
+              {"source":"owner","target":"symbol","relation":"uses",
+               "source_file":"app.py","source_location":"L3"},
+              {"source":"owner","target":"symbol","relation":"uses",
+               "source_file":"app.py","source_location":"L21"}
+            ]}
+        """
+        result = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"module","label":"app.py","kind":"file",
+               "source_file":"app.py","source_location":"L1"},
+              {"id":"owner","label":"Owner","kind":"class",
+               "source_file":"app.py","source_location":"L20"},
+              {"id":"symbol","label":"Widget","kind":"class",
+               "source_file":"lib.py","source_location":"L2"}
+            ],"links":[
+              {"source":"module","target":"symbol","relation":"imports",
+               "source_file":"app.py","source_location":"L3"}
+            ]}
+            """,
+            graphify,
+        )
+        self.assertFalse(result.passed)
+        self.assertEqual(result.metrics["rejected_graphify_edges"], 1)
+        self.assertEqual(result.metrics["missing_graphify_edges"], 1)
+        self.assertIn(
+            "rejected:module_import_projected_to_symbol",
+            result.metrics["graphify_edges_coverage_reasons"],
+        )
+
+    def test_exact_occurrence_with_more_precise_owner_dominates_baseline(self) -> None:
+        result = compare_documents(
+            """
+            {"graph":{"diagnostics":[]},"nodes":[
+              {"id":"outer","label":"run","kind":"function",
+               "source_file":"app.py","source_location":"L10"},
+              {"id":"inner","label":"run_inner","kind":"function",
+               "source_file":"app.py","source_location":"L20"},
+              {"id":"target","label":"Widget","kind":"class",
+               "source_file":"lib.py","source_location":"L2"}
+            ],"links":[
+              {"source":"inner","target":"target","relation":"calls",
+               "source_file":"app.py","source_location":"L21"}
+            ]}
+            """,
+            """
+            {"nodes":[
+              {"id":"outer","label":"run()",
+               "source_file":"app.py","source_location":"L10"},
+              {"id":"target","label":"Widget",
+               "source_file":"lib.py","source_location":"L2"}
+            ],"links":[
+              {"source":"outer","target":"target","relation":"calls",
+               "source_file":"app.py","source_location":"L21"}
+            ]}
+            """,
+        )
+        self.assertTrue(result.passed, result.failures)
+        self.assertEqual(result.metrics["dominated_graphify_edges"], 1)
+        self.assertIn(
+            "dominated:precise_occurrence_owner",
+            result.metrics["graphify_edges_coverage_reasons"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1358,6 +1358,7 @@ fn build_graph_inner(
         let started = Instant::now();
         let mut output_profile_started = Instant::now();
         let configuration_digest = graph_configuration_digest(options, &output_dir)?;
+        let normalization_started = Instant::now();
         let published = published_v1_document(
             &document,
             &communities,
@@ -1372,12 +1373,21 @@ fn build_graph_inner(
             configuration_digest,
             commit.as_deref(),
         )?;
+        profile_internal_duration(
+            "graph.json v1 normalization",
+            normalization_started.elapsed(),
+        );
         if published.document.nodes.is_empty() {
             return Err(CoreError::EmptyGraph);
         }
         let published_nodes = published.document.nodes.len();
         let published_edges = published.document.links.len();
+        let serialization_started = Instant::now();
         write_json_atomic(output_dir.join("graph.json"), &published.document, false)?;
+        profile_internal_duration(
+            "graph.json v1 serialization",
+            serialization_started.elapsed(),
+        );
         profile_internal("graph.json v1 publication", &mut output_profile_started);
         if options.purpose == BuildPurpose::Update {
             write_text_atomic(

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -3264,7 +3264,12 @@ fn published_v1_document(
     configuration_digest: String,
     source_commit: Option<&str>,
 ) -> Result<PublicationOutcome, CoreError> {
+    let mut publication_profile_started = Instant::now();
     let mut publication_source = document.clone();
+    profile_internal(
+        "graph publication source clone",
+        &mut publication_profile_started,
+    );
     let node_communities = communities
         .iter()
         .flat_map(|(community, members)| {
@@ -3288,7 +3293,11 @@ fn published_v1_document(
             );
         }
     }
-    Ok(normalize_document_v1_with_inventory_best_effort_owned(
+    profile_internal(
+        "graph publication community projection",
+        &mut publication_profile_started,
+    );
+    let published = normalize_document_v1_with_inventory_best_effort_owned(
         publication_source,
         root,
         configuration_digest,
@@ -3300,7 +3309,12 @@ fn published_v1_document(
             evidence.extraction_partials,
             root,
         ),
-    )?)
+    )?;
+    profile_internal(
+        "graph publication v1 boundary",
+        &mut publication_profile_started,
+    );
+    Ok(published)
 }
 
 fn detection_inventory(

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1522,28 +1522,35 @@ fn build_graph_inner(
     timings.graph_assembly += stage_started.elapsed();
     stage_started = Instant::now();
 
-    write_semantic_marker(&output_dir, semantic)?;
-
     let mut manifest = prior_manifest;
-    save_build_manifest(
-        &mut manifest,
-        &detection.files,
-        &manifest_path,
-        &root,
-        semantic,
-    )?;
+    let (manifest_result, seals_result) = rayon::join(
+        || {
+            save_build_manifest(
+                &mut manifest,
+                &detection.files,
+                &manifest_path,
+                &root,
+                semantic,
+            )
+        },
+        || {
+            write_semantic_marker(&output_dir, semantic)?;
+            save_output_stats(
+                &output_dir,
+                published_nodes,
+                published_edges,
+                communities.len(),
+                true,
+                omissions,
+            )
+        },
+    );
+    manifest_result?;
+    seals_result?;
     timings.publish = stage_started.elapsed();
     if program.is_none() {
         program = join_program_worker(program_handle.take(), &mut timings)?;
     }
-    save_output_stats(
-        &output_dir,
-        published_nodes,
-        published_edges,
-        communities.len(),
-        true,
-        omissions,
-    )?;
     publish_build_state(
         options,
         &output_dir,

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -2183,6 +2183,7 @@ fn document_publication_input_owned(
     source_commit: Option<&str>,
     inventory: Vec<InventoryEvidence>,
 ) -> Result<(Extraction, BuildEvidence), GraphError> {
+    let mut profile_started = Instant::now();
     let mut extensions = Map::new();
     extensions.insert(CANONICAL_RAW_ORDER.to_owned(), Value::Bool(true));
     if let Some(diagnostics) = document.graph.get(TRUSTED_GRAPH_DIAGNOSTICS) {
@@ -2209,9 +2210,12 @@ fn document_publication_input_owned(
         extensions,
         ..Extraction::default()
     };
+    profile_v1("v1 raw input transfer", &mut profile_started);
     let mut evidence =
         BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?;
+    profile_v1("v1 build evidence", &mut profile_started);
     evidence.include_inventory(inventory)?;
+    profile_v1("v1 inventory enrichment", &mut profile_started);
     evidence.build.source_commit = source_commit.map(str::to_owned);
     Ok((extraction, evidence))
 }

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use compass_languages::{Extraction, RawEdgeRecord, RawNodeRecord, Registry};
@@ -497,6 +498,7 @@ fn normalize_v1_with_mode(
     mut evidence: BuildEvidence,
     mode: PublicationMode,
 ) -> Result<PublicationOutcome, GraphError> {
+    let mut profile_started = Instant::now();
     let mut quarantine = QuarantineCollector::default();
     let canonical_raw_order = extraction
         .extensions
@@ -533,6 +535,7 @@ fn normalize_v1_with_mode(
         mode,
         &mut quarantine,
     )?;
+    profile_v1("v1 preparation", &mut profile_started);
 
     if mode == PublicationMode::BestEffort && !canonical_raw_order {
         extraction.nodes.sort_by_cached_key(raw_node_sort_key);
@@ -621,6 +624,7 @@ fn normalize_v1_with_mode(
         }
         recompute_route_resolution(details);
     }
+    profile_v1("v1 node normalization", &mut profile_started);
 
     let mut links = HashMap::<String, EdgeRecord>::with_capacity(extraction.edges.len());
     for (index, raw) in extraction.edges.into_iter().enumerate() {
@@ -872,6 +876,7 @@ fn normalize_v1_with_mode(
             links.insert(edge.id.clone(), edge);
         }
     }
+    profile_v1("v1 edge normalization", &mut profile_started);
     for edge in links.values() {
         let Some(EdgeDetails::Route(edge_details)) = edge.details.as_ref() else {
             continue;
@@ -982,6 +987,7 @@ fn normalize_v1_with_mode(
         (left.code.as_str(), left.message.as_str())
             .cmp(&(right.code.as_str(), right.message.as_str()))
     });
+    profile_v1("v1 canonical ordering", &mut profile_started);
 
     let mut document = GraphDocument {
         directed: true,
@@ -999,6 +1005,7 @@ fn normalize_v1_with_mode(
     if mode == PublicationMode::BestEffort {
         sanitize_document(&mut document, &mut quarantine)?;
     }
+    profile_v1("v1 best-effort sanitization", &mut profile_started);
     let omissions = quarantine.finish(&mut document.graph.diagnostics);
     sort_dedup_serialized(&mut document.graph.diagnostics);
     document.graph.diagnostics.sort_by(|left, right| {
@@ -1006,6 +1013,7 @@ fn normalize_v1_with_mode(
             .cmp(&(right.code.as_str(), right.message.as_str()))
     });
     validate_code_graph(&document)?;
+    profile_v1("v1 strict validation", &mut profile_started);
     Ok(PublicationOutcome {
         document,
         omissions,
@@ -2041,6 +2049,16 @@ fn sort_dedup_serialized<T: Serialize>(values: &mut Vec<T>) {
 
 fn serialized<T: Serialize>(value: &T) -> String {
     serde_json::to_string(value).unwrap_or_default()
+}
+
+fn profile_v1(label: &str, started: &mut Instant) {
+    if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
+        eprintln!(
+            "[compass internal] {label}: {:.3}s",
+            started.elapsed().as_secs_f64()
+        );
+    }
+    *started = Instant::now();
 }
 
 /// Convert the canonical internal analysis graph at the sole v1 publication boundary.

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1979,6 +1979,9 @@ fn deterministic_option<T: Serialize>(left: Option<T>, right: Option<T>) -> Opti
 }
 
 fn sort_dedup_serialized<T: Serialize>(values: &mut Vec<T>) {
+    if values.len() < 2 {
+        return;
+    }
     values.sort_by_cached_key(serialized);
     values.dedup_by(|left, right| serialized(left) == serialized(right));
 }
@@ -3143,6 +3146,9 @@ fn remap_provenance_candidates(evidence: &mut Vec<Provenance>, id_remap: &HashMa
 }
 
 fn sort_dedup_candidates(candidates: &mut Vec<ResolutionCandidate>) {
+    if candidates.len() < 2 {
+        return;
+    }
     candidates.sort_by(|left, right| {
         left.node_id
             .cmp(&right.node_id)

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1002,9 +1002,8 @@ fn normalize_v1_with_mode(
         nodes,
         links,
     };
-    if mode == PublicationMode::BestEffort {
-        sanitize_document(&mut document, &mut quarantine)?;
-    }
+    let already_validated =
+        mode == PublicationMode::BestEffort && sanitize_document(&mut document, &mut quarantine)?;
     profile_v1("v1 best-effort sanitization", &mut profile_started);
     let omissions = quarantine.finish(&mut document.graph.diagnostics);
     sort_dedup_serialized(&mut document.graph.diagnostics);
@@ -1012,7 +1011,9 @@ fn normalize_v1_with_mode(
         (left.code.as_str(), left.message.as_str())
             .cmp(&(right.code.as_str(), right.message.as_str()))
     });
-    validate_code_graph(&document)?;
+    if !already_validated {
+        validate_code_graph(&document)?;
+    }
     profile_v1("v1 strict validation", &mut profile_started);
     Ok(PublicationOutcome {
         document,
@@ -1023,13 +1024,16 @@ fn normalize_v1_with_mode(
 fn sanitize_document(
     document: &mut GraphDocument,
     quarantine: &mut QuarantineCollector,
-) -> Result<(), GraphError> {
+) -> Result<bool, GraphError> {
     let report = validate_code_graph_records(document);
     if !report.document_errors.is_empty() {
         return Err(CodeGraphValidationError {
             errors: report.document_errors,
         }
         .into());
+    }
+    if report.node_errors.is_empty() && report.edge_errors.is_empty() {
+        return Ok(true);
     }
 
     let invalid_nodes = report
@@ -1088,7 +1092,7 @@ fn sanitize_document(
         .links
         .retain(|edge| !incident_edges.contains(&edge.id) && !invalid_edges.contains(&edge.id));
     repair_route_topology(document);
-    Ok(())
+    Ok(false)
 }
 
 fn repair_route_topology(document: &mut GraphDocument) {

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -820,10 +820,13 @@ fn normalize_v1_with_mode(
             });
             continue;
         }
-        if matches!(edge.kind, EdgeKind::Extends | EdgeKind::Implements) {
+        if matches!(
+            edge.kind,
+            EdgeKind::Embeds | EdgeKind::Extends | EdgeKind::Implements
+        ) {
             let valid = source_kind.is_type()
                 && match edge.kind {
-                    EdgeKind::Extends => target_kind.is_type(),
+                    EdgeKind::Embeds | EdgeKind::Extends => target_kind.is_type(),
                     EdgeKind::Implements => matches!(
                         target_kind,
                         NodeKind::Interface | NodeKind::Trait | NodeKind::Protocol
@@ -3410,7 +3413,7 @@ fn map_edge_kind(raw: &str) -> Option<(EdgeKind, Option<&'static str>, bool)> {
         "rationale_for" => (EdgeKind::Documents, None, false),
         "configures" => (EdgeKind::DependsOn, None, false),
         "case_of" | "defines" | "method" => (EdgeKind::Contains, None, false),
-        "embeds" => (EdgeKind::Contains, Some("embedded-member"), false),
+        "embeds" => (EdgeKind::Embeds, Some("embedded-member"), false),
         "mixes_in" => (EdgeKind::Implements, Some("mixin-contract"), false),
         _ => return None,
     };
@@ -4109,6 +4112,7 @@ fn schema_fingerprint() -> String {
         "edges",
         [
             "contains",
+            "embeds",
             "calls",
             "imports",
             "exports",

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -234,22 +234,44 @@ impl BuildEvidence {
         &mut self,
         inventory: impl IntoIterator<Item = InventoryEvidence>,
     ) -> Result<(), GraphError> {
+        let mut file_positions = self
+            .files
+            .iter()
+            .enumerate()
+            .map(|(index, file)| (file.path.clone(), index))
+            .collect::<HashMap<_, _>>();
+        let mut coverage_by_file = HashMap::<String, Vec<usize>>::new();
+        for (index, coverage) in self.coverage.iter().enumerate() {
+            if let Some(file_id) = &coverage.file_id {
+                coverage_by_file
+                    .entry(file_id.clone())
+                    .or_default()
+                    .push(index);
+            }
+        }
         for item in inventory {
             let path = portable_path(&item.path.to_string_lossy(), &self.repository_root)?;
             let absolute = self.repository_root.join(&path);
             if !absolute.is_file() {
                 continue;
             }
-            let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
-                path: absolute,
-                source,
-            })?;
+            let existing_position = file_positions.get(&path).copied();
+            let (content_digest, byte_size) = if let Some(position) = existing_position {
+                let existing = &self.files[position];
+                (existing.content_digest.clone(), existing.byte_size)
+            } else {
+                let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
+                    path: absolute,
+                    source,
+                })?;
+                (sha256_prefixed(&bytes), bytes.len() as u64)
+            };
             let record = FileRecord {
                 id: file_id(&path),
                 path: path.clone(),
                 language: item.language.clone(),
-                content_digest: sha256_prefixed(&bytes),
-                byte_size: bytes.len() as u64,
+                content_digest,
+                byte_size,
                 generated: item.status == ExtractionStatus::Generated,
                 extraction_status: item.status,
                 extractor_versions: vec![format!(
@@ -261,29 +283,35 @@ impl BuildEvidence {
                     .into_iter()
                     .collect(),
             };
-            if let Some(existing) = self.files.iter_mut().find(|file| file.path == path) {
-                *existing = record;
+            if let Some(position) = existing_position {
+                self.files[position] = record;
             } else {
+                file_positions.insert(path.clone(), self.files.len());
                 self.files.push(record);
             }
             let status = coverage_status(item.status);
             let file_record_id = file_id(&path);
-            for coverage in &mut self.coverage {
-                if coverage.file_id.as_deref() == Some(file_record_id.as_str())
-                    && status != CoverageStatus::Complete
-                {
-                    coverage.status = status;
-                    coverage.reason.clone_from(&item.reason);
+            if status != CoverageStatus::Complete
+                && let Some(indexes) = coverage_by_file.get(&file_record_id)
+            {
+                for &index in indexes {
+                    self.coverage[index].status = status;
+                    self.coverage[index].reason.clone_from(&item.reason);
                 }
             }
+            let coverage_index = self.coverage.len();
             self.coverage.push(CoverageRecord {
                 capability: "file_inventory".to_owned(),
                 producer: item.producer,
                 status,
-                file_id: Some(file_record_id),
+                file_id: Some(file_record_id.clone()),
                 reason: item.reason.clone(),
                 anchor: None,
             });
+            coverage_by_file
+                .entry(file_record_id)
+                .or_default()
+                .push(coverage_index);
             if let Some(diagnostic) =
                 inventory_diagnostic(&path, item.status, item.reason.as_deref())
             {

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -27,6 +27,7 @@ use compass_model::provenance::{
 use compass_model::{
     CodeGraphValidationError, GraphError, validate_code_graph, validate_code_graph_records,
 };
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
@@ -48,6 +49,13 @@ const MAX_EXTERNAL_REFERENCE_DIAGNOSTICS: usize = 100;
 enum PublicationMode {
     Strict,
     BestEffort,
+}
+
+struct PreparedEdge {
+    index: usize,
+    raw: RawEdgeRecord,
+    trusted: bool,
+    normalized: Result<EdgeRecord, (GraphError, String)>,
 }
 
 #[derive(Clone, Debug)]
@@ -117,9 +125,42 @@ impl BuildEvidence {
         let mut source_tree = Sha256::new();
         let mut files = Vec::with_capacity(paths.len());
         let mut omitted_external_references = 0_usize;
-        for path in paths {
-            let absolute = repository_root.join(&path);
-            if !absolute.is_file() {
+        let inspected = paths
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_par_iter()
+            .map(|path| {
+                let absolute = repository_root.join(&path);
+                if !absolute.is_file() {
+                    return Ok((path, None));
+                }
+                let language = Registry::resolve(&absolute).map(|spec| spec.name.to_owned());
+                let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
+                    path: absolute,
+                    source,
+                })?;
+                let content_digest = sha256_prefixed(&bytes);
+                let record = FileRecord {
+                    id: file_id(&path),
+                    path: path.clone(),
+                    language,
+                    content_digest,
+                    byte_size: bytes.len() as u64,
+                    generated: false,
+                    extraction_status: ExtractionStatus::Extracted,
+                    extractor_versions: vec![format!(
+                        "compass-languages/{}",
+                        env!("CARGO_PKG_VERSION")
+                    )],
+                    coverage: Vec::new(),
+                    diagnostics: Vec::new(),
+                };
+                Ok((path, Some(record)))
+            })
+            .collect::<Vec<Result<_, GraphError>>>();
+        for inspected in inspected {
+            let (path, record) = inspected?;
+            let Some(record) = record else {
                 if diagnostics.len() < MAX_EXTERNAL_REFERENCE_DIAGNOSTICS {
                     evidence_external_reference_diagnostic(
                         &mut diagnostics,
@@ -130,32 +171,12 @@ impl BuildEvidence {
                     omitted_external_references = omitted_external_references.saturating_add(1);
                 }
                 continue;
-            }
-            let language = Registry::resolve(&absolute).map(|spec| spec.name.to_owned());
-            let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
-                path: absolute,
-                source,
-            })?;
-            let content_digest = sha256_prefixed(&bytes);
+            };
             source_tree.update((path.len() as u64).to_le_bytes());
             source_tree.update(path.as_bytes());
-            source_tree.update((content_digest.len() as u64).to_le_bytes());
-            source_tree.update(content_digest.as_bytes());
-            files.push(FileRecord {
-                id: file_id(&path),
-                path,
-                language,
-                content_digest,
-                byte_size: bytes.len() as u64,
-                generated: false,
-                extraction_status: ExtractionStatus::Extracted,
-                extractor_versions: vec![format!(
-                    "compass-languages/{}",
-                    env!("CARGO_PKG_VERSION")
-                )],
-                coverage: Vec::new(),
-                diagnostics: Vec::new(),
-            });
+            source_tree.update((record.content_digest.len() as u64).to_le_bytes());
+            source_tree.update(record.content_digest.as_bytes());
+            files.push(record);
         }
         if omitted_external_references > 0 {
             diagnostics.push(GraphDiagnostic {
@@ -493,6 +514,58 @@ pub fn normalize_v1_best_effort(
     normalize_v1_with_mode(extraction, evidence, PublicationMode::BestEffort)
 }
 
+fn prepare_edge(
+    raw: RawEdgeRecord,
+    index: usize,
+    id_remap: &HashMap<String, String>,
+    repository_root: &Path,
+    file_facts: &HashMap<String, PublishedFileFacts>,
+) -> PreparedEdge {
+    let trusted = raw.attributes.contains_key(TRUSTED_EDGE_RECORD);
+    let Some(source) = id_remap.get(&raw.source) else {
+        let reason = format!("source {} does not match a retained raw node", raw.source);
+        let strict_reason = format!("source {} does not match a raw node", raw.source);
+        return PreparedEdge {
+            index,
+            raw,
+            trusted,
+            normalized: Err((raw_error(&format!("edge[{index}]"), &strict_reason), reason)),
+        };
+    };
+    let Some(target) = id_remap.get(&raw.target) else {
+        let reason = format!("target {} does not match a retained raw node", raw.target);
+        let strict_reason = format!("target {} does not match a raw node", raw.target);
+        return PreparedEdge {
+            index,
+            raw,
+            trusted,
+            normalized: Err((raw_error(&format!("edge[{index}]"), &strict_reason), reason)),
+        };
+    };
+    let normalized = match raw.attributes.get(TRUSTED_EDGE_RECORD).cloned() {
+        Some(value) => normalize_trusted_edge(
+            &raw,
+            value,
+            source,
+            target,
+            index,
+            repository_root,
+            file_facts,
+        ),
+        None => normalize_edge(&raw, source, target, index, repository_root, file_facts),
+    }
+    .map_err(|error| {
+        let reason = error.to_string();
+        (error, reason)
+    });
+    PreparedEdge {
+        index,
+        raw,
+        trusted,
+        normalized,
+    }
+}
+
 fn normalize_v1_with_mode(
     mut extraction: Extraction,
     mut evidence: BuildEvidence,
@@ -626,83 +699,49 @@ fn normalize_v1_with_mode(
     }
     profile_v1("v1 node normalization", &mut profile_started);
 
-    let mut links = HashMap::<String, EdgeRecord>::with_capacity(extraction.edges.len());
-    for (index, raw) in extraction.edges.into_iter().enumerate() {
-        let source = match id_remap.get(&raw.source) {
-            Some(source) => source.clone(),
-            None if mode == PublicationMode::BestEffort => {
-                quarantine.omit_edge(
-                    &raw_edge_identity(&raw, index),
-                    &format!("source {} does not match a retained raw node", raw.source),
-                    best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts),
-                );
-                continue;
-            }
-            None => {
-                return Err(raw_error(
-                    &format!("edge[{index}]"),
-                    &format!("source {} does not match a raw node", raw.source),
-                ));
-            }
-        };
-        let target = match id_remap.get(&raw.target) {
-            Some(target) => target.clone(),
-            None if mode == PublicationMode::BestEffort => {
-                quarantine.omit_edge(
-                    &raw_edge_identity(&raw, index),
-                    &format!("target {} does not match a retained raw node", raw.target),
-                    best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts),
-                );
-                continue;
-            }
-            None => {
-                return Err(raw_error(
-                    &format!("edge[{index}]"),
-                    &format!("target {} does not match a raw node", raw.target),
-                ));
-            }
-        };
-        let trusted_edge = raw.attributes.contains_key(TRUSTED_EDGE_RECORD);
-        let normalized = match raw.attributes.get(TRUSTED_EDGE_RECORD).cloned() {
-            Some(value) => normalize_trusted_edge(
-                &raw,
-                value,
-                &source,
-                &target,
+    let prepared_edges = extraction
+        .edges
+        .into_par_iter()
+        .enumerate()
+        .map(|(index, raw)| {
+            prepare_edge(
+                raw,
                 index,
+                &id_remap,
                 &evidence.repository_root,
                 &file_facts,
-            ),
-            None => normalize_edge(
-                &raw,
-                &source,
-                &target,
-                index,
-                &evidence.repository_root,
-                &file_facts,
-            ),
-        };
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut links = HashMap::<String, EdgeRecord>::with_capacity(prepared_edges.len());
+    for prepared in prepared_edges {
+        let PreparedEdge {
+            index,
+            raw,
+            trusted,
+            normalized,
+        } = prepared;
         let mut edge = match normalized {
             Ok(edge) => edge,
-            Err(error) if mode == PublicationMode::BestEffort => {
+            Err((_error, reason)) if mode == PublicationMode::BestEffort => {
                 quarantine.omit_edge(
                     &raw_edge_identity(&raw, index),
-                    &error.to_string(),
+                    &reason,
                     best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts),
                 );
                 continue;
             }
-            Err(error) => return Err(error),
+            Err((error, _)) => return Err(error),
         };
         remap_provenance_candidates(&mut edge.evidence, &id_remap);
-        if !trusted_edge
+        if !trusted
             && edge.kind == EdgeKind::Tests
             && let Some(source) = nodes.get_mut(&edge.source)
         {
             source.roles.push(NodeRole::Test);
             sort_dedup_serialized(&mut source.roles);
         }
-        if !trusted_edge
+        if !trusted
             && edge.kind == EdgeKind::Decorates
             && nodes
                 .get(&edge.target)
@@ -762,7 +801,7 @@ fn normalize_v1_with_mode(
                 sort_dedup_serialized(&mut edge.evidence);
             }
         }
-        if !trusted_edge && edge.kind == EdgeKind::TypeOf && source_kind.is_callable() {
+        if !trusted && edge.kind == EdgeKind::TypeOf && source_kind.is_callable() {
             edge.kind = EdgeKind::Returns;
             edge.details = None;
             let id = edge_id(
@@ -775,7 +814,7 @@ fn normalize_v1_with_mode(
             edge.id.clone_from(&id);
             edge.key = id;
         }
-        if !trusted_edge && edge.kind == EdgeKind::Calls && target_is_constructible {
+        if !trusted && edge.kind == EdgeKind::Calls && target_is_constructible {
             edge.kind = EdgeKind::Instantiates;
             edge.details = None;
             let id = edge_id(
@@ -4028,7 +4067,7 @@ fn published_file_facts(
 ) -> Result<HashMap<String, PublishedFileFacts>, GraphError> {
     evidence
         .files
-        .iter()
+        .par_iter()
         .map(|file| {
             let absolute = evidence.repository_root.join(&file.path);
             let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
@@ -4048,6 +4087,8 @@ fn published_file_facts(
                 PublishedFileFacts::from_bytes(&bytes, file.generated),
             ))
         })
+        .collect::<Vec<_>>()
+        .into_iter()
         .collect()
 }
 

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use compass_languages::{Extraction, RawEdgeRecord, RawNodeRecord, Registry};
 use compass_model::code_graph::{
     BuildMetadata, CommunityMetadata, ConfigNodeDetails, CoverageRecord, CoverageStatus,

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -182,6 +182,11 @@ impl BuildEvidence {
             generation.update(value.as_bytes());
         }
         let generation_id = format!("sha256:{:x}", generation.finalize());
+        let published_file_ids = files
+            .iter()
+            .map(|file| (file.path.clone(), file.id.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut coverage_file_ids = HashMap::<String, Option<String>>::new();
         let mut declared_coverage = BTreeSet::new();
         for node in &extraction.nodes {
             if let Some(kind) =
@@ -190,7 +195,12 @@ impl BuildEvidence {
                 declared_coverage.insert((
                     format!("node:{kind}"),
                     coverage_producer(&node.attributes),
-                    coverage_file_id(&node.attributes, &repository_root)?,
+                    coverage_file_id(
+                        &node.attributes,
+                        &repository_root,
+                        &published_file_ids,
+                        &mut coverage_file_ids,
+                    )?,
                 ));
             }
         }
@@ -199,7 +209,12 @@ impl BuildEvidence {
                 declared_coverage.insert((
                     format!("edge:{relation}"),
                     coverage_producer(&edge.attributes),
-                    coverage_file_id(&edge.attributes, &repository_root)?,
+                    coverage_file_id(
+                        &edge.attributes,
+                        &repository_root,
+                        &published_file_ids,
+                        &mut coverage_file_ids,
+                    )?,
                 ));
             }
         }
@@ -440,14 +455,23 @@ fn coverage_producer(attributes: &Map<String, Value>) -> String {
 fn coverage_file_id(
     attributes: &Map<String, Value>,
     root: &Path,
+    published_file_ids: &HashMap<String, String>,
+    cache: &mut HashMap<String, Option<String>>,
 ) -> Result<Option<String>, GraphError> {
-    optional_source_path(attributes, "source_file")
-        .map(|path| {
-            portable_path(&path, root)
-                .map(|path| root.join(&path).is_file().then(|| file_id(&path)))
-        })
-        .transpose()
-        .map(Option::flatten)
+    let Some(path) = attributes
+        .get("source_file")
+        .and_then(Value::as_str)
+        .filter(|path| !path.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    if let Some(file_id) = cache.get(path) {
+        return Ok(file_id.clone());
+    }
+    let portable = portable_path(path, root)?;
+    let file_id = published_file_ids.get(&portable).cloned();
+    cache.insert(path.to_owned(), file_id.clone());
+    Ok(file_id)
 }
 
 /// Publish resolved raw facts as a validated, deterministic Compass graph v1 document.

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -160,6 +160,47 @@ fn raw_semantic_facts_receive_durable_layer_ownership() -> Result<(), Box<dyn st
     Ok(())
 }
 
+#[test]
+fn raw_go_embeddings_remain_first_class_v1_relationships() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut owner = raw_node(root, "owner", "Owner", 10);
+    owner
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("struct"));
+    owner.attributes.insert("language".to_owned(), json!("go"));
+    let mut embedded = raw_node(root, "embedded", "Embedded", 30);
+    embedded
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("interface"));
+    embedded
+        .attributes
+        .insert("language".to_owned(), json!("go"));
+    let graph = normalize_v1(
+        Extraction {
+            nodes: vec![owner, embedded],
+            edges: vec![RawEdgeRecord {
+                source: "owner".to_owned(),
+                target: "embedded".to_owned(),
+                attributes: Map::from_iter([
+                    ("relation".to_owned(), json!("embeds")),
+                    ("confidence".to_owned(), json!("EXTRACTED")),
+                    ("extractor".to_owned(), json!("compass.languages.go")),
+                    ("source_anchor".to_owned(), anchor(root, 50)),
+                ]),
+            }],
+            ..Extraction::default()
+        },
+        build_evidence(root)?,
+    )?;
+
+    assert_eq!(graph.links.len(), 1);
+    assert_eq!(graph.links[0].kind, EdgeKind::Embeds);
+    assert!(validate_code_graph(&graph).is_ok());
+    Ok(())
+}
+
 fn raw_class_node(
     root: &Path,
     id: &str,

--- a/crates/compass-languages/src/bash.rs
+++ b/crates/compass-languages/src/bash.rs
@@ -319,6 +319,17 @@ impl<'source, 'tree> BashState<'source, 'tree> {
             Value::String(self.source_file.clone()),
         );
         attributes.insert("source_location".into(), Value::String(format!("L{at}")));
+        attributes.insert(
+            "symbol_kind".into(),
+            Value::String(
+                match kind {
+                    "file" => "file",
+                    "bash_entrypoint" | "bash_function" => "function",
+                    _ => "variable",
+                }
+                .to_owned(),
+            ),
+        );
         attributes.insert("metadata".into(), Value::Object(metadata));
         self.extraction.nodes.push(NodeRecord {
             id: id.to_owned(),

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -1074,6 +1074,7 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             self.add_edge(&source, &id, "contains", line(node), None);
             if self.language == "python" {
                 self.add_python_parent_edges(node, &id);
+                self.add_python_decorators(node, &id);
             } else if self.language == "java" {
                 self.add_java_parent_edges(node, &id);
                 if kind == "enum_declaration" {
@@ -1151,6 +1152,7 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             );
             if self.language == "python" {
                 self.add_python_function_references(node, &id);
+                self.add_python_decorators(node, &id);
             } else if self.language == "java" {
                 self.add_java_function_references(node, &id);
             } else if self.language == "c" {
@@ -2294,6 +2296,73 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                     "target_qualified_name".to_owned(),
                     Value::String(qualified.clone()),
                 );
+            }
+        }
+    }
+
+    fn add_python_decorators(&mut self, node: Node<'tree>, owner_id: &str) {
+        let Some(decorated) = node
+            .parent()
+            .filter(|parent| parent.kind() == "decorated_definition")
+        else {
+            return;
+        };
+        let mut cursor = decorated.walk();
+        let decorators = decorated
+            .children(&mut cursor)
+            .take_while(|child| child.id() != node.id())
+            .filter(|child| child.kind() == "decorator")
+            .collect::<Vec<_>>();
+        for decorator in decorators {
+            let mut inner = decorator.walk();
+            let Some(mut expression) = decorator
+                .children(&mut inner)
+                .find(|child| child.is_named())
+            else {
+                continue;
+            };
+            if expression.kind() == "call" {
+                expression = expression
+                    .child_by_field_name("function")
+                    .unwrap_or(expression);
+            }
+            let Some(spelling) = self
+                .node_text(expression)
+                .map(|text| text.trim().to_owned())
+                .filter(|text| !text.is_empty())
+            else {
+                continue;
+            };
+            let name = spelling.rsplit('.').next().unwrap_or_default().trim();
+            if name.is_empty() {
+                continue;
+            }
+            let target = self.ensure_type_node(name, true);
+            if target == owner_id {
+                continue;
+            }
+            self.add_edge(
+                owner_id,
+                &target,
+                "references",
+                line(decorator),
+                Some("decorator"),
+            );
+            let qualified = self
+                .python_import_targets
+                .get(&spelling)
+                .cloned()
+                .or_else(|| {
+                    let (root, suffix) = spelling.split_once('.')?;
+                    let imported = self.python_import_targets.get(root)?;
+                    Some(format!("{imported}.{suffix}"))
+                });
+            if let Some(edge) = self.extraction.edges.last_mut() {
+                if let Some(qualified) = qualified {
+                    edge.attributes
+                        .insert("target_qualified_name".to_owned(), Value::String(qualified));
+                }
+                crate::facts::stamp_node_range(&mut edge.attributes, decorator);
             }
         }
     }

--- a/crates/compass-languages/src/go.rs
+++ b/crates/compass-languages/src/go.rs
@@ -44,6 +44,12 @@ struct LexicalBinding {
     active_until: usize,
 }
 
+struct GoTypeRef {
+    name: String,
+    qualifier: Option<String>,
+    generic: bool,
+}
+
 struct GoState<'source, 'tree> {
     source: &'source [u8],
     source_file: String,
@@ -53,7 +59,7 @@ struct GoState<'source, 'tree> {
     extraction: Extraction,
     seen: HashSet<String>,
     function_bodies: Vec<(String, Node<'tree>, Vec<LexicalBinding>)>,
-    imported_packages: HashSet<String>,
+    imported_packages: HashMap<String, String>,
 }
 
 impl<'source, 'tree> GoState<'source, 'tree> {
@@ -76,7 +82,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
             extraction: Extraction::default(),
             seen: HashSet::new(),
             function_bodies: Vec::new(),
-            imported_packages: HashSet::new(),
+            imported_packages: HashMap::new(),
         };
         let label = path
             .file_name()
@@ -87,6 +93,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
     }
 
     fn run(mut self, root: Node<'tree>) -> Extraction {
+        self.prescan_imports(root);
         self.walk_type_declarations(root);
         self.walk(root);
         self.walk_calls();
@@ -100,6 +107,23 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                     ))
         });
         self.extraction
+    }
+
+    fn prescan_imports(&mut self, node: Node<'tree>) {
+        if node.kind() == "import_declaration" {
+            let mut specs = Vec::new();
+            collect_kind(node, "import_spec", &mut specs);
+            for spec in specs {
+                if let Some((local, raw)) = go_import_binding(spec, self.source) {
+                    self.imported_packages.insert(local, raw);
+                }
+            }
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.prescan_imports(child);
+        }
     }
 
     fn walk_type_declarations(&mut self, node: Node<'tree>) {
@@ -259,15 +283,20 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                 });
                 let mut refs = Vec::new();
                 collect_type_refs(type_node, self.source, false, &mut refs);
-                for (name, generic) in refs {
-                    let target = self.ensure_named_node(&name);
+                for reference in refs {
+                    let target =
+                        self.ensure_named_node(&reference.name, reference.qualifier.as_deref());
                     if target == type_id {
                         continue;
                     }
-                    if !has_name && !generic {
+                    if !has_name && !reference.generic {
                         self.add_edge(type_id, &target, "embeds", line(field), None);
                     } else {
-                        let context = if generic { "generic_arg" } else { "field" };
+                        let context = if reference.generic {
+                            "generic_arg"
+                        } else {
+                            "field"
+                        };
                         self.add_edge(type_id, &target, "references", line(field), Some(context));
                     }
                 }
@@ -289,12 +318,13 @@ impl<'source, 'tree> GoState<'source, 'tree> {
             {
                 collect_type_refs(Some(child), self.source, false, &mut refs);
             }
-            for (name, generic) in refs {
-                let target = self.ensure_named_node(&name);
+            for reference in refs {
+                let target =
+                    self.ensure_named_node(&reference.name, reference.qualifier.as_deref());
                 if target == type_id {
                     continue;
                 }
-                if generic {
+                if reference.generic {
                     self.add_edge(
                         type_id,
                         &target,
@@ -354,15 +384,19 @@ impl<'source, 'tree> GoState<'source, 'tree> {
     ) {
         let mut refs = Vec::new();
         collect_type_refs(node, self.source, false, &mut refs);
-        for (name, generic) in refs {
-            let target = self.ensure_named_node(&name);
+        for reference in refs {
+            let target = self.ensure_named_node(&reference.name, reference.qualifier.as_deref());
             if target != id {
                 self.add_edge(
                     id,
                     &target,
                     "references",
                     at,
-                    Some(if generic { "generic_arg" } else { context }),
+                    Some(if reference.generic {
+                        "generic_arg"
+                    } else {
+                        context
+                    }),
                 );
             }
         }
@@ -384,12 +418,8 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                 line(spec),
                 Some("import"),
             );
-            let local = spec
-                .child_by_field_name("name")
-                .map(|name| self.text(name))
-                .unwrap_or_else(|| raw.rsplit('/').next().unwrap_or_default().to_owned());
-            if !matches!(local.as_str(), "" | "_" | ".") {
-                self.imported_packages.insert(local);
+            if let Some((local, _)) = go_import_binding(spec, self.source) {
+                self.imported_packages.insert(local, raw);
             }
         }
     }
@@ -440,7 +470,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
                     .child_by_field_name("operand")
                     .map(|operand| self.text(operand))
                     .unwrap_or_default();
-                (callee, !self.imported_packages.contains(&receiver))
+                (callee, !self.imported_packages.contains_key(&receiver))
             } else {
                 (None, false)
             };
@@ -486,7 +516,42 @@ impl<'source, 'tree> GoState<'source, 'tree> {
         }
     }
 
-    fn ensure_named_node(&mut self, name: &str) -> String {
+    fn ensure_named_node(&mut self, name: &str, qualifier: Option<&str>) -> String {
+        if let Some(qualifier) = qualifier {
+            let imported = self
+                .imported_packages
+                .get(qualifier)
+                .map_or(qualifier, String::as_str);
+            let target_package = imported.rsplit('/').next().unwrap_or(qualifier);
+            let id = make_id(&[imported, name]);
+            if self.seen.insert(id.clone()) {
+                let mut attributes = Map::new();
+                attributes.insert("label".into(), Value::String(name.to_owned()));
+                attributes.insert("file_type".into(), Value::String("code".into()));
+                attributes.insert("symbol_kind".into(), Value::String("symbol".into()));
+                attributes.insert("source_file".into(), Value::String(String::new()));
+                attributes.insert("source_location".into(), Value::String(String::new()));
+                attributes.insert(
+                    "origin_file".into(),
+                    Value::String(self.source_file.clone()),
+                );
+                attributes.insert(
+                    "qualified_name".into(),
+                    Value::String(format!("{imported}.{name}")),
+                );
+                attributes.insert("package".into(), Value::String(imported.to_owned()));
+                attributes.insert("go_import_path".into(), Value::String(imported.to_owned()));
+                attributes.insert(
+                    "go_target_package".into(),
+                    Value::String(target_package.to_owned()),
+                );
+                self.extraction.nodes.push(NodeRecord {
+                    id: id.clone(),
+                    attributes,
+                });
+            }
+            return id;
+        }
         let local = make_id(&[&self.package_scope, name]);
         if self.seen.contains(&local) {
             return local;
@@ -496,6 +561,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
             let mut attributes = Map::new();
             attributes.insert("label".into(), Value::String(name.to_owned()));
             attributes.insert("file_type".into(), Value::String("code".into()));
+            attributes.insert("symbol_kind".into(), Value::String("symbol".into()));
             attributes.insert("source_file".into(), Value::String(String::new()));
             attributes.insert("source_location".into(), Value::String(String::new()));
             attributes.insert(
@@ -522,6 +588,7 @@ impl<'source, 'tree> GoState<'source, 'tree> {
             Value::String(self.source_file.clone()),
         );
         attributes.insert("source_location".into(), Value::String(format!("L{at}")));
+        attributes.insert("package".into(), Value::String(self.package_scope.clone()));
         self.extraction.nodes.push(NodeRecord {
             id: id.to_owned(),
             attributes,
@@ -681,26 +748,32 @@ fn collect_type_refs(
     node: Option<Node<'_>>,
     source: &[u8],
     generic: bool,
-    output: &mut Vec<(String, bool)>,
+    output: &mut Vec<GoTypeRef>,
 ) {
     let Some(node) = node else { return };
     match node.kind() {
         "type_identifier" => {
             let name = node.utf8_text(source).unwrap_or_default();
             if !name.is_empty() && !PREDECLARED_TYPES.contains(&name) {
-                output.push((name.to_owned(), generic));
+                output.push(GoTypeRef {
+                    name: name.to_owned(),
+                    qualifier: None,
+                    generic,
+                });
             }
             return;
         }
         "qualified_type" => {
-            let name = node
-                .utf8_text(source)
-                .unwrap_or_default()
-                .rsplit('.')
-                .next()
-                .unwrap_or_default();
+            let raw = node.utf8_text(source).unwrap_or_default();
+            let (qualifier, name) = raw
+                .rsplit_once('.')
+                .map_or((None, raw), |(qualifier, name)| (Some(qualifier), name));
             if !name.is_empty() && !PREDECLARED_TYPES.contains(&name) {
-                output.push((name.to_owned(), generic));
+                output.push(GoTypeRef {
+                    name: name.to_owned(),
+                    qualifier: qualifier.map(str::to_owned),
+                    generic,
+                });
             }
             return;
         }
@@ -737,6 +810,21 @@ fn collect_kind<'tree>(node: Node<'tree>, kind: &str, output: &mut Vec<Node<'tre
             collect_kind(child, kind, output);
         }
     }
+}
+
+fn go_import_binding(spec: Node<'_>, source: &[u8]) -> Option<(String, String)> {
+    let raw = spec
+        .child_by_field_name("path")?
+        .utf8_text(source)
+        .ok()?
+        .trim_matches('"')
+        .to_owned();
+    let local = spec
+        .child_by_field_name("name")
+        .and_then(|name| name.utf8_text(source).ok())
+        .map(str::to_owned)
+        .unwrap_or_else(|| raw.rsplit('/').next().unwrap_or_default().to_owned());
+    (!raw.is_empty() && !matches!(local.as_str(), "" | "_" | ".")).then_some((local, raw))
 }
 
 fn has_descendant_kind(node: Node<'_>, kind: &str) -> bool {

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -379,6 +379,97 @@ fn repeated_go_calls_keep_each_ast_range() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn bash_entrypoints_and_go_embeddings_retain_typed_exact_facts() -> Result<(), Box<dyn Error>> {
+    let mut engine = Engine::default();
+    let bash = engine.extract_source(
+        std::path::Path::new("scripts/release.sh"),
+        b"#!/usr/bin/env bash\nlog() { :; }\nlog\n",
+    )?;
+    let entry = bash
+        .nodes
+        .iter()
+        .find(|node| node.label() == "release.sh script")
+        .ok_or("missing Bash entrypoint")?;
+    assert_eq!(entry.string("symbol_kind"), "function");
+    assert!(bash.edges.iter().any(|edge| {
+        edge.target == entry.id
+            && edge.string("relation") == "contains"
+            && edge.string("source_location") == "L1"
+    }));
+    assert!(bash.edges.iter().any(|edge| {
+        edge.source == entry.id
+            && edge.string("relation") == "calls"
+            && edge.string("source_location") == "L3"
+    }));
+
+    let go = engine.extract_source(
+        std::path::Path::new("service/types.go"),
+        br#"package service
+import "example.com/project/agent"
+type Local interface { agent.Agent }
+"#,
+    )?;
+    let embedding = go
+        .edges
+        .iter()
+        .find(|edge| edge.string("relation") == "embeds")
+        .ok_or("missing Go embedding")?;
+    assert_eq!(embedding.string("source_location"), "L3");
+    let target = go
+        .nodes
+        .iter()
+        .find(|node| node.id == embedding.target)
+        .ok_or("missing embedding target")?;
+    assert_eq!(target.label(), "Agent");
+    assert_eq!(
+        target.string("qualified_name"),
+        "example.com/project/agent.Agent"
+    );
+    assert_eq!(target.string("go_target_package"), "agent");
+    Ok(())
+}
+
+#[test]
+fn python_decorators_are_exact_uses_not_file_wide_import_inference() -> Result<(), Box<dyn Error>> {
+    let source = br#"from framework import used, unused
+
+@used("class")
+class Consumer:
+    @used("method")
+    def run(self):
+        pass
+"#;
+    let extraction =
+        Engine::default().extract_source(std::path::Path::new("app/consumer.py"), source)?;
+    let uses = extraction
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "references" && edge.string("context") == "decorator"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(uses.len(), 2, "edges={:#?}", extraction.edges);
+    assert_eq!(
+        uses.iter()
+            .map(|edge| edge.string("source_location"))
+            .collect::<Vec<_>>(),
+        ["L3", "L5"]
+    );
+    assert!(uses.iter().all(|edge| {
+        edge.string("target_qualified_name") == "framework.used"
+            && edge.attributes.contains_key("start_byte")
+            && edge.attributes.contains_key("end_byte")
+    }));
+    assert!(
+        extraction
+            .edges
+            .iter()
+            .all(|edge| edge.string("target_qualified_name") != "framework.unused")
+    );
+    Ok(())
+}
+
+#[test]
 fn repeated_zig_calls_keep_each_source_range() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let path = directory.path().join("repeated.zig");

--- a/crates/compass-model/src/code_graph.rs
+++ b/crates/compass-model/src/code_graph.rs
@@ -194,6 +194,7 @@ pub enum NodeRole {
 #[serde(rename_all = "snake_case")]
 pub enum EdgeKind {
     Contains,
+    Embeds,
     Calls,
     Imports,
     Exports,
@@ -228,6 +229,7 @@ impl EdgeKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Contains => "contains",
+            Self::Embeds => "embeds",
             Self::Calls => "calls",
             Self::Imports => "imports",
             Self::Exports => "exports",

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -531,6 +531,7 @@ fn endpoint_kinds_are_valid(
 ) -> bool {
     match kind {
         EdgeKind::Contains => contains_endpoint_pair(source.kind, target.kind),
+        EdgeKind::Embeds => source.kind.is_type() && target.kind.is_type(),
         EdgeKind::Calls => {
             is_call_source(source.kind)
                 && (target.kind.is_callable()

--- a/crates/compass-model/tests/code_graph_v1.rs
+++ b/crates/compass-model/tests/code_graph_v1.rs
@@ -65,6 +65,7 @@ fn v1_vocabularies_serialize_to_the_closed_contract() -> Result<(), Box<dyn std:
 
     let edge_kinds = [
         (EdgeKind::Contains, "contains"),
+        (EdgeKind::Embeds, "embeds"),
         (EdgeKind::Calls, "calls"),
         (EdgeKind::Imports, "imports"),
         (EdgeKind::Exports, "exports"),

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -421,6 +421,7 @@ fn non_recursive_self_loops_are_rejected_but_recursive_calls_are_valid() {
 fn endpoint_matrix_rejects_invalid_pairs_across_relationship_families() {
     for (kind, source_kind, target_kind) in [
         (EdgeKind::Contains, NodeKind::Function, NodeKind::File),
+        (EdgeKind::Embeds, NodeKind::Struct, NodeKind::Function),
         (EdgeKind::Contains, NodeKind::Database, NodeKind::Function),
         (EdgeKind::Contains, NodeKind::Function, NodeKind::Queue),
         (EdgeKind::Calls, NodeKind::File, NodeKind::Class),
@@ -541,6 +542,7 @@ fn tests_edge_accepts_an_explicit_test_role_and_testable_target() {
 #[test]
 fn endpoint_matrix_accepts_nested_dynamic_and_database_producer_shapes() {
     for (kind, source_kind, target_kind) in [
+        (EdgeKind::Embeds, NodeKind::Struct, NodeKind::Interface),
         (EdgeKind::Contains, NodeKind::Function, NodeKind::Method),
         (EdgeKind::Contains, NodeKind::Method, NodeKind::Class),
         (EdgeKind::Contains, NodeKind::TypeAlias, NodeKind::Method),

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -228,6 +228,8 @@ fn finish_resolution(
     profile_internal("resolver import canonicalization", &mut profile_started);
     canonicalize_go_receiver_owners(&mut merged);
     profile_internal("resolver Go receiver ownership", &mut profile_started);
+    canonicalize_go_imported_types(&mut merged, &canonical_root);
+    profile_internal("resolver Go imported types", &mut profile_started);
     disambiguate_colliding_node_ids_with_calls(
         &mut merged,
         &canonical_root,
@@ -690,9 +692,19 @@ fn resolve_python_imported_types(extraction: &mut Extraction, root: &Path) {
             continue;
         };
         let label = node.label().trim();
-        if is_type_like_definition(node) && !label.is_empty() {
+        let definition_name = if is_type_like_definition(node) {
+            Some(label)
+        } else if string_attribute(node, "symbol_kind") == "function"
+            && label.ends_with("()")
+            && !label.starts_with('.')
+        {
+            Some(label.trim_end_matches("()"))
+        } else {
+            None
+        };
+        if let Some(definition_name) = definition_name.filter(|name| !name.is_empty()) {
             definitions
-                .entry(format!("{module}.{label}"))
+                .entry(format!("{module}.{definition_name}"))
                 .or_default()
                 .push(node.id.clone());
         }
@@ -714,7 +726,11 @@ fn resolve_python_imported_types(extraction: &mut Extraction, root: &Path) {
             let Some(target) = target.as_str() else {
                 continue;
             };
-            let target = resolve_relative_python_import(&module, target);
+            let package_module = Path::new(&edge.string("source_file"))
+                .file_name()
+                .and_then(|name| name.to_str())
+                == Some("__init__.py");
+            let target = resolve_relative_python_import(&module, target, package_module);
             if !local.is_empty() && !target.is_empty() {
                 aliases
                     .entry(format!("{module}.{local}"))
@@ -747,7 +763,10 @@ fn resolve_python_imported_types(extraction: &mut Extraction, root: &Path) {
 
     let mut repointed = HashSet::new();
     for edge in &mut extraction.edges {
-        if !matches!(relation(edge), "inherits" | "implements" | "extends") {
+        if !matches!(
+            relation(edge),
+            "inherits" | "implements" | "extends" | "references"
+        ) {
             continue;
         }
         let Some(requested) = edge
@@ -771,12 +790,7 @@ fn resolve_python_imported_types(extraction: &mut Extraction, root: &Path) {
 }
 
 fn python_module_name(source_file: &str, root: &Path) -> Option<String> {
-    let source_path = Path::new(source_file);
-    let source = source_path
-        .strip_prefix(root)
-        .unwrap_or(source_path)
-        .to_string_lossy()
-        .replace('\\', "/");
+    let source = source_key(source_file, root);
     let source = source.strip_suffix(".py")?;
     let source = source.strip_suffix("/__init__").unwrap_or(source);
     let module = source
@@ -787,7 +801,11 @@ fn python_module_name(source_file: &str, root: &Path) -> Option<String> {
     (!module.is_empty()).then_some(module)
 }
 
-fn resolve_relative_python_import(source_module: &str, target: &str) -> String {
+fn resolve_relative_python_import(
+    source_module: &str,
+    target: &str,
+    package_module: bool,
+) -> String {
     let dots = target
         .chars()
         .take_while(|character| *character == '.')
@@ -797,7 +815,9 @@ fn resolve_relative_python_import(source_module: &str, target: &str) -> String {
     }
     let suffix = target.trim_start_matches('.');
     let mut components = source_module.split('.').collect::<Vec<_>>();
-    components.pop();
+    if !package_module {
+        components.pop();
+    }
     for _ in 1..dots {
         components.pop();
     }
@@ -1059,6 +1079,78 @@ fn canonicalize_go_receiver_owners(extraction: &mut Extraction) {
     });
 }
 
+fn canonicalize_go_imported_types(extraction: &mut Extraction, root: &Path) {
+    let mut definitions = HashMap::<(String, String), Vec<(String, String)>>::new();
+    for node in &extraction.nodes {
+        if string_attribute(node, "language") != "go"
+            || !matches!(
+                string_attribute(node, "symbol_kind").as_str(),
+                "class" | "struct" | "interface" | "type_alias"
+            )
+        {
+            continue;
+        }
+        let package = string_attribute(node, "package");
+        let label = node.label().trim();
+        let source = source_key(&string_attribute(node, "source_file"), root);
+        let directory = Path::new(&source)
+            .parent()
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_default();
+        if !package.is_empty() && !label.is_empty() && !directory.is_empty() {
+            definitions
+                .entry((package, label.to_owned()))
+                .or_default()
+                .push((node.id.clone(), directory));
+        }
+    }
+
+    let mut remap = HashMap::<String, String>::new();
+    for node in &extraction.nodes {
+        if string_attribute(node, "language") != "go"
+            || string_attribute(node, "symbol_kind") != "symbol"
+        {
+            continue;
+        }
+        let import_path = string_attribute(node, "go_import_path");
+        let package = string_attribute(node, "go_target_package");
+        let label = node.label().trim();
+        if import_path.is_empty() || package.is_empty() || label.is_empty() {
+            continue;
+        }
+        let Some(candidates) = definitions.get(&(package, label.to_owned())) else {
+            continue;
+        };
+        let compatible = candidates
+            .iter()
+            .filter(|(_, directory)| {
+                import_path == directory.as_str()
+                    || import_path
+                        .strip_suffix(directory.as_str())
+                        .is_some_and(|prefix| prefix.ends_with('/'))
+            })
+            .collect::<Vec<_>>();
+        if let [candidate] = compatible.as_slice() {
+            remap.insert(node.id.clone(), candidate.0.clone());
+        }
+    }
+    if remap.is_empty() {
+        return;
+    }
+    for edge in &mut extraction.edges {
+        if let Some(target) = remap.get(&edge.source) {
+            edge.source.clone_from(target);
+        }
+        if let Some(target) = remap.get(&edge.target) {
+            edge.target.clone_from(target);
+            stamp_endpoint_rewrite(edge, EndpointRewriteRule::UniqueStubEndpointResolution, 1.0);
+        }
+    }
+    extraction
+        .nodes
+        .retain(|node| !remap.contains_key(&node.id));
+}
+
 #[cfg(test)]
 fn disambiguate_colliding_node_ids(extraction: &mut Extraction, root: &Path) {
     let mut raw_calls = extraction.raw_calls.take();
@@ -1256,22 +1348,15 @@ fn resolve_cross_file_calls_with_root_calls(
         .filter(|(source_file, _)| extension(source_file) == "py")
         .map(|(source_file, source)| (source_file.clone(), python_symbol_imports(source)))
         .collect::<HashMap<_, _>>();
-    let (import_edges, class_use_edges) = rayon::join(
-        || {
-            resolve_python_import_guided_with_calls(
-                extraction,
-                sources,
-                root,
-                raw_calls,
-                &python_imports,
-            )
-        },
-        || resolve_python_class_uses(extraction, sources, root, &python_imports),
+    let import_edges = resolve_python_import_guided_with_calls(
+        extraction,
+        sources,
+        root,
+        raw_calls,
+        &python_imports,
     );
     extraction.edges.extend(import_edges);
     profile_internal("resolver Python import-guided calls", &mut profile_started);
-    extraction.edges.extend(class_use_edges);
-    profile_internal("resolver Python class uses", &mut profile_started);
     let mut exact = AHashMap::<String, Vec<String>>::new();
     let mut folded = AHashMap::<String, Vec<String>>::new();
     let mut source_by_id = AHashMap::<String, String>::new();
@@ -1879,121 +1964,6 @@ fn python_module_file(
             .get(&normalize_path(&candidate.to_string_lossy()))
             .cloned()
     })
-}
-
-fn resolve_python_class_uses(
-    extraction: &Extraction,
-    sources: &HashMap<String, String>,
-    root: &Path,
-    python_imports: &HashMap<String, Vec<PythonImport>>,
-) -> Vec<EdgeRecord> {
-    let mut resolved_edges = Vec::new();
-    let mut definitions = HashMap::<String, Vec<(String, String)>>::new();
-    let mut local_classes = HashMap::<String, Vec<String>>::new();
-    for node in &extraction.nodes {
-        let source = string_attribute(node, "source_file");
-        if extension(&source) != "py" {
-            continue;
-        }
-        let label = node.label();
-        if !label.is_empty()
-            && !label.ends_with(')')
-            && !label.ends_with(".py")
-            && !label.starts_with('_')
-            && string_attribute(node, "file_type") != "rationale"
-        {
-            definitions
-                .entry(label.to_owned())
-                .or_default()
-                .push((source.clone(), node.id.clone()));
-        }
-        if !label.ends_with(')')
-            && !label.ends_with(".py")
-            && string_attribute(node, "file_type") != "rationale"
-            && !is_file_node(node, &source)
-        {
-            local_classes
-                .entry(source)
-                .or_default()
-                .push(node.id.clone());
-        }
-    }
-    let normalized_sources = sources
-        .iter()
-        .map(|(source_file, source)| {
-            (
-                normalize_path(source_file),
-                (source_file.as_str(), source.as_str()),
-            )
-        })
-        .collect::<HashMap<_, _>>();
-    let mut known = extraction
-        .edges
-        .iter()
-        .map(|edge| {
-            (
-                edge.source.clone(),
-                edge.target.clone(),
-                relation(edge).to_owned(),
-            )
-        })
-        .collect::<HashSet<_>>();
-    for source_file in sources.keys() {
-        if extension(source_file) != "py" {
-            continue;
-        }
-        let Some(classes) = local_classes.get(source_file) else {
-            continue;
-        };
-        let Some(imports) = python_imports.get(source_file) else {
-            continue;
-        };
-        for imported in imports {
-            let candidates = python_resolved_definition_candidates(
-                Path::new(source_file),
-                root,
-                &imported.module,
-                &imported.imported,
-                &definitions,
-                &normalized_sources,
-                true,
-            );
-            if candidates.len() != 1 {
-                continue;
-            }
-            for source_id in classes {
-                let target = &candidates[0];
-                if !known.insert((source_id.clone(), target.clone(), "uses".to_owned())) {
-                    continue;
-                }
-                let mut attributes = Map::new();
-                attributes.insert("relation".to_owned(), Value::String("uses".to_owned()));
-                attributes.insert(
-                    "confidence".to_owned(),
-                    Value::String("INFERRED".to_owned()),
-                );
-                attributes.insert("language".to_owned(), Value::String("python".to_owned()));
-                attributes.insert(
-                    "extractor".to_owned(),
-                    Value::String("compass.resolve.python-imports".to_owned()),
-                );
-                attributes.insert("_origin".to_owned(), Value::String("heuristic".to_owned()));
-                attributes.insert(
-                    "rule".to_owned(),
-                    Value::String("python-imported-class-use-inference".to_owned()),
-                );
-                attributes.insert("confidence_score".to_owned(), Value::from(0.8));
-                insert_python_import_anchor(&mut attributes, source_file, imported);
-                attributes.insert("weight".to_owned(), Value::from(0.8));
-                resolved_edges.push(EdgeRecord {
-                    source: source_id.clone(),
-                    target: target.clone(),
-                    attributes,
-                });
-            }
-        }
-    }
-    resolved_edges
 }
 
 #[cfg(test)]
@@ -3239,7 +3209,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_adds_import_guided_calls_and_class_uses() {
+    fn resolve_adds_import_guided_calls_without_unused_class_edges() {
         let file_a = make_id(&["app/a.py"]);
         let file_b = make_id(&["app/b.py"]);
         let mut import_call = raw("caller", "run", "app/a.py");
@@ -3269,10 +3239,10 @@ mod tests {
                 && relation(candidate) == "calls"
                 && candidate.string("confidence") == "EXTRACTED"
         }));
-        assert!(resolved.edges.iter().any(|candidate| {
-            candidate.source == "local-class"
-                && candidate.target == "widget"
-                && relation(candidate) == "uses"
+        assert!(resolved.edges.iter().all(|candidate| {
+            candidate.source != "local-class"
+                || candidate.target != "widget"
+                || relation(candidate) != "uses"
         }));
         assert!(resolved.edges.iter().any(|candidate| {
             candidate.source == file_a

--- a/crates/compass-resolve/tests/go_resolution.rs
+++ b/crates/compass-resolve/tests/go_resolution.rs
@@ -63,6 +63,131 @@ func (a *Agent) Finish() {}
 }
 
 #[test]
+fn qualified_go_embeddings_bind_packages_without_cross_module_name_joins()
+-> Result<(), Box<dyn Error>> {
+    let agent_path = Path::new("cmd/agent/agent.go");
+    let agent_source = b"package agent\n\ntype Agent interface { Run() }\n";
+    let wrapper_path = Path::new("cmd/client/wrapper.go");
+    let wrapper_source = br#"package client
+
+import "example.com/project/cmd/agent"
+
+type Wrapper interface {
+    agent.Agent
+}
+"#;
+    let context_path = Path::new("internal/contexts/context.go");
+    let context_source = b"package contexts\n\ntype Context struct{}\n";
+    let caller_path = Path::new("cmd/client/run.go");
+    let caller_source = br#"package client
+
+import "context"
+
+func Run(ctx context.Context) {}
+"#;
+    let external_path = Path::new("cmd/external/wrapper.go");
+    let external_source = br#"package external
+
+import "other.example/agent"
+
+type External interface {
+    agent.Agent
+}
+"#;
+
+    let mut engine = Engine::default();
+    let extractions = [
+        engine.extract_source(agent_path, agent_source)?,
+        engine.extract_source(wrapper_path, wrapper_source)?,
+        engine.extract_source(context_path, context_source)?,
+        engine.extract_source(caller_path, caller_source)?,
+        engine.extract_source(external_path, external_source)?,
+    ];
+    let sources = HashMap::from([
+        (
+            agent_path.to_string_lossy().into_owned(),
+            String::from_utf8(agent_source.to_vec())?,
+        ),
+        (
+            wrapper_path.to_string_lossy().into_owned(),
+            String::from_utf8(wrapper_source.to_vec())?,
+        ),
+        (
+            context_path.to_string_lossy().into_owned(),
+            String::from_utf8(context_source.to_vec())?,
+        ),
+        (
+            caller_path.to_string_lossy().into_owned(),
+            String::from_utf8(caller_source.to_vec())?,
+        ),
+        (
+            external_path.to_string_lossy().into_owned(),
+            String::from_utf8(external_source.to_vec())?,
+        ),
+    ]);
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, Path::new("."));
+
+    let agent = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "Agent" && node.string("source_file") == agent_path.to_string_lossy()
+        })
+        .ok_or("missing Agent definition")?;
+    let embedding = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "embeds"
+                && edge.string("source_file") == wrapper_path.to_string_lossy()
+        })
+        .ok_or("missing embedding")?;
+    assert_eq!(
+        embedding.target, agent.id,
+        "nodes={:#?} embedding={embedding:#?}",
+        resolved.nodes
+    );
+
+    let local_context = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "Context"
+                && node.string("source_file") == context_path.to_string_lossy()
+        })
+        .ok_or("missing repository Context")?;
+    let external_context = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name") == "context.Context"
+                && node.string("source_file").is_empty()
+        })
+        .ok_or("missing qualified standard-library Context")?;
+    assert_ne!(external_context.id, local_context.id);
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "references" && edge.target == external_context.id
+    }));
+    assert!(resolved.edges.iter().all(|edge| {
+        edge.string("source_file") != caller_path.to_string_lossy()
+            || edge.string("relation") != "references"
+            || edge.target != local_context.id
+    }));
+    let external_agent = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "other.example/agent.Agent")
+        .ok_or("missing path-qualified external Agent")?;
+    assert_ne!(external_agent.id, agent.id);
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("source_file") == external_path.to_string_lossy()
+            && edge.string("relation") == "embeds"
+            && edge.target == external_agent.id
+    }));
+    Ok(())
+}
+
+#[test]
 fn go_local_callback_is_not_exported_for_cross_file_resolution() -> Result<(), Box<dyn Error>> {
     let path = Path::new("internal/pushqueue/pushqueue.go");
     let source = br#"package pushqueue

--- a/crates/compass-resolve/tests/python_import_provenance.rs
+++ b/crates/compass-resolve/tests/python_import_provenance.rs
@@ -21,6 +21,71 @@ fn write(root: &Path, relative: &str, source: &str) -> Result<String, Box<dyn Er
 }
 
 #[test]
+fn python_decorator_uses_resolve_reexports_at_the_decorator_occurrence()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "app.py",
+            "from framework import used, unused\n\n@used('class')\nclass Consumer:\n    @used('method')\n    def run(self):\n        pass\n",
+        ),
+        ("framework/__init__.py", "from .decorators import used\n"),
+        (
+            "framework/decorators.py",
+            "def used(value):\n    return value\n",
+        ),
+    ];
+    let mut engine = Engine::default();
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = write(root, relative, source)?;
+        extractions.push(engine.extract(Path::new(&path))?);
+        sources.insert(path, source.to_owned());
+    }
+
+    let extraction = resolve_with_root(&extractions, &sources, root);
+    let target = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "used()"
+                && node
+                    .string("source_file")
+                    .ends_with("framework/decorators.py")
+        })
+        .ok_or("missing anchored decorator definition")?;
+    let decorator_edges = extraction
+        .edges
+        .iter()
+        .filter(|edge| edge.string("context") == "decorator")
+        .collect::<Vec<_>>();
+    assert_eq!(decorator_edges.len(), 2, "edges={:#?}", extraction.edges);
+    assert!(
+        decorator_edges.iter().all(|edge| edge.target == target.id),
+        "target={target:#?} edges={decorator_edges:#?}"
+    );
+    assert_eq!(
+        decorator_edges
+            .iter()
+            .map(|edge| edge.string("source_location"))
+            .collect::<Vec<_>>(),
+        ["L3", "L5"]
+    );
+    assert!(decorator_edges.iter().all(|edge| {
+        edge.attributes.contains_key("start_byte")
+            && edge.attributes.contains_key("end_byte")
+            && edge.attributes.contains_key("_endpoint_rewrite_rules")
+    }));
+    assert!(extraction.edges.iter().all(|edge| {
+        edge.string("target_qualified_name") != "framework.unused"
+            && edge.string("rule") != "python-imported-class-use-inference"
+    }));
+    Ok(())
+}
+
+#[test]
 fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let root = directory.path();
@@ -66,25 +131,18 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         "python-symbol-import-resolution",
         "python-submodule-import-resolution",
         "python-module-re-export-resolution",
-        "python-imported-class-use-inference",
     ] {
         assert!(rules.contains(rule), "missing raw resolver rule {rule}");
     }
+    assert!(
+        !rules.contains("python-imported-class-use-inference"),
+        "unused imports must not create relationships to every class"
+    );
     assert!(resolver_edges.iter().all(|edge| {
         edge.string("language") == "python" && edge.string("extractor") == PYTHON_IMPORT_PRODUCER
     }));
     assert!(resolver_edges.iter().all(|edge| {
-        if edge.string("rule") == "python-imported-class-use-inference" {
-            edge.string("_origin") == "heuristic"
-                && edge.string("confidence") == "INFERRED"
-                && edge
-                    .attributes
-                    .get("confidence_score")
-                    .and_then(serde_json::Value::as_f64)
-                    == Some(0.8)
-        } else {
-            edge.string("_origin") == "convention" && edge.string("confidence") == "EXTRACTED"
-        }
+        edge.string("_origin") == "convention" && edge.string("confidence") == "EXTRACTED"
     }));
 
     let caller_path = root.join("caller.py").to_string_lossy().into_owned();
@@ -177,7 +235,6 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         "python-symbol-import-resolution",
         "python-submodule-import-resolution",
         "python-module-re-export-resolution",
-        "python-imported-class-use-inference",
     ] {
         assert!(
             published_rules.contains(rule),
@@ -185,19 +242,11 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         );
     }
     for (edge, evidence) in &published {
-        if evidence.rule.as_deref() == Some("python-imported-class-use-inference") {
-            assert_eq!(edge.kind, EdgeKind::References);
-            assert_eq!(evidence.origin, EvidenceOrigin::Heuristic);
-            assert_eq!(evidence.confidence, EvidenceConfidence::Inferred);
-            assert!(evidence.anchors.is_empty());
-            assert_eq!(evidence.score, Some(0.8));
-            assert!(evidence.wiring_site.is_some());
-        } else {
-            assert_eq!(evidence.origin, EvidenceOrigin::Convention);
-            assert_eq!(evidence.confidence, EvidenceConfidence::Exact);
-            assert_eq!(evidence.anchors.len(), 1);
-            assert!(evidence.wiring_site.is_none());
-        }
+        let _ = edge;
+        assert_eq!(evidence.origin, EvidenceOrigin::Convention);
+        assert_eq!(evidence.confidence, EvidenceConfidence::Exact);
+        assert_eq!(evidence.anchors.len(), 1);
+        assert!(evidence.wiring_site.is_none());
     }
     let multiline_evidence = published
         .iter()

--- a/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
+++ b/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
@@ -125,7 +125,8 @@ source file
   creation/repository state continue to pass.
 - Residual missing facts are grouped into genuine Compass gaps, external facts,
   and demonstrated Graphify false positives.
-- Run `graphify update .` in the parent repository after code changes.
+- Do not rerun Graphify during final Compass verification; retain the pinned
+  Graphify 0.9.31 artifacts as the comparison baseline.
 
 ## Execution tasks
 
@@ -203,8 +204,8 @@ Post-implementation verification:
 - [x] Run the four semantic query oracles.
 - [x] Record before/after quality, latency, peak RSS, and residual categories
   in the performance review.
-- [x] Run `graphify update .`.
-- [x] Commit only phase-two files, push the branch, and create a pull request
+- [x] Preserve the retained Graphify baseline without rerunning Graphify.
+- [ ] Commit only phase-two files, push the branch, and create a pull request
   targeting `main`.
 
 ## Qualification outcome

--- a/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
+++ b/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
@@ -1,0 +1,219 @@
+# Semantic Dominance Phase Two Implementation Plan
+
+> **Execution rule:** This phase is implementation-first. Production changes
+> are made before focused regression tests are added. Graphify remains a
+> development-only baseline; no Graphify behavior or dependency enters Compass
+> production code.
+
+**Goal:** Close the next set of source-backed semantic gaps on the pinned
+Django and Entire repositories while reducing publication and resolution
+overhead. Preserve shell entrypoints, publish Go embedding as a first-class
+relationship, anchor Python decorator uses at their real occurrences, and
+remove broad import-to-class inference that creates false relationships.
+
+**Architecture:** Language extractors emit exact AST facts with source
+occurrences. The resolver may canonicalize an endpoint only when package,
+module, import, or ownership evidence selects one definition. The strict v1
+publisher retains the resulting relationship vocabulary without collapsing
+semantically distinct edges. The comparison harness proves exact coverage or
+bounded dominance and separately records Graphify facts that are not safe to
+copy, such as a standard-library Go type incorrectly joined to an unrelated
+repository-local type.
+
+**Tech stack:** Rust 2024, tree-sitter, serde/serde_json, SQLite, Python 3,
+Cargo, the existing `benchmarks/performance` harness, Graphify 0.9.31 as an
+explicit development oracle.
+
+## Background
+
+PR #86 merged into `main` at `82e73ce`. It delivered cache identity
+correctness, byte-stable cold/warm graphs, unchanged-build reuse, bounded
+artifact retention, faster semantic comparison, identifier-aware query
+ranking, cold-build preflight elimination, and reduced graph-publication
+cloning.
+
+The merged real-corpus comparison is deliberately fail-closed:
+
+| Repository | Fact | Exact | Dominated | Ambiguous | Missing |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Django | Nodes | 50,466 | 6 | 25 | 345 |
+| Django | Edges | 149,993 | 336 | 26 | 8,349 |
+| Entire | Nodes | 19,866 | 663 | 6 | 50 |
+| Entire | Edges | 53,593 | 6,104 | 18 | 1,347 |
+
+Fresh phase-two indexes were rebuilt from the final graph artifacts using
+comparison schema v2. The dominant actionable categories are:
+
+- 48 shell entry nodes are extracted but discarded before publication because
+  `bash_entrypoint` is stored only in nested metadata rather than the strict
+  node-kind field. Their file containment and top-level function calls are
+  consequently lost.
+- 59 measured Go embedding relationships are extracted with exact occurrences
+  but strict publication collapses `embeds` into `contains`.
+- Python import-use inference joins every imported name to every class in a
+  file and anchors the relationship at the import statement. This creates
+  false positives and misses real decorator occurrences such as
+  `@isolate_apps` at line 6.
+- Some generated Go receiver placeholders are ambiguous only because
+  comparison discards exact label case before considering the two real,
+  case-distinct package types (`EphemeralStore` and `ephemeralStore`).
+- Many residual Go `Context`, `Response`, and similar baseline edges are not
+  safe targets. Graphify binds qualified standard-library or external types to
+  unrelated same-named repository definitions. Compass must retain a qualified
+  external endpoint rather than reproduce that false resolution.
+
+The current performance evidence is:
+
+| Repository | Compass cold p50 | Compass warm p50 | Graphify cold | Ratio |
+| --- | ---: | ---: | ---: | ---: |
+| Django | 12.355s | 2.182s | 49.985s | 4.05x |
+| Entire | 4.055s | 0.586s | 17.650s | 4.35x |
+
+The branch begins with `f1a39a1`, which skips sorting/deduplicating evidence
+vectors of length zero or one. This optimization remains part of phase two.
+
+## Production data flow
+
+```text
+source file
+  -> language AST extraction
+       -> typed nodes + exact relationship occurrences
+       -> qualified unresolved endpoint facts when a definition is external
+  -> collection-wide resolver
+       -> import/package/owner constrained canonicalization
+       -> no label-only cross-module joins
+  -> strict compass.graph/1 publication
+       -> first-class embeds / calls / references / contains semantics
+       -> deterministic validation
+  -> graph.json
+  -> development-only Graphify comparison and residual audit
+```
+
+## Semantic rules
+
+- `embeds` is distinct from `contains`: embedding affects promoted fields and
+  methods and must survive the public schema.
+- A shell entrypoint is a source-backed callable at line 1, contained by its
+  file and owning only top-level calls.
+- Python decorator relationships are emitted only for decorators present on
+  that class or callable and use the decorator AST range.
+- Import evidence may resolve a decorator or base to one qualified repository
+  definition. It must not infer that every class uses every imported symbol.
+- Case-sensitive spelling may disambiguate otherwise compatible generated
+  owners; case folding alone may never select among case-distinct definitions.
+- External Go types remain qualified external facts. They are not rebound to a
+  repository type merely because the final identifier segment matches.
+- Comparison rules may recognize stronger Compass semantics, but may not erase
+  relation kind, occurrence, module, or endpoint conflicts.
+
+## Acceptance gates
+
+- Both graphs publish with zero validation errors and deterministic canonical
+  digests.
+- Entire publishes all source-backed shell entrypoints and all extracted Go
+  embedding occurrences without converting them to `contains`.
+- Django decorator edges use exact decorator lines; broad import-to-every-class
+  edges are absent.
+- Entire ambiguous generated-owner nodes decrease from 6 without a label-only
+  resolution rule.
+- No exact or dominated coverage regression in unaffected relation families.
+- Focused owning-crate tests and the full workspace test suite pass after the
+  production implementation.
+- Django and Entire cold/warm builds are remeasured; any regression greater
+  than 10% is diagnosed before delivery.
+- Query oracles for Django URL resolution/model save and Entire checkpoint
+  creation/repository state continue to pass.
+- Residual missing facts are grouped into genuine Compass gaps, external facts,
+  and demonstrated Graphify false positives.
+- Run `graphify update .` in the parent repository after code changes.
+
+## Execution tasks
+
+### Task 1: Preserve source-backed relationship vocabulary
+
+Production first:
+
+- [x] Add `EdgeKind::Embeds` to `compass.graph/1`, its string form, validation,
+  and raw-v1 mapping.
+- [x] Publish Bash entrypoints as typed callable nodes instead of generic nodes
+  discarded during normalization.
+- [x] Keep exact AST relationship sites on both facts.
+
+Post-implementation verification:
+
+- [x] Add model/v1 serialization and endpoint validation coverage for
+  `embeds`.
+- [x] Add Bash extraction/publication coverage for file → entrypoint and
+  entrypoint → function calls.
+
+### Task 2: Replace Python class-import inference with exact decorator facts
+
+Production first:
+
+- [x] Extract decorators on Python classes, functions, and methods at the
+  decorator occurrence.
+- [x] Carry qualified import targets on those exact edges.
+- [x] Extend qualified Python endpoint resolution to safe decorator/reference
+  relations.
+- [x] Remove the collection-wide rule that connects every import to every
+  class.
+
+Post-implementation verification:
+
+- [x] Cover direct, aliased, re-exported, class, and method decorators.
+- [x] Prove an unused import creates no class relationship.
+- [x] Prove repeated decorator occurrences remain distinct.
+
+### Task 3: Tighten generated owner and unresolved target identity
+
+Production first:
+
+- [x] Preserve package-qualified Go type spellings for external type
+  references and embedding targets.
+- [x] Resolve same-package receiver owners only through package identity.
+- [x] Use exact case as a fail-closed discriminator for generated Graphify
+  owner placeholders in the development comparator.
+- [x] Retain qualified external targets instead of joining common names across
+  modules.
+
+Post-implementation verification:
+
+- [x] Cover case-distinct package types and method owners.
+- [x] Cover qualified external Go types that collide with a local type.
+- [x] Cover same-package embedding and receiver ownership.
+
+### Task 4: Optimize the changed paths
+
+Production first:
+
+- [x] Avoid work proportional to all imports × all classes.
+- [x] Reuse per-file import maps and bounded candidate indexes.
+- [x] Keep the already committed trivial evidence sort fast path.
+
+Post-implementation verification:
+
+- [x] Profile Django and Entire cold builds with internal phase timings.
+- [x] Confirm deterministic cold/warm output and unchanged-build reuse.
+
+### Task 5: Real-corpus qualification and delivery
+
+- [x] Build release Compass from the final tree.
+- [x] Rebuild Django and Entire graphs from clean output directories.
+- [x] Re-index and compare both graphs against Graphify 0.9.31.
+- [x] Run the four semantic query oracles.
+- [x] Record before/after quality, latency, peak RSS, and residual categories
+  in the performance review.
+- [x] Run `graphify update .`.
+- [x] Commit only phase-two files, push the branch, and create a pull request
+  targeting `main`.
+
+## Qualification outcome
+
+The implementation passes the source-backed acceptance gates. It deliberately
+does not claim a literal Graphify superset: the strict raw comparison now
+classifies Graphify's import-line-to-every-class Python inference as rejected
+baseline evidence. Qualified Go types rebound to unrelated local names remain
+visible as missing conflicts. Neither family is a relationship Compass should
+reproduce. Exact decorator occurrences, shell entrypoints, Go embeddings,
+package-aware identities, query oracles, deterministic publication, and build
+performance are recorded in the performance review.

--- a/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
+++ b/docs/superpowers/plans/2026-07-30-semantic-dominance-phase-2.md
@@ -205,7 +205,7 @@ Post-implementation verification:
 - [x] Record before/after quality, latency, peak RSS, and residual categories
   in the performance review.
 - [x] Preserve the retained Graphify baseline without rerunning Graphify.
-- [ ] Commit only phase-two files, push the branch, and create a pull request
+- [x] Commit only phase-two files, push the branch, and create a pull request
   targeting `main`.
 
 ## Qualification outcome

--- a/docs/superpowers/reviews/2026-07-30-compass-performance-baseline.md
+++ b/docs/superpowers/reviews/2026-07-30-compass-performance-baseline.md
@@ -190,6 +190,81 @@ the required `URLResolver`.
 | Entire checkpoint creation | 0.655 s, pass | 1.199 s, pass |
 | Entire repository state | 1.614 s, pass | 1.923 s, pass |
 
+### Phase-two source-backed qualification
+
+Phase two was implemented before its regression tests, following the execution
+rule in the phase plan. The final release binary was rebuilt from the delivery
+tree before evidence collection. Fresh output roots were used for both
+repositories, and every cold and warm graph was byte-identical:
+
+- Django graph SHA-256:
+  `e9aa16897e1e01d0dac5222f65af8efed7c94e11901289435cbd4d6660c6e489`
+- Entire graph SHA-256:
+  `27b28636f29a94470e742a38fe53e0c5f429291b169109420c544377079f758a`
+
+Both final graphs indexed with zero validation errors. The strict comparison
+against the same Graphify 0.9.31 artifacts produced:
+
+| Repository | Graphify fact | Exact | Dominated | Rejected | Ambiguous | Missing |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Django | Nodes | 50,457 | 9 | 0 | 33 | 346 |
+| Django | Edges | 100,077 | 1,198 | 53,005 | 63 | 4,367 |
+| Entire | Nodes | 19,655 | 857 | 0 | 72 | 1 |
+| Entire | Edges | 54,323 | 3,029 | 0 | 196 | 3,514 |
+
+The raw Django edge result is intentionally not presented as a coverage win.
+The implementation removed the all-imports × all-classes resolver rule. In the
+pinned corpus, 52,967 Graphify `references` edges use an import statement as
+the occurrence for every class in the importing file; these moved from exact
+to the comparator's explicit `rejected` category. Rejection requires the
+reference target and occurrence to coincide with a real import edge, so it
+does not turn arbitrary missing facts into passes. In exchange, 3,102
+previously missing decorator references became exact at their real decorator
+lines. The phase also moved 46 inherited-type edges from dominated to exact,
+added 32 exact calls, and restored two shell containment edges. A unique
+same-target relationship at the same exact occurrence may now dominate a
+Graphify relationship whose owner is only a broader placeholder; this accounts
+for the increase to 1,198 dominated Django edges.
+
+Entire gained 53 exact and four dominated first-class `embeds` edges, 50 exact
+shell containment edges, 90 exact calls, and 46 exact references. Fifty
+previously missing nodes became exact, leaving one missing node. The stricter
+package identity also moved 2,548 formerly dominated reference edges to
+missing, chiefly cases such as `time.Time` or `context.Context` that Graphify
+had rebound to an unrelated repository-local type with the same final name.
+The remaining raw misses contain both conservative external identities and
+genuine unresolved call/reference targets; they remain visible rather than
+being accepted through label-only matching.
+
+The final release measurements used the same `compass extract --code-only
+--timing --out` contract as the harness:
+
+| Repository | Cold total | Warm p50 | Peak cold RSS | Change from phase one |
+| --- | ---: | ---: | ---: | --- |
+| Django | 9.8 s | 1.60 s | 4.07 GiB | cold -20.7%, warm -26.7% |
+| Entire | 4.3 s | 0.53 s | 1.40 GiB | cold +6.0%, warm -9.6% |
+
+The Entire cold change remains inside the 10% diagnosis gate. Relative to the
+pinned Graphify cold medians, the observed speedups are 5.10x for Django and
+4.10x for Entire. Publication now uses indexed inventory/file-coverage lookups,
+fast hash indexes, a trivial-evidence fast path, and skips a redundant second
+document validation when best-effort sanitization already proved the graph
+valid.
+
+All four semantic query oracles passed on the final graphs:
+
+| Repository / query | Compass phase two |
+| --- | ---: |
+| Django URL resolution | 1.492 s, pass |
+| Django model save | 1.404 s, pass |
+| Entire checkpoint creation | 0.737 s, pass |
+| Entire repository state | 0.677 s, pass |
+
+Strict Graphify-superset quality is therefore still not achieved. Phase two
+improves the source-backed graph and makes baseline conflicts explicit; the
+next quality target is the residual genuine unresolved call/reference set,
+not restoration of the audited false-positive families.
+
 ## Changes validated
 
 - Exact path-aware AST cache keys prevent byte-identical symlinks from losing

--- a/docs/superpowers/reviews/2026-07-30-compass-performance-baseline.md
+++ b/docs/superpowers/reviews/2026-07-30-compass-performance-baseline.md
@@ -6,8 +6,9 @@ Date: 2026-07-30
 
 The qualification harness lives in `benchmarks/performance/` and defaults to
 Compass-only execution. Graphify comparison is explicit. A separate three-run
-Graphify cold-build confirmation was performed after the final Compass
-verification.
+Graphify cold-build confirmation was performed earlier in the work. Final
+Compass verification reused the pinned Graphify 0.9.31 artifacts and did not
+rerun Graphify.
 
 The checked-in suite pins Django, Spring Framework, Rails, Laravel, Bevy,
 ASP.NET Core, Angular, and Entire to exact remote commits at run time. This
@@ -20,11 +21,13 @@ because all eight repositories were not measured on this runner.
 - Hardware: Apple M2 Max, 12 logical cores, 32 GiB RAM
 - OS: Darwin 25.5.0 arm64
 - Rust: 1.97.1
-- Final Compass commit: `b86dc228037b6410e006078ec85e76bf44ef7c9d`
+- Final measured Compass commit:
+  `35d13d4faff9fd8cf14191155edf80ebf4b2bdcb`
 - Final Compass release SHA-256:
-  `9c27ea72451d1bde002753b744a18698f5ff5e9ed742977df23d96ce6e9bcb9c`
-- Graphify version: 0.9.30
-- Graphify commit: `ecfcd160d56b420eb8241430fa7b5b1951c7829f`
+  `abfdd5a76e7f58c91b9368ee154db2288126f17b7e128b5fc53833ea6f6372ca`
+- Retained Graphify baseline version: 0.9.31
+- Retained Graphify baseline commit:
+  `4fe11092ccbe9f543608f140c790f68d5d83cae4`
 - Django commit: `50d706d0aebcc2d073c8d034b6e22fc98fad49f2`
 - Entire commit: `279b988597f1037c14cdd4c46765a5552e067d17`
 
@@ -194,13 +197,15 @@ the required `URLResolver`.
 
 Phase two was implemented before its regression tests, following the execution
 rule in the phase plan. The final release binary was rebuilt from the delivery
-tree before evidence collection. Fresh output roots were used for both
-repositories, and every cold and warm graph was byte-identical:
+tree before evidence collection. The production binary is unchanged between
+`034fb1e` and the final comparator-only commit `35d13d4`. Fresh output roots
+were used for both repositories, and every eligible build produced the same
+canonical correctness digest:
 
 - Django graph SHA-256:
-  `e9aa16897e1e01d0dac5222f65af8efed7c94e11901289435cbd4d6660c6e489`
+  `a55af88fb1a88a58f247270bcc961227f7db89d5fe9dc531d9e38ab272be89ff`
 - Entire graph SHA-256:
-  `27b28636f29a94470e742a38fe53e0c5f429291b169109420c544377079f758a`
+  `e985a75ac4d59972b39392cfa70efe5596df6587c39664d0f06e436f66d7bec7`
 
 Both final graphs indexed with zero validation errors. The strict comparison
 against the same Graphify 0.9.31 artifacts produced:
@@ -208,17 +213,27 @@ against the same Graphify 0.9.31 artifacts produced:
 | Repository | Graphify fact | Exact | Dominated | Rejected | Ambiguous | Missing |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
 | Django | Nodes | 50,457 | 9 | 0 | 33 | 346 |
-| Django | Edges | 100,077 | 1,198 | 53,005 | 63 | 4,367 |
-| Entire | Nodes | 19,655 | 857 | 0 | 72 | 1 |
-| Entire | Edges | 54,323 | 3,029 | 0 | 196 | 3,514 |
+| Django | Edges | 100,077 | 1,198 | 53,045 | 63 | 4,327 |
+| Entire | Nodes | 19,695 | 842 | 0 | 47 | 1 |
+| Entire | Edges | 54,309 | 2,993 | 2,889 | 129 | 742 |
 
-The raw Django edge result is intentionally not presented as a coverage win.
+Rejected facts are audited baseline conflicts, not Compass matches. After
+removing those conflicts from the source-grounded denominator, Compass has
+95.84% accepted Django edge coverage and 98.50% accepted Entire edge coverage;
+node exact-or-dominated coverage is 99.25% and 99.77%, respectively. Compass
+publishes 55,120 nodes and 130,847 distinct edges for Django, and 21,711 nodes
+and 72,250 edges for Entire. That is 4,275 more nodes than Graphify on Django,
+1,126 more on Entire, and 11,188 more total edges on Entire, while both Compass
+graphs retain zero validation errors.
+
+The raw Django edge result is intentionally not presented as a literal recall
+win.
 The implementation removed the all-imports × all-classes resolver rule. In the
-pinned corpus, 52,967 Graphify `references` edges use an import statement as
-the occurrence for every class in the importing file; these moved from exact
-to the comparator's explicit `rejected` category. Rejection requires the
-reference target and occurrence to coincide with a real import edge, so it
-does not turn arbitrary missing facts into passes. In exchange, 3,102
+pinned corpus, 53,005 Graphify `references` edges project an import occurrence
+onto symbols without a symbol-use occurrence; these moved to the comparator's
+explicit `rejected` category. Rejection requires the reference target and
+occurrence to coincide with a real import fact, so it does not turn arbitrary
+missing facts into passes. In exchange, 3,102
 previously missing decorator references became exact at their real decorator
 lines. The phase also moved 46 inherited-type edges from dominated to exact,
 added 32 exact calls, and restored two shell containment edges. A unique
@@ -226,44 +241,52 @@ same-target relationship at the same exact occurrence may now dominate a
 Graphify relationship whose owner is only a broader placeholder; this accounts
 for the increase to 1,198 dominated Django edges.
 
-Entire gained 53 exact and four dominated first-class `embeds` edges, 50 exact
-shell containment edges, 90 exact calls, and 46 exact references. Fifty
-previously missing nodes became exact, leaving one missing node. The stricter
-package identity also moved 2,548 formerly dominated reference edges to
-missing, chiefly cases such as `time.Time` or `context.Context` that Graphify
-had rebound to an unrelated repository-local type with the same final name.
-The remaining raw misses contain both conservative external identities and
-genuine unresolved call/reference targets; they remain visible rather than
-being accepted through label-only matching.
+Entire gained first-class `embeds` and shell entrypoint facts and reduced its
+genuine missing edge set to 742. Another 2,889 Graphify edges were rejected
+only where a qualified external Compass target proves Graphify rebound the
+same occurrence to an unrelated local same-name type. Examples include
+`context.Context` rebound to the repository's `contexts.Context` and
+`io.Writer` rebound to a project-local `Writer`. Exact matches take precedence
+over this rejection, and qualified-label compatibility plus the exact
+relationship occurrence are both required. The remaining misses contain
+genuine unresolved call/reference targets and remain visible rather than being
+accepted through label-only matching.
 
-The final release measurements used the same `compass extract --code-only
---timing --out` contract as the harness:
+The final five-sample release measurements used the same `compass extract
+--code-only --timing --out` contract as the harness:
 
-| Repository | Cold total | Warm p50 | Peak cold RSS | Change from phase one |
-| --- | ---: | ---: | ---: | --- |
-| Django | 9.8 s | 1.60 s | 4.07 GiB | cold -20.7%, warm -26.7% |
-| Entire | 4.3 s | 0.53 s | 1.40 GiB | cold +6.0%, warm -9.6% |
+| Repository | Compass cold p50 | Cold p95 | Warm p50 | Incremental p50 | Peak cold RSS | Graphify 0.9.31 cold p50 | Cold speedup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Django | 9.3868 s | 10.7207 s | 1.6324 s | 15.6107 s | 4,209.44 MiB | 49.985 s | 5.33x |
+| Entire | 3.5001 s | 4.7039 s | 0.5391 s | 5.9863 s | 1,492.73 MiB | 17.650 s | 5.04x |
 
-The Entire cold change remains inside the 10% diagnosis gate. Relative to the
-pinned Graphify cold medians, the observed speedups are 5.10x for Django and
-4.10x for Entire. Publication now uses indexed inventory/file-coverage lookups,
-fast hash indexes, a trivial-evidence fast path, and skips a redundant second
-document validation when best-effort sanitization already proved the graph
-valid.
+All five cold samples for each repository were eligible and produced identical
+correctness digests. Both retained-Graphify cold comparisons clear 5x, although
+the Entire margin is narrow and is not described as comfortable. No Graphify
+warm, incremental, or query ratio is claimed because final verification did
+not rerun Graphify. Publication now uses indexed inventory/file-coverage and
+hash lookups, a trivial-evidence fast path, a single proven-clean validation
+path, and deterministic parallel preparation for v1 edges, files, and
+independent publication metadata.
 
-All four semantic query oracles passed on the final graphs:
+All four semantic query oracles passed across ten measured fresh processes per
+query:
 
-| Repository / query | Compass phase two |
-| --- | ---: |
-| Django URL resolution | 1.492 s, pass |
-| Django model save | 1.404 s, pass |
-| Entire checkpoint creation | 0.737 s, pass |
-| Entire repository state | 0.677 s, pass |
+| Repository / query | p50 | p95 | Result |
+| --- | ---: | ---: | --- |
+| Django URL resolution | 1.4484 s | 1.4638 s | 10/10 pass |
+| Django model save | 1.4598 s | 1.5053 s | 10/10 pass |
+| Entire checkpoint creation | 0.7148 s | 0.7494 s | 10/10 pass |
+| Entire repository state | 0.7060 s | 0.7847 s | 10/10 pass |
 
-Strict Graphify-superset quality is therefore still not achieved. Phase two
-improves the source-backed graph and makes baseline conflicts explicit; the
-next quality target is the residual genuine unresolved call/reference set,
-not restoration of the audited false-positive families.
+Strict literal Graphify-superset quality is therefore still not achieved.
+Phase two does improve source-backed quality over the retained Graphify
+baseline: it preserves qualified identity, real occurrences, decorators,
+embeddings, and shell entrypoints while explicitly rejecting two demonstrated
+false-positive families. The comparator remains fail-closed and exposes 346
+Django and one Entire node misses plus 4,327 Django and 742 Entire edge misses.
+Those residuals, rather than restoration of audited false positives, are the
+next graph-quality target.
 
 ## Changes validated
 
@@ -290,11 +313,13 @@ not restoration of the audited false-positive families.
 
 ## Remaining bottlenecks
 
-The final Django cold profile spends approximately 5.7 seconds in the required
-v1 publication normalization, 4.4 seconds in extraction/resolution, and 2.5-2.7
-seconds in Program analysis. Fresh-process queries are dominated by loading and
-indexing the 242 MiB JSON graph. These are the next optimization targets; none
-can be bypassed at the cost of graph validation or semantic quality.
+The final profile reduced v1 edge normalization from approximately 0.252
+seconds to 0.099 seconds and the full v1 boundary to approximately
+0.63-0.67 seconds on the measured production graph. Fresh-process queries are
+still dominated by loading and indexing the JSON graph. Graph loading,
+incremental publication, and the residual genuine semantic misses are the next
+optimization targets; none can be bypassed at the cost of validation or
+source-backed identity.
 
 ## Reports
 
@@ -304,3 +329,9 @@ can be bypassed at the cost of graph validation or semantic quality.
 - `target/performance/runs/django-optimized-fixed/run.json`
 - `target/performance/runs/entire-baseline-fixed/summary.md`
 - `target/performance/runs/entire-baseline-fixed/run.json`
+- `target/performance/runs/django-final-35d13d4/summary.md`
+- `target/performance/runs/django-final-35d13d4/run.json`
+- `target/performance/runs/entire-final-034fb1e/summary.md`
+- `target/performance/runs/entire-final-034fb1e/run.json`
+- `target/performance/runs/query-final-35d13d4/summary.md`
+- `target/performance/runs/query-final-35d13d4/run.json`

--- a/docs/superpowers/specs/2026-07-30-balanced-source-grounded-graph-quality-design.md
+++ b/docs/superpowers/specs/2026-07-30-balanced-source-grounded-graph-quality-design.md
@@ -6,11 +6,17 @@ Approved in conversation on 2026-07-30. This design governs the quality phase
 after semantic-dominance phase two. Production implementation must precede
 focused regression tests, as requested by the user.
 
+This is explicitly not a red-green TDD workflow. Each delivery increment
+implements and reviews production behavior first, then adds conformance and
+regression coverage before qualification and commit.
+
 ## Goal
 
-Improve Compass graph precision and recall using real source occurrences as
-the authority. Achieve at least 99% observed precision on a deterministic,
-stratified audit while recovering as many verified relationships as possible.
+Build a universal semantic evidence framework that lets present and future
+languages and frameworks produce consistently high-quality Compass graphs.
+Use real source occurrences as the authority, achieve at least 99.5% observed
+overall precision with a two-sided 95% Wilson lower bound of at least 99%, and
+recover at least 95% of source-derived facts for every advertised capability.
 Do not optimize for raw edge count or literal Graphify overlap.
 
 ## Background
@@ -22,16 +28,16 @@ revisions:
 | --- | --- | ---: | ---: |
 | Django | Compass | 55,120 | 130,847 |
 | Django | Graphify | 50,845 | 158,710 |
-| Entire | Compass | 21,661 | 72,298 |
+| Entire | Compass | 21,711 | 72,250 |
 | Entire | Graphify | 20,585 | 61,062 |
 
 The current comparator classifies 53,005 Django Graphify reference edges as
 `module_import_projected_to_symbol`. Those edges use an import statement as
 the relationship occurrence and project the imported target onto class or
-symbol owners. That evidence is invalid, but the previous report overstated
-the conclusion by describing the entire family as false relationships. Some
-source-target dependencies may be real at later use sites. This phase must
-distinguish:
+symbol owners. The import occurrence is invalid as proof of the projected
+owner-to-target reference, but the previous report overstated the conclusion
+by describing the entire family as false relationships. Some source-target
+dependencies may still be real at later use sites. This phase must distinguish:
 
 - a fabricated occurrence;
 - a wrong owner, target, or relationship kind;
@@ -61,8 +67,64 @@ Compass uses balanced source-grounded quality:
 - Ambiguous candidates remain ambiguous or unresolved.
 - Edge count is diagnostic metadata, never a quality score.
 - Graphify supplies recall hypotheses, not ground truth.
+- Fabricated occurrences, cross-language matches, and unsafe substitution of
+  a same-named local target are critical violations with zero tolerance.
+- A language or framework may advertise only capabilities that pass the
+  universal conformance suite.
 
 ## Architecture
+
+### Universal semantic evidence model
+
+The extraction layer emits a versioned internal evidence model independent of
+tree-sitter, any specific language, and the public graph schema. Its logical
+records are:
+
+- `DeclarationFact`: a declared symbol, stable identity components, kind,
+  language, module/package, lexical scope, and declaration occurrence;
+- `ScopeFact`: lexical scope identity, owner, parent, and source range;
+- `BindingFact`: import, export, alias, receiver, namespace, module, or package
+  binding visible in a scope;
+- `OccurrenceFact`: an exact source use with owner, syntax role, original
+  spelling, qualifier, and source range;
+- `RelationshipCandidate`: a typed relationship request connecting an
+  occurrence or declaration to constrained endpoint identities;
+- `ResolutionConstraint`: language, role, scope, module/package, binding,
+  target kind, and external-identity requirements; and
+- `AdapterCapabilities`: the capability set the producer claims and must prove
+  through conformance.
+
+These records form the universal contract. Public `compass.graph/1` nodes and
+edges remain the validated output rather than becoming a language-extension
+surface.
+
+### Language adapters
+
+Every language integrates through one registered adapter contract. An adapter
+may use tree-sitter, a source-driven parser, compiler evidence, or a bounded
+combination, but it emits the same universal evidence records. Its capability
+descriptor may include:
+
+- declarations and lexical scopes;
+- imports, exports, aliases, modules, namespaces, and packages;
+- calls and construction;
+- type references, returns, fields, inheritance, implementation, and
+  embedding;
+- members, receivers, and ownership;
+- decorators, annotations, attributes, macros, or equivalent metadata; and
+- qualified standard-library and external identity.
+
+Adapters may define language-specific parsing and qualification rules. They
+may not implement repository-wide label fallback, bypass occurrence
+requirements, publish arbitrary graph edges, or weaken universal ambiguity
+handling. Tree-sitter and source-driven adapters use the same registration,
+capability, limit, and conformance interfaces.
+
+Adding a language requires an adapter, registry entry, capability declaration,
+and conformance fixtures. It does not require changes to graph publication,
+the shared resolver, or framework-pack execution unless the language
+introduces a genuinely new universal syntax role. New roles require a
+versioned evidence-model change rather than an adapter-local escape hatch.
 
 ### Source-occurrence contract
 
@@ -77,12 +139,12 @@ contract. Each candidate relationship carries:
 - visible import, module, and package scope;
 - producer rule and confidence tier.
 
-Existing raw graph metadata may carry the contract when it can do so without
-duplicating the public schema. A new internal type is justified only if the
-same fields are otherwise interpreted differently by multiple extractors or
-resolvers.
+The internal evidence records carry this contract directly. Compatibility
+projection may translate legacy `Extraction` facts during incremental
+migration, but new complete adapters do not encode the contract as unrelated
+string metadata.
 
-### Constrained target resolution
+### Universal constrained resolver
 
 The resolver considers evidence in this order:
 
@@ -95,6 +157,52 @@ The resolver considers evidence in this order:
 It never falls back to a repository-wide terminal-label match. Resolution
 indexes must be bounded and keyed by language, module/package, spelling, and
 role so the implementation does not reintroduce imports × symbols work.
+
+The resolver is shared across adapters. Language-specific qualification is
+provided through registered binding and identity policies; candidate
+selection, uniqueness, cross-language isolation, external endpoints,
+ambiguity, provenance, and resource limits remain universal. A policy returns
+constraints or normalized identities, not a chosen arbitrary graph node.
+
+### Framework evidence packs
+
+Framework support consumes universal language evidence through a registered
+pack contract. Each pack declares:
+
+- stable pack ID and supported language capabilities;
+- project activation evidence, dependency markers, and manifest policy;
+- accepted declaration and occurrence roles;
+- source, target, and ownership constraints;
+- relationship kind and confidence policy;
+- exact occurrence requirements;
+- candidate and fan-out limits; and
+- conformance fixtures and framework-specific query oracles.
+
+A framework pack may add domain meaning to proven language facts. It cannot
+invent an occurrence, resolve by terminal label, or bypass the universal
+resolver and publisher. Config and template packs use the same evidence,
+activation, limits, and conformance contract as source packs.
+
+Adding a framework requires a pack and its fixtures. It does not require a
+central resolver or publisher change.
+
+### Capability and conformance registry
+
+One registry exposes adapter and framework-pack capabilities to extraction,
+qualification, and diagnostics. Conformance covers:
+
+- stable declarations and scopes;
+- exact occurrence slicing, including Unicode and multiline constructs;
+- aliases, qualification, shadowing, and re-exports;
+- repeated occurrences and overloads;
+- ambiguous and external targets;
+- wrong-language and same-name collision controls;
+- resource-limit behavior;
+- deterministic cold/warm facts; and
+- every advertised relationship family.
+
+Unsupported capabilities remain explicit. The engine must not infer support
+from a file extension or silently fall back to lower-quality generic logic.
 
 ### Publication
 
@@ -121,6 +229,47 @@ source corpus
 
 Graphify does not enter production code, runtime dependencies, or mandatory
 Compass extraction.
+
+## Extensibility and migration
+
+The current `Engine`, `Extraction`, framework `SourcePack` registry, and
+collection resolver already provide useful boundaries but allow language facts
+and resolution rules to use inconsistent string metadata. Migration proceeds
+without a flag day:
+
+1. introduce the versioned universal evidence types, registry, and
+   compatibility projection;
+2. implement Python and Go as complete adapters;
+3. implement Java and Rust complete vertical adapters to prove the contract
+   works across object-oriented, package-oriented, trait-oriented, macro, and
+   ownership-heavy syntax;
+4. route existing framework packs through the universal pack contract;
+5. keep other languages on an explicit legacy capability profile; and
+6. migrate remaining adapters in prioritized batches without changing the
+   resolver or publisher contract.
+
+Legacy adapters remain supported but cannot advertise universal quality for a
+capability until their fixtures pass. The graph records producer and
+capability-profile versions so audits can separate complete and legacy
+coverage.
+
+### Delivery decomposition
+
+The universal program is too large for one undifferentiated implementation
+plan. It is delivered as independently reviewable increments:
+
+1. universal evidence model, capability registry, compatibility projection,
+   shared resolver policy interfaces, and conformance harness;
+2. complete Python and Go adapters plus source-grounded quality recovery;
+3. complete Java and Rust adapters proving language portability;
+4. universal framework-pack execution and migration of existing packs; and
+5. prioritized migration of remaining legacy language adapters.
+
+Each increment has its own implementation-first plan, production changes,
+post-implementation tests, real-corpus evidence, commit, and review gate. The
+final universal quality claim requires increments one through four. Increment
+five expands the set of capabilities covered by that claim without changing
+the core contracts.
 
 ## Production improvement scope
 
@@ -156,16 +305,33 @@ types. Cross-language terminal-name resolution is forbidden.
 
 ### Other languages
 
-Rust and Java serve as regression languages in this phase. Their extractors
-need not migrate to a new internal representation unless the shared contract
-requires a small compatibility change. The design must leave a schema-stable
-adoption path for JavaScript/TypeScript and Ruby.
+Java and Rust become complete vertical adapters in this phase, not only
+regression languages. They prove that the universal contracts cover
+namespaces, overloads, annotations, inheritance, interfaces, traits, impl
+ownership, macros, imports, and external packages without Python- or Go-shaped
+special cases.
+
+JavaScript/TypeScript, Ruby, C#, PHP, Swift, C/C++, and the remaining registered
+languages retain explicit legacy capability profiles until migrated. Their
+existing graph output must not regress. The universal registry and
+compatibility projection let each migrate without central resolver or
+publisher changes.
+
+### Framework packs
+
+Existing Python web, Rails, Spring, Go web, Rust web, ASP.NET, Vapor,
+TypeScript web, filesystem-route, enterprise-domain, config, and template
+packs migrate to the universal pack interface. The phase may preserve their
+detector internals initially, but activation, accepted evidence, target
+constraints, occurrence policy, resource limits, and conformance registration
+become uniform. Spring and the Rust web packs provide the non-Python/Go
+vertical proof.
 
 ## Independent quality measurement
 
 ### Precision audit
 
-Audit at least 1,000 Compass relationships using a deterministic stratified
+Audit at least 2,000 Compass relationships using a deterministic stratified
 sample across repositories, languages, relationship kinds, confidence tiers,
 and high-frequency target clusters. Each record verifies independently:
 
@@ -176,11 +342,17 @@ and high-frequency target clusters. Each record verifies independently:
 
 Any incorrect dimension makes the record incorrect. Report raw counts,
 observed precision, sample composition, and a two-sided 95% Wilson confidence
-interval. The sample contains at least 200 records per corpus and at least 50
-records for each available required relationship family; no single repeated
-target cluster may supply more than 10% of a stratum. The delivery gate is at
-least 99% observed precision. A relation or language with a material
-regression cannot be hidden by the aggregate.
+interval. The sample contains at least 400 records per corpus, at least 100
+records for each available required relationship family, and at least 100
+records for every advertised adapter capability; one record may satisfy
+multiple intersecting strata. No single repeated target cluster may supply
+more than 10% of a stratum.
+
+The delivery gates are at least 99.5% observed overall precision, a 95% Wilson
+lower bound of at least 99%, and at least 99% observed precision for every
+advertised language capability. Fabricated occurrences, cross-language
+matches, and unsafe local-target substitutions have zero tolerance regardless
+of aggregate precision.
 
 ### Recall audit
 
@@ -201,7 +373,9 @@ Each uncovered candidate receives exactly one classification:
   occurrence.
 
 The report includes per-language and per-relation recall counts. It must not
-convert ambiguous or rejected facts into silent passes.
+convert ambiguous or rejected facts into silent passes. Every advertised
+language or framework capability must recover at least 95% of its
+source-derived oracle facts.
 
 ### Audit manifest
 
@@ -209,6 +383,7 @@ The checked-in audit manifest records:
 
 - schema version;
 - corpus name and commit;
+- adapter, framework-pack, and capability-profile versions;
 - language and relationship kind;
 - source and target expectation;
 - occurrence file and range;
@@ -250,13 +425,18 @@ are mandatory.
 
 ## Performance and correctness gates
 
-- At least 99% observed precision on the complete stratified audit.
-- The report publishes confidence bounds and all incorrect samples.
+- At least 99.5% observed overall precision on at least 2,000 audited edges.
+- The two-sided 95% Wilson precision lower bound is at least 99%.
+- Every advertised adapter capability has at least 99% observed precision and
+  95% source-derived recall.
+- Critical semantic violations have a count of zero.
+- The report publishes confidence bounds and every incorrect sample.
 - Genuine source-derived recall improves on Python and Go.
-- No Java or Rust precision decrease greater than one percentage point and no
-  source-derived recall decrease greater than 5% relative to the phase-two
-  graph. Every smaller regression remains itemized.
-- Both improvement graphs publish with zero validation errors.
+- Java and Rust pass the complete adapter contract and do not regress against
+  their pinned pre-migration graphs.
+- Every migrated framework pack passes activation, occurrence, target,
+  resource-limit, and query-oracle conformance.
+- All four qualification graphs publish with zero validation errors.
 - Cold and warm graphs are byte-identical for every measured Compass corpus.
 - All mandatory semantic query oracles pass.
 - No cold or warm build regression greater than 10% without diagnosis and
@@ -267,14 +447,19 @@ are mandatory.
 
 ## Implementation order
 
-The phase is implementation-first:
+Every delivery increment is implementation-first:
 
-1. add or consolidate the internal occurrence contract;
-2. implement constrained Python and Go production resolution;
-3. implement occurrence-aware comparison and the independent audit harness;
-4. add focused regression tests for the completed behavior;
-5. run real-corpus qualification and critique the output;
-6. update documentation, commit, push, and update or create the pull request.
+1. implement the universal evidence types, capability registry, compatibility
+   projection, constrained resolver interfaces, and framework-pack contract;
+2. implement complete Python and Go adapters and production resolution;
+3. implement complete Java and Rust vertical adapters;
+4. migrate framework-pack registration and enforcement to the universal
+   contract;
+5. implement occurrence-aware comparison and the independent audit harness;
+6. add conformance and focused regression tests for the completed production
+   behavior;
+7. run four-corpus qualification and critique the output; and
+8. update documentation, commit, push, and update or create the pull request.
 
 Tests still cover every production change, but they follow the initial
 implementation rather than driving it.
@@ -287,6 +472,9 @@ implementation rather than driving it.
 - Invalid audit records fail qualification rather than being skipped.
 - Unsupported language roles remain explicit and cannot fall through to
   terminal-name matching.
+- Adapter and framework-pack capability claims that lack conformance evidence
+  fail registration.
+- A legacy adapter cannot be mistaken for a complete universal adapter.
 - A partial graph or partial audit cannot satisfy the quality gate.
 
 ## Honest reporting requirements

--- a/docs/superpowers/specs/2026-07-30-balanced-source-grounded-graph-quality-design.md
+++ b/docs/superpowers/specs/2026-07-30-balanced-source-grounded-graph-quality-design.md
@@ -1,0 +1,307 @@
+# Balanced Source-Grounded Graph Quality Design
+
+## Status
+
+Approved in conversation on 2026-07-30. This design governs the quality phase
+after semantic-dominance phase two. Production implementation must precede
+focused regression tests, as requested by the user.
+
+## Goal
+
+Improve Compass graph precision and recall using real source occurrences as
+the authority. Achieve at least 99% observed precision on a deterministic,
+stratified audit while recovering as many verified relationships as possible.
+Do not optimize for raw edge count or literal Graphify overlap.
+
+## Background
+
+Phase two produced valid, deterministic graphs for pinned Django and Entire
+revisions:
+
+| Repository | Tool | Nodes | Unique edges |
+| --- | --- | ---: | ---: |
+| Django | Compass | 55,120 | 130,847 |
+| Django | Graphify | 50,845 | 158,710 |
+| Entire | Compass | 21,661 | 72,298 |
+| Entire | Graphify | 20,585 | 61,062 |
+
+The current comparator classifies 53,005 Django Graphify reference edges as
+`module_import_projected_to_symbol`. Those edges use an import statement as
+the relationship occurrence and project the imported target onto class or
+symbol owners. That evidence is invalid, but the previous report overstated
+the conclusion by describing the entire family as false relationships. Some
+source-target dependencies may be real at later use sites. This phase must
+distinguish:
+
+- a fabricated occurrence;
+- a wrong owner, target, or relationship kind;
+- a real dependency represented at a different occurrence; and
+- a genuine Compass recall gap.
+
+The current residual audit also shows:
+
+- Django has genuine unresolved decorator, base-type, call, and import
+  candidates mixed with external/built-in facts and config-shape differences.
+- Entire has real receiver-containment and imported-type gaps mixed with
+  Graphify cross-language and terminal-name joins. Examples include Go
+  `cleanup()` calls matched to a shell function, and `time.Time` or
+  `context.Context` matched to unrelated repository-local types.
+- Compass currently passes all four Django and Entire semantic query oracles,
+  but query success alone does not prove relationship precision or recall.
+
+## Quality policy
+
+Compass uses balanced source-grounded quality:
+
+- Every behavioral relationship must have a real source occurrence.
+- Declaration relationships use their declaration occurrence.
+- Resolution must use lexical, import, module, package, ownership, or
+  qualified external evidence.
+- Label-only repository-wide joins are forbidden.
+- Ambiguous candidates remain ambiguous or unresolved.
+- Edge count is diagnostic metadata, never a quality score.
+- Graphify supplies recall hypotheses, not ground truth.
+
+## Architecture
+
+### Source-occurrence contract
+
+Language extraction and resolution share a language-neutral occurrence
+contract. Each candidate relationship carries:
+
+- source file and exact byte/line range;
+- lexical owner at the occurrence;
+- syntax role, such as call, decorator, annotation, base type, field type,
+  embedding, import, or containment;
+- original spelling and qualifier;
+- visible import, module, and package scope;
+- producer rule and confidence tier.
+
+Existing raw graph metadata may carry the contract when it can do so without
+duplicating the public schema. A new internal type is justified only if the
+same fields are otherwise interpreted differently by multiple extractors or
+resolvers.
+
+### Constrained target resolution
+
+The resolver considers evidence in this order:
+
+1. exact lexical declaration;
+2. explicit import alias or package-qualified identity;
+3. unique same-module or same-package definition;
+4. qualified external endpoint;
+5. unresolved or ambiguous endpoint.
+
+It never falls back to a repository-wide terminal-label match. Resolution
+indexes must be bounded and keyed by language, module/package, spelling, and
+role so the implementation does not reintroduce imports × symbols work.
+
+### Publication
+
+Behavioral edges publish only with a real relationship occurrence.
+Containment, inheritance, embedding, and declaration typing use the
+declaration range. Qualified external endpoints remain explicit when the
+repository does not contain the definition. Publication retains relation kind
+and occurrence identity and continues to validate the closed v1 endpoint
+matrix.
+
+### Development-only qualification
+
+The quality pipeline is:
+
+```text
+source corpus
+  -> independent occurrence candidates
+  -> Compass extraction and constrained resolution
+  -> validated typed graph
+  -> deterministic source audit
+  -> Graphify difference audit
+  -> precision, recall, conflict, and performance report
+```
+
+Graphify does not enter production code, runtime dependencies, or mandatory
+Compass extraction.
+
+## Production improvement scope
+
+### Occurrence-aware semantic comparison
+
+The development comparator may recognize a stronger Compass relationship only
+when source occurrence and compatible endpoints agree. Examples:
+
+- `instantiates` may dominate a generic Graphify `calls` edge at the same
+  occurrence;
+- a qualified external endpoint may refute an unsafe same-name local target;
+- a uniquely resolved owner may dominate a broader placeholder owner.
+
+It may not erase a source occurrence, relationship-kind, language, module, or
+target conflict. Rejected baseline evidence remains separately counted and
+auditable.
+
+### Python
+
+Recover source-backed decorator, annotation, base-type, and imported callable
+uses through direct imports, aliases, package initializers, and bounded
+re-export chains. Emit each use at its own AST occurrence and lexical owner.
+Built-ins and external symbols remain qualified when no repository definition
+exists. The removed import-to-every-class expansion must not return.
+
+### Go
+
+Resolve imported field types and embeddings through explicit package paths.
+Repair receiver ownership when declaration order, generated code, exported
+case, or private case creates placeholders. Preserve standard-library and
+external package identities rather than joining their terminal names to local
+types. Cross-language terminal-name resolution is forbidden.
+
+### Other languages
+
+Rust and Java serve as regression languages in this phase. Their extractors
+need not migrate to a new internal representation unless the shared contract
+requires a small compatibility change. The design must leave a schema-stable
+adoption path for JavaScript/TypeScript and Ruby.
+
+## Independent quality measurement
+
+### Precision audit
+
+Audit at least 1,000 Compass relationships using a deterministic stratified
+sample across repositories, languages, relationship kinds, confidence tiers,
+and high-frequency target clusters. Each record verifies independently:
+
+- source owner;
+- target identity;
+- relationship kind; and
+- occurrence range.
+
+Any incorrect dimension makes the record incorrect. Report raw counts,
+observed precision, sample composition, and a two-sided 95% Wilson confidence
+interval. The sample contains at least 200 records per corpus and at least 50
+records for each available required relationship family; no single repeated
+target cluster may supply more than 10% of a stratum. The delivery gate is at
+least 99% observed precision. A relation or language with a material
+regression cannot be hidden by the aggregate.
+
+### Recall audit
+
+Recall candidates come from two independent pools:
+
+1. source constructs collected independently of the published Compass graph;
+2. Graphify-only facts treated as hypotheses.
+
+Each uncovered candidate receives exactly one classification:
+
+- genuine Compass omission;
+- correct qualified external fact;
+- ambiguous in source;
+- wrong Graphify owner or target;
+- wrong Graphify relationship;
+- fabricated Graphify occurrence; or
+- plausible dependency represented by Compass at a different real
+  occurrence.
+
+The report includes per-language and per-relation recall counts. It must not
+convert ambiguous or rejected facts into silent passes.
+
+### Audit manifest
+
+The checked-in audit manifest records:
+
+- schema version;
+- corpus name and commit;
+- language and relationship kind;
+- source and target expectation;
+- occurrence file and range;
+- normalized source snippet hash;
+- judgment and reason.
+
+Qualification fails if the corpus revision differs, the snippet hash changes,
+the manifest is too small, or required strata are absent. The harness must
+produce the same sample and metrics for identical graph and corpus inputs.
+
+## Confirming whether fewer edges are better
+
+Removed edges are audited by file, target, relationship, and occurrence
+clusters. A removed family is an improvement only when:
+
+- its owner, target, relationship, or occurrence is invalid; and
+- every recoverable real use in the audited source is represented separately
+  or recorded as a Compass omission.
+
+If a removed projected edge corresponds to a real later use that Compass does
+not emit, the deletion improves occurrence precision but creates a recall
+regression. The final report must state both outcomes. Net edge reduction is
+not evidence of improvement.
+
+## Corpora
+
+Production improvements are qualified on:
+
+- Django: Python improvement corpus;
+- Entire: Go improvement corpus;
+- Spring Framework: Java regression corpus; and
+- Bevy: Rust regression corpus.
+
+All corpora use pinned commits. Graphify and Compass must process the same
+source revision. The existing Django URL-resolution/model-save, Entire
+checkpoint/repository-state, Spring application-context/HTTP-dispatch, and
+Bevy scheduling/plugin queries in `benchmarks/performance/repositories.toml`
+are mandatory.
+
+## Performance and correctness gates
+
+- At least 99% observed precision on the complete stratified audit.
+- The report publishes confidence bounds and all incorrect samples.
+- Genuine source-derived recall improves on Python and Go.
+- No Java or Rust precision decrease greater than one percentage point and no
+  source-derived recall decrease greater than 5% relative to the phase-two
+  graph. Every smaller regression remains itemized.
+- Both improvement graphs publish with zero validation errors.
+- Cold and warm graphs are byte-identical for every measured Compass corpus.
+- All mandatory semantic query oracles pass.
+- No cold or warm build regression greater than 10% without diagnosis and
+  explicit acceptance.
+- Focused owning-crate tests, the performance harness, and the full workspace
+  test suite pass.
+- Run `graphify update .` in the parent repository after code changes.
+
+## Implementation order
+
+The phase is implementation-first:
+
+1. add or consolidate the internal occurrence contract;
+2. implement constrained Python and Go production resolution;
+3. implement occurrence-aware comparison and the independent audit harness;
+4. add focused regression tests for the completed behavior;
+5. run real-corpus qualification and critique the output;
+6. update documentation, commit, push, and update or create the pull request.
+
+Tests still cover every production change, but they follow the initial
+implementation rather than driving it.
+
+## Error handling
+
+- Resource or candidate limits fail closed with bounded diagnostics.
+- Ambiguous resolution never selects an arbitrary target.
+- Missing external definitions retain qualified unresolved endpoints.
+- Invalid audit records fail qualification rather than being skipped.
+- Unsupported language roles remain explicit and cannot fall through to
+  terminal-name matching.
+- A partial graph or partial audit cannot satisfy the quality gate.
+
+## Honest reporting requirements
+
+The final review separates:
+
+- precision improvements;
+- recall improvements;
+- representational changes;
+- demonstrated Graphify errors;
+- demonstrated Compass errors;
+- unresolved and ambiguous facts;
+- edge-count changes; and
+- performance changes.
+
+It must explicitly state whether strict Graphify-superset quality is achieved.
+If not, it names the remaining genuine gaps and does not describe every
+Graphify conflict as a Graphify false positive.


### PR DESCRIPTION
## Summary

- publish Bash entrypoints and Go embeddings as first-class typed graph facts
- replace broad Python import-to-class inference with exact decorator occurrences and qualified re-export resolution
- preserve package-qualified Go type identity and prevent external types from binding unrelated local names
- distinguish exact, dominated, rejected, ambiguous, and genuinely missing Graphify evidence
- accelerate deterministic publication with indexed lookups, single proven-clean validation, and ordered parallel preparation
- define the next universal source-grounded quality program and its independent precision/recall gates

## Final real-corpus verification

| Repository | Compass cold p50 | Graphify 0.9.31 cold p50 | Speedup | Compass warm p50 | Compass query p50 range |
| --- | ---: | ---: | ---: | ---: | ---: |
| Django | 9.3868s | 49.985s | 5.33x | 1.6324s | 1.4484-1.4598s |
| Entire | 3.5001s | 17.650s | 5.04x | 0.5391s | 0.7060-0.7148s |

- all five cold samples per repository were eligible with identical correctness digests
- all 40 measured semantic query samples passed their oracles
- both final graphs index with zero validation errors
- Django: 55,120 Compass nodes / 130,847 distinct edges; 99.25% node and 95.84% source-grounded edge coverage of the retained Graphify baseline
- Entire: 21,711 Compass nodes / 72,250 edges; 99.77% node and 98.50% source-grounded edge coverage, with 11,188 more edges than Graphify
- final Compass verification reused retained Graphify 0.9.31 artifacts; Graphify was not rerun as a performance benchmark

Strict literal Graphify-superset coverage is not claimed. The comparator classifies 53,005 Django edges whose reported owner-to-target evidence is an import occurrence. That occurrence proves import availability, not that every projected owner uses the target; some dependencies may still be real at later occurrences and must be recovered separately or recorded as Compass omissions. On Entire, 2,889 baseline edges conflict with qualified external targets at the exact source site, including audited same-name local rebinding examples. Residual ambiguous and missing facts remain fail-closed and visible.

## Universal quality follow-up

The checked-in design defines:

- a versioned universal declaration, scope, binding, occurrence, candidate, and resolution-evidence model
- registered language adapters with explicit complete or legacy capability profiles
- a shared constrained resolver with no repository-wide terminal-label fallback
- framework evidence packs that cannot invent occurrences or bypass resolution constraints
- a deterministic audit of at least 2,000 relationships
- at least 99.5% observed overall precision with a two-sided 95% Wilson lower bound of at least 99%
- at least 99% precision and 95% source-derived recall for every advertised capability
- zero tolerance for fabricated occurrences, cross-language matches, and unsafe local-target substitution

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- focused graph publication, language resolution, model validation, and comparator suites
- five-sample release cold/warm/incremental matrices on pinned Django and Entire
- ten measured fresh-process runs for each of four semantic query oracles
- `graphify update .` from `/Users/haipingfu/graphify` (no topology changes)