### PR TITLE
Release Compass 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.1 - 2026-08-01
+
 - Improve native Python, Rust, Go, Java, TypeScript, and JavaScript graph
   extraction and resolution, with three-run deterministic qualification on six
   pinned real repositories and explicit reporting of comparator defects and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "regex",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "compass-core",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,28 +35,28 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.2.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.0" }
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-program = { path = "../compass-program", version = "0.2.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.2.0" }
-compass-cargo = { path = "../compass-cargo", version = "0.2.0" }
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.2.0" }
-compass-global = { path = "../compass-global", version = "0.2.0" }
-compass-history = { path = "../compass-history", version = "0.2.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.0" }
-compass-ingest = { path = "../compass-ingest", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-mcp = { path = "../compass-mcp", version = "0.2.0" }
-compass-output = { path = "../compass-output", version = "0.2.0" }
-compass-postgres = { path = "../compass-postgres", version = "0.2.0" }
-compass-prs = { path = "../compass-prs", version = "0.2.0" }
-compass-query = { path = "../compass-query", version = "0.2.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.2.0" }
-compass-semantic = { path = "../compass-semantic", version = "0.2.0" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.2.0" }
+compass-core = { path = "../compass-core", version = "0.2.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-program = { path = "../compass-program", version = "0.2.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
+compass-cargo = { path = "../compass-cargo", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.2.1" }
+compass-global = { path = "../compass-global", version = "0.2.1" }
+compass-history = { path = "../compass-history", version = "0.2.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.1" }
+compass-ingest = { path = "../compass-ingest", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-mcp = { path = "../compass-mcp", version = "0.2.1" }
+compass-output = { path = "../compass-output", version = "0.2.1" }
+compass-postgres = { path = "../compass-postgres", version = "0.2.1" }
+compass-prs = { path = "../compass-prs", version = "0.2.1" }
+compass-query = { path = "../compass-query", version = "0.2.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.2.1" }
+compass-semantic = { path = "../compass-semantic", version = "0.2.1" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.2.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.2.0" }
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-program = { path = "../compass-program", version = "0.2.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-program = { path = "../compass-program", version = "0.2.1" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,15 +24,15 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.0" }
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
-compass-history = { path = "../compass-history", version = "0.2.0" }
-compass-output = { path = "../compass-output", version = "0.2.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.2.0" }
-compass-resolve = { path = "../compass-resolve", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-history = { path = "../compass-history", version = "0.2.1" }
+compass-output = { path = "../compass-output", version = "0.2.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.2.1" }
+compass-resolve = { path = "../compass-resolve", version = "0.2.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.2.0" }
+compass-media = { path = "../compass-media", version = "0.2.1" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,14 +19,14 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true
 
 [dev-dependencies]
-compass-resolve = { path = "../compass-resolve", version = "0.2.0" }
+compass-resolve = { path = "../compass-resolve", version = "0.2.1" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.0" }
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,7 +19,7 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-program = { path = "../compass-program", version = "0.2.0" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-program = { path = "../compass-program", version = "0.2.1" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -24,7 +24,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-language-pack.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,12 +19,12 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.2.0" }
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-prs = { path = "../compass-prs", version = "0.2.0" }
-compass-query = { path = "../compass-query", version = "0.2.0" }
+compass-core = { path = "../compass-core", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-prs = { path = "../compass-prs", version = "0.2.1" }
+compass-query = { path = "../compass-query", version = "0.2.1" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,12 +20,12 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.2.0" }
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
-compass-history = { path = "../compass-history", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-query = { path = "../compass-query", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-history = { path = "../compass-history", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-query = { path = "../compass-query", version = "0.2.1" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
 protobuf.workspace = true
 scip.workspace = true
 serde.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-files = { path = "../compass-files", version = "0.2.0" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -18,10 +18,10 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.0" }
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -29,9 +29,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.2.0" }
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
-compass-program = { path = "../compass-program", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-program = { path = "../compass-program", version = "0.2.1" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-graph = { path = "../compass-graph", version = "0.2.0" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.2.1" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.2.0" }
-compass-history = { path = "../compass-history", version = "0.2.0" }
-compass-ir = { path = "../compass-ir", version = "0.2.0" }
-compass-model = { path = "../compass-model", version = "0.2.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
+compass-history = { path = "../compass-history", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.2.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.2.0" }
-compass-program = { path = "../compass-program", version = "0.2.0" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-program = { path = "../compass-program", version = "0.2.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.0" }
-compass-media = { path = "../compass-media", version = "0.2.0" }
+compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-media = { path = "../compass-media", version = "0.2.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.2.0", path = "../compass-ingest" }
-compass-whisper = { version = "0.2.0", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.2.1", path = "../compass-ingest" }
+compass-whisper = { version = "0.2.1", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "regex",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-ir",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "compass-core",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.2.0", path = "../crates/compass-model" }
-compass-cli = { version = "0.2.0", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.2.0", path = "../crates/compass-cypher" }
-compass-files = { version = "0.2.0", path = "../crates/compass-files" }
-compass-graph = { version = "0.2.0", path = "../crates/compass-graph" }
-compass-languages = { version = "0.2.0", path = "../crates/compass-languages" }
-compass-output = { version = "0.2.0", path = "../crates/compass-output" }
-compass-query = { version = "0.2.0", path = "../crates/compass-query" }
-compass-semantic = { version = "0.2.0", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.2.0", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.2.1", path = "../crates/compass-model" }
+compass-cli = { version = "0.2.1", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.2.1", path = "../crates/compass-cypher" }
+compass-files = { version = "0.2.1", path = "../crates/compass-files" }
+compass-graph = { version = "0.2.1", path = "../crates/compass-graph" }
+compass-languages = { version = "0.2.1", path = "../crates/compass-languages" }
+compass-output = { version = "0.2.1", path = "../crates/compass-output" }
+compass-query = { version = "0.2.1", path = "../crates/compass-query" }
+compass-semantic = { version = "0.2.1", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.2.1", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1599,7 +1599,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.2.0"
+    "producerVersion": "compass-languages/0.2.1"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## What changed

- bump the Compass workspace and internal crate requirements from 0.2.0 to 0.2.1
- refresh the root and fuzz lockfiles without changing third-party dependency versions
- promote the accumulated Unreleased changelog entries to dated 0.2.1 release notes
- align the code-graph qualification producer version with the release

## User impact

Compass 0.2.1 packages the post-0.2.0 language-resolution, lower-memory structural build, history, graph workbench, and natural-language query improvements for macOS, Linux, and Windows on ARM64 and x64.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/check_product_boundary.sh`
- `sh scripts/test_release_scripts.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- optimized Apple Silicon release build, archive checksum, and `compass 0.2.1` smoke test

The optional pre-publication `cargo package --workspace` audit packaged crates through `compass-languages` and then stopped because the new unpublished `compass-graph 0.2.1` registry entry does not exist yet. The GitHub native-binary release does not depend on crates.io publication.
