### PR TITLE
Improve Java calls with verified SCIP evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Use fresh, verified SCIP symbol evidence to disambiguate Java call targets in
+  `graph.json` through exact AST call and declaration anchors, while rejecting
+  non-call references, stale artifacts, ambiguous definitions, and conflicting
+  providers.
 - Introduce the first supported Compass code graph contract,
   `compass.graph/1`, as a strict versioned NetworkX-compatible multigraph with
   structural, framework, enterprise, messaging, job, schema, configuration,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,8 +1341,10 @@ version = "0.1.10"
 dependencies = [
  "ahash",
  "compass-graph",
+ "compass-ir",
  "compass-languages",
  "compass-model",
+ "compass-program",
  "rayon",
  "regex",
  "serde",

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -37,7 +37,10 @@ use compass_output::{
     DetectionSummary, HtmlOptions, OutputError, ReportOptions, TokenCost, generate_report,
     graph_view_model_document, write_html,
 };
-use compass_resolve::{merge_decl_def_classes, resolve_owned_with_root};
+use compass_resolve::{
+    apply_program_projection, collect_program_projection_sites, merge_decl_def_classes,
+    resolve_owned_with_root,
+};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -978,9 +981,25 @@ fn build_graph_inner(
     };
     fresh_source_text.extend(cached_source_text);
     let source_text = fresh_source_text;
+    let program_projection_sites = collect_program_projection_sites(&ordered);
     let mut resolved = resolve_owned_with_root(ordered, &source_text, &root);
     profile_internal("cross-file resolution total", &mut internal_started);
     drop(source_text);
+    let defer_program_join = options.force && !options.no_cluster && !has_program_artifacts;
+    let mut program = if defer_program_join {
+        None
+    } else {
+        join_program_worker(program_handle.take(), &mut timings)?
+    };
+    profile_internal("wait for Program analysis", &mut internal_started);
+    if let Some(program) = program.as_ref() {
+        apply_program_projection(
+            &mut resolved,
+            &program_projection_sites,
+            &program.compiler_projection,
+        );
+    }
+    profile_internal("Program graph projection", &mut internal_started);
     finalize_ast_extraction(&mut resolved, &root);
     profile_internal("AST finalization", &mut internal_started);
     let ast_cache_elapsed = ast_cache_handle
@@ -989,13 +1008,6 @@ fn build_graph_inner(
     profile_internal_duration("AST cache publication worker", ast_cache_elapsed);
     internal_started = Instant::now();
     timings.deterministic_extract = stage_started.elapsed();
-    let defer_program_join = options.force && !options.no_cluster;
-    let mut program = if defer_program_join {
-        None
-    } else {
-        join_program_worker(program_handle.take(), &mut timings)?
-    };
-    profile_internal("wait for Program analysis", &mut internal_started);
     stage_started = Instant::now();
     if preserve_prior_semantic {
         let refreshed = semantic

--- a/crates/compass-core/src/program.rs
+++ b/crates/compass-core/src/program.rs
@@ -10,7 +10,8 @@ use compass_ir::{ProviderDescriptor, canonical_json_bytes, hex_sha256};
 use compass_languages::{Registry, TREE_SITTER_PROGRAM_PROVIDER_VERSION, TreeSitterSyntaxProvider};
 use compass_program::{
     ArtifactInput, ArtifactProvider, DecodedScipArtifact, DecodedScipDocument, EvidenceBatch,
-    OfficialScipProvider, SyntaxProvider, merge_evidence, parse_artifact_manifest,
+    OfficialScipProvider, SyntaxProvider, compiler_projection, merge_evidence,
+    parse_artifact_manifest,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -31,6 +32,7 @@ pub(crate) struct ProgramBuild {
     pub artifact_documents_analyzed: usize,
     pub artifact_documents_reused: usize,
     pub conflicts: usize,
+    pub compiler_projection: compass_program::CompilerProjection,
 }
 
 #[derive(Clone)]
@@ -265,6 +267,7 @@ pub(crate) fn build_program(
     cache.prune_program(&artifact_kind, &live_artifact_keys)?;
     profile_internal("Program artifact processing", &mut internal_started);
 
+    let compiler_projection = compiler_projection(&batches);
     let program = merge_evidence(batches)?;
     profile_internal("Program evidence merge", &mut internal_started);
     let analysis = compass_analysis::analyze_prevalidated(program)?;
@@ -287,6 +290,7 @@ pub(crate) fn build_program(
         artifact_documents_analyzed,
         artifact_documents_reused,
         conflicts,
+        compiler_projection,
     })
 }
 
@@ -391,6 +395,7 @@ pub(crate) fn load_current_program(
         artifact_documents_analyzed: 0,
         artifact_documents_reused: 0,
         conflicts,
+        compiler_projection: compass_program::CompilerProjection::default(),
     }))
 }
 

--- a/crates/compass-core/tests/program_pipeline.rs
+++ b/crates/compass-core/tests/program_pipeline.rs
@@ -165,6 +165,66 @@ fn write_multi_scip(
     Ok(())
 }
 
+fn write_java_overload_scip(
+    artifact: &Path,
+    source_path: &str,
+    source: &str,
+) -> Result<(), Box<dyn Error>> {
+    let int_symbol = "java maven fixture 1.0 Demo#pick(int).";
+    let string_symbol = "java maven fixture 1.0 Demo#pick(java.lang.String).";
+    let use_symbol = "java maven fixture 1.0 Demo#use().";
+    let mut occurrences = Vec::new();
+    for (range, symbol, role) in [
+        (vec![1, 7, 11], int_symbol, SymbolRole::Definition),
+        (vec![2, 7, 11], string_symbol, SymbolRole::Definition),
+        (vec![3, 7, 10], use_symbol, SymbolRole::Definition),
+        (vec![3, 15, 19], string_symbol, SymbolRole::ReadAccess),
+    ] {
+        let mut occurrence = Occurrence::new();
+        occurrence.range = range;
+        occurrence.symbol = symbol.to_owned();
+        occurrence.symbol_roles = role as i32;
+        occurrences.push(occurrence);
+    }
+    let symbols = [int_symbol, string_symbol, use_symbol]
+        .into_iter()
+        .map(|symbol| {
+            let mut information = SymbolInformation::new();
+            information.symbol = symbol.to_owned();
+            information
+        })
+        .collect();
+    let mut document = Document::new();
+    document.language = "java".to_owned();
+    document.relative_path = source_path.to_owned();
+    document.occurrences = occurrences;
+    document.symbols = symbols;
+    document.text = source.to_owned();
+    document.position_encoding =
+        EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart);
+    let mut tool = ToolInfo::new();
+    tool.name = "fixture-indexer".to_owned();
+    tool.version = "1.0".to_owned();
+    let mut metadata = Metadata::new();
+    metadata.tool_info = MessageField::some(tool);
+    metadata.text_document_encoding = EnumOrUnknown::new(TextEncoding::UTF8);
+    let mut index = Index::new();
+    index.metadata = MessageField::some(metadata);
+    index.documents = vec![document];
+    let bytes = index.write_to_bytes()?;
+    fs::write(artifact, &bytes)?;
+    let companion = artifact.with_file_name("index.scip.compass-manifest.json");
+    fs::write(
+        companion,
+        serde_json::to_vec(&serde_json::json!({
+            "schema": "compass.scip-manifest/1",
+            "index_sha256": hex_sha256(&bytes),
+            "documents": {source_path: hex_sha256(source.as_bytes())},
+        }))?,
+    )?;
+    Ok(())
+}
+
 #[test]
 fn program_pipeline_is_deterministic_incremental_and_uses_program_json()
 -> Result<(), Box<dyn Error>> {
@@ -394,6 +454,56 @@ fn scip_cache_tracks_artifact_manifest_and_source_freshness() -> Result<(), Box<
     assert!(
         !String::from_utf8_lossy(&fs::read(deleted.output_dir.join("program.json"))?)
             .contains("src/app.ts")
+    );
+    Ok(())
+}
+
+#[test]
+fn fresh_scip_symbols_resolve_java_overloads_in_graph_json() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let source_text = "class Demo {\n  void pick(int x) {}\n  void pick(String x) {}\n  void use() { pick(\"x\"); }\n}\n";
+    fs::create_dir(directory.path().join("src"))?;
+    fs::write(directory.path().join("src/Demo.java"), source_text)?;
+    write_java_overload_scip(
+        &directory.path().join("index.scip"),
+        "src/Demo.java",
+        source_text,
+    )?;
+
+    let result = build_local_graph(&program_options(directory.path()))?;
+    let graph =
+        compass_model::code_graph::GraphDocument::load(&result.output_dir.join("graph.json"))?;
+    let compiler_call = graph
+        .links
+        .iter()
+        .find(|edge| {
+            edge.kind == compass_model::code_graph::EdgeKind::Calls
+                && edge
+                    .evidence
+                    .iter()
+                    .any(|evidence| evidence.rule.as_deref() == Some("compiler-exact-anchor"))
+        })
+        .ok_or("missing compiler-resolved Java call")?;
+    assert!(compiler_call.evidence.iter().any(|evidence| {
+        evidence.origin == compass_model::provenance::EvidenceOrigin::Artifact
+            && evidence.confidence == compass_model::provenance::EvidenceConfidence::Exact
+            && evidence.extractor == "compass.resolve.java.program"
+    }));
+    let target = graph
+        .nodes
+        .iter()
+        .find(|node| node.id == compiler_call.target)
+        .ok_or("missing compiler-resolved target")?;
+    assert_eq!(
+        target.source.as_ref().map(|source| source.start_line),
+        Some(3)
+    );
+    assert_eq!(
+        compiler_call
+            .relationship_site
+            .as_ref()
+            .map(|source| (source.start_line, source.start_column)),
+        Some((4, 15))
     );
     Ok(())
 }

--- a/crates/compass-program/src/lib.rs
+++ b/crates/compass-program/src/lib.rs
@@ -4,6 +4,7 @@ mod evidence;
 mod manifest;
 mod merge;
 mod path;
+mod projection;
 mod provider;
 mod scip;
 mod scip_stream;
@@ -14,6 +15,7 @@ pub use evidence::{
 pub use manifest::{SCIP_MANIFEST_SCHEMA, parse_artifact_manifest};
 pub use merge::{MERGER_VERSION, MergeError, merge_evidence};
 pub use path::normalize_source_path;
+pub use projection::{CompilerCall, CompilerDefinition, CompilerProjection, compiler_projection};
 pub use provider::{
     ArtifactInput, ArtifactLimits, ArtifactManifest, ArtifactProvider, ArtifactReader, FileInput,
     ProjectAnalyzer, ProjectFile, ProjectInput, ProviderError, SyntaxProvider,

--- a/crates/compass-program/src/projection.rs
+++ b/crates/compass-program/src/projection.rs
@@ -1,0 +1,172 @@
+use std::collections::BTreeSet;
+
+use compass_ir::{Capability, CoverageState, ProviderKind, SourceAnchor};
+
+use crate::{EvidenceBatch, FactKind, Role};
+
+const UNVERIFIED_REVISION: &str = "artifact_revision_unverified";
+const STALE_DOCUMENT: &str = "stale_artifact_document";
+const SCIP_INDEX_SCOPE: &str = "scip_index_scope";
+
+/// Compact, source-anchored compiler facts that can safely enrich graph output.
+///
+/// This intentionally does not infer whether a reference is a call. Consumers
+/// must join `calls` to a syntax-proven call occurrence at the exact anchor.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CompilerProjection {
+    pub definitions: Vec<CompilerDefinition>,
+    pub calls: Vec<CompilerCall>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CompilerDefinition {
+    pub provider_id: String,
+    pub symbol: String,
+    pub anchor: SourceAnchor,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct CompilerCall {
+    pub provider_id: String,
+    pub target: String,
+    pub anchor: SourceAnchor,
+}
+
+#[must_use]
+pub fn compiler_projection(batches: &[EvidenceBatch]) -> CompilerProjection {
+    let mut definitions = BTreeSet::new();
+    let mut calls = BTreeSet::new();
+    for batch in batches.iter().filter(|batch| {
+        matches!(
+            batch.descriptor.kind,
+            ProviderKind::Artifact | ProviderKind::Project
+        )
+    }) {
+        for fact in &batch.facts {
+            if !coverage_allows_projection(batch, &fact.anchor.source_file, &fact.capability) {
+                continue;
+            }
+            match &fact.kind {
+                FactKind::Symbol { symbol, roles } if roles.contains(&Role::Definition) => {
+                    definitions.insert(CompilerDefinition {
+                        provider_id: batch.descriptor.id.clone(),
+                        symbol: symbol.clone(),
+                        anchor: fact.anchor.clone(),
+                    });
+                }
+                FactKind::CallResolution { target } => {
+                    calls.insert(CompilerCall {
+                        provider_id: batch.descriptor.id.clone(),
+                        target: target.clone(),
+                        anchor: fact.anchor.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+    CompilerProjection {
+        definitions: definitions.into_iter().collect(),
+        calls: calls.into_iter().collect(),
+    }
+}
+
+fn coverage_allows_projection(
+    batch: &EvidenceBatch,
+    source_file: &str,
+    capability: &Capability,
+) -> bool {
+    let Some(state) = batch
+        .coverage
+        .get(source_file)
+        .and_then(|coverage| coverage.get(capability))
+    else {
+        return false;
+    };
+    match state {
+        CoverageState::Complete => true,
+        CoverageState::Partial { reasons } => {
+            !reasons.is_empty()
+                && !reasons
+                    .iter()
+                    .any(|reason| matches!(reason.as_str(), UNVERIFIED_REVISION | STALE_DOCUMENT))
+                && reasons.iter().all(|reason| reason == SCIP_INDEX_SCOPE)
+        }
+        CoverageState::Indeterminate { .. } | CoverageState::Failed { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use compass_ir::{ProviderDescriptor, ProviderKind};
+
+    use super::*;
+    use crate::{EvidenceFact, coverage_with};
+
+    fn batch(reason: Option<&str>) -> EvidenceBatch {
+        let anchor = SourceAnchor {
+            source_file: "src/A.java".to_owned(),
+            start_byte: 10,
+            end_byte: 13,
+        };
+        let state = reason.map_or(CoverageState::Complete, |reason| CoverageState::Partial {
+            reasons: vec![reason.to_owned()],
+        });
+        EvidenceBatch {
+            descriptor: ProviderDescriptor {
+                id: "scip/test".to_owned(),
+                kind: ProviderKind::Artifact,
+                version: "1".to_owned(),
+                scope: "repository".to_owned(),
+                input_digest: "digest".to_owned(),
+                configuration_digest: "config".to_owned(),
+            },
+            evidence: Vec::new(),
+            modules: Vec::new(),
+            facts: vec![
+                EvidenceFact {
+                    evidence_id: "definition".to_owned(),
+                    capability: Capability::Definitions,
+                    anchor: anchor.clone(),
+                    kind: FactKind::Symbol {
+                        symbol: "java method A#run().".to_owned(),
+                        roles: vec![Role::Definition],
+                    },
+                },
+                EvidenceFact {
+                    evidence_id: "call".to_owned(),
+                    capability: Capability::CallResolution,
+                    anchor,
+                    kind: FactKind::CallResolution {
+                        target: "java method A#run().".to_owned(),
+                    },
+                },
+            ],
+            coverage: BTreeMap::from([(
+                "src/A.java".to_owned(),
+                coverage_with([
+                    (Capability::Definitions, state.clone()),
+                    (Capability::CallResolution, state),
+                ]),
+            )]),
+        }
+    }
+
+    #[test]
+    fn keeps_fresh_artifact_facts() {
+        let projection = compiler_projection(&[batch(Some(SCIP_INDEX_SCOPE))]);
+        assert_eq!(projection.definitions.len(), 1);
+        assert_eq!(projection.calls.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unverified_and_stale_artifact_facts() {
+        for reason in [UNVERIFIED_REVISION, STALE_DOCUMENT, "unknown_partial_scope"] {
+            let projection = compiler_projection(&[batch(Some(reason))]);
+            assert!(projection.definitions.is_empty());
+            assert!(projection.calls.is_empty());
+        }
+    }
+}

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -21,10 +21,12 @@ sha1.workspace = true
 thiserror.workspace = true
 compass-languages = { path = "../compass-languages", version = "0.1.4" }
 compass-model = { path = "../compass-model", version = "0.1.4" }
+compass-program = { path = "../compass-program", version = "0.1.4" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
+compass-ir = { path = "../compass-ir", version = "0.1.4" }
 compass-graph = { path = "../compass-graph", version = "0.1.4" }
 tempfile.workspace = true

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -3,8 +3,12 @@
 pub mod evidence;
 pub mod frameworks;
 mod members;
+mod program;
 
 pub use members::resolve_language_calls;
+pub use program::{
+    ProgramProjectionSites, apply_program_projection, collect_program_projection_sites,
+};
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;

--- a/crates/compass-resolve/src/program.rs
+++ b/crates/compass-resolve/src/program.rs
@@ -1,0 +1,489 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use compass_languages::{
+    CandidateRelation, EvidenceRange, Extraction, RawEdgeRecord, RelationshipCandidate,
+};
+use compass_model::provenance::OCCURRENCE_RULE_ATTRIBUTE;
+use compass_program::CompilerProjection;
+use serde_json::{Map, Value};
+
+type AnchorKey = (String, u64, u64);
+
+#[derive(Clone, Debug, Default)]
+pub struct ProgramProjectionSites {
+    declarations: BTreeMap<AnchorKey, Vec<DeclarationSite>>,
+    calls: BTreeMap<AnchorKey, Vec<CallSite>>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct DeclarationSite {
+    evidence_id: String,
+    kind: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CallSite {
+    candidate_id: String,
+    source_declaration_id: String,
+    allowed_target_kinds: Vec<String>,
+    range: EvidenceRange,
+}
+
+/// Retain the small subset of Java AST evidence needed for a later compiler join.
+#[must_use]
+pub fn collect_program_projection_sites(extractions: &[Extraction]) -> ProgramProjectionSites {
+    let mut sites = ProgramProjectionSites::default();
+    for batch in extractions
+        .iter()
+        .filter_map(|extraction| extraction.semantic_evidence.as_ref())
+        .filter(|batch| batch.adapter.language == "java")
+    {
+        for declaration in &batch.declarations {
+            sites
+                .declarations
+                .entry(anchor_key(&declaration.range))
+                .or_default()
+                .push(DeclarationSite {
+                    evidence_id: declaration.id.clone(),
+                    kind: declaration.kind.clone(),
+                });
+        }
+        let occurrences = batch
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.id.as_str(), &occurrence.range))
+            .collect::<BTreeMap<_, _>>();
+        for candidate in batch.candidates.iter().filter(|candidate| {
+            matches!(
+                candidate.relation,
+                CandidateRelation::Calls | CandidateRelation::Constructs
+            )
+        }) {
+            let Some(range) = candidate
+                .occurrence_id
+                .as_deref()
+                .and_then(|id| occurrences.get(id).copied())
+            else {
+                continue;
+            };
+            sites
+                .calls
+                .entry(anchor_key(range))
+                .or_default()
+                .push(call_site(candidate, range));
+        }
+    }
+    for values in sites.declarations.values_mut() {
+        values.sort();
+        values.dedup();
+    }
+    for values in sites.calls.values_mut() {
+        values.sort_by(|left, right| {
+            (
+                &left.candidate_id,
+                &left.source_declaration_id,
+                &left.allowed_target_kinds,
+                &left.range.source_file,
+                left.range.start_byte,
+                left.range.end_byte,
+            )
+                .cmp(&(
+                    &right.candidate_id,
+                    &right.source_declaration_id,
+                    &right.allowed_target_kinds,
+                    &right.range.source_file,
+                    right.range.start_byte,
+                    right.range.end_byte,
+                ))
+        });
+        values.dedup();
+    }
+    sites
+}
+
+/// Apply fresh compiler identities only where exact Java AST evidence proves a call.
+///
+/// Conflicting providers, ambiguous anchors, non-local targets, and non-call
+/// references are deliberately left to the structural resolver.
+pub fn apply_program_projection(
+    extraction: &mut Extraction,
+    sites: &ProgramProjectionSites,
+    projection: &CompilerProjection,
+) {
+    let graph_ids = extraction
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            node.attributes
+                .get("evidence_declaration_id")
+                .and_then(Value::as_str)
+                .map(|id| (id.to_owned(), node.id.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let declaration_sites = sites
+        .declarations
+        .values()
+        .flatten()
+        .map(|site| (site.evidence_id.as_str(), site))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut symbols = BTreeMap::<String, BTreeMap<String, BTreeSet<String>>>::new();
+    for definition in &projection.definitions {
+        let key = (
+            definition.anchor.source_file.clone(),
+            definition.anchor.start_byte,
+            definition.anchor.end_byte,
+        );
+        let Some([site]) = sites.declarations.get(&key).map(Vec::as_slice) else {
+            continue;
+        };
+        symbols
+            .entry(definition.symbol.clone())
+            .or_default()
+            .entry(site.evidence_id.clone())
+            .or_default()
+            .insert(definition.provider_id.clone());
+    }
+
+    let mut calls = BTreeMap::<AnchorKey, BTreeMap<String, BTreeSet<String>>>::new();
+    for call in &projection.calls {
+        let key = (
+            call.anchor.source_file.clone(),
+            call.anchor.start_byte,
+            call.anchor.end_byte,
+        );
+        calls
+            .entry(key)
+            .or_default()
+            .entry(call.target.clone())
+            .or_default()
+            .insert(call.provider_id.clone());
+    }
+
+    for (anchor, targets) in calls {
+        let target_entries = targets.into_iter().collect::<Vec<_>>();
+        let [(target_symbol, _call_providers)] = target_entries.as_slice() else {
+            continue;
+        };
+        let Some(symbol_targets) = symbols.get(target_symbol) else {
+            continue;
+        };
+        let target_declarations = symbol_targets.iter().collect::<Vec<_>>();
+        let [(target_declaration, _definition_providers)] = target_declarations.as_slice() else {
+            continue;
+        };
+        let Some([call_site]) = sites.calls.get(&anchor).map(Vec::as_slice) else {
+            continue;
+        };
+        let Some(target_site) = declaration_sites.get(target_declaration.as_str()).copied() else {
+            continue;
+        };
+        if !call_site.allowed_target_kinds.is_empty()
+            && !call_site.allowed_target_kinds.contains(&target_site.kind)
+        {
+            continue;
+        }
+        let (Some(source), Some(target)) = (
+            graph_ids.get(&call_site.source_declaration_id),
+            graph_ids.get(*target_declaration),
+        ) else {
+            continue;
+        };
+        extraction.edges.retain(|edge| {
+            !(edge.source == *source
+                && edge.attributes.get("relation").and_then(Value::as_str) == Some("calls")
+                && edge.attributes.get("source_file").and_then(Value::as_str)
+                    == Some(call_site.range.source_file.as_str())
+                && edge.attributes.get("start_byte").and_then(Value::as_u64)
+                    == Some(call_site.range.start_byte)
+                && edge.attributes.get("end_byte").and_then(Value::as_u64)
+                    == Some(call_site.range.end_byte))
+        });
+        extraction
+            .edges
+            .push(compiler_edge(source.clone(), target.clone(), call_site));
+    }
+    extraction.edges.sort_by_cached_key(|edge| {
+        (
+            edge.source.clone(),
+            edge.target.clone(),
+            Value::Object(edge.attributes.clone()).to_string(),
+        )
+    });
+    extraction.edges.dedup();
+}
+
+fn call_site(candidate: &RelationshipCandidate, range: &EvidenceRange) -> CallSite {
+    let mut allowed_target_kinds = candidate.constraints.allowed_target_kinds.clone();
+    allowed_target_kinds.sort();
+    allowed_target_kinds.dedup();
+    CallSite {
+        candidate_id: candidate.id.clone(),
+        source_declaration_id: candidate.source_declaration_id.clone(),
+        allowed_target_kinds,
+        range: range.clone(),
+    }
+}
+
+fn anchor_key(range: &EvidenceRange) -> AnchorKey {
+    (range.source_file.clone(), range.start_byte, range.end_byte)
+}
+
+fn compiler_edge(source: String, target: String, site: &CallSite) -> RawEdgeRecord {
+    let rule = "compiler-exact-anchor";
+    let attributes = Map::from_iter([
+        ("relation".to_owned(), Value::String("calls".to_owned())),
+        ("_origin".to_owned(), Value::String("artifact".to_owned())),
+        (
+            "confidence".to_owned(),
+            Value::String("EXTRACTED".to_owned()),
+        ),
+        (
+            "source_file".to_owned(),
+            Value::String(site.range.source_file.clone()),
+        ),
+        (
+            "source_location".to_owned(),
+            Value::String(format!("L{}", site.range.start_line)),
+        ),
+        ("start_byte".to_owned(), Value::from(site.range.start_byte)),
+        ("end_byte".to_owned(), Value::from(site.range.end_byte)),
+        ("line_start".to_owned(), Value::from(site.range.start_line)),
+        ("line_end".to_owned(), Value::from(site.range.end_line)),
+        (
+            "column_start".to_owned(),
+            Value::from(site.range.start_column),
+        ),
+        ("column_end".to_owned(), Value::from(site.range.end_column)),
+        ("weight".to_owned(), Value::from(1.0)),
+        ("language".to_owned(), Value::String("java".to_owned())),
+        (
+            "extractor".to_owned(),
+            Value::String("compass.resolve.java.program".to_owned()),
+        ),
+        ("resolution_rule".to_owned(), Value::String(rule.to_owned())),
+        ("rule".to_owned(), Value::String(rule.to_owned())),
+        (
+            OCCURRENCE_RULE_ATTRIBUTE.to_owned(),
+            Value::String(rule.to_owned()),
+        ),
+        (
+            "evidence_candidate_id".to_owned(),
+            Value::String(site.candidate_id.clone()),
+        ),
+    ]);
+    RawEdgeRecord {
+        source,
+        target,
+        attributes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::error::Error;
+    use std::path::Path;
+
+    use compass_languages::Engine;
+    use compass_program::{CompilerCall, CompilerDefinition};
+
+    use super::*;
+    use crate::resolve_owned_with_root;
+
+    const SOURCE_FILE: &str = "src/Demo.java";
+    const SOURCE: &str = "class Demo {\n  void pick(int x) {}\n  void pick(String x) {}\n  void use() { pick(\"x\"); }\n}\n";
+
+    #[test]
+    fn exact_compiler_symbol_resolves_java_overload() -> Result<(), Box<dyn Error>> {
+        let extraction =
+            Engine::default().extract_source(Path::new(SOURCE_FILE), SOURCE.as_bytes())?;
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing Java evidence")?;
+        let target = evidence
+            .declarations
+            .iter()
+            .find(|declaration| {
+                declaration.name == "pick"
+                    && declaration
+                        .signature
+                        .as_deref()
+                        .is_some_and(|signature| signature.contains("String"))
+            })
+            .ok_or("missing String overload")?;
+        let call = evidence
+            .candidates
+            .iter()
+            .find(|candidate| candidate.relation == CandidateRelation::Calls)
+            .ok_or("missing call candidate")?;
+        let occurrence = evidence
+            .occurrences
+            .iter()
+            .find(|occurrence| Some(occurrence.id.as_str()) == call.occurrence_id.as_deref())
+            .ok_or("missing call occurrence")?;
+        let target_node = target.graph_node_id.clone();
+        let projection = CompilerProjection {
+            definitions: vec![CompilerDefinition {
+                provider_id: "scip/java".to_owned(),
+                symbol: "java maven fixture Demo#pick(java.lang.String).".to_owned(),
+                anchor: compiler_anchor(&target.range),
+            }],
+            calls: vec![CompilerCall {
+                provider_id: "scip/java".to_owned(),
+                target: "java maven fixture Demo#pick(java.lang.String).".to_owned(),
+                anchor: compiler_anchor(&occurrence.range),
+            }],
+        };
+        let sites = collect_program_projection_sites(std::slice::from_ref(&extraction));
+        let mut resolved =
+            resolve_owned_with_root(vec![extraction], &HashMap::new(), Path::new("/repo"));
+
+        apply_program_projection(&mut resolved, &sites, &projection);
+
+        assert!(resolved.edges.iter().any(|edge| {
+            edge.target == target_node
+                && edge.attributes.get("extractor").and_then(Value::as_str)
+                    == Some("compass.resolve.java.program")
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn compiler_reference_must_be_an_ast_call_and_providers_must_agree()
+    -> Result<(), Box<dyn Error>> {
+        let extraction =
+            Engine::default().extract_source(Path::new(SOURCE_FILE), SOURCE.as_bytes())?;
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing Java evidence")?;
+        let definitions = evidence
+            .declarations
+            .iter()
+            .filter(|declaration| declaration.name == "pick")
+            .collect::<Vec<_>>();
+        let [first, second] = definitions.as_slice() else {
+            return Err("expected two overloads".into());
+        };
+        let call = evidence
+            .candidates
+            .iter()
+            .find(|candidate| candidate.relation == CandidateRelation::Calls)
+            .ok_or("missing call candidate")?;
+        let call_range = evidence
+            .occurrences
+            .iter()
+            .find(|occurrence| Some(occurrence.id.as_str()) == call.occurrence_id.as_deref())
+            .map(|occurrence| &occurrence.range)
+            .ok_or("missing call occurrence")?;
+        let type_reference = evidence
+            .occurrences
+            .iter()
+            .find(|occurrence| occurrence.spelling == "String")
+            .ok_or("missing type reference")?;
+        let projection = CompilerProjection {
+            definitions: vec![
+                CompilerDefinition {
+                    provider_id: "scip/one".to_owned(),
+                    symbol: "first".to_owned(),
+                    anchor: compiler_anchor(&first.range),
+                },
+                CompilerDefinition {
+                    provider_id: "scip/two".to_owned(),
+                    symbol: "second".to_owned(),
+                    anchor: compiler_anchor(&second.range),
+                },
+            ],
+            calls: vec![
+                CompilerCall {
+                    provider_id: "scip/one".to_owned(),
+                    target: "first".to_owned(),
+                    anchor: compiler_anchor(call_range),
+                },
+                CompilerCall {
+                    provider_id: "scip/two".to_owned(),
+                    target: "second".to_owned(),
+                    anchor: compiler_anchor(call_range),
+                },
+                CompilerCall {
+                    provider_id: "scip/one".to_owned(),
+                    target: "second".to_owned(),
+                    anchor: compiler_anchor(&type_reference.range),
+                },
+            ],
+        };
+        let sites = collect_program_projection_sites(std::slice::from_ref(&extraction));
+        let mut resolved =
+            resolve_owned_with_root(vec![extraction], &HashMap::new(), Path::new("/repo"));
+
+        apply_program_projection(&mut resolved, &sites, &projection);
+
+        assert!(resolved.edges.iter().all(|edge| {
+            edge.attributes.get("extractor").and_then(Value::as_str)
+                != Some("compass.resolve.java.program")
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn exact_compiler_symbol_preserves_recursive_java_call() -> Result<(), Box<dyn Error>> {
+        let source = "class Recursive { void run() { run(); } }\n";
+        let extraction =
+            Engine::default().extract_source(Path::new(SOURCE_FILE), source.as_bytes())?;
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing Java evidence")?;
+        let declaration = evidence
+            .declarations
+            .iter()
+            .find(|declaration| declaration.name == "run")
+            .ok_or("missing run declaration")?;
+        let candidate = evidence
+            .candidates
+            .iter()
+            .find(|candidate| candidate.relation == CandidateRelation::Calls)
+            .ok_or("missing recursive call")?;
+        let occurrence = evidence
+            .occurrences
+            .iter()
+            .find(|occurrence| Some(occurrence.id.as_str()) == candidate.occurrence_id.as_deref())
+            .ok_or("missing recursive occurrence")?;
+        let projection = CompilerProjection {
+            definitions: vec![CompilerDefinition {
+                provider_id: "scip/java".to_owned(),
+                symbol: "recursive".to_owned(),
+                anchor: compiler_anchor(&declaration.range),
+            }],
+            calls: vec![CompilerCall {
+                provider_id: "scip/java".to_owned(),
+                target: "recursive".to_owned(),
+                anchor: compiler_anchor(&occurrence.range),
+            }],
+        };
+        let graph_node_id = declaration.graph_node_id.clone();
+        let sites = collect_program_projection_sites(std::slice::from_ref(&extraction));
+        let mut resolved =
+            resolve_owned_with_root(vec![extraction], &HashMap::new(), Path::new("/repo"));
+
+        apply_program_projection(&mut resolved, &sites, &projection);
+
+        assert!(resolved.edges.iter().any(|edge| {
+            edge.source == graph_node_id
+                && edge.target == graph_node_id
+                && edge.attributes.get("extractor").and_then(Value::as_str)
+                    == Some("compass.resolve.java.program")
+        }));
+        Ok(())
+    }
+
+    fn compiler_anchor(range: &EvidenceRange) -> compass_ir::SourceAnchor {
+        compass_ir::SourceAnchor {
+            source_file: range.source_file.clone(),
+            start_byte: range.start_byte,
+            end_byte: range.end_byte,
+        }
+    }
+}

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -223,6 +223,42 @@ Multiple valid targets remain unresolved. Wildcard and terminal-name matches nev
 
 The projector converts resolved evidence into the normalized Compass graph contract. It preserves exact occurrence anchors and derives containment from declaration ownership and scope parentage.
 
+### Compiler artifact enrichment
+
+Tree-sitter remains the native structural baseline, but an enabled Program
+analysis may also consume offline SCIP evidence. Compiler facts do not replace
+the Java AST and do not independently invent graph relationships. Compass
+projects a compiler-selected Java call target only when all of these
+conditions hold:
+
+- the artifact revision is verified against the current source manifest;
+- Tree-sitter emitted a Java `Calls` or `Constructs` candidate at the exact
+  same repository-relative byte range;
+- the compiler target symbol has exactly one local definition whose identifier
+  range exactly matches one Java declaration;
+- the target declaration kind satisfies the AST candidate; and
+- all compiler providers at the call site agree on the target symbol.
+
+When those conditions hold, the compiler identity may disambiguate overloads
+and replace the structural call edge at that occurrence. The published edge
+keeps the AST wiring site, records artifact origin, and uses the
+`compiler-exact-anchor` rule; `program.json` retains the provider descriptors.
+A stale or unverified artifact, a compiler reference outside an AST-proven
+call, an external-only symbol, or provider disagreement leaves the structural
+result unchanged.
+
+This boundary is intentionally narrower than Program IR merging. SCIP encodes
+symbol references, and Compass's current decoder retains a call-resolution
+fact for each non-definition reference. The exact AST call join is therefore
+the semantic guard that prevents a field read or type reference from becoming
+a call edge.
+
+The projection contract also accepts `Project` provider batches so a future
+bounded `javac`, JDT, or language-server analyzer can reuse the same join and
+failure policy. No such analyzer is invoked by the current build pipeline; it
+requires its own process isolation, limits, freshness contract, and
+qualification before it can become a shipped provider.
+
 ## Established and universal profiles
 
 Profiles describe publication architecture, not implementation quality.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -50,6 +50,7 @@ Make a saved current-tree graph match the project:
 
 ```text
 compass update [PATH]
+  [--program-artifact PATH]
   [--out DIR]
   [--no-cluster]
   [--force]
@@ -60,7 +61,10 @@ compass update [PATH]
   [--exclude-hubs N]
 ```
 
-Use for normal cold/incremental structural builds.
+Use for normal cold/incremental structural builds. Supply a verified offline
+SCIP index with repeatable `--program-artifact`. For Java, fresh exact symbol
+evidence can disambiguate AST-proven call sites in `graph.json`; stale,
+unverified, conflicting, and non-call references are not projected.
 
 ### `extract`
 
@@ -68,6 +72,7 @@ Expose the full build surface:
 
 ```text
 compass extract [PATH]
+  [--program-artifact PATH]
   [--code-only]
   [--cargo]
   [--google-workspace]

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -265,6 +265,27 @@ must add and qualify its own explicit strategy; it must not reinterpret C3 or
 guess an owner because a member name is repository-unique. No version value
 changes for this extension.
 
+### Offline compiler evidence
+
+Offline SCIP batches are Program evidence, not `SemanticEvidenceBatch`
+records. For Java calls, Compass can join their symbol identities to this
+contract without weakening its invariants: the compiler reference must match
+an adapter-emitted call occurrence by normalized source path and exact
+half-open byte range, and the compiler definition must match an adapter-emitted
+declaration the same way. Only fresh, unanimous, locally defined targets are
+projected. Non-call references, stale or unverified documents, ambiguous
+definition anchors, and provider conflicts do not create or retarget an edge.
+
+The resulting graph provenance has artifact origin and the
+`compiler-exact-anchor` rule while retaining the adapter's exact occurrence as
+the relationship site. Tree-sitter-only builds and `--no-program` builds keep
+the existing structural behavior.
+
+The compact projection type also admits `Project` providers, but the current
+pipeline does not run `javac`, JDT, or a language server. Adding one requires a
+separately bounded and qualified `ProjectAnalyzer`; parser availability alone
+does not enable it.
+
 ## Framework pack registration
 
 `FrameworkPackDescriptor` is the registration contract for framework meaning


### PR DESCRIPTION
## Summary

- project fresh, verified SCIP definition/reference facts into Java call edges through exact AST declaration and call-site anchors
- fail closed for stale, unverified, ambiguous, conflicting, external-only, and non-call evidence
- preserve artifact provenance and recursive calls while retaining Tree-sitter as the structural fallback
- document the provider boundary for future bounded javac, JDT, or language-server analyzers

## Why

SCIP facts were decoded into Program evidence but did not improve `graph.json`. The current decoder also represents every non-definition reference as call-resolution evidence, so projecting SCIP directly could invent calls from field or type references. Joining compiler identities only at exact Tree-sitter `Calls` or `Constructs` anchors provides semantic disambiguation without weakening the native structural baseline.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-program -p compass-resolve --locked`: new projection/resolution tests passed; suite later stopped on the unrelated existing `rust_import_aliases_resolve_cross_file_types_functions_and_methods` assertion
- `cargo test -p compass-core --test program_pipeline --locked`: 9 passed
- `cargo clippy -p compass-program -p compass-resolve -p compass-core --lib --bins --locked -- -D warnings`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`: build and scale checks passed; semantic assertions stopped on the existing `external_placeholder ... not typed inferred heuristic evidence` fixture assertion

All Cargo commands used the checkout-specific external `CARGO_TARGET_DIR` required by the repository policy.
