### PR TITLE
fix(query): restore typed source locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-
 - Reduce immutable history build overhead with stage-level artifact-load
   instrumentation, verified single-pass graph and Program loading, concurrent
   graph/Program reads, and an in-process typed-artifact handoff for native
@@ -21,6 +20,8 @@
   `graph` and `community_detail` capabilities, accelerate immutable large-graph
   snapshots with copy-on-write filesystem clones when available, and remove
   repeated linear node lookups from graph interactions.
+- Restore source ranges and named communities in natural-language query output
+  when reading typed `compass.graph/1` nodes and relationships.
 
 ## 0.2.0 - 2026-08-01
 

--- a/crates/compass-cli/tests/code_query_cli.rs
+++ b/crates/compass-cli/tests/code_query_cli.rs
@@ -166,3 +166,27 @@ fn natural_query_reads_legacy_only_when_the_generation_pointer_is_absent()
     );
     Ok(())
 }
+
+#[test]
+fn natural_query_renders_typed_source_locations() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph = support::write_typed_graph(directory.path())?;
+
+    let outcome = run(
+        Frontend::Compass,
+        [
+            OsString::from("query"),
+            OsString::from("Target"),
+            OsString::from("--graph"),
+            graph.into_os_string(),
+        ],
+    );
+
+    assert_eq!(outcome.code, 0, "{}", outcome.stderr);
+    assert!(
+        outcome
+            .stdout
+            .contains("NODE Target [src=src/lib.rs loc=L1:0-L1:4")
+    );
+    Ok(())
+}

--- a/crates/compass-model/src/document.rs
+++ b/crates/compass-model/src/document.rs
@@ -37,6 +37,18 @@ impl NodeRecord {
                     .and_then(|source| source.get("file"))
                     .and_then(Value::as_str)
                     .map(str::to_owned),
+                "source_location" => self
+                    .attributes
+                    .get("source")
+                    .and_then(Value::as_object)
+                    .and_then(source_anchor_location),
+                "community_name" => self
+                    .attributes
+                    .get("community")
+                    .and_then(Value::as_object)
+                    .and_then(|community| community.get("label"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
                 "symbol_kind" | "type" | "node_type" => self
                     .attributes
                     .get("kind")
@@ -151,6 +163,11 @@ impl EdgeRecord {
                     .and_then(|site| site.get("file"))
                     .and_then(Value::as_str)
                     .map(str::to_owned),
+                "source_location" => self
+                    .attributes
+                    .get("relationshipSite")
+                    .and_then(Value::as_object)
+                    .and_then(source_anchor_location),
                 "_origin" => evidence_field(&self.attributes, "origin").map(str::to_owned),
                 "confidence" => evidence_field(&self.attributes, "confidence").map(|confidence| {
                     match confidence {
@@ -237,6 +254,21 @@ impl EdgeRecord {
                 .map(|(key, value)| (key.as_str(), value.clone())),
         )
     }
+}
+
+fn source_anchor_location(anchor: &Map<String, Value>) -> Option<String> {
+    let start_line = anchor.get("startLine")?.as_u64()?;
+    let exact_range = anchor
+        .get("startColumn")
+        .and_then(Value::as_u64)
+        .zip(anchor.get("endLine").and_then(Value::as_u64))
+        .zip(anchor.get("endColumn").and_then(Value::as_u64));
+    Some(exact_range.map_or_else(
+        || format!("L{start_line}"),
+        |((start_column, end_line), end_column)| {
+            format!("L{start_line}:{start_column}-L{end_line}:{end_column}")
+        },
+    ))
 }
 
 fn evidence_field<'a>(attributes: &'a Map<String, Value>, field: &str) -> Option<&'a str> {
@@ -663,6 +695,45 @@ mod tests {
             serde_json::from_str(r#"{"multigraph":false,"nodes":[{"id":"a"}],"links":[]}"#)
                 .unwrap_or_else(|_| std::process::abort());
         assert!(!document.multigraph);
+    }
+
+    #[test]
+    fn typed_records_project_compatibility_source_locations()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let document: GraphDocument = serde_json::from_str(
+            r#"{
+                "nodes": [{
+                    "id": "a",
+                    "name": "source",
+                    "source": {
+                        "file": "src/lib.rs",
+                        "startLine": 2,
+                        "startColumn": 3,
+                        "endLine": 4,
+                        "endColumn": 5
+                    },
+                    "community": {"id": 7, "label": "Core"}
+                }, {"id": "b", "name": "target"}],
+                "links": [{
+                    "id": "edge",
+                    "source": "a",
+                    "target": "b",
+                    "kind": "calls",
+                    "relationshipSite": {
+                        "file": "src/lib.rs",
+                        "startLine": 8,
+                        "startColumn": 9,
+                        "endLine": 8,
+                        "endColumn": 15
+                    }
+                }]
+            }"#,
+        )?;
+
+        assert_eq!(document.nodes[0].string("source_location"), "L2:3-L4:5");
+        assert_eq!(document.nodes[0].string("community_name"), "Core");
+        assert_eq!(document.links[0].string("source_location"), "L8:9-L8:15");
+        Ok(())
     }
 
     #[test]

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -82,6 +82,48 @@ mod tests {
     }
 
     #[test]
+    fn natural_query_projects_typed_source_location_and_community() -> Result<(), Box<dyn Error>> {
+        let graph = load(
+            r#"{
+                "directed": true, "multigraph": true, "graph": {},
+                "nodes": [{
+                    "id": "method",
+                    "kind": "method",
+                    "name": ".process_delayed_slices()",
+                    "qualifiedName": "crate::RedisMetaStore::process_delayed_slices",
+                    "source": {
+                        "file": "src/meta/stores/redis/mod.rs",
+                        "startByte": 100,
+                        "endByte": 122,
+                        "startLine": 3086,
+                        "startColumn": 13,
+                        "endLine": 3086,
+                        "endColumn": 35
+                    },
+                    "community": {"id": 4, "label": "RedisMetaStore"}
+                }],
+                "links": []
+            }"#,
+        )?;
+
+        let output = query_graph_text(
+            &graph,
+            "process_delayed_slices",
+            TraversalMode::Bfs,
+            2,
+            2000,
+            &[],
+            &HashMap::new(),
+        );
+
+        assert!(output.contains(
+            "NODE .process_delayed_slices() [src=src/meta/stores/redis/mod.rs \
+             loc=L3086:13-L3086:35 community=RedisMetaStore]"
+        ));
+        Ok(())
+    }
+
+    #[test]
     fn omitted_multigraph_preserves_parallel_edge_hub_semantics() -> Result<(), Box<dyn Error>> {
         let links = std::iter::once(serde_json::json!({
             "source": "seed",


### PR DESCRIPTION
## Summary

- project typed `source` anchors into natural-language query `source_location` output
- project typed community labels instead of rendering the raw community object
- preserve typed relationship-site locations through the compatibility reader
- add model, query, and CLI regression coverage

## Root cause

The `compass.graph/1` artifact retained the complete source anchor, but the legacy-compatible `GraphDocument` reader only projected `source.file`. Natural-language query rendering asked that reader for `source_location`, so typed nodes produced a blank `loc=` even though the line and column range remained in `graph.json`.

## Impact

Existing graph generations and query caches remain valid. After upgrading the binary, natural-language queries recover source ranges and named communities without another `compass update`.

## Validation

- reproduced against the existing brewfs graph and confirmed `loc=L3086:13-L3086:35`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo clippy -p compass-model -p compass-query -p compass-cli --all-targets --all-features --locked -- -D warnings`
- `cargo test -p compass-cli --test code_query_cli --locked`
- `sh scripts/check_product_boundary.sh`
