### PR TITLE
fix: display Code Graph v1 node names in Viewer

### DIFF
--- a/crates/compass-output/src/html.rs
+++ b/crates/compass-output/src/html.rs
@@ -783,7 +783,7 @@ fn degrees(document: &GraphDocument) -> HashMap<&str, usize> {
 }
 
 fn node_label(node: &NodeRecord) -> String {
-    match node.property("label") {
+    match node.property("label").or_else(|| node.property("name")) {
         None => node.id.clone(),
         Some(Value::Null) => String::new(),
         Some(value) => python_value_string(&value),
@@ -2361,6 +2361,19 @@ mod tests {
         .ok_or("HTML unexpectedly skipped")?;
         assert!(rendered.html.contains("\"learning_status\": \"preferred\""));
         assert!(rendered.html.contains("\"learning_stale\": false"));
+        Ok(())
+    }
+
+    #[test]
+    fn viewer_node_label_projects_code_graph_v1_name() -> Result<(), Box<dyn Error>> {
+        let node: NodeRecord = serde_json::from_value(json!({
+            "id": "sha256:8cfda4",
+            "name": "metavoice.rs",
+            "kind": "file",
+            "language": "rust"
+        }))?;
+
+        assert_eq!(node_label(&node), "metavoice.rs");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- project the canonical Code Graph v1 `name` into the Viewer `label`
- retain explicit presentation labels and keep the `sha256:` value as the stable node identity
- add a regression test for a v1-shaped Rust file node

## Root cause

`compass.graph/1` publishes human-readable node names in `name`, while `compass.viewer.graph/1` renders `label`. The output projection checked only `label` and fell back directly to the node ID, causing valid v1 nodes to display their opaque `sha256:` identity.

## Impact

Viewer and VS Code graph hover cards now show the human-readable Code Graph node name while queries and graph edges continue to use the unchanged stable ID.

## Validation

- `cargo test -p compass-output` — 30 passed
- `cargo fmt --all --check`
- `cargo clippy -p compass-output --lib --all-features -- -D warnings`
