### PR TITLE
docs: add document processing implementation plans

### DIFF
--- a/advisor-plans/006-harden-media-ingestion.md
+++ b/advisor-plans/006-harden-media-ingestion.md
@@ -1,0 +1,219 @@
+# Plan 006: Make media ingestion fail explicitly and remain memory-bounded
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update this plan's row in
+> `advisor-plans/README.md` unless a reviewer says they maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-media crates/compass-semantic docs/design/security-and-privacy.md CHANGELOG.md`
+> The working tree used to write this plan already contained unrelated changes.
+> Preserve them. If an in-scope file has changed, compare the excerpts below to
+> live code and stop if the named behavior no longer exists.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: security, bug
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+Compass parses attacker-controlled Office/PDF inputs. ZIP-size limits exist,
+but XLSX cell coordinates can still amplify a small XML member into an
+unbounded vector allocation. Separately, the semantic reader converts any
+DOCX/XLSX/PDF parse failure into an apparently successful empty source. That
+violates Compass's explicit-limit invariant and can mark a file complete even
+though no content was analyzed.
+
+This plan hardens the existing string-returning API without introducing the
+document IR planned in 007. It is intentionally safe to land first.
+
+## Current state
+
+- `crates/compass-media/src/lib.rs` owns bounded local extraction.
+  - Lines 12–15 cap raw/archive/member bytes.
+  - Lines 356–405 parse worksheet rows.
+  - Lines 369–374 derive a column from arbitrary `c@r` text and call
+    `values.resize(column + 1, ...)` without a column/cell bound.
+  - Lines 418–428 saturate arbitrarily long column names to `usize::MAX`.
+- `crates/compass-semantic/src/lib.rs:757-838` reads semantic files.
+  - Lines 802–805 turn errors for `pdf`, `docx`, and `xlsx` into
+    `Some(String::new())` with no warning.
+- `docs/design/security-and-privacy.md:143-144` says a limit failure must not be
+  reinterpreted as empty or complete.
+- Tests use `Result<(), Box<dyn Error>>`, temporary files, and synthetic ZIP
+  members; follow `crates/compass-media/src/lib.rs:460-580`.
+- Rust policy: no unsafe code; no `unwrap`/`expect`/`panic`; deterministic
+  collections or explicit sorting at contract boundaries.
+
+## Commands you will need
+
+Set the external target on every Cargo invocation:
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Media tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-media --locked` | exit 0 |
+| Semantic tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-semantic --locked` | exit 0 |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-media -p compass-semantic --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Boundary | `sh scripts/check_product_boundary.sh` | exit 0 |
+
+If `/Volumes/Workspace` is unavailable or unwritable, stop. Do not fall back to
+a target directory inside the checkout.
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-media/src/lib.rs`
+- `crates/compass-semantic/src/lib.rs`
+- `crates/compass-semantic/src/tests.rs`
+- `crates/compass-semantic/tests/edge_coverage.rs`
+- `docs/design/security-and-privacy.md` only if diagnostics need clarification
+- `CHANGELOG.md` for the release-visible hardening note
+
+**Out of scope**:
+
+- Adding PPTX, RTF, HTML, ODT, or EPUB support.
+- Changing the public graph schema or relationship vocabulary.
+- Building the document IR from plan 007.
+- Running Graphify or adding Graphify fixtures/dependencies.
+- Lowering the existing raw/archive byte ceilings without maintainer approval.
+
+## Git workflow
+
+- Suggested branch: `advisor/006-harden-media-ingestion`
+- Use conventional commits such as `fix(media): bound worksheet coordinates`.
+- Keep the XLSX allocation fix and semantic failure-policy change as separate
+  logical commits if both are committed.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Add hostile XLSX regression tests
+
+In the existing `compass-media` test module, add synthetic ZIP tests for:
+
+1. a cell coordinate with enough letters to saturate the current fold;
+2. a coordinate beyond Excel's last valid column (`XFD` is valid; the next
+   column is invalid);
+3. too many non-empty cells/rows according to new Compass processing limits;
+4. malformed coordinates such as missing letters or non-ASCII letters;
+5. exactly-at-limit input succeeding deterministically.
+
+Tests must assert `MediaError::Rejected` or `MediaError::Parse`; they must not
+accept a process panic as success.
+
+**Verify**: run the media test command before implementation. At least the
+hostile-coordinate tests must fail for the expected reason, not because their
+fixture ZIP is malformed.
+
+### Step 2: Replace coordinate amplification with checked limits
+
+Add named constants near the current media limits:
+
+- `XLSX_MAX_COLUMNS = 16_384` (the XLSX format maximum);
+- `XLSX_MAX_ROWS = 100_000` (Compass processing ceiling);
+- `XLSX_MAX_CELLS = 1_000_000` (non-empty/visited cell ceiling);
+- `OFFICE_MAX_TEXT_CHARS = 20_000_000` (aggregate normalized text ceiling).
+
+Change `excel_column_index` to return a checked `Result<usize, MediaError>`.
+Reject empty/malformed references, arithmetic overflow, and columns outside
+`0..XLSX_MAX_COLUMNS`. In `parse_xlsx_rows`, track rows and visited cells with
+checked/saturating counters and return `MediaError::Rejected` before resizing
+or appending beyond a limit. Bound shared-string count and accumulated output
+characters under the same policy.
+
+Do not silently clamp a coordinate: truncating a sheet changes which value
+belongs to which column and invents meaning. Return an actionable limit error.
+
+**Verify**: media tests exit 0; the new hostile tests assert typed errors and a
+normal sparse `A1/C1` fixture still renders identically.
+
+### Step 3: Make semantic media failures observable
+
+In `read_semantic_units`, remove the `is_compat_binary_document` branch that
+turns `MediaError` into an empty source. On any `extract_text` error:
+
+- do not add a `LoadedSemanticSource`;
+- add one deterministic warning containing the logical path and error class;
+- never include uncontrolled parser text beyond the existing diagnostic style;
+- preserve valid empty documents as successful only when parsing itself
+  returned `Ok(String::new())`.
+
+Keep `extract_text_compat` for any explicitly documented compatibility caller;
+do not use it in the semantic pipeline.
+
+Add tests proving malformed PDF/DOCX/XLSX each produces a warning and no loaded
+source, while a valid empty text file remains a loaded empty source. Assert
+warning ordering follows input ordering.
+
+**Verify**: semantic tests exit 0 and `rg 'is_compat_binary_document' crates/compass-semantic` returns no matches.
+
+### Step 4: Propagate incomplete-file status to corpus orchestration
+
+Trace `read_semantic_units` through `extract_semantic_units` and cached corpus
+orchestration. A skipped parse must be represented as a failed/partial source,
+not included among finalized cache entries and not counted as successfully
+refreshed. Use existing `partial_files`, `failures`, and provider-warning
+contracts rather than adding an unversioned side channel.
+
+Add a corpus-level test that dispatches one valid Markdown file and one
+malformed DOCX. The valid file may complete, the DOCX must remain partial or
+failed, and the result must not write a complete per-file semantic cache entry
+for the DOCX.
+
+**Verify**: `cargo test -p compass-semantic --locked` exits 0; the new test
+asserts the malformed path appears exactly once in incomplete diagnostics.
+
+### Step 5: Document and verify the boundary
+
+Add a concise changelog entry explaining that malformed/over-limit Office and
+PDF inputs are reported as incomplete instead of treated as empty. Update the
+security design only if the implementation introduces a named limit not
+already described there.
+
+Run all commands in the table. Inspect `git diff --check` and confirm no test
+fixture or diagnostic contains private source material.
+
+## Test plan
+
+- Unit tests in `compass-media` for coordinate overflow, format bounds, total
+  cells, total text, and exact-limit success.
+- Semantic reader tests for malformed binary inputs, valid empty text, stable
+  warning order, and no false successful source.
+- Corpus cache test for incomplete media not being finalized/replayed.
+- Existing six media tests and all semantic tests remain green.
+
+## Done criteria
+
+- [ ] No XLSX coordinate can request a vector beyond `XLSX_MAX_COLUMNS`.
+- [ ] Worksheet rows, cells, shared strings, and normalized output are bounded.
+- [ ] Media limit/parse errors never become successful empty semantic sources.
+- [ ] Failed media is not finalized in semantic cache state.
+- [ ] Targeted tests, Clippy, formatting, product boundary, and `git diff --check` pass.
+- [ ] `git status --short` contains only in-scope changes plus pre-existing user changes.
+- [ ] Plan 006 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- live code already replaced `Vec::resize` with a bounded sparse structure;
+- changing failure semantics requires altering a published machine schema
+  rather than existing warning/partial contracts;
+- existing compatibility tests require malformed media to count as complete;
+- an in-scope file overlaps unresolved user changes that cannot be preserved;
+- any Cargo command would use a local `target/` directory.
+
+## Maintenance notes
+
+Every future document decoder must use the same explicit rejection policy.
+Reviewers should look for allocations driven by declared indexes/counts, not
+only byte-size caps. Plan 007 will centralize these limits in a document IR; do
+not pre-empt that larger refactor here.

--- a/advisor-plans/007-versioned-document-artifact.md
+++ b/advisor-plans/007-versioned-document-artifact.md
@@ -1,0 +1,296 @@
+# Plan 007: Introduce a versioned, provenance-preserving document artifact
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update this plan's row in
+> `advisor-plans/README.md` unless a reviewer says they maintain the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-media crates/compass-semantic crates/compass-files docs/design COMPATIBILITY.md CHANGELOG.md Cargo.toml Cargo.lock`
+> The working tree used to write this plan already contained unrelated changes.
+> Preserve them. If an in-scope file changed, compare the symbols below with
+> live code and stop if the ownership or cache behavior no longer matches.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L
+- **Risk**: HIGH
+- **Depends on**: `advisor-plans/006-harden-media-ingestion.md`
+- **Category**: tech-debt, direction
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+Today every rich document is flattened immediately to one Markdown-like
+`String`. That destroys block order, hierarchy, link provenance, exact source
+locations, parser diagnostics, and the distinction between complete and
+partial extraction. It also makes cache correctness depend on undocumented
+normalizer behavior. This plan adds one bounded, typed intermediate contract
+that all later Markdown, HTML, Office, PDF, semantic, and graph work can share.
+
+The artifact is not a universal AST. It represents only evidence Compass can
+prove: ordered blocks, containment, links, metadata, diagnostics, and source
+locators. It must never invent byte offsets inside ZIP packages or PDFs.
+
+## Current state
+
+- `crates/compass-media/src/lib.rs` owns bounded PDF/DOCX/XLSX extraction.
+  `extract_text(path)` dispatches by extension and returns only `String`.
+- `crates/compass-semantic/src/lib.rs:742-838` owns `SemanticUnit` and rereads
+  paths through `compass_media::extract_text`.
+- `crates/compass-semantic/src/orchestration.rs:1069,1216` namespaces semantic
+  cache entries with `compass_files::prompt_fingerprint(prompt)` only.
+- `crates/compass-files/src/cache.rs:175-269` already accepts a fingerprint
+  string for semantic cache directories. Reuse that interface; do not create a
+  second cache implementation.
+- Root `Cargo.toml` already provides `serde`, `serde_json`, and
+  `serde_yaml_ng` as workspace dependencies.
+- Compass contracts require deterministic ordering, explicit unknown-major
+  rejection, bounded untrusted input, relative/provenance-safe paths, and
+  explicit incomplete results. These rules are in root `AGENTS.md` and
+  `docs/design/security-and-privacy.md`.
+
+## Target contract
+
+Add `crates/compass-media/src/document.rs` with public types equivalent to the
+following shape. Exact Rust field names may change only if tests and design
+documentation use the final names consistently.
+
+```rust
+pub const DOCUMENT_SCHEMA: &str = "compass.document/1";
+pub const DOCUMENT_NORMALIZER_VERSION: u32 = 1;
+
+pub struct DocumentArtifact {
+    pub schema: String,
+    pub normalizer_version: u32,
+    pub format: DocumentFormat,
+    pub blocks: Vec<DocumentBlock>,
+    pub links: Vec<DocumentLink>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub diagnostics: Vec<DocumentDiagnostic>,
+    pub complete: bool,
+}
+
+pub struct DocumentBlock {
+    pub ordinal: u32,
+    pub parent: Option<u32>,
+    pub kind: DocumentBlockKind,
+    pub text: String,
+    pub locator: DocumentLocator,
+}
+```
+
+Required enums:
+
+- `DocumentFormat`: plain text, Markdown, HTML, PDF, DOCX, XLSX, PPTX, RTF.
+  A variant is vocabulary, not a support claim; unsupported decoders still
+  return a typed error.
+- `DocumentBlockKind`: document title, heading with level, paragraph, list,
+  list item, code, quote, table, row, cell, page, sheet, slide, note, and an
+  explicit `Other { role }` for bounded forward compatibility.
+- `DocumentLocator`: exact text range; package part plus logical block path;
+  PDF page plus item; spreadsheet sheet/row/column; slide/shape. Text ranges
+  contain checked byte and line positions. Package/PDF locators are logical
+  and must not claim original byte offsets.
+- `DocumentLink`: source block ordinal, destination string, optional label,
+  relationship kind, and locator.
+- `DocumentDiagnostic`: stable code, severity, optional locator, and bounded
+  message. `complete=false` means some source content was intentionally skipped
+  or could not be represented; a hard limit or corrupt container remains an
+  error, not a partial artifact.
+
+Validation must reject unknown schema majors, duplicate/out-of-order ordinals,
+missing parents, forward/cyclic parents, invalid ranges, links to missing
+blocks, absolute/package-escaping part names, and oversized fields.
+
+## Commands you will need
+
+Set the external target on every Cargo invocation:
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Media | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-media --locked` | exit 0 |
+| Semantic | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-semantic --locked` | exit 0 |
+| Files | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-files --locked` | exit 0 |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-media -p compass-semantic -p compass-files --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Boundary | `sh scripts/check_product_boundary.sh` | exit 0 |
+
+If `/Volumes/Workspace` is unavailable or unwritable, stop rather than using a
+local `target/` directory.
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-media/src/lib.rs`
+- `crates/compass-media/src/document.rs` (create)
+- `crates/compass-media/src/limits.rs` (create if plan 006 did not already)
+- `crates/compass-media/tests/document_contract.rs` (create)
+- `crates/compass-media/Cargo.toml`
+- `crates/compass-semantic/src/orchestration.rs`
+- `crates/compass-semantic/src/tests.rs`
+- `crates/compass-files/src/hash.rs` and its tests only if the fingerprint
+  helper belongs there after ownership review
+- `Cargo.toml`, `Cargo.lock` only for workspace dependency wiring
+- `docs/design/document-processing.md` (create)
+- `docs/README.md`, `COMPATIBILITY.md`, `CHANGELOG.md`
+
+**Out of scope**:
+
+- Rewriting Markdown/HTML/Office decoders; plans 009–011 own that work.
+- Changing graph JSON, node kinds, or CompassQL.
+- Semantic chunking or structural/semantic fusion; plan 008 owns it.
+- Runtime grammar downloads, Python, LibreOffice, Pandoc, or Graphify.
+- Stable block IDs based on text content. Content hashes are fingerprints, not
+  identity; edits must not silently create a different logical document.
+
+## Git workflow
+
+- Suggested branch: `advisor/007-versioned-document-artifact`
+- Use logical commits: contract/tests, decoder migration, cache namespace,
+  documentation.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Lock the artifact contract with failing tests
+
+Create `document_contract.rs`. Construct artifacts directly and test:
+
+1. JSON round-trip preserves every enum, locator, metadata value, diagnostic,
+   ordering, multiplicity, and `complete` value.
+2. an unknown schema major is rejected explicitly;
+3. invalid parents, ordinals, ranges, and block references are rejected;
+4. package paths containing absolute roots or `..` escape are rejected;
+5. diagnostics/messages and every accumulated collection obey named limits;
+6. serialization contains no machine-absolute source path;
+7. equal logical inputs serialize byte-for-byte identically.
+
+Use `BTreeMap` and explicit vector ordering at serialization boundaries. Do not
+use `HashMap` iteration to publish fields.
+
+**Verify**: run media tests before implementation. New tests must fail because
+the types do not exist, while existing tests still pass independently.
+
+### Step 2: Implement types, validation, and central limits
+
+Implement the target contract in `document.rs`. Centralize the byte, member,
+block, link, metadata, diagnostic, depth, and normalized-text limits in
+`limits.rs`; reuse the XLSX and Office limits introduced by plan 006. Expose a
+single `DocumentArtifact::validate()` path and call it before returning or
+deserializing an artifact.
+
+Define a typed `DocumentError` that distinguishes unsupported format, rejected
+limit, corrupt/parse input, invalid artifact, and I/O. Preserve actionable
+context without embedding unbounded source content.
+
+**Verify**: media tests exit 0, including every contract rejection test.
+
+### Step 3: Add byte-oriented decoding and a compatibility renderer
+
+Add an API equivalent to:
+
+```rust
+pub fn decode_document(
+    logical_path: &Path,
+    bytes: &[u8],
+) -> Result<DocumentArtifact, DocumentError>;
+```
+
+The path supplies a relative logical name/extension only; all source bytes are
+already present. Decoders must use `Cursor<&[u8]>` for archives so callers do
+not need a second disk read. Migrate current PDF/DOCX/XLSX functions behind
+this API without intentionally changing their extraction output yet.
+
+Keep `extract_text(path)` as a compatibility wrapper: perform one bounded read,
+call `decode_document`, validate, then call a deterministic
+`render_document_markdown(&artifact)`. Escape table pipes, backslashes, and
+newlines at rendering time rather than mutating IR text. Keep
+`extract_text_compat` only for documented legacy callers.
+
+**Verify**: existing media fixtures render identically except for intentional,
+tested Markdown escaping. `rg 'read\(|File::open' crates/compass-media/src`
+must show one top-level source read per compatibility call; ZIP member reads
+are allowed.
+
+### Step 4: Version the semantic cache namespace
+
+Add one helper, preferably owned by `compass-semantic`, that hashes these exact
+inputs with unambiguous separators:
+
+- semantic prompt and deep/standard mode;
+- `DOCUMENT_SCHEMA`;
+- `DOCUMENT_NORMALIZER_VERSION`.
+
+Replace direct `prompt_fingerprint` use at orchestration cache read/write sites
+with the combined fingerprint. Old entries must be cache misses; do not probe
+the old prompt-only directory as a fallback. Add tests proving that a prompt
+change, mode change, schema change, or normalizer version change changes the
+namespace, while repeated identical inputs do not.
+
+Document the hard cache cut in `COMPATIBILITY.md`; users do not need to delete
+old cache entries manually, so `MIGRATION.md` is unnecessary unless live code
+shows otherwise.
+
+**Verify**: semantic and files tests exit 0; `rg 'prompt_fingerprint\(' crates/compass-semantic/src/orchestration.rs`
+finds use only inside the combined helper or none.
+
+### Step 5: Document ownership and land the compatibility boundary
+
+Create `docs/design/document-processing.md` describing:
+
+- source bytes → validated `DocumentArtifact` → structural graph and semantic
+  chunk consumers;
+- exact versus logical locators;
+- completeness and diagnostic semantics;
+- format-support claims versus enum vocabulary;
+- cache invalidation rules;
+- why no subprocess/runtime-model dependency is permitted.
+
+Link it from `docs/README.md`. Update `CHANGELOG.md` and `COMPATIBILITY.md` for
+the new public crate contract and cache namespace.
+
+Run all commands in the table plus `git diff --check`.
+
+## Test plan
+
+- Artifact construction, validation, serde round-trip, deterministic encoding,
+  unknown-major rejection, limits, path containment, and locator semantics.
+- Compatibility rendering for plain text and current PDF/DOCX/XLSX fixtures.
+- Semantic cache namespace tests covering all four inputs.
+- Existing media, semantic, and files suites remain green.
+
+## Done criteria
+
+- [ ] All supported document decoders return validated `DocumentArtifact`.
+- [ ] Exact byte locators are used only when exact byte evidence exists.
+- [ ] `extract_text` is a compatibility renderer over the artifact, not a
+  parallel extraction implementation.
+- [ ] Semantic caches include schema and normalizer versions and never fall
+  back to prompt-only entries.
+- [ ] The design and compatibility docs define the contract.
+- [ ] Targeted tests, Clippy, format, product boundary, and `git diff --check` pass.
+- [ ] Plan 007 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- plan 006 is incomplete or live media errors still become successful empty
+  semantic sources;
+- implementing serde requires an unknown-major value to be accepted silently;
+- an existing public consumer relies on absolute paths in serialized media;
+- a decoder can only provide approximate package byte offsets—use logical
+  locators, and stop if a reviewer requires fabricated offsets;
+- the change requires a graph schema migration before plan 008;
+- an in-scope user modification cannot be preserved.
+
+## Maintenance notes
+
+Increment `DOCUMENT_NORMALIZER_VERSION` for any output-affecting normalization
+change. Increment the schema major only for incompatible field semantics. New
+format decoders must validate before publication and must expose unsupported or
+partial constructs through typed errors/diagnostics rather than silent loss.

--- a/advisor-plans/008-lossless-document-fusion.md
+++ b/advisor-plans/008-lossless-document-fusion.md
@@ -1,0 +1,258 @@
+# Plan 008: Chunk rich documents losslessly and fuse structural with semantic evidence
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If a STOP condition occurs, stop and report. Update this plan's
+> status row in `advisor-plans/README.md` when complete unless instructed not to.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-semantic crates/compass-core crates/compass-graph crates/compass-media crates/compass-model docs/design CHANGELOG.md`
+> Plan 007 must already be complete. If the live `DocumentArtifact` contract
+> differs from the assumptions below, stop and revise this plan with a reviewer.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L
+- **Risk**: HIGH
+- **Depends on**: `advisor-plans/007-versioned-document-artifact.md`
+- **Category**: bug, perf, direction
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+Rich documents currently bypass normal source slicing: their raw ZIP/PDF byte
+size is used for planning, then extracted text is capped at 20,000 characters.
+Large documents therefore lose content silently and cannot be retried in
+smaller units. At the same time, `compass-core` suppresses deterministic
+Markdown structure whenever semantic extraction covers the file. This plan
+makes normalized document text gap-free and sliceable, then publishes native
+structure and provider semantics together instead of forcing a choice.
+
+## Current state
+
+- `crates/compass-semantic/src/lib.rs:742-838` defines `SemanticUnit::File` and
+  `SemanticUnit::Slice`; rich media is extracted only while reading a file.
+- `crates/compass-semantic/src/orchestration.rs:94-138` slices using source-file
+  character estimates before DOCX/XLSX/PDF normalization.
+- The same reader truncates loaded content at roughly 20,000 characters.
+- `crates/compass-core/src/pipeline.rs:484-510` builds a
+  `semantic_documents` set and excludes those paths from language extraction.
+- `crates/compass-graph/src/lib.rs:456-478` has `doc_twin_remap`, a heuristic
+  that recognizes semantic document twins by a `_doc` suffix.
+- The artifact from plan 007 provides ordered blocks, locators, completeness,
+  diagnostics, `DOCUMENT_SCHEMA`, and `DOCUMENT_NORMALIZER_VERSION`.
+- Preserve relationship direction, multiplicity, source anchors, provider
+  provenance, deterministic order, and explicit ambiguity.
+
+## Target flow
+
+```text
+bounded bytes
+  -> validated DocumentArtifact (once)
+  -> deterministic structural projection
+  -> lossless DocumentSlice sequence
+  -> bounded semantic requests/retries
+  -> semantic nodes linked to proven document/block identities
+  -> one graph containing both evidence classes
+```
+
+A slice sequence is lossless when concatenating slice text in ordinal order
+reconstructs the exact normalized semantic text, including separators. Empty
+or repeated blocks must not disappear. Slices should prefer artifact block
+boundaries and split an oversized block only at checked UTF-8 character
+boundaries.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Semantic | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-semantic --locked` | exit 0 |
+| Core | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-core --locked` | exit 0 |
+| Graph | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-graph --locked` | exit 0 |
+| CLI contract | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-cli --test compass_product --locked` | exit 0 |
+| Qualification | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_code_graph_v1.sh --fixtures-only` | exit 0 |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-semantic -p compass-core -p compass-graph --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+
+Stop if the external target volume is unavailable; never build into the repo.
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-semantic/src/lib.rs`
+- `crates/compass-semantic/src/orchestration.rs`
+- focused semantic tests under `crates/compass-semantic/src/` and `tests/`
+- `crates/compass-core/src/pipeline.rs` and its focused tests
+- `crates/compass-graph/src/lib.rs` and graph publication tests
+- `crates/compass-media/src/document.rs` only for a deterministic semantic
+  rendering/slice helper missing from plan 007
+- `crates/compass-model` only if an existing provenance field must accept a new
+  typed value without changing schema meaning
+- `docs/design/document-processing.md`, `COMPATIBILITY.md`, `CHANGELOG.md`
+
+**Out of scope**:
+
+- Improving format parsing; plans 009–011 own extractors.
+- Changing provider protocols or adding a provider.
+- Embeddings, vector databases, natural-language querying, or Graphify.
+- Deduplicating two nodes merely because their labels/text are similar.
+- Altering stable graph identity without a compatibility review and migration.
+
+## Git workflow
+
+- Suggested branch: `advisor/008-lossless-document-fusion`
+- Prefer commits for prepared corpus/slices, retry behavior, graph fusion, docs.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Specify lossless prepared-document units
+
+Extend `SemanticUnit` with a document-backed unit or introduce a nearby
+`PreparedSemanticUnit`. It must carry:
+
+- canonical relative source path;
+- shared normalized content or an owned bounded slice (avoid N full copies);
+- checked start/end character offsets in normalized content;
+- first/last artifact block ordinal and locators;
+- slice ordinal and total count;
+- document schema/normalizer fingerprint;
+- completeness/diagnostics needed by orchestration.
+
+Write failing tests for a synthetic artifact containing headings, an empty
+paragraph, repeated paragraphs, a table, a Unicode paragraph, and a single
+oversized block. Assert concatenation reconstructs normalized text exactly,
+all offsets lie on UTF-8 boundaries, every block occurrence is covered once,
+and repeated text remains distinct by ordinal/locator.
+
+**Verify**: semantic tests fail only because document-preparation behavior is
+not implemented.
+
+### Step 2: Decode before packing and slice by normalized content
+
+Introduce an explicit preparation phase before the current request packer:
+
+1. read each file once with existing bounded readers;
+2. decode rich documents to `DocumentArtifact` once;
+3. derive normalized semantic text plus block-boundary indexes;
+4. calculate request size from that normalized content;
+5. emit gap-free slices under `FILE_CHAR_CAP`/request limits.
+
+Replace or wrap `expand_oversized_semantic_files`; callers must no longer use
+compressed/raw byte length as the rich-document text estimate. Retain the
+existing plain-text fast path if it produces the same unit contract. No unit
+may truncate at 20,000 characters. A hard size/parse error remains incomplete
+and must not be cached as success.
+
+**Verify**: add a synthetic rich document over 20,000 characters with unique
+sentinels near the beginning, middle, and end. Provider-fixture requests must
+contain every sentinel exactly once across ordered units.
+
+### Step 3: Make retries bisect document slices
+
+Route oversized-provider responses through the same checked `bisect_slice`
+policy used for text. Bisect only within the failed prepared unit; preserve its
+parent source, locator range, schema fingerprint, and deterministic left/right
+order. Stop at the existing minimum size and surface an explicit partial
+result if the provider still rejects it.
+
+Cache only a fully completed set for the document normalizer/prompt namespace.
+Partial retry results may contribute to the current response under existing
+policy but must remain marked partial and must not masquerade as a finalized
+document cache.
+
+**Verify**: a fake provider that rejects above N characters causes a single
+document unit to bisect deterministically and eventually covers every sentinel;
+a provider that always rejects returns one bounded failure without a loop.
+
+### Step 4: Publish deterministic structure even with semantic coverage
+
+In `compass-core/src/pipeline.rs`, remove the exclusion that prevents normal
+language extraction for paths in `semantic_documents`. Keep semantic refresh
+selection logic, but always run a registered deterministic extractor for the
+same file. Add a regression test using Markdown: with semantic mode enabled,
+the graph must contain the document/heading/link structure and semantic
+concepts/relationships.
+
+This step must not double-count a source file in discovery statistics or
+create two canonical file resources. Make the canonical relative path the
+join key; do not use display labels.
+
+**Verify**: core tests assert one source resource, structural headings present,
+semantic nodes present, and stable output across two identical builds.
+
+### Step 5: Replace suffix-based twin merging with evidence-based fusion
+
+Refactor `doc_twin_remap` in `compass-graph`. A semantic document root may map
+to a structural document root only when all of these are true:
+
+- canonical relative source identity is equal;
+- provenance identifies one node as semantic and one as deterministic
+  structure;
+- the candidate is unique in both directions;
+- document schema/normalizer evidence is compatible.
+
+Do not use `_doc`, labels, text similarity, or first-candidate selection.
+Ambiguous candidates remain separate and emit/preserve existing unresolved
+evidence instead of an invented merge. Preserve semantic provider provenance
+on remapped nodes/edges and all structural source anchors.
+
+Add tests for unique mapping, two structural candidates, two semantic
+candidates, same label/different path, and same path/different realization.
+
+**Verify**: graph tests exit 0 and `rg '_doc' crates/compass-graph/src/lib.rs`
+returns no match associated with document-twin selection.
+
+### Step 6: Document compatibility and run gates
+
+Update document-processing design with prepared units, completeness, retries,
+and fusion. Add a changelog entry for removal of rich-document truncation and
+simultaneous structural/semantic evidence. Update `COMPATIBILITY.md` if node or
+cache realization behavior changes; add `MIGRATION.md` only if users must act.
+
+Run all commands in the table, `sh scripts/check_product_boundary.sh`, and
+`git diff --check`.
+
+## Test plan
+
+- Gap-free slicing over empty, repeated, Unicode, table, and oversized blocks.
+- Rich-document source above 20,000 characters reaches provider fixtures in
+  full and in deterministic order.
+- Adaptive retry bisects and terminates under both eventual-success and
+  permanent-failure fixtures.
+- Semantic Markdown graph retains structural headings/links and concepts.
+- Evidence-based twin mapping covers uniqueness and ambiguity negatives.
+- Incremental/cached rebuild yields the same realized graph as a cold build.
+
+## Done criteria
+
+- [ ] Rich documents are decoded before request-size planning.
+- [ ] No fixed 20,000-character truncation remains in semantic reading.
+- [ ] Ordered slices reconstruct normalized content exactly.
+- [ ] Retry and cache completeness operate at document-slice granularity.
+- [ ] Deterministic structure and semantic evidence coexist for one source.
+- [ ] Twin fusion uses explicit source/provenance evidence, never suffixes.
+- [ ] All targeted tests, qualification, lint, format, boundary, and diff checks pass.
+- [ ] Plan 008 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- plan 007's artifact cannot reconstruct normalized semantic text without
+  losing separators or occurrence identity;
+- fusion requires selecting among ambiguous source candidates;
+- eliminating suppression changes public stable IDs without an approved
+  compatibility/migration decision;
+- provider request schemas would need an unversioned breaking change;
+- an in-scope user change cannot be preserved;
+- any verification would write Cargo artifacts to local `target/`.
+
+## Maintenance notes
+
+Every future decoder receives slicing/retry/fusion automatically by producing
+a valid artifact; do not add format-specific semantic readers. Reviewers should
+scrutinize gap coverage, cache completion, and identity proof rather than only
+checking concept counts.

--- a/advisor-plans/009-structural-markdown-html.md
+++ b/advisor-plans/009-structural-markdown-html.md
@@ -1,0 +1,264 @@
+# Plan 009: Make Markdown and HTML first-class structural documents
+
+> **Executor instructions**: Follow this plan in order. Run each verification
+> command and confirm the stated outcome. Stop rather than improvising when a
+> STOP condition occurs. Mark the row in `advisor-plans/README.md` `DONE` after
+> completion unless a reviewer maintains the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-languages crates/compass-media crates/compass-ingest crates/compass-files crates/compass-core vendor/compass-tree-sitter-language-pack docs CHANGELOG.md COMPATIBILITY.md`
+> Plans 007 and 008 must be complete. The original working tree had user edits
+> in Markdown/cache/pipeline files; preserve them and stop on an overlap that
+> cannot be reconciled.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L
+- **Risk**: MED
+- **Depends on**: `advisor-plans/007-versioned-document-artifact.md`, `advisor-plans/008-lossless-document-fusion.md`
+- **Category**: direction
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+Markdown is currently recognized with line-oriented regular expressions, HTML
+is flattened with tag-stripping regular expressions during URL ingestion, and
+semantic-backed Markdown loses its native structure. This misses Setext
+headings, nested blocks, reference links, section-local link provenance,
+frontmatter, and most HTML semantics. The static parser pack already vendors
+Markdown, Markdown-inline, and HTML grammars, so Compass can produce deeper
+local graphs without runtime downloads or model dependence.
+
+## Current state
+
+- `crates/compass-languages/src/markdown.rs` extracts headings/links using
+  regular expressions and opens the Markdown path itself.
+- `crates/compass-languages/src/engine.rs:84-103` already has bounded source
+  bytes/text before dispatch, so the Markdown path can read the same file twice.
+- `crates/compass-files/src/hash.rs:197-237` strips Markdown frontmatter for
+  hashing even though frontmatter can affect document meaning and semantic
+  prompts.
+- `crates/compass-ingest/src/lib.rs:525-529` implements `html_to_markdown` by
+  removing `script`, `style`, and all remaining tags with regexes.
+- `crates/compass-files/src/detect.rs` classifies `md`, `mdx`, `qmd`, `html`,
+  and other text/document extensions.
+- `vendor/compass-tree-sitter-language-pack` statically contains the pinned
+  Markdown, Markdown-inline, and HTML grammars. Do not edit vendored code and
+  do not add runtime grammar fetching.
+- `serde_yaml_ng` is already a workspace dependency and is used by
+  `crates/compass-languages/src/package_manifest.rs`; use its bounded parsing
+  pattern rather than adding another YAML parser.
+- Plans 007–008 provide `DocumentArtifact`, exact text locators, deterministic
+  structural projection, and structural/semantic coexistence.
+
+## Required semantics
+
+- Markdown and local HTML use exact byte/line locators into the original bytes.
+- A link belongs to its smallest containing section/block; a file-root link is
+  used only when no containing block exists.
+- A fragment resolves to a heading only when the slug or explicit ID is unique.
+  Duplicate headings remain ambiguous; never select the first occurrence.
+- YAML frontmatter is metadata, not visible body text. Only JSON-compatible
+  scalars and bounded scalar arrays are published. Unsupported YAML values
+  produce a diagnostic, not arbitrary nested graph attributes.
+- HTML excludes `script`, `style`, `template`, and `noscript` content, decodes
+  entities, preserves visible structural order, and never executes/fetches a
+  resource discovered in markup.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Languages | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-languages --locked` | exit 0 |
+| Markdown coverage | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-languages --test markdown_coverage --locked` | exit 0 |
+| Media | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-media --locked` | exit 0 |
+| Ingest | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-ingest --locked` | exit 0 |
+| Core | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-core --locked` | exit 0 |
+| Qualification | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_code_graph_v1.sh --fixtures-only` | exit 0 |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-languages -p compass-media -p compass-ingest -p compass-core --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-languages/src/markdown.rs`
+- `crates/compass-languages/src/html.rs` (create)
+- `crates/compass-languages/src/engine.rs`, `lib.rs`, registry wiring/tests
+- `crates/compass-languages/Cargo.toml`
+- `crates/compass-media/src/document.rs` and a focused HTML normalization
+  module if shared normalization belongs in media
+- `crates/compass-media/Cargo.toml`
+- `crates/compass-ingest/src/lib.rs`, `Cargo.toml`, and tests
+- `crates/compass-files/src/hash.rs` and hash/cache tests
+- focused fixtures/tests in the affected crates
+- `docs/design/document-processing.md`, `docs/reference/`, `docs/README.md`
+- `COMPATIBILITY.md`, `CHANGELOG.md`
+
+**Out of scope**:
+
+- Editing `vendor/` or downloading grammars at runtime.
+- Network fetching from links, images, stylesheets, frames, or base URLs.
+- Full MDX/JSX execution; opaque JSX must remain bounded source evidence.
+- Treating frontmatter as trusted configuration or secrets.
+- Office/RTF work from plans 010–011.
+
+## Git workflow
+
+- Suggested branch: `advisor/009-structural-markdown-html`
+- Commit parser wiring/tests, Markdown, HTML/shared ingest, then cache/docs.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Change extraction to source-driven parser APIs
+
+Before editing, read `crates/compass-languages/src/lib.rs`, `Cargo.toml`,
+`engine.rs`, `markdown.rs`, registry tests, and
+`docs/design/language-architecture.md`. Change Markdown extraction to accept
+the already-loaded source and source-file facts supplied by the engine. Remove
+the extractor's direct filesystem read. Add a test runner or counter fixture
+showing one source read per Markdown file.
+
+Wire the existing statically linked Markdown, Markdown-inline, and HTML parser
+factories through the language pack's normal ownership boundary. Do not create
+direct raw FFI or a second parser registry.
+
+**Verify**: language tests exit 0 and `rg 'read_to_string|File::open' crates/compass-languages/src/markdown.rs`
+returns no matches.
+
+### Step 2: Parse bounded Markdown frontmatter into artifact metadata
+
+Recognize frontmatter only when the source begins with a whole-line `---` and
+has a whole-line closing `---` within 64 KiB. Parse with `serde_yaml_ng`, reject
+aliases/tags or values outside JSON-compatible scalar/scalar-array policy, cap
+published keys at 256, cap individual strings at the document field limit, and
+preserve deterministic key order.
+
+Publish approved general metadata without application behavior: `title`,
+`tags`, `type`, `source_url`, `status`, and `date`. Preserve other valid scalar
+keys in the artifact metadata map if the plan-007 contract permits it, but do
+not make them control execution. Add diagnostics for invalid/unclosed/oversized
+frontmatter and continue parsing the body only when bounds permit.
+
+Change Markdown cache hashing to include raw frontmatter because metadata now
+changes graph output. Remove body-only hashing for Markdown or introduce an
+explicit, versioned graph hash that includes metadata. Invalidate old entries;
+do not probe both meanings under one key.
+
+**Verify**: tests show a title/tag-only edit changes the graph/cache hash, body
+offsets remain exact, and malformed YAML is bounded and diagnosed.
+
+### Step 3: Replace line regexes with Markdown syntax evidence
+
+Walk the Markdown and inline trees to emit ordered artifact blocks/facts for:
+
+- ATX and Setext headings with hierarchy;
+- paragraphs, nested lists/items, tasks, block quotes, thematic breaks;
+- fenced/indented code with language/info string;
+- pipe tables, rows, and cells;
+- inline links/images, reference definitions/usages, autolinks, footnotes;
+- Quarto/MDX constructs as explicit bounded `Other` blocks when the grammar
+  recognizes them but Compass does not assign deeper meaning.
+
+Preserve occurrence, exact byte ranges, heading levels, and parent section.
+Slug headings deterministically using one documented algorithm. Build a
+multimap from slug/explicit ID to heading ordinals; resolve only unique targets.
+Retain unresolved/ambiguous evidence instead of inventing an edge target.
+
+Keep the existing public graph vocabulary where it is expressive enough. If a
+new node/edge kind is unavoidable, stop for schema/compatibility review rather
+than publishing an undocumented string.
+
+**Verify**: expand `markdown_coverage` with nested, duplicate-heading,
+reference-link, footnote, table, code-fence, Unicode, malformed, and CRLF cases.
+Assert identities, relationship direction, multiplicity, ranges, provenance,
+and deterministic order.
+
+### Step 4: Add structural HTML normalization and extraction
+
+Create a shared HTML-to-`DocumentArtifact` decoder using the pinned HTML
+grammar. In document order, support:
+
+- document title, headings, `main`/`article`/`section`/`nav` landmarks;
+- paragraphs, lists/items, block quotes, `pre`/`code`, tables/rows/cells;
+- anchors with resolved entity text, `id`, `href`, optional `rel`;
+- bounded `<meta name|property content>` values and canonical/base URL as
+  metadata/link evidence;
+- visible text with HTML entity decoding and whitespace normalization that
+  does not merge separate blocks.
+
+Skip script/style/template/noscript subtrees entirely. Treat malformed markup
+according to parser recovery while recording a diagnostic when content is
+incomplete. Resolve relative URLs against a validated source/base URL string,
+but never fetch them.
+
+Add an HTML language adapter that projects the artifact structurally. Change
+URL ingestion to call the same deterministic renderer instead of private
+`html_to_markdown` regexes. Preserve the current ingestion return contract.
+
+**Verify**: ingest and language tests prove scripts/styles are absent, entities
+decode once, nested structure remains ordered, links use containing sections,
+malformed HTML is deterministic, and no fixture fetch occurs beyond the
+original requested page.
+
+### Step 5: Verify structural and semantic coexistence
+
+Add core integration fixtures for the same Markdown and HTML documents with
+semantic mode off and with a fake semantic provider. Both modes must retain
+identical deterministic document/block/link subgraphs. Semantic mode adds
+provider concepts/edges without replacing, duplicating, or changing stable
+structural identities.
+
+Run the normalizer twice and under a relocated temporary root; graph records
+must be byte-identical and contain no absolute paths.
+
+**Verify**: core tests and fixture-only qualification exit 0.
+
+### Step 6: Publish the supported-feature contract
+
+Update document-processing design and create/update a document-format reference
+matrix covering shipped Markdown and HTML constructs, unsupported constructs,
+locator guarantees, frontmatter policy, and local/network boundary. Add
+compatibility and changelog notes for the new graph facts and cache cut.
+
+Run every command in the table, product-boundary check, and `git diff --check`.
+
+## Test plan
+
+- Markdown parser coverage for every construct and ambiguity listed above.
+- Frontmatter bounds, YAML types, hash invalidation, and secret-safe diagnostics.
+- HTML structural/order/entity/script/link/base/malformed cases.
+- URL-ingestion parity through shared normalization.
+- Cold/cached, semantic/non-semantic, and relocated-root graph determinism.
+
+## Done criteria
+
+- [ ] Markdown and HTML extraction use pinned syntax trees and already-read bytes.
+- [ ] Frontmatter changes invalidate graph/semantic cache inputs.
+- [ ] Links carry containing-block provenance and ambiguous fragments remain unresolved.
+- [ ] HTML ingestion no longer relies on regex tag stripping.
+- [ ] Structural graphs survive semantic enrichment unchanged.
+- [ ] Docs state exactly what is and is not supported.
+- [ ] All targeted tests, lint, format, qualification, boundary, and diff checks pass.
+- [ ] Plan 009 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- the language pack does not expose the pinned Markdown/inline/HTML grammars;
+- implementation would require editing vendored parser sources or runtime
+  grammar downloads;
+- a proposed graph kind is not covered by a versioned public contract;
+- exact Markdown/HTML byte ranges cannot be preserved after normalization;
+- cache invalidation would reuse an old key for new frontmatter semantics;
+- an in-scope user edit cannot be preserved.
+
+## Maintenance notes
+
+Parser recovery is evidence, not permission to invent hierarchy. Add grammar
+corpus fixtures before extending syntax mapping. Keep HTML normalization shared
+between local files and fetched content so security, semantics, and cache
+behavior cannot drift.

--- a/advisor-plans/010-native-ooxml-documents.md
+++ b/advisor-plans/010-native-ooxml-documents.md
@@ -1,0 +1,242 @@
+# Plan 010: Preserve OOXML order and add native PPTX document graphs
+
+> **Executor instructions**: Read this entire plan before editing. Execute each
+> step and verification in order. Stop on a listed condition; do not substitute
+> a subprocess converter. Update `advisor-plans/README.md` when complete unless
+> a reviewer owns status updates.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-media crates/compass-files crates/compass-semantic crates/compass-core fixtures docs CHANGELOG.md COMPATIBILITY.md Cargo.toml Cargo.lock`
+> Plans 006–008 must be complete. Reconcile pre-existing user edits carefully.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L
+- **Risk**: HIGH
+- **Depends on**: `advisor-plans/006-harden-media-ingestion.md`, `advisor-plans/007-versioned-document-artifact.md`, `advisor-plans/008-lossless-document-fusion.md`
+- **Category**: direction
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+The current DOCX decoder collects paragraphs and tables in separate passes, so
+it changes source order; XLSX expands sparse coordinates into rows of strings;
+and PPTX is not classified as a semantic document. OOXML already contains rich
+ordering, hierarchy, relationships, notes, and stable logical locations. A
+bounded native decoder can preserve that evidence locally and deterministically
+without LibreOffice, Python, credentials, or a model.
+
+## Current state
+
+- `crates/compass-media/src/lib.rs:74-112` reads DOCX paragraphs and tables
+  separately and concatenates them, losing interleaving.
+- The same file parses XLSX shared strings/sheets into Markdown-like rows;
+  plan 006 adds coordinate/cell/text bounds.
+- `crates/compass-files/src/detect.rs` lists `docx` and `xlsx` in semantic text
+  extensions but not `pptx`.
+- Current archive validation caps raw, archive, member, and compression-ratio
+  sizes. Retain all limits and the explicit rejection policy.
+- Plans 007–008 provide ordered artifact blocks, package locators, diagnostics,
+  lossless semantic slices, and graph fusion.
+- OOXML relationship targets are untrusted. Internal parts must remain within
+  the package; external targets are link evidence only and must never be read.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Media | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-media --locked` | exit 0 |
+| Files | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-files --locked` | exit 0 |
+| Semantic | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-semantic --locked` | exit 0 |
+| Core | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-core --locked` | exit 0 |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-media -p compass-files -p compass-semantic -p compass-core --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Boundary | `sh scripts/check_product_boundary.sh` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-media/src/lib.rs`
+- `crates/compass-media/src/ooxml/mod.rs` (create)
+- `crates/compass-media/src/ooxml/package.rs` (create)
+- `crates/compass-media/src/ooxml/docx.rs` (create)
+- `crates/compass-media/src/ooxml/xlsx.rs` (create)
+- `crates/compass-media/src/ooxml/pptx.rs` (create)
+- `crates/compass-media/tests/ooxml_contract.rs` and bounded XML/ZIP fixtures
+- `crates/compass-media/Cargo.toml`, root dependency files only if required
+- `crates/compass-files/src/detect.rs` and tests
+- focused semantic/core integration tests
+- document-processing design/reference docs, `COMPATIBILITY.md`, `CHANGELOG.md`
+
+**Out of scope**:
+
+- Legacy binary `.doc`, `.xls`, or `.ppt`.
+- Macros, embedded OLE objects, ActiveX, media transcription, or image OCR.
+- Executing formulas, macros, field code, external relationships, or links.
+- Pixel-perfect slide rendering or presentation visual layout reconstruction.
+- LibreOffice/Pandoc subprocesses, Python packages, or Graphify dependencies.
+- Editing existing binary fixtures with opaque GUI-generated noise; prefer
+  reviewable XML parts assembled into ZIPs by Rust test helpers.
+
+## Git workflow
+
+- Suggested branch: `advisor/010-native-ooxml-documents`
+- Commit common package reader, DOCX, XLSX, PPTX, then integration/docs.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Build one bounded OPC package reader
+
+Before editing, read `compass-media`'s `src/lib.rs`, `Cargo.toml`, and tests.
+Move common ZIP/OOXML behavior into `ooxml/package.rs` without weakening plan
+006 limits. The reader must:
+
+- validate central-directory counts, member sizes, aggregate expansion, and
+  compression ratios before allocating output;
+- reject duplicate normalized member names;
+- normalize `/`, `.`, and percent-independent package components and reject
+  absolute or parent-escaping targets;
+- parse `[Content_Types].xml` and `.rels` with bounded XML events/depth/text;
+- distinguish `TargetMode="External"` and return it as inert link evidence;
+- read any package part at most once per decoder, with a deterministic cache;
+- reject missing required parts explicitly and diagnose optional missing parts.
+
+Add hostile tests for duplicates, `../` targets, absolute targets, oversized
+XML depth/event counts, external relationships, and ZIP amplification.
+
+**Verify**: media tests exit 0; no decoder accesses ZIP members directly except
+through the package reader.
+
+### Step 2: Rebuild DOCX in body order
+
+Walk `word/document.xml` body children in document order. Emit:
+
+- paragraphs with preserved run text, tabs, explicit line/page breaks, and
+  significant whitespace;
+- headings from paragraph styles/outline levels;
+- nested list/item evidence from `numbering.xml` without inventing sequence
+  values when definitions are missing;
+- tables at their exact interleaved position, with rows/cells and merged-cell
+  metadata;
+- hyperlinks resolved through relationships as inert internal/external links;
+- footnotes, endnotes, comments, headers, and footers as separate located
+  blocks when present and supported;
+- diagnostics plus `complete=false` for bounded unsupported content.
+
+Use package-part plus paragraph/table/run occurrence locators. Escape Markdown
+only in the compatibility renderer. Do not expose raw relationship IDs as
+stable user identity.
+
+**Verify**: a fixture `paragraph → table → paragraph` produces that exact block
+order; repeated equal paragraphs remain separate; pipes/backslashes survive IR
+round-trip and render escaped.
+
+### Step 3: Rebuild XLSX as a sparse, typed sheet artifact
+
+Preserve workbook sheet order and actual row/cell coordinates without resizing
+to attacker-declared widths. Parse bounded shared strings, inline strings,
+booleans, errors, ISO dates where explicitly typed, cached formula values, and
+formula text as separate evidence. Never execute a formula.
+
+Represent sheets, rows, and non-empty cells with `Spreadsheet` locators.
+Preserve merged ranges, hyperlinks, and named tables when valid. Missing shared
+string indexes, invalid ranges, and unsupported cell types produce typed
+diagnostics or errors according to whether extraction can remain coherent.
+Keep plan 006's column/row/cell/text ceilings.
+
+**Verify**: sparse `A1` and `XFD100000` do not allocate intermediate cells;
+formula/error/inline/shared values remain distinguishable; sheet order and
+serialization are deterministic.
+
+### Step 4: Add native PPTX decoding
+
+Detect `.pptx` as a supported semantic/document extension. Parse
+`ppt/presentation.xml` and relationships to determine slide order; never infer
+order from filenames. For each slide, walk shape tree order and emit:
+
+- slide block and optional title;
+- text shapes with paragraph/list hierarchy;
+- tables with rows/cells;
+- shape name, placeholder role, and alt text as bounded metadata;
+- internal/external hyperlinks;
+- speaker notes linked to the owning slide;
+- diagnostics for charts, SmartArt, equations, animations, or media that are
+  present but not structurally decoded.
+
+Use slide number plus shape/tree occurrence logical locators. Do not claim
+pixel geometry or reading order beyond XML/tree/placeholder evidence; if
+multiple plausible visual orders exist, preserve tree order and diagnose the
+limitation.
+
+**Verify**: a three-slide fixture with non-lexical relationship targets follows
+presentation order, includes notes and a table, skips an embedded object
+safely, and reaches semantic fixture requests through plan 008 slices.
+
+### Step 5: Integrate graph projection, cache version, and compatibility
+
+Route all three formats through the plan-007 artifact and plan-008 structural
+plus semantic flow. Increment `DOCUMENT_NORMALIZER_VERSION`, making old
+semantic caches miss. Add cold/cached/reordered-ZIP-member tests: identical
+logical packages with different ZIP member order/time metadata must publish
+identical graphs and cache fingerprints based on source bytes plus normalizer
+contract as documented.
+
+If raw source-byte digest intentionally changes for byte-different equivalent
+packages, graph output must still be identical; do not claim cache equivalence
+unless canonical package hashing is separately designed and tested.
+
+**Verify**: media/files/semantic/core tests exit 0; graph records contain no
+absolute paths or ZIP metadata timestamps.
+
+### Step 6: Document exact support and run gates
+
+Update the format matrix with supported/partial/unsupported constructs for
+DOCX, XLSX, and PPTX; locator guarantees; formulas/macros/external-link safety;
+and no-rendering/OCR boundary. Add changelog and compatibility notes. Add a
+migration note only if a user-facing option or schema requires action.
+
+Run every command in the table and `git diff --check`.
+
+## Test plan
+
+- OPC containment, duplicate, external relationship, XML and ZIP limit tests.
+- DOCX body order, headings/lists/tables/links/notes/repeated text/escaping.
+- XLSX sparse extremes, typed values, formulas, merged ranges, invalid indexes.
+- PPTX relationship-defined slide order, shapes, tables, notes, links, alt text,
+  unsupported objects, and semantic slicing.
+- Determinism across ZIP member ordering, repeated runs, and relocated roots.
+- Malformed and over-limit packages never become empty successful documents.
+
+## Done criteria
+
+- [ ] All OOXML access goes through one bounded, containment-safe reader.
+- [ ] DOCX block order matches document body order.
+- [ ] XLSX remains sparse and never executes formulas.
+- [ ] PPTX is natively detected, structurally extracted, and semantically sliced.
+- [ ] External links/objects remain inert evidence.
+- [ ] Normalizer/cache version and documentation are updated.
+- [ ] Targeted tests, lint, format, boundary, and diff checks pass.
+- [ ] Plan 010 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- plans 006–008 are incomplete;
+- OOXML parsing would require an unbounded DOM or unchecked archive read;
+- a proposed decoder needs to execute fields, formulas, macros, or objects;
+- PPTX visual reading order would be presented as exact without evidence;
+- a new dependency introduces runtime binaries, unsafe code in Compass, or
+  network access and no bounded native alternative has been reviewed;
+- public stable IDs must change without compatibility approval;
+- an in-scope user edit cannot be preserved.
+
+## Maintenance notes
+
+Treat OOXML as an untrusted relationship graph, not merely a ZIP of XML.
+Future chart/image/OCR support should add explicit evidence types and limits;
+it must not overload text blocks or silently turn unsupported content into
+complete extraction.

--- a/advisor-plans/011-bounded-native-rtf.md
+++ b/advisor-plans/011-bounded-native-rtf.md
@@ -1,0 +1,248 @@
+# Plan 011: Add a bounded native RTF decoder with explicit fidelity diagnostics
+
+> **Executor instructions**: Follow every step and verification in order. Do
+> not replace the native decoder with a system application or subprocess. Stop
+> and report when a STOP condition applies. On completion, update the plan row
+> in `advisor-plans/README.md` unless a reviewer owns the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-media crates/compass-files crates/compass-semantic crates/compass-core docs CHANGELOG.md COMPATIBILITY.md Cargo.toml Cargo.lock`
+> Plans 007 and 008 must be complete. Preserve all pre-existing user changes.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L
+- **Risk**: HIGH
+- **Depends on**: `advisor-plans/007-versioned-document-artifact.md`, `advisor-plans/008-lossless-document-fusion.md`
+- **Category**: direction, security
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+RTF is common in legal, medical, government, and legacy knowledge collections,
+but its group state, destinations, binary escapes, code pages, and embedded
+objects make regex extraction unsafe and incorrect. Compass can support useful
+text, hierarchy, tables, fields, and provenance with a small streaming state
+machine, provided it caps every attacker-controlled count and openly marks
+unsupported fidelity. This expands local-first coverage without LibreOffice,
+Word automation, Python, or network services.
+
+## Current state
+
+- `.rtf` is not a supported decoder in `compass-media` and is not in the
+  semantic document extension list in `crates/compass-files/src/detect.rs`.
+- Plan 007 defines `DocumentArtifact`, logical/exact locators, diagnostics,
+  completeness, and shared limits. Plan 008 makes every artifact sliceable and
+  fuses deterministic structure with optional semantic evidence.
+- Compass forbids unbounded work and requires a limit error to remain distinct
+  from an empty result. Inputs and diagnostic text are untrusted.
+- Root `Cargo.toml` does not currently advertise an RTF subsystem. Prefer a
+  focused internal parser; add an encoding dependency only after license,
+  unsafe/transitive, and workspace policy review.
+
+## Supported subset and safety contract
+
+Support these constructs in the first release:
+
+- groups, escaped braces/backslashes, control symbols, and control words;
+- ANSI text and `\'hh` escapes under declared/common Windows code pages;
+- signed UTF-16 `\uN` values with checked `\ucN` fallback skipping, including
+  surrogate-pair handling;
+- paragraphs/line breaks/tabs, basic heading styles, lists, and simple tables;
+- `HYPERLINK` fields as inert link evidence;
+- bounded document metadata from the `info` destination;
+- exact raw-byte ranges for tokens/blocks when they are provable.
+
+Skip these destinations safely and mark `complete=false` when content-bearing:
+font/color/style tables after extracting needed decoding/style facts, pictures,
+objects, data stores, files, themes, XML, drawing payloads, and unknown starred
+destinations. Never execute, decompress, open, or emit embedded payload bytes.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Media | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-media --locked` | exit 0 |
+| Files | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-files --locked` | exit 0 |
+| Semantic | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-semantic --locked` | exit 0 |
+| Core | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-core --locked` | exit 0 |
+| Dependency policy | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo tree -p compass-media --locked` | exit 0; review only intended dependency changes |
+| Lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy -p compass-media -p compass-files -p compass-semantic -p compass-core --all-targets --all-features --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Boundary | `sh scripts/check_product_boundary.sh` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `crates/compass-media/src/rtf.rs` (create)
+- `crates/compass-media/src/lib.rs`, document/limits modules
+- `crates/compass-media/tests/rtf_contract.rs` and reviewable text fixtures
+- `crates/compass-media/Cargo.toml`, `Cargo.toml`, `Cargo.lock` only if a vetted
+  text-encoding dependency is required
+- `crates/compass-files/src/detect.rs` and tests
+- focused semantic/core integration tests
+- `docs/design/document-processing.md`, document-format reference,
+  `docs/design/security-and-privacy.md`, `COMPATIBILITY.md`, `CHANGELOG.md`
+
+**Out of scope**:
+
+- Legacy Word `.doc`, Windows COM/Word automation, LibreOffice, or Pandoc.
+- Rendering layout, fonts, colors, images, equations, OLE, or drawing objects.
+- Executing RTF fields or opening file/network references.
+- Lossy “best effort” that returns `complete=true` after skipped content.
+- A general-purpose public RTF library; keep the parser owned by media needs.
+
+## Git workflow
+
+- Suggested branch: `advisor/011-bounded-native-rtf`
+- Commit lexer/state/limits, text decoding, blocks/fields, integration/docs.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Lock limits and hostile grammar cases before parsing
+
+Define named ceilings in the shared limits module, starting with:
+
+- group nesting depth: 256;
+- total tokens/control words: 1,000,000;
+- control-word length: 64 ASCII letters;
+- numeric parameter digits: 12 with checked signed conversion;
+- destinations: 100,000;
+- output text: the shared `OFFICE_MAX_TEXT_CHARS` or plan-007 equivalent;
+- `\binN` skip length: remaining input and raw document size, checked before
+  advancing;
+- metadata fields/links/blocks: shared artifact limits.
+
+Write failing tests for excessive nesting, unmatched braces, huge numeric
+parameters, negative/overflow `\bin`, truncated hex escapes, token flood,
+output amplification, malicious object/picture payloads, and exact-limit
+success. Tests must assert typed `Rejected`/`Parse` errors, never panic/OOM.
+
+**Verify**: media tests fail for missing RTF implementation, not malformed test
+fixtures.
+
+### Step 2: Implement a streaming lexer and group-state stack
+
+Parse bounded bytes in one forward pass with an explicit state stack. Each
+group state tracks destination, ignorable flag, Unicode fallback count,
+encoding/code page, paragraph/style state, and pending field context. Use
+checked arithmetic for every index/length and consume at least one byte per
+loop iteration.
+
+Recognize literal text, `{`, `}`, escaped literal symbols, control symbols,
+control words with optional signed parameters/delimiters, hex escapes, and
+`\binN`. `\binN` bytes must be skipped without tokenizing or copying. Unknown
+control words are ignored per RTF semantics; unknown starred destinations are
+skipped as a group and diagnosed when content-bearing.
+
+Never store an entire skipped destination or an unbounded token stream. Keep
+only bounded state plus normalized output/artifact builders.
+
+**Verify**: lexer tests cover byte progress, nested state restore, starred
+destinations, binary data containing braces/backslashes, and all limits.
+
+### Step 3: Decode Unicode and code pages deterministically
+
+Implement `\uN` as signed 16-bit code units, honoring the current bounded
+`\ucN` fallback count. Combine valid surrogate pairs; emit U+FFFD plus a stable
+diagnostic for unpaired values. Decode `\'hh` and literal high bytes under the
+declared `\ansicpgN`/known charset. Support at minimum ASCII/UTF-8-safe input
+and Windows-1252; unsupported code pages must use a documented deterministic
+replacement policy with `complete=false`, never the host locale.
+
+If a new encoding crate is proposed, inspect its license, default features,
+unsafe/transitive footprint, and no-network behavior. Add it at the root as a
+workspace dependency. Do not write a large ad hoc code-page table silently.
+
+**Verify**: tests cover ASCII, Windows-1252 punctuation, hex escapes, Unicode
+fallback bytes, surrogate pairs, unpaired surrogates, unsupported code page,
+and identical results under different process locales.
+
+### Step 4: Emit ordered blocks, tables, fields, and diagnostics
+
+Map paragraph boundaries and explicit line/tab controls into ordered artifact
+blocks while preserving exact token byte ranges. Support heading evidence from
+recognized styles/outline controls only when the style definition is proven.
+Represent list paragraphs and simple `\trowd`/`\cell`/`\row` tables without
+inventing missing cells or nesting.
+
+Parse `FIELD` instruction/result destinations only enough to recognize a
+strictly bounded, quoted/unquoted `HYPERLINK` target. Emit an inert link from the
+containing block. Other fields retain visible result text and a diagnostic;
+they are never executed. Extract bounded `title`, `subject`, `author`,
+`keywords`, and creation/modification timestamps from `info` as metadata,
+without trusting them as configuration.
+
+Set `complete=false` for skipped content-bearing destinations, unsupported
+encodings/styles, or recoverable malformed structures. A broken group stack,
+limit breach, or incoherent byte stream remains a hard error.
+
+**Verify**: fixtures cover paragraphs, headings, nested lists, a simple table,
+hyperlinks, field result text, metadata, skipped picture/object, and malformed
+but recoverable input. Assert ordering, occurrences, byte ranges, link source,
+diagnostics, and completeness.
+
+### Step 5: Integrate detection, semantic slicing, graph projection, and cache
+
+Add `.rtf` detection only after the decoder and negative tests pass. Route RTF
+through `decode_document`, plan-008 slicing/retry, and the shared deterministic
+projector. Increment `DOCUMENT_NORMALIZER_VERSION` so old caches miss.
+
+Add an integration fixture above one semantic request cap. Fake-provider input
+must contain first/middle/last sentinels exactly once across slices. With
+semantic mode enabled, the graph must retain RTF blocks/links and add semantic
+evidence without replacing structure.
+
+**Verify**: files, semantic, and core tests exit 0; malformed RTF is incomplete
+or an explicit error and never a successful empty document.
+
+### Step 6: Publish the fidelity and security boundary
+
+Update format-reference and security docs with the supported subset, exact
+limits, `complete` policy, code-page behavior, embedded-object policy, and no
+layout fidelity claim. Add changelog/compatibility notes. Do not market RTF as
+fully supported while unsupported content yields diagnostics.
+
+Run all commands in the table and `git diff --check`.
+
+## Test plan
+
+- Lexer progress, grammar, state restoration, malformed groups, and every limit.
+- Unicode/code-page/fallback/locale independence.
+- Ordered paragraph/list/table/field/link/metadata artifacts.
+- Embedded destinations remain inert and bounded.
+- Semantic lossless slicing and structural-plus-semantic graph integration.
+- Repeated and relocated-root runs serialize identically.
+
+## Done criteria
+
+- [ ] RTF parsing is native, single-pass/bounded, and locale-independent.
+- [ ] Unicode fallback, code pages, binary skips, and group restoration are tested.
+- [ ] Embedded objects/fields never execute or cause external reads.
+- [ ] Unsupported fidelity is represented by diagnostics and `complete=false`.
+- [ ] Detection, graph projection, semantic slicing, and cache version are wired.
+- [ ] Targeted tests, dependency review, lint, format, boundary, and diff checks pass.
+- [ ] Plan 011 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- plans 007–008 are incomplete;
+- required fidelity depends on executing Word/LibreOffice or embedded fields;
+- the parser cannot guarantee forward progress or bounded stack/token/output;
+- a dependency adds runtime network/process requirements or violates license/
+  unsafe policy without explicit approval;
+- skipped content would need to be reported as `complete=true`;
+- stable graph identity changes without compatibility approval;
+- an in-scope user change cannot be preserved.
+
+## Maintenance notes
+
+RTF's permissive grammar invites accidental scope growth. Add a malicious and
+normal fixture for every newly recognized destination/control word, document
+whether it affects completeness, and keep binary/media handling outside the
+text decoder until an explicit bounded media design exists.

--- a/advisor-plans/012-document-qualification-gate.md
+++ b/advisor-plans/012-document-qualification-gate.md
@@ -1,0 +1,281 @@
+# Plan 012: Qualify document graphs across formats, limits, and determinism
+
+> **Executor instructions**: This plan turns completed decoder work into a
+> release claim. Follow the steps and run every command. Do not weaken expected
+> fixtures to make a failure pass. Stop and report on a STOP condition. Update
+> `advisor-plans/README.md` after completion unless a reviewer owns the index.
+>
+> **Drift check (run first)**:
+> `git diff --stat 743a170..HEAD -- crates/compass-media crates/compass-languages crates/compass-semantic crates/compass-core tests fixtures scripts docs PERFORMANCE.md CHANGELOG.md COMPATIBILITY.md .github/workflows/compass-ci.yml Makefile`
+> Plans 009, 010, and 011 must be complete. Reconcile the live support matrix
+> with this plan before adding qualification expectations.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: `advisor-plans/009-structural-markdown-html.md`, `advisor-plans/010-native-ooxml-documents.md`, `advisor-plans/011-bounded-native-rtf.md`
+- **Category**: tests, perf, docs
+- **Planned at**: commit `743a170`, 2026-08-01
+
+## Why this matters
+
+Format checkboxes do not establish a better knowledge-graph product. Compass
+needs repeatable evidence that document graphs preserve hierarchy, links,
+tables, order, provenance, completeness, and bounded failure across cold,
+cached, relocated, and semantic builds. This plan creates a Compass-owned
+qualification corpus and release gate; it does not depend on Graphify, private
+documents, model credentials, or network access.
+
+## Current state
+
+- `./scripts/qualify_code_graph_v1.sh --fixtures-only` is the closest existing
+  fixture qualification pattern. Read it and its expected artifacts before
+  adding a document-specific gate.
+- Root `AGENTS.md` requires regression tests at the lowest owner plus a public
+  contract test, deterministic fixtures, bounded failures, and performance
+  evidence before performance claims.
+- Plans 009–011 should leave a format matrix in docs and native fixtures in
+  their owning crates. This plan promotes a minimal cross-format subset to a
+  stable qualification corpus.
+- The local Graphify checkout observed during planning used regex Markdown and
+  optional Python Office libraries. That is audit context only. Do not invoke
+  it, copy its fixtures, or add it to CI/product boundaries.
+
+## Qualification contract
+
+For every shipped format, qualification must assert:
+
+1. deterministic document/block identity and order;
+2. heading/list/table containment and multiplicity where supported;
+3. link direction, containing-block source, target/unresolved state;
+4. exact text locators or honest format-specific logical locators;
+5. provenance and completeness/diagnostics;
+6. structural-only and structural-plus-semantic coexistence;
+7. cold, warm-cache, repeated, and relocated-root equivalence;
+8. malformed/limit inputs fail explicitly and leave no coherent-looking
+   partial artifact set;
+9. machine output contains no absolute path, credential, or private source.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Document qualification | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_document_graph_v1.sh --fixtures-only` | exit 0; all format cases pass |
+| Code qualification | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_code_graph_v1.sh --fixtures-only` | exit 0 |
+| Product contract | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test -p compass-cli --test compass_product --locked` | exit 0 |
+| Workspace tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test --workspace --lib --bins --locked` | exit 0 |
+| Workspace lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy --workspace --lib --bins --locked -- -D warnings` | exit 0 |
+| Format | `cargo fmt --all -- --check` | exit 0 |
+| Boundary | `sh scripts/check_product_boundary.sh` | exit 0 |
+
+The first command does not exist before this plan. Build it in step 3. If the
+external volume is unavailable, stop and do not use a local Cargo target.
+
+## Scope
+
+**In scope**:
+
+- `tests/qualification/documents/` or the repository's live qualification
+  fixture location after inspecting the code-graph exemplar
+- focused native fixture builders under affected crate tests when ZIP/package
+  assembly is required
+- `scripts/qualify_document_graph_v1.sh` (create)
+- `scripts/check_document_support.py` only if the repository's support-matrix
+  checks are already Python-based; this is a developer gate, never runtime
+- `Makefile` and `.github/workflows/compass-ci.yml` for one named CI target
+- `docs/reference/document-formats.md` (or the live format matrix)
+- `docs/implementation/document-qualification.md` (create)
+- `docs/README.md`, `PERFORMANCE.md`, `COMPATIBILITY.md`, `CHANGELOG.md`
+- minimal focused test harness changes in media/languages/semantic/core/CLI
+
+**Out of scope**:
+
+- Adding new decoder behavior to make a qualification case pass; route a bug
+  back to plans 009–011 or a focused follow-up.
+- Private/customer documents, real model calls, credentials, or network tests.
+- Runtime dependence on Python, Graphify, LibreOffice, Pandoc, or office apps.
+- Benchmark claims against another product without a reproducible, approved,
+  license-safe methodology and equivalent configuration.
+- Storing opaque generated graph outputs too large for human review.
+
+## Git workflow
+
+- Suggested branch: `advisor/012-document-qualification-gate`
+- Commit corpus/contracts, runner, CI/docs/performance evidence separately.
+- Do not push or open a PR unless instructed.
+
+## Steps
+
+### Step 1: Freeze a reviewable cross-format corpus manifest
+
+Create a versioned machine-readable manifest, for example
+`tests/qualification/documents/v1/cases.json`, with one or more cases for:
+
+- Markdown: frontmatter, duplicate headings, nested list, table, reference and
+  relative/fragment links, Unicode;
+- HTML: title/metadata, sections, table, entities, relative links, skipped
+  script/style, malformed recovery;
+- DOCX: interleaved paragraph/table/list/link/note;
+- XLSX: multiple sheets, sparse cells, typed values/formula evidence, merge/link;
+- PPTX: relationship-defined slide order, shapes/table/link/notes/alt text;
+- RTF: code page/Unicode, headings/list/table/link/metadata, skipped object;
+- current PDF behavior, with page locators and honest structural limitations;
+- negative/limit cases for every decoder family.
+
+Each manifest entry must declare source fixture path, format, expected
+completeness, expected diagnostic codes, minimum/exact block and edge facts,
+locator kind, and modes to run. Do not embed timestamps, absolute paths, or
+provider-generated free text.
+
+Keep text/XML fixture sources reviewable. Assemble OOXML ZIPs deterministically
+inside Rust tests or a checked repository helper; normalize ZIP timestamps and
+member order. If binary PDF bytes are necessary, document their creation and
+license in an adjacent README.
+
+**Verify**: a manifest-validation test rejects duplicate IDs, missing fixtures,
+unknown schema major, unsupported formats/statuses, and absolute paths.
+
+### Step 2: Add one typed assertion harness
+
+Build a Rust integration harness at the lowest shared layer that reads the
+manifest, constructs/loads fixtures, runs normalizers and graph publication,
+and asserts typed graph records—not rendered prose. For each case assert:
+
+- ordered block kinds/parents/locators and stable IDs;
+- exact selected attributes and link/edge evidence;
+- diagnostic codes and completeness;
+- no unknown major versions or absolute paths;
+- identical normalized graph JSON after stable sorting on two runs and under a
+  different temporary workspace root;
+- hard negative cases return the declared typed error and publish nothing.
+
+Use a deterministic fake semantic provider for semantic mode. It must return
+fixed typed fragments keyed by case/unit ID, assert all sentinels were supplied,
+and never contact a network. Compare the structural subgraph against the
+structural-only run before checking added semantic facts.
+
+**Verify**: the focused integration test exits 0 and reports case IDs on any
+failure. Deliberately perturb one expected fact locally to confirm the harness
+fails, then restore it without committing the perturbation.
+
+### Step 3: Create the fixture-only qualification command
+
+Model `scripts/qualify_document_graph_v1.sh` after the code-graph qualification
+script's argument parsing, temp-directory safety, output bounding, and cleanup.
+It must:
+
+- accept `--fixtures-only` and reject unknown flags;
+- require `CARGO_TARGET_DIR` to be an absolute path outside the Compass checkout
+  rather than silently choosing a local target; local executions under this
+  repository must use `/Volumes/Workspace/crabbuild-target/compass-main`, while
+  CI may use a checkout-specific directory under its runner temp volume;
+- run manifest validation and the typed cross-format test;
+- run product-boundary checks relevant to documents;
+- emit a concise per-format pass/fail summary and return nonzero on any skip,
+  missing expected format, partial publication, or test failure;
+- create temporary output with `mktemp -d` and remove only its own directory.
+
+Do not make the script download tools or fixtures. Add a Make target only if it
+matches existing naming, such as `qualify-document-graph-v1`.
+
+**Verify**: the new command exits 0; an unknown flag exits nonzero; unsetting
+`CARGO_TARGET_DIR` exits nonzero before Cargo runs; a target path contained by
+the checkout also exits nonzero; `sh -n` exits 0.
+
+### Step 4: Gate support claims and CI on the corpus
+
+Add a small checker that compares the documented format matrix's machine-readable
+support statuses with manifest coverage. A format may be called `supported`
+only when at least one positive, one malformed/limit, determinism, locator, and
+structural-plus-semantic case passes. Use `partial` for intentionally incomplete
+construct coverage and list the diagnostic behavior.
+
+Wire the fixture-only command into the existing CI workflow near code-graph
+qualification. It must not require secrets, external checkouts, network access,
+or platform-specific office software. Reuse the checkout-specific external
+Cargo target convention in CI where applicable.
+
+**Verify**: the support checker exits 0; changing one documented format to an
+unsupported claim/status mismatch makes it fail; workflow syntax remains valid
+under the repository's existing CI validation.
+
+### Step 5: Establish performance and boundedness baselines
+
+Add a reproducible local benchmark corpus with small/medium/limit-adjacent cases
+and record, per format:
+
+- source and expanded bytes;
+- blocks/links/normalized characters;
+- cold decode, warm decode/cache, structural publication, and semantic-packing
+  time (fake provider only);
+- maximum configured allocations/counts, not an unportable guessed RSS value;
+- toolchain, hardware, command, and run count.
+
+Run enough iterations to report median and variability. Put measured results
+and the exact date/commit in `PERFORMANCE.md`. Do not add a hard wall-clock CI
+threshold from one developer machine. CI should enforce count/limit invariants
+and optionally a broad regression ceiling only after baseline evidence on its
+runner is stable.
+
+**Verify**: the documented command reproduces a machine-readable result; all
+limit-adjacent cases remain below configured counts and terminate successfully
+or with their declared limit error.
+
+### Step 6: Publish the release contract and run the full baseline
+
+Write `docs/implementation/document-qualification.md` explaining corpus
+ownership, adding a case, regenerating deterministic packages, interpreting
+completeness, and running the gate. Link it and the format matrix from
+`docs/README.md`. Update compatibility and changelog entries without claiming
+unqualified parity or superiority.
+
+Run every command in the table, the document support checker, any documented
+workflow validation, and `git diff --check`. Inspect `git status --short` for
+generated graphs, local `.compass/`, output directories, or credentials; none
+may be committed.
+
+## Test plan
+
+- Manifest schema/duplicate/path/coverage validation.
+- Positive and hostile cases for Markdown, HTML, PDF, DOCX, XLSX, PPTX, RTF.
+- Typed structural, link, locator, provenance, diagnostic, completeness facts.
+- Cold/warm/relocated/repeated determinism.
+- Structural versus fake-semantic enrichment equivalence.
+- Script flag/target-directory/failure/cleanup behavior.
+- Support-matrix drift and bounded benchmark corpus.
+
+## Done criteria
+
+- [ ] Every shipped document-format claim has manifest-backed positive and
+  negative evidence.
+- [ ] The qualification gate is local, deterministic, bounded, and credential-free.
+- [ ] Structural facts are invariant when fake semantic enrichment is enabled.
+- [ ] Relocated/cached/repeated runs produce equivalent graph contracts.
+- [ ] CI and documentation support claims use the same versioned corpus.
+- [ ] Performance claims cite reproducible measurements and configured limits.
+- [ ] Full baseline, lint, format, product boundary, and diff checks pass.
+- [ ] Plan 012 is marked `DONE` in `advisor-plans/README.md`.
+
+## STOP conditions
+
+Stop and report if:
+
+- any prerequisite format plan is incomplete or its support matrix is unclear;
+- qualification requires real credentials, network, private documents, or an
+  external product checkout;
+- a test can pass by comparing only counts/prose instead of typed evidence;
+- deterministic fixtures cannot be reproduced from reviewable sources;
+- a decoder bug or schema change is needed—open a focused prerequisite instead
+  of hiding it in qualification;
+- performance results are too noisy to support a published claim;
+- CI would build into the repository's local `target/` directory;
+- pre-existing user changes cannot be preserved.
+
+## Maintenance notes
+
+The corpus is a product contract, not a snapshot dumping ground. Every format
+change must add the smallest reviewable fixture proving the new behavior and a
+negative/boundary case. Keep competitor comparisons outside the required gate;
+Compass should win on reproducible evidence, not an imported runtime oracle.

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -1,6 +1,6 @@
 # Compass enhancement advisor plans
 
-Generated from a deep comparison on 2026-07-23.
+Generated from deep product/code audits on 2026-07-23 and 2026-08-01.
 
 Upstream snapshots:
 
@@ -13,6 +13,13 @@ Graphify `origin/main` is a divergent v1 product line, not a newer commit on
 the frozen v8 oracle's ancestry. Read
 [`000-origin-main-audit.md`](000-origin-main-audit.md) before executing a plan.
 
+Plans 006–012 are a second, self-contained sequence for native document and
+text processing. They were planned against Compass commit `743a170` and a
+read-only local inspection of Graphify v0.9.26 at `66d8110`. That comparison is
+context only: the plans prohibit Graphify runtime, fixture, test, or fallback
+dependencies. Each executor should read the selected plan in full; no audit or
+conversation context is required beyond the plan file.
+
 ## Execution order and status
 
 | Plan | Title | Priority | Effort | Depends on | Status |
@@ -22,6 +29,13 @@ the frozen v8 oracle's ancestry. Read
 | 003 | Return structured provenance from path and discovery queries | P1 | M | 001 | TODO |
 | 004 | Publish current outputs as one observable generation | P1 | L | 001 | TODO |
 | 005 | Gate pull requests and releases on production qualification | P1 | M | 001 | TODO |
+| 006 | Make media ingestion fail explicitly and remain memory-bounded | P1 | M | — | TODO |
+| 007 | Introduce a versioned, provenance-preserving document artifact | P1 | L | 006 | TODO |
+| 008 | Chunk rich documents losslessly and fuse structural with semantic evidence | P1 | L | 007 | TODO |
+| 009 | Make Markdown and HTML first-class structural documents | P1 | L | 007, 008 | TODO |
+| 010 | Preserve OOXML order and add native PPTX document graphs | P2 | L | 006, 007, 008 | TODO |
+| 011 | Add a bounded native RTF decoder with explicit fidelity diagnostics | P2 | L | 007, 008 | TODO |
+| 012 | Qualify document graphs across formats, limits, and determinism | P1 | M | 009, 010, 011 | TODO |
 
 Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
 
@@ -34,6 +48,18 @@ Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
 - Plans 003 and 004 are independent after plan 001.
 - Plan 005 should consume the manifest and evidence targets introduced by plan
   001 rather than introducing another compatibility configuration.
+- Plan 006 closes correctness and denial-of-service gaps before expanding the
+  media surface.
+- Plan 007 establishes the one typed document contract, locator vocabulary,
+  completeness policy, and cache version used by every later format.
+- Plan 008 makes that artifact losslessly sliceable and allows deterministic
+  structure to coexist with optional provider semantics.
+- Plans 009, 010, and 011 can proceed independently after their listed shared
+  prerequisites. They own Markdown/HTML, OOXML/PPTX, and RTF respectively.
+- Plan 012 runs last because it converts the actual shipped support of all
+  three format plans into one stable qualification and documentation gate.
+- Plan 012 complements plan 005 rather than depending on it: plan 005 owns the
+  broad production release gate; plan 012 owns document-specific evidence.
 
 ## Direction options not promoted to implementation plans
 
@@ -51,6 +77,14 @@ Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
   stability, latency, and memory measurements.
 - **Linux and Windows release artifacts:** clear distribution gap; deferred
   only to keep this first plan set at five items.
+- **Image OCR and slide-layout understanding:** valuable for scanned PDFs and
+  diagram-heavy decks, but require a separate bounded media/provenance design;
+  these plans deliberately cover native text and package evidence first.
+- **Legacy binary Office formats (`.doc`, `.xls`, `.ppt`):** require a safe
+  parser/conversion boundary distinct from OOXML and are not implied by plan
+  010.
+- **ODT/ODS/ODP and EPUB:** architecturally fit the document artifact after the
+  core formats are qualified, but have their own package and semantic rules.
 
 ## Findings considered and rejected
 
@@ -68,3 +102,16 @@ Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
   rejected because focused Compass tests pass and the native implementation
   already handles custom hook paths, safe managed blocks, background refresh,
   history, and external SCIP changes.
+- Add Pandoc, LibreOffice, Word automation, or Python document libraries as a
+  normal runtime fallback: rejected because it violates Compass's native,
+  local-first, bounded, portable product boundary and weakens deterministic
+  failure semantics.
+- Keep flattening every document to one Markdown string: rejected because it
+  discards order, hierarchy, locators, diagnostics, completeness, and stable
+  block-level provenance needed for higher-quality graph construction.
+- Suppress structural parsing whenever semantic extraction runs: rejected
+  because deterministic evidence and provider-derived concepts answer different
+  questions and should coexist under a proven source identity.
+- Make Graphify a CI oracle for document support: rejected because qualification
+  must be Compass-owned, offline, deterministic, and independent of another
+  product's changing implementation and optional dependencies.


### PR DESCRIPTION
## Summary

- add seven self-contained implementation plans for native document and text processing
- sequence bounded ingestion, a versioned document IR, lossless semantic slicing and evidence fusion, Markdown/HTML, OOXML/PPTX, RTF, and qualification
- update the advisor-plan index with priorities, dependencies, deferred areas, and rejected approaches

## Why

Compass currently flattens rich documents too early, loses structural and provenance evidence, and has format-specific correctness and boundedness gaps. These plans provide executable handoffs for improving the framework while preserving Compass's deterministic, native, local-first product boundary.

## Impact

This is documentation-only. It does not change runtime behavior. Each plan defines exact scope, compatibility constraints, implementation steps, regression tests, verification commands, done criteria, and stop conditions.

## Validation

- `git diff --check origin/main..agent/document-processing-plans`
- verified plans 006–012 are present in `advisor-plans/README.md`
- verified every plan contains status, context, commands, scope, steps, tests, done criteria, stop conditions, and maintenance notes
- no Cargo tests run because this PR changes planning documentation only

## Scope safety

The branch was constructed directly from `origin/main` and contains only `advisor-plans/README.md` and plans 006–012. Unrelated changes in the original working tree were not staged or included.
