### PR TITLE
Improve natural query and explain source parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@
   repeated linear node lookups from graph interactions.
 - Restore source ranges and named communities in natural-language query output
   when reading typed `compass.graph/1` nodes and relationships.
+- Prefer source-backed declarations over unresolved call placeholders in
+  natural-language queries, show placeholder wiring and relationship sites,
+  and make `explain` report ambiguous labels before accepting an exact node ID.
 
 ## 0.2.0 - 2026-08-01
 

--- a/crates/compass-cli/tests/code_query_cli.rs
+++ b/crates/compass-cli/tests/code_query_cli.rs
@@ -190,3 +190,53 @@ fn natural_query_renders_typed_source_locations() -> Result<(), Box<dyn Error>> 
     );
     Ok(())
 }
+
+#[test]
+fn explain_requires_an_exact_id_for_ambiguous_typed_nodes() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph = directory.path().join("graph.json");
+    let first = format!("sha256:{}", "a".repeat(64));
+    let second = format!("sha256:{}", "b".repeat(64));
+    std::fs::write(
+        &graph,
+        format!(
+            r#"{{
+                "directed": true, "multigraph": true, "nodes": [
+                    {{"id":"{first}","kind":"method","name":".run()","source":{{"file":"src/a.rs","startLine":3,"startColumn":1,"endLine":3,"endColumn":6}}}},
+                    {{"id":"{second}","kind":"method","name":".run()","source":{{"file":"src/b.rs","startLine":7,"startColumn":1,"endLine":7,"endColumn":6}}}}
+                ], "links": []
+            }}"#
+        ),
+    )?;
+
+    let ambiguous = run(
+        Frontend::Compass,
+        [
+            OsString::from("explain"),
+            OsString::from("run"),
+            OsString::from("--graph"),
+            graph.clone().into_os_string(),
+        ],
+    );
+    assert_eq!(ambiguous.code, 0, "{}", ambiguous.stderr);
+    assert!(
+        ambiguous
+            .stdout
+            .contains("Ambiguous: 'run' matches 2 source-backed nodes.")
+    );
+    assert!(ambiguous.stdout.contains("Retry with the full node ID."));
+
+    let exact = run(
+        Frontend::Compass,
+        [
+            OsString::from("explain"),
+            OsString::from(&second),
+            OsString::from("--graph"),
+            graph.into_os_string(),
+        ],
+    );
+    assert_eq!(exact.code, 0, "{}", exact.stderr);
+    assert!(exact.stdout.contains("Source:    src/b.rs L7:1-L7:6"));
+    assert!(exact.stdout.contains("Type:      code"));
+    Ok(())
+}

--- a/crates/compass-model/src/document.rs
+++ b/crates/compass-model/src/document.rs
@@ -49,6 +49,13 @@ impl NodeRecord {
                     .and_then(|community| community.get("label"))
                     .and_then(Value::as_str)
                     .map(str::to_owned),
+                "wiring_file" => evidence_anchor(&self.attributes, "wiringSite")
+                    .and_then(|site| site.get("file"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+                "wiring_location" => {
+                    evidence_anchor(&self.attributes, "wiringSite").and_then(source_anchor_location)
+                }
                 "symbol_kind" | "type" | "node_type" => self
                     .attributes
                     .get("kind")
@@ -269,6 +276,20 @@ fn source_anchor_location(anchor: &Map<String, Value>) -> Option<String> {
             format!("L{start_line}:{start_column}-L{end_line}:{end_column}")
         },
     ))
+}
+
+fn evidence_anchor<'a>(
+    attributes: &'a Map<String, Value>,
+    field: &str,
+) -> Option<&'a Map<String, Value>> {
+    attributes
+        .get("evidence")
+        .and_then(Value::as_array)
+        .and_then(|evidence| {
+            evidence
+                .iter()
+                .find_map(|entry| entry.as_object()?.get(field)?.as_object())
+        })
 }
 
 fn evidence_field<'a>(attributes: &'a Map<String, Value>, field: &str) -> Option<&'a str> {
@@ -704,6 +725,7 @@ mod tests {
             r#"{
                 "nodes": [{
                     "id": "a",
+                    "kind": "method",
                     "name": "source",
                     "source": {
                         "file": "src/lib.rs",
@@ -713,7 +735,23 @@ mod tests {
                         "endColumn": 5
                     },
                     "community": {"id": 7, "label": "Core"}
-                }, {"id": "b", "name": "target"}],
+                }, {
+                    "id": "b",
+                    "kind": "function",
+                    "name": "target",
+                    "evidence": [{
+                        "origin": "heuristic",
+                        "extractor": "compass.graph.external-placeholder",
+                        "confidence": "inferred",
+                        "wiringSite": {
+                            "file": "src/caller.rs",
+                            "startLine": 11,
+                            "startColumn": 7,
+                            "endLine": 11,
+                            "endColumn": 13
+                        }
+                    }]
+                }],
                 "links": [{
                     "id": "edge",
                     "source": "a",
@@ -732,6 +770,8 @@ mod tests {
 
         assert_eq!(document.nodes[0].string("source_location"), "L2:3-L4:5");
         assert_eq!(document.nodes[0].string("community_name"), "Core");
+        assert_eq!(document.nodes[1].string("wiring_file"), "src/caller.rs");
+        assert_eq!(document.nodes[1].string("wiring_location"), "L11:7-L11:13");
         assert_eq!(document.links[0].string("source_location"), "L8:9-L8:15");
         Ok(())
     }

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -124,6 +124,115 @@ mod tests {
     }
 
     #[test]
+    fn natural_query_prefers_declarations_and_renders_relationship_sites()
+    -> Result<(), Box<dyn Error>> {
+        let graph = load(
+            r#"{
+                "directed": true, "multigraph": true, "graph": {},
+                "nodes": [{
+                    "id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "kind": "method",
+                    "name": ".process_delayed_slices()",
+                    "source": {
+                        "file": "src/store.rs", "startLine": 20, "startColumn": 4,
+                        "endLine": 20, "endColumn": 28
+                    }
+                }, {
+                    "id": "placeholder",
+                    "kind": "function",
+                    "name": "process_delayed_slices",
+                    "evidence": [{
+                        "origin": "heuristic",
+                        "extractor": "compass.graph.external-placeholder",
+                        "confidence": "inferred",
+                        "wiringSite": {
+                            "file": "tests/workflow.rs", "startLine": 96, "startColumn": 8,
+                            "endLine": 96, "endColumn": 30
+                        }
+                    }]
+                }],
+                "links": [{
+                    "id": "edge", "source": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "target": "placeholder", "kind": "calls",
+                    "relationshipSite": {
+                        "file": "src/store.rs", "startLine": 25, "startColumn": 8,
+                        "endLine": 25, "endColumn": 32
+                    },
+                    "evidence": [{"origin": "ast", "extractor": "test", "confidence": "exact"}]
+                }]
+            }"#,
+        )?;
+
+        let output = query_graph_text(
+            &graph,
+            "process_delayed_slices",
+            TraversalMode::Bfs,
+            2,
+            2000,
+            &[],
+            &HashMap::new(),
+        );
+
+        assert!(output.contains("Start: ['.process_delayed_slices()']"));
+        assert!(!output.contains("Start: ['.process_delayed_slices()', 'process_delayed_slices']"));
+        assert!(output.contains("wiring=src/store.rs:L25:8-L25:32"));
+        assert!(output.contains("at=src/store.rs:L25:8-L25:32"));
+        Ok(())
+    }
+
+    #[test]
+    fn explanation_reports_ambiguity_and_exact_ids_preserve_locations() -> Result<(), Box<dyn Error>>
+    {
+        let first = format!("sha256:{}", "a".repeat(64));
+        let second = format!("sha256:{}", "b".repeat(64));
+        let graph = load(&format!(
+            r#"{{
+                "directed": true, "multigraph": true, "graph": {{}},
+                "nodes": [{{
+                    "id": "{first}", "kind": "method", "name": ".process_delayed_slices()",
+                    "source": {{"file": "src/database.rs", "startLine": 10, "startColumn": 4,
+                        "endLine": 10, "endColumn": 28}}
+                }}, {{
+                    "id": "{second}", "kind": "method", "name": ".process_delayed_slices()",
+                    "source": {{"file": "src/tikv.rs", "startLine": 20, "startColumn": 4,
+                        "endLine": 20, "endColumn": 28}}
+                }}, {{
+                    "id": "placeholder", "kind": "function", "name": "process_delayed_slices",
+                    "evidence": [{{"origin": "heuristic", "extractor": "compass.graph.external-placeholder",
+                        "confidence": "inferred", "wiringSite": {{"file": "tests/workflow.rs",
+                        "startLine": 96, "startColumn": 8, "endLine": 96, "endColumn": 30}}}}]
+                }}],
+                "links": [{{
+                    "id": "edge", "source": "{second}", "target": "placeholder", "kind": "calls",
+                    "relationshipSite": {{"file": "src/tikv.rs", "startLine": 24, "startColumn": 8,
+                        "endLine": 24, "endColumn": 30}},
+                    "evidence": [{{"origin": "ast", "extractor": "test", "confidence": "exact"}}]
+                }}]
+            }}"#
+        ))?;
+
+        let ambiguous = render_explanation(&graph, "process_delayed_slices", &HashMap::new());
+        assert!(
+            ambiguous
+                .contains("Ambiguous: 'process_delayed_slices' matches 2 source-backed nodes.")
+        );
+        assert!(ambiguous.contains("src/database.rs L10:4-L10:28"));
+        assert!(ambiguous.contains("src/tikv.rs L20:4-L20:28"));
+        assert!(!ambiguous.contains("tests/workflow.rs"));
+
+        let exact = render_explanation(&graph, &second, &HashMap::new());
+        assert!(exact.contains(&format!("ID:        {second}")));
+        assert!(exact.contains("Source:    src/tikv.rs L20:4-L20:28"));
+        assert!(exact.contains("Type:      code"));
+        assert!(
+            exact.contains(
+                "--> process_delayed_slices [calls] [EXTRACTED] src/tikv.rs:L24:8-L24:30"
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
     fn omitted_multigraph_preserves_parallel_edge_hub_semantics() -> Result<(), Box<dyn Error>> {
         let links = std::iter::once(serde_json::json!({
             "source": "seed",

--- a/crates/compass-query/src/score.rs
+++ b/crates/compass-query/src/score.rs
@@ -64,7 +64,9 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
 
     let mut ranked = Vec::new();
     let mut best: HashMap<String, BestSeed> = HashMap::new();
+    let mut tie_breakers = HashMap::new();
     for (node_index, node) in graph.nodes() {
+        let tie_breaker = SeedTieBreaker::new(graph, node_index, node);
         let norm_label = normalized_label(node);
         let bare_label = norm_label.trim_end_matches(['(', ')']);
         let label_tokens = search_tokens(&node.string("label")).join(" ");
@@ -118,8 +120,7 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
                 if singleton > 0.0 {
                     let candidate = BestSeed {
                         score: singleton,
-                        degree: graph.degree(node_index),
-                        label_len: node.label().chars().count(),
+                        tie_breaker,
                         id: node.id.clone(),
                         node: node_index,
                     };
@@ -135,6 +136,7 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
         let coverage = matched as f64 / term_count as f64;
         score += tiered * coverage.powi(2);
         if score > 0.0 {
+            tie_breakers.insert(node_index, tie_breaker);
             ranked.push(ScoredNode {
                 score,
                 node: node_index,
@@ -142,26 +144,20 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
         }
     }
     ranked.sort_by(|left, right| {
+        let left_tie = tie_breakers[&left.node];
+        let right_tie = tie_breakers[&right.node];
         right
             .score
             .total_cmp(&left.score)
+            .then_with(|| right_tie.source_backed.cmp(&left_tie.source_backed))
+            .then_with(|| right_tie.semantic_rank.cmp(&left_tie.semantic_rank))
+            .then_with(|| left_tie.test_or_generated.cmp(&right_tie.test_or_generated))
             .then_with(|| {
-                semantic_seed_rank(graph.node(right.node))
-                    .cmp(&semantic_seed_rank(graph.node(left.node)))
+                right_tie
+                    .source_backed_degree
+                    .cmp(&left_tie.source_backed_degree)
             })
-            .then_with(|| {
-                source_is_test_or_generated(graph.node(left.node))
-                    .cmp(&source_is_test_or_generated(graph.node(right.node)))
-            })
-            .then_with(|| graph.degree(right.node).cmp(&graph.degree(left.node)))
-            .then_with(|| {
-                graph
-                    .node(left.node)
-                    .label()
-                    .chars()
-                    .count()
-                    .cmp(&graph.node(right.node).label().chars().count())
-            })
+            .then_with(|| left_tie.label_len.cmp(&right_tie.label_len))
             .then_with(|| graph.node(left.node).id.cmp(&graph.node(right.node).id))
     });
     QueryScores {
@@ -231,7 +227,7 @@ pub fn pick_seeds(
             break;
         }
         let node = graph.node(candidate.node);
-        let key = normalized_label(node);
+        let key = seed_label_key(node);
         let key = if key.is_empty() { node.id.clone() } else { key };
         if labels.insert(key) {
             seeds.push(candidate.node);
@@ -242,7 +238,7 @@ pub fn pick_seeds(
     for term in terms {
         let node = scores.best_seed_by_term[term];
         let record = graph.node(node);
-        let key = normalized_label(record);
+        let key = seed_label_key(record);
         let key = if key.is_empty() {
             record.id.clone()
         } else {
@@ -257,6 +253,9 @@ pub fn pick_seeds(
 
 #[must_use]
 pub fn find_node(graph: &Graph, label: &str) -> Vec<NodeIndex> {
+    if let Some(index) = graph.node_index(label.trim()) {
+        return vec![index];
+    }
     let term = search_tokens(label).join(" ");
     if term.is_empty() {
         return Vec::new();
@@ -323,6 +322,33 @@ pub fn find_node(graph: &Graph, label: &str) -> Vec<NodeIndex> {
     source_exact
 }
 
+pub(crate) fn find_exact_nodes(graph: &Graph, label: &str) -> Vec<NodeIndex> {
+    if let Some(index) = graph.node_index(label.trim()) {
+        return vec![index];
+    }
+    let term = search_tokens(label).join(" ");
+    if term.is_empty() {
+        return Vec::new();
+    }
+    let norm_query = strip_diacritics(label).to_lowercase().trim().to_owned();
+    graph
+        .nodes()
+        .filter_map(|(index, node)| {
+            let norm_label = normalized_label(node);
+            let bare_label = norm_label.trim_end_matches(['(', ')']);
+            let label_tokens = search_tokens(&node.string("label")).join(" ");
+            let node_id = node.id.to_lowercase();
+            (term == norm_label
+                || term == bare_label
+                || term == label_tokens
+                || term == node_id
+                || norm_query == norm_label
+                || norm_query == bare_label)
+                .then_some(index)
+        })
+        .collect()
+}
+
 fn compute_idf(graph: &Graph, terms: &[String]) -> HashMap<String, f64> {
     let mut frequencies = terms
         .iter()
@@ -381,10 +407,61 @@ fn source_is_test_or_generated(node: &NodeRecord) -> bool {
         .is_some_and(|name| name.starts_with("test_") || name.ends_with("_test.go"))
 }
 
+fn seed_label_key(node: &NodeRecord) -> String {
+    let key = normalized_label(node)
+        .trim_end_matches(['(', ')'])
+        .to_owned();
+    if key.is_empty() { node.id.clone() } else { key }
+}
+
+fn source_backed_degree(graph: &Graph, node: NodeIndex) -> usize {
+    graph
+        .outgoing_edges(node)
+        .chain(graph.incoming_edges(node))
+        .filter_map(|edge| graph.edge_endpoints(edge))
+        .filter(|(source, target)| {
+            let neighbor = if *source == node { *target } else { *source };
+            graph
+                .node(neighbor)
+                .source_file()
+                .is_some_and(|source| !source.is_empty())
+        })
+        .count()
+}
+
+#[derive(Clone, Copy)]
+struct SeedTieBreaker {
+    source_backed: bool,
+    semantic_rank: u8,
+    test_or_generated: bool,
+    source_backed_degree: usize,
+    label_len: usize,
+}
+
+impl SeedTieBreaker {
+    fn new(graph: &Graph, node_index: NodeIndex, node: &NodeRecord) -> Self {
+        Self {
+            source_backed: node.source_file().is_some_and(|source| !source.is_empty()),
+            semantic_rank: semantic_seed_rank(node),
+            test_or_generated: source_is_test_or_generated(node),
+            source_backed_degree: source_backed_degree(graph, node_index),
+            label_len: node.label().chars().count(),
+        }
+    }
+
+    fn cmp_preference(&self, other: &Self) -> Ordering {
+        self.source_backed
+            .cmp(&other.source_backed)
+            .then_with(|| self.semantic_rank.cmp(&other.semantic_rank))
+            .then_with(|| other.test_or_generated.cmp(&self.test_or_generated))
+            .then_with(|| self.source_backed_degree.cmp(&other.source_backed_degree))
+            .then_with(|| other.label_len.cmp(&self.label_len))
+    }
+}
+
 struct BestSeed {
     score: f64,
-    degree: usize,
-    label_len: usize,
+    tie_breaker: SeedTieBreaker,
     id: String,
     node: NodeIndex,
 }
@@ -394,12 +471,11 @@ impl BestSeed {
         match self.score.total_cmp(&other.score) {
             Ordering::Greater => true,
             Ordering::Less => false,
-            Ordering::Equal => {
-                self.degree > other.degree
-                    || (self.degree == other.degree
-                        && (self.label_len < other.label_len
-                            || (self.label_len == other.label_len && self.id < other.id)))
-            }
+            Ordering::Equal => match self.tie_breaker.cmp_preference(&other.tie_breaker) {
+                Ordering::Greater => true,
+                Ordering::Less => false,
+                Ordering::Equal => self.id < other.id,
+            },
         }
     }
 }
@@ -420,8 +496,13 @@ mod tests {
     fn seed(score: f64, degree: usize, label_len: usize, id: &str) -> BestSeed {
         BestSeed {
             score,
-            degree,
-            label_len,
+            tie_breaker: super::SeedTieBreaker {
+                source_backed: true,
+                semantic_rank: 4,
+                test_or_generated: false,
+                source_backed_degree: degree,
+                label_len,
+            },
             id: id.to_owned(),
             node: 0,
         }
@@ -439,6 +520,35 @@ mod tests {
         assert!(seed(10.0, 2, 5, "a").better_than(&baseline));
         assert!(!seed(10.0, 2, 5, "c").better_than(&baseline));
         assert!(!seed(10.0, 2, 5, "b").better_than(&baseline));
+    }
+
+    #[test]
+    fn source_backed_seed_beats_a_higher_degree_placeholder() -> Result<(), Box<dyn Error>> {
+        let document: GraphDocument = serde_json::from_value(json!({
+            "directed": true,
+            "multigraph": true,
+            "nodes": [
+                {"id":"declaration","kind":"method","name":".run()","source_file":"src/lib.rs"},
+                {"id":"placeholder","kind":"function","name":"run"},
+                {"id":"caller-a","kind":"method","name":"caller_a()","source_file":"src/a.rs"},
+                {"id":"caller-b","kind":"method","name":"caller_b()","source_file":"src/b.rs"},
+                {"id":"caller-c","kind":"method","name":"caller_c()","source_file":"src/c.rs"}
+            ],
+            "links": [
+                {"source":"caller-a","target":"placeholder","kind":"calls"},
+                {"source":"caller-b","target":"placeholder","kind":"calls"},
+                {"source":"caller-c","target":"placeholder","kind":"calls"}
+            ]
+        }))?;
+        let graph = Graph::from_document(document)?;
+        let scores = score_nodes(&graph, &["run".to_owned()], true);
+        let seeds = pick_seeds(&graph, &scores, 3, 0.2);
+
+        assert_eq!(
+            seeds,
+            [graph.node_index("declaration").ok_or("declaration")?]
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/compass-query/src/traversal.rs
+++ b/crates/compass-query/src/traversal.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use compass_model::{Graph, NodeIndex};
 use serde_json::{Map, Value};
 
-use crate::score::{find_node, pick_scored_endpoint, pick_seeds, score_nodes};
+use crate::score::{find_exact_nodes, find_node, pick_scored_endpoint, pick_seeds, score_nodes};
 use crate::text::{infer_context_filters, normalize_context_filters, query_terms, sanitize_label};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -70,7 +70,7 @@ pub fn query_graph_text(
     format!(
         "{}\n\n{}",
         header.join(" | "),
-        render_subgraph(&filtered, &nodes, &edges, token_budget, &[], overlay)
+        render_subgraph(&filtered, &nodes, &edges, token_budget, &seeds, overlay)
     )
 }
 
@@ -161,7 +161,23 @@ pub fn render_explanation(
     label: &str,
     overlay: &HashMap<String, Map<String, Value>>,
 ) -> String {
-    let matches = find_node(graph, label);
+    let exact_matches = find_exact_nodes(graph, label);
+    let mut matches = if exact_matches.is_empty() {
+        find_node(graph, label)
+    } else {
+        exact_matches
+    };
+    let source_backed = matches
+        .iter()
+        .copied()
+        .filter(|index| !graph.node(*index).string("source_file").is_empty())
+        .collect::<Vec<_>>();
+    if !source_backed.is_empty() {
+        matches = source_backed;
+    }
+    if matches.len() > 1 {
+        return render_ambiguity(graph, label, &matches);
+    }
     let Some(&node_index) = matches.first() else {
         return format!("No node matching '{label}' found.");
     };
@@ -177,7 +193,16 @@ pub fn render_explanation(
             .trim_end()
             .to_owned(),
     );
-    lines.push(format!("  Type:      {}", node.string("file_type")));
+    let wiring_file = node.string("wiring_file");
+    let wiring_location = node.string("wiring_location");
+    if source.is_empty() && (!wiring_file.is_empty() || !wiring_location.is_empty()) {
+        lines.push(
+            format!("  Wiring:    {wiring_file} {wiring_location}")
+                .trim_end()
+                .to_owned(),
+        );
+    }
+    lines.push(format!("  Type:      {}", rendered_file_type(node)));
     let community_name = node.string("community_name");
     let community = if community_name.is_empty() {
         node.string("community")
@@ -235,21 +260,87 @@ pub fn render_explanation(
     if !connections.is_empty() {
         lines.push(String::new());
         lines.push(format!("Connections ({}):", connections.len()));
-        connections.sort_by_key(|(_, neighbor, _)| std::cmp::Reverse(graph.degree(*neighbor)));
+        connections.sort_by(|left, right| {
+            let left_source_backed = !graph.node(left.1).string("source_file").is_empty();
+            let right_source_backed = !graph.node(right.1).string("source_file").is_empty();
+            right_source_backed
+                .cmp(&left_source_backed)
+                .then_with(|| graph.degree(right.1).cmp(&graph.degree(left.1)))
+                .then_with(|| graph.node(left.1).id.cmp(&graph.node(right.1).id))
+        });
         for (outgoing, neighbor, edge_index) in connections.iter().take(20) {
             let edge = graph.edge(*edge_index);
+            let site = formatted_site(&edge.string("source_file"), &edge.string("source_location"));
             lines.push(format!(
-                "  {} {} [{}] [{}]",
+                "  {} {} [{}] [{}]{}",
                 if *outgoing { "-->" } else { "<--" },
                 graph.node(*neighbor).label(),
                 edge.string("relation"),
-                edge.string("confidence")
+                edge.string("confidence"),
+                if site.is_empty() {
+                    String::new()
+                } else {
+                    format!(" {site}")
+                }
             ));
         }
         if connections.len() > 20 {
             lines.push(format!("  ... and {} more", connections.len() - 20));
         }
     }
+    lines.join("\n")
+}
+
+fn render_ambiguity(graph: &Graph, label: &str, matches: &[NodeIndex]) -> String {
+    let mut matches = matches.to_vec();
+    matches.sort_by(|left, right| {
+        let left_node = graph.node(*left);
+        let right_node = graph.node(*right);
+        left_node
+            .string("source_file")
+            .cmp(&right_node.string("source_file"))
+            .then_with(|| {
+                left_node
+                    .string("source_location")
+                    .cmp(&right_node.string("source_location"))
+            })
+            .then_with(|| left_node.id.cmp(&right_node.id))
+    });
+    let all_source_backed = matches
+        .iter()
+        .all(|index| !graph.node(*index).string("source_file").is_empty());
+    let qualifier = if all_source_backed {
+        " source-backed"
+    } else {
+        ""
+    };
+    let mut lines = vec![format!(
+        "Ambiguous: '{label}' matches {}{qualifier} nodes.",
+        matches.len()
+    )];
+    for index in matches.iter().take(20) {
+        let node = graph.node(*index);
+        let source_file = node.string("source_file");
+        let source_location = node.string("source_location");
+        let source = match (source_file.is_empty(), source_location.is_empty()) {
+            (true, true) => String::new(),
+            (false, true) => source_file,
+            (true, false) => source_location,
+            (false, false) => format!("{source_file} {source_location}"),
+        };
+        let wiring = formatted_site(&node.string("wiring_file"), &node.string("wiring_location"));
+        let site = if source.is_empty() { wiring } else { source };
+        if site.is_empty() {
+            lines.push(format!("  {}", node.label()));
+        } else {
+            lines.push(format!("  {site}"));
+        }
+        lines.push(format!("    id: {}", node.id));
+    }
+    if matches.len() > 20 {
+        lines.push(format!("  ... and {} more", matches.len() - 20));
+    }
+    lines.push("Retry with the full node ID.".to_owned());
     lines.join("\n")
 }
 
@@ -347,9 +438,11 @@ fn render_subgraph(
         .filter(|node| !seed_set.contains(node))
         .collect::<Vec<_>>();
     remainder.sort_by(|left, right| {
-        graph
-            .degree(*right)
-            .cmp(&graph.degree(*left))
+        let left_source_backed = !graph.node(*left).string("source_file").is_empty();
+        let right_source_backed = !graph.node(*right).string("source_file").is_empty();
+        right_source_backed
+            .cmp(&left_source_backed)
+            .then_with(|| graph.degree(*right).cmp(&graph.degree(*left)))
             .then_with(|| graph.node(*left).id.cmp(&graph.node(*right).id))
     });
     ordered.extend(remainder);
@@ -369,11 +462,22 @@ fn render_subgraph(
                 format!(" learning={status}{}", if stale { ":stale" } else { "" })
             })
         });
+        let source = node.string("source_file");
+        let location = node.string("source_location");
+        let wiring = contextual_wiring_site(graph, node_index, edges).unwrap_or_else(|| {
+            formatted_site(&node.string("wiring_file"), &node.string("wiring_location"))
+        });
+        let wiring = if source.is_empty() && !wiring.is_empty() {
+            format!(" wiring={}", sanitize_label(&wiring))
+        } else {
+            String::new()
+        };
         lines.push(format!(
-            "NODE {} [src={} loc={} community={}{}]",
+            "NODE {} [src={} loc={}{} community={}{}]",
             sanitize_label(node.label()),
-            sanitize_label(&node.string("source_file")),
-            sanitize_label(&node.string("source_location")),
+            sanitize_label(&source),
+            sanitize_label(&location),
+            wiring,
             sanitize_label(&community),
             learning.unwrap_or_default()
         ));
@@ -392,16 +496,64 @@ fn render_subgraph(
         } else {
             format!(" context={}", sanitize_label(&context))
         };
+        let site = formatted_site(&edge.string("source_file"), &edge.string("source_location"));
+        let site = if site.is_empty() {
+            String::new()
+        } else {
+            format!(" at={}", sanitize_label(&site))
+        };
         lines.push(format!(
-            "EDGE {} --{} [{}{}]--> {}",
+            "EDGE {} --{} [{}{}]--> {}{}",
             sanitize_label(graph.node(source).label()),
             sanitize_label(&edge.string("relation")),
             sanitize_label(&edge.string("confidence")),
             context,
-            sanitize_label(graph.node(target).label())
+            sanitize_label(graph.node(target).label()),
+            site
         ));
     }
     truncate_to_budget(&lines, token_budget)
+}
+
+fn formatted_site(file: &str, location: &str) -> String {
+    match (file.is_empty(), location.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => file.to_owned(),
+        (true, false) => location.to_owned(),
+        (false, false) => format!("{file}:{location}"),
+    }
+}
+
+fn rendered_file_type(node: &compass_model::NodeRecord) -> String {
+    let stored = node.string("file_type");
+    if !stored.is_empty() {
+        return stored;
+    }
+    node.attributes
+        .get("kind")
+        .and_then(Value::as_str)
+        .map_or_else(String::new, |kind| {
+            if kind == "resource" {
+                "document".to_owned()
+            } else {
+                "code".to_owned()
+            }
+        })
+}
+
+fn contextual_wiring_site(
+    graph: &Graph,
+    node: NodeIndex,
+    edges: &[(NodeIndex, NodeIndex)],
+) -> Option<String> {
+    edges
+        .iter()
+        .filter(|(source, target)| *source == node || *target == node)
+        .filter_map(|(source, target)| graph.edge_between(*source, *target))
+        .map(|edge| graph.edge(edge))
+        .map(|edge| formatted_site(&edge.string("source_file"), &edge.string("source_location")))
+        .filter(|site| !site.is_empty())
+        .min()
 }
 
 fn truncate_to_budget(lines: &[String], token_budget: usize) -> String {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -182,6 +182,12 @@ compass query "<question>"
   [--graph PATH | --at REV]
 ```
 
+Query seeds prefer source-backed declarations over unresolved external-symbol
+placeholders with the same callable label. Source-less placeholder nodes retain
+an explicit `wiring=FILE:LOCATION` site, and traversed relationships render
+their occurrence as `at=FILE:LOCATION`; neither is presented as a declaration
+location.
+
 CompassQL:
 
 ```text
@@ -224,7 +230,10 @@ Renders a shortest known graph path while preserving relationship direction.
 compass explain "<node>" [--graph PATH | --at REV]
 ```
 
-Shows one node and incoming/outgoing connections.
+Shows one node and incoming/outgoing connections. An exact node ID resolves
+directly. When a label names multiple source-backed declarations, Compass lists
+the candidates and their source ranges and asks for the full node ID instead of
+silently selecting one. Connection lines include the stored relationship site.
 
 ### `affected`
 

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -208,6 +208,11 @@ Reject unknown schema identifiers rather than guessing compatibility.
 human-readable text. It is stable enough for people, not the preferred machine
 contract.
 
+Natural-language `query` output distinguishes declaration locations (`src` and
+`loc`) from unresolved-symbol occurrence sites (`wiring`) and relationship
+occurrences (`at`). `explain` similarly reports `Source` for declarations,
+`Wiring` for source-less placeholders, and source sites on connections.
+
 When exact automation is required, use:
 
 - CompassQL JSON/JSONL;


### PR DESCRIPTION
## What changed

- prefer source-backed declarations over unresolved placeholders when selecting natural-query seeds
- collapse callable/bare-label duplicates so one unresolved placeholder does not become a second seed
- make `compass explain` fail closed on ambiguous labels, list source-backed candidates, and resolve exact Compass node IDs
- render declaration ranges, contextual placeholder wiring sites, and relationship occurrence sites in query/explain text
- prioritize source-backed nodes and connections within bounded output
- document the human-readable output and add model, query, and CLI regressions

## Why

Compass's graph is richer than Graphify's for the brewfs reproduction: it preserves six declarations plus inferred external-symbol placeholders, while Graphify reports four implementations and models many call sites as located nodes. The old query ranking used raw degree, so placeholder-heavy nodes won, and explain silently selected the first label match. The text renderer also omitted the stored wiring and relationship anchors.

This change keeps Compass's stricter identities and provenance instead of collapsing the graphs, while making the user-facing query and explain results comparably actionable.

## Validation

- reproduced against the current `/Volumes/Workspace/Github/brewfs` Compass artifact
- `cargo fmt --all -- --check`
- `cargo test -p compass-model --lib --locked`
- `cargo test -p compass-query --lib --locked`
- `cargo test -p compass-query --test coverage_paths --locked`
- `cargo test -p compass-cli --test code_query_cli --locked`
- `cargo clippy -p compass-model -p compass-query -p compass-cli --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/check_product_boundary.sh`

A separate full `cargo test -p compass-query --locked` run exposes the existing `callees_return_each_exact_source_site_for_parallel_calls` integration-fixture failure on current `origin/main`: the Rust adapter produces universal semantic evidence while that fixture passes the empty legacy node list to normalization. This patch does not change extraction, normalization, or the structured callee API.
