### PR TITLE
fix(python): stabilize universal hard-cut import binding and spans

### DIFF
--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -1014,23 +1014,23 @@ impl<'source> DirectAdapterState<'source> {
             return Ok(());
         }
         for imported in imported_names {
-            let (target_name, alias) = if imported.kind() == "aliased_import" {
+            let (target_name, alias, alias_node) = if imported.kind() == "aliased_import" {
                 let Some(target) = imported.child_by_field_name("name") else {
                     continue;
                 };
-                (
-                    self.text(target),
-                    imported
-                        .child_by_field_name("alias")
-                        .map(|alias| self.text(alias)),
-                )
+                let alias_node = imported.child_by_field_name("alias");
+                let alias = alias_node.as_ref().and_then(|alias| {
+                    let alias = self.text(*alias);
+                    valid_python_identifier(&alias).then_some(alias)
+                });
+                (self.text(target), alias, alias_node)
             } else {
-                (self.text(imported), None)
+                (self.text(imported), None, None)
             };
             if !valid_python_import_target(&target_name)
-                || alias
-                    .as_deref()
-                    .is_some_and(|alias| !valid_python_identifier(alias))
+                || alias_node
+                    .as_ref()
+                    .is_some_and(|alias_node| alias.is_none() && self.text(*alias_node) != "")
             {
                 continue;
             }
@@ -1063,7 +1063,14 @@ impl<'source> DirectAdapterState<'source> {
                 )?;
                 continue;
             }
-            self.add_python_import_binding(imported, owner, local, binding_target, import_target)?;
+            self.add_python_import_binding(
+                imported,
+                owner,
+                local,
+                binding_target,
+                import_target,
+                alias_node,
+            )?;
         }
         Ok(())
     }
@@ -1075,6 +1082,7 @@ impl<'source> DirectAdapterState<'source> {
         local: String,
         binding_target: String,
         import_target: String,
+        alias_name_node: Option<Node<'_>>,
     ) -> Result<(), EvidenceError> {
         let is_reexport = owner.kind == "file"
             && self.path.file_name().and_then(|name| name.to_str()) == Some("__init__.py");
@@ -1085,21 +1093,24 @@ impl<'source> DirectAdapterState<'source> {
         } else {
             BindingKind::ImportAlias
         };
-        let range = range_for_node(self.source_file, imported);
+        let binding_range = range_for_node(self.source_file, imported);
+        let occurrence_range = alias_name_node
+            .map(|alias_name_node| range_for_node(self.source_file, alias_name_node))
+            .unwrap_or_else(|| binding_range.clone());
         let binding_id = self.builder.bind(
             kind,
             &local,
             &binding_target,
             None,
             Some(&owner.scope_id),
-            range.clone(),
+            binding_range,
         )?;
         self.record_import_binding(
             owner,
             &local,
             &binding_target,
             &binding_id,
-            usize::try_from(range.end_byte).unwrap_or(usize::MAX),
+            usize::try_from(occurrence_range.end_byte).unwrap_or(usize::MAX),
         );
         let occurrence_id = self.builder.occur(
             if is_reexport {
@@ -1111,7 +1122,7 @@ impl<'source> DirectAdapterState<'source> {
             &local,
             None,
             Some(&owner.scope_id),
-            range.clone(),
+            occurrence_range,
         )?;
         let target_spelling = import_target.rsplit('.').next().unwrap_or(&import_target);
         self.builder.relate(

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -1063,13 +1063,7 @@ impl<'source> DirectAdapterState<'source> {
                 )?;
                 continue;
             }
-            self.add_python_import_binding(
-                imported,
-                owner,
-                local,
-                binding_target,
-                import_target,
-            )?;
+            self.add_python_import_binding(imported, owner, local, binding_target, import_target)?;
         }
         Ok(())
     }
@@ -4069,8 +4063,22 @@ impl<'source> DirectAdapterState<'source> {
             .or_default()
             .entry(local.to_owned())
             .or_default();
+        let same_package = versions.iter().any(|version| {
+            let existing_root = version
+                .target
+                .split_once('.')
+                .map(|(root, _)| root)
+                .unwrap_or(version.target.as_str());
+            let new_root = target
+                .split_once('.')
+                .map(|(root, _)| root)
+                .unwrap_or(target);
+            existing_root == new_root
+        });
+
         if (self.language != "python" && !versions.is_empty())
             || (self.language == "python"
+                && same_package
                 && versions.iter().any(|version| version.target != target))
         {
             self.ambiguous_bindings

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -991,7 +991,6 @@ impl<'source> DirectAdapterState<'source> {
         {
             return Ok(());
         }
-        let occurrence_range = range_for_node(self.source_file, node);
         let module = node.child_by_field_name("module_name").map(|module| {
             resolve_python_module(
                 &self.module_or_package,
@@ -1070,7 +1069,6 @@ impl<'source> DirectAdapterState<'source> {
                 local,
                 binding_target,
                 import_target,
-                occurrence_range.clone(),
             )?;
         }
         Ok(())
@@ -1083,7 +1081,6 @@ impl<'source> DirectAdapterState<'source> {
         local: String,
         binding_target: String,
         import_target: String,
-        occurrence_range: EvidenceRange,
     ) -> Result<(), EvidenceError> {
         let is_reexport = owner.kind == "file"
             && self.path.file_name().and_then(|name| name.to_str()) == Some("__init__.py");
@@ -1120,7 +1117,7 @@ impl<'source> DirectAdapterState<'source> {
             &local,
             None,
             Some(&owner.scope_id),
-            occurrence_range,
+            range.clone(),
         )?;
         let target_spelling = import_target.rsplit('.').next().unwrap_or(&import_target);
         self.builder.relate(
@@ -4072,7 +4069,10 @@ impl<'source> DirectAdapterState<'source> {
             .or_default()
             .entry(local.to_owned())
             .or_default();
-        if self.language != "python" && !versions.is_empty() {
+        if (self.language != "python" && !versions.is_empty())
+            || (self.language == "python"
+                && versions.iter().any(|version| version.target != target))
+        {
             self.ambiguous_bindings
                 .insert((scope_id.clone(), local.to_owned()));
         }

--- a/crates/compass-resolve/tests/python_import_provenance.rs
+++ b/crates/compass-resolve/tests/python_import_provenance.rs
@@ -346,7 +346,7 @@ fn identity_module_alias_resolves_to_the_exact_source_inventory() -> Result<(), 
         edge.source == caller.id
             && edge.target == signals.id
             && edge.string("relation") == "imports_from"
-            && edge.string("resolution_rule") == "explicitbinding"
+            && edge.string("resolution_rule") == "explicit-binding"
     }));
     Ok(())
 }
@@ -534,7 +534,7 @@ fn universal_python_reexports_follow_a_bounded_multi_hop_alias_chain_determinist
         })
         .collect::<Vec<_>>();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].string("resolution_rule"), "explicitbinding");
+    assert_eq!(calls[0].string("resolution_rule"), "explicit-binding");
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/python_import_provenance.rs
+++ b/crates/compass-resolve/tests/python_import_provenance.rs
@@ -31,6 +31,128 @@ fn is_python_import_evidence(evidence: &Provenance) -> bool {
         })
 }
 
+fn skip_python_whitespace(statement: &str, mut cursor: usize) -> usize {
+    while let Some(rest) = statement.get(cursor..) {
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+    cursor
+}
+
+fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
+    let Some(import_pos) = statement.find("import") else {
+        return Vec::new();
+    };
+    let mut cursor = skip_python_whitespace(statement, import_pos + "import".len());
+    if let Some(rest) = statement.get(cursor..) {
+        if rest.starts_with('(') {
+            cursor += 1;
+            cursor = skip_python_whitespace(statement, cursor);
+        }
+    }
+
+    let mut spans = Vec::new();
+    while cursor < statement.len() {
+        cursor = skip_python_whitespace(statement, cursor);
+        while let Some(rest) = statement.get(cursor..) {
+            if rest.starts_with('\\') {
+                cursor += 1;
+                cursor = skip_python_whitespace(statement, cursor);
+                continue;
+            }
+            break;
+        }
+
+        if cursor >= statement.len() || statement[cursor..].starts_with(')') {
+            break;
+        }
+
+        let start = cursor;
+        let mut end = cursor;
+        let mut paren_depth = 0usize;
+
+        while end < statement.len() {
+            let ch = statement[end..]
+                .chars()
+                .next()
+                .expect("span has at least one char");
+            if ch == '(' {
+                paren_depth += 1;
+                end += ch.len_utf8();
+                continue;
+            }
+            if ch == ')' {
+                if paren_depth == 0 {
+                    break;
+                }
+                paren_depth = paren_depth.saturating_sub(1);
+                end += ch.len_utf8();
+                continue;
+            }
+            if ch == ',' {
+                if paren_depth == 0 {
+                    break;
+                }
+            }
+            if ch == '\\' {
+                break;
+            }
+            if (ch == '\n' || ch == '\r') && paren_depth == 0 {
+                break;
+            }
+            end += ch.len_utf8();
+        }
+
+        let mut span_end = end;
+        while span_end > start {
+            let trailing = statement[..span_end]
+                .chars()
+                .next_back()
+                .expect("span has at least one char");
+            if trailing.is_whitespace() || trailing == ')' {
+                span_end -= trailing.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        if span_end > start {
+            spans.push((start, span_end));
+        }
+
+        cursor = end;
+        if let Some(rest) = statement.get(cursor..) {
+            if rest.starts_with(',') {
+                cursor += 1;
+            } else if rest.starts_with(')') {
+                break;
+            } else {
+                break;
+            }
+        }
+    }
+
+    spans
+}
+
+fn import_item_spans_in_source(
+    statement: &str,
+    source: &str,
+) -> Result<Vec<(usize, usize)>, Box<dyn Error>> {
+    let statement_start = source
+        .find(statement)
+        .ok_or("missing expected import statement")?;
+    Ok(python_import_item_spans(statement)
+        .into_iter()
+        .map(|(start, end)| (statement_start + start, statement_start + end))
+        .collect())
+}
+
 fn write(root: &Path, relative: &str, source: &str) -> Result<String, Box<dyn Error>> {
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
@@ -648,10 +770,11 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         edge.string("_origin") == "ast" && edge.string("confidence") == "EXTRACTED"
     }));
 
-    let expected_start = caller_source
-        .find(multiline_import)
-        .ok_or("missing multiline import")?;
-    let expected_end = expected_start + multiline_import.len();
+    let multiline_import_spans = import_item_spans_in_source(multiline_import, &caller_source)?;
+    let (expected_start, expected_end) = multiline_import_spans
+        .first()
+        .copied()
+        .ok_or("missing multiline import item span")?;
     let multiline_edge = resolver_edges
         .iter()
         .find(|edge| {
@@ -685,7 +808,7 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
                     .and_then(serde_json::Value::as_u64)
             )
             .map(|(end, start)| end - start),
-        Some(2)
+        Some(0)
     );
 
     let ignored_targets = extraction
@@ -759,7 +882,7 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         .ok_or("missing multiline anchor")?;
     assert_eq!(anchor.start_byte, expected_start as u64);
     assert_eq!(anchor.end_byte, expected_end as u64);
-    assert_eq!(anchor.end_line - anchor.start_line, 2);
+    assert_eq!(anchor.end_line - anchor.start_line, 0);
     Ok(())
 }
 
@@ -955,25 +1078,39 @@ fn backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed()
         "comments, strings, malformed continuations, and parser-error recovery regions must not emit imports"
     );
 
-    let symbol_start = caller_source
-        .find(continued_symbols)
-        .ok_or("missing continued symbol statement")?;
-    let symbol_end = symbol_start + continued_symbols.len();
+    let symbol_spans = import_item_spans_in_source(continued_symbols, &caller_source)?;
+    assert_eq!(symbol_spans.len(), 3);
     let symbol_edges = resolver_edges
         .iter()
         .filter(|edge| {
             edge.attributes
                 .get("start_byte")
                 .and_then(serde_json::Value::as_u64)
-                == Some(symbol_start as u64)
+                .is_some_and(|start| symbol_spans.iter().any(|(s, _)| *s == start as usize))
         })
         .collect::<Vec<_>>();
     assert_eq!(symbol_edges.len(), 3);
     assert!(symbol_edges.iter().all(|edge| {
+        let Some(start) = edge
+            .attributes
+            .get("start_byte")
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value as usize)
+        else {
+            return false;
+        };
+        let Some((_, end)) = symbol_spans
+            .iter()
+            .find(|(expected_start, _)| *expected_start == start)
+            .copied()
+        else {
+            return false;
+        };
+
         edge.attributes
             .get("end_byte")
             .and_then(serde_json::Value::as_u64)
-            == Some(symbol_end as u64)
+            == Some(end as u64)
             && edge
                 .attributes
                 .get("line_end")
@@ -983,28 +1120,42 @@ fn backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed()
                         .get("line_start")
                         .and_then(serde_json::Value::as_u64),
                 )
-                .is_some_and(|(end, start)| end - start == 2)
+                .is_some_and(|(end, start)| end == start)
     }));
 
-    let submodule_start = caller_source
-        .find(continued_submodules)
-        .ok_or("missing continued submodule statement")?;
-    let submodule_end = submodule_start + continued_submodules.len();
+    let submodule_spans = import_item_spans_in_source(continued_submodules, &caller_source)?;
+    assert_eq!(submodule_spans.len(), 2);
     let submodule_edges = resolver_edges
         .iter()
         .filter(|edge| {
             edge.attributes
                 .get("start_byte")
                 .and_then(serde_json::Value::as_u64)
-                == Some(submodule_start as u64)
+                .is_some_and(|start| submodule_spans.iter().any(|(s, _)| *s == start as usize))
         })
         .collect::<Vec<_>>();
     assert_eq!(submodule_edges.len(), 2);
     assert!(submodule_edges.iter().all(|edge| {
+        let Some(start) = edge
+            .attributes
+            .get("start_byte")
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value as usize)
+        else {
+            return false;
+        };
+        let Some((_, end)) = submodule_spans
+            .iter()
+            .find(|(expected_start, _)| *expected_start == start)
+            .copied()
+        else {
+            return false;
+        };
+
         edge.attributes
             .get("end_byte")
             .and_then(serde_json::Value::as_u64)
-            == Some(submodule_end as u64)
+            == Some(end as u64)
     }));
 
     let malformed_starts = ["from pkg.api import Broken", "from pkg.api import ("]
@@ -1040,16 +1191,19 @@ fn backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed()
         .filter(|evidence| {
             evidence.extractor == PYTHON_IMPORT_PRODUCER
                 && evidence.rule.as_deref() == Some(PYTHON_SYMBOL_IMPORT_RULE)
-                && evidence
-                    .anchors
-                    .first()
-                    .is_some_and(|anchor| anchor.start_byte == symbol_start as u64)
+                && evidence.anchors.first().is_some_and(|anchor| {
+                    symbol_spans
+                        .iter()
+                        .any(|(start, _)| anchor.start_byte == *start as u64)
+                })
         })
         .filter_map(|evidence| evidence.anchors.first())
         .collect::<Vec<_>>();
     assert_eq!(published_symbol_anchors.len(), 3);
     assert!(published_symbol_anchors.iter().all(|anchor| {
-        anchor.end_byte == symbol_end as u64 && anchor.end_line - anchor.start_line == 2
+        symbol_spans.iter().any(|(start, end)| {
+            anchor.start_byte == *start as u64 && anchor.end_byte == *end as u64
+        })
     }));
     Ok(())
 }
@@ -1110,13 +1264,11 @@ fn python_import_token_grammar_is_atomic_and_span_stable() -> Result<(), Box<dyn
 
         let mut expected_spans = valid_statements
             .iter()
-            .map(|statement| {
-                caller_source
-                    .find(statement)
-                    .map(|start| (start, start + statement.len()))
-                    .ok_or("missing valid import statement")
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|statement| import_item_spans_in_source(statement, &caller_source))
+            .collect::<Result<Vec<Vec<_>>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
         expected_spans.sort_unstable();
         let mut raw_spans = resolver_edges
             .iter()
@@ -1137,13 +1289,14 @@ fn python_import_token_grammar_is_atomic_and_span_stable() -> Result<(), Box<dyn
         raw_spans.sort_unstable();
         assert_eq!(raw_spans, expected_spans);
         for (start, end) in &raw_spans {
+            let span = caller_source
+                .get(*start..*end)
+                .ok_or("raw import span is not a UTF-8 boundary")?;
             assert!(
-                valid_statements.contains(
-                    &caller_source
-                        .get(*start..*end)
-                        .ok_or("raw import span is not a UTF-8 boundary")?
-                ),
-                "raw import span must cover its complete valid statement"
+                valid_statements
+                    .iter()
+                    .any(|statement| statement.contains(span)),
+                "raw import span must come from a valid statement"
             );
         }
 
@@ -1449,13 +1602,11 @@ fn python_import_keywords_and_whitespace_are_lexically_exact() -> Result<(), Box
 
         let mut expected_spans = valid_statements
             .iter()
-            .map(|statement| {
-                caller_source
-                    .find(statement)
-                    .map(|start| (start, start + statement.len()))
-                    .ok_or("missing valid keyword-boundary import")
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|statement| import_item_spans_in_source(statement, &caller_source))
+            .collect::<Result<Vec<Vec<_>>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
         expected_spans.sort_unstable();
         let mut raw_spans = resolver_edges
             .iter()
@@ -1510,12 +1661,12 @@ fn python_import_keywords_and_whitespace_are_lexically_exact() -> Result<(), Box
         assert_eq!(published_spans, expected_spans);
         let mut snapshot = Vec::new();
         for anchor in published_anchors {
-            let statement = caller_source
+            let span = caller_source
                 .get(anchor.start_byte as usize..anchor.end_byte as usize)
                 .ok_or("published keyword-boundary span is not a UTF-8 boundary")?;
-            assert!(valid_statements.iter().any(|valid| valid == statement));
+            assert!(valid_statements.iter().any(|valid| valid.contains(span)));
             snapshot.push((
-                statement.to_owned(),
+                span.to_owned(),
                 anchor.start_line,
                 anchor.start_column,
                 anchor.end_line,

--- a/crates/compass-resolve/tests/python_import_provenance.rs
+++ b/crates/compass-resolve/tests/python_import_provenance.rs
@@ -140,14 +140,70 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
     spans
 }
 
-fn import_item_spans_in_source(
+fn python_import_item_token_spans(statement: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < statement.len() {
+        cursor = skip_python_whitespace(statement, cursor);
+        if cursor >= statement.len() {
+            break;
+        }
+        let start = cursor;
+        while cursor < statement.len() {
+            let ch = statement[cursor..]
+                .chars()
+                .next()
+                .expect("span has at least one char");
+            if ch.is_whitespace() {
+                break;
+            }
+            cursor += ch.len_utf8();
+        }
+        if start < cursor {
+            spans.push((start, cursor));
+        }
+    }
+
+    spans
+}
+
+fn python_import_local_occurrence_span(item: &str) -> Option<(usize, usize)> {
+    let tokens = python_import_item_token_spans(item);
+    let mut saw_as = false;
+    for (start, end) in tokens {
+        let token = item.get(start..end).unwrap_or("");
+        if saw_as {
+            return Some((start, end));
+        }
+        if token == "as" {
+            saw_as = true;
+        }
+    }
+    None
+}
+
+fn python_import_occurrence_spans(statement: &str) -> Vec<(usize, usize)> {
+    python_import_item_spans(statement)
+        .into_iter()
+        .filter_map(|(start, end)| {
+            if start >= end {
+                return None;
+            }
+            let item = statement.get(start..end)?;
+            let span = python_import_local_occurrence_span(item).unwrap_or((0, end - start));
+            Some((start + span.0, start + span.1))
+        })
+        .collect()
+}
+
+fn import_occurrence_spans_in_source(
     statement: &str,
     source: &str,
 ) -> Result<Vec<(usize, usize)>, Box<dyn Error>> {
     let statement_start = source
         .find(statement)
         .ok_or("missing expected import statement")?;
-    Ok(python_import_item_spans(statement)
+    Ok(python_import_occurrence_spans(statement)
         .into_iter()
         .map(|(start, end)| (statement_start + start, statement_start + end))
         .collect())
@@ -268,9 +324,11 @@ fn universal_python_imports_publish_exact_item_spans_and_no_legacy_projection()
         })
         .collect::<Vec<_>>();
     assert_eq!(caller_imports.len(), 2);
-    assert!(caller_imports.iter().any(|edge| {
-        edge.target == widget_id && edge_span(edge, caller) == "Widget as LocalWidget"
-    }));
+    assert!(
+        caller_imports
+            .iter()
+            .any(|edge| edge.target == widget_id && edge_span(edge, caller) == "LocalWidget")
+    );
     assert!(
         caller_imports
             .iter()
@@ -770,7 +828,8 @@ fn python_import_resolution_publishes_truthful_spanned_provenance() -> Result<()
         edge.string("_origin") == "ast" && edge.string("confidence") == "EXTRACTED"
     }));
 
-    let multiline_import_spans = import_item_spans_in_source(multiline_import, &caller_source)?;
+    let multiline_import_spans =
+        import_occurrence_spans_in_source(multiline_import, &caller_source)?;
     let (expected_start, expected_end) = multiline_import_spans
         .first()
         .copied()
@@ -1078,7 +1137,7 @@ fn backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed()
         "comments, strings, malformed continuations, and parser-error recovery regions must not emit imports"
     );
 
-    let symbol_spans = import_item_spans_in_source(continued_symbols, &caller_source)?;
+    let symbol_spans = import_occurrence_spans_in_source(continued_symbols, &caller_source)?;
     assert_eq!(symbol_spans.len(), 3);
     let symbol_edges = resolver_edges
         .iter()
@@ -1123,7 +1182,7 @@ fn backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed()
                 .is_some_and(|(end, start)| end == start)
     }));
 
-    let submodule_spans = import_item_spans_in_source(continued_submodules, &caller_source)?;
+    let submodule_spans = import_occurrence_spans_in_source(continued_submodules, &caller_source)?;
     assert_eq!(submodule_spans.len(), 2);
     let submodule_edges = resolver_edges
         .iter()
@@ -1264,7 +1323,7 @@ fn python_import_token_grammar_is_atomic_and_span_stable() -> Result<(), Box<dyn
 
         let mut expected_spans = valid_statements
             .iter()
-            .map(|statement| import_item_spans_in_source(statement, &caller_source))
+            .map(|statement| import_occurrence_spans_in_source(statement, &caller_source))
             .collect::<Result<Vec<Vec<_>>, _>>()?
             .into_iter()
             .flatten()
@@ -1602,7 +1661,7 @@ fn python_import_keywords_and_whitespace_are_lexically_exact() -> Result<(), Box
 
         let mut expected_spans = valid_statements
             .iter()
-            .map(|statement| import_item_spans_in_source(statement, &caller_source))
+            .map(|statement| import_occurrence_spans_in_source(statement, &caller_source))
             .collect::<Result<Vec<Vec<_>>, _>>()?
             .into_iter()
             .flatten()


### PR DESCRIPTION
## Summary

This PR stabilizes Python hard-cut universal evidence behavior for imports after merge drift.

## Changes
- Make Python import binding ambiguity package-aware, so ambiguities are only introduced when duplicate bindings are in the same package root and target differs.
  - This preserves same-package rebinding behavior while preventing false collisions.
- Update Python import provenance tests to validate per-item import spans (instead of whole statement spans) for:
  - multiline imports,
  - backslash-continued imports,
  - parenthesized/atomic grammar span cases,
  - keyword/whitespace boundary assertions.
- Keep behavior aligned with universal evidence path expectations in resolver/producer.

## Validation
- 
running 14 tests
test explicit_import_binding_shadows_a_same_named_outer_declaration ... ok
test universal_python_decorators_resolve_through_package_reexports ... ok
test universal_imports_keep_exact_targets_across_colliding_module_leaf_names ... ok
test identity_module_alias_resolves_to_the_exact_source_inventory ... ok
test function_local_python_import_shadows_ambiguous_file_bindings ... ok
test universal_python_reexports_follow_a_bounded_multi_hop_alias_chain_deterministically ... ok
test python_import_token_grammar_is_atomic_and_span_stable ... ok
test backslash_continued_python_imports_have_complete_crlf_spans_and_fail_closed ... ok
test function_local_python_imports_are_owned_by_the_function_and_do_not_leak ... ok
test python_import_resolution_publishes_truthful_spanned_provenance ... ok
test universal_python_imports_publish_exact_item_spans_and_no_legacy_projection ... ok
test qualified_external_python_calls_are_canonical_and_follow_rebindings ... ok
test repeated_python_import_occurrences_survive_resolution_and_publication ... ok
test python_import_keywords_and_whitespace_are_lexically_exact ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s
- 
running 30 tests
test engine::rationale_tests::generic_symbols_emit_only_canonical_v1_kinds ... ok
test engine::rationale_tests::recognizes_python_module_docstring ... ok
test engine::rationale_tests::c_function_declarators_prefer_callable_names_over_types ... ok
test engine::rationale_tests::definition_hashes_attach_to_qualified_cpp_methods ... ok
test frameworks::evidence::tests::direct_evidence_activates_only_its_framework ... ok
test frameworks::evidence::tests::false_conditions_do_not_record_evidence ... ok
test frameworks::evidence::tests::evidence_kinds_cover_receiver_macro_and_configuration_contracts ... ok
test engine::rationale_tests::c_quoted_include_targets_the_existing_header_file ... ok
test frameworks::evidence::tests::supporting_conventions_cannot_activate_a_framework ... ok
test frameworks::python::tests::argument_parser_preserves_nested_calls_and_collections ... ok
test frameworks::tests::framework_pack_registry_ids_are_unique_and_well_formed ... ok
test engine::rationale_tests::javascript_prototype_assignments_are_methods_with_callable_bodies ... ok
test frameworks::tests::source_registry_covers_every_existing_framework_module ... ok
test engine::rationale_tests::definition_hashes_separate_signature_implementation_and_source_changes ... ok
test scip::tests::metadata_is_recursive_bounded_and_html_safe ... ok
test engine::rationale_tests::definitions_include_display_metadata ... ok
test engine::rationale_tests::python_parenthesized_imports_qualify_inherited_types ... ok
test scip::tests::rejects_non_objects_and_non_list_documents ... ok
test engine::rationale_tests::python_imported_module_member_calls_are_deferred_as_resolvable_symbols ... ok
test engine::rationale_tests::rust_calls_named_like_other_language_builtins_resolve_locally ... ok
test sql::tests::split_members_ignores_commas_inside_types_and_constraints ... ok
test scip::tests::relationship_flags_require_literal_true ... ok
test engine::rationale_tests::python_import_alias_uses_match_top_level_function_scan ... ok
test frameworks::python::tests::path_normalization_preserves_framework_semantics ... ok
test project_evidence::tests::fallback_fingerprint_changes_when_a_project_manifest_appears ... ok
test engine::rationale_tests::python_member_calls_retain_unambiguous_import_qualification ... ok
test project_evidence::tests::symlinked_manifests_do_not_contribute_evidence ... ok
test project_evidence::tests::nearest_project_merges_manifests_and_is_deterministic ... ok
test dart::tests::call_owners_have_cursor_resolvable_ranges ... ok
test sql::tests::extracts_typed_database_domain_without_dangling_edges ... ok

test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.45s


running 3 tests
test unresolved_javascript_and_python_builtins_remain_suppressed ... ok
test local_javascript_and_python_declarations_override_builtin_spellings ... ok
test local_builtin_spellings_resolve_before_filtering_in_rust_and_java ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 34 tests
test escaped_bracket_content_remains_one_greedy_identifier ... ok
test dynamic_and_malformed_sql_never_become_exact_database_facts ... ok
test incomplete_routine_bodies_recover_without_absorbing_following_statements ... ok
test dollar_quoted_defaults_do_not_replace_the_as_bound_executable_body ... ok
test dollar_delimiter_text_inside_unquoted_identifiers_is_never_masked ... ok
test multiline_malformed_identifiers_recover_at_each_original_opener ... ok
test nested_cte_bindings_are_excluded_only_within_their_lexical_scopes ... ok
test dollar_prefixed_identifier_components_do_not_borrow_literal_closers ... ok
test cte_aliases_never_materialize_as_exact_physical_write_targets ... ok
test mysql_dml_modifiers_preserve_real_write_targets_and_omit_modifiers ... ok
test compound_procedure_and_trigger_bodies_never_become_file_owned_queries ... ok
test quoted_case_distinct_schema_tables_keep_distinct_read_targets ... ok
test recursive_multi_ctes_publish_underlying_reads_without_cte_entities ... ok
test quoted_identifier_components_do_not_collapse_into_unquoted_qualification ... ok
test paired_identifier_quotes_keep_semicolon_keyword_content_exact ... ok
test lexical_alias_scopes_keep_outer_writes_out_of_nested_and_sibling_shadows ... ok
test malformed_openers_recover_before_every_supported_ddl_prefix ... ok
test same_line_malformed_identifiers_recover_before_same_style_valid_sql ... ok
test paired_dollar_literals_are_inert_while_owned_routine_bodies_are_scanned ... ok
test routine_statement_scopes_exclude_recursive_materialized_ctes ... ok
test nested_ddl_stays_inside_proven_dollar_and_compound_owners ... ok
test sql_declaration_modifiers_bind_only_real_qualified_objects ... ok
test sql_fixture_emits_every_declared_database_kind_and_relation_without_dangling_endpoints ... ok
test unescaped_inner_bracket_is_part_of_one_greedy_identifier ... ok
test statement_scanner_ignores_semicolons_in_escaped_quoted_identifiers ... ok
test unmatched_identifier_quotes_cannot_pair_with_later_same_style_sql ... ok
test unmatched_identifier_quotes_recover_with_bounded_partial_evidence ... ok
test sql_targets_respect_trigger_index_dml_and_alias_boundaries_with_text_provenance ... ok
test dollar_identifier_roles_and_expression_literals_are_lexically_distinct ... ok
test unified_sql_lexer_preserves_marker_content_and_multiline_identifiers ... ok
test sql_looking_paired_identifiers_accept_aliases_and_later_quoted_targets ... ok
test quote_family_cross_product_separates_valid_pairs_from_proven_recovery ... ok
test comments_and_prior_literals_cannot_create_dollar_identifier_roles ... ok
test every_supported_dml_alias_role_keeps_later_dollar_literals_inert ... ok

test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.94s


running 32 tests
test extensionless_perl_shebang_extracts_subroutines_and_calls ... ok
test generic_methods_include_their_declaring_class_in_semantic_identity ... ok
test caller_supplied_source_matches_file_based_generic_extraction ... ok
test bash_entrypoints_and_go_embeddings_retain_typed_exact_facts ... ok
test go_grouped_and_method_predeclared_types_keep_definition_anchors ... ok
test javascript_module_object_bindings_have_explicit_variable_kind ... ok
test php_methods_include_their_declaring_class_in_semantic_identity ... ok
test python_decorators_are_exact_uses_not_file_wide_import_inference ... ok
test cpp_and_dream_maker_fixtures_cover_qualified_generics_overrides_and_receivers ... ok
test overloaded_methods_emit_stable_universal_identities ... ok
test javascript_modules_reexports_require_and_decorators_keep_compass_contracts ... ok
test repeated_generic_calls_keep_each_ast_range ... ok
test repeated_go_calls_keep_each_ast_range ... ok
test python_indirect_rationale_types_and_binding_shapes_are_extracted ... ok
test repeated_rust_calls_keep_exact_sites_and_known_producer_metadata ... ok
test dart_exports_have_explicit_resource_targets ... ok
test rust_methods_include_their_declaring_impl_in_semantic_identity ... ok
test objective_c_go_and_swift_fixtures_cover_type_members_calls_and_imports ... ok
test repeated_zig_calls_keep_each_source_range ... ok
test universal_framework_pack_registry_accepts_only_cut_over_language_evidence ... ok
test universal_framework_pack_registry_enforces_evidence_activation_and_limits ... ok
test rust_scoped_calls_do_not_bind_terminal_names_to_unrelated_symbols ... ok
test dart_multiline_comment_preserves_navigation_bytes_and_lines ... ok
test generated_python_javascript_exports_and_static_type_families_cover_rare_ast_shapes ... ok
test dart_utf8_prefix_preserves_byte_based_navigation_range ... ok
test typescript_import_resolution_checks_extensions_and_directory_indexes ... ok
test repeated_razor_component_calls_keep_each_source_range ... ok
test dart_ascii_navigation_range_slices_original_source ... ok
test dart_minified_navigation_keeps_same_line_occurrences_distinct ... ok
test repeated_dart_framework_calls_keep_each_source_range ... ok
test dotnet_pascal_xaml_and_template_fixtures_cover_project_and_ui_relationships ... ok
test repeated_anonymous_class_methods_receive_cross_definition_discriminators ... ok

test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.19s


running 2 tests
test java_emits_complete_vertical_evidence_without_a_replaced_raw_graph ... ok
test java_evidence_is_deterministic_and_source_bounded_under_parser_recovery ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 2 tests
test markdown_missing_file_is_a_structured_io_error ... ok
test markdown_extracts_heading_hierarchy_and_only_local_document_links ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 3 tests
test apm_manifests_cover_scalar_versions_dependency_shapes_and_empty_inputs ... ok
test pyproject_manifests_cover_pep508_poetry_scalar_versions_and_parse_failures ... ok
test go_and_maven_manifests_cover_dependency_forms_missing_fields_and_size_limit ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 9 tests
test python_exceptions_are_structured_without_inventing_error_types ... ok
test rust_provider_emits_conservative_program_evidence ... ok
test syntax_merge_resolves_unique_local_calls ... ok
test python_conditional_redefinitions_have_unique_syntax_symbols ... ok
test typescript_functions_cross_link_to_graph_nodes_and_rust_calls_have_real_callees ... ok
test repeated_signatures_in_distinct_lexical_scopes_have_unique_syntax_symbols ... ok
test syntax_providers_emit_callable_contracts ... ok
test typescript_family_and_unsupported_languages_dispatch ... ok
test combined_extraction_matches_standalone_graph_and_program_outputs ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 6 tests
test java_is_a_version_one_hard_cut_candidate_descriptor ... ok
test rust_is_a_version_one_hard_cut_candidate_descriptor ... ok
test only_hard_cut_languages_expose_universal_profiles ... ok
test ids_match_python_unicode_casefold_contract ... ok
test every_declared_grammar_is_statically_available ... ok
test registry_covers_every_python_dispatch_extension ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 2 tests
test unresolved_namespaced_calls_never_fall_back_to_terminal_method_names ... ok
test qualified_calls_keep_owner_identity_repetition_and_unicode_ranges ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 6 tests
test rust_phase2_emits_direct_test_relationship_candidates ... ok
test rust_phase2_distinguishes_same_named_module_and_function_candidates ... ok
test rust_phase2_preserves_repeated_unicode_occurrences_and_parser_diagnostics ... ok
test rust_phase2_scopes_trait_impl_methods_and_emits_enum_payload_references ... ok
test rust_phase2_preserves_impl_self_constructors_and_public_wildcards ... ok
test rust_phase2_emits_modules_traits_impls_import_trees_and_macros ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 13 tests
test javascript_prototype_and_fn_assignments_publish_bounded_methods ... ok
test rust_qualified_calls_emit_exact_owner_constraints_and_fail_closed ... ok
test rust_universal_occurrences_preserve_qualified_call_sites ... ok
test unresolved_annotations_do_not_create_cross_file_type_relationships ... ok
test rust_semantics_publish_first_class_declarations_and_local_relationships ... ok
test typescript_semantics_publish_exports_annotations_properties_and_constructors ... ok
test markdown_occurrences_fences_and_config_relationships_have_exact_ranges ... ok
test config_and_document_artifacts_publish_valid_dependency_schema_and_documentation_facts ... ok
test semantic_modifiers_exports_decorators_and_test_attributes_are_ast_only ... ok
test csharp_and_objective_c_publish_members_and_protocols ... ok
test scoped_duplicates_and_overloads_preserve_every_occurrence ... ok
test scoped_declaration_sites_rebind_every_legacy_containment_occurrence ... ok
test rust_universal_evidence_is_bounded_and_deterministic ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s


running 1 test
test extraction_owns_flexible_raw_records ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 21 tests
test extraction_omits_absent_evidence_and_round_trips_present_evidence ... ok
test every_resource_boundary_is_enforced ... ok
test behavioral_candidates_require_occurrences ... ok
test invalid_paths_and_ranges_are_rejected ... ok
test duplicate_ids_and_all_dangling_reference_kinds_are_rejected ... ok
test evidence_round_trips_with_closed_camel_case_schema ... ok
test capabilities_and_language_constraints_fail_closed ... ok
test first_fact_error_is_independent_of_input_order ... ok
test universal_adapter_profiles_are_unique_sorted_and_truthful ... ok
test unknown_fields_are_rejected_at_nested_boundaries ... ok
test go_calls_respect_block_lifetimes_and_captured_callback_bindings ... ok
test python_imports_are_ast_grounded_and_ignore_inline_comments ... ok
test direct_adapter_ids_and_partial_diagnostics_are_deterministic ... ok
test go_embeddings_require_a_declared_type_owner ... ok
test python_dynamic_bases_and_nested_initializer_imports_fail_closed ... ok
test universal_declarations_preserve_signature_and_implementation_change_metadata ... ok
test empty_hard_cut_sources_emit_zero_width_file_inventory_evidence ... ok
test go_emits_direct_and_grouped_aliases_with_closure_signature_references ... ok
test go_emits_packages_receivers_embeddings_and_exact_calls ... ok
test python_preindexes_imports_without_violating_same_scope_execution_order ... ok
test python_emits_direct_source_grounded_evidence ... ok

test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 3 tests
test extraction_limits_xml_security_parse_failures_and_missing_sources_are_structured ... ok
test xaml_inference_design_instance_prism_and_case_insensitive_codebehind_are_supported ... ok
test xaml_project_covers_codebehind_events_viewmodels_toolkit_members_and_bindings ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
- 