### PR TITLE
Qualify Java universal candidate

### DIFF
--- a/benchmarks/performance/compass/correctness.py
+++ b/benchmarks/performance/compass/correctness.py
@@ -575,6 +575,33 @@ def _qualified_name_has_owner(qualified_name: str) -> bool:
     return "." in qualified_name or "::" in qualified_name
 
 
+def _constructor_matches_name(constructor: NodeFact, normalized_label: str) -> bool:
+    qualified_parts = [
+        part for part in re.split(r"::|\.", constructor.qualified_name) if part
+    ]
+    return bool(
+        len(qualified_parts) >= 2
+        and qualified_parts[-1] in {"<init>", "new"}
+        and qualified_parts[-2] == _terminal_symbol(normalized_label)
+    )
+
+
+def _unique_nearest_definition(
+    candidates: list[NodeFact], source_line: int, *, maximum_distance: int = 8
+) -> NodeFact | None:
+    nearby = [
+        (abs(candidate_line - source_line), candidate)
+        for candidate in candidates
+        if (candidate_line := _line_number(candidate.source_location)) is not None
+        and abs(candidate_line - source_line) <= maximum_distance
+    ]
+    if not nearby:
+        return None
+    minimum_distance = min(distance for distance, _ in nearby)
+    nearest = [candidate for distance, candidate in nearby if distance == minimum_distance]
+    return nearest[0] if len(nearest) == 1 else None
+
+
 def _unverifiable_placeholder(node: NodeFact) -> bool:
     return bool(
         node.placeholder
@@ -592,20 +619,228 @@ def _classify_nodes(
 ) -> tuple[dict[str, Coverage], dict[str, str]]:
     compass_by_fact: dict[str, list[NodeFact]] = {}
     compass_by_label: dict[str, list[NodeFact]] = {}
+    compass_callables_by_site: dict[tuple[str, str, str], list[NodeFact]] = {}
+    compass_callables_by_file_name: dict[tuple[str, str], list[NodeFact]] = {}
+    compass_constructors_by_site: dict[tuple[str, str], list[NodeFact]] = {}
+    compass_constructors_by_file: dict[str, list[NodeFact]] = {}
+    compass_definitions_by_site: dict[tuple[str, str, str], list[NodeFact]] = {}
+    compass_definitions_by_file_name: dict[tuple[str, str], list[NodeFact]] = {}
     for node in compass_nodes.values():
         compass_by_fact.setdefault(node.fact_key, []).append(node)
         if node.anchored_definition and not node.callable:
             compass_by_label.setdefault(node.normalized_label, []).append(node)
+            definition_name = _terminal_symbol(node.normalized_label)
+            compass_definitions_by_site.setdefault(
+                (
+                    node.source_file,
+                    node.source_location,
+                    definition_name,
+                ),
+                [],
+            ).append(node)
+            compass_definitions_by_file_name.setdefault(
+                (node.source_file, definition_name), []
+            ).append(node)
+        if node.anchored_definition and node.callable:
+            callable_name = _terminal_symbol(node.normalized_label)
+            compass_callables_by_site.setdefault(
+                (
+                    node.source_file,
+                    node.source_location,
+                    callable_name,
+                ),
+                [],
+            ).append(node)
+            compass_callables_by_file_name.setdefault(
+                (node.source_file, callable_name), []
+            ).append(node)
+            if node.kind == "constructor":
+                compass_constructors_by_site.setdefault(
+                    (node.source_file, node.source_location), []
+                ).append(node)
+                compass_constructors_by_file.setdefault(node.source_file, []).append(node)
 
     coverage: dict[str, Coverage] = {}
     mapping: dict[str, str] = {}
     excluded_kinds = {"file", "import", "export", "resource", "rationale"}
     for identifier, graphify in graphify_nodes.items():
         exact = compass_by_fact.get(graphify.fact_key, [])
+        exact_compatible = [
+            candidate
+            for candidate in exact
+            if (not graphify.kind or not candidate.kind or graphify.kind == candidate.kind)
+            and (
+                not graphify.language
+                or not candidate.language
+                or graphify.language == candidate.language
+            )
+            and (
+                not _qualified_name_has_owner(graphify.qualified_name)
+                or not _qualified_name_has_owner(candidate.qualified_name)
+                or graphify.qualified_name == candidate.qualified_name
+            )
+        ]
+        if len(exact_compatible) == 1 and not _unverifiable_placeholder(graphify):
+            coverage[identifier] = Coverage(
+                "exact", "source_fact", exact_compatible[0].identifier
+            )
+            mapping[identifier] = exact_compatible[0].identifier
+            continue
+        if graphify.callable and graphify.source_file and graphify.source_location:
+            callable_candidates = [
+                candidate
+                for candidate in compass_callables_by_site.get(
+                    (
+                        graphify.source_file,
+                        graphify.source_location,
+                        _terminal_symbol(graphify.normalized_label),
+                    ),
+                    [],
+                )
+                if not graphify.language
+                or not candidate.language
+                or graphify.language == candidate.language
+            ]
+            if len(callable_candidates) == 1:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "canonical_callable_owner",
+                    callable_candidates[0].identifier,
+                )
+                mapping[identifier] = callable_candidates[0].identifier
+                continue
+            graphify_line = _line_number(graphify.source_location)
+            constructor_candidates = [
+                candidate
+                for candidate in compass_constructors_by_site.get(
+                    (graphify.source_file, graphify.source_location), []
+                )
+                if _constructor_matches_name(candidate, graphify.normalized_label)
+            ]
+            if len(constructor_candidates) == 1:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "canonical_constructor_anchor",
+                    constructor_candidates[0].identifier,
+                )
+                mapping[identifier] = constructor_candidates[0].identifier
+                continue
+            nearest_constructor = (
+                _unique_nearest_definition(
+                    [
+                        candidate
+                        for candidate in compass_constructors_by_file.get(
+                            graphify.source_file, []
+                        )
+                        if _constructor_matches_name(
+                            candidate, graphify.normalized_label
+                        )
+                    ],
+                    graphify_line,
+                )
+                if graphify_line is not None
+                else None
+            )
+            if nearest_constructor is not None:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "nearby_constructor_declaration",
+                    nearest_constructor.identifier,
+                )
+                mapping[identifier] = nearest_constructor.identifier
+                continue
+            nearby_candidates = [
+                candidate
+                for candidate in compass_callables_by_file_name.get(
+                    (
+                        graphify.source_file,
+                        _terminal_symbol(graphify.normalized_label),
+                    ),
+                    [],
+                )
+                if (
+                    not graphify.language
+                    or not candidate.language
+                    or graphify.language == candidate.language
+                )
+            ]
+            nearest_candidate = (
+                _unique_nearest_definition(nearby_candidates, graphify_line)
+                if graphify_line is not None
+                else None
+            )
+            if nearest_candidate is not None:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "nearby_callable_declaration",
+                    nearest_candidate.identifier,
+                )
+                mapping[identifier] = nearest_candidate.identifier
+                continue
+        if (
+            not graphify.callable
+            and graphify.source_file
+            and graphify.source_location
+            and Path(graphify.source_file).name.casefold()
+            != graphify.normalized_label.casefold()
+        ):
+            definition_candidates = [
+                candidate
+                for candidate in compass_definitions_by_site.get(
+                    (
+                        graphify.source_file,
+                        graphify.source_location,
+                        _terminal_symbol(graphify.normalized_label),
+                    ),
+                    [],
+                )
+                if (not graphify.kind or not candidate.kind or graphify.kind == candidate.kind)
+                and (
+                    not graphify.language
+                    or not candidate.language
+                    or graphify.language == candidate.language
+                )
+            ]
+            if len(definition_candidates) == 1:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "canonical_definition_anchor",
+                    definition_candidates[0].identifier,
+                )
+                mapping[identifier] = definition_candidates[0].identifier
+                continue
+            graphify_line = _line_number(graphify.source_location)
+            nearby_definitions = [
+                candidate
+                for candidate in compass_definitions_by_file_name.get(
+                    (
+                        graphify.source_file,
+                        _terminal_symbol(graphify.normalized_label),
+                    ),
+                    [],
+                )
+                if (not graphify.kind or not candidate.kind or graphify.kind == candidate.kind)
+                and (
+                    not graphify.language
+                    or not candidate.language
+                    or graphify.language == candidate.language
+                )
+            ]
+            nearest_definition = (
+                _unique_nearest_definition(nearby_definitions, graphify_line)
+                if graphify_line is not None
+                else None
+            )
+            if nearest_definition is not None:
+                coverage[identifier] = Coverage(
+                    "dominated",
+                    "nearby_definition_anchor",
+                    nearest_definition.identifier,
+                )
+                mapping[identifier] = nearest_definition.identifier
+                continue
         if exact and not _unverifiable_placeholder(graphify):
             coverage[identifier] = Coverage("exact", "source_fact", exact[0].identifier)
-            if len(exact) == 1:
-                mapping[identifier] = exact[0].identifier
             continue
         if _unverifiable_placeholder(graphify):
             generated_owner = [
@@ -746,16 +981,17 @@ def _precise_inheritance_occurrence(
         return False
     if (
         graphify.occurrence_file != graphify_source.source_file
-        or graphify.occurrence_location != graphify_source.source_location
         or compass.occurrence_file != graphify.occurrence_file
     ):
         return False
     declaration_line = _line_number(graphify.occurrence_location)
+    source_line = _line_number(graphify_source.source_location)
     base_line = _line_number(compass.occurrence_location)
     return bool(
-        declaration_line is not None
+        source_line is not None
+        and declaration_line is not None
         and base_line is not None
-        and declaration_line <= base_line <= declaration_line + 8
+        and source_line <= declaration_line <= base_line <= source_line + 8
     )
 
 
@@ -785,6 +1021,7 @@ def _classify_edges(
     inheritance_occurrence_targets: dict[
         tuple[str, str, str, str], set[str]
     ] = {}
+    typed_reference_index: dict[tuple[str, str], list[EdgeFact]] = {}
     containment: dict[str, set[str]] = {}
     import_occurrences: set[tuple[str, str, str]] = set()
     for edges in (graphify_edges, compass_edges):
@@ -810,6 +1047,8 @@ def _classify_edges(
         source = canonical_endpoints.get(edge.source, edge.source)
         target = canonical_endpoints.get(edge.target, edge.target)
         direct_index.setdefault((edge.relation, source, target), []).append(edge)
+        if edge.relation in {"returns", "type_of"}:
+            typed_reference_index.setdefault((source, target), []).append(edge)
         source_node = compass_nodes.get(edge.source)
         if (
             edge.relation in {"extends", "implements"}
@@ -1199,6 +1438,27 @@ def _classify_edges(
             )
             output.append(Coverage(status, "uncovered_endpoint", None))
             continue
+
+        if graphify.relation == "references":
+            typed_references = [
+                edge
+                for edge in typed_reference_index.get((source, target), [])
+                if _occurrence_match(graphify, edge, occurrence_oracle) is not None
+            ]
+            if len(typed_references) == 1:
+                output.append(
+                    Coverage(
+                        "dominated",
+                        "precise_typed_reference",
+                        typed_references[0].payload_sha256,
+                    )
+                )
+                continue
+            if len(typed_references) > 1:
+                output.append(
+                    Coverage("ambiguous", "multiple_typed_reference_facts", None)
+                )
+                continue
 
         direct = direct_index.get((graphify.relation, source, target), [])
         if graphify.relation in {"extends", "implements"}:

--- a/benchmarks/performance/tests/test_language_fixture_compare.py
+++ b/benchmarks/performance/tests/test_language_fixture_compare.py
@@ -109,6 +109,125 @@ class LanguageFixtureCompareTests(unittest.TestCase):
             ],
         )
 
+    def test_typed_relations_dominate_only_same_site_generic_references(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            nodes = [
+                {
+                    "id": "owner",
+                    "label": "build",
+                    "kind": "function",
+                    "source_file": "src/lib.rs",
+                    "source_location": "L1",
+                },
+                {
+                    "id": "target",
+                    "label": "Result",
+                    "kind": "struct",
+                    "source_file": "src/result.rs",
+                    "source_location": "L2",
+                },
+            ]
+            manifest = self.fixture(
+                root,
+                "typed-reference",
+                {
+                    "graph": {"diagnostics": []},
+                    "nodes": nodes,
+                    "edges": [
+                        {
+                            "source": "owner",
+                            "target": "target",
+                            "kind": "returns",
+                            "source_file": "src/lib.rs",
+                            "source_location": "L1",
+                        }
+                    ],
+                },
+                {
+                    "nodes": nodes,
+                    "links": [
+                        {
+                            "source": "owner",
+                            "target": "target",
+                            "relation": "uses",
+                            "source_file": "src/lib.rs",
+                            "source_location": "L1",
+                        },
+                        {
+                            "source": "owner",
+                            "target": "target",
+                            "relation": "uses",
+                            "source_file": "src/lib.rs",
+                            "source_location": "L8",
+                        },
+                    ],
+                },
+            )
+            report = build_report([manifest])
+        self.assertEqual(report["coverage"][0]["dominated"], 1)
+        self.assertEqual(report["coverage"][0]["missing"], 1)
+
+    def test_precise_multiline_base_sites_dominate_only_the_bounded_heritage_clause(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            nodes = [
+                {
+                    "id": "derived",
+                    "label": "Derived",
+                    "kind": "interface",
+                    "source_file": "src/types.ts",
+                    "source_location": "L1",
+                },
+                {
+                    "id": "base",
+                    "label": "Base",
+                    "kind": "interface",
+                    "source_file": "src/base.ts",
+                    "source_location": "L1",
+                },
+            ]
+            manifest = self.fixture(
+                root,
+                "multiline-heritage",
+                {
+                    "graph": {"diagnostics": []},
+                    "nodes": nodes,
+                    "edges": [
+                        {
+                            "source": "derived",
+                            "target": "base",
+                            "kind": "extends",
+                            "source_file": "src/types.ts",
+                            "source_location": "L3",
+                        }
+                    ],
+                },
+                {
+                    "nodes": nodes,
+                    "links": [
+                        {
+                            "source": "derived",
+                            "target": "base",
+                            "relation": "extends",
+                            "source_file": "src/types.ts",
+                            "source_location": "L2",
+                        },
+                        {
+                            "source": "derived",
+                            "target": "base",
+                            "relation": "extends",
+                            "source_file": "src/types.ts",
+                            "source_location": "L20",
+                        },
+                    ],
+                },
+                language="typescript",
+            )
+            row = build_report([manifest])["coverage"][0]
+        self.assertEqual(row["dominated"], 1)
+        self.assertEqual(row["missing"], 1)
+
     def test_reports_rejected_qualified_external_rebinding(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -182,6 +301,31 @@ class LanguageFixtureCompareTests(unittest.TestCase):
         self.assertEqual(row["rejected"], 1)
         self.assertEqual(row["missing"], 0)
 
+    def test_reports_and_excludes_graphify_dangling_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            nodes = [{"id": "owner", "label": "owner", "kind": "function"}]
+            manifest = self.fixture(
+                root,
+                "dangling-graphify",
+                {"graph": {"diagnostics": []}, "nodes": nodes, "edges": []},
+                {
+                    "nodes": nodes,
+                    "links": [
+                        {
+                            "source": "owner",
+                            "target": "missing",
+                            "relation": "calls",
+                        }
+                    ],
+                },
+            )
+            report = build_report([manifest])
+
+        self.assertEqual(report["fixtures"][0]["graphify"]["dangling_edges"], 1)
+        self.assertEqual(report["fixtures"][0]["graphify"]["edges"], 0)
+        self.assertEqual(report["fixtures"][0]["node_coverage"]["exact"], 1)
+
     def test_reports_missing_endpoints(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -231,6 +375,241 @@ class LanguageFixtureCompareTests(unittest.TestCase):
         self.assertEqual(row["missing"], 1)
         self.assertEqual(row["handled"], 0)
 
+    def test_matches_callable_owner_spelling_at_the_exact_source_site(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = self.fixture(
+                root,
+                "java-callable-owner",
+                {
+                    "graph": {"diagnostics": []},
+                    "nodes": [
+                        {
+                            "id": "candidate-owner",
+                            "label": "Owner",
+                            "kind": "class",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L1",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-method",
+                            "label": ".run()",
+                            "kind": "method",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L3",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-get-route",
+                            "label": "GET /run",
+                            "kind": "route",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L2",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-post-route",
+                            "label": "POST /run",
+                            "kind": "route",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L2",
+                            "language": "java",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "source": "candidate-owner",
+                            "target": "candidate-method",
+                            "kind": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L3",
+                        }
+                    ],
+                },
+                {
+                    "nodes": [
+                        {
+                            "id": "baseline-owner",
+                            "label": "Owner",
+                            "kind": "class",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L1",
+                            "language": "java",
+                        },
+                        {
+                            "id": "baseline-method",
+                            "label": "Owner::run()",
+                            "kind": "method",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L2",
+                            "language": "java",
+                        },
+                    ],
+                    "links": [
+                        {
+                            "source": "baseline-owner",
+                            "target": "baseline-method",
+                            "relation": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L2",
+                        }
+                    ],
+                },
+                language="java",
+            )
+            row = build_report([manifest])["coverage"][0]
+        self.assertEqual(row["handled"], 1)
+        self.assertEqual(row["missing"], 0)
+
+    def test_matches_the_unique_nearest_java_overload_declaration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = self.fixture(
+                root,
+                "java-overload-anchor",
+                {
+                    "graph": {"diagnostics": []},
+                    "nodes": [
+                        {
+                            "id": "candidate-owner",
+                            "label": "Owner",
+                            "kind": "class",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L1",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-first",
+                            "label": ".run()",
+                            "kind": "method",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L4",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-second",
+                            "label": ".run()",
+                            "kind": "method",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L9",
+                            "language": "java",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "source": "candidate-owner",
+                            "target": "candidate-first",
+                            "kind": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L4",
+                        }
+                    ],
+                },
+                {
+                    "nodes": [
+                        {
+                            "id": "baseline-owner",
+                            "label": "Owner",
+                            "kind": "class",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L1",
+                            "language": "java",
+                        },
+                        {
+                            "id": "baseline-first",
+                            "label": "Owner::run()",
+                            "kind": "method",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L3",
+                            "language": "java",
+                        },
+                    ],
+                    "links": [
+                        {
+                            "source": "baseline-owner",
+                            "target": "baseline-first",
+                            "relation": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L3",
+                        }
+                    ],
+                },
+                language="java",
+            )
+            row = build_report([manifest])["coverage"][0]
+        self.assertEqual(row["handled"], 1)
+        self.assertEqual(row["ambiguous"], 0)
+
+    def test_matches_java_class_and_constructor_across_graphify_spelling(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = self.fixture(
+                root,
+                "java-constructor",
+                {
+                    "graph": {"diagnostics": []},
+                    "nodes": [
+                        {
+                            "id": "candidate-owner",
+                            "label": "Owner",
+                            "kind": "class",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L4",
+                            "qualified_name": "example.Owner",
+                            "language": "java",
+                        },
+                        {
+                            "id": "candidate-constructor",
+                            "label": "<init>",
+                            "kind": "constructor",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L8",
+                            "qualified_name": "example.Owner::<init>",
+                            "language": "java",
+                        },
+                    ],
+                    "edges": [
+                        {
+                            "source": "candidate-owner",
+                            "target": "candidate-constructor",
+                            "kind": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L8",
+                        }
+                    ],
+                },
+                {
+                    "nodes": [
+                        {
+                            "id": "baseline-owner",
+                            "label": "Owner",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L3",
+                        },
+                        {
+                            "id": "baseline-constructor",
+                            "label": ".Owner()",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L8",
+                        },
+                    ],
+                    "links": [
+                        {
+                            "source": "baseline-owner",
+                            "target": "baseline-constructor",
+                            "relation": "contains",
+                            "source_file": "src/Owner.java",
+                            "source_location": "L8",
+                        }
+                    ],
+                },
+                language="java",
+            )
+            row = build_report([manifest])["coverage"][0]
+        self.assertEqual(row["handled"], 1)
+        self.assertEqual(row["missing"], 0)
+
     def test_output_is_deterministic_and_sorted(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -250,6 +629,31 @@ class LanguageFixtureCompareTests(unittest.TestCase):
                 [item["fixture"] for item in first["fixtures"]], ["alpha", "zeta"]
             )
             self.assertIn("| Language | Fixture | Relation |", render_markdown(first))
+
+    def test_three_run_manifest_enforces_byte_and_occurrence_determinism(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            graph = {"graph": {"diagnostics": []}, "nodes": [], "edges": []}
+            manifest = self.fixture(root, "repeated", graph, graph, language="java")
+            fixture_root = manifest.parent
+            for name in ("candidate-2.json", "candidate-3.json"):
+                (fixture_root / name).write_text(json.dumps(graph), encoding="utf-8")
+            document = json.loads(manifest.read_text(encoding="utf-8"))
+            document.pop("compass_graph")
+            document["compass_graphs"] = [
+                "compass.json",
+                "candidate-2.json",
+                "candidate-3.json",
+            ]
+            manifest.write_text(json.dumps(document), encoding="utf-8")
+            report = build_report([manifest])
+            self.assertEqual(report["fixtures"][0]["compass"]["runs"], 3)
+
+            (fixture_root / "candidate-3.json").write_text(
+                json.dumps(graph, indent=2), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "run 3 graph bytes differ"):
+                build_report([manifest])
 
     def test_invalid_manifest_and_graph_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/benchmarks/performance/tools/compare_language_fixtures.py
+++ b/benchmarks/performance/tools/compare_language_fixtures.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
+import hashlib
 import json
 from pathlib import Path
 import sqlite3
-from typing import Sequence
+import tempfile
+from typing import Iterator, Sequence
 
 from benchmarks.performance.compass.correctness import (
     _classify_edges,
@@ -22,13 +25,14 @@ from benchmarks.performance.compass.correctness import (
 SCHEMA = "compass.language-fixture-comparison/1"
 FIXTURE_SCHEMA = "compass.language-fixture/1"
 STATUSES = ("exact", "dominated", "rejected", "ambiguous", "missing")
+MAX_GRAPHIFY_COMPARISON_BYTES = 512 * 1024 * 1024
 
 
 @dataclass(frozen=True)
 class FixtureSpec:
     language: str
     fixture: str
-    compass_graph: Path
+    compass_graphs: tuple[Path, ...]
     graphify_graph: Path
 
 
@@ -56,9 +60,14 @@ class FixtureResult:
     compass_nodes: int
     compass_edges: int
     compass_digest: str
+    compass_bytes_digest: str
+    compass_occurrence_digest: str
+    compass_runs: int
     graphify_nodes: int
     graphify_edges: int
+    graphify_dangling_edges: int
     graphify_digest: str
+    node_coverage: dict[str, int]
     rows: tuple[CoverageRow, ...]
 
 
@@ -67,6 +76,97 @@ def _required_text(document: dict[str, object], key: str, manifest: Path) -> str
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"fixture manifest {manifest} has invalid {key!r}")
     return value.strip()
+
+
+def _compass_graphs(
+    document: dict[str, object], root: Path, manifest: Path
+) -> tuple[Path, ...]:
+    repeated = document.get("compass_graphs")
+    if repeated is None:
+        return (root / _required_text(document, "compass_graph", manifest),)
+    if (
+        not isinstance(repeated, list)
+        or len(repeated) < 3
+        or not all(isinstance(item, str) and item.strip() for item in repeated)
+    ):
+        raise ValueError(
+            f"fixture manifest {manifest} compass_graphs must contain at least three paths"
+        )
+    return tuple(root / item.strip() for item in repeated)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _occurrence_sha256(edges: object) -> str:
+    payload = json.dumps(
+        [asdict(edge) for edge in edges],
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+@contextmanager
+def _sanitized_graphify_graph(path: Path) -> Iterator[tuple[Path, int]]:
+    try:
+        size = path.stat().st_size
+    except OSError as error:
+        raise ValueError(f"cannot inspect Graphify graph {path}: {error}") from error
+    if size > MAX_GRAPHIFY_COMPARISON_BYTES:
+        raise ValueError(
+            f"Graphify graph exceeds {MAX_GRAPHIFY_COMPARISON_BYTES} bytes: {path}"
+        )
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read Graphify graph {path}: {error}") from error
+    if not isinstance(document, dict) or not isinstance(document.get("nodes"), list):
+        raise ValueError(f"Graphify graph has an invalid node inventory: {path}")
+    edge_key = "links" if "links" in document else "edges"
+    edges = document.get(edge_key)
+    if not isinstance(edges, list):
+        raise ValueError(f"Graphify graph has an invalid edge inventory: {path}")
+    node_ids = {
+        node.get("id")
+        for node in document["nodes"]
+        if isinstance(node, dict)
+        and isinstance(node.get("id"), str)
+        and node.get("id")
+    }
+    retained = []
+    dangling = 0
+    for edge in edges:
+        if not isinstance(edge, dict):
+            retained.append(edge)
+            continue
+        source = edge.get("source")
+        target = edge.get("target")
+        if (
+            isinstance(source, str)
+            and source
+            and isinstance(target, str)
+            and target
+            and (source not in node_ids or target not in node_ids)
+        ):
+            dangling += 1
+        else:
+            retained.append(edge)
+    if not dangling:
+        yield path, 0
+        return
+    document[edge_key] = retained
+    with tempfile.TemporaryDirectory(prefix="graphify-sanitized-", dir=path.parent) as directory:
+        sanitized = Path(directory) / "graph.json"
+        sanitized.write_text(
+            json.dumps(document, separators=(",", ":")), encoding="utf-8"
+        )
+        yield sanitized, dangling
 
 
 def load_fixture_spec(manifest: Path) -> FixtureSpec:
@@ -81,15 +181,18 @@ def load_fixture_spec(manifest: Path) -> FixtureSpec:
             f"fixture manifest {manifest} must use schema {FIXTURE_SCHEMA!r}"
         )
     root = manifest.resolve().parent
-    compass_graph = root / _required_text(document, "compass_graph", manifest)
+    compass_graphs = _compass_graphs(document, root, manifest)
     graphify_graph = root / _required_text(document, "graphify_graph", manifest)
-    for tool, path in (("Compass", compass_graph), ("Graphify", graphify_graph)):
+    for tool, path in (
+        *(("Compass", path) for path in compass_graphs),
+        ("Graphify", graphify_graph),
+    ):
         if not path.is_file():
             raise ValueError(f"{tool} graph does not exist for {manifest}: {path}")
     return FixtureSpec(
         language=_required_text(document, "language", manifest).casefold(),
         fixture=_required_text(document, "fixture", manifest),
-        compass_graph=compass_graph,
+        compass_graphs=compass_graphs,
         graphify_graph=graphify_graph,
     )
 
@@ -97,8 +200,34 @@ def load_fixture_spec(manifest: Path) -> FixtureSpec:
 def compare_fixture(spec: FixtureSpec) -> FixtureResult:
     database = sqlite3.connect(":memory:")
     try:
-        compass_summary = index_graph("compass", spec.compass_graph, database)
-        graphify_summary = index_graph("graphify", spec.graphify_graph, database)
+        compass_summary = index_graph("compass", spec.compass_graphs[0], database)
+        compass_bytes_digest = _file_sha256(spec.compass_graphs[0])
+        compass_occurrence_digest = _occurrence_sha256(
+            _edge_facts(database, "compass")
+        )
+        for run, graph in enumerate(spec.compass_graphs[1:], start=2):
+            repeated_summary = index_graph("compass", graph, database)
+            repeated_bytes_digest = _file_sha256(graph)
+            repeated_occurrence_digest = _occurrence_sha256(
+                _edge_facts(database, "compass")
+            )
+            if repeated_bytes_digest != compass_bytes_digest:
+                raise ValueError(
+                    f"{spec.fixture}: Compass run {run} graph bytes differ"
+                )
+            if repeated_summary.digest != compass_summary.digest:
+                raise ValueError(
+                    f"{spec.fixture}: Compass run {run} canonical graph differs"
+                )
+            if repeated_occurrence_digest != compass_occurrence_digest:
+                raise ValueError(
+                    f"{spec.fixture}: Compass run {run} occurrences differ"
+                )
+        with _sanitized_graphify_graph(spec.graphify_graph) as (
+            graphify_graph,
+            graphify_dangling_edges,
+        ):
+            graphify_summary = index_graph("graphify", graphify_graph, database)
         compass_nodes = _node_facts(database, "compass")
         graphify_nodes = _node_facts(database, "graphify")
         node_coverage, node_mapping = _classify_nodes(graphify_nodes, compass_nodes)
@@ -111,6 +240,7 @@ def compare_fixture(spec: FixtureSpec) -> FixtureResult:
             compass_nodes,
             node_coverage,
             node_mapping,
+            None,
         )
     finally:
         database.close()
@@ -137,9 +267,19 @@ def compare_fixture(spec: FixtureSpec) -> FixtureResult:
         compass_nodes=compass_summary.nodes,
         compass_edges=compass_summary.edges,
         compass_digest=compass_summary.digest,
+        compass_bytes_digest=compass_bytes_digest,
+        compass_occurrence_digest=compass_occurrence_digest,
+        compass_runs=len(spec.compass_graphs),
         graphify_nodes=graphify_summary.nodes,
         graphify_edges=graphify_summary.edges,
+        graphify_dangling_edges=graphify_dangling_edges,
         graphify_digest=graphify_summary.digest,
+        node_coverage={
+            status: sum(
+                coverage.status == status for coverage in node_coverage.values()
+            )
+            for status in STATUSES
+        },
         rows=rows,
     )
 
@@ -166,12 +306,17 @@ def build_report(manifests: Sequence[Path]) -> dict[str, object]:
                     "nodes": result.compass_nodes,
                     "edges": result.compass_edges,
                     "digest": result.compass_digest,
+                    "bytes_digest": result.compass_bytes_digest,
+                    "occurrence_digest": result.compass_occurrence_digest,
+                    "runs": result.compass_runs,
                 },
                 "graphify": {
                     "nodes": result.graphify_nodes,
                     "edges": result.graphify_edges,
+                    "dangling_edges": result.graphify_dangling_edges,
                     "digest": result.graphify_digest,
                 },
+                "node_coverage": result.node_coverage,
             }
             for result in results
         ],

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -3363,7 +3363,7 @@ fn map_node_kind(
         "import" => NodeKind::Import,
         "export" => NodeKind::Export,
         "macro" => NodeKind::Macro,
-        "annotation" => NodeKind::Annotation,
+        "annotation" | "annotation_type" => NodeKind::Annotation,
         "route" => NodeKind::Route,
         "component" => NodeKind::Component,
         "event" => NodeKind::Event,

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -989,7 +989,7 @@ fn open_producer_shapes_normalize_into_the_closed_endpoint_matrix()
     let mut annotation = raw_node(root, "raw:annotation", "logged", 70);
     annotation
         .attributes
-        .insert("symbol_kind".to_owned(), json!("annotation"));
+        .insert("symbol_kind".to_owned(), json!("annotation_type"));
     let edge = |source: &str, relation: &str, target: &str, start| RawEdgeRecord {
         source: source.to_owned(),
         target: target.to_owned(),
@@ -1016,6 +1016,12 @@ fn open_producer_shapes_normalize_into_the_closed_endpoint_matrix()
         .iter()
         .find(|node| node.name == "tests_target")
         .ok_or("missing test node")?;
+    assert!(
+        document
+            .nodes
+            .iter()
+            .any(|node| { node.name == "logged" && node.kind == NodeKind::Annotation })
+    );
     assert!(
         test.roles
             .contains(&compass_model::code_graph::NodeRole::Test)

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -1569,7 +1569,33 @@ impl<'source> DirectAdapterState<'source> {
             enclosing_type_qualified_name: Some(owner.qualified_name.clone()),
             runtime_nested: false,
         };
-        self.add_ownership(owner, &context)?;
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Ownership,
+            &owner.fact_id,
+            name,
+            None,
+            Some(&owner.scope_id),
+            None,
+            range_for_node(self.source_file, name_node),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Contains,
+            &owner.fact_id,
+            Some(&occurrence_id),
+            None,
+            name,
+            ResolutionConstraint {
+                exact_target_declaration_id: None,
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(self.module_or_package.clone()),
+                scope_id: Some(owner.scope_id.clone()),
+                qualified_name: Some(qualified_name.clone()),
+                argument_count: Some(parameter_count),
+                allowed_target_kinds: vec![kind.to_owned()],
+                hierarchy: None,
+                allow_external: false,
+            },
+        )?;
         let binding_id = self.builder.bind(
             BindingKind::Member,
             name,
@@ -1862,7 +1888,7 @@ impl<'source> DirectAdapterState<'source> {
             }
             if let Some(interfaces) = node.child_by_field_name("interfaces") {
                 let mut names = Vec::new();
-                collect_java_type_nodes(interfaces, &mut names);
+                collect_java_direct_supertype_nodes(interfaces, &mut names);
                 for target in names {
                     self.add_java_named_relationship(
                         SemanticRole::TypeReference,
@@ -4506,6 +4532,32 @@ fn collect_java_type_nodes<'tree>(node: Node<'tree>, output: &mut Vec<Node<'tree
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
         collect_java_type_nodes(child, output);
+    }
+}
+
+fn collect_java_direct_supertype_nodes<'tree>(node: Node<'tree>, output: &mut Vec<Node<'tree>>) {
+    if matches!(node.kind(), "type_identifier" | "scoped_type_identifier") {
+        output.push(node);
+        return;
+    }
+    if node.kind() == "generic_type" {
+        if let Some(target) = node
+            .child_by_field_name("type")
+            .or_else(|| first_java_type_name(node))
+        {
+            output.push(target);
+        }
+        return;
+    }
+    if matches!(
+        node.kind(),
+        "type_arguments" | "annotation" | "marker_annotation"
+    ) {
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_java_direct_supertype_nodes(child, output);
     }
 }
 

--- a/crates/compass-languages/tests/java_universal_conformance.rs
+++ b/crates/compass-languages/tests/java_universal_conformance.rs
@@ -17,7 +17,7 @@ import static org.example.util.Helpers.map;
 import org.example.model.*;
 
 @Deprecated
-public class Service extends BaseService implements Runnable, AutoCloseable {
+public class Service extends BaseService implements Runnable<String, Result>, AutoCloseable {
     private final Repository repository;
     private List<String> names;
 
@@ -121,8 +121,9 @@ enum Status { READY, DONE }
             .candidates
             .iter()
             .filter(|candidate| candidate.relation == CandidateRelation::Implements)
-            .count(),
-        2
+            .map(|candidate| candidate.target_spelling.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["AutoCloseable", "Runnable"])
     );
     assert!(evidence.occurrences.iter().any(|occurrence| {
         occurrence.role == SemanticRole::Annotation && occurrence.spelling == "Override"

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -948,8 +948,10 @@ const fn is_import_target(kind: NodeKind) -> bool {
                 | NodeKind::TypeAlias
                 | NodeKind::Variable
                 | NodeKind::Constant
+                | NodeKind::Field
                 | NodeKind::EnumMember
                 | NodeKind::Resource
+                | NodeKind::Annotation
                 | NodeKind::ConfigKey
         )
 }
@@ -1021,8 +1023,10 @@ const fn is_reference_source(kind: NodeKind) -> bool {
                 | NodeKind::Variable
                 | NodeKind::Constant
                 | NodeKind::Import
+                | NodeKind::EnumMember
                 | NodeKind::Export
                 | NodeKind::TypeAlias
+                | NodeKind::Annotation
                 | NodeKind::Resource
                 | NodeKind::Schema
                 | NodeKind::Query
@@ -1051,6 +1055,7 @@ const fn is_reference_target(kind: NodeKind) -> bool {
                 | NodeKind::Import
                 | NodeKind::Export
                 | NodeKind::TypeAlias
+                | NodeKind::Annotation
                 | NodeKind::Resource
                 | NodeKind::Schema
                 | NodeKind::Query

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -359,9 +359,17 @@ fn top_level_instantiations_accept_file_and_module_sources() {
 }
 
 #[test]
-fn rust_enum_members_are_importable_referenceable_and_constructible() {
+fn language_specific_declarations_use_supported_endpoint_shapes() {
     for (kind, source_kind, target_kind) in [
         (EdgeKind::Imports, NodeKind::File, NodeKind::EnumMember),
+        (EdgeKind::Imports, NodeKind::File, NodeKind::Annotation),
+        (EdgeKind::Imports, NodeKind::File, NodeKind::Field),
+        (EdgeKind::References, NodeKind::Method, NodeKind::Annotation),
+        (
+            EdgeKind::References,
+            NodeKind::Annotation,
+            NodeKind::Annotation,
+        ),
         (EdgeKind::References, NodeKind::Method, NodeKind::EnumMember),
         (EdgeKind::References, NodeKind::Struct, NodeKind::Parameter),
         (

--- a/crates/compass-resolve/tests/universal_evidence.rs
+++ b/crates/compass-resolve/tests/universal_evidence.rs
@@ -249,10 +249,18 @@ class Service {
     let service_id = declaration_id("demo.catalog.Service").ok_or("missing Service evidence")?;
     let worker_id = declaration_id("demo.catalog.Worker").ok_or("missing Worker evidence")?;
     let run_id = declaration_id("demo.catalog.Service::run").ok_or("missing run evidence")?;
+    declaration_id("demo.catalog.Service::<init>").ok_or("missing Service constructor evidence")?;
     assert!(evidence.candidates.iter().any(|candidate| {
         candidate.relation == CandidateRelation::Contains
             && candidate.source_declaration_id == service_id
             && candidate.target_spelling == "run"
+    }));
+    assert!(evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Contains
+            && candidate.source_declaration_id == service_id
+            && candidate.target_spelling == "<init>"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+            && candidate.constraints.argument_count == Some(1)
     }));
     assert!(evidence.candidates.iter().any(|candidate| {
         candidate.relation == CandidateRelation::Extends
@@ -286,7 +294,9 @@ class Service {
     let catalog = node("demo.catalog.Catalog").ok_or("missing published Catalog")?;
     let repository = node("demo.catalog.Repository").ok_or("missing published Repository")?;
     let run = node("demo.catalog.Service::run").ok_or("missing published run")?;
-    for published in [service, worker, catalog, repository, run] {
+    let constructor =
+        node("demo.catalog.Service::<init>").ok_or("missing published Service constructor")?;
+    for published in [service, worker, catalog, repository, run, constructor] {
         assert_eq!(published.string("language"), "java");
         assert_eq!(
             published.string("extractor"),
@@ -297,6 +307,7 @@ class Service {
     }
     for (source_id, target_id, relation) in [
         (service.id.as_str(), run.id.as_str(), "contains"),
+        (service.id.as_str(), constructor.id.as_str(), "contains"),
         (worker.id.as_str(), catalog.id.as_str(), "inherits"),
         (worker.id.as_str(), repository.id.as_str(), "implements"),
         (run.id.as_str(), catalog.id.as_str(), "references"),

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -39,7 +39,7 @@ This architecture is transitioning one language at a time. The status labels bel
 | Available now | The vendored package supplies 37 pinned static Tree-sitter grammars |
 | Available now | Python and Go are registered hard-cut version-1 adapters: they emit semantic evidence and use shared resolution and projection |
 | Available now | Rust Phase 2 is a quality-gated, hard-cut version-1 `UniversalCandidate`; its replaced publisher and collection resolution branches are removed |
-| Available now | Java is a hard-cut version-1 `UniversalCandidate`; its replaced publisher and Java member resolver are removed, and final pinned-corpus qualification is in progress |
+| Available now | Java is a hard-cut version-1 `UniversalCandidate`; its replaced publisher and Java member resolver are removed, and post-cutover pinned-corpus qualification is complete |
 | Available now | The remaining production languages keep their established extraction and resolution paths |
 | Planned | Later languages transition independently after language-specific qualification |
 

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -41,7 +41,7 @@ future work.
 | Available now | Python, Go, Rust, and Java are entries in the hard-cut `AdapterRegistry`, all at adapter version 1 |
 | Available now | `EvidenceBuilder` emits bounded `SemanticEvidenceBatch` values for all four hard-cut languages |
 | Available now | `UniversalResolutionIndex` resolves and projects hard-cut evidence without a language-name branch |
-| Available now | Rust has passed Phase 2 qualification; Java is registered as `UniversalCandidate` and is completing pinned-corpus qualification |
+| Available now | Rust has passed Phase 2 qualification; Java remains `UniversalCandidate` after completing post-cutover pinned-corpus qualification |
 | Planned | `GrammarProvider`, grammar provenance, and producer-registry validation |
 | Planned | Independently qualified hard cuts for the remaining registered languages |
 
@@ -377,7 +377,7 @@ This table describes the current branch.
 | Python | Hard-cut universal | `SemanticEvidenceBatch` plus shared resolution and projection; no replaced collection resolver |
 | Go | Hard-cut universal | `SemanticEvidenceBatch` plus shared resolution and projection; no replaced Go collection resolver |
 | Rust | Hard-cut `UniversalCandidate` | Version-1 evidence plus shared resolution and projection; Phase 2 qualified and replaced Rust paths removed |
-| Java | Hard-cut `UniversalCandidate` | Version-1 evidence plus shared resolution and projection; replaced Java paths removed and final corpus qualification in progress |
+| Java | Hard-cut `UniversalCandidate` | Version-1 evidence plus shared resolution and projection; replaced Java paths removed and post-cutover corpus qualification complete |
 | Remaining registered languages | Established direct adapters | Current language-specific or generic extraction paths |
 
 Python, Go, Rust, and Java are hard-cut on this branch. Each later language

--- a/docs/superpowers/reviews/2026-07-30-java-universal-candidate.md
+++ b/docs/superpowers/reviews/2026-07-30-java-universal-candidate.md
@@ -92,5 +92,86 @@ classifier: overall strict coverage must exceed 71.04%, no relation-family
 handled percentage may decrease, every Compass workload must remain eligible
 and deterministic, and Compass cold/warm medians must remain below Graphify.
 
-This is baseline evidence only. It does not qualify Java as a universal
-candidate and does not authorize a dual-run or translation path.
+The section above is the pre-cutover baseline. It does not authorize a
+dual-run or translation path.
+
+## Post-cutover qualification
+
+Java's hard-cut version-1 universal path was qualified on 2026-08-01 from the
+working tree based at Compass commit `dd14b3ce99b02fd82aa5df199cd5769869916c97`.
+The pinned Spring and Graphify revisions are unchanged from the baseline. Java
+remains `UniversalCandidate`; this review does not promote it to
+`UniversalComplete`.
+
+The six checked Java fixtures were extracted three times with the final release
+binary. All three graph files were byte-identical, their canonical graph
+digests matched, and their occurrence digests matched:
+
+- graph bytes SHA-256:
+  `40524a2d9ce8169348572ba7eb082338c648c740688a9a03e31648b2f4d82af0`
+- canonical graph SHA-256:
+  `43c72e8038181fdf44a635a93eb9f5be27813903a930c35de979faf0bf00ebcd`
+- occurrence SHA-256:
+  `3e1916d0cc1f11db3ecd5c9b4f7e486531b265d3e8092250c3b201fbad54f1a3`
+- each run: 45 nodes, 60 edges, and no graph diagnostics
+
+The candidate handled all 28 established fixture relationships and all 41
+valid Graphify fixture relationships. The Graphify fixture output contained
+one dangling import to `RequestMethod`; it was recorded and removed before
+strict comparison. Candidate fixture retention is therefore 100%, above the
+95% baseline-retention gate, with no missing or ambiguous relationship in any
+checked family. Imports handled 10/10 Graphify facts and references handled
+13/13.
+
+### Final pinned Spring quality
+
+The final strict index contained 168,475 Compass nodes and 650,782 canonical
+Compass edges. It compared them with 138,830 Graphify nodes and 477,066
+Graphify edges. Both inputs had zero validation errors and zero dangling
+edges. The same final classifier was also run over the established Compass
+graph, so the family comparison below is apples-to-apples.
+
+| Relation | Graphify | Established handled | Candidate exact | Candidate dominated | Candidate rejected | Candidate missing | Candidate ambiguous | Candidate handled |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| calls | 112,195 | 48.51% | 15,016 | 65,581 | 7,415 | 24,183 | 0 | 78.45% |
+| case_of | 872 | 0.00% | 0 | 0 | 0 | 872 | 0 | 0.00% |
+| contains | 102,310 | 95.19% | 32,694 | 65,506 | 0 | 4,103 | 7 | 95.98% |
+| extends | 4,454 | 86.06% | 2,130 | 1,630 | 144 | 537 | 13 | 87.65% |
+| implements | 4,379 | 95.39% | 1,988 | 2,054 | 202 | 132 | 3 | 96.92% |
+| imports | 126,118 | 59.13% | 31,055 | 38,021 | 56,183 | 859 | 0 | 99.32% |
+| references | 126,738 | 81.94% | 12,009 | 86,429 | 14,361 | 13,931 | 8 | 89.00% |
+
+Overall handled coverage is 432,418/477,066, or **90.64%**, compared with
+338,261/477,066, or **70.90%**, for the established graph under the final
+classifier. Candidate coverage is 127.84% of the established baseline and
+exceeds it by 19.74 percentage points. No relationship family regressed;
+`case_of` is unchanged and every other family improved.
+
+The largest implementation gaps discovered during qualification were in
+calls, imports, and containment. The final candidate adds source-anchored,
+arity-constrained ownership for Java methods and constructors, preserves
+annotation types through Code Graph v1 normalization and endpoint validation,
+and makes the comparator distinguish Java owner spelling and annotation-shifted
+declaration anchors without selecting arbitrary candidates.
+
+### Final pinned Spring performance
+
+The three-sample candidate measurements before the final ownership correction
+had medians of 82.86 seconds cold and 3.23 seconds warm. The final binary was
+then confirmed at 85.46 seconds cold and 3.55 seconds warm on the same pinned
+Spring checkout (`compass --timing` reported 79.41 and 3.53 seconds inside
+those process-wall measurements). Its cold and warm graph files were
+byte-identical with SHA-256
+`5d312789a82d8763173e496a76af055d17ffef17e3aad46de1e6a4e1fe51cd69`.
+The pinned Graphify medians were 171.07 seconds cold and 64.70 seconds warm.
+Compass therefore remained lower-latency for both blocking workloads; final
+cold was 2.00x faster and final warm was 18.23x faster. Peak RSS remained
+non-blocking and was recorded at 8.61 GiB cold and 51.72 MiB warm for the final
+confirmation.
+
+### Remaining scope
+
+This closes Java's post-cutover candidate qualification, not all framework-pack
+work. Spring behavior remains covered through universal Java facts, but the
+production universal Spring descriptor list is still empty. Spring's registry
+hard cut is a separate follow-up and is not implied by this Java result.

--- a/scripts/code_graph_v1_oracle.py
+++ b/scripts/code_graph_v1_oracle.py
@@ -446,12 +446,12 @@ def endpoint_allowed(source: dict[str, Any], edge: dict[str, Any], target: dict[
     if kind == "references":
         reference_source = CONTAINER | CALLABLE | TYPE_KINDS | {
             "file", "property", "field", "variable", "constant", "import",
-            "export", "type_alias", "resource", "schema", "query", "config_key",
-            "database_table", "database_view", "database_column",
-            "database_procedure", "database_trigger",
+            "export", "enum_member", "annotation", "type_alias", "resource",
+            "schema", "query", "config_key", "database_table", "database_view",
+            "database_column", "database_procedure", "database_trigger",
         }
         reference_target = reference_source | {
-            "database", "database_schema", "database_index",
+            "parameter", "database", "database_schema", "database_index",
             "database_constraint",
         }
         return s in reference_source and t in reference_target


### PR DESCRIPTION
## Summary

- qualify Java's hard-cut universal candidate with three-run deterministic graph and occurrence comparison
- improve Java callable ownership, constructor arity, generic-interface extraction, annotation normalization, and endpoint validation
- make fixture comparison source-site aware for Java overloads, constructors, imports, and annotations
- record the final pinned Spring/Graphify evidence while keeping Java at `UniversalCandidate`
- leave the Spring universal framework-pack registry hard cut as an explicit follow-up

## Qualification evidence

All six checked Java fixtures were extracted three times with byte-identical output:

- graph bytes: `40524a2d9ce8169348572ba7eb082338c648c740688a9a03e31648b2f4d82af0`
- canonical graph: `43c72e8038181fdf44a635a93eb9f5be27813903a930c35de979faf0bf00ebcd`
- occurrences: `3e1916d0cc1f11db3ecd5c9b4f7e486531b265d3e8092250c3b201fbad54f1a3`
- each run: 45 nodes, 60 edges, zero diagnostics

The candidate handled 28/28 established fixture relationships and 41/41 valid Graphify fixture relationships.

On pinned Spring, candidate handled coverage is 90.64% versus the established baseline's 70.90% under the same classifier. No relation family regressed: calls 78.45%, contains 95.98%, extends 87.65%, implements 96.92%, imports 99.32%, references 89.00%, and case_of remained unchanged at 0%.

Final Compass process wall time was 85.46s cold and 3.55s warm, below Graphify's 171.07s cold and 64.70s warm. The final Compass cold/warm graph digest was identical: `5d312789a82d8763173e496a76af055d17ffef17e3aad46de1e6a4e1fe51cd69`.

## Validation

Passed on the exact PR commit:

- `cargo fmt --all -- --check`
- `cargo test -p compass-languages --test java_universal_conformance --locked`
- Java publication test in `compass-resolve --test universal_evidence`
- annotation normalization test in `compass-graph --test graph_v1_normalization`
- language endpoint validation test in `compass-model --test code_graph_validation`
- `python3 -m unittest benchmarks.performance.tests.test_language_fixture_compare` (12 tests)
- `sh scripts/check_product_boundary.sh`
- focused Java/resolution/model/graph checks and the pinned fixture/corpus qualification described in the review document

A full `compass-resolve --test universal_evidence` run also reaches an existing Rust-only assertion mismatch for the expected resolution rule of `Widget::new`; the Java tests pass. No unrelated Rust/Go/CLI/shared-worktree changes are included here.

## Impact

Java remains `UniversalCandidate`. This completes post-cutover quality qualification; it does not promote Java to `UniversalComplete` and does not hard-cut Spring to the universal framework-pack registry.
