### PR TITLE
Finalize Python/Go hard-cut quality gates and comparison tooling

### DIFF
--- a/benchmarks/performance/compass/correctness.py
+++ b/benchmarks/performance/compass/correctness.py
@@ -956,7 +956,7 @@ def _classify_edges(
             for fact in (source_coverage, target_coverage)
         )
         exact = [
-            (edge, occurrence)
+            edge
             for edge in exact_index.get(
                 (
                     graphify.relation,

--- a/crates/compass-cypher/src/optimize.rs
+++ b/crates/compass-cypher/src/optimize.rs
@@ -5,7 +5,6 @@ use crate::{
 
 #[must_use]
 pub fn optimize(mut plan: LogicalPlan) -> LogicalPlan {
-    let mut eliminated_path_bindings = 0usize;
     for part in &mut plan.ast.parts {
         eliminate_unused_path_bindings(part, &mut plan.optimizations);
         for clause in &mut part.clauses {
@@ -50,14 +49,6 @@ pub fn optimize(mut plan: LogicalPlan) -> LogicalPlan {
                 });
             }
         }
-    }
-    if eliminated_path_bindings > 0 {
-        plan.optimizations.push(OptimizationRecord {
-            rule: "unused-path-binding-elimination",
-            reason: format!(
-                "removed {eliminated_path_bindings} unreferenced path binding(s) before execution"
-            ),
-        });
     }
     plan
 }

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -1030,7 +1030,7 @@ impl<'source> DirectAdapterState<'source> {
             if !valid_python_import_target(&target_name)
                 || alias_node
                     .as_ref()
-                    .is_some_and(|alias_node| alias.is_none() && self.text(*alias_node) != "")
+                    .is_some_and(|alias_node| alias.is_none() && !self.text(*alias_node).is_empty())
             {
                 continue;
             }

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -1885,7 +1885,7 @@ mod tests {
             ..Extraction::default()
         };
 
-        resolve_cross_file_calls_with_root(&mut extraction, Path::new("/repo"));
+        resolve_cross_file_calls_with_root(&mut extraction, &HashMap::new(), Path::new("/repo"));
 
         assert!(!extraction.edges.iter().any(|edge| {
             edge.source == "dispatch"


### PR DESCRIPTION
## Summary

This PR finalizes the Python + Go hard-cut validation context and makes the graph comparison workflow reliable by fixing a real comparator bug discovered during the same run.

### What changed

- **Hard-cut quality gates remain green (Python + Go):**
  - `benchmarks/performance/performance` hard-path test coverage for Python/Go-adopted evidence and resolution behavior.
  - Evidence tests and resolution tests were re-run and all passed.

- **Comparator correctness fix:**
  - Fixed an in-tree analyzer regression in
    `benchmarks/performance/compass/correctness.py` where exact edge matches were incorrectly built as `(edge, occurrence)` tuples but later treated as `EdgeFact`.
  - The wrong tuple shape caused `analyze.py` comparisons to fail on valid input.

- **Targeted cleanup in core runtime files:**
  - `crates/compass-cypher/src/optimize.rs`
    - removed unused accumulation path for an optimization counter that was no longer used for diagnostics.
  - `crates/compass-languages/src/evidence/build.rs`
    - tightened string emptiness check on alias text for Python import target filtering.
  - `crates/compass-resolve/src/lib.rs`
    - updated test call-site to match the hard-cut cross-file resolver API shape (`HashMap` argument required for alias-resolution map).

### Why this matters

- Ensures the Python/Go hard-cut evidence path and resolver behavior can be validated without false infrastructure failures.
- Removes a hard stop in cross-tool compare jobs so the benchmark report can complete end-to-end.
- Keeps the result set and code changes scoped to quality gates and comparison stability, with no behavior extension of language extraction in this PR.

## Validation run

- `cargo test -p compass-languages --test universal_evidence -- --nocapture` *(21 passed)*
- `cargo test -p compass-resolve --test go_resolution -- --nocapture` *(5 passed)*
- `cargo test -p compass-resolve --test python_import_provenance -- --nocapture` *(14 passed)*
- `cargo test -p compass-resolve --test universal_resolution -- --nocapture` *(28 passed)*
- `python3 -m unittest benchmarks/performance/tests/test_analyze.py` *(2 passed)*

## Notes

- Existing repository has been left on the branch at `0.1.10` behavior baseline.
- A manual Compass/Graphify comparison was executed for `django` and `entire` corpora in the benchmark workspace during this validation pass; summary artifacts are present in `target/performance/manual/pg-compare/metrics/results.json` and `target/performance/manual/pg-compare/REPORT.md`.
