### PR TITLE
Fix 0.2.1 publishable workspace test cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,6 @@ dependencies = [
  "ahash",
  "compass-languages",
  "compass-model",
- "compass-resolve",
  "rayon",
  "serde",
  "serde_json",

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -26,7 +26,6 @@ unicode-casefold.workspace = true
 unicode-normalization.workspace = true
 
 [dev-dependencies]
-compass-resolve = { path = "../compass-resolve", version = "0.2.1" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-graph/tests/domain_normalization.rs
+++ b/crates/compass-graph/tests/domain_normalization.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -6,7 +6,6 @@ use compass_graph::{BuildEvidence, normalize_v1};
 use compass_languages::{Engine, extract_sql_content};
 use compass_model::code_graph::{EdgeKind, NodeKind};
 use compass_model::provenance::EvidenceOrigin;
-use compass_resolve::resolve_with_root;
 
 #[test]
 fn sql_domain_facts_publish_as_a_valid_closed_v1_graph() -> Result<(), Box<dyn std::error::Error>> {
@@ -201,61 +200,6 @@ fn package_manifest_self_dependency_is_diagnostic_not_topology()
             .iter()
             .any(|diagnostic| { diagnostic.code == "suppressed_dependency_self_loop" })
     );
-    Ok(())
-}
-
-#[test]
-fn unresolved_java_inheritance_is_typed_deferred_and_not_exact_topology()
--> Result<(), Box<dyn std::error::Error>> {
-    let directory = tempfile::tempdir()?;
-    let root = directory.path();
-    let relative = Path::new("src/Child.java");
-    let source = b"package a;\nclass Child extends Missing {}\n";
-    fs::create_dir_all(root.join("src"))?;
-    fs::write(root.join(relative), source)?;
-
-    let extracted = Engine::default().extract_source(relative, source)?;
-    let sources = HashMap::from([(
-        relative.to_string_lossy().into_owned(),
-        String::from_utf8(source.to_vec())?,
-    )]);
-    let extraction = resolve_with_root(&[extracted], &sources, root);
-    assert!(extraction.error.is_none(), "{:#?}", extraction.error);
-    assert!(!extraction.nodes.is_empty(), "resolved Java graph is empty");
-    let evidence = BuildEvidence::from_extraction(root, &extraction, "sha256:test-java")?;
-    let graph = normalize_v1(extraction, evidence)?;
-    let inheritance = graph
-        .links
-        .iter()
-        .find(|edge| edge.kind == EdgeKind::Extends)
-        .ok_or_else(|| format!("missing deferred inheritance edge: {graph:#?}"))?;
-    assert!(inheritance.deferred);
-    assert!(inheritance.evidence.iter().any(|evidence| {
-        evidence.origin == EvidenceOrigin::Heuristic
-            && evidence.extractor == "compass.graph.external-placeholder"
-            && evidence.wiring_site.is_some()
-    }));
-    assert!(
-        graph
-            .links
-            .iter()
-            .filter(|edge| matches!(edge.kind, EdgeKind::Extends | EdgeKind::Implements))
-            .all(|edge| edge.deferred)
-    );
-    let unresolved = graph
-        .nodes
-        .iter()
-        .find(|node| node.name == "Missing")
-        .ok_or("missing unresolved superclass")?;
-    assert_eq!(unresolved.kind, NodeKind::Class);
-    assert!(unresolved.evidence.iter().any(|evidence| {
-        evidence.origin == EvidenceOrigin::Heuristic
-            && evidence.extractor == "compass.graph.external-placeholder"
-            && evidence.wiring_site.is_some()
-    }));
-    assert!(unresolved.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "unresolved_external_symbol" && diagnostic.anchor.is_some()
-    }));
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/unresolved_inheritance_graph.rs
+++ b/crates/compass-resolve/tests/unresolved_inheritance_graph.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use compass_graph::{BuildEvidence, normalize_v1};
+use compass_languages::Engine;
+use compass_model::code_graph::{EdgeKind, NodeKind};
+use compass_model::provenance::EvidenceOrigin;
+use compass_resolve::resolve_with_root;
+
+#[test]
+fn unresolved_java_inheritance_is_typed_deferred_and_not_exact_topology()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let relative = Path::new("src/Child.java");
+    let source = b"package a;\nclass Child extends Missing {}\n";
+    fs::create_dir_all(root.join("src"))?;
+    fs::write(root.join(relative), source)?;
+
+    let extracted = Engine::default().extract_source(relative, source)?;
+    let sources = HashMap::from([(
+        relative.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let extraction = resolve_with_root(&[extracted], &sources, root);
+    assert!(extraction.error.is_none(), "{:#?}", extraction.error);
+    assert!(!extraction.nodes.is_empty(), "resolved Java graph is empty");
+    let evidence = BuildEvidence::from_extraction(root, &extraction, "sha256:test-java")?;
+    let graph = normalize_v1(extraction, evidence)?;
+    let inheritance = graph
+        .links
+        .iter()
+        .find(|edge| edge.kind == EdgeKind::Extends)
+        .ok_or_else(|| format!("missing deferred inheritance edge: {graph:#?}"))?;
+    assert!(inheritance.deferred);
+    assert!(inheritance.evidence.iter().any(|evidence| {
+        evidence.origin == EvidenceOrigin::Heuristic
+            && evidence.extractor == "compass.graph.external-placeholder"
+            && evidence.wiring_site.is_some()
+    }));
+    assert!(
+        graph
+            .links
+            .iter()
+            .filter(|edge| matches!(edge.kind, EdgeKind::Extends | EdgeKind::Implements))
+            .all(|edge| edge.deferred)
+    );
+    let unresolved = graph
+        .nodes
+        .iter()
+        .find(|node| node.name == "Missing")
+        .ok_or("missing unresolved superclass")?;
+    assert_eq!(unresolved.kind, NodeKind::Class);
+    assert!(unresolved.evidence.iter().any(|evidence| {
+        evidence.origin == EvidenceOrigin::Heuristic
+            && evidence.extractor == "compass.graph.external-placeholder"
+            && evidence.wiring_site.is_some()
+    }));
+    assert!(unresolved.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "unresolved_external_symbol" && diagnostic.anchor.is_some()
+    }));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- remove the compass-graph ↔ compass-resolve dev-test dependency cycle
- keep the unresolved-inheritance graph regression in compass-resolve
- make the full `cargo package --workspace --locked --no-verify` archive gate pass before registry publication

## Verification
- `cargo test -p compass-graph --test domain_normalization --locked`
- `cargo test -p compass-resolve --test unresolved_inheritance_graph --locked`
- `cargo package --workspace --locked --no-verify --allow-dirty --exclude compass-transcribe --exclude compass-whisper`
