### PR TITLE
Fix Markdown and MCP extraction

### DIFF
--- a/crates/compass-languages/src/markdown.rs
+++ b/crates/compass-languages/src/markdown.rs
@@ -157,12 +157,20 @@ pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
             .entry(qualified_base.clone())
             .or_default();
         *occurrence += 1;
-        let qualified_name = if *occurrence == 1 {
+        let mut qualified_name = if *occurrence == 1 {
             qualified_base
         } else {
             format!("{qualified_base}#{occurrence}")
         };
-        let id = make_id(&[&state.stem, &qualified_name]);
+        if state.heading_stack.is_empty()
+            && path_file_name(state.path).is_some_and(|name| name == qualified_name)
+        {
+            qualified_name.push_str("::heading");
+        }
+        let mut id = make_id(&[&state.stem, &qualified_name]);
+        if id == state.file_id {
+            id = make_id(&[&state.source_file, "heading", &qualified_name]);
+        }
         state.add_node(id.clone(), title, line, Some(&qualified_name));
         let parent = state
             .heading_stack
@@ -182,6 +190,10 @@ pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
         .extensions
         .insert("output_tokens".to_owned(), json!(0));
     Ok(state.extraction)
+}
+
+fn path_file_name(path: &Path) -> Option<&str> {
+    path.file_name()?.to_str()
 }
 
 struct State<'path> {

--- a/crates/compass-languages/src/mcp.rs
+++ b/crates/compass-languages/src/mcp.rs
@@ -56,6 +56,8 @@ pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
     let (servers, server_prefix) =
         if let Some(servers) = root.get("mcpServers").and_then(Value::as_object) {
             (servers, vec!["mcpServers".to_owned()])
+        } else if let Some(servers) = root.get("servers").and_then(Value::as_object) {
+            (servers, vec!["servers".to_owned()])
         } else if let Some(servers) = root
             .get("mcp")
             .and_then(Value::as_object)
@@ -64,7 +66,7 @@ pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
         {
             (servers, vec!["mcp".to_owned(), "servers".to_owned()])
         } else {
-            return Ok(failure("mcp_ingest: no mcpServers map"));
+            return Ok(failure("mcp_ingest: no supported server map"));
         };
     let key_spans = JsonKeyScanner::new(text).scan();
 

--- a/crates/compass-languages/tests/markdown_coverage.rs
+++ b/crates/compass-languages/tests/markdown_coverage.rs
@@ -117,3 +117,29 @@ fn markdown_missing_file_is_a_structured_io_error() -> Result<(), Box<dyn Error>
     assert!(error.to_string().contains("absent.md"));
     Ok(())
 }
+
+#[test]
+fn markdown_file_and_same_named_heading_have_distinct_identities() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("AGENTS.md");
+    fs::write(&path, "# AGENTS.md\n")?;
+
+    let extraction = Engine::default().extract(&path)?;
+    assert!(extraction.error.is_none());
+    assert_eq!(extraction.nodes.len(), 2);
+    assert_ne!(extraction.nodes[0].id, extraction.nodes[1].id);
+    assert_eq!(
+        extraction.nodes[1].string("qualified_name"),
+        "AGENTS.md::heading"
+    );
+    assert!(extraction.edges.iter().any(|edge| {
+        edge.source == extraction.nodes[0].id
+            && edge.target == extraction.nodes[1].id
+            && edge
+                .attributes
+                .get("relation")
+                .and_then(serde_json::Value::as_str)
+                == Some("contains")
+    }));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- keep Markdown file nodes distinct from a same-named top-level heading
- accept the VS Code-style top-level `servers` map when extracting MCP configuration
- preserve exact containment and MCP key-path evidence

## Root cause

Markdown heading IDs could collide with the containing file ID when a heading matched the filename. The MCP extractor recognized `mcpServers` and nested `mcp.servers`, but not the top-level `servers` shape used by VS Code MCP configuration.

## Impact

Markdown graphs no longer silently lose a same-named heading node, and VS Code MCP server configuration publishes its command, package, and environment-key facts without exposing environment values.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p compass-languages --test markdown_coverage markdown_file_and_same_named_heading_have_distinct_identities --locked`
- `cargo test -p compass-languages --test semantic_producers vscode_mcp_servers_publish_exact_command_package_and_environment_facts --locked`
