### PR TITLE
fix: preserve Code Graph v1 source ranges in Viewer

### DIFF
--- a/crates/compass-output/src/html.rs
+++ b/crates/compass-output/src/html.rs
@@ -386,8 +386,12 @@ pub(crate) fn node_values(
         let language = sanitize_label(&node.string("language"));
         let signature = sanitize_metadata(&node.string("signature"), 500);
         let (location_start, location_end) = source_line_range(&source_location);
-        let line_start = node.unsigned("line_start").or(location_start);
-        let line_end = node.unsigned("line_end").or(location_end).or(line_start);
+        let line_start = source_anchor_unsigned(node, "line_start", "startLine").or(location_start);
+        let line_end = source_anchor_unsigned(node, "line_end", "endLine")
+            .or(location_end)
+            .or(line_start);
+        let start_byte = source_anchor_unsigned(node, "start_byte", "startByte");
+        let end_byte = source_anchor_unsigned(node, "end_byte", "endByte");
         let display_kind = if symbol_kind.is_empty() {
             sanitize_label(&node.string("file_type"))
         } else {
@@ -404,6 +408,11 @@ pub(crate) fn node_values(
             line_start.map_or(Value::Null, Value::from),
         );
         output.insert("line_end".into(), line_end.map_or(Value::Null, Value::from));
+        output.insert(
+            "start_byte".into(),
+            start_byte.map_or(Value::Null, Value::from),
+        );
+        output.insert("end_byte".into(), end_byte.map_or(Value::Null, Value::from));
         output.insert("signature".into(), Value::String(signature.clone()));
         if let Some(counts) = options.member_counts {
             output.insert("is_community".into(), Value::Bool(true));
@@ -440,6 +449,18 @@ pub(crate) fn node_values(
         nodes.push(Value::Object(output));
     }
     nodes
+}
+
+fn source_anchor_unsigned(node: &NodeRecord, legacy_key: &str, v1_key: &str) -> Option<u64> {
+    node.unsigned(legacy_key).or_else(|| {
+        node.property("source")
+            .and_then(|source| {
+                source
+                    .as_object()
+                    .and_then(|source| source.get(v1_key).cloned())
+            })
+            .and_then(|value| value.as_u64())
+    })
 }
 
 fn community_details(

--- a/crates/compass-output/src/viewer_model.rs
+++ b/crates/compass-output/src/viewer_model.rs
@@ -72,6 +72,10 @@ pub struct GraphViewSource {
     pub start_line: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_line: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_byte: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_byte: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -137,6 +141,8 @@ pub fn graph_view_model(
                         file,
                         start_line: object.get("line_start").and_then(Value::as_u64),
                         end_line: object.get("line_end").and_then(Value::as_u64),
+                        start_byte: object.get("start_byte").and_then(Value::as_u64),
+                        end_byte: object.get("end_byte").and_then(Value::as_u64),
                     }),
                 color: color.and_then(|color| {
                     Some(GraphViewColor {
@@ -326,6 +332,49 @@ mod tests {
         assert_eq!(
             node.source.as_ref().and_then(|source| source.end_line),
             Some(8)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn graph_model_preserves_code_graph_v1_source_anchor() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let document: GraphDocument = serde_json::from_value(json!({
+            "nodes": [{
+                "id": "sha256:8cfda4",
+                "name": "metavoice.rs",
+                "kind": "file",
+                "language": "rust",
+                "source": {
+                    "file": "candle-transformers/src/models/metavoice.rs",
+                    "startByte": 1842,
+                    "endByte": 1976,
+                    "startLine": 61,
+                    "startColumn": 4,
+                    "endLine": 66,
+                    "endColumn": 5
+                }
+            }],
+            "links": []
+        }))?;
+        let communities: Communities = BTreeMap::from([(0, vec!["sha256:8cfda4".to_owned()])]);
+        let model = graph_view_model(
+            &document,
+            &communities,
+            "Code Graph v1",
+            &HtmlOptions::default(),
+            false,
+        );
+
+        assert_eq!(
+            serde_json::to_value(&model.nodes[0].source)?,
+            json!({
+                "file": "candle-transformers/src/models/metavoice.rs",
+                "startLine": 61,
+                "endLine": 66,
+                "startByte": 1842,
+                "endByte": 1976
+            })
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- project structured `compass.graph/1` node source anchors into the Viewer model
- preserve start/end lines and byte offsets while retaining legacy flat source fields
- add a v1-shaped regression covering the complete Viewer source payload

## Root cause

Code Graph v1 stores positions under `source.startLine`, `source.endLine`, `source.startByte`, and `source.endByte`. The Viewer projection read only legacy flat `line_start` and `line_end` fields, so it retained the file path but silently discarded the range.

## Impact

Graph hover cards and the inspector can display the node line range, and existing Viewer/VS Code source activation receives a navigable file and position. Stable `sha256:` node identities remain unchanged. Evidence and wiring-site anchors are not substituted for a node definition site.

## Validation

- regression demonstrated red: file-only source payload instead of the expected line and byte range
- `cargo test -p compass-output` — 31 passed
- `cargo fmt --all --check`
- `cargo clippy -p compass-output --lib --all-features -- -D warnings`
- `git diff --check`
- `graphify update .`