### PR TITLE
feat(frameworks): hard-cut Spring Java to universal evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Hard-cut Java Spring framework extraction to the production universal
+  `spring-java` pack, including composed and inherited HTTP mappings, constants,
+  bean and injection topology, messaging, scheduling, JPA, transactions, and
+  security; Kotlin Spring remains on its established detector.
+- Advance universal extraction semantics to `compass.languages.extraction/4`
+  so cached Java evidence cannot be reused across the Spring pack cutover.
 - Introduce the first supported Compass code graph contract,
   `compass.graph/1`, as a strict versioned NetworkX-compatible multigraph with
   structural, framework, enterprise, messaging, job, schema, configuration,

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1936,6 +1936,7 @@ fn prepare_portable_ast_cache_entry(extraction: &mut Extraction, source: &Path, 
         let source_file = match fact {
             RawFrameworkFact::Route(route) => &mut route.anchor.source_file,
             RawFrameworkFact::Domain(domain) => &mut domain.anchor.source_file,
+            RawFrameworkFact::Annotation(annotation) => &mut annotation.anchor.source_file,
         };
         *source_file = normalize_origin_path(source_file);
     }
@@ -4298,25 +4299,48 @@ mod tests {
                     ("origin_file".to_owned(), Value::String(escaped.to_owned())),
                 ]),
             }],
-            framework_facts: vec![serde_json::from_value(json!({
-                "type": "domain",
-                "fact": {
-                    "framework": "aspnet",
-                    "kind": "controller",
-                    "name": "AspNetController",
-                    "declaringScope": "AspNetController",
-                    "anchor": {
-                        "sourceFile": escaped,
-                        "startByte": 0,
-                        "endByte": 5,
-                        "startLine": 1,
-                        "startColumn": 0,
-                        "endLine": 1,
-                        "endColumn": 5
-                    },
-                    "origin": "ast"
-                }
-            }))?],
+            framework_facts: vec![
+                serde_json::from_value(json!({
+                    "type": "domain",
+                    "fact": {
+                        "framework": "aspnet",
+                        "kind": "controller",
+                        "name": "AspNetController",
+                        "declaringScope": "AspNetController",
+                        "anchor": {
+                            "sourceFile": escaped,
+                            "startByte": 0,
+                            "endByte": 5,
+                            "startLine": 1,
+                            "startColumn": 0,
+                            "endLine": 1,
+                            "endColumn": 5
+                        },
+                        "origin": "ast"
+                    }
+                }))?,
+                serde_json::from_value(json!({
+                    "type": "annotation",
+                    "fact": {
+                        "packId": "spring-java",
+                        "framework": "spring",
+                        "annotationName": "Controller",
+                        "ownerDeclarationId": "controller-declaration",
+                        "ownerGraphNodeId": "controller",
+                        "ownerQualifiedName": "AspNetController",
+                        "ownerKind": "class",
+                        "anchor": {
+                            "sourceFile": escaped,
+                            "startByte": 0,
+                            "endByte": 5,
+                            "startLine": 1,
+                            "startColumn": 0,
+                            "endLine": 1,
+                            "endColumn": 5
+                        }
+                    }
+                }))?,
+            ],
             ..Extraction::default()
         };
 
@@ -4325,11 +4349,14 @@ mod tests {
         let expected = "fixtures/code-graph/routes/csharp/AspNetController.cs";
         assert_eq!(extraction.nodes[0].string("source_file"), expected);
         assert_eq!(extraction.nodes[0].string("origin_file"), expected);
-        let framework_source = match &extraction.framework_facts[0] {
-            RawFrameworkFact::Route(route) => &route.anchor.source_file,
-            RawFrameworkFact::Domain(domain) => &domain.anchor.source_file,
-        };
-        assert_eq!(framework_source, expected);
+        assert!(extraction.framework_facts.iter().all(|fact| {
+            let framework_source = match fact {
+                RawFrameworkFact::Route(route) => &route.anchor.source_file,
+                RawFrameworkFact::Domain(domain) => &domain.anchor.source_file,
+                RawFrameworkFact::Annotation(annotation) => &annotation.anchor.source_file,
+            };
+            framework_source == expected
+        }));
         Ok(())
     }
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -3498,6 +3498,7 @@ fn make_framework_fact_sources_portable(extraction: &mut Extraction, root: &Path
         let source_file = match fact {
             RawFrameworkFact::Route(route) => &mut route.anchor.source_file,
             RawFrameworkFact::Domain(domain) => &mut domain.anchor.source_file,
+            RawFrameworkFact::Annotation(annotation) => &mut annotation.anchor.source_file,
         };
         let path = Path::new(source_file);
         if !path.is_absolute() {

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -1817,6 +1817,25 @@ impl<'source> DirectAdapterState<'source> {
             self.add_java_annotations(node, &active)?;
             self.add_java_type_relationships(node, &active)?;
         }
+        if matches!(node.kind(), "field_declaration" | "constant_declaration") {
+            let mut declarators = Vec::new();
+            collect_direct_or_nested_nodes(node, "variable_declarator", &mut declarators);
+            for declarator in declarators {
+                if let Some(field) = self.declarations.get(&declarator.id()).cloned() {
+                    self.add_java_annotations(node, &field)?;
+                    self.add_java_type_relationships(node, &field)?;
+                }
+            }
+        }
+        if matches!(
+            node.kind(),
+            "method_declaration" | "constructor_declaration"
+        ) {
+            self.add_java_parameter_annotations(node, &active)?;
+        }
+        if node.kind() == "annotation_type_element_declaration" {
+            self.add_java_annotations(node, &active)?;
+        }
         match node.kind() {
             "import_declaration" => return Ok(()),
             "method_invocation" => self.add_java_method_call(node, &active)?,
@@ -1866,6 +1885,25 @@ impl<'source> DirectAdapterState<'source> {
         Ok(())
     }
 
+    fn add_java_parameter_annotations(
+        &mut self,
+        node: Node<'_>,
+        owner: &DeclarationContext,
+    ) -> Result<(), EvidenceError> {
+        let Some(parameters) = node.child_by_field_name("parameters") else {
+            return Ok(());
+        };
+        let mut parameter_nodes = Vec::new();
+        collect_nodes(parameters, "formal_parameter", &mut parameter_nodes);
+        collect_nodes(parameters, "spread_parameter", &mut parameter_nodes);
+        parameter_nodes.sort_by_key(Node::start_byte);
+        parameter_nodes.dedup_by_key(|parameter| parameter.id());
+        for parameter in parameter_nodes {
+            self.add_java_annotations(parameter, owner)?;
+        }
+        Ok(())
+    }
+
     fn add_java_type_relationships(
         &mut self,
         node: Node<'_>,
@@ -1896,6 +1934,24 @@ impl<'source> DirectAdapterState<'source> {
                         owner,
                         target,
                         Some("interface"),
+                        vec!["interface", "annotation_type"],
+                    )?;
+                }
+            }
+            if let Some(interfaces) = node.child_by_field_name("extends_interfaces").or_else(|| {
+                let mut cursor = node.walk();
+                node.children(&mut cursor)
+                    .find(|child| child.kind() == "extends_interfaces")
+            }) {
+                let mut names = Vec::new();
+                collect_java_direct_supertype_nodes(interfaces, &mut names);
+                for target in names {
+                    self.add_java_named_relationship(
+                        SemanticRole::BaseType,
+                        CandidateRelation::Extends,
+                        owner,
+                        target,
+                        Some("superinterface"),
                         vec!["interface", "annotation_type"],
                     )?;
                 }

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -11,23 +11,26 @@ mod play;
 mod python;
 mod ruby;
 mod rust;
+mod spring;
 mod swift;
 mod text;
 mod typescript;
 
 pub use model::{
-    FrameworkLimitError, FrameworkLimits, RawDomainFact, RawFrameworkAnchor, RawFrameworkFact,
-    RawFrameworkOrigin, RawRouteFact,
+    FrameworkLimitError, FrameworkLimits, RawDomainFact, RawFrameworkAnchor,
+    RawFrameworkAnnotationFact, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact,
 };
 pub use pack::{
-    FrameworkManifestPolicy, FrameworkOccurrencePolicy, FrameworkPackDescriptor, FrameworkPackKind,
-    FrameworkPackRegistry, FrameworkPackRegistryError,
+    FrameworkCapability, FrameworkManifestPolicy, FrameworkOccurrencePolicy,
+    FrameworkPackDescriptor, FrameworkPackKind, FrameworkPackRegistry, FrameworkPackRegistryError,
+    FrameworkRelation,
 };
 
 use std::path::Path;
 
 use tree_sitter::Node;
 
+use crate::SemanticEvidenceBatch;
 use crate::{Extraction, ProjectEvidence};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,6 +58,21 @@ struct SourcePack {
     dependency_markers: &'static [&'static str],
     manifest_policy: ManifestPolicy,
     detector: SourceDetector,
+}
+
+struct UniversalDetectionContext<'source, 'tree> {
+    source: &'source [u8],
+    root: Node<'tree>,
+    project: Option<&'source ProjectEvidence>,
+    evidence: &'source SemanticEvidenceBatch,
+}
+
+type UniversalSourceDetector =
+    for<'source, 'tree> fn(&UniversalDetectionContext<'source, 'tree>) -> Vec<RawFrameworkFact>;
+
+struct UniversalSourcePack {
+    descriptor: &'static FrameworkPackDescriptor,
+    detector: UniversalSourceDetector,
 }
 
 type ConfigMatcher = fn(&Path) -> bool;
@@ -86,13 +104,13 @@ const SOURCE_PACKS: &[SourcePack] = &[
     ),
     source_pack("rails-routes", &["ruby"], &["rails"], detect_ruby),
     source_pack(
-        "spring-web",
-        &["java", "kotlin"],
+        "spring-web-kotlin",
+        &["kotlin"],
         &[
             "org.springframework:spring-web",
             "org.springframework.boot:spring-boot",
         ],
-        detect_java,
+        detect_kotlin,
     ),
     source_pack("go-web", &["go"], &[], detect_go),
     source_pack("rust-web", &["rust"], &[], detect_rust),
@@ -129,7 +147,6 @@ const SOURCE_PACKS: &[SourcePack] = &[
             "typescript",
             "tsx",
             "javascript",
-            "java",
             "csharp",
             "ruby",
             "php",
@@ -141,6 +158,11 @@ const SOURCE_PACKS: &[SourcePack] = &[
         detector: detect_enterprise,
     },
 ];
+
+const UNIVERSAL_SOURCE_PACKS: &[UniversalSourcePack] = &[UniversalSourcePack {
+    descriptor: &pack::SPRING_JAVA_DESCRIPTOR,
+    detector: spring::detect,
+}];
 
 const CONFIG_PACKS: &[ConfigPack] = &[
     ConfigPack {
@@ -193,6 +215,21 @@ pub(crate) fn detect(
         project,
     };
     let mut facts = Vec::new();
+    if let Some(evidence) = extraction.semantic_evidence.as_ref() {
+        for pack in UNIVERSAL_SOURCE_PACKS {
+            debug_assert_eq!(pack.descriptor.kind, FrameworkPackKind::Source);
+            if pack.descriptor.languages.contains(&language)
+                && universal_pack_enabled(pack.descriptor, project)
+            {
+                facts.extend((pack.detector)(&UniversalDetectionContext {
+                    source,
+                    root,
+                    project,
+                    evidence,
+                }));
+            }
+        }
+    }
     for pack in SOURCE_PACKS {
         debug_assert!(!pack.id.is_empty());
         if pack.languages.contains(&language) && pack_enabled(pack, project) {
@@ -237,6 +274,18 @@ pub(crate) fn detect_template_file_route(
 
 fn pack_enabled(pack: &SourcePack, project: Option<&ProjectEvidence>) -> bool {
     manifest_policy_allows(pack.manifest_policy, pack.dependency_markers, project)
+}
+
+fn universal_pack_enabled(
+    descriptor: &FrameworkPackDescriptor,
+    project: Option<&ProjectEvidence>,
+) -> bool {
+    match descriptor.manifest_policy {
+        FrameworkManifestPolicy::Advisory => true,
+        FrameworkManifestPolicy::Required => {
+            project.is_none_or(|project| project.has_any_dependency(descriptor.dependency_markers))
+        }
+    }
 }
 
 fn template_pack_enabled(pack: &TemplatePack, project: Option<&ProjectEvidence>) -> bool {
@@ -287,7 +336,7 @@ fn detect_ruby(
     ruby::detect(context.path, context.source, context.root)
 }
 
-fn detect_java(
+fn detect_kotlin(
     context: &DetectionContext<'_, '_>,
     _extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
@@ -392,7 +441,7 @@ mod tests {
             "python-web",
             "php-frameworks",
             "rails-routes",
-            "spring-web",
+            "spring-web-kotlin",
             "go-web",
             "rust-web",
             "aspnet-web",

--- a/crates/compass-languages/src/frameworks/model.rs
+++ b/crates/compass-languages/src/frameworks/model.rs
@@ -109,11 +109,39 @@ pub struct RawDomainFact {
     pub detail: Map<String, Value>,
 }
 
+/// Exact universal-language annotation evidence consumed by a framework pack.
+///
+/// The pack records the language fact without deciding project-wide framework
+/// meaning. Collection resolution can then correlate composed annotations,
+/// interface declarations, inheritance, and same-named types without falling
+/// back to terminal labels.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RawFrameworkAnnotationFact {
+    pub pack_id: String,
+    pub framework: String,
+    pub annotation_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotation_qualified_name: Option<String>,
+    pub owner_declaration_id: String,
+    pub owner_graph_node_id: String,
+    pub owner_qualified_name: String,
+    pub owner_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_signature: Option<String>,
+    pub anchor: RawFrameworkAnchor,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub arguments: Map<String, Value>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub detail: Map<String, Value>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "fact", rename_all = "snake_case")]
 pub enum RawFrameworkFact {
     Route(RawRouteFact),
     Domain(RawDomainFact),
+    Annotation(RawFrameworkAnnotationFact),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/compass-languages/src/frameworks/pack.rs
+++ b/crates/compass-languages/src/frameworks/pack.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::{AdapterRegistry, CandidateRelation, LanguageCapability, SemanticRole};
+use crate::{AdapterRegistry, LanguageCapability, SemanticRole};
 
 use super::FrameworkLimits;
 
@@ -29,6 +29,88 @@ pub enum FrameworkOccurrencePolicy {
     ExactAnchoredHeuristic,
 }
 
+/// Framework meaning a pack is qualified to derive from language evidence.
+///
+/// These capabilities are deliberately separate from `LanguageCapability`:
+/// Java may truthfully emit annotations and ownership without every
+/// annotation consumer being qualified to infer Spring HTTP or bean meaning.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FrameworkCapability {
+    HttpRoutes,
+    Beans,
+    DependencyInjection,
+    Messaging,
+    Scheduling,
+    Persistence,
+    Transactions,
+    Security,
+}
+
+/// Closed framework relationship vocabulary advertised by a universal pack.
+///
+/// The persisted spelling intentionally matches the Code Graph v1 edge
+/// vocabulary. Pack registration therefore cannot hide a framework relation
+/// behind a language-level `CandidateRelation` such as `Calls`.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FrameworkRelation {
+    Decorates,
+    RoutesTo,
+    Registers,
+    Handles,
+    Publishes,
+    Subscribes,
+    Produces,
+    Consumes,
+    Schedules,
+    Triggers,
+    DependsOn,
+    MapsTo,
+}
+
+impl FrameworkRelation {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Decorates => "decorates",
+            Self::RoutesTo => "routes_to",
+            Self::Registers => "registers",
+            Self::Handles => "handles",
+            Self::Publishes => "publishes",
+            Self::Subscribes => "subscribes",
+            Self::Produces => "produces",
+            Self::Consumes => "consumes",
+            Self::Schedules => "schedules",
+            Self::Triggers => "triggers",
+            Self::DependsOn => "depends_on",
+            Self::MapsTo => "maps_to",
+        }
+    }
+
+    #[must_use]
+    pub fn is_supported_by(self, capabilities: &[FrameworkCapability]) -> bool {
+        let required = match self {
+            Self::RoutesTo => Some(FrameworkCapability::HttpRoutes),
+            Self::Registers => Some(FrameworkCapability::Beans),
+            Self::DependsOn => Some(FrameworkCapability::DependencyInjection),
+            Self::Handles
+            | Self::Publishes
+            | Self::Subscribes
+            | Self::Produces
+            | Self::Consumes => Some(FrameworkCapability::Messaging),
+            Self::Schedules | Self::Triggers => Some(FrameworkCapability::Scheduling),
+            Self::MapsTo => Some(FrameworkCapability::Persistence),
+            Self::Decorates => None,
+        };
+        required.map_or_else(
+            || {
+                capabilities.contains(&FrameworkCapability::Transactions)
+                    || capabilities.contains(&FrameworkCapability::Security)
+            },
+            |required| capabilities.contains(&required),
+        )
+    }
+}
+
 /// Static contract a framework pack must satisfy before registration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FrameworkPackDescriptor {
@@ -36,11 +118,12 @@ pub struct FrameworkPackDescriptor {
     pub kind: FrameworkPackKind,
     pub languages: &'static [&'static str],
     pub required_capabilities: &'static [LanguageCapability],
+    pub framework_capabilities: &'static [FrameworkCapability],
     pub dependency_markers: &'static [&'static str],
     pub manifest_policy: FrameworkManifestPolicy,
     pub activation_rules: &'static [&'static str],
     pub accepted_roles: &'static [SemanticRole],
-    pub emitted_relation_families: &'static [CandidateRelation],
+    pub emitted_relation_families: &'static [FrameworkRelation],
     pub occurrence_policy: FrameworkOccurrencePolicy,
     pub limits: FrameworkLimits,
 }
@@ -83,14 +166,18 @@ pub enum FrameworkPackRegistryError {
     },
     #[error("framework pack {0:?} must emit at least one relationship family")]
     EmptyRelationFamilies(&'static str),
+    #[error("framework pack {0:?} must declare at least one framework capability")]
+    EmptyFrameworkCapabilities(&'static str),
+    #[error("framework pack {0:?} framework capabilities must be sorted and unique")]
+    InvalidFrameworkCapabilityOrder(&'static str),
     #[error("framework pack {0:?} relationship families must be sorted and unique")]
     InvalidRelationOrder(&'static str),
     #[error(
-        "framework pack {pack:?} emits relationship {relation:?} without its required capability"
+        "framework pack {pack:?} emits relationship {relation:?} without its required framework capability"
     )]
     RelationCapabilityNotDeclared {
         pack: &'static str,
-        relation: CandidateRelation,
+        relation: FrameworkRelation,
     },
     #[error("framework pack {0:?} dependency markers must be non-empty, sorted, and unique")]
     InvalidDependencyMarkers(&'static str),
@@ -181,6 +268,20 @@ fn validate_descriptor(
             descriptor.id,
         ));
     }
+    if descriptor.framework_capabilities.is_empty() {
+        return Err(FrameworkPackRegistryError::EmptyFrameworkCapabilities(
+            descriptor.id,
+        ));
+    }
+    if descriptor
+        .framework_capabilities
+        .windows(2)
+        .any(|pair| pair[0] >= pair[1])
+    {
+        return Err(FrameworkPackRegistryError::InvalidFrameworkCapabilityOrder(
+            descriptor.id,
+        ));
+    }
     if descriptor
         .accepted_roles
         .windows(2)
@@ -214,10 +315,7 @@ fn validate_descriptor(
         }
     }
     for &relation in descriptor.emitted_relation_families {
-        if !descriptor
-            .required_capabilities
-            .contains(&relation.required_capability())
-        {
+        if !relation.is_supported_by(descriptor.framework_capabilities) {
             return Err(FrameworkPackRegistryError::RelationCapabilityNotDeclared {
                 pack: descriptor.id,
                 relation,
@@ -269,4 +367,72 @@ fn validate_strings(values: &[&str]) -> Result<(), ()> {
     Ok(())
 }
 
-const UNIVERSAL_FRAMEWORK_PACKS: &[FrameworkPackDescriptor] = &[];
+pub(super) const SPRING_JAVA_DESCRIPTOR: FrameworkPackDescriptor = FrameworkPackDescriptor {
+    id: "spring-java",
+    kind: FrameworkPackKind::Source,
+    languages: &["java"],
+    required_capabilities: &[
+        LanguageCapability::Declarations,
+        LanguageCapability::LexicalScopes,
+        LanguageCapability::Namespaces,
+        LanguageCapability::Imports,
+        LanguageCapability::Calls,
+        LanguageCapability::Construction,
+        LanguageCapability::TypeReferences,
+        LanguageCapability::BaseTypes,
+        LanguageCapability::Members,
+        LanguageCapability::Ownership,
+    ],
+    framework_capabilities: &[
+        FrameworkCapability::HttpRoutes,
+        FrameworkCapability::Beans,
+        FrameworkCapability::DependencyInjection,
+        FrameworkCapability::Messaging,
+        FrameworkCapability::Scheduling,
+        FrameworkCapability::Persistence,
+        FrameworkCapability::Transactions,
+        FrameworkCapability::Security,
+    ],
+    dependency_markers: &[
+        "org.springframework.boot:spring-boot",
+        "org.springframework:spring-web",
+    ],
+    manifest_policy: FrameworkManifestPolicy::Advisory,
+    activation_rules: &[
+        "spring-annotation-import",
+        "spring-direct-annotation",
+        "spring-project-dependency",
+    ],
+    accepted_roles: &[
+        SemanticRole::Import,
+        SemanticRole::Call,
+        SemanticRole::Construction,
+        SemanticRole::Annotation,
+        SemanticRole::BaseType,
+        SemanticRole::TypeReference,
+        SemanticRole::Ownership,
+    ],
+    emitted_relation_families: &[
+        FrameworkRelation::Decorates,
+        FrameworkRelation::RoutesTo,
+        FrameworkRelation::Registers,
+        FrameworkRelation::Handles,
+        FrameworkRelation::Publishes,
+        FrameworkRelation::Subscribes,
+        FrameworkRelation::Produces,
+        FrameworkRelation::Consumes,
+        FrameworkRelation::Schedules,
+        FrameworkRelation::Triggers,
+        FrameworkRelation::DependsOn,
+        FrameworkRelation::MapsTo,
+    ],
+    occurrence_policy: FrameworkOccurrencePolicy::ExactEvidence,
+    limits: FrameworkLimits {
+        max_candidates: 20,
+        max_include_depth: 32,
+        max_alias_expansions: 1_000,
+        max_facts_per_file: 100_000,
+    },
+};
+
+const UNIVERSAL_FRAMEWORK_PACKS: &[FrameworkPackDescriptor] = &[SPRING_JAVA_DESCRIPTOR];

--- a/crates/compass-languages/src/frameworks/spring.rs
+++ b/crates/compass-languages/src/frameworks/spring.rs
@@ -1,0 +1,762 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde_json::{Map, Value};
+use tree_sitter::Node;
+
+use crate::{CandidateRelation, DeclarationFact, SemanticRole};
+
+use super::{
+    RawFrameworkAnchor, RawFrameworkAnnotationFact, RawFrameworkFact, UniversalDetectionContext,
+};
+
+const PACK_ID: &str = "spring-java";
+const FRAMEWORK: &str = "spring";
+const SPRING_PREFIX: &str = "org.springframework.";
+
+pub(super) fn detect(context: &UniversalDetectionContext<'_, '_>) -> Vec<RawFrameworkFact> {
+    if context.evidence.adapter.language != "java" {
+        return Vec::new();
+    }
+    let declarations = context
+        .evidence
+        .declarations
+        .iter()
+        .map(|declaration| (declaration.id.as_str(), declaration))
+        .collect::<HashMap<_, _>>();
+    let candidates = context
+        .evidence
+        .candidates
+        .iter()
+        .filter_map(|candidate| {
+            candidate
+                .occurrence_id
+                .as_deref()
+                .map(|occurrence| (occurrence, candidate))
+        })
+        .collect::<HashMap<_, _>>();
+    let activated = context.project.is_some_and(|project| {
+        project.has_any_dependency(super::pack::SPRING_JAVA_DESCRIPTOR.dependency_markers)
+    }) || context
+        .evidence
+        .bindings
+        .iter()
+        .any(|binding| is_framework_qualified_name(&binding.qualified_target))
+        || candidates.values().any(|candidate| {
+            candidate
+                .constraints
+                .qualified_name
+                .as_deref()
+                .is_some_and(is_framework_qualified_name)
+        });
+    if !activated {
+        return Vec::new();
+    }
+
+    let mut annotation_nodes = BTreeMap::new();
+    collect_annotation_nodes(context.root, &mut annotation_nodes);
+    let mut facts = context
+        .evidence
+        .occurrences
+        .iter()
+        .filter(|occurrence| occurrence.role == SemanticRole::Annotation)
+        .filter_map(|occurrence| {
+            let declaration = declarations.get(occurrence.owner_declaration_id.as_str())?;
+            let start = usize::try_from(occurrence.range.start_byte).ok()?;
+            let annotation = annotation_nodes.get(&start).copied();
+            let arguments = annotation
+                .map(|node| annotation_arguments(node, context.source))
+                .unwrap_or_default();
+            let candidate = candidates.get(occurrence.id.as_str());
+            let qualified_name = candidate
+                .and_then(|candidate| candidate.constraints.qualified_name.clone())
+                .or_else(|| imported_annotation_name(context, &occurrence.spelling));
+            let mut detail = Map::new();
+            detail.insert(
+                "occurrenceId".to_owned(),
+                Value::String(occurrence.id.clone()),
+            );
+            if let Some(scope_id) = occurrence.scope_id.as_ref() {
+                detail.insert("scopeId".to_owned(), Value::String(scope_id.clone()));
+            }
+            let binding_map = unique_binding_map(context);
+            if !binding_map.is_empty() {
+                detail.insert("bindings".to_owned(), Value::Object(binding_map));
+            }
+            if declaration.kind == "annotation_type" {
+                detail.insert("declaration".to_owned(), Value::Bool(true));
+                if let Some(attribute) =
+                    annotation.and_then(|node| annotation_attribute_name(node, context.source))
+                {
+                    detail.insert("annotationAttribute".to_owned(), Value::String(attribute));
+                }
+            }
+            let targets = injection_targets(context, declaration.id.as_str(), &candidates);
+            if !targets.is_empty() {
+                detail.insert(
+                    "targetReferences".to_owned(),
+                    Value::Array(targets.into_iter().map(Value::String).collect()),
+                );
+            }
+            Some(RawFrameworkFact::Annotation(annotation_fact(
+                declaration,
+                &occurrence.spelling,
+                qualified_name,
+                anchor(&occurrence.range),
+                arguments,
+                detail,
+            )))
+        })
+        .collect::<Vec<_>>();
+    facts.extend(constructor_facts(context, &candidates));
+    facts.extend(constant_facts(context));
+    facts.extend(producer_facts(context, &declarations, &candidates));
+    facts.extend(repository_facts(context, &declarations));
+    facts.sort_by(|left, right| annotation_fact_key(left).cmp(&annotation_fact_key(right)));
+    facts
+}
+
+fn repository_facts(
+    context: &UniversalDetectionContext<'_, '_>,
+    declarations: &HashMap<&str, &DeclarationFact>,
+) -> Vec<RawFrameworkFact> {
+    context
+        .evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            matches!(
+                candidate.relation,
+                CandidateRelation::Extends | CandidateRelation::Implements
+            )
+        })
+        .filter_map(|candidate| {
+            let qualified = candidate.constraints.qualified_name.as_deref()?;
+            if !qualified.starts_with("org.springframework.data.")
+                || !qualified.ends_with("Repository")
+            {
+                return None;
+            }
+            let declaration = declarations.get(candidate.source_declaration_id.as_str())?;
+            Some(RawFrameworkFact::Domain(crate::RawDomainFact {
+                framework: FRAMEWORK.to_owned(),
+                kind: "bean_definition".to_owned(),
+                name: decapitalize_name(&declaration.name),
+                declaring_scope: declaration.qualified_name.clone(),
+                anchor: anchor(&declaration.range),
+                origin: crate::RawFrameworkOrigin::Ast,
+                detail: Map::from_iter([
+                    (
+                        "frameworkPack".to_owned(),
+                        Value::String(PACK_ID.to_owned()),
+                    ),
+                    (
+                        "bean_kind".to_owned(),
+                        Value::String("SpringDataRepository".to_owned()),
+                    ),
+                    (
+                        "handler_reference".to_owned(),
+                        Value::String(declaration.graph_node_id.clone()),
+                    ),
+                    (
+                        "owner_kind".to_owned(),
+                        Value::String("interface".to_owned()),
+                    ),
+                    (
+                        "relationship".to_owned(),
+                        Value::String("registers".to_owned()),
+                    ),
+                    ("primary".to_owned(), Value::Bool(false)),
+                    (
+                        "repository_base".to_owned(),
+                        Value::String(qualified.to_owned()),
+                    ),
+                ]),
+            }))
+        })
+        .collect()
+}
+
+fn decapitalize_name(value: &str) -> String {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    first.to_lowercase().chain(chars).collect()
+}
+
+fn is_framework_qualified_name(qualified: &str) -> bool {
+    qualified.starts_with(SPRING_PREFIX)
+        || qualified.starts_with("jakarta.persistence.")
+        || qualified.starts_with("javax.persistence.")
+        || qualified.starts_with("jakarta.transaction.")
+        || qualified.starts_with("javax.transaction.")
+}
+
+fn unique_binding_map(context: &UniversalDetectionContext<'_, '_>) -> Map<String, Value> {
+    let grouped = context.evidence.bindings.iter().fold(
+        BTreeMap::<&str, Vec<&str>>::new(),
+        |mut grouped, binding| {
+            grouped
+                .entry(binding.spelling.as_str())
+                .or_default()
+                .push(binding.qualified_target.as_str());
+            grouped
+        },
+    );
+    grouped
+        .into_iter()
+        .filter_map(|(spelling, mut targets)| {
+            targets.sort_unstable();
+            targets.dedup();
+            (targets.len() == 1)
+                .then(|| (spelling.to_owned(), Value::String(targets[0].to_owned())))
+        })
+        .collect()
+}
+
+fn constant_facts(context: &UniversalDetectionContext<'_, '_>) -> Vec<RawFrameworkFact> {
+    let mut declarations = BTreeMap::new();
+    for declaration in &context.evidence.declarations {
+        if matches!(declaration.kind.as_str(), "field" | "constant") {
+            declarations.insert(declaration.range.start_byte, declaration);
+        }
+    }
+    let mut nodes = Vec::new();
+    collect_constant_nodes(context.root, context.source, &mut nodes);
+    nodes
+        .into_iter()
+        .filter_map(|declarator| {
+            let name = declarator.child_by_field_name("name")?;
+            let value = declarator.child_by_field_name("value")?;
+            let declaration = declarations.get(&u64::try_from(name.start_byte()).ok()?)?;
+            let expression = context
+                .source
+                .get(value.start_byte()..value.end_byte())
+                .and_then(|value| std::str::from_utf8(value).ok())?
+                .trim();
+            (!expression.is_empty()).then(|| {
+                RawFrameworkFact::Domain(crate::RawDomainFact {
+                    framework: FRAMEWORK.to_owned(),
+                    kind: "_spring_constant".to_owned(),
+                    name: declaration.qualified_name.clone(),
+                    declaring_scope: declaration
+                        .qualified_name
+                        .rsplit_once("::")
+                        .map(|(owner, _)| owner)
+                        .unwrap_or(declaration.qualified_name.as_str())
+                        .to_owned(),
+                    anchor: anchor(&declaration.range),
+                    origin: crate::RawFrameworkOrigin::Ast,
+                    detail: Map::from_iter([
+                        (
+                            "expression".to_owned(),
+                            Value::String(expression.to_owned()),
+                        ),
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(declaration.graph_node_id.clone()),
+                        ),
+                    ]),
+                })
+            })
+        })
+        .collect()
+}
+
+fn collect_constant_nodes<'tree>(node: Node<'tree>, source: &[u8], output: &mut Vec<Node<'tree>>) {
+    if matches!(node.kind(), "field_declaration" | "constant_declaration") {
+        let text = node
+            .child_by_field_name("modifiers")
+            .or_else(|| {
+                let mut cursor = node.walk();
+                node.children(&mut cursor)
+                    .find(|child| child.kind() == "modifiers")
+            })
+            .and_then(|modifiers| source.get(modifiers.start_byte()..modifiers.end_byte()))
+            .and_then(|value| std::str::from_utf8(value).ok())
+            .unwrap_or_default();
+        if node.kind() == "constant_declaration"
+            || (text.split_whitespace().any(|part| part == "static")
+                && text.split_whitespace().any(|part| part == "final"))
+        {
+            let mut cursor = node.walk();
+            output.extend(
+                node.named_children(&mut cursor)
+                    .filter(|child| child.kind() == "variable_declarator"),
+            );
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_constant_nodes(child, source, output);
+    }
+}
+
+fn annotation_attribute_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.kind() == "annotation_type_element_declaration" {
+            let name = parent.child_by_field_name("name").or_else(|| {
+                let mut cursor = parent.walk();
+                parent
+                    .named_children(&mut cursor)
+                    .find(|child| child.kind() == "identifier")
+            })?;
+            return source
+                .get(name.start_byte()..name.end_byte())
+                .and_then(|value| std::str::from_utf8(value).ok())
+                .map(str::to_owned);
+        }
+        if parent.kind() == "annotation_type_declaration" {
+            break;
+        }
+        current = parent.parent();
+    }
+    None
+}
+
+fn producer_facts(
+    context: &UniversalDetectionContext<'_, '_>,
+    declarations: &HashMap<&str, &DeclarationFact>,
+    candidates: &HashMap<&str, &crate::RelationshipCandidate>,
+) -> Vec<RawFrameworkFact> {
+    let mut call_nodes = BTreeMap::new();
+    collect_named_nodes(context.root, "method_invocation", "name", &mut call_nodes);
+    context
+        .evidence
+        .occurrences
+        .iter()
+        .filter(|occurrence| occurrence.role == SemanticRole::Call)
+        .filter_map(|occurrence| {
+            let candidate = candidates.get(occurrence.id.as_str())?;
+            if candidate.relation != CandidateRelation::Calls {
+                return None;
+            }
+            let qualified = candidate.constraints.qualified_name.as_deref()?;
+            let (kind, transport, relationship, mut argument_index) =
+                producer_signature(qualified)?;
+            if qualified.ends_with("RabbitTemplate::convertAndSend") {
+                argument_index =
+                    usize::from(candidate.constraints.argument_count.unwrap_or(0) >= 3);
+            }
+            let declaration = declarations.get(occurrence.owner_declaration_id.as_str())?;
+            let call = call_nodes
+                .get(&usize::try_from(occurrence.range.start_byte).ok()?)
+                .copied()?;
+            let subject = call_argument(call, argument_index, context.source)?;
+            let mut detail = Map::new();
+            detail.insert(
+                "handler_reference".to_owned(),
+                Value::String(declaration.graph_node_id.clone()),
+            );
+            detail.insert("transport".to_owned(), Value::String(transport.to_owned()));
+            detail.insert(
+                "relationship".to_owned(),
+                Value::String(relationship.to_owned()),
+            );
+            detail.insert(
+                "frameworkPack".to_owned(),
+                Value::String(PACK_ID.to_owned()),
+            );
+            Some(RawFrameworkFact::Domain(crate::RawDomainFact {
+                framework: FRAMEWORK.to_owned(),
+                kind: kind.to_owned(),
+                name: subject,
+                declaring_scope: declaration.qualified_name.clone(),
+                anchor: anchor(&occurrence.range),
+                origin: crate::RawFrameworkOrigin::Ast,
+                detail,
+            }))
+        })
+        .collect()
+}
+
+fn producer_signature(
+    qualified: &str,
+) -> Option<(&'static str, &'static str, &'static str, usize)> {
+    if qualified.ends_with("ApplicationEventPublisher::publishEvent") {
+        Some(("event", "spring", "publishes", 0))
+    } else if qualified.ends_with("KafkaTemplate::send") {
+        Some(("topic", "kafka", "produces", 0))
+    } else if qualified.ends_with("RabbitTemplate::convertAndSend") {
+        Some(("queue", "rabbitmq", "produces", 1))
+    } else {
+        None
+    }
+}
+
+fn call_argument(node: Node<'_>, index: usize, source: &[u8]) -> Option<String> {
+    let arguments = node.child_by_field_name("arguments")?;
+    let mut cursor = arguments.walk();
+    let argument = arguments
+        .named_children(&mut cursor)
+        .filter(|child| child.kind() != "comment")
+        .nth(index)
+        .or_else(|| {
+            if index == 1 {
+                let mut fallback = arguments.walk();
+                arguments.named_children(&mut fallback).next()
+            } else {
+                None
+            }
+        })?;
+    source
+        .get(argument.start_byte()..argument.end_byte())
+        .and_then(|value| std::str::from_utf8(value).ok())
+        .map(canonical_argument)
+        .filter(|value| !value.is_empty())
+}
+
+fn collect_named_nodes<'tree>(
+    node: Node<'tree>,
+    expected_kind: &str,
+    field: &str,
+    output: &mut BTreeMap<usize, Node<'tree>>,
+) {
+    if node.kind() == expected_kind
+        && let Some(name) = node.child_by_field_name(field)
+    {
+        output.insert(name.start_byte(), node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_named_nodes(child, expected_kind, field, output);
+    }
+}
+
+fn injection_targets(
+    context: &UniversalDetectionContext<'_, '_>,
+    owner_declaration_id: &str,
+    candidates: &HashMap<&str, &crate::RelationshipCandidate>,
+) -> Vec<String> {
+    let mut targets = context
+        .evidence
+        .occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence.owner_declaration_id == owner_declaration_id
+                && occurrence.role == SemanticRole::TypeReference
+                && matches!(
+                    occurrence.context.as_deref(),
+                    Some("type" | "parameter_type")
+                )
+        })
+        .filter_map(|occurrence| {
+            candidates
+                .get(occurrence.id.as_str())
+                .and_then(|candidate| candidate.constraints.qualified_name.clone())
+                .or_else(|| Some(occurrence.spelling.clone()))
+        })
+        .collect::<Vec<_>>();
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
+fn constructor_facts(
+    context: &UniversalDetectionContext<'_, '_>,
+    candidates: &HashMap<&str, &crate::RelationshipCandidate>,
+) -> Vec<RawFrameworkFact> {
+    context
+        .evidence
+        .declarations
+        .iter()
+        .filter(|declaration| declaration.kind == "constructor")
+        .filter_map(|declaration| {
+            let targets = injection_targets(context, declaration.id.as_str(), candidates);
+            (!targets.is_empty()).then(|| {
+                let mut detail = Map::new();
+                detail.insert(
+                    "handler_reference".to_owned(),
+                    Value::String(declaration.graph_node_id.clone()),
+                );
+                detail.insert(
+                    "targetReferences".to_owned(),
+                    Value::Array(targets.into_iter().map(Value::String).collect()),
+                );
+                detail.insert(
+                    "parameterCount".to_owned(),
+                    Value::from(declaration.parameter_count.unwrap_or_default()),
+                );
+                RawFrameworkFact::Domain(crate::RawDomainFact {
+                    framework: FRAMEWORK.to_owned(),
+                    kind: "_spring_constructor".to_owned(),
+                    name: declaration.qualified_name.clone(),
+                    declaring_scope: declaration
+                        .qualified_name
+                        .rsplit_once("::")
+                        .map(|(owner, _)| owner)
+                        .unwrap_or(declaration.qualified_name.as_str())
+                        .to_owned(),
+                    anchor: anchor(&declaration.range),
+                    origin: crate::RawFrameworkOrigin::Ast,
+                    detail,
+                })
+            })
+        })
+        .collect()
+}
+
+fn annotation_fact(
+    owner: &DeclarationFact,
+    annotation_name: &str,
+    annotation_qualified_name: Option<String>,
+    anchor: RawFrameworkAnchor,
+    arguments: Map<String, Value>,
+    detail: Map<String, Value>,
+) -> RawFrameworkAnnotationFact {
+    RawFrameworkAnnotationFact {
+        pack_id: PACK_ID.to_owned(),
+        framework: FRAMEWORK.to_owned(),
+        annotation_name: annotation_name.to_owned(),
+        annotation_qualified_name,
+        owner_declaration_id: owner.id.clone(),
+        owner_graph_node_id: owner.graph_node_id.clone(),
+        owner_qualified_name: owner.qualified_name.clone(),
+        owner_kind: owner.kind.clone(),
+        owner_signature: owner.signature.clone(),
+        anchor,
+        arguments,
+        detail,
+    }
+}
+
+fn imported_annotation_name(
+    context: &UniversalDetectionContext<'_, '_>,
+    spelling: &str,
+) -> Option<String> {
+    context
+        .evidence
+        .bindings
+        .iter()
+        .filter(|binding| binding.spelling == spelling)
+        .map(|binding| binding.qualified_target.as_str())
+        .find(|qualified| qualified.starts_with(SPRING_PREFIX))
+        .map(str::to_owned)
+}
+
+fn annotation_fact_key(fact: &RawFrameworkFact) -> (&str, u64, &str, &str) {
+    match fact {
+        RawFrameworkFact::Annotation(fact) => (
+            fact.anchor.source_file.as_str(),
+            fact.anchor.start_byte,
+            fact.owner_declaration_id.as_str(),
+            fact.annotation_name.as_str(),
+        ),
+        RawFrameworkFact::Route(fact) => (
+            fact.anchor.source_file.as_str(),
+            fact.anchor.start_byte,
+            fact.declaring_scope.as_str(),
+            fact.operation.as_str(),
+        ),
+        RawFrameworkFact::Domain(fact) => (
+            fact.anchor.source_file.as_str(),
+            fact.anchor.start_byte,
+            fact.declaring_scope.as_str(),
+            fact.kind.as_str(),
+        ),
+    }
+}
+
+fn anchor(range: &crate::EvidenceRange) -> RawFrameworkAnchor {
+    RawFrameworkAnchor {
+        source_file: range.source_file.clone(),
+        start_byte: range.start_byte,
+        end_byte: range.end_byte,
+        start_line: range.start_line,
+        start_column: range.start_column,
+        end_line: range.end_line,
+        end_column: range.end_column,
+    }
+}
+
+fn collect_annotation_nodes<'tree>(node: Node<'tree>, output: &mut BTreeMap<usize, Node<'tree>>) {
+    if matches!(node.kind(), "annotation" | "marker_annotation")
+        && let Some(name) = annotation_name_node(node)
+    {
+        output.insert(name.start_byte(), node);
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_annotation_nodes(child, output);
+    }
+}
+
+fn annotation_name_node(node: Node<'_>) -> Option<Node<'_>> {
+    node.child_by_field_name("name").or_else(|| {
+        let mut cursor = node.walk();
+        node.children(&mut cursor).find_map(|child| {
+            matches!(
+                child.kind(),
+                "identifier" | "type_identifier" | "scoped_identifier"
+            )
+            .then_some(child)
+            .or_else(|| annotation_name_node(child))
+        })
+    })
+}
+
+fn annotation_arguments(node: Node<'_>, source: &[u8]) -> Map<String, Value> {
+    let Some(name) = annotation_name_node(node) else {
+        return Map::new();
+    };
+    let start = name.end_byte().min(source.len());
+    let end = node.end_byte().min(source.len());
+    let Some(text) = source
+        .get(start..end)
+        .and_then(|value| std::str::from_utf8(value).ok())
+    else {
+        return Map::new();
+    };
+    let text = text.trim();
+    let Some(text) = text
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+    else {
+        return Map::new();
+    };
+    let mut values = BTreeMap::<String, Vec<String>>::new();
+    for argument in split_top_level(text, ',') {
+        let argument = argument.trim();
+        if argument.is_empty() {
+            continue;
+        }
+        let (name, value) = split_assignment(argument)
+            .map_or(("value", argument), |(name, value)| {
+                (name.trim(), value.trim())
+            });
+        values
+            .entry(name.to_owned())
+            .or_default()
+            .extend(flatten_argument_values(value));
+    }
+    values
+        .into_iter()
+        .map(|(name, values)| {
+            (
+                name,
+                Value::Array(values.into_iter().map(Value::String).collect()),
+            )
+        })
+        .collect()
+}
+
+fn split_assignment(value: &str) -> Option<(&str, &str)> {
+    top_level_separator(value, '=')
+        .map(|offset| (&value[..offset], &value[offset.saturating_add(1)..]))
+}
+
+fn flatten_argument_values(value: &str) -> Vec<String> {
+    let value = value.trim();
+    let value = value
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+        .unwrap_or(value);
+    split_top_level(value, ',')
+        .into_iter()
+        .map(|value| canonical_argument(value.trim()))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn canonical_argument(value: &str) -> String {
+    let value = value.trim();
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        return value[1..value.len().saturating_sub(1)].to_owned();
+    }
+    value.split_whitespace().collect()
+}
+
+fn split_top_level(value: &str, separator: char) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0_usize;
+    let mut stack = Vec::new();
+    let mut quote = None;
+    let mut escaped = false;
+    for (offset, character) in value.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '"' | '\'' => quote = Some(character),
+            '(' | '[' | '{' | '<' => stack.push(character),
+            ')' | ']' | '}' | '>' => {
+                stack.pop();
+            }
+            _ if character == separator && stack.is_empty() => {
+                parts.push(&value[start..offset]);
+                start = offset.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+    }
+    parts.push(&value[start..]);
+    parts
+}
+
+fn top_level_separator(value: &str, separator: char) -> Option<usize> {
+    split_top_level_offsets(value, separator).into_iter().next()
+}
+
+fn split_top_level_offsets(value: &str, separator: char) -> Vec<usize> {
+    let mut offsets = Vec::new();
+    let mut stack = Vec::new();
+    let mut quote = None;
+    let mut escaped = false;
+    for (offset, character) in value.char_indices() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '"' | '\'' => quote = Some(character),
+            '(' | '[' | '{' | '<' => stack.push(character),
+            ')' | ']' | '}' | '>' => {
+                stack.pop();
+            }
+            _ if character == separator && stack.is_empty() => offsets.push(offset),
+            _ => {}
+        }
+    }
+    offsets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_argument, flatten_argument_values, split_assignment, split_top_level};
+
+    #[test]
+    fn annotation_argument_parser_preserves_arrays_constants_and_nested_values() {
+        assert_eq!(
+            split_top_level(r#"path = {"/a", PREFIX + "/b"}, method = {GET, POST}"#, ','),
+            [r#"path = {"/a", PREFIX + "/b"}"#, " method = {GET, POST}"]
+        );
+        assert_eq!(split_assignment("path = VALUE"), Some(("path ", " VALUE")));
+        assert_eq!(
+            flatten_argument_values(r#"{"/a", PREFIX + "/b"}"#),
+            ["/a", "PREFIX+\"/b\""]
+        );
+        assert_eq!(
+            canonical_argument(" RequestMethod.GET "),
+            "RequestMethod.GET"
+        );
+    }
+}

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -590,7 +590,7 @@ fn collect_route_config(
         Map::new(),
     ) {
         RawFrameworkFact::Route(route) => route,
-        RawFrameworkFact::Domain(_) => unreachable!(),
+        RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => unreachable!(),
     };
     fact.middleware_references = middleware;
     facts.push(RawFrameworkFact::Route(fact));

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -18,7 +18,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/3";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/4";
 mod go;
 mod groovy;
 mod ids;
@@ -60,9 +60,10 @@ pub use evidence::{
 };
 pub use facts::{Extraction, RawCall, RawEdgeRecord, RawNodeRecord};
 pub use frameworks::{
-    FrameworkLimitError, FrameworkLimits, FrameworkManifestPolicy, FrameworkOccurrencePolicy,
-    FrameworkPackDescriptor, FrameworkPackKind, FrameworkPackRegistry, FrameworkPackRegistryError,
-    RawDomainFact, RawFrameworkAnchor, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact,
+    FrameworkCapability, FrameworkLimitError, FrameworkLimits, FrameworkManifestPolicy,
+    FrameworkOccurrencePolicy, FrameworkPackDescriptor, FrameworkPackKind, FrameworkPackRegistry,
+    FrameworkPackRegistryError, FrameworkRelation, RawDomainFact, RawFrameworkAnchor,
+    RawFrameworkAnnotationFact, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact,
 };
 pub use ids::{file_stem, make_id, normalize_id};
 pub use program::{TREE_SITTER_PROGRAM_PROVIDER_VERSION, TreeSitterSyntaxProvider};

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -2,9 +2,10 @@ use std::error::Error;
 use std::fs;
 
 use compass_languages::{
-    CandidateRelation, Engine, ExtractError, FrameworkLimits, FrameworkManifestPolicy,
-    FrameworkOccurrencePolicy, FrameworkPackDescriptor, FrameworkPackKind, FrameworkPackRegistry,
-    FrameworkPackRegistryError, LanguageCapability, Registry, SemanticRole, make_id,
+    CandidateRelation, Engine, ExtractError, FrameworkCapability, FrameworkLimits,
+    FrameworkManifestPolicy, FrameworkOccurrencePolicy, FrameworkPackDescriptor, FrameworkPackKind,
+    FrameworkPackRegistry, FrameworkPackRegistryError, FrameworkRelation, LanguageCapability,
+    Registry, SemanticRole, make_id,
 };
 
 fn valid_universal_framework_pack(id: &'static str) -> FrameworkPackDescriptor {
@@ -13,11 +14,12 @@ fn valid_universal_framework_pack(id: &'static str) -> FrameworkPackDescriptor {
         kind: FrameworkPackKind::Source,
         languages: &["go", "python"],
         required_capabilities: &[LanguageCapability::Calls],
+        framework_capabilities: &[FrameworkCapability::Messaging],
         dependency_markers: &["example/framework"],
         manifest_policy: FrameworkManifestPolicy::Required,
         activation_rules: &["decorated-handler"],
         accepted_roles: &[SemanticRole::Call],
-        emitted_relation_families: &[CandidateRelation::Calls],
+        emitted_relation_families: &[FrameworkRelation::Handles],
         occurrence_policy: FrameworkOccurrencePolicy::ExactEvidence,
         limits: FrameworkLimits::default(),
     }
@@ -30,7 +32,8 @@ fn universal_framework_pack_registry_accepts_only_cut_over_language_evidence() {
         FrameworkPackRegistry::validate_descriptors(&[descriptor]),
         Ok(())
     );
-    assert!(FrameworkPackRegistry::descriptors().is_empty());
+    assert_eq!(FrameworkPackRegistry::descriptors().len(), 1);
+    assert_eq!(FrameworkPackRegistry::descriptors()[0].id, "spring-java");
     assert_eq!(FrameworkPackRegistry::validate(), Ok(()));
 
     let rust = FrameworkPackDescriptor {
@@ -90,15 +93,26 @@ fn universal_framework_pack_registry_enforces_evidence_activation_and_limits() {
     );
 
     let missing_relation_capability = FrameworkPackDescriptor {
-        emitted_relation_families: &[CandidateRelation::Imports],
+        emitted_relation_families: &[FrameworkRelation::RoutesTo],
         ..descriptor
     };
     assert_eq!(
         FrameworkPackRegistry::validate_descriptors(&[missing_relation_capability]),
         Err(FrameworkPackRegistryError::RelationCapabilityNotDeclared {
             pack: descriptor.id,
-            relation: CandidateRelation::Imports,
+            relation: FrameworkRelation::RoutesTo,
         })
+    );
+
+    let missing_framework_capability = FrameworkPackDescriptor {
+        framework_capabilities: &[],
+        ..descriptor
+    };
+    assert_eq!(
+        FrameworkPackRegistry::validate_descriptors(&[missing_framework_capability]),
+        Err(FrameworkPackRegistryError::EmptyFrameworkCapabilities(
+            descriptor.id
+        ))
     );
 
     let missing_manifest_evidence = FrameworkPackDescriptor {

--- a/crates/compass-resolve/src/frameworks/domain.rs
+++ b/crates/compass-resolve/src/frameworks/domain.rs
@@ -36,7 +36,7 @@ pub(super) fn resolve_domains_with_targets(
         .iter()
         .filter_map(|fact| match fact {
             RawFrameworkFact::Domain(fact) => Some(fact),
-            RawFrameworkFact::Route(_) => None,
+            RawFrameworkFact::Route(_) | RawFrameworkFact::Annotation(_) => None,
         })
         .collect::<Vec<_>>();
     limits.check_facts(facts.len())?;
@@ -99,6 +99,71 @@ pub fn publish_resolved_domains(extraction: &mut Extraction, resolved: &[Resolve
                     "model": fact.name,
                     "databaseTable": fact.detail.get("database_table"),
                     "source": fact.anchor.source_file,
+                    "line": fact.anchor.start_line,
+                    "resolution": resolution_name(resolved.state),
+                }));
+            }
+            continue;
+        }
+        if fact.kind == "framework_decoration" {
+            if resolved.state == ResolutionState::Exact
+                && let Some(trait_name) = fact.detail.get("trait").and_then(Value::as_str)
+            {
+                for candidate in &resolved.source_candidates {
+                    if let Some(node) = extraction
+                        .nodes
+                        .iter_mut()
+                        .find(|node| node.id == candidate.node_id)
+                    {
+                        let traits = node
+                            .attributes
+                            .entry("framework_traits".to_owned())
+                            .or_insert_with(|| Value::Array(Vec::new()));
+                        if let Some(traits) = traits.as_array_mut()
+                            && !traits
+                                .iter()
+                                .any(|value| value.as_str() == Some(trait_name))
+                        {
+                            traits.push(Value::String(trait_name.to_owned()));
+                            traits.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+                        }
+                    }
+                }
+            } else {
+                diagnostics.push(json!({
+                    "kind": "unresolved_framework_decoration",
+                    "framework": fact.framework,
+                    "trait": fact.name,
+                    "source": fact.anchor.source_file,
+                    "line": fact.anchor.start_line,
+                    "resolution": resolution_name(resolved.state),
+                }));
+            }
+            continue;
+        }
+        if fact.kind == "injection" {
+            if resolved.state == ResolutionState::Exact
+                && let ([source], [target]) = (
+                    resolved.source_candidates.as_slice(),
+                    resolved.target_candidates.as_slice(),
+                )
+            {
+                push_edge(
+                    extraction,
+                    &mut edges,
+                    &source.node_id,
+                    &target.node_id,
+                    "depends_on",
+                    fact,
+                    resolved.state,
+                );
+            } else {
+                diagnostics.push(json!({
+                    "kind": "unresolved_injection",
+                    "framework": fact.framework,
+                    "source": fact.detail.get("source_reference"),
+                    "target": fact.detail.get("target_reference"),
+                    "sourceFile": fact.anchor.source_file,
                     "line": fact.anchor.start_line,
                     "resolution": resolution_name(resolved.state),
                 }));
@@ -251,6 +316,38 @@ fn resolve_one(
             target_candidates: targets,
         });
     }
+    if fact.kind == "injection" {
+        let source = fact
+            .detail
+            .get("source_reference")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let target = fact
+            .detail
+            .get("target_reference")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let sources = resolve_reference(
+            targets,
+            source,
+            TargetKind::Type,
+            &fact.anchor.source_file,
+            limits,
+        )?;
+        let targets = resolve_reference(
+            targets,
+            target,
+            TargetKind::Type,
+            &fact.anchor.source_file,
+            limits,
+        )?;
+        return Ok(ResolvedDomainFact {
+            fact: fact.clone(),
+            state: pair_state(&sources, &targets),
+            source_candidates: sources,
+            target_candidates: targets,
+        });
+    }
     let signature_reference = fact
         .detail
         .get("target_signature_qualified")
@@ -278,6 +375,18 @@ fn resolve_one(
             targets,
             qualified_reference,
             TargetKind::Callable,
+            &fact.anchor.source_file,
+            limits,
+        )?;
+    }
+    if candidates.is_empty()
+        && fact.kind == "bean_definition"
+        && fact.detail.get("owner_kind").and_then(Value::as_str) != Some("method")
+    {
+        candidates = resolve_reference(
+            targets,
+            qualified_reference,
+            TargetKind::Type,
             &fact.anchor.source_file,
             limits,
         )?;
@@ -378,6 +487,7 @@ fn domain_node_kind(kind: &str) -> Option<&'static str> {
         "topic" => Some("topic"),
         "queue" => Some("queue"),
         "job" => Some("job"),
+        "bean_definition" => Some("component"),
         _ => None,
     }
 }

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -5,6 +5,7 @@ mod php;
 mod python;
 mod routes;
 mod ruby;
+mod spring;
 mod target_index;
 mod typescript;
 
@@ -16,6 +17,12 @@ pub use routes::{
     FrameworkResolutionError, ResolvedRoute, RouteStage, RouteStageRole, publish_resolved_routes,
     resolve_and_publish_framework_routes, resolve_routes,
 };
+
+pub(crate) fn expand_universal_framework_facts(
+    extraction: &mut compass_languages::Extraction,
+) -> Result<(), FrameworkResolutionError> {
+    spring::expand(extraction)
+}
 
 pub(crate) fn resolve_framework_facts(
     extraction: &compass_languages::Extraction,

--- a/crates/compass-resolve/src/frameworks/python.rs
+++ b/crates/compass-resolve/src/frameworks/python.rs
@@ -13,7 +13,7 @@ pub(super) fn expand_django_includes(
         .iter()
         .filter_map(|fact| match fact {
             RawFrameworkFact::Route(route) => Some(route.clone()),
-            RawFrameworkFact::Domain(_) => None,
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
         })
         .collect::<Vec<_>>();
     let mut by_scope = HashMap::<String, Vec<usize>>::new();

--- a/crates/compass-resolve/src/frameworks/routes.rs
+++ b/crates/compass-resolve/src/frameworks/routes.rs
@@ -407,6 +407,7 @@ fn validate_fact_limits(
         let file = match fact {
             RawFrameworkFact::Route(route) => route.anchor.source_file.as_str(),
             RawFrameworkFact::Domain(domain) => domain.anchor.source_file.as_str(),
+            RawFrameworkFact::Annotation(annotation) => annotation.anchor.source_file.as_str(),
         };
         *counts.entry(file).or_default() += 1;
     }

--- a/crates/compass-resolve/src/frameworks/spring.rs
+++ b/crates/compass-resolve/src/frameworks/spring.rs
@@ -1,0 +1,1463 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use compass_languages::{
+    Extraction, RawDomainFact, RawFrameworkAnnotationFact, RawFrameworkFact, RawFrameworkOrigin,
+    RawRouteFact,
+};
+use serde_json::{Map, Value};
+
+use super::FrameworkResolutionError;
+
+const PACK_ID: &str = "spring-java";
+const SPRING_WEB_ANNOTATION_PREFIX: &str = "org.springframework.web.bind.annotation.";
+
+#[derive(Clone, Debug)]
+struct MappingSpec {
+    paths: Vec<String>,
+    operations: Vec<String>,
+    rule: &'static str,
+}
+
+pub(super) fn expand(extraction: &mut Extraction) -> Result<(), FrameworkResolutionError> {
+    let mut annotations = extraction
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Annotation(annotation) if annotation.pack_id == PACK_ID => {
+                Some(annotation.clone())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let repository_beans = derive_repository_beans(extraction);
+    if annotations.is_empty() {
+        extraction.framework_facts.extend(repository_beans);
+        return Ok(());
+    }
+    let constructors = extraction
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Domain(fact) if fact.kind == "_spring_constructor" => {
+                Some(fact.clone())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let constants = spring_constants(extraction);
+    resolve_annotation_arguments(&mut annotations, &constants);
+
+    let by_owner = annotations.iter().fold(
+        BTreeMap::<String, Vec<&RawFrameworkAnnotationFact>>::new(),
+        |mut grouped, annotation| {
+            grouped
+                .entry(annotation.owner_declaration_id.clone())
+                .or_default()
+                .push(annotation);
+            grouped
+        },
+    );
+    let definitions = mapping_definitions(&annotations, &by_owner);
+    let aliases = alias_definitions(&annotations);
+    let mappings = annotations
+        .iter()
+        .filter_map(|annotation| {
+            mapping_for(annotation, &definitions, &aliases).map(|mapping| (annotation, mapping))
+        })
+        .collect::<Vec<_>>();
+
+    let mut class_mappings = BTreeMap::<String, Vec<MappingSpec>>::new();
+    for (annotation, mapping) in &mappings {
+        if matches!(
+            annotation.owner_kind.as_str(),
+            "class" | "interface" | "record"
+        ) {
+            class_mappings
+                .entry(annotation.owner_qualified_name.clone())
+                .or_default()
+                .push(mapping.clone());
+        }
+    }
+    inherit_class_mappings(extraction, &mut class_mappings);
+
+    let mut derived = repository_beans;
+    let mut route_keys = BTreeSet::new();
+    for (annotation, mapping) in &mappings {
+        if annotation.owner_kind != "method" {
+            continue;
+        }
+        let owner = annotation
+            .owner_qualified_name
+            .rsplit_once("::")
+            .map(|(owner, _)| owner)
+            .unwrap_or(annotation.owner_qualified_name.as_str());
+        let prefixes = class_mappings
+            .get(owner)
+            .map(|mappings| {
+                mappings
+                    .iter()
+                    .flat_map(|mapping| mapping.paths.iter().cloned())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|prefixes| !prefixes.is_empty())
+            .unwrap_or_else(|| vec![String::new()]);
+        for prefix in prefixes {
+            for path in &mapping.paths {
+                let normalized = join_route_path(&prefix, path);
+                for operation in &mapping.operations {
+                    let key = (
+                        annotation.anchor.source_file.clone(),
+                        annotation.anchor.start_byte,
+                        operation.clone(),
+                        normalized.clone(),
+                        annotation.owner_graph_node_id.clone(),
+                    );
+                    if !route_keys.insert(key) {
+                        continue;
+                    }
+                    let mut detail = Map::new();
+                    detail.insert(
+                        "frameworkPack".to_owned(),
+                        Value::String(PACK_ID.to_owned()),
+                    );
+                    detail.insert(
+                        "target_qualified_name".to_owned(),
+                        Value::String(annotation.owner_qualified_name.clone()),
+                    );
+                    if let Some(signature) = annotation.owner_signature.as_deref() {
+                        detail.insert(
+                            "target_signature_qualified".to_owned(),
+                            Value::String(format!(
+                                "{}{}",
+                                annotation.owner_qualified_name,
+                                signature
+                                    .find('(')
+                                    .map(|offset| &signature[offset..])
+                                    .unwrap_or_default()
+                            )),
+                        );
+                    }
+                    derived.push(RawFrameworkFact::Route(RawRouteFact {
+                        framework: "spring".to_owned(),
+                        operation: operation.clone(),
+                        raw_path: path.clone(),
+                        normalized_path: normalized.clone(),
+                        declaring_scope: owner.to_owned(),
+                        anchor: annotation.anchor.clone(),
+                        handler_reference: annotation.owner_graph_node_id.clone(),
+                        middleware_references: Vec::new(),
+                        origin: RawFrameworkOrigin::Ast,
+                        rule: Some(mapping.rule.to_owned()),
+                        detail,
+                    }));
+                }
+            }
+        }
+    }
+    derive_inherited_method_routes(
+        extraction,
+        &mappings,
+        &class_mappings,
+        &mut route_keys,
+        &mut derived,
+    );
+
+    derive_beans_and_domains(&annotations, &by_owner, &constructors, &mut derived);
+    extraction.framework_facts.retain(|fact| {
+        !matches!(fact, RawFrameworkFact::Annotation(annotation) if annotation.pack_id == PACK_ID)
+            && !matches!(fact, RawFrameworkFact::Domain(domain) if domain.kind == "_spring_constructor")
+            && !matches!(fact, RawFrameworkFact::Domain(domain) if domain.kind == "_spring_constant")
+    });
+    extraction.framework_facts.extend(derived);
+    Ok(())
+}
+
+fn derive_repository_beans(extraction: &Extraction) -> Vec<RawFrameworkFact> {
+    let nodes = extraction
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let mut seen = BTreeSet::new();
+    extraction
+        .edges
+        .iter()
+        .filter(|edge| {
+            matches!(
+                edge.string("relation").as_str(),
+                "implements" | "inherits" | "extends"
+            )
+        })
+        .filter_map(|edge| {
+            let source = nodes.get(edge.source.as_str())?;
+            let target = nodes.get(edge.target.as_str())?;
+            let target_qualified = target.string("qualified_name");
+            if !target_qualified.starts_with("org.springframework.data.")
+                || !target_qualified.ends_with("Repository")
+                || source.string("symbol_kind") != "interface"
+                || !seen.insert(source.id.clone())
+            {
+                return None;
+            }
+            let qualified = source.string("qualified_name");
+            Some(RawFrameworkFact::Domain(RawDomainFact {
+                framework: "spring".to_owned(),
+                kind: "bean_definition".to_owned(),
+                name: decapitalize(terminal(&qualified)),
+                declaring_scope: qualified,
+                anchor: compass_languages::RawFrameworkAnchor {
+                    source_file: edge.string("source_file"),
+                    start_byte: edge
+                        .attributes
+                        .get("start_byte")
+                        .and_then(Value::as_u64)
+                        .unwrap_or_default(),
+                    end_byte: edge
+                        .attributes
+                        .get("end_byte")
+                        .and_then(Value::as_u64)
+                        .unwrap_or_default(),
+                    start_line: edge
+                        .attributes
+                        .get("line_start")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| u32::try_from(value).ok())
+                        .unwrap_or(1),
+                    start_column: edge
+                        .attributes
+                        .get("column_start")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| u32::try_from(value).ok())
+                        .unwrap_or_default(),
+                    end_line: edge
+                        .attributes
+                        .get("line_end")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| u32::try_from(value).ok())
+                        .unwrap_or(1),
+                    end_column: edge
+                        .attributes
+                        .get("column_end")
+                        .and_then(Value::as_u64)
+                        .and_then(|value| u32::try_from(value).ok())
+                        .unwrap_or_default(),
+                },
+                origin: RawFrameworkOrigin::Ast,
+                detail: Map::from_iter([
+                    (
+                        "frameworkPack".to_owned(),
+                        Value::String(PACK_ID.to_owned()),
+                    ),
+                    (
+                        "bean_kind".to_owned(),
+                        Value::String("SpringDataRepository".to_owned()),
+                    ),
+                    (
+                        "handler_reference".to_owned(),
+                        Value::String(source.id.clone()),
+                    ),
+                    (
+                        "owner_kind".to_owned(),
+                        Value::String("interface".to_owned()),
+                    ),
+                    (
+                        "relationship".to_owned(),
+                        Value::String("registers".to_owned()),
+                    ),
+                    ("primary".to_owned(), Value::Bool(false)),
+                ]),
+            }))
+        })
+        .collect()
+}
+
+#[derive(Default)]
+struct SpringConstants {
+    by_qualified: BTreeMap<String, String>,
+    by_terminal: BTreeMap<String, Vec<String>>,
+}
+
+fn spring_constants(extraction: &Extraction) -> SpringConstants {
+    let mut constants = SpringConstants::default();
+    for fact in &extraction.framework_facts {
+        let RawFrameworkFact::Domain(fact) = fact else {
+            continue;
+        };
+        if fact.kind != "_spring_constant" {
+            continue;
+        }
+        let Some(expression) = fact.detail.get("expression").and_then(Value::as_str) else {
+            continue;
+        };
+        let qualified = fact.name.replace("::", ".");
+        constants
+            .by_terminal
+            .entry(terminal(&qualified).to_owned())
+            .or_default()
+            .push(qualified.clone());
+        constants
+            .by_qualified
+            .insert(qualified, expression.to_owned());
+    }
+    for qualified in constants.by_terminal.values_mut() {
+        qualified.sort();
+        qualified.dedup();
+    }
+    constants
+}
+
+fn resolve_annotation_arguments(
+    annotations: &mut [RawFrameworkAnnotationFact],
+    constants: &SpringConstants,
+) {
+    for annotation in annotations {
+        let bindings = annotation
+            .detail
+            .get("bindings")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for (argument_name, value) in &mut annotation.arguments {
+            let Some(values) = value.as_array_mut() else {
+                continue;
+            };
+            for value in values {
+                let Some(expression) = value.as_str() else {
+                    continue;
+                };
+                if let Some(resolved) = evaluate_constant_expression(
+                    expression,
+                    &bindings,
+                    constants,
+                    &mut BTreeSet::new(),
+                    0,
+                ) {
+                    *value = Value::String(resolved);
+                } else if matches!(argument_name.as_str(), "path" | "value")
+                    && looks_like_unresolved_constant(expression)
+                {
+                    *value = Value::String("__COMPASS_UNRESOLVED_CONSTANT__".to_owned());
+                }
+            }
+        }
+    }
+}
+
+fn looks_like_unresolved_constant(value: &str) -> bool {
+    value.contains('+')
+        || (!value.starts_with('/')
+            && value
+                .chars()
+                .any(|character| character.is_ascii_uppercase())
+            && value.chars().all(|character| {
+                character.is_ascii_uppercase()
+                    || character.is_ascii_digit()
+                    || matches!(character, '_' | '.')
+            }))
+}
+
+fn evaluate_constant_expression(
+    expression: &str,
+    bindings: &Map<String, Value>,
+    constants: &SpringConstants,
+    visiting: &mut BTreeSet<String>,
+    depth: usize,
+) -> Option<String> {
+    if depth >= 16 {
+        return None;
+    }
+    let expression = expression.trim();
+    if expression.len() >= 2 && expression.starts_with('"') && expression.ends_with('"') {
+        return serde_json::from_str::<String>(expression).ok();
+    }
+    let parts = split_expression(expression, '+');
+    if parts.len() > 1 {
+        let mut value = String::new();
+        for part in parts {
+            value.push_str(&evaluate_constant_expression(
+                part,
+                bindings,
+                constants,
+                visiting,
+                depth.saturating_add(1),
+            )?);
+        }
+        return Some(value);
+    }
+    let normalized = expression.replace("::", ".");
+    let bound = bindings
+        .get(expression)
+        .and_then(Value::as_str)
+        .map(|value| value.replace("::", "."));
+    let qualified = if constants.by_qualified.contains_key(&normalized) {
+        Some(normalized)
+    } else if let Some(bound) = bound {
+        constants.by_qualified.contains_key(&bound).then_some(bound)
+    } else {
+        constants
+            .by_terminal
+            .get(expression)
+            .filter(|matches| matches.len() == 1)
+            .and_then(|matches| matches.first().cloned())
+    }?;
+    if !visiting.insert(qualified.clone()) {
+        return None;
+    }
+    let value = constants
+        .by_qualified
+        .get(&qualified)
+        .and_then(|expression| {
+            evaluate_constant_expression(
+                expression,
+                bindings,
+                constants,
+                visiting,
+                depth.saturating_add(1),
+            )
+        });
+    visiting.remove(&qualified);
+    value
+}
+
+fn split_expression(value: &str, separator: char) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut quote = false;
+    let mut escaped = false;
+    let mut depth = 0_u16;
+    for (offset, character) in value.char_indices() {
+        if quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                quote = false;
+            }
+            continue;
+        }
+        match character {
+            '"' => quote = true,
+            '(' | '[' | '{' => depth = depth.saturating_add(1),
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            _ if character == separator && depth == 0 => {
+                parts.push(value[start..offset].trim());
+                start = offset.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+    }
+    parts.push(value[start..].trim());
+    parts
+}
+
+fn inherit_class_mappings(
+    extraction: &Extraction,
+    class_mappings: &mut BTreeMap<String, Vec<MappingSpec>>,
+) {
+    let qualified_by_id = extraction
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let qualified = node.string("qualified_name");
+            (!qualified.is_empty()).then_some((node.id.as_str(), qualified))
+        })
+        .collect::<BTreeMap<_, _>>();
+    for _ in 0..16 {
+        let mut additions = Vec::new();
+        for edge in &extraction.edges {
+            if !matches!(
+                edge.string("relation").as_str(),
+                "implements" | "inherits" | "extends"
+            ) {
+                continue;
+            }
+            let (Some(child), Some(parent)) = (
+                qualified_by_id.get(edge.source.as_str()),
+                qualified_by_id.get(edge.target.as_str()),
+            ) else {
+                continue;
+            };
+            if class_mappings.contains_key(child.as_str()) {
+                continue;
+            }
+            if let Some(mappings) = class_mappings.get(parent.as_str()) {
+                additions.push((child.clone(), mappings.clone()));
+            }
+        }
+        if additions.is_empty() {
+            break;
+        }
+        for (child, mappings) in additions {
+            class_mappings.entry(child).or_insert(mappings);
+        }
+    }
+}
+
+fn derive_inherited_method_routes(
+    extraction: &Extraction,
+    mappings: &[(&RawFrameworkAnnotationFact, MappingSpec)],
+    class_mappings: &BTreeMap<String, Vec<MappingSpec>>,
+    route_keys: &mut BTreeSet<(String, u64, String, String, String)>,
+    output: &mut Vec<RawFrameworkFact>,
+) {
+    let nodes = extraction
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let types = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            matches!(
+                node.string("symbol_kind").as_str(),
+                "class" | "interface" | "record" | "type"
+            )
+        })
+        .filter_map(|node| {
+            let qualified = node.string("qualified_name");
+            (!qualified.is_empty()).then_some((qualified, node.id.as_str()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut descendants = BTreeMap::<&str, BTreeSet<&str>>::new();
+    for edge in &extraction.edges {
+        if matches!(
+            edge.string("relation").as_str(),
+            "implements" | "inherits" | "extends"
+        ) {
+            descendants
+                .entry(edge.target.as_str())
+                .or_default()
+                .insert(edge.source.as_str());
+        }
+    }
+    for _ in 0..16 {
+        let snapshot = descendants.clone();
+        let mut changed = false;
+        for children in descendants.values_mut() {
+            let inherited = children
+                .clone()
+                .into_iter()
+                .flat_map(|child| snapshot.get(child).into_iter().flatten().copied())
+                .collect::<Vec<_>>();
+            for child in inherited {
+                changed |= children.insert(child);
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    let contained =
+        extraction
+            .edges
+            .iter()
+            .fold(BTreeMap::<&str, Vec<&str>>::new(), |mut contained, edge| {
+                if edge.string("relation") == "contains" {
+                    contained
+                        .entry(edge.source.as_str())
+                        .or_default()
+                        .push(edge.target.as_str());
+                }
+                contained
+            });
+
+    for (annotation, mapping) in mappings {
+        if annotation.owner_kind != "method" {
+            continue;
+        }
+        let Some((base_owner, method_name)) = annotation.owner_qualified_name.rsplit_once("::")
+        else {
+            continue;
+        };
+        let Some(base_id) = types.get(base_owner) else {
+            continue;
+        };
+        let expected_arity = signature_arity(annotation.owner_signature.as_deref());
+        for child_id in descendants.get(base_id).into_iter().flatten() {
+            for method_id in contained.get(child_id).into_iter().flatten() {
+                let Some(method) = nodes.get(method_id) else {
+                    continue;
+                };
+                if terminal(&method.string("qualified_name")) != method_name
+                    || signature_arity(method.attributes.get("signature").and_then(Value::as_str))
+                        != expected_arity
+                {
+                    continue;
+                }
+                let qualified = method.string("qualified_name");
+                let child_owner = qualified
+                    .rsplit_once("::")
+                    .map(|(owner, _)| owner)
+                    .unwrap_or_default();
+                let prefixes = class_mappings
+                    .get(child_owner)
+                    .map(|mappings| {
+                        mappings
+                            .iter()
+                            .flat_map(|mapping| mapping.paths.iter().cloned())
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|prefixes| !prefixes.is_empty())
+                    .unwrap_or_else(|| vec![String::new()]);
+                for prefix in prefixes {
+                    for path in &mapping.paths {
+                        let normalized = join_route_path(&prefix, path);
+                        for operation in &mapping.operations {
+                            let key = (
+                                annotation.anchor.source_file.clone(),
+                                annotation.anchor.start_byte,
+                                operation.clone(),
+                                normalized.clone(),
+                                method.id.clone(),
+                            );
+                            if !route_keys.insert(key) {
+                                continue;
+                            }
+                            output.push(RawFrameworkFact::Route(RawRouteFact {
+                                framework: "spring".to_owned(),
+                                operation: operation.clone(),
+                                raw_path: path.clone(),
+                                normalized_path: normalized.clone(),
+                                declaring_scope: child_owner.to_owned(),
+                                anchor: annotation.anchor.clone(),
+                                handler_reference: method.id.clone(),
+                                middleware_references: Vec::new(),
+                                origin: RawFrameworkOrigin::Ast,
+                                rule: Some("spring-inherited-request-mapping".to_owned()),
+                                detail: Map::from_iter([
+                                    (
+                                        "frameworkPack".to_owned(),
+                                        Value::String(PACK_ID.to_owned()),
+                                    ),
+                                    (
+                                        "target_qualified_name".to_owned(),
+                                        Value::String(qualified.clone()),
+                                    ),
+                                ]),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn signature_arity(signature: Option<&str>) -> Option<usize> {
+    let parameters = signature?.split_once('(')?.1.rsplit_once(')')?.0.trim();
+    if parameters.is_empty() {
+        Some(0)
+    } else {
+        Some(parameters.split(',').count())
+    }
+}
+
+fn mapping_definitions(
+    annotations: &[RawFrameworkAnnotationFact],
+    by_owner: &BTreeMap<String, Vec<&RawFrameworkAnnotationFact>>,
+) -> BTreeMap<String, MappingSpec> {
+    let mut definitions = BTreeMap::new();
+    for annotation in annotations {
+        if annotation.owner_kind != "annotation_type" {
+            continue;
+        }
+        let Some(owner_annotations) = by_owner.get(&annotation.owner_declaration_id) else {
+            continue;
+        };
+        if let Some(mapping) = owner_annotations
+            .iter()
+            .find_map(|candidate| direct_mapping(candidate))
+        {
+            definitions.insert(annotation.owner_qualified_name.clone(), mapping.clone());
+            definitions
+                .entry(terminal(&annotation.owner_qualified_name).to_owned())
+                .or_insert(mapping);
+        }
+    }
+    definitions
+}
+
+fn alias_definitions(
+    annotations: &[RawFrameworkAnnotationFact],
+) -> BTreeMap<String, BTreeMap<String, String>> {
+    let mut aliases = BTreeMap::<String, BTreeMap<String, String>>::new();
+    for annotation in annotations {
+        if !matches!(annotation.owner_kind.as_str(), "method" | "annotation_type")
+            || annotation_terminal(annotation) != "AliasFor"
+        {
+            continue;
+        }
+        let (annotation_owner, attribute) = if annotation.owner_kind == "method" {
+            let Some((owner, attribute)) = annotation.owner_qualified_name.rsplit_once("::") else {
+                continue;
+            };
+            (owner, attribute)
+        } else {
+            let Some(attribute) = annotation
+                .detail
+                .get("annotationAttribute")
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            (annotation.owner_qualified_name.as_str(), attribute)
+        };
+        let target = argument_values(annotation, "attribute")
+            .into_iter()
+            .chain(argument_values(annotation, "value"))
+            .next()
+            .unwrap_or_else(|| attribute.to_owned());
+        for owner in [annotation_owner, terminal(annotation_owner)] {
+            aliases
+                .entry(owner.to_owned())
+                .or_default()
+                .insert(attribute.to_owned(), target.clone());
+        }
+    }
+    aliases
+}
+
+fn mapping_for(
+    annotation: &RawFrameworkAnnotationFact,
+    definitions: &BTreeMap<String, MappingSpec>,
+    aliases: &BTreeMap<String, BTreeMap<String, String>>,
+) -> Option<MappingSpec> {
+    if let Some(mapping) = direct_mapping(annotation) {
+        return Some(mapping);
+    }
+    let qualified = annotation.annotation_qualified_name.as_deref();
+    let definition_key = qualified
+        .filter(|qualified| definitions.contains_key(*qualified))
+        .unwrap_or(annotation.annotation_name.as_str());
+    let mut mapping = definitions.get(definition_key)?.clone();
+    let alias_key = qualified.unwrap_or(definition_key);
+    if let Some(alias_rules) = aliases.get(alias_key) {
+        for (source, target) in alias_rules {
+            let values = argument_values(annotation, source);
+            if values.is_empty() {
+                continue;
+            }
+            match target.as_str() {
+                "path" | "value" => mapping.paths = values,
+                "method" => mapping.operations = operations_from_values(&values),
+                _ => {}
+            }
+        }
+    }
+    mapping.rule = "spring-composed-request-mapping";
+    Some(mapping)
+}
+
+fn direct_mapping(annotation: &RawFrameworkAnnotationFact) -> Option<MappingSpec> {
+    let qualified = annotation.annotation_qualified_name.as_deref()?;
+    if !qualified.starts_with(SPRING_WEB_ANNOTATION_PREFIX) {
+        return None;
+    }
+    let name = annotation_terminal(annotation);
+    let operation = match name {
+        "GetMapping" => Some("GET"),
+        "PostMapping" => Some("POST"),
+        "PutMapping" => Some("PUT"),
+        "PatchMapping" => Some("PATCH"),
+        "DeleteMapping" => Some("DELETE"),
+        "RequestMapping" => None,
+        _ => return None,
+    };
+    let mut paths = argument_values(annotation, "path");
+    if paths.is_empty() {
+        paths = argument_values(annotation, "value");
+    }
+    if paths.is_empty() {
+        paths.push(String::new());
+    }
+    paths.retain(|path| !path.contains('+') && path != "__COMPASS_UNRESOLVED_CONSTANT__");
+    if paths.is_empty() {
+        return None;
+    }
+    let operations = operation.map_or_else(
+        || {
+            let methods = argument_values(annotation, "method");
+            if methods.is_empty() {
+                vec!["ANY".to_owned()]
+            } else {
+                operations_from_values(&methods)
+            }
+        },
+        |operation| vec![operation.to_owned()],
+    );
+    Some(MappingSpec {
+        paths,
+        operations,
+        rule: "spring-request-mapping",
+    })
+}
+
+fn operations_from_values(values: &[String]) -> Vec<String> {
+    let mut operations = values
+        .iter()
+        .filter_map(|value| {
+            let operation = value.rsplit(['.', ':']).next().unwrap_or(value).trim();
+            (!operation.is_empty()).then(|| operation.to_ascii_uppercase())
+        })
+        .collect::<Vec<_>>();
+    operations.sort();
+    operations.dedup();
+    if operations.is_empty() {
+        operations.push("ANY".to_owned());
+    }
+    operations
+}
+
+fn derive_beans_and_domains(
+    annotations: &[RawFrameworkAnnotationFact],
+    by_owner: &BTreeMap<String, Vec<&RawFrameworkAnnotationFact>>,
+    constructors: &[RawDomainFact],
+    output: &mut Vec<RawFrameworkFact>,
+) {
+    let mut component_definitions = annotations
+        .iter()
+        .filter(|annotation| annotation.owner_kind == "annotation_type")
+        .filter(|annotation| is_component_annotation(annotation))
+        .map(|annotation| {
+            (
+                annotation.owner_qualified_name.clone(),
+                annotation_terminal(annotation).to_owned(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for _ in 0..16 {
+        let additions = annotations
+            .iter()
+            .filter(|annotation| annotation.owner_kind == "annotation_type")
+            .filter_map(|annotation| {
+                let kind = annotation
+                    .annotation_qualified_name
+                    .as_ref()
+                    .and_then(|qualified| component_definitions.get(qualified))?;
+                (!component_definitions.contains_key(&annotation.owner_qualified_name))
+                    .then(|| (annotation.owner_qualified_name.clone(), kind.clone()))
+            })
+            .collect::<Vec<_>>();
+        if additions.is_empty() {
+            break;
+        }
+        component_definitions.extend(additions);
+    }
+    let component_owners = annotations
+        .iter()
+        .filter(|annotation| {
+            is_component_owner(annotation)
+                && (is_component_annotation(annotation)
+                    || annotation
+                        .annotation_qualified_name
+                        .as_ref()
+                        .is_some_and(|qualified| component_definitions.contains_key(qualified)))
+        })
+        .map(|annotation| {
+            (
+                annotation.owner_qualified_name.clone(),
+                annotation.owner_graph_node_id.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for annotation in annotations {
+        let name = annotation_terminal(annotation);
+        match name {
+            "Component" | "Service" | "Repository" | "Controller" | "RestController"
+            | "Configuration"
+                if is_spring_annotation(annotation) && is_component_owner(annotation) =>
+            {
+                let bean_name = argument_values(annotation, "value")
+                    .into_iter()
+                    .next()
+                    .unwrap_or_else(|| decapitalize(terminal(&annotation.owner_qualified_name)));
+                output.push(domain_fact(
+                    annotation,
+                    "bean_definition",
+                    &bean_name,
+                    Map::from_iter([
+                        ("bean_kind".to_owned(), Value::String(name.to_owned())),
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(annotation.owner_graph_node_id.clone()),
+                        ),
+                        (
+                            "owner_kind".to_owned(),
+                            Value::String(annotation.owner_kind.clone()),
+                        ),
+                        (
+                            "relationship".to_owned(),
+                            Value::String("registers".to_owned()),
+                        ),
+                        (
+                            "primary".to_owned(),
+                            Value::Bool(owner_has_annotation(by_owner, annotation, "Primary")),
+                        ),
+                    ]),
+                ));
+            }
+            "Bean" if is_spring_annotation(annotation) => {
+                let bean_name = argument_values(annotation, "name")
+                    .into_iter()
+                    .chain(argument_values(annotation, "value"))
+                    .next()
+                    .unwrap_or_else(|| terminal(&annotation.owner_qualified_name).to_owned());
+                output.push(domain_fact(
+                    annotation,
+                    "bean_definition",
+                    &bean_name,
+                    Map::from_iter([
+                        ("bean_kind".to_owned(), Value::String("Bean".to_owned())),
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(annotation.owner_graph_node_id.clone()),
+                        ),
+                        (
+                            "owner_kind".to_owned(),
+                            Value::String(annotation.owner_kind.clone()),
+                        ),
+                        (
+                            "relationship".to_owned(),
+                            Value::String("registers".to_owned()),
+                        ),
+                        (
+                            "primary".to_owned(),
+                            Value::Bool(owner_has_annotation(by_owner, annotation, "Primary")),
+                        ),
+                    ]),
+                ));
+            }
+            "KafkaListener" if is_spring_annotation(annotation) => {
+                for topic in values_or(annotation, &["topics", "topicPattern", "value"]) {
+                    output.push(message_fact(
+                        annotation, "topic", &topic, "kafka", "consumes",
+                    ));
+                }
+            }
+            "RabbitListener" if is_spring_annotation(annotation) => {
+                for queue in values_or(annotation, &["queues", "queuesToDeclare", "value"]) {
+                    output.push(message_fact(
+                        annotation, "queue", &queue, "rabbitmq", "consumes",
+                    ));
+                }
+            }
+            "EventListener" if is_spring_annotation(annotation) => {
+                let mut events = values_or(annotation, &["classes", "value"]);
+                if events.is_empty() {
+                    events = target_references(&annotation.detail);
+                }
+                for event in events {
+                    output.push(message_fact(
+                        annotation, "event", &event, "spring", "handles",
+                    ));
+                }
+            }
+            "Scheduled" if is_spring_annotation(annotation) => {
+                let schedule = [
+                    "cron",
+                    "fixedRate",
+                    "fixedRateString",
+                    "fixedDelay",
+                    "fixedDelayString",
+                ]
+                .into_iter()
+                .find_map(|name| argument_values(annotation, name).into_iter().next())
+                .unwrap_or_else(|| "unspecified".to_owned());
+                output.push(domain_fact(
+                    annotation,
+                    "job",
+                    &annotation.owner_qualified_name,
+                    Map::from_iter([
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(annotation.owner_graph_node_id.clone()),
+                        ),
+                        (
+                            "owner_kind".to_owned(),
+                            Value::String(annotation.owner_kind.clone()),
+                        ),
+                        ("schedule".to_owned(), Value::String(schedule)),
+                    ]),
+                ));
+            }
+            "Transactional" if is_transaction_annotation(annotation) => {
+                output.push(domain_fact(
+                    annotation,
+                    "framework_decoration",
+                    "transactional",
+                    Map::from_iter([
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(annotation.owner_graph_node_id.clone()),
+                        ),
+                        (
+                            "owner_kind".to_owned(),
+                            Value::String(annotation.owner_kind.clone()),
+                        ),
+                        (
+                            "trait".to_owned(),
+                            Value::String("transactional".to_owned()),
+                        ),
+                    ]),
+                ));
+            }
+            "PreAuthorize" | "PostAuthorize" | "Secured" | "RolesAllowed"
+                if is_security_annotation(annotation) =>
+            {
+                output.push(domain_fact(
+                    annotation,
+                    "framework_decoration",
+                    "secured",
+                    Map::from_iter([
+                        (
+                            "handler_reference".to_owned(),
+                            Value::String(annotation.owner_graph_node_id.clone()),
+                        ),
+                        ("trait".to_owned(), Value::String("secured".to_owned())),
+                        (
+                            "policy".to_owned(),
+                            Value::Array(
+                                argument_values(annotation, "value")
+                                    .into_iter()
+                                    .map(Value::String)
+                                    .collect(),
+                            ),
+                        ),
+                    ]),
+                ));
+            }
+            "Entity" if is_jpa_annotation(annotation) => {
+                let table = by_owner
+                    .get(&annotation.owner_declaration_id)
+                    .into_iter()
+                    .flatten()
+                    .find(|candidate| {
+                        annotation_terminal(candidate) == "Table" && is_jpa_annotation(candidate)
+                    });
+                let table_name = table
+                    .into_iter()
+                    .flat_map(|table| argument_values(table, "name"))
+                    .next()
+                    .unwrap_or_else(|| terminal(&annotation.owner_qualified_name).to_owned());
+                let schema = table
+                    .into_iter()
+                    .flat_map(|table| argument_values(table, "schema"))
+                    .next();
+                let mut detail = Map::from_iter([
+                    (
+                        "model_reference".to_owned(),
+                        Value::String(annotation.owner_graph_node_id.clone()),
+                    ),
+                    ("database_table".to_owned(), Value::String(table_name)),
+                ]);
+                if let Some(schema) = schema {
+                    detail.insert("database_schema".to_owned(), Value::String(schema));
+                }
+                output.push(domain_fact(
+                    annotation,
+                    "orm_mapping",
+                    &annotation.owner_qualified_name,
+                    detail,
+                ));
+            }
+            _ => {}
+        }
+    }
+    for annotation in annotations.iter().filter(|annotation| {
+        is_component_owner(annotation)
+            && annotation
+                .annotation_qualified_name
+                .as_ref()
+                .is_some_and(|qualified| component_definitions.contains_key(qualified))
+    }) {
+        let qualified = annotation
+            .annotation_qualified_name
+            .as_deref()
+            .unwrap_or_default();
+        let kind = component_definitions
+            .get(qualified)
+            .map(String::as_str)
+            .unwrap_or("Component");
+        let bean_name = argument_values(annotation, "value")
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| decapitalize(terminal(&annotation.owner_qualified_name)));
+        output.push(domain_fact(
+            annotation,
+            "bean_definition",
+            &bean_name,
+            Map::from_iter([
+                ("bean_kind".to_owned(), Value::String(kind.to_owned())),
+                (
+                    "handler_reference".to_owned(),
+                    Value::String(annotation.owner_graph_node_id.clone()),
+                ),
+                (
+                    "owner_kind".to_owned(),
+                    Value::String(annotation.owner_kind.clone()),
+                ),
+                (
+                    "relationship".to_owned(),
+                    Value::String("registers".to_owned()),
+                ),
+                (
+                    "primary".to_owned(),
+                    Value::Bool(owner_has_annotation(by_owner, annotation, "Primary")),
+                ),
+                ("composed".to_owned(), Value::Bool(true)),
+            ]),
+        ));
+    }
+    derive_injections(annotations, constructors, &component_owners, output);
+}
+
+fn derive_injections(
+    annotations: &[RawFrameworkAnnotationFact],
+    constructors: &[RawDomainFact],
+    component_owners: &BTreeMap<String, String>,
+    output: &mut Vec<RawFrameworkFact>,
+) {
+    let explicit_constructors = annotations
+        .iter()
+        .filter(|annotation| {
+            annotation.owner_kind == "constructor" && is_injection_annotation(annotation)
+        })
+        .map(|annotation| annotation.owner_qualified_name.as_str())
+        .collect::<BTreeSet<_>>();
+    let constructor_counts =
+        constructors
+            .iter()
+            .fold(BTreeMap::<&str, usize>::new(), |mut counts, constructor| {
+                *counts
+                    .entry(constructor.declaring_scope.as_str())
+                    .or_default() += 1;
+                counts
+            });
+
+    for annotation in annotations
+        .iter()
+        .filter(|annotation| is_injection_annotation(annotation))
+    {
+        let owner = enclosing_type(annotation);
+        let Some(source) = component_owners.get(owner) else {
+            continue;
+        };
+        for target in target_references(&annotation.detail) {
+            output.push(injection_fact(
+                &annotation.anchor,
+                owner,
+                source,
+                &target,
+                "annotated-injection",
+            ));
+        }
+    }
+
+    for constructor in constructors {
+        let owner = constructor.declaring_scope.as_str();
+        let Some(source) = component_owners.get(owner) else {
+            continue;
+        };
+        let explicit = explicit_constructors.contains(constructor.name.as_str());
+        let implicit = constructor_counts.get(owner).copied() == Some(1);
+        if !explicit && !implicit {
+            continue;
+        }
+        for target in target_references(&constructor.detail) {
+            output.push(injection_fact(
+                &constructor.anchor,
+                owner,
+                source,
+                &target,
+                if explicit {
+                    "annotated-constructor-injection"
+                } else {
+                    "single-constructor-injection"
+                },
+            ));
+        }
+    }
+}
+
+fn injection_fact(
+    anchor: &compass_languages::RawFrameworkAnchor,
+    owner: &str,
+    source: &str,
+    target: &str,
+    rule: &str,
+) -> RawFrameworkFact {
+    RawFrameworkFact::Domain(RawDomainFact {
+        framework: "spring".to_owned(),
+        kind: "injection".to_owned(),
+        name: target.to_owned(),
+        declaring_scope: owner.to_owned(),
+        anchor: anchor.clone(),
+        origin: RawFrameworkOrigin::Ast,
+        detail: Map::from_iter([
+            (
+                "frameworkPack".to_owned(),
+                Value::String(PACK_ID.to_owned()),
+            ),
+            (
+                "source_reference".to_owned(),
+                Value::String(source.to_owned()),
+            ),
+            (
+                "target_reference".to_owned(),
+                Value::String(target.to_owned()),
+            ),
+            (
+                "relationship".to_owned(),
+                Value::String("depends_on".to_owned()),
+            ),
+            ("rule".to_owned(), Value::String(rule.to_owned())),
+        ]),
+    })
+}
+
+fn target_references(detail: &Map<String, Value>) -> Vec<String> {
+    detail
+        .get("targetReferences")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect()
+}
+
+fn enclosing_type(annotation: &RawFrameworkAnnotationFact) -> &str {
+    if matches!(
+        annotation.owner_kind.as_str(),
+        "class" | "interface" | "record"
+    ) {
+        annotation.owner_qualified_name.as_str()
+    } else {
+        annotation
+            .owner_qualified_name
+            .rsplit_once("::")
+            .map(|(owner, _)| owner)
+            .unwrap_or(annotation.owner_qualified_name.as_str())
+    }
+}
+
+fn is_component_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    matches!(
+        annotation_terminal(annotation),
+        "Component" | "Service" | "Repository" | "Controller" | "RestController" | "Configuration"
+    ) && is_spring_annotation(annotation)
+}
+
+fn is_component_owner(annotation: &RawFrameworkAnnotationFact) -> bool {
+    matches!(annotation.owner_kind.as_str(), "class" | "record")
+}
+
+fn is_injection_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .is_some_and(|qualified| {
+            matches!(
+                qualified,
+                "org.springframework.beans.factory.annotation.Autowired"
+                    | "jakarta.inject.Inject"
+                    | "javax.inject.Inject"
+            )
+        })
+}
+
+fn message_fact(
+    annotation: &RawFrameworkAnnotationFact,
+    kind: &str,
+    subject: &str,
+    transport: &str,
+    relationship: &str,
+) -> RawFrameworkFact {
+    domain_fact(
+        annotation,
+        kind,
+        subject,
+        Map::from_iter([
+            (
+                "handler_reference".to_owned(),
+                Value::String(annotation.owner_graph_node_id.clone()),
+            ),
+            ("transport".to_owned(), Value::String(transport.to_owned())),
+            (
+                "relationship".to_owned(),
+                Value::String(relationship.to_owned()),
+            ),
+        ]),
+    )
+}
+
+fn domain_fact(
+    annotation: &RawFrameworkAnnotationFact,
+    kind: &str,
+    name: &str,
+    mut detail: Map<String, Value>,
+) -> RawFrameworkFact {
+    detail.insert(
+        "frameworkPack".to_owned(),
+        Value::String(PACK_ID.to_owned()),
+    );
+    RawFrameworkFact::Domain(RawDomainFact {
+        framework: "spring".to_owned(),
+        kind: kind.to_owned(),
+        name: name.to_owned(),
+        declaring_scope: annotation.owner_qualified_name.clone(),
+        anchor: annotation.anchor.clone(),
+        origin: RawFrameworkOrigin::Ast,
+        detail,
+    })
+}
+
+fn owner_has_annotation(
+    by_owner: &BTreeMap<String, Vec<&RawFrameworkAnnotationFact>>,
+    annotation: &RawFrameworkAnnotationFact,
+    expected: &str,
+) -> bool {
+    by_owner
+        .get(&annotation.owner_declaration_id)
+        .is_some_and(|annotations| {
+            annotations
+                .iter()
+                .any(|candidate| annotation_terminal(candidate) == expected)
+        })
+}
+
+fn values_or(annotation: &RawFrameworkAnnotationFact, names: &[&str]) -> Vec<String> {
+    names
+        .iter()
+        .find_map(|name| {
+            let values = argument_values(annotation, name);
+            (!values.is_empty()).then_some(values)
+        })
+        .unwrap_or_default()
+}
+
+fn argument_values(annotation: &RawFrameworkAnnotationFact, name: &str) -> Vec<String> {
+    annotation
+        .arguments
+        .get(name)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect()
+}
+
+fn annotation_terminal(annotation: &RawFrameworkAnnotationFact) -> &str {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .map(terminal)
+        .unwrap_or(annotation.annotation_name.as_str())
+}
+
+fn terminal(value: &str) -> &str {
+    value.rsplit(['.', ':']).next().unwrap_or(value)
+}
+
+fn is_spring_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .is_some_and(|qualified| qualified.starts_with("org.springframework."))
+}
+
+fn is_security_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .is_some_and(|qualified| {
+            qualified.starts_with("org.springframework.security.")
+                || qualified.starts_with("jakarta.annotation.security.")
+                || qualified.starts_with("javax.annotation.security.")
+        })
+}
+
+fn is_transaction_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .is_some_and(|qualified| {
+            qualified == "org.springframework.transaction.annotation.Transactional"
+                || qualified == "jakarta.transaction.Transactional"
+                || qualified == "javax.transaction.Transactional"
+        })
+}
+
+fn is_jpa_annotation(annotation: &RawFrameworkAnnotationFact) -> bool {
+    annotation
+        .annotation_qualified_name
+        .as_deref()
+        .is_some_and(|qualified| {
+            qualified.starts_with("jakarta.persistence.")
+                || qualified.starts_with("javax.persistence.")
+        })
+}
+
+fn decapitalize(value: &str) -> String {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    first.to_lowercase().chain(chars).collect()
+}
+
+fn join_route_path(prefix: &str, path: &str) -> String {
+    let prefix = normalize_route_path(prefix);
+    let path = normalize_route_path(path);
+    match (prefix.as_str(), path.as_str()) {
+        ("/", "/") => "/".to_owned(),
+        ("/", path) => path.to_owned(),
+        (prefix, "/") => prefix.to_owned(),
+        (prefix, path) => format!("{}{}", prefix.trim_end_matches('/'), path),
+    }
+}
+
+fn normalize_route_path(path: &str) -> String {
+    let path = path.trim();
+    if path.is_empty() {
+        return "/".to_owned();
+    }
+    let mut normalized = String::with_capacity(path.len().saturating_add(1));
+    if !path.starts_with('/') {
+        normalized.push('/');
+    }
+    let mut slash = false;
+    for character in path.chars() {
+        if character == '/' {
+            if slash {
+                continue;
+            }
+            slash = true;
+        } else {
+            slash = false;
+        }
+        normalized.push(character);
+    }
+    if normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_route_path, normalize_route_path, operations_from_values};
+
+    #[test]
+    fn spring_paths_and_methods_are_canonical() {
+        assert_eq!(normalize_route_path("api//users/"), "/api/users");
+        assert_eq!(join_route_path("/api", "/users"), "/api/users");
+        assert_eq!(
+            operations_from_values(&["RequestMethod.POST".to_owned(), "GET".to_owned()]),
+            ["GET", "POST"]
+        );
+    }
+}

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -356,6 +356,15 @@ fn finish_resolution(
     profile_internal("resolver cross-file calls", &mut profile_started);
     members::resolve_language_call_facts(language_facts, &mut merged);
     profile_internal("resolver language calls", &mut profile_started);
+    if let Err(error) = frameworks::expand_universal_framework_facts(&mut merged) {
+        merged
+            .error
+            .get_or_insert_with(|| format!("universal framework expansion failed: {error}"));
+    }
+    profile_internal(
+        "resolver universal framework expansion",
+        &mut profile_started,
+    );
     let (routes, domains) = frameworks::resolve_framework_facts(
         &merged,
         compass_languages::FrameworkLimits::default(),

--- a/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
+++ b/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
@@ -67,7 +67,7 @@ fn laravel_routes_expand_resources_prefixes_and_handler_syntaxes() -> Result<(),
         .iter()
         .filter_map(|fact| match fact {
             RawFrameworkFact::Route(route) => Some(route),
-            RawFrameworkFact::Domain(_) => None,
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
         })
         .collect::<Vec<_>>();
     assert_eq!(
@@ -141,7 +141,7 @@ Route::prefix('/wrong')->group(function () {
         .iter()
         .filter_map(|fact| match fact {
             RawFrameworkFact::Route(route) => Some(route),
-            RawFrameworkFact::Domain(_) => None,
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
         })
         .collect::<Vec<_>>();
     assert_eq!(routes.len(), 4, "routes={routes:#?}");
@@ -220,12 +220,25 @@ fn spring_composes_class_and_method_mappings_without_custom_annotation_matches()
     let mut extraction = extract_and_resolve(&["jvm/SpringController.java"])?;
     let resolved =
         resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
-    assert!(resolved.iter().any(|route| {
-        route.route.operation == "GET"
-            && route.route.normalized_path == "/api/users/{id}"
-            && route.route.handler_reference == "SpringController.show"
-            && route.state == ResolutionState::Exact
-    }));
+    let show = resolved
+        .iter()
+        .find(|route| {
+            route.route.operation == "GET"
+                && route.route.normalized_path == "/api/users/{id}"
+                && route.state == ResolutionState::Exact
+        })
+        .ok_or("missing exact Spring GET route")?;
+    let [candidate] = show.candidates.as_slice() else {
+        return Err("Spring GET route did not resolve uniquely".into());
+    };
+    assert_eq!(
+        extraction
+            .nodes
+            .iter()
+            .find(|node| node.id == candidate.node_id)
+            .map(|node| node.string("qualified_name")),
+        Some("example.SpringController::show".to_owned())
+    );
     assert_eq!(
         resolved
             .iter()

--- a/crates/compass-resolve/tests/python_routes.rs
+++ b/crates/compass-resolve/tests/python_routes.rs
@@ -347,7 +347,7 @@ fn routes(extraction: &Extraction) -> Vec<&compass_languages::RawRouteFact> {
         .iter()
         .filter_map(|fact| match fact {
             RawFrameworkFact::Route(route) => Some(route),
-            RawFrameworkFact::Domain(_) => None,
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
         })
         .collect()
 }

--- a/crates/compass-resolve/tests/spring_universal_pack.rs
+++ b/crates/compass-resolve/tests/spring_universal_pack.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+use compass_languages::{Engine, RawFrameworkFact};
+use compass_resolve::resolve;
+
+fn extract_java(path: &str, source: &str) -> Result<compass_languages::Extraction, Box<dyn Error>> {
+    Ok(Engine::default().extract_source(Path::new(path), source.as_bytes())?)
+}
+
+#[test]
+fn spring_java_routes_are_derived_from_universal_annotation_evidence() -> Result<(), Box<dyn Error>>
+{
+    let extraction = extract_java(
+        "src/main/java/example/UserController.java",
+        r#"
+package example;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = {"/api", "/internal"})
+class UserController {
+    @GetMapping(path = {"/users", "/people"})
+    String list() { return "ok"; }
+}
+"#,
+    )?;
+    assert!(extraction.framework_facts.iter().any(|fact| {
+        matches!(fact, RawFrameworkFact::Annotation(annotation)
+            if annotation.pack_id == "spring-java"
+                && annotation.annotation_name == "GetMapping")
+    }));
+    assert!(
+        !extraction
+            .framework_facts
+            .iter()
+            .any(|fact| { matches!(fact, RawFrameworkFact::Route(_)) })
+    );
+
+    let resolved = resolve(&[extraction], &HashMap::new());
+    let routes = resolved
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => {
+                Some((route.operation.as_str(), route.normalized_path.as_str()))
+            }
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        routes,
+        [
+            ("GET", "/api/users"),
+            ("GET", "/api/people"),
+            ("GET", "/internal/users"),
+            ("GET", "/internal/people"),
+        ]
+    );
+    assert!(
+        resolved
+            .edges
+            .iter()
+            .any(|edge| edge.string("relation") == "routes_to")
+    );
+    assert!(
+        resolved
+            .edges
+            .iter()
+            .any(|edge| edge.string("relation") == "registers")
+    );
+    Ok(())
+}
+
+#[test]
+fn spring_components_register_and_single_constructors_inject_exact_types()
+-> Result<(), Box<dyn Error>> {
+    let repository = extract_java(
+        "src/main/java/example/UserRepository.java",
+        r#"
+package example;
+import org.springframework.stereotype.Repository;
+@Repository class UserRepository {}
+"#,
+    )?;
+    let service = extract_java(
+        "src/main/java/example/UserService.java",
+        r#"
+package example;
+import org.springframework.stereotype.Service;
+@Service class UserService {
+    private final UserRepository repository;
+    UserService(UserRepository repository) { this.repository = repository; }
+}
+"#,
+    )?;
+    let composed = extract_java(
+        "src/main/java/example/UseCase.java",
+        r#"
+package example;
+import org.springframework.stereotype.Service;
+@Service @interface UseCase {}
+@UseCase class BillingService {}
+"#,
+    )?;
+    let resolved = resolve(&[repository, service, composed], &HashMap::new());
+    assert_eq!(
+        resolved
+            .edges
+            .iter()
+            .filter(|edge| edge.string("relation") == "registers")
+            .count(),
+        3
+    );
+    assert!(resolved.framework_facts.iter().any(|fact| {
+        matches!(fact, RawFrameworkFact::Domain(domain)
+            if domain.kind == "bean_definition" && domain.name == "billingService")
+    }));
+    let dependency = resolved
+        .edges
+        .iter()
+        .find(|edge| edge.string("relation") == "depends_on")
+        .ok_or("missing constructor injection")?;
+    let source = resolved
+        .nodes
+        .iter()
+        .find(|node| node.id == dependency.source)
+        .ok_or("missing dependency source")?;
+    let target = resolved
+        .nodes
+        .iter()
+        .find(|node| node.id == dependency.target)
+        .ok_or("missing dependency target")?;
+    assert_eq!(source.string("qualified_name"), "example.UserService");
+    assert_eq!(target.string("qualified_name"), "example.UserRepository");
+    Ok(())
+}
+
+#[test]
+fn spring_composed_and_interface_mappings_target_the_implementation() -> Result<(), Box<dyn Error>>
+{
+    let api = extract_java(
+        "src/main/java/example/Api.java",
+        r#"
+package example;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Target(ElementType.METHOD)
+@GetMapping("/default")
+@interface Read {
+    @AliasFor(annotation = GetMapping.class, attribute = "path")
+    String[] value() default {};
+}
+
+@RequestMapping("/api")
+interface Api {
+    @Read("/users") String users();
+}
+"#,
+    )?;
+    let implementation = extract_java(
+        "src/main/java/example/ApiController.java",
+        r#"
+package example;
+import org.springframework.web.bind.annotation.RestController;
+@RestController class ApiController implements Api {
+    public String users() { return "ok"; }
+}
+"#,
+    )?;
+    assert!(
+        api.framework_facts.iter().any(|fact| {
+            matches!(fact, RawFrameworkFact::Annotation(annotation)
+            if annotation.annotation_name == "AliasFor"
+                && annotation.detail.get("annotationAttribute").and_then(serde_json::Value::as_str)
+                    == Some("value"))
+        }),
+        "missing alias evidence: {:#?}",
+        api.framework_facts
+    );
+    let resolved = resolve(&[api, implementation], &HashMap::new());
+    let inherited = resolved
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route)
+                if route.rule.as_deref() == Some("spring-inherited-request-mapping") =>
+            {
+                Some(route)
+            }
+            _ => None,
+        })
+        .find(|route| route.normalized_path == "/api/users")
+        .ok_or_else(|| {
+            format!(
+                "missing inherited composed route: {:#?}",
+                resolved.framework_facts
+            )
+        })?;
+    let target = resolved
+        .nodes
+        .iter()
+        .find(|node| node.id == inherited.handler_reference)
+        .ok_or("missing inherited handler")?;
+    assert_eq!(
+        target.string("qualified_name"),
+        "example.ApiController::users"
+    );
+    Ok(())
+}
+
+#[test]
+fn spring_messaging_producers_and_consumers_publish_typed_domain_edges()
+-> Result<(), Box<dyn Error>> {
+    let extraction = extract_java(
+        "src/main/java/example/Messaging.java",
+        r#"
+package example;
+import org.springframework.stereotype.Service;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+@Service class Messaging {
+    private final KafkaTemplate<String, String> kafka;
+    Messaging(KafkaTemplate<String, String> kafka) { this.kafka = kafka; }
+    @KafkaListener(topics = {"orders", "audit"})
+    void consume(String value) {}
+    void produce(String value) { kafka.send("orders", value); }
+}
+"#,
+    )?;
+    let resolved = resolve(&[extraction], &HashMap::new());
+    for relation in ["consumes", "produces"] {
+        assert!(
+            resolved
+                .edges
+                .iter()
+                .any(|edge| edge.string("relation") == relation),
+            "missing {relation}: {:#?}",
+            resolved.framework_facts
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn spring_route_constants_resolve_across_static_imports_and_concatenation()
+-> Result<(), Box<dyn Error>> {
+    let paths = extract_java(
+        "src/main/java/example/Paths.java",
+        r#"
+package example;
+import org.springframework.web.bind.annotation.RequestMapping;
+final class Paths {
+    static final String ROOT = "/api";
+    static final String USERS = ROOT + "/users";
+}
+"#,
+    )?;
+    let controller = extract_java(
+        "src/main/java/example/ConstantController.java",
+        r#"
+package example;
+import static example.Paths.USERS;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+@RestController class ConstantController {
+    @GetMapping(USERS) String users() { return "ok"; }
+}
+"#,
+    )?;
+    assert!(
+        paths.framework_facts.iter().any(|fact| {
+            matches!(fact, RawFrameworkFact::Domain(domain) if domain.kind == "_spring_constant")
+        }),
+        "missing constant evidence: {:#?}",
+        paths.framework_facts
+    );
+    let resolved = resolve(&[paths, controller], &HashMap::new());
+    assert!(
+        resolved.framework_facts.iter().any(|fact| {
+            matches!(fact, RawFrameworkFact::Route(route) if route.normalized_path == "/api/users")
+        }),
+        "missing constant route: {:#?}",
+        resolved.framework_facts
+    );
+    assert!(!resolved.framework_facts.iter().any(|fact| {
+        matches!(fact, RawFrameworkFact::Domain(domain) if domain.kind == "_spring_constant")
+    }));
+    Ok(())
+}
+
+#[test]
+fn spring_stereotypes_data_scheduling_transactions_and_security_stay_typed()
+-> Result<(), Box<dyn Error>> {
+    let model = extract_java(
+        "src/main/java/example/User.java",
+        r#"
+package example;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+@Entity @Table(name = "users", schema = "app") class User {}
+"#,
+    )?;
+    let repository = extract_java(
+        "src/main/java/example/UserRepository.java",
+        r#"
+package example;
+import org.springframework.data.jpa.repository.JpaRepository;
+interface UserRepository extends JpaRepository<User, Long> {}
+"#,
+    )?;
+    let service = extract_java(
+        "src/main/java/example/SecuredService.java",
+        r#"
+package example;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Service class SecuredService {
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    @PreAuthorize("hasRole('ADMIN')")
+    void reconcile() {}
+}
+"#,
+    )?;
+    let resolved = resolve(&[model, repository, service], &HashMap::new());
+    assert!(resolved.framework_facts.iter().any(|fact| {
+        matches!(fact, RawFrameworkFact::Domain(domain)
+            if domain.kind == "orm_mapping"
+                && domain.detail.get("database_table").and_then(|value| value.as_str()) == Some("users"))
+    }));
+    assert!(
+        resolved.framework_facts.iter().any(|fact| {
+            matches!(fact, RawFrameworkFact::Domain(domain)
+            if domain.kind == "bean_definition" && domain.name == "userRepository")
+        }),
+        "missing repository bean: {:#?}",
+        resolved.framework_facts
+    );
+    for relation in ["registers", "schedules", "triggers"] {
+        assert!(
+            resolved
+                .edges
+                .iter()
+                .any(|edge| edge.string("relation") == relation)
+        );
+    }
+    let method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "example.SecuredService::reconcile")
+        .ok_or("missing secured scheduled method")?;
+    let traits = method
+        .attributes
+        .get("framework_traits")
+        .and_then(|value| value.as_array())
+        .ok_or("missing framework traits")?;
+    for expected in ["secured", "transactional"] {
+        assert!(traits.iter().any(|value| value.as_str() == Some(expected)));
+    }
+    Ok(())
+}

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -268,14 +268,13 @@ Framework detection is downstream of language parsing but upstream of final
 Code Graph v1 publication. Packs emit anchored route or domain facts; the
 framework resolver validates targets and materializes typed relationships.
 
-The universal pack descriptor and validator exist, but its production registry
-is currently empty. Python web, Rails, Spring, Go web, Rust web, ASP.NET,
-Vapor, TypeScript web, filesystem-route, enterprise-domain, config, and
-template packs therefore retain their established pack registries today. Each
-pack transitions atomically to the universal interface only after its declared
-activation evidence, accepted roles, target constraints, occurrence policy,
-limits, and language capabilities validate. No established detector is
-silently translated into a universal pack.
+The Java Spring source pack is the first production universal framework pack.
+It consumes exact Java annotation, call, import, type, ownership, and hierarchy
+evidence and derives HTTP, bean, injection, messaging, scheduling, persistence,
+transaction, and security meaning before framework resolution. Its Java legacy
+detectors are removed atomically; Kotlin Spring routing remains on its explicit
+established pack until Kotlin has a universal language adapter. Other packs
+retain their established registries until their own qualification and hard cut.
 
 ## Quality and failure boundaries
 

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -388,14 +388,16 @@ transition does not alter the publication route of any other language.
 ## Framework-pack status
 
 `FrameworkPackDescriptor` and `FrameworkPackRegistry` define the universal pack
-contract and validate language capabilities, activation evidence, accepted
-roles, relationship families, occurrence policy, and limits. The production
-universal descriptor list is currently empty. Established source, config, and
-template pack registries remain active until their individual hard cutovers.
+contract and validate language capabilities, framework capabilities, activation
+evidence, accepted roles, typed relationship families, occurrence policy, and
+limits. The production registry contains `spring-java`. It derives framework
+meaning only from universal Java evidence and publishes through the shared
+framework resolver. Established source, config, and template packs remain
+active until their individual hard cutovers.
 
-This separation prevents a language hard cutover from implicitly changing
-Rails, Spring, Rust web, ASP.NET, Vapor, TypeScript web, filesystem-route,
-enterprise-domain, config, or template semantics.
+The Java hard cut is limited to Spring's Java-facing behavior. Kotlin Spring,
+Rails, Rust web, ASP.NET, Vapor, TypeScript web, filesystem-route, config, and
+template semantics are unchanged.
 
 ## Verification gates
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -271,10 +271,11 @@ changes for this extension.
 derived from universal language evidence. It declares:
 
 - stable pack ID and source, config, or template kind;
-- universal languages and required capabilities;
+- universal languages, required language capabilities, and framework
+  capabilities;
 - dependency markers and manifest policy;
 - named activation rules;
-- accepted semantic roles and emitted relation families;
+- accepted semantic roles and typed framework relation families;
 - exact-evidence or exact-anchored-heuristic occurrence policy; and
 - nonzero candidate, include-depth, alias-expansion, and per-file fact limits.
 
@@ -291,9 +292,9 @@ descriptor and implementation together.
 
 ```rust
 use compass_languages::{
-    CandidateRelation, FrameworkLimits, FrameworkManifestPolicy,
+    FrameworkCapability, FrameworkLimits, FrameworkManifestPolicy,
     FrameworkOccurrencePolicy, FrameworkPackDescriptor, FrameworkPackKind,
-    FrameworkPackRegistry, LanguageCapability, SemanticRole,
+    FrameworkPackRegistry, FrameworkRelation, LanguageCapability, SemanticRole,
 };
 
 let descriptor = FrameworkPackDescriptor {
@@ -301,11 +302,12 @@ let descriptor = FrameworkPackDescriptor {
     kind: FrameworkPackKind::Source,
     languages: &["python"],
     required_capabilities: &[LanguageCapability::Calls],
+    framework_capabilities: &[FrameworkCapability::Messaging],
     dependency_markers: &["example/framework"],
     manifest_policy: FrameworkManifestPolicy::Required,
     activation_rules: &["decorated-handler"],
     accepted_roles: &[SemanticRole::Call],
-    emitted_relation_families: &[CandidateRelation::Calls],
+    emitted_relation_families: &[FrameworkRelation::Handles],
     occurrence_policy: FrameworkOccurrencePolicy::ExactEvidence,
     limits: FrameworkLimits::default(),
 };
@@ -393,8 +395,10 @@ Python or Go has met the production qualification gates.
 
 ## Current qualification boundary
 
-Python and Go are the only universal adapters in this increment. The contract
-is designed for any language or framework, but Java, Rust, other languages,
-and existing framework packs are not yet cut over or qualified. Do not infer
-support from file extensions, existing raw graph output, or total node and
-edge counts.
+Python, Go, Rust, and Java are hard-cut universal language adapters. Rust and
+Java remain `UniversalCandidate`; this framework change does not promote Java.
+`spring-java` is the first production universal framework pack and advertises
+typed HTTP, bean, injection, messaging, scheduling, persistence, transaction,
+and security capabilities. Kotlin Spring remains on its established detector.
+Do not infer support for another language or framework from file extensions,
+raw graph output, or total node and edge counts.

--- a/docs/superpowers/reviews/2026-07-30-java-universal-candidate.md
+++ b/docs/superpowers/reviews/2026-07-30-java-universal-candidate.md
@@ -171,7 +171,10 @@ confirmation.
 
 ### Remaining scope
 
-This closes Java's post-cutover candidate qualification, not all framework-pack
-work. Spring behavior remains covered through universal Java facts, but the
-production universal Spring descriptor list is still empty. Spring's registry
-hard cut is a separate follow-up and is not implied by this Java result.
+This closes Java's post-cutover candidate qualification without promoting Java
+past `UniversalCandidate`. The former Spring follow-up is now implemented by
+the production `spring-java` universal framework pack at Compass commit
+`1946012aa67bba474f4016aa2d9f79010a3c1476`; its independent evidence is
+recorded in the 2026-08-01 Spring universal-pack review. Java Spring no longer
+runs through the legacy source detector. Kotlin Spring remains on the
+established framework path and is not covered by the Java hard cut.

--- a/docs/superpowers/reviews/2026-08-01-spring-universal-pack.md
+++ b/docs/superpowers/reviews/2026-08-01-spring-universal-pack.md
@@ -68,15 +68,69 @@ post-cutover review:
 - Spring Framework: `eceebb3077dda9e1b19d73c0398ef022cd91f99c`
 - Graphify: `4fe11092ccbe9f543608f140c790f68d5d83cae4`
 - established Compass Java result: `e4599f9`
-- universal Spring pack: `1946012aa67bba474f4016aa2d9f79010a3c1476`
+- universal Spring pack implementation: `1946012aa67bba474f4016aa2d9f79010a3c1476`
+- qualified candidate: `d0be66c`
 - samples: three cold, warm, incremental, and restore runs per tool
 
-The comparison is recorded separately from the implementation commit so the
-qualification report can cite the exact committed candidate that produced it.
+Every sample was eligible. The final candidate published 168,791 nodes and
+683,564 canonical edges; Graphify published 138,830 nodes and 477,066 edges.
+Both outputs were deterministic, with Compass graph SHA-256
+`5a20342e18f46b9a455d442854cb4dc77945a38a651447684388dbc02a720518`
+and Graphify graph SHA-256
+`cdf2873b915709886c137b9b6e54259c6a9aa1f037efe8c7dee5020f41df1b59`.
+
+### Graph quality
+
+The same strict classifier used for Java's established result classified
+439,235 of 477,066 Graphify edges as exact, dominated, or rejected with
+stronger evidence. Overall handled coverage is therefore **92.07%**, compared
+with **70.90%** for established Java. The candidate retains **129.86%** of the
+baseline, exceeding the 95% gate. No relation family regressed against the
+established baseline; `case_of` remains unchanged and every other family
+improves.
+
+| Relation | Graphify | Established handled | Exact | Dominated | Rejected | Missing | Ambiguous | Candidate handled |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| calls | 112,195 | 48.51% | 15,016 | 65,314 | 7,414 | 24,451 | 0 | 78.21% |
+| case_of | 872 | 0.00% | 0 | 0 | 0 | 872 | 0 | 0.00% |
+| contains | 102,310 | 95.19% | 32,694 | 65,476 | 0 | 4,133 | 7 | 95.95% |
+| extends | 4,454 | 86.06% | 2,477 | 1,727 | 121 | 116 | 13 | 97.10% |
+| implements | 4,379 | 95.39% | 1,988 | 2,054 | 202 | 132 | 3 | 96.92% |
+| imports | 126,118 | 59.13% | 31,108 | 37,968 | 56,183 | 859 | 0 | 99.32% |
+| references | 126,738 | 81.94% | 12,009 | 94,949 | 12,535 | 7,237 | 8 | 94.28% |
+
+Calls remain the largest Java relationship gap. Imports meet the requested
+priority at 99.32% handled coverage; the remaining 859 Graphify import facts
+are unchanged from Java's final candidate. The Spring pack adds framework
+semantics only when backed by universal Java evidence and does not turn
+unresolved source calls into invented targets.
+
+### Latency
+
+| Tool and workload | Eligible | p50 | p95 | Peak RSS |
+|---|---:|---:|---:|---:|
+| Compass cold | 3/3 | 101.815 s | 102.499 s | 9,133.80 MiB |
+| Graphify cold | 3/3 | 181.975 s | 189.013 s | 1,505.78 MiB |
+| Compass warm | 3/3 | 3.847 s | 3.969 s | 51.92 MiB |
+| Graphify warm | 3/3 | 67.656 s | 78.430 s | 1,978.12 MiB |
+| Compass incremental | 3/3 | 3.783 s | 3.880 s | 52.02 MiB |
+| Graphify incremental | 3/3 | 77.317 s | 78.744 s | 1,977.12 MiB |
+
+Compass is **1.787x** faster cold, **17.586x** faster warm, and **20.438x**
+faster incrementally. This satisfies the Java qualification requirement that
+Compass cold and warm latency be lower than Graphify.
+
+The generic performance harness reports `FAIL` because it additionally
+requires a 5x cold speedup, lower cold peak RSS, and zero missing or ambiguous
+Graphify facts. Those are not the Java post-cutover acceptance gates: all
+requested coverage, relation-family non-regression, determinism, and
+lower-latency gates pass. The full machine-readable run is preserved outside
+the repository under run ID `20260801T161731Z`; generated graphs and local
+qualification state are not committed.
 
 ## Verification
 
-The following checks passed against the implementation commit:
+The following checks passed against the final code candidate:
 
 - `cargo fmt --all -- --check`
 - `cargo clippy --workspace --lib --bins --locked -- -D warnings`
@@ -85,8 +139,23 @@ The following checks passed against the implementation commit:
 - the six-test `spring_universal_pack` integration suite
 - the eight-test JVM route and six-test domain-resolution suites
 - release construction of `compass-cli`
+- `scripts/check_product_boundary.sh`
 
 The all-target targeted Clippy run also reaches a pre-existing unrelated lint
 in `crates/compass-resolve/tests/python_import_provenance.rs`; the required
 workspace library/binary Clippy baseline is green.
 
+The repository-wide `qualify_code_graph_v1.sh --fixtures-only` gate remains
+red on pre-existing cross-language qualification-manifest drift: current
+Python, Go, Rust, and Java universal identities differ from stale expected
+names, and the Rust fixture expects `type_of`, `returns`, and `documents`
+vocabulary not emitted by the current runtime. No Graphify dependency or
+fallback was added to bypass that independent debt.
+
+## Final status
+
+The production universal framework-pack registry is no longer empty for
+Spring: `spring-java` is registered and Java Spring interpretation is hard-cut
+to it. The separate Spring gap identified by the Java review is closed. Java
+intentionally remains `UniversalCandidate`; promotion to `UniversalComplete`
+is outside this change.

--- a/docs/superpowers/reviews/2026-08-01-spring-universal-pack.md
+++ b/docs/superpowers/reviews/2026-08-01-spring-universal-pack.md
@@ -1,0 +1,92 @@
+# Spring Java Universal Framework-Pack Quality Review
+
+## Decision
+
+Compass commit `1946012aa67bba474f4016aa2d9f79010a3c1476` hard-cuts
+Java Spring interpretation to the production `spring-java` universal
+framework-pack registry. The pack consumes Java's version-1 universal semantic
+evidence and exact syntax anchors; it does not discover Java declarations with
+regular expressions and does not run beside the legacy Java Spring detector.
+
+This is a framework-pack cutover, not a Java language-profile promotion. Java
+remains `UniversalCandidate`. Kotlin Spring remains explicitly owned by the
+established `spring-web-kotlin` path.
+
+## Shipped contract
+
+The descriptor declares bounded support for HTTP routes, beans, dependency
+injection, messaging, scheduling, persistence, transactions, and security. Its
+typed relation contract covers decoration, route targets, bean registration,
+message handlers and producers, scheduled jobs, dependencies, and ORM mappings.
+
+The implementation resolves:
+
+- direct, array-valued, multiline, composed, inherited, and interface Spring
+  mappings, including `@AliasFor`;
+- controller path constants, concatenation, and static imports across files,
+  while leaving ambiguous constants unresolved;
+- component stereotypes, composed stereotypes, `@Configuration`, `@Bean`,
+  constructor injection, and Spring Data repository beans;
+- Kafka, RabbitMQ, and application-event consumers and exact call-backed
+  producers;
+- scheduled methods, JPA entities and tables, and transaction/security traits.
+
+Universal Java evidence now preserves field and parameter annotations,
+annotation-element metadata, and interface-extension facts required by those
+semantics. Cross-file selection remains in `compass-resolve`; the language
+framework runtime emits bounded evidence rather than publishing graph records.
+
+## Checked-fixture determinism
+
+The six checked Java fixtures from routes, scheduling, messaging, and JPA were
+copied into an isolated corpus and extracted three times with the final release
+binary. Every run published 45 nodes and 60 edges. The three graph files were
+byte-identical, and their independently canonicalized graphs and occurrence
+streams were identical:
+
+- graph bytes SHA-256:
+  `ea284581c9bbd071ef14e05c8e0c9fdbf14afa2259fc0fe24511ba1068d38442`
+- canonical graph SHA-256:
+  `f8947e839f5054fa4efd3c496a46d312b8ca75b6eda430c74f12f5500243fcbd`
+- occurrence SHA-256:
+  `7e8b67bd538c1e08c0cf959e255b0e404018d696259e1f04ec4459b7eae53495`
+
+Best-effort publication reported the same one-node/one-edge omission in each
+run for the fixture's dangling external `RequestMethod` import. The omission is
+stable and does not invent an endpoint.
+
+The dedicated six-test Spring pack suite covers positive, negative, ambiguity,
+identity, direction, source occurrence, and multiplicity behavior. The existing
+eight JVM route tests and six domain-resolution tests remain green, including
+the Kotlin legacy route.
+
+## Pinned Spring Framework comparison
+
+The real-corpus qualification uses the same immutable inputs as Java's final
+post-cutover review:
+
+- Spring Framework: `eceebb3077dda9e1b19d73c0398ef022cd91f99c`
+- Graphify: `4fe11092ccbe9f543608f140c790f68d5d83cae4`
+- established Compass Java result: `e4599f9`
+- universal Spring pack: `1946012aa67bba474f4016aa2d9f79010a3c1476`
+- samples: three cold, warm, incremental, and restore runs per tool
+
+The comparison is recorded separately from the implementation commit so the
+qualification report can cite the exact committed candidate that produced it.
+
+## Verification
+
+The following checks passed against the implementation commit:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
+- `cargo test --workspace --lib --bins --locked`
+- all `compass-languages` and `compass-resolve` tests
+- the six-test `spring_universal_pack` integration suite
+- the eight-test JVM route and six-test domain-resolution suites
+- release construction of `compass-cli`
+
+The all-target targeted Clippy run also reaches a pre-existing unrelated lint
+in `crates/compass-resolve/tests/python_import_provenance.rs`; the required
+workspace library/binary Clippy baseline is green.
+


### PR DESCRIPTION
## Summary

- hard-cut Java Spring interpretation to the production `spring-java` universal framework pack while keeping Java `UniversalCandidate`
- consume typed universal Java annotations and exact syntax anchors for routes, beans and DI, messaging, scheduling, JPA, transactions, and security
- add bounded cross-file resolution for composed/inherited/interface mappings, `@AliasFor`, constants/static imports, producers/consumers, and framework identities
- keep Kotlin Spring on the established `spring-web-kotlin` path and prevent Java from running beside the legacy detector
- add focused positive, negative, ambiguity, identity, direction, occurrence, multiplicity, and determinism coverage
- record the pinned Spring Framework comparison and final qualification evidence

## Qualification result

- checked Java fixtures: 3/3 byte-identical runs, 45 nodes and 60 edges; graph SHA-256 `ea284581c9bbd071ef14e05c8e0c9fdbf14afa2259fc0fe24511ba1068d38442`
- pinned Spring corpus: 168,791 Compass nodes and 683,564 edges, deterministic across all eligible samples
- handled Graphify edge coverage: 92.07% vs 70.90% established Java baseline (129.86% retention; required >95%)
- no relation-family regression against the established baseline; calls 78.21%, imports 99.32%, references 94.28%
- latency: Compass 1.787x faster cold, 17.586x faster warm, and 20.438x faster incrementally
- Java remains `UniversalCandidate`; this PR does not promote it to `UniversalComplete`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- all `compass-languages` and `compass-resolve` tests
- `spring_universal_pack`, JVM route, and domain-resolution suites
- release `compass-cli` build
- `sh scripts/check_product_boundary.sh`

## Known independent gates

The generic performance harness reports failure because it additionally requires a 5x cold speedup, lower cold peak RSS, and zero missing/ambiguous Graphify facts. Those are broader than the Java post-cutover acceptance criteria above; the requested coverage, non-regression, determinism, and lower cold/warm latency gates pass.

`scripts/qualify_code_graph_v1.sh --fixtures-only` also remains red on pre-existing cross-language qualification-manifest drift (stale Python/Go/Rust/Java expected identities and Rust relation vocabulary). This PR does not add Graphify runtime/test dependencies or weaken the product boundary to bypass that debt.
