### PR TITLE
Improve versioned history build performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Reduce immutable history build overhead by removing redundant trusted-graph,
+  ordering, source-inventory, and Program module/function storage; encode
+  independent records in parallel while retaining exact export and backward
+  read compatibility, and reject stale worktree paths in shared AST caches.
 - Use fresh, verified SCIP symbol evidence to disambiguate Java call targets in
   `graph.json` through exact AST call and declaration anchors, while rejecting
   non-call references, stale artifacts, ambiguous definitions, and conflicting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "prolly-map",
  "prolly-store-sqlite",
  "rand 0.8.7",
+ "rayon",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1857,26 +1857,32 @@ fn prepare_portable_ast_cache_entry(extraction: &mut Extraction, source: &Path, 
         return;
     };
     let portable = relative.to_string_lossy().replace('\\', "/");
+    let normalize_path = |value: &str| {
+        let path = Path::new(value);
+        let canonical = if path.is_absolute() {
+            canonicalize_allow_missing(path)
+        } else {
+            canonicalize_allow_missing(&root.join(path))
+        };
+        canonical.strip_prefix(root).map_or_else(
+            |_| portable_out_of_root_source(&canonical, root),
+            |relative| relative.to_string_lossy().replace('\\', "/"),
+        )
+    };
+    let normalize_origin_path = |value: &str| {
+        let path = Path::new(value);
+        let canonical_value = if path.is_absolute() {
+            canonicalize_allow_missing(path)
+        } else {
+            canonicalize_allow_missing(&root.join(path))
+        };
+        if path == source || canonical_value == canonical {
+            portable.clone()
+        } else {
+            normalize_path(value)
+        }
+    };
     let set_portable = |attributes: &mut serde_json::Map<String, serde_json::Value>| {
-        let normalize_path = |value: &str| {
-            let path = Path::new(value);
-            if path.is_absolute() {
-                let canonical = canonicalize_allow_missing(path);
-                canonical.strip_prefix(root).map_or_else(
-                    |_| portable_out_of_root_source(&canonical, root),
-                    |relative| relative.to_string_lossy().replace('\\', "/"),
-                )
-            } else {
-                value.replace('\\', "/")
-            }
-        };
-        let normalize_origin_path = |value: &str| {
-            if Path::new(value) == source {
-                portable.clone()
-            } else {
-                normalize_path(value)
-            }
-        };
         for key in ["source_file", "origin_file"] {
             let Some(value) = attributes
                 .get(key)
@@ -1925,6 +1931,13 @@ fn prepare_portable_ast_cache_entry(extraction: &mut Extraction, source: &Path, 
         if let Some(attributes) = hyperedge.as_object_mut() {
             set_portable(attributes);
         }
+    }
+    for fact in &mut extraction.framework_facts {
+        let source_file = match fact {
+            RawFrameworkFact::Route(route) => &mut route.anchor.source_file,
+            RawFrameworkFact::Domain(domain) => &mut domain.anchor.source_file,
+        };
+        *source_file = normalize_origin_path(source_file);
     }
     if let Some(calls) = extraction.raw_calls.as_mut() {
         for call in calls {
@@ -4263,6 +4276,59 @@ mod tests {
         );
         assert_eq!(extraction.edges[0].target, "ext_core_core_csproj");
         assert_eq!(extraction.edges[0].source, source_id);
+        Ok(())
+    }
+
+    #[test]
+    fn portable_ast_cache_removes_worktree_relative_source_paths() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let worktrees = directory.path().join("tmp");
+        let root = worktrees.join("worktree-current/checkout");
+        let source = root.join("fixtures/code-graph/routes/csharp/AspNetController.cs");
+        fs::create_dir_all(source.parent().ok_or("source path has no parent")?)?;
+        fs::write(&source, "class AspNetController {}\n")?;
+        let escaped =
+            "../../worktree-current/checkout/fixtures/code-graph/routes/csharp/AspNetController.cs";
+        let mut extraction = Extraction {
+            nodes: vec![RawNodeRecord {
+                id: "controller".to_owned(),
+                attributes: Map::from_iter([
+                    ("source_file".to_owned(), Value::String(escaped.to_owned())),
+                    ("origin_file".to_owned(), Value::String(escaped.to_owned())),
+                ]),
+            }],
+            framework_facts: vec![serde_json::from_value(json!({
+                "type": "domain",
+                "fact": {
+                    "framework": "aspnet",
+                    "kind": "controller",
+                    "name": "AspNetController",
+                    "declaringScope": "AspNetController",
+                    "anchor": {
+                        "sourceFile": escaped,
+                        "startByte": 0,
+                        "endByte": 5,
+                        "startLine": 1,
+                        "startColumn": 0,
+                        "endLine": 1,
+                        "endColumn": 5
+                    },
+                    "origin": "ast"
+                }
+            }))?],
+            ..Extraction::default()
+        };
+
+        prepare_portable_ast_cache_entry(&mut extraction, &source, &root);
+
+        let expected = "fixtures/code-graph/routes/csharp/AspNetController.cs";
+        assert_eq!(extraction.nodes[0].string("source_file"), expected);
+        assert_eq!(extraction.nodes[0].string("origin_file"), expected);
+        let framework_source = match &extraction.framework_facts[0] {
+            RawFrameworkFact::Route(route) => &route.anchor.source_file,
+            RawFrameworkFact::Domain(domain) => &domain.anchor.source_file,
+        };
+        assert_eq!(framework_source, expected);
         Ok(())
     }
 

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 use crate::{FileError, StatHashIndex, file_hash, io_error, write_bytes_atomic, write_json_atomic};
 
 /// Changes whenever cached extraction semantics change, even if the wire encoding does not.
-pub const AST_CACHE_VERSION: &str = "3";
+pub const AST_CACHE_VERSION: &str = "5";
 /// Portable cache encoding version used in the on-disk namespace.
 pub const CACHE_ENCODING_VERSION: u32 = 7;
 const MESSAGEPACK_EXTENSION: &str = "msgpack";

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -715,7 +715,7 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     assert!(
         default_cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/v3/e7")
+            .ends_with("ast/v5/e7")
     );
     assert!(!cache_root.join("compass-out/cache/ast/v0.9.21").exists());
 

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 prolly-map.workspace = true
 prolly-store-sqlite.workspace = true
 rand.workspace = true
+rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-history/src/artifacts.rs
+++ b/crates/compass-history/src/artifacts.rs
@@ -8,6 +8,7 @@ use compass_ir::{EvidenceRecord, FunctionIr, ModuleIr, ProgramBundle, ProviderDe
 use compass_model::code_graph::GraphDocument as TrustedGraphDocument;
 use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
 use prolly::{KeyBuilder, VersionedValue, decode_segments};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -24,6 +25,7 @@ const METADATA_SCHEMA: &[u8] = &[1];
 const METADATA_KIND: &[u8] = &[5];
 const MOVED_NODE_FIELDS: [&str; 3] = ["community", "community_name", "norm_label"];
 const TRUSTED_GRAPH_CONTENT: &str = ".compass-history/graph.v1.json";
+const SOURCE_INVENTORY_CONTENT: &str = ".compass_source_inventory.json";
 
 /// All authoritative inputs needed to reconstruct a complete Compass output.
 #[derive(Clone, Debug, PartialEq)]
@@ -62,6 +64,17 @@ struct ProgramHeader {
     analyzer_version: u32,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct IndexedProgramModule {
+    pub(crate) module: ModuleIr,
+    pub(crate) function_ids: Vec<String>,
+}
+
+pub(crate) enum DecodedProgramModule {
+    Embedded(ModuleIr),
+    Indexed(IndexedProgramModule),
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct DocumentHeader {
     directed: bool,
@@ -70,6 +83,11 @@ struct DocumentHeader {
     extras: BTreeMap<String, Value>,
     graph_hyperedges_present: bool,
     top_hyperedges_present: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct TrustedGraphMarker {
+    schema: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -202,7 +220,9 @@ impl GraphArtifacts {
             .get(TRUSTED_GRAPH_CONTENT)
             .map(|bytes| serde_json::from_slice::<TrustedGraphDocument>(bytes))
             .transpose()?;
-        canonicalize_graph_document(&mut self.document)?;
+        if trusted_graph.is_none() {
+            canonicalize_graph_document(&mut self.document)?;
+        }
         let registry = artifact_registry_from_canonical(&self)?;
         let mut partitioned = PartitionedGraph::default();
 
@@ -232,76 +252,117 @@ impl GraphArtifacts {
                     })?,
                 )?,
             ));
-            for provider in providers {
-                let key = program_key("provider", &provider.id);
-                partitioned.program_facts.push((
-                    key,
-                    encode_record("compass.program.provider", &serde_json::to_value(provider)?)?,
-                ));
-            }
-            for evidence in evidence {
-                let key = program_key("evidence", &evidence.id);
-                partitioned.program_facts.push((
-                    key,
-                    encode_record("compass.program.evidence", &serde_json::to_value(evidence)?)?,
-                ));
-            }
-            for module in modules {
-                let key = program_key("module", &module.source_file);
-                partitioned.program_facts.push((
-                    key,
-                    encode_record("compass.program.module", &serde_json::to_value(&module)?)?,
-                ));
-                for function in module.functions {
-                    let key = program_key("function", &function.symbol_id);
-                    partitioned.program_facts.push((
+            partitioned.program_facts.extend(
+                providers
+                    .into_par_iter()
+                    .map(|provider| {
+                        Ok((
+                            program_key("provider", &provider.id),
+                            encode_record(
+                                "compass.program.provider",
+                                &serde_json::to_value(provider)?,
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, HistoryError>>()?,
+            );
+            partitioned.program_facts.extend(
+                evidence
+                    .into_par_iter()
+                    .map(|evidence| {
+                        Ok((
+                            program_key("evidence", &evidence.id),
+                            encode_record(
+                                "compass.program.evidence",
+                                &serde_json::to_value(evidence)?,
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, HistoryError>>()?,
+            );
+            let module_records = modules
+                .into_par_iter()
+                .map(|mut module| {
+                    let key = program_key("module", &module.source_file);
+                    let function_ids = module
+                        .functions
+                        .iter()
+                        .map(|function| function.symbol_id.clone())
+                        .collect();
+                    let functions = std::mem::take(&mut module.functions);
+                    let module_record = (
                         key,
                         encode_record(
-                            "compass.program.function",
-                            &serde_json::to_value(function)?,
+                            "compass.program.module-index",
+                            &serde_json::to_value(IndexedProgramModule {
+                                module,
+                                function_ids,
+                            })?,
                         )?,
-                    ));
-                }
+                    );
+                    let functions = functions
+                        .into_iter()
+                        .map(|function| {
+                            Ok((
+                                program_key("function", &function.symbol_id),
+                                encode_record(
+                                    "compass.program.function",
+                                    &serde_json::to_value(function)?,
+                                )?,
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, HistoryError>>()?;
+                    Ok((module_record, functions))
+                })
+                .collect::<Result<Vec<_>, HistoryError>>()?;
+            for (module, functions) in module_records {
+                partitioned.program_facts.push(module);
+                partitioned.program_facts.extend(functions);
             }
-            for summary in summaries {
-                let key = program_key("summary", &summary.symbol_id);
-                partitioned.program_summaries.push((
-                    key,
-                    encode_record("compass.program.summary", &serde_json::to_value(summary)?)?,
-                ));
-            }
-            for (target, callers) in reverse_calls {
-                partitioned.program_summaries.push((
-                    program_key("reverse-call", &target),
-                    encode_record(
-                        "compass.program.reverse-call",
-                        &serde_json::to_value(callers)?,
-                    )?,
-                ));
-            }
+            partitioned.program_summaries.extend(
+                summaries
+                    .into_par_iter()
+                    .map(|summary| {
+                        Ok((
+                            program_key("summary", &summary.symbol_id),
+                            encode_record(
+                                "compass.program.summary",
+                                &serde_json::to_value(summary)?,
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, HistoryError>>()?,
+            );
+            partitioned.program_summaries.extend(
+                reverse_calls
+                    .into_par_iter()
+                    .map(|(target, callers)| {
+                        Ok((
+                            program_key("reverse-call", &target),
+                            encode_record(
+                                "compass.program.reverse-call",
+                                &serde_json::to_value(callers)?,
+                            )?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, HistoryError>>()?,
+            );
         }
 
-        // The owned document was canonicalized before its registry digest was
-        // computed, so records can consume that exact order without retaining
-        // a second graph-sized allocation.
+        // Strict v1 input was validated in canonical contract order when it
+        // was loaded, so records can consume that order without retaining a
+        // second graph-sized ordering index.
         if let Some(trusted) = &trusted_graph {
-            for (rank, node) in trusted.nodes.iter().enumerate() {
-                let key = node_key(&node.id);
-                partitioned.nodes.push((
-                    key.clone(),
-                    encode_record("compass.graph.node.v1", &serde_json::to_value(node)?)?,
-                ));
-                partitioned.metadata.push((
-                    metadata_rank_key("node-order", rank)?,
-                    encode_record(
-                        "compass.metadata.order",
-                        &serde_json::to_value(OrderedRecord {
-                            key,
-                            location: None,
-                        })?,
-                    )?,
-                ));
-            }
+            partitioned.nodes = trusted
+                .nodes
+                .par_iter()
+                .map(|node| {
+                    Ok((
+                        node_key(&node.id),
+                        encode_record("compass.graph.node.v1", &serde_json::to_value(node)?)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>, HistoryError>>()?;
         } else {
             for (rank, mut node) in std::mem::take(&mut self.document.nodes)
                 .into_iter()
@@ -335,29 +396,22 @@ impl GraphArtifacts {
 
         let mut edge_occurrences = BTreeMap::<Vec<u8>, u64>::new();
         if let Some(trusted) = &trusted_graph {
-            for (rank, edge) in trusted.links.iter().enumerate() {
-                let key = edge_key(
-                    &edge.source,
-                    &edge.target,
-                    edge.kind.as_str(),
-                    true,
-                    Some(edge.id.as_bytes()),
-                );
-                partitioned.edges.push((
-                    key.clone(),
-                    encode_record("compass.graph.edge.v1", &serde_json::to_value(edge)?)?,
-                ));
-                partitioned.metadata.push((
-                    metadata_rank_key("edge-order", rank)?,
-                    encode_record(
-                        "compass.metadata.order",
-                        &serde_json::to_value(OrderedRecord {
-                            key,
-                            location: None,
-                        })?,
-                    )?,
-                ));
-            }
+            partitioned.edges = trusted
+                .links
+                .par_iter()
+                .map(|edge| {
+                    Ok((
+                        edge_key(
+                            &edge.source,
+                            &edge.target,
+                            edge.kind.as_str(),
+                            true,
+                            Some(edge.id.as_bytes()),
+                        ),
+                        encode_record("compass.graph.edge.v1", &serde_json::to_value(edge)?)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>, HistoryError>>()?;
         } else {
             for (rank, edge) in std::mem::take(&mut self.document.links)
                 .into_iter()
@@ -468,6 +522,17 @@ impl GraphArtifacts {
                 &serde_json::to_value(completion)?,
             )?,
         ));
+        if trusted_graph.is_some() {
+            partitioned.metadata.push((
+                metadata_key(&[b"trusted-graph"]),
+                encode_record(
+                    "compass.metadata.trusted-graph",
+                    &serde_json::to_value(TrustedGraphMarker {
+                        schema: compass_model::code_graph::CODE_GRAPH_SCHEMA_V1.to_owned(),
+                    })?,
+                )?,
+            ));
+        }
 
         add_optional_analysis(
             &mut partitioned,
@@ -483,6 +548,22 @@ impl GraphArtifacts {
             ));
         }
         for (path, bytes) in std::mem::take(&mut self.authoritative_sidecars) {
+            if path == TRUSTED_GRAPH_CONTENT {
+                continue;
+            }
+            if path == SOURCE_INVENTORY_CONTENT {
+                let inventory = serde_json::from_slice::<Value>(&bytes)?;
+                if canonical_json_bytes(&inventory)? != bytes {
+                    return Err(HistoryError::InvalidArtifacts(
+                        "source inventory is not canonical JSON".to_owned(),
+                    ));
+                }
+                partitioned.metadata.push((
+                    metadata_key(&[b"source-inventory"]),
+                    encode_record("compass.metadata.source-inventory", &inventory)?,
+                ));
+                continue;
+            }
             let key = metadata_key(&[b"sidecar", path.as_bytes()]);
             partitioned.metadata.push((
                 key,
@@ -511,8 +592,6 @@ impl GraphArtifacts {
     pub fn reconstruct(partitioned: &PartitionedGraph) -> Result<Self, HistoryError> {
         let program =
             reconstruct_program(&partitioned.program_facts, &partitioned.program_summaries)?;
-        let mut nodes = decode_node_map(&partitioned.nodes)?;
-        let mut edges = decode_edge_map(&partitioned.edges)?;
         let mut hyperedges = decode_value_map(&partitioned.hyperedges, "compass.hyperedge")?;
         let mut node_analysis = BTreeMap::<String, Map<String, Value>>::new();
         let mut analysis = None;
@@ -552,22 +631,12 @@ impl GraphArtifacts {
                 }
             }
         }
-        for node in nodes.values_mut() {
-            if let Some(fields) = node_analysis.remove(&node.id) {
-                node.attributes.extend(fields);
-            }
-        }
-        if !node_analysis.is_empty() {
-            return Err(HistoryError::InvalidArtifacts(
-                "analysis references a missing node".to_owned(),
-            ));
-        }
-
         let mut header = None;
         let mut completion = None;
         let mut registry = None;
         let mut manifest = None;
         let mut sidecars = BTreeMap::new();
+        let mut trusted_graph_marker = None;
         let mut node_order = BTreeMap::new();
         let mut edge_order = BTreeMap::new();
         let mut hyperedge_order = BTreeMap::new();
@@ -586,6 +655,31 @@ impl GraphArtifacts {
                         decode_typed(bytes, "compass.metadata.completion")?;
                     evidence.validate()?;
                     completion = Some(evidence);
+                }
+                [_, _, name] if name == b"trusted-graph" => {
+                    let marker: TrustedGraphMarker =
+                        decode_typed(bytes, "compass.metadata.trusted-graph")?;
+                    if marker.schema != compass_model::code_graph::CODE_GRAPH_SCHEMA_V1
+                        || trusted_graph_marker.replace(marker).is_some()
+                    {
+                        return Err(HistoryError::InvalidArtifacts(
+                            "invalid trusted graph marker".to_owned(),
+                        ));
+                    }
+                }
+                [_, _, name] if name == b"source-inventory" => {
+                    let inventory = decode_record(bytes, "compass.metadata.source-inventory")?;
+                    if sidecars
+                        .insert(
+                            SOURCE_INVENTORY_CONTENT.to_owned(),
+                            canonical_json_bytes(&inventory)?,
+                        )
+                        .is_some()
+                    {
+                        return Err(HistoryError::InvalidArtifacts(
+                            "duplicate source inventory".to_owned(),
+                        ));
+                    }
                 }
                 [_, _, name] if name == b"artifact-registry" => {
                     registry = Some(decode_typed::<Vec<ArtifactRegistryEntry>>(
@@ -629,8 +723,57 @@ impl GraphArtifacts {
         let mut header: DocumentHeader = header.ok_or_else(|| {
             HistoryError::InvalidArtifacts("missing document metadata".to_owned())
         })?;
-        let ordered_nodes = restore_order(&mut nodes, node_order, "node")?;
-        let ordered_edges = restore_order(&mut edges, edge_order, "edge")?;
+        let (mut ordered_nodes, trusted_nodes) = if trusted_graph_marker.is_some() {
+            let mut nodes = decode_trusted_node_map(&partitioned.nodes)?;
+            let mut trusted = if node_order.is_empty() {
+                nodes.into_values().collect::<Vec<_>>()
+            } else {
+                restore_order(&mut nodes, node_order, "node")?
+            };
+            trusted.sort_by(|left, right| left.id.cmp(&right.id));
+            let compatible = trusted.iter().map(compat_node).collect();
+            (compatible, Some(trusted))
+        } else {
+            let mut nodes = decode_node_map(&partitioned.nodes)?;
+            (restore_order(&mut nodes, node_order, "node")?, None)
+        };
+        let (ordered_edges, trusted_edges) = if trusted_graph_marker.is_some() {
+            let mut edges = decode_trusted_edge_map(&partitioned.edges)?;
+            let mut trusted = if edge_order.is_empty() {
+                edges.into_values().collect::<Vec<_>>()
+            } else {
+                restore_order(&mut edges, edge_order, "edge")?
+            };
+            trusted.sort_by(|left, right| {
+                (
+                    left.source.as_str(),
+                    left.kind.as_str(),
+                    left.target.as_str(),
+                    left.key.as_str(),
+                )
+                    .cmp(&(
+                        right.source.as_str(),
+                        right.kind.as_str(),
+                        right.target.as_str(),
+                        right.key.as_str(),
+                    ))
+            });
+            let compatible = trusted.iter().map(compat_edge).collect();
+            (compatible, Some(trusted))
+        } else {
+            let mut edges = decode_edge_map(&partitioned.edges)?;
+            (restore_order(&mut edges, edge_order, "edge")?, None)
+        };
+        for node in &mut ordered_nodes {
+            if let Some(fields) = node_analysis.remove(&node.id) {
+                node.attributes.extend(fields);
+            }
+        }
+        if !node_analysis.is_empty() {
+            return Err(HistoryError::InvalidArtifacts(
+                "analysis references a missing node".to_owned(),
+            ));
+        }
         let ordered_hyperedges = restore_hyperedge_order(&mut hyperedges, hyperedge_order)?;
         let mut graph_values = Vec::new();
         let mut top_values = Vec::new();
@@ -649,6 +792,28 @@ impl GraphArtifacts {
             header
                 .extras
                 .insert("hyperedges".to_owned(), Value::Array(top_values));
+        }
+        if let (Some(nodes), Some(links)) = (trusted_nodes, trusted_edges) {
+            if header.graph_hyperedges_present
+                || header.top_hyperedges_present
+                || !header.extras.is_empty()
+            {
+                return Err(HistoryError::InvalidArtifacts(
+                    "trusted graph metadata contains unsupported extension fields".to_owned(),
+                ));
+            }
+            let graph = serde_json::from_value(Value::Object(header.graph.clone()))?;
+            let trusted = TrustedGraphDocument {
+                directed: header.directed,
+                multigraph: header.multigraph,
+                graph,
+                nodes,
+                links,
+            };
+            sidecars.insert(
+                TRUSTED_GRAPH_CONTENT.to_owned(),
+                canonical_json_bytes(&serde_json::to_value(trusted)?)?,
+            );
         }
         let restored = Self {
             document: GraphDocument {
@@ -919,7 +1084,9 @@ fn artifact_registry_with_graph_bytes(
             continue;
         }
         let mut entry = authoritative_entry(path, "application/octet-stream", bytes);
-        entry.storage = Some(bytes.clone());
+        if path != SOURCE_INVENTORY_CONTENT {
+            entry.storage = Some(bytes.clone());
+        }
         registry.push(entry);
     }
     for path in [
@@ -1244,7 +1411,7 @@ fn reconstruct_program(
     let mut header = None;
     let mut providers = Vec::<ProviderDescriptor>::new();
     let mut evidence = Vec::<EvidenceRecord>::new();
-    let mut modules = Vec::<ModuleIr>::new();
+    let mut modules = Vec::<DecodedProgramModule>::new();
     let mut indexed_functions = BTreeMap::<String, FunctionIr>::new();
     for (key, bytes) in facts {
         let segments = decode_segments(key)
@@ -1286,8 +1453,12 @@ fn reconstruct_program(
                 evidence.push(value);
             }
             b"module" => {
-                let value: ModuleIr = decode_typed(bytes, "compass.program.module")?;
-                if value.source_file != identity {
+                let value = decode_program_module(bytes)?;
+                let source_file = match &value {
+                    DecodedProgramModule::Embedded(module) => &module.source_file,
+                    DecodedProgramModule::Indexed(indexed) => &indexed.module.source_file,
+                };
+                if source_file != identity {
                     return Err(HistoryError::InvalidArtifacts(
                         "program module key does not match its source".to_owned(),
                     ));
@@ -1319,14 +1490,51 @@ fn reconstruct_program(
     }
     let header: ProgramHeader = header
         .ok_or_else(|| HistoryError::InvalidArtifacts("missing program header".to_owned()))?;
-    let module_functions = modules
-        .iter()
-        .flat_map(|module| &module.functions)
-        .map(|function| (function.symbol_id.clone(), function.clone()))
-        .collect::<BTreeMap<_, _>>();
-    if indexed_functions != module_functions {
+    let mut referenced_functions = BTreeSet::new();
+    let modules = modules
+        .into_iter()
+        .map(|stored| match stored {
+            DecodedProgramModule::Embedded(module) => {
+                for function in &module.functions {
+                    let indexed = indexed_functions.get(&function.symbol_id).ok_or_else(|| {
+                        HistoryError::InvalidArtifacts(
+                            "program module references a missing indexed function".to_owned(),
+                        )
+                    })?;
+                    if indexed != function
+                        || !referenced_functions.insert(function.symbol_id.clone())
+                    {
+                        return Err(HistoryError::InvalidArtifacts(
+                            "indexed program functions do not match module contents".to_owned(),
+                        ));
+                    }
+                }
+                Ok(module)
+            }
+            DecodedProgramModule::Indexed(mut indexed) => {
+                indexed.module.functions = indexed
+                    .function_ids
+                    .into_iter()
+                    .map(|symbol_id| {
+                        if !referenced_functions.insert(symbol_id.clone()) {
+                            return Err(HistoryError::InvalidArtifacts(
+                                "program function is indexed by multiple modules".to_owned(),
+                            ));
+                        }
+                        indexed_functions.get(&symbol_id).cloned().ok_or_else(|| {
+                            HistoryError::InvalidArtifacts(
+                                "program module references a missing indexed function".to_owned(),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(indexed.module)
+            }
+        })
+        .collect::<Result<Vec<_>, HistoryError>>()?;
+    if referenced_functions.len() != indexed_functions.len() {
         return Err(HistoryError::InvalidArtifacts(
-            "indexed program functions do not match module contents".to_owned(),
+            "unreferenced indexed program function".to_owned(),
         ));
     }
     let mut function_summaries = Vec::<FunctionSummary>::new();
@@ -1410,12 +1618,41 @@ pub(crate) fn decode_typed<T: for<'de> Deserialize<'de>>(
     serde_json::from_value(decode_record(bytes, schema)?).map_err(HistoryError::from)
 }
 
+pub(crate) fn decode_program_module(bytes: &[u8]) -> Result<DecodedProgramModule, HistoryError> {
+    let envelope = VersionedValue::from_bytes(bytes)?;
+    envelope.require_schema(&envelope.schema, RECORD_VERSION)?;
+    match envelope.schema.as_str() {
+        "compass.program.module" => Ok(DecodedProgramModule::Embedded(serde_json::from_slice(
+            &envelope.payload,
+        )?)),
+        "compass.program.module-index" => Ok(DecodedProgramModule::Indexed(
+            serde_json::from_slice(&envelope.payload)?,
+        )),
+        schema => Err(HistoryError::InvalidArtifacts(format!(
+            "unsupported program module record schema {schema}"
+        ))),
+    }
+}
+
 fn decode_node_map(
     entries: &[(Vec<u8>, Vec<u8>)],
 ) -> Result<BTreeMap<Vec<u8>, NodeRecord>, HistoryError> {
     entries
         .iter()
         .map(|(key, bytes)| Ok((key.clone(), decode_compatible_node(bytes)?)))
+        .collect()
+}
+
+fn decode_trusted_node_map(
+    entries: &[(Vec<u8>, Vec<u8>)],
+) -> Result<BTreeMap<Vec<u8>, compass_model::code_graph::NodeRecord>, HistoryError> {
+    entries
+        .iter()
+        .map(|(key, bytes)| {
+            let envelope = VersionedValue::from_bytes(bytes)?;
+            envelope.require_schema("compass.graph.node.v1", RECORD_VERSION)?;
+            Ok((key.clone(), serde_json::from_slice(&envelope.payload)?))
+        })
         .collect()
 }
 
@@ -1444,6 +1681,19 @@ fn decode_edge_map(
     entries
         .iter()
         .map(|(key, bytes)| Ok((key.clone(), decode_compatible_edge(bytes)?)))
+        .collect()
+}
+
+fn decode_trusted_edge_map(
+    entries: &[(Vec<u8>, Vec<u8>)],
+) -> Result<BTreeMap<Vec<u8>, compass_model::code_graph::EdgeRecord>, HistoryError> {
+    entries
+        .iter()
+        .map(|(key, bytes)| {
+            let envelope = VersionedValue::from_bytes(bytes)?;
+            envelope.require_schema("compass.graph.edge.v1", RECORD_VERSION)?;
+            Ok((key.clone(), serde_json::from_slice(&envelope.payload)?))
+        })
         .collect()
 }
 

--- a/crates/compass-history/src/reader.rs
+++ b/crates/compass-history/src/reader.rs
@@ -130,9 +130,24 @@ impl RealizationReader<'_> {
                     OwnedHistoryRecordKey::Node(_) => {
                         HistoryRecord::Node(crate::artifacts::decode_compatible_node(&bytes)?)
                     }
-                    OwnedHistoryRecordKey::ProgramModule(_) => HistoryRecord::ProgramModule(
-                        crate::artifacts::decode_typed(&bytes, schema)?,
-                    ),
+                    OwnedHistoryRecordKey::ProgramModule(_) => {
+                        let module = match crate::artifacts::decode_program_module(&bytes)? {
+                            crate::artifacts::DecodedProgramModule::Embedded(module) => module,
+                            crate::artifacts::DecodedProgramModule::Indexed(indexed) => {
+                                hydrate_indexed_module(indexed, |symbol_id| {
+                                    match self.read(HistoryRecordKey::ProgramFunction(symbol_id))? {
+                                        Some(HistoryRecord::ProgramFunction(function)) => {
+                                            Ok(function)
+                                        }
+                                        _ => Err(HistoryError::CorruptHistory(format!(
+                                            "program module references missing function {symbol_id}"
+                                        ))),
+                                    }
+                                })?
+                            }
+                        };
+                        HistoryRecord::ProgramModule(module)
+                    }
                     OwnedHistoryRecordKey::ProgramFunction(_) => HistoryRecord::ProgramFunction(
                         crate::artifacts::decode_typed(&bytes, schema)?,
                     ),
@@ -158,5 +173,74 @@ impl RealizationReader<'_> {
 
     pub(crate) fn tree(&self, stored: &StoredTree) -> Tree {
         stored.to_tree()
+    }
+}
+
+fn hydrate_indexed_module(
+    mut indexed: crate::artifacts::IndexedProgramModule,
+    mut read_function: impl FnMut(&str) -> Result<compass_ir::FunctionIr, HistoryError>,
+) -> Result<compass_ir::ModuleIr, HistoryError> {
+    indexed.module.functions = indexed
+        .function_ids
+        .iter()
+        .map(|symbol_id| read_function(symbol_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(indexed.module)
+}
+
+#[cfg(test)]
+mod tests {
+    use compass_ir::{ExecutionMode, FunctionIr, ModuleIr, SourceAnchor, Visibility, hex_sha256};
+
+    use super::hydrate_indexed_module;
+    use crate::artifacts::IndexedProgramModule;
+
+    #[test]
+    fn indexed_module_reads_functions_in_declared_order() -> Result<(), crate::HistoryError> {
+        let function = |symbol_id: &str| FunctionIr {
+            symbol_id: symbol_id.to_owned(),
+            name: symbol_id.to_owned(),
+            graph_node_id: None,
+            signature_digest: hex_sha256(symbol_id.as_bytes()),
+            body_digest: hex_sha256(b"body"),
+            visibility: Visibility::Public,
+            execution_mode: ExecutionMode::Sync,
+            is_test: false,
+            anchor: SourceAnchor {
+                source_file: "src/lib.rs".to_owned(),
+                start_byte: 0,
+                end_byte: 1,
+            },
+            parameters: Vec::new(),
+            return_type: None,
+            blocks: Vec::new(),
+            coverage: Default::default(),
+            evidence: Vec::new(),
+        };
+        let module = ModuleIr {
+            source_file: "src/lib.rs".to_owned(),
+            language: "rust".to_owned(),
+            source_digest: hex_sha256(b"source"),
+            graph_node_id: None,
+            functions: Vec::new(),
+            coverage: Default::default(),
+            evidence: Vec::new(),
+        };
+        let hydrated = hydrate_indexed_module(
+            IndexedProgramModule {
+                module,
+                function_ids: vec!["second".to_owned(), "first".to_owned()],
+            },
+            |symbol_id| Ok(function(symbol_id)),
+        )?;
+        assert_eq!(
+            hydrated
+                .functions
+                .iter()
+                .map(|function| function.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            ["second", "first"]
+        );
+        Ok(())
     }
 }

--- a/crates/compass-history/src/store.rs
+++ b/crates/compass-history/src/store.rs
@@ -1,9 +1,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
 
 use prolly::{
-    Config, KeyBuilder, ManifestStoreScan, NamedRootUpdate, Prolly, SortedBatchBuilder,
+    BatchBuilder, Config, KeyBuilder, ManifestStoreScan, NamedRootUpdate, Prolly,
     TransactionUpdate, Tree,
 };
 use prolly_store_sqlite::{SqliteStore, SqliteStoreConfig};
@@ -187,7 +188,9 @@ impl HistoryStore {
             })
         };
 
+        let started = Instant::now();
         let validated = validate_publication_partition(request.artifacts, &request.completion)?;
+        profile_publication("artifact validation and partitioning", started);
         let report = validated.report;
         let partitioned = validated.partitioned;
         let node_count = report.nodes;
@@ -197,13 +200,15 @@ impl HistoryStore {
         let metadata_count = report.metadata_records;
         let program_fact_count = report.program_fact_records;
         let program_summary_count = report.program_summary_records;
-        let nodes = self.build_tree(partitioned.nodes)?;
-        let edges = self.build_tree(partitioned.edges)?;
-        let hyperedges = self.build_tree(partitioned.hyperedges)?;
-        let analysis = self.build_tree(partitioned.analysis)?;
-        let metadata = self.build_tree(partitioned.metadata)?;
-        let program_facts = self.build_tree(partitioned.program_facts)?;
-        let program_summaries = self.build_tree(partitioned.program_summaries)?;
+        let nodes = self.build_tree_profiled("nodes tree", partitioned.nodes)?;
+        let edges = self.build_tree_profiled("edges tree", partitioned.edges)?;
+        let hyperedges = self.build_tree_profiled("hyperedges tree", partitioned.hyperedges)?;
+        let analysis = self.build_tree_profiled("analysis tree", partitioned.analysis)?;
+        let metadata = self.build_tree_profiled("metadata tree", partitioned.metadata)?;
+        let program_facts =
+            self.build_tree_profiled("program facts tree", partitioned.program_facts)?;
+        let program_summaries =
+            self.build_tree_profiled("program summaries tree", partitioned.program_summaries)?;
         let profile_digest = hex(&request.profile.digest()?);
         let version = GraphVersion {
             schema_version: crate::HISTORY_SCHEMA_VERSION,
@@ -705,11 +710,22 @@ impl HistoryStore {
     }
 
     fn build_tree(&self, entries: Vec<(Vec<u8>, Vec<u8>)>) -> Result<Tree, HistoryError> {
-        let mut builder = SortedBatchBuilder::new(self.prolly.store().clone(), Config::default());
+        let mut builder = BatchBuilder::new(self.prolly.store().clone(), Config::default());
         for (key, value) in entries {
-            builder.add(key, value)?;
+            builder.add(key, value);
         }
         builder.build().map_err(HistoryError::from)
+    }
+
+    fn build_tree_profiled(
+        &self,
+        name: &'static str,
+        entries: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> Result<Tree, HistoryError> {
+        let started = Instant::now();
+        let tree = self.build_tree(entries)?;
+        profile_publication(name, started);
+        Ok(tree)
     }
 
     fn load_realization_root(
@@ -924,6 +940,15 @@ impl HistoryStore {
         } else {
             Err(HistoryError::IncompatibleStoreFormat)
         }
+    }
+}
+
+fn profile_publication(name: &str, started: Instant) {
+    if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
+        eprintln!(
+            "[compass history internal] {name}: {:.3}s",
+            started.elapsed().as_secs_f64()
+        );
     }
 }
 

--- a/crates/compass-history/src/validate.rs
+++ b/crates/compass-history/src/validate.rs
@@ -115,6 +115,17 @@ pub(crate) fn validate_publication_partition(
             partitioned.program_summaries.as_slice(),
         ),
     ] {
+        if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
+            let bytes = entries.iter().fold(0_u64, |total, (key, value)| {
+                total
+                    .saturating_add(key.len() as u64)
+                    .saturating_add(value.len() as u64)
+            });
+            eprintln!(
+                "[compass history internal] {kind}: {} records, {bytes} bytes",
+                entries.len()
+            );
+        }
         validate_generated_partition_records(kind, entries, &mut total_bytes, &mut problems);
     }
     if !problems.is_empty() {
@@ -352,27 +363,57 @@ fn validate_record_size_limits(
     problems: &mut Vec<ValidationProblem>,
 ) {
     if exceeds_limit(key.len() as u64, MAX_KEY_BYTES as u64) {
-        problems.push(ValidationProblem::ResourceLimit {
-            kind: "key bytes",
-            limit: MAX_KEY_BYTES as u64,
-            actual: key.len() as u64,
-        });
+        record_resource_limit(
+            problems,
+            "key bytes",
+            MAX_KEY_BYTES as u64,
+            key.len() as u64,
+        );
     }
     if exceeds_limit(value.len() as u64, MAX_RECORD_VALUE_BYTES as u64) {
-        problems.push(ValidationProblem::ResourceLimit {
-            kind: "record value bytes",
-            limit: MAX_RECORD_VALUE_BYTES as u64,
-            actual: value.len() as u64,
-        });
+        record_resource_limit(
+            problems,
+            "record value bytes",
+            MAX_RECORD_VALUE_BYTES as u64,
+            value.len() as u64,
+        );
     }
     *total_bytes = total_bytes
         .saturating_add(key.len() as u64)
         .saturating_add(value.len() as u64);
     if exceeds_limit(*total_bytes, MAX_AUTHORITATIVE_BYTES) {
+        record_resource_limit(
+            problems,
+            "authoritative bytes",
+            MAX_AUTHORITATIVE_BYTES,
+            *total_bytes,
+        );
+    }
+}
+
+fn record_resource_limit(
+    problems: &mut Vec<ValidationProblem>,
+    kind: &'static str,
+    limit: u64,
+    actual: u64,
+) {
+    if let Some(ValidationProblem::ResourceLimit {
+        actual: recorded, ..
+    }) = problems.iter_mut().find(|problem| {
+        matches!(
+            problem,
+            ValidationProblem::ResourceLimit {
+                kind: recorded_kind,
+                ..
+            } if *recorded_kind == kind
+        )
+    }) {
+        *recorded = (*recorded).max(actual);
+    } else {
         problems.push(ValidationProblem::ResourceLimit {
-            kind: "authoritative bytes",
-            limit: MAX_AUTHORITATIVE_BYTES,
-            actual: *total_bytes,
+            kind,
+            limit,
+            actual,
         });
     }
 }
@@ -532,7 +573,8 @@ fn json_depth(value: &Value) -> usize {
 mod tests {
     use super::{
         MAX_AUTHORITATIVE_BYTES, MAX_DIAGNOSTIC_BYTES, MAX_JOB_BYTES, MAX_JSON_DEPTH,
-        MAX_KEY_BYTES, MAX_RECORD_VALUE_BYTES, MAX_RECORDS_PER_TREE, exceeds_limit,
+        MAX_KEY_BYTES, MAX_RECORD_VALUE_BYTES, MAX_RECORDS_PER_TREE, ValidationProblem,
+        exceeds_limit, record_resource_limit,
     };
 
     #[test]
@@ -549,5 +591,20 @@ mod tests {
             assert!(!exceeds_limit(limit, limit));
             assert!(exceeds_limit(limit + 1, limit));
         }
+    }
+
+    #[test]
+    fn repeated_resource_limit_failures_collapse_to_the_largest_observation() {
+        let mut problems = Vec::new();
+        record_resource_limit(&mut problems, "authoritative bytes", 10, 11);
+        record_resource_limit(&mut problems, "authoritative bytes", 10, 15);
+        assert_eq!(
+            problems,
+            vec![ValidationProblem::ResourceLimit {
+                kind: "authoritative bytes",
+                limit: 10,
+                actual: 15,
+            }]
+        );
     }
 }

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -219,3 +219,53 @@ fn small_change_reuses_content_addressed_nodes() -> Result<(), Box<dyn std::erro
     );
     Ok(())
 }
+
+#[test]
+#[ignore = "performance evidence; requires COMPASS_HISTORY_PERF_ARTIFACTS"]
+fn real_artifact_publication_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
+    let artifacts_path = PathBuf::from(
+        std::env::var_os("COMPASS_HISTORY_PERF_ARTIFACTS")
+            .ok_or("COMPASS_HISTORY_PERF_ARTIFACTS is required")?,
+    );
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("fixture.rs"), "pub struct Fixture;\n")?;
+    commit(directory.path(), "fixture")?;
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let commit = repository.resolve("HEAD")?;
+    let mut profile = compass_history::BuildProfile::default();
+    profile.insert("graph_schema", compass_history::HISTORY_GRAPH_SCHEMA)?;
+    let started = Instant::now();
+    let published = history.publish(PublishRequest {
+        parents: repository.parents(&commit)?,
+        profile,
+        artifacts: GraphArtifacts::load(&artifacts_path)?,
+        completion: CompletionEvidence {
+            extraction_succeeded: true,
+            allow_partial: false,
+            semantic_files_expected: 0,
+            semantic_files_completed: 0,
+            failed_chunks: 0,
+        },
+        fingerprint: "c".repeat(64).parse()?,
+        commit,
+        make_preferred: true,
+    })?;
+    println!(
+        "real_artifact_publish={:?} nodes={} edges={} metadata={} program_facts={} program_summaries={}",
+        started.elapsed(),
+        published.version.node_count,
+        published.version.edge_count,
+        published.version.metadata_count,
+        published.version.program_fact_count,
+        published.version.program_summary_count
+    );
+    Ok(())
+}

--- a/crates/compass-history/tests/roundtrip.rs
+++ b/crates/compass-history/tests/roundtrip.rs
@@ -11,7 +11,7 @@ use compass_ir::{
 };
 use compass_model::GraphDocument;
 use compass_model::identity::file_id;
-use prolly::VersionedValue;
+use prolly::{VersionedValue, decode_segments};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
@@ -108,6 +108,65 @@ fn trusted_graph_partitions_store_full_typed_node_records() -> Result<(), Box<dy
     assert_eq!(payload["evidence"][0]["origin"], "config");
     assert_eq!(payload["coverage"][0]["status"], "partial");
     assert_eq!(payload["diagnostics"][0]["code"], "fixture");
+    Ok(())
+}
+
+#[test]
+fn trusted_graph_partition_does_not_duplicate_full_graph_as_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph = empty_trusted_graph();
+    let graph_bytes = canonical_json_bytes(&graph)?;
+    std::fs::write(directory.path().join("graph.json"), &graph_bytes)?;
+
+    let partition = GraphArtifacts::load(directory.path())?.partition(&completion())?;
+    assert!(partition.metadata.iter().all(|(key, _)| {
+        !matches!(
+            decode_segments(key).as_deref(),
+            Ok([_, _, kind, path])
+                if kind == b"sidecar" && path == b".compass-history/graph.v1.json"
+        )
+    }));
+    assert!(partition.metadata.iter().all(|(key, _)| {
+        !matches!(
+            decode_segments(key).as_deref(),
+            Ok([_, _, kind, _]) if kind == b"node-order" || kind == b"edge-order"
+        )
+    }));
+
+    let restored = GraphArtifacts::reconstruct(&partition)?;
+    assert_eq!(restored.graph_json_bytes()?, graph_bytes);
+    Ok(())
+}
+
+#[test]
+fn source_inventory_uses_one_decomposed_canonical_record() -> Result<(), Box<dyn std::error::Error>>
+{
+    let inventory = canonical_json_bytes(&json!({
+        "schema": "compass.history.source_inventory/1",
+        "code_files": {"src/lib.rs": {"git_object": "fixture"}}
+    }))?;
+    let mut artifacts = empty_trusted_artifacts()?;
+    artifacts.authoritative_sidecars.insert(
+        ".compass_source_inventory.json".to_owned(),
+        inventory.clone(),
+    );
+
+    let registry = artifacts.artifact_registry()?;
+    let entry = registry
+        .iter()
+        .find(|entry| entry.relative_path == ".compass_source_inventory.json")
+        .ok_or("source inventory registry entry missing")?;
+    assert!(entry.storage.is_none());
+
+    let partition = artifacts.partition(&completion())?;
+    assert_eq!(GraphArtifacts::reconstruct(&partition)?, artifacts);
+    assert!(partition.metadata.iter().any(|(key, _)| {
+        matches!(
+            decode_segments(key).as_deref(),
+            Ok([_, _, name]) if name == b"source-inventory"
+        )
+    }));
     Ok(())
 }
 
@@ -265,6 +324,16 @@ fn complete_graph_and_build_state_round_trip() -> Result<(), Box<dyn std::error:
     );
     assert_eq!(partitioned.program_facts.len(), 5);
     assert_eq!(partitioned.program_summaries.len(), 2);
+    let module_record = partitioned
+        .program_facts
+        .iter()
+        .find(|(key, _)| matches!(decode_segments(key).as_deref(), Ok([kind, _]) if kind == b"module"))
+        .ok_or("missing indexed module record")?;
+    let module = VersionedValue::from_bytes(&module_record.1)?;
+    assert_eq!(module.schema, "compass.program.module-index");
+    let module: Value = serde_json::from_slice(&module.payload)?;
+    assert_eq!(module["module"]["functions"], json!([]));
+    assert_eq!(module["function_ids"], json!(["run"]));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- add stage-level artifact loading instrumentation behind `COMPASS_PROFILE_INTERNAL`
- load and validate trusted graph/Program artifacts once, with concurrent graph and Program reads
- retain typed graph, Program, and analysis artifacts for native code-only history builds, eliminating the child-process JSON handoff
- remove redundant trusted graph, ordering, source-inventory, and Program function storage from immutable history realizations
- encode independent records and build Prolly trees in parallel while preserving deterministic roots and backward reads
- normalize shared AST cache paths and root-aware framework aliases so detached/incremental builds stay byte-identical

## Why

Large versioned code-graph builds stored the complete trusted graph again as metadata, emitted an ordering record for every node and edge, duplicated every Program function inside its module, and then paid a large cross-process serialization/deserialization cost before history publication.

The delivery sequence in this PR is instrumentation → verified single-pass loading → concurrent loading → in-process history build.

## Impact

On the 1,035-file qualification repository before the latest in-process handoff:

- authoritative partition size fell from 767.8 MB to 530.3 MB (decimal), below the unchanged 512 MiB / 536.9 MB bound
- metadata fell from 161.1 MB to about 3.0 MB
- Program facts fell from 260.2 MB to 181.1 MB
- an end-to-end versioned build improved from 288.4s to 259.6s
- unchanged history lookup completed in 0.05s

The new native code-only path removes the remaining executable and JSON artifact handoff. Provider-backed and Cargo-integrated profiles deliberately retain the bounded subprocess boundary. Older realizations remain readable, exact exports round-trip, resource limits are unchanged, and the optimized rebuild produces the same deterministic realization ID.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test history_cli --locked`
- `cargo test -p compass-history --test roundtrip --locked`
- `cargo test -p compass-core --test history_materialize --locked`
- `cargo test -p compass-model --test code_graph_loading --locked`
- `cargo test -p compass-resolve --locked` (all route/cache tests pass; one unrelated existing Rust universal-evidence assertion fails)
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` now passes clean/warm/forced/restored/alternate-checkout byte equality; the later semantic oracle still fails on the existing external-placeholder provenance contract
