### PR TITLE
Improve structural Markdown and HTML extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   file hashes so metadata-only edits refresh graph and semantic cache entries;
   recognize `.markdown` files as documents. Extraction semantics advance to
   version 5 so old structural facts cannot be reused.
+- Add a pinned structural HTML adapter for `.html`/`.htm`, shared entity-aware
+  normalization for URL ingestion, semantic landmarks/tables/links, bounded
+  metadata and malformed-input diagnostics, and explicit MDX/Quarto/footnote
+  evidence.
 
 ## 0.2.1 - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Make Markdown extraction source-driven and structurally parsed with pinned
+  block and inline grammars. Publish bounded frontmatter metadata, headings,
+  nested blocks, tables, code fences, reference definitions, exact link sites,
+  and explicit ambiguous-fragment evidence. Include raw frontmatter in Markdown
+  file hashes so metadata-only edits refresh graph and semantic cache entries;
+  recognize `.markdown` files as documents. Extraction semantics advance to
+  version 5 so old structural facts cannot be reused.
+
 ## 0.2.1 - 2026-08-01
 
 - Improve native Python, Rust, Go, Java, TypeScript, and JavaScript graph

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -56,6 +56,17 @@ direction, multiplicity, and source ranges. Markdown frontmatter is part of
 the file hash, so metadata-only edits invalidate compatible extraction/cache
 entries and are rebuilt under the current extraction semantics version.
 
+HTML (`.html`/`.htm`) now has the same source-driven structural contract. HTML
+nodes and link evidence preserve exact source ranges and deterministic order;
+`script`, `style`, `template`, and `noscript` subtrees are excluded. The new
+`html_*` metadata and diagnostic extensions are forward-compatible attributes.
+The extraction semantics version is bumped so older realizations are not
+silently reused. URL ingestion uses the same parser-backed HTML normalizer and
+does not fetch discovered links.
+If semantic enrichment is enabled, these structural nodes and relationships
+remain in the published graph; provider concepts are additive and cannot
+replace the local realization.
+
 ## Attribution
 
 Compass was inspired by

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,6 +49,13 @@ A user-visible incompatible change requires:
 Versioned formats use Compass-owned identifiers. Consumers should reject
 unknown major versions instead of attempting legacy fallback behavior.
 
+Markdown graph extraction is a structural, extensible projection. New
+document/block attributes and bounded diagnostic extensions may appear without
+changing node identity; consumers must preserve unknown attributes, edge
+direction, multiplicity, and source ranges. Markdown frontmatter is part of
+the file hash, so metadata-only edits invalidate compatible extraction/cache
+entries and are rebuilt under the current extraction semantics version.
+
 ## Attribution
 
 Compass was inspired by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-dm",
+ "tree-sitter-md",
  "unicode-casefold",
  "unicode-normalization",
  "unicode-properties",
@@ -4941,6 +4942,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "try-lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ name = "compass-ingest"
 version = "0.2.1"
 dependencies = [
  "compass-files",
+ "compass-languages",
  "regex",
  "serde_json",
  "sha1",
@@ -1184,10 +1185,12 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-dm",
+ "tree-sitter-html",
  "tree-sitter-md",
  "unicode-casefold",
  "unicode-normalization",
  "unicode-properties",
+ "url",
 ]
 
 [[package]]
@@ -4932,6 +4935,16 @@ name = "tree-sitter-dm"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e7cb9dcfcd10c84ec03e3a0717a1d6fc7d6454ae5e54d03e3b17cc25564e4f6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tokio-postgres = { version = "0.7.18", features = ["array-impls"] }
 tokio-postgres-rustls = { version = "0.14.0", default-features = false, features = ["native-certs", "ring", "webpki-roots"] }
 tree-sitter = "0.26"
 tree-sitter-dm = "0.25.1"
+tree-sitter-html = "=0.23.2"
 tree-sitter-md = "0.5.3"
 tree-sitter-language-pack = { package = "compass-tree-sitter-language-pack", version = "=1.13.1", path = "vendor/compass-tree-sitter-language-pack", default-features = false }
 ureq = { version = "3.3.0", default-features = false, features = ["json", "rustls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tokio-postgres = { version = "0.7.18", features = ["array-impls"] }
 tokio-postgres-rustls = { version = "0.14.0", default-features = false, features = ["native-certs", "ring", "webpki-roots"] }
 tree-sitter = "0.26"
 tree-sitter-dm = "0.25.1"
+tree-sitter-md = "0.5.3"
 tree-sitter-language-pack = { package = "compass-tree-sitter-language-pack", version = "=1.13.1", path = "vendor/compass-tree-sitter-language-pack", default-features = false }
 ureq = { version = "3.3.0", default-features = false, features = ["json", "rustls"] }
 wait-timeout = "0.2.1"

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -32,7 +32,7 @@ conversation context is required beyond the plan file.
 | 006 | Make media ingestion fail explicitly and remain memory-bounded | P1 | M | — | TODO |
 | 007 | Introduce a versioned, provenance-preserving document artifact | P1 | L | 006 | TODO |
 | 008 | Chunk rich documents losslessly and fuse structural with semantic evidence | P1 | L | 007 | TODO |
-| 009 | Make Markdown and HTML first-class structural documents | P1 | L | 007, 008 | TODO |
+| 009 | Make Markdown and HTML first-class structural documents | P1 | L | 007, 008 | DONE |
 | 010 | Preserve OOXML order and add native PPTX document graphs | P2 | L | 006, 007, 008 | TODO |
 | 011 | Add a bounded native RTF decoder with explicit fidelity diagnostics | P2 | L | 007, 008 | TODO |
 | 012 | Qualify document graphs across formats, limits, and determinism | P1 | M | 009, 010, 011 | TODO |

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -537,8 +537,12 @@ fn build_graph_inner(
             .flatten()
             .map(PathBuf::from)
             .filter(|path| {
+                let structural_document = Registry::resolve(path).is_some_and(|spec| {
+                    matches!(spec.kind, ExtractorKind::Markdown | ExtractorKind::Html)
+                });
                 Registry::resolve(path).is_some()
-                    && !semantic_documents.contains(&canonical_identity(path))
+                    && (structural_document
+                        || !semantic_documents.contains(&canonical_identity(path)))
             }),
     );
 
@@ -4838,6 +4842,68 @@ mod tests {
                 .count(),
             1
         );
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_enrichment_preserves_markdown_and_html_structure() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path();
+        fs::write(root.join("guide.md"), "# Guide\n\n[Next](next.md)\n")?;
+        fs::write(
+            root.join("page.html"),
+            "<main id=\"top\"><h1>Page</h1><p><a href=\"#top\">Top</a></p></main>\n",
+        )?;
+        let mut options = BuildOptions::new(root);
+        options.no_viz = true;
+        let semantic = SemanticLayer {
+            fragment: json!({
+                "nodes": [{
+                    "id": "semantic_page",
+                    "label": "Page concept",
+                    "file_type": "concept",
+                    "source_file": "page.html",
+                }],
+                "edges": [],
+                "hyperedges": [],
+                "failed_chunks": 0,
+            }),
+            refreshed_files: vec![PathBuf::from("guide.md"), PathBuf::from("page.html")],
+            partial_files: Vec::new(),
+            allow_partial: false,
+        };
+        let cold = build_local_graph(&options)?;
+        let cold_graph = V1GraphDocument::load(&cold.output_dir.join("graph.json"))?;
+        let structural_ids = cold_graph
+            .nodes
+            .iter()
+            .filter(|node| matches!(node.source_file(), Some("guide.md" | "page.html")))
+            .map(|node| node.id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(!structural_ids.is_empty());
+
+        let enriched = build_graph_with_semantic(&options, &semantic)?;
+        let enriched_graph = V1GraphDocument::load(&enriched.output_dir.join("graph.json"))?;
+        let enriched_ids = enriched_graph
+            .nodes
+            .iter()
+            .map(|node| node.id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(
+            structural_ids.is_subset(&enriched_ids),
+            "missing structural IDs: {:?}; enriched IDs: {:?}",
+            structural_ids.difference(&enriched_ids).collect::<Vec<_>>(),
+            enriched_ids
+        );
+        assert!(
+            enriched_graph
+                .nodes
+                .iter()
+                .any(|node| node.label() == "Page concept")
+        );
+        assert!(enriched_graph.links.iter().any(|edge| {
+            edge.source_file() == Some("page.html") && edge.relation() == "contains"
+        }));
         Ok(())
     }
 

--- a/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
+++ b/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
@@ -609,7 +609,7 @@ fn every_registered_extractor_family_crosses_production_v1_publication()
 -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let root = directory.path();
-    assert_eq!(Registry::cases().len(), 65, "registry case count changed");
+    assert_eq!(Registry::cases().len(), 66, "registry case count changed");
     for case in Registry::cases() {
         write(root, case.fixture_path, case.fixture_source)?;
         let resolved = Registry::resolve(&root.join(case.fixture_path))
@@ -624,6 +624,7 @@ fn every_registered_extractor_family_crosses_production_v1_publication()
     for expected in [
         "Generic",
         "Markdown",
+        "Html",
         "JsonConfig",
         "Terraform",
         "PascalForm",

--- a/crates/compass-files/src/detect.rs
+++ b/crates/compass-files/src/detect.rs
@@ -24,8 +24,8 @@ const CODE_EXTENSIONS: &[&str] = &[
     "cshtml", "cls", "trigger",
 ];
 const DOCUMENT_EXTENSIONS: &[&str] = &[
-    "md", "markdown", "mdx", "qmd", "skill", "txt", "rst", "html", "yaml", "yml", "docx", "xlsx",
-    "gdoc", "gsheet", "gslides",
+    "md", "markdown", "mdx", "qmd", "skill", "txt", "rst", "html", "htm", "yaml", "yml", "docx",
+    "xlsx", "gdoc", "gsheet", "gslides",
 ];
 const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg"];
 const VIDEO_EXTENSIONS: &[&str] = &[

--- a/crates/compass-files/src/detect.rs
+++ b/crates/compass-files/src/detect.rs
@@ -24,8 +24,8 @@ const CODE_EXTENSIONS: &[&str] = &[
     "cshtml", "cls", "trigger",
 ];
 const DOCUMENT_EXTENSIONS: &[&str] = &[
-    "md", "mdx", "qmd", "skill", "txt", "rst", "html", "yaml", "yml", "docx", "xlsx", "gdoc",
-    "gsheet", "gslides",
+    "md", "markdown", "mdx", "qmd", "skill", "txt", "rst", "html", "yaml", "yml", "docx", "xlsx",
+    "gdoc", "gsheet", "gslides",
 ];
 const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg"];
 const VIDEO_EXTENSIONS: &[&str] = &[

--- a/crates/compass-files/src/hash.rs
+++ b/crates/compass-files/src/hash.rs
@@ -221,15 +221,10 @@ pub fn body_content(content: &[u8]) -> Vec<u8> {
 }
 
 fn file_hash_bytes(path: &Path, salt: &str) -> Result<String, FileError> {
-    let raw = fs::read(path).map_err(|source| io_error(path, source))?;
-    let content = if path
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
-    {
-        body_content(&raw)
-    } else {
-        raw
-    };
+    // Frontmatter is part of Markdown semantics and must invalidate the same
+    // cache entries as body edits. `body_content` remains a compatibility
+    // helper for callers that explicitly need the legacy body-only view.
+    let content = fs::read(path).map_err(|source| io_error(path, source))?;
     let mut hash = Sha256::new();
     hash.update(&content);
     hash.update([0]);

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -96,6 +96,18 @@ fn markdown_frontmatter_matches_legacy_bytes() {
 }
 
 #[test]
+fn markdown_file_hash_includes_frontmatter_semantics() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("document.md");
+    fs::write(&path, "---\ntitle: First\n---\n\nShared body\n")?;
+    let first_hash = file_hash(&path, directory.path())?;
+    fs::write(&path, "---\ntitle: Second\n---\n\nShared body\n")?;
+    let second_hash = file_hash(&path, directory.path())?;
+    assert_ne!(first_hash, second_hash);
+    Ok(())
+}
+
+#[test]
 fn watcher_filter_reuses_ignore_and_output_boundaries() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let root = directory.path();

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -2296,9 +2296,11 @@ fn document_publication_input_owned(
     source_commit: Option<&str>,
     inventory: Vec<InventoryEvidence>,
 ) -> Result<(Extraction, BuildEvidence), GraphError> {
+    // The owned document may have been assembled from parallel extraction
+    // results. Leave raw-order canonicalization enabled so relocation and
+    // repeated builds receive the same quarantine identities and diagnostics.
     let mut profile_started = Instant::now();
     let mut extensions = Map::new();
-    extensions.insert(CANONICAL_RAW_ORDER.to_owned(), Value::Bool(true));
     if let Some(diagnostics) = document.graph.get(TRUSTED_GRAPH_DIAGNOSTICS) {
         extensions.insert(TRUSTED_GRAPH_DIAGNOSTICS.to_owned(), diagnostics.clone());
     }

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -20,6 +20,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
 compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.2.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-ingest/src/lib.rs
+++ b/crates/compass-ingest/src/lib.rs
@@ -24,11 +24,7 @@ const USER_AGENT: &str = "Mozilla/5.0 compass/1.0";
 
 static UNSAFE_FILENAME: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"[^\w\-]"));
 static REPEATED_UNDERSCORE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"_+"));
-static SCRIPT: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?is)<script[^>]*>.*?</script>"));
-static STYLE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?is)<style[^>]*>.*?</style>"));
 static TAG: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?s)<[^>]+>"));
-static WHITESPACE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"\s+"));
-static TITLE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?is)<title[^>]*>(.*?)</title>"));
 static ARXIV_ID: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(\d{4}\.\d{4,5})"));
 static ARXIV_ABSTRACT: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(r#"(?is)class="abstract[^"]*"[^>]*>(.*?)</blockquote>"#));
@@ -401,14 +397,19 @@ fn fetch_webpage(
     fetcher: &dyn Fetcher,
 ) -> Result<(String, String), IngestError> {
     let html = fetch_text(request.url, fetcher)?;
-    let title = TITLE
-        .captures(&html)
-        .and_then(|captures| captures.get(1))
-        .map_or_else(
-            || request.url.to_owned(),
-            |value| collapse_whitespace(value.as_str()),
-        );
-    let markdown = html_to_markdown(&html);
+    let normalized =
+        compass_languages::normalize_html(request.url, html.as_bytes()).map_err(|error| {
+            IngestError::Fetch {
+                url: request.url.to_owned(),
+                message: format!("HTML normalization failed: {error}"),
+            }
+        })?;
+    let title = if normalized.title.is_empty() {
+        request.url.to_owned()
+    } else {
+        normalized.title
+    };
+    let markdown = normalized.markdown;
     let contributor = request.contributor.or(request.author).unwrap_or("unknown");
     let timestamp = python_timestamp(captured_at);
     let content = format!(
@@ -520,17 +521,6 @@ fn validate_url_syntax(input: &str) -> Result<Url, IngestError> {
         )));
     }
     Ok(url)
-}
-
-fn html_to_markdown(html: &str) -> String {
-    let html = SCRIPT.replace_all(html, "");
-    let html = STYLE.replace_all(&html, "");
-    let text = TAG.replace_all(&html, " ");
-    truncate_chars(&collapse_whitespace(&text), 8_000)
-}
-
-fn collapse_whitespace(value: &str) -> String {
-    WHITESPACE.replace_all(value, " ").trim().to_owned()
 }
 
 fn truncate_chars(value: &str, limit: usize) -> String {
@@ -713,7 +703,7 @@ mod tests {
         assert_eq!(result.message, "Saved webpage: example_com_a-page.md");
         assert_eq!(
             fs::read_to_string(result.path)?,
-            "---\nsource_url: \"https://example.com/a-page?q=1\"\ntype: webpage\ntitle: \"A &amp; B\"\ncaptured_at: 2023-11-14T22:13:20.123456+00:00\ncontributor: \"Alice\"\n---\n\n# A &amp; B\n\nSource: https://example.com/a-page?q=1\n\n---\n\nA &amp; B Hello world\n"
+            "---\nsource_url: \"https://example.com/a-page?q=1\"\ntype: webpage\ntitle: \"A & B\"\ncaptured_at: 2023-11-14T22:13:20.123456+00:00\ncontributor: \"Alice\"\n---\n\n# A & B\n\nSource: https://example.com/a-page?q=1\n\n---\n\n# Hello\n\nworld\n"
         );
         Ok(())
     }

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -27,11 +27,13 @@ toml.workspace = true
 compass-files = { path = "../compass-files", version = "0.2.1" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
+tree-sitter-html.workspace = true
 tree-sitter-md.workspace = true
 tree-sitter-language-pack.workspace = true
 unicode-normalization.workspace = true
 unicode-casefold.workspace = true
 unicode-properties.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -27,6 +27,7 @@ toml.workspace = true
 compass-files = { path = "../compass-files", version = "0.2.1" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
+tree-sitter-md.workspace = true
 tree-sitter-language-pack.workspace = true
 unicode-normalization.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -49,6 +49,14 @@ impl Engine {
                 let source_file = path.to_string_lossy().into_owned();
                 crate::markdown::extract_source(path, &source_file, &source)
             }
+            ExtractorKind::Html => {
+                let source = fs::read(path).map_err(|source| compass_files::FileError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                let source_file = path.to_string_lossy().into_owned();
+                crate::html::extract_source(path, &source_file, &source)
+            }
             ExtractorKind::JsonConfig => self.extract_json(path, spec),
             ExtractorKind::McpConfig => crate::mcp::extract(path),
             ExtractorKind::PackageManifest => crate::package_manifest::extract(path),
@@ -104,6 +112,10 @@ impl Engine {
                 let source_file = path.to_string_lossy().into_owned();
                 crate::markdown::extract_source(path, &source_file, source)
             }
+            ExtractorKind::Html => {
+                let source_file = path.to_string_lossy().into_owned();
+                crate::html::extract_source(path, &source_file, source)
+            }
             ExtractorKind::JsonConfig => self.extract_json_source(path, spec, source),
             ExtractorKind::Terraform => self.extract_terraform_source(path, spec, source),
             ExtractorKind::FrameworkConfig => Ok(crate::frameworks::detect_config_file(
@@ -153,6 +165,15 @@ impl Engine {
             Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
         if spec.kind == ExtractorKind::Markdown {
             let mut graph = crate::markdown::extract_source(path, source_file, source)?;
+            self.stamp_project_evidence(path, &mut graph);
+            stamp_producer_metadata(&mut graph, spec.name);
+            return Ok(CombinedExtraction {
+                graph,
+                program: None,
+            });
+        }
+        if spec.kind == ExtractorKind::Html {
+            let mut graph = crate::html::extract_source(path, source_file, source)?;
             self.stamp_project_evidence(path, &mut graph);
             stamp_producer_metadata(&mut graph, spec.name);
             return Ok(CombinedExtraction {

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -41,7 +41,14 @@ impl Engine {
             Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
         let mut extraction = match spec.kind {
             ExtractorKind::Generic => self.extract_generic(path, spec),
-            ExtractorKind::Markdown => crate::markdown::extract(path),
+            ExtractorKind::Markdown => {
+                let source = fs::read(path).map_err(|source| compass_files::FileError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                let source_file = path.to_string_lossy().into_owned();
+                crate::markdown::extract_source(path, &source_file, &source)
+            }
             ExtractorKind::JsonConfig => self.extract_json(path, spec),
             ExtractorKind::McpConfig => crate::mcp::extract(path),
             ExtractorKind::PackageManifest => crate::package_manifest::extract(path),
@@ -93,6 +100,10 @@ impl Engine {
             Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
         let mut extraction = match spec.kind {
             ExtractorKind::Generic => self.extract_generic_source(path, spec, source),
+            ExtractorKind::Markdown => {
+                let source_file = path.to_string_lossy().into_owned();
+                crate::markdown::extract_source(path, &source_file, source)
+            }
             ExtractorKind::JsonConfig => self.extract_json_source(path, spec, source),
             ExtractorKind::Terraform => self.extract_terraform_source(path, spec, source),
             ExtractorKind::FrameworkConfig => Ok(crate::frameworks::detect_config_file(
@@ -140,6 +151,15 @@ impl Engine {
     ) -> Result<CombinedExtraction, ExtractError> {
         let spec =
             Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
+        if spec.kind == ExtractorKind::Markdown {
+            let mut graph = crate::markdown::extract_source(path, source_file, source)?;
+            self.stamp_project_evidence(path, &mut graph);
+            stamp_producer_metadata(&mut graph, spec.name);
+            return Ok(CombinedExtraction {
+                graph,
+                program: None,
+            });
+        }
         if spec.kind == ExtractorKind::Generic && matches!(spec.name, "go" | "java") {
             let tree = self.parse(path, spec, source)?;
             let mut graph =

--- a/crates/compass-languages/src/html.rs
+++ b/crates/compass-languages/src/html.rs
@@ -1,0 +1,1432 @@
+//! Bounded structural HTML extraction and the shared HTML-to-text renderer.
+//!
+//! HTML is deliberately parsed with the pinned, statically linked
+//! `tree-sitter-html` grammar.  The renderer in this module is also used by URL
+//! ingestion so ingestion and repository extraction agree about what is
+//! visible, what is metadata, and which elements are ignored.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+use crate::facts::stamp_source_range;
+use crate::{RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord};
+use serde_json::{Map, Value, json};
+use tree_sitter::{Node, Parser, Tree};
+use tree_sitter_html::LANGUAGE;
+use url::Url;
+
+const MAX_NODES: usize = 100_000;
+const MAX_LINKS: usize = 100_000;
+const MAX_DIAGNOSTICS: usize = 256;
+const MAX_ATTRIBUTES: usize = 256;
+const MAX_ATTRIBUTE_BYTES: usize = 16 * 1024;
+const MAX_VISIBLE_TEXT_BYTES: usize = 1_048_576;
+const MAX_RENDERED_BYTES: usize = 2 * 1_048_576;
+
+/// Bounded, normalized HTML suitable for URL ingestion and other text-only
+/// consumers.  `markdown` is intentionally conservative: it preserves block
+/// boundaries and links without pretending that HTML presentation is Markdown
+/// semantics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HtmlNormalization {
+    pub title: String,
+    pub markdown: String,
+    pub metadata: Map<String, Value>,
+    pub diagnostics: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HtmlError {
+    #[error("HTML grammar setup failed: {0}")]
+    Grammar(String),
+    #[error("HTML parser was cancelled")]
+    ParseCancelled,
+}
+
+/// Normalize HTML using the same pinned parser and visibility rules as graph
+/// extraction.  The function never fetches a URL and treats malformed markup
+/// as recoverable input, returning diagnostics alongside the partial text.
+pub fn normalize_html(source_file: &str, source: &[u8]) -> Result<HtmlNormalization, HtmlError> {
+    let tree = parse(source)?;
+    let mut renderer = Renderer {
+        source,
+        source_file,
+        diagnostics: Vec::new(),
+        metadata: Map::new(),
+        title: String::new(),
+        base_href: None,
+        rendered_bytes: 0,
+    };
+    let markdown = renderer.render_document(tree.root_node());
+    if tree.root_node().has_error() {
+        renderer.add_diagnostic("HTML parser recovered from malformed syntax");
+    }
+    let visible_text = visible_text_for_node(tree.root_node(), source);
+    renderer.metadata.insert(
+        "visible_text".to_owned(),
+        Value::String(truncate_bytes(&visible_text, MAX_VISIBLE_TEXT_BYTES)),
+    );
+    if let Some(base_href) = renderer.base_href {
+        renderer
+            .metadata
+            .insert("base_href".to_owned(), Value::String(base_href));
+    }
+    Ok(HtmlNormalization {
+        title: bounded_string(&renderer.title),
+        markdown: truncate_bytes(&markdown, MAX_RENDERED_BYTES),
+        metadata: renderer.metadata,
+        diagnostics: renderer.diagnostics,
+    })
+}
+
+/// Extract structural HTML graph facts from caller-supplied bytes.
+pub(crate) fn extract_source(
+    path: &Path,
+    source_file: &str,
+    source: &[u8],
+) -> Result<crate::Extraction, crate::ExtractError> {
+    let tree = parse(source).map_err(|error| match error {
+        HtmlError::Grammar(detail) => crate::ExtractError::MissingGrammar {
+            language: "html".to_owned(),
+            detail,
+        },
+        HtmlError::ParseCancelled => crate::ExtractError::ParseCancelled(path.to_path_buf()),
+    })?;
+    let file_id = crate::make_id(&[source_file]);
+    let mut state = State {
+        path,
+        source,
+        source_file: source_file.to_owned(),
+        file_id: file_id.clone(),
+        extraction: crate::Extraction {
+            raw_calls: None,
+            ..crate::Extraction::default()
+        },
+        seen_nodes: HashSet::new(),
+        anchor_targets: HashMap::new(),
+        pending_links: Vec::new(),
+        unresolved_links: Vec::new(),
+        external_links: Vec::new(),
+        diagnostics: Vec::new(),
+        next_index: 1,
+        hidden_depth: 0,
+        base_href: None,
+        title: String::new(),
+        visible_text: String::new(),
+    };
+    state.add_root(file_id, &tree);
+    if tree.root_node().has_error() {
+        state.add_diagnostic("HTML parser recovered from malformed syntax");
+        state.mark_partial();
+    }
+    let root_id = state.file_id.clone();
+    state.walk_children(tree.root_node(), Some(&root_id));
+    state.finalize_links();
+    state.finish_metadata();
+    Ok(state.extraction)
+}
+
+fn parse(source: &[u8]) -> Result<Tree, HtmlError> {
+    let mut parser = Parser::new();
+    let language = LANGUAGE.into();
+    parser
+        .set_language(&language)
+        .map_err(|error| HtmlError::Grammar(error.to_string()))?;
+    parser.parse(source, None).ok_or(HtmlError::ParseCancelled)
+}
+
+struct State<'source, 'path> {
+    path: &'path Path,
+    source: &'source [u8],
+    source_file: String,
+    file_id: String,
+    extraction: crate::Extraction,
+    seen_nodes: HashSet<String>,
+    anchor_targets: HashMap<String, Vec<String>>,
+    pending_links: Vec<PendingLink>,
+    unresolved_links: Vec<Value>,
+    external_links: Vec<Value>,
+    diagnostics: Vec<String>,
+    next_index: usize,
+    hidden_depth: usize,
+    base_href: Option<String>,
+    title: String,
+    visible_text: String,
+}
+
+#[derive(Clone)]
+struct PendingLink {
+    raw: String,
+    owner_id: String,
+    site: LinkSite,
+    kind: &'static str,
+    rel: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+struct LinkSite {
+    start_byte: usize,
+    end_byte: usize,
+    line: usize,
+}
+
+impl State<'_, '_> {
+    fn add_root(&mut self, id: String, tree: &Tree) {
+        self.seen_nodes.insert(id.clone());
+        let mut attributes = Map::new();
+        attributes.insert(
+            "label".to_owned(),
+            Value::String(
+                self.path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default()
+                    .to_owned(),
+            ),
+        );
+        attributes.insert("file_type".to_owned(), Value::String("document".to_owned()));
+        attributes.insert(
+            "document_kind".to_owned(),
+            Value::String("document".to_owned()),
+        );
+        attributes.insert(
+            "document_format".to_owned(),
+            Value::String("html".to_owned()),
+        );
+        attributes.insert(
+            "source_file".to_owned(),
+            Value::String(self.source_file.clone()),
+        );
+        attributes.insert("source_location".to_owned(), Value::String("L1".to_owned()));
+        attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
+        stamp_source_range(&mut attributes, self.source, 0, self.source.len());
+        if tree.root_node().has_error() {
+            attributes.insert(
+                crate::EXTRACTION_QUALITY_EXTENSION.to_owned(),
+                Value::String(crate::EXTRACTION_QUALITY_PARTIAL.to_owned()),
+            );
+        }
+        self.extraction.nodes.push(NodeRecord {
+            id: id.clone(),
+            attributes,
+        });
+        self.file_id = id;
+    }
+
+    fn walk_children(&mut self, node: Node<'_>, parent: Option<&str>) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            self.walk_node(child, parent);
+        }
+    }
+
+    fn walk_node(&mut self, node: Node<'_>, parent: Option<&str>) {
+        if node.kind() == "comment" || node.kind() == "doctype" {
+            return;
+        }
+        if node.kind() == "ERROR" || node.is_error() || node.is_missing() {
+            self.add_diagnostic(format!(
+                "HTML malformed syntax near byte {}",
+                node.start_byte()
+            ));
+            return;
+        }
+        if node.kind() == "text" || node.kind() == "entity" {
+            if self.hidden_depth == 0 {
+                self.append_visible_text(&decode_html_entities(node_text(self.source, node)));
+            }
+            return;
+        }
+        let (tag, start_tag) = match node.kind() {
+            "element" => element_tag_name(node, self.source),
+            "script_element" => (Some("script".to_owned()), None),
+            "style_element" => (Some("style".to_owned()), None),
+            _ => (None, None),
+        };
+        let Some(tag) = tag else {
+            self.walk_children(node, parent);
+            return;
+        };
+        let tag = tag.to_ascii_lowercase();
+        if is_hidden_tag(&tag) {
+            self.hidden_depth = self.hidden_depth.saturating_add(1);
+            self.hidden_depth = self.hidden_depth.saturating_sub(1);
+            return;
+        }
+        if self.next_index > MAX_NODES {
+            self.add_diagnostic("HTML node limit exceeded");
+            return;
+        }
+        let attributes = collect_attributes(start_tag, self.source);
+        if tag == "base"
+            && let Some(href) = attributes.get("href").and_then(Value::as_str)
+        {
+            self.base_href = Some(href.to_owned());
+        }
+        let kind = html_kind(&tag);
+        let label = visible_text_for_node(node, self.source);
+        let id = crate::make_id(&[
+            &self.source_file,
+            "html",
+            kind,
+            &self.next_index.to_string(),
+            &node.start_byte().to_string(),
+        ]);
+        let mut extra = Map::new();
+        extra.insert("tag_name".to_owned(), Value::String(tag.clone()));
+        extra.insert(
+            "html_attributes".to_owned(),
+            Value::Object(attributes.clone()),
+        );
+        extra.insert(
+            "visible_text".to_owned(),
+            Value::String(bounded_string(&label)),
+        );
+        if let Some(level) = heading_level(&tag) {
+            extra.insert("heading_level".to_owned(), json!(level));
+            extra.insert("anchor_slug".to_owned(), Value::String(slugify(&label)));
+        }
+        if let Some(id_attr) = attributes.get("id").and_then(Value::as_str) {
+            extra.insert("explicit_id".to_owned(), Value::String(id_attr.to_owned()));
+        }
+        let id = self.add_node(id, &bounded_label(&label), kind, node, parent, extra);
+        if let Some(anchor) = attributes
+            .get("id")
+            .or_else(|| attributes.get("name"))
+            .and_then(Value::as_str)
+        {
+            self.anchor_targets
+                .entry(anchor.to_ascii_lowercase())
+                .or_default()
+                .push(id.clone());
+        }
+        if tag == "title" && self.title.is_empty() {
+            self.title = bounded_string(&label);
+        }
+        if tag == "a" {
+            self.add_pending_link(&attributes, node, "anchor", parent);
+        } else if tag == "link" {
+            self.add_pending_link(&attributes, node, "link", parent);
+        }
+        self.collect_metadata(&tag, &attributes);
+        if tag == "br" {
+            self.append_visible_text("\n");
+        }
+        self.walk_children(node, Some(&id));
+        if matches!(
+            tag.as_str(),
+            "p" | "div"
+                | "section"
+                | "article"
+                | "main"
+                | "nav"
+                | "li"
+                | "blockquote"
+                | "pre"
+                | "table"
+                | "h1"
+                | "h2"
+                | "h3"
+                | "h4"
+                | "h5"
+                | "h6"
+        ) {
+            self.append_visible_text("\n");
+        }
+    }
+
+    fn add_node(
+        &mut self,
+        id: String,
+        label: &str,
+        kind: &str,
+        node: Node<'_>,
+        parent: Option<&str>,
+        mut extra: Map<String, Value>,
+    ) -> String {
+        if !self.seen_nodes.insert(id.clone()) {
+            return id;
+        }
+        extra.insert("label".to_owned(), Value::String(bounded_label(label)));
+        extra.insert("file_type".to_owned(), Value::String("document".to_owned()));
+        extra.insert("document_kind".to_owned(), Value::String(kind.to_owned()));
+        extra.insert(
+            "source_file".to_owned(),
+            Value::String(self.source_file.clone()),
+        );
+        extra.insert(
+            "source_location".to_owned(),
+            Value::String(format!("L{}", self.line_at(node.start_byte()))),
+        );
+        extra.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
+        stamp_source_range(&mut extra, self.source, node.start_byte(), node.end_byte());
+        self.extraction.nodes.push(NodeRecord {
+            id: id.clone(),
+            attributes: extra,
+        });
+        self.next_index = self.next_index.saturating_add(1);
+        if let Some(parent) = parent {
+            self.add_relation(parent, &id, "contains", node.start_byte(), node.end_byte());
+        }
+        id
+    }
+
+    fn add_pending_link(
+        &mut self,
+        attributes: &Map<String, Value>,
+        node: Node<'_>,
+        kind: &'static str,
+        parent: Option<&str>,
+    ) {
+        let Some(raw) = attributes
+            .get("href")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return;
+        };
+        if self.pending_links.len() >= MAX_LINKS {
+            self.add_diagnostic("HTML link limit exceeded");
+            return;
+        }
+        let owner_id = self.containing_owner(parent);
+        self.pending_links.push(PendingLink {
+            raw: raw.to_owned(),
+            owner_id,
+            site: self.link_site(node.start_byte(), node.end_byte()),
+            kind,
+            rel: attributes
+                .get("rel")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        });
+    }
+
+    fn containing_owner(&self, parent: Option<&str>) -> String {
+        let mut candidate = parent.map(str::to_owned);
+        let mut visited = HashSet::new();
+        while let Some(id) = candidate {
+            if !visited.insert(id.clone()) {
+                break;
+            }
+            if id == self.file_id {
+                return id;
+            }
+            if self
+                .extraction
+                .nodes
+                .iter()
+                .find(|node| node.id == id)
+                .and_then(|node| node.attributes.get("document_kind"))
+                .and_then(Value::as_str)
+                .is_some_and(is_html_block_kind)
+            {
+                return id;
+            }
+            candidate = self
+                .extraction
+                .edges
+                .iter()
+                .rev()
+                .find(|edge| {
+                    edge.target == id
+                        && edge.attributes.get("relation").and_then(Value::as_str)
+                            == Some("contains")
+                })
+                .map(|edge| edge.source.clone());
+        }
+        self.file_id.clone()
+    }
+
+    fn collect_metadata(&mut self, tag: &str, attributes: &Map<String, Value>) {
+        if tag == "meta" {
+            let key = attributes
+                .get("name")
+                .or_else(|| attributes.get("property"))
+                .or_else(|| attributes.get("charset"))
+                .and_then(Value::as_str)
+                .map(str::to_ascii_lowercase);
+            if let Some(key) = key {
+                let content = attributes
+                    .get("content")
+                    .or_else(|| attributes.get("charset"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                self.extraction
+                    .extensions
+                    .entry("html_meta".to_owned())
+                    .or_insert_with(|| Value::Object(Map::new()));
+                if let Some(Value::Object(meta)) = self.extraction.extensions.get_mut("html_meta")
+                    && meta.len() < MAX_ATTRIBUTES
+                {
+                    meta.insert(key, Value::String(bounded_string(content)));
+                }
+            }
+        }
+        if tag == "link"
+            && attributes
+                .get("rel")
+                .and_then(Value::as_str)
+                .is_some_and(|rel| {
+                    rel.split_ascii_whitespace()
+                        .any(|item| item.eq_ignore_ascii_case("canonical"))
+                })
+            && let Some(href) = attributes.get("href").and_then(Value::as_str)
+        {
+            self.extraction.extensions.insert(
+                "html_canonical".to_owned(),
+                Value::String(bounded_string(href)),
+            );
+        }
+    }
+
+    fn finish_metadata(&mut self) {
+        if !self.title.is_empty() {
+            self.extraction
+                .extensions
+                .insert("html_title".to_owned(), Value::String(self.title.clone()));
+        }
+        if let Some(base_href) = &self.base_href {
+            self.extraction.extensions.insert(
+                "html_base_href".to_owned(),
+                Value::String(bounded_string(base_href)),
+            );
+        }
+        self.extraction.extensions.insert(
+            "html_visible_text".to_owned(),
+            Value::String(truncate_bytes(
+                &collapse_whitespace(&self.visible_text),
+                MAX_VISIBLE_TEXT_BYTES,
+            )),
+        );
+        self.extraction.extensions.insert(
+            "html_node_count".to_owned(),
+            json!(self.extraction.nodes.len().saturating_sub(1)),
+        );
+        self.extraction.extensions.insert(
+            "html_link_count".to_owned(),
+            json!(
+                self.extraction
+                    .edges
+                    .iter()
+                    .filter(|edge| edge.attributes.get("link_kind").is_some())
+                    .count()
+                    .saturating_add(self.external_links.len())
+                    .saturating_add(self.unresolved_links.len())
+            ),
+        );
+        if !self.diagnostics.is_empty() {
+            self.extraction.extensions.insert(
+                "html_diagnostics".to_owned(),
+                Value::Array(
+                    self.diagnostics
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            );
+        }
+        if !self.external_links.is_empty() {
+            self.extraction.extensions.insert(
+                "html_external_links".to_owned(),
+                Value::Array(std::mem::take(&mut self.external_links)),
+            );
+        }
+        if !self.unresolved_links.is_empty() {
+            self.extraction.extensions.insert(
+                "html_unresolved_links".to_owned(),
+                Value::Array(std::mem::take(&mut self.unresolved_links)),
+            );
+        }
+        let root_metadata = [
+            "html_title",
+            "html_base_href",
+            "html_visible_text",
+            "html_meta",
+            "html_canonical",
+        ];
+        let values = root_metadata
+            .iter()
+            .filter_map(|key| {
+                self.extraction
+                    .extensions
+                    .get(*key)
+                    .cloned()
+                    .map(|value| ((*key).to_owned(), value))
+            })
+            .collect::<Vec<_>>();
+        if let Some(root) = self
+            .extraction
+            .nodes
+            .iter_mut()
+            .find(|node| node.id == self.file_id)
+        {
+            for (key, value) in values {
+                root.attributes.insert(key, value);
+            }
+        }
+    }
+
+    fn finalize_links(&mut self) {
+        let pending = std::mem::take(&mut self.pending_links);
+        for link in pending {
+            let raw = link.raw.trim().trim_matches('<').trim_matches('>');
+            if raw.is_empty() {
+                continue;
+            }
+            let (path_part, fragment) =
+                raw.split_once('#').map_or((raw, None), |(path, fragment)| {
+                    (path, Some(fragment.trim()))
+                });
+            if is_external_url(raw) {
+                self.external_links
+                    .push(self.link_value(&link, raw, "external"));
+                continue;
+            }
+            if has_unsupported_scheme(raw) {
+                self.add_unresolved(&link, "unsupported_url_scheme", raw);
+                continue;
+            }
+            let target_path = self.resolve_target(path_part);
+            let same_file = target_path.as_deref().is_some_and(|target| {
+                match (Url::parse(&self.source_file), Url::parse(target)) {
+                    (Ok(source), Ok(target)) => source == target,
+                    _ => lexical_normalize(self.path) == lexical_normalize(Path::new(target)),
+                }
+            });
+            if same_file {
+                if let Some(fragment) = fragment.filter(|fragment| !fragment.is_empty()) {
+                    let key = fragment.to_ascii_lowercase();
+                    match self.anchor_targets.get(&key) {
+                        Some(candidates) if candidates.len() == 1 => {
+                            self.add_link_edge(&link, candidates[0].clone(), Some(fragment));
+                        }
+                        Some(_) => self.add_unresolved(&link, "ambiguous_fragment", fragment),
+                        None => self.add_unresolved(&link, "missing_fragment", fragment),
+                    }
+                }
+                continue;
+            }
+            let Some(target) = target_path else {
+                self.add_unresolved(&link, "invalid_relative_url", raw);
+                continue;
+            };
+            if is_external_url(&target) {
+                self.external_links
+                    .push(self.link_value(&link, &target, "external"));
+                continue;
+            }
+            if !is_supported_local_link(Path::new(&target)) {
+                self.add_unresolved(&link, "unsupported_local_suffix", &target);
+                continue;
+            }
+            self.add_link_edge(&link, crate::make_id(&[&target]), fragment);
+        }
+    }
+
+    fn resolve_target(&self, path_part: &str) -> Option<String> {
+        if path_part.is_empty() {
+            return Some(self.path.to_string_lossy().replace('\\', "/"));
+        }
+        if let Ok(source_url) = Url::parse(&self.source_file)
+            && matches!(source_url.scheme(), "http" | "https")
+        {
+            let base = self
+                .base_href
+                .as_deref()
+                .and_then(|href| source_url.join(href).ok())
+                .unwrap_or(source_url);
+            return base.join(path_part).ok().map(|url| url.to_string());
+        }
+        let candidate = PathBuf::from(path_part);
+        let joined = if candidate.is_absolute() {
+            candidate
+        } else {
+            let parent = self.path.parent().unwrap_or_else(|| Path::new(""));
+            if let Some(base_href) = self
+                .base_href
+                .as_deref()
+                .filter(|href| !has_unsupported_scheme(href))
+            {
+                let base = PathBuf::from(base_href);
+                if base.is_absolute() {
+                    base.join(candidate)
+                } else {
+                    parent.join(base).join(candidate)
+                }
+            } else {
+                parent.join(candidate)
+            }
+        };
+        Some(
+            lexical_normalize(&joined)
+                .to_string_lossy()
+                .replace('\\', "/"),
+        )
+    }
+
+    fn add_link_edge(&mut self, link: &PendingLink, target: String, fragment: Option<&str>) {
+        let mut attributes = self.link_attributes(link, "references");
+        if let Some(fragment) = fragment.filter(|value| !value.is_empty()) {
+            attributes.insert("fragment".to_owned(), Value::String(fragment.to_owned()));
+        }
+        self.extraction.edges.push(EdgeRecord {
+            source: link.owner_id.clone(),
+            target,
+            attributes,
+        });
+    }
+
+    fn link_value(&self, link: &PendingLink, target: &str, kind: &str) -> Value {
+        let mut value = self.link_attributes(link, kind);
+        value.insert("source".to_owned(), Value::String(link.owner_id.clone()));
+        value.insert("target".to_owned(), Value::String(target.to_owned()));
+        Value::Object(value)
+    }
+
+    fn add_unresolved(&mut self, link: &PendingLink, reason: &str, target: &str) {
+        if self.unresolved_links.len() < MAX_DIAGNOSTICS {
+            let mut value = self.link_attributes(link, "unresolved");
+            value.insert("source".to_owned(), Value::String(link.owner_id.clone()));
+            value.insert("target".to_owned(), Value::String(target.to_owned()));
+            value.insert("reason".to_owned(), Value::String(reason.to_owned()));
+            self.unresolved_links.push(Value::Object(value));
+        }
+    }
+
+    fn link_attributes(&self, link: &PendingLink, relation: &str) -> Map<String, Value> {
+        let mut attributes = Map::new();
+        attributes.insert("relation".to_owned(), Value::String(relation.to_owned()));
+        attributes.insert(
+            "confidence".to_owned(),
+            Value::String("EXTRACTED".to_owned()),
+        );
+        attributes.insert(
+            "source_file".to_owned(),
+            Value::String(self.source_file.clone()),
+        );
+        attributes.insert(
+            "source_location".to_owned(),
+            Value::String(format!("L{}", link.site.line)),
+        );
+        attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
+        stamp_source_range(
+            &mut attributes,
+            self.source,
+            link.site.start_byte,
+            link.site.end_byte,
+        );
+        attributes.insert("start_line".to_owned(), json!(link.site.line));
+        attributes.insert(
+            "end_line".to_owned(),
+            json!(self.line_at(link.site.end_byte)),
+        );
+        attributes.insert("weight".to_owned(), json!(1.0));
+        attributes.insert("link_kind".to_owned(), Value::String(link.kind.to_owned()));
+        if let Some(rel) = link.rel.as_deref().filter(|rel| !rel.is_empty()) {
+            attributes.insert("rel".to_owned(), Value::String(bounded_string(rel)));
+        }
+        attributes
+    }
+
+    fn add_relation(
+        &mut self,
+        source: &str,
+        target: &str,
+        relation: &str,
+        start: usize,
+        end: usize,
+    ) {
+        let mut attributes = Map::new();
+        attributes.insert("relation".to_owned(), Value::String(relation.to_owned()));
+        attributes.insert(
+            "confidence".to_owned(),
+            Value::String("EXTRACTED".to_owned()),
+        );
+        attributes.insert(
+            "source_file".to_owned(),
+            Value::String(self.source_file.clone()),
+        );
+        attributes.insert(
+            "source_location".to_owned(),
+            Value::String(format!("L{}", self.line_at(start))),
+        );
+        attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
+        stamp_source_range(&mut attributes, self.source, start, end);
+        attributes.insert("start_line".to_owned(), json!(self.line_at(start)));
+        attributes.insert("end_line".to_owned(), json!(self.line_at(end)));
+        attributes.insert("weight".to_owned(), json!(1.0));
+        self.extraction.edges.push(EdgeRecord {
+            source: source.to_owned(),
+            target: target.to_owned(),
+            attributes,
+        });
+    }
+
+    fn append_visible_text(&mut self, text: &str) {
+        if self.visible_text.len() >= MAX_VISIBLE_TEXT_BYTES {
+            return;
+        }
+        let remaining = MAX_VISIBLE_TEXT_BYTES.saturating_sub(self.visible_text.len());
+        self.visible_text.push_str(&truncate_bytes(text, remaining));
+    }
+
+    fn add_diagnostic(&mut self, text: impl Into<String>) {
+        if self.diagnostics.len() < MAX_DIAGNOSTICS {
+            self.diagnostics.push(text.into());
+        }
+    }
+
+    fn mark_partial(&mut self) {
+        self.extraction.extensions.insert(
+            crate::EXTRACTION_QUALITY_EXTENSION.to_owned(),
+            Value::String(crate::EXTRACTION_QUALITY_PARTIAL.to_owned()),
+        );
+        self.extraction.extensions.insert(
+            crate::EXTRACTION_QUALITY_REASON_EXTENSION.to_owned(),
+            Value::String("html_parser_recovery".to_owned()),
+        );
+    }
+
+    fn link_site(&self, start: usize, end: usize) -> LinkSite {
+        let start = start.min(self.source.len());
+        let end = end.clamp(start, self.source.len());
+        LinkSite {
+            start_byte: start,
+            end_byte: end,
+            line: self.line_at(start),
+        }
+    }
+
+    fn line_at(&self, offset: usize) -> usize {
+        self.source[..offset.min(self.source.len())]
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count()
+            .saturating_add(1)
+    }
+}
+
+struct Renderer<'source> {
+    source: &'source [u8],
+    source_file: &'source str,
+    diagnostics: Vec<String>,
+    metadata: Map<String, Value>,
+    title: String,
+    base_href: Option<String>,
+    rendered_bytes: usize,
+}
+
+impl Renderer<'_> {
+    fn render_document(&mut self, root: Node<'_>) -> String {
+        let mut output = String::new();
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor).filter(Node::is_named) {
+            self.render_node(child, &mut output, 0);
+        }
+        collapse_markdown(&output)
+    }
+
+    fn render_node(&mut self, node: Node<'_>, output: &mut String, depth: usize) {
+        if node.kind() == "comment" || node.kind() == "doctype" {
+            return;
+        }
+        if node.kind() == "text" || node.kind() == "entity" {
+            self.push_rendered(output, &decode_html_entities(node_text(self.source, node)));
+            return;
+        }
+        let (tag, start_tag) = match node.kind() {
+            "element" => element_tag_name(node, self.source),
+            "script_element" => (Some("script".to_owned()), None),
+            "style_element" => (Some("style".to_owned()), None),
+            _ => (None, None),
+        };
+        let Some(tag) = tag else {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor).filter(Node::is_named) {
+                self.render_node(child, output, depth);
+            }
+            return;
+        };
+        let tag = tag.to_ascii_lowercase();
+        if is_hidden_tag(&tag) {
+            return;
+        }
+        let attrs = collect_attributes(start_tag, self.source);
+        if tag == "base" && self.base_href.is_none() {
+            self.base_href = attrs.get("href").and_then(Value::as_str).map(str::to_owned);
+        }
+        if tag == "title" && self.title.is_empty() {
+            self.title = bounded_string(&visible_text_for_node(node, self.source));
+        }
+        self.collect_renderer_metadata(&tag, &attrs);
+        if let Some(level) = heading_level(&tag) {
+            self.push_rendered(output, &format!("{} ", "#".repeat(level)));
+            self.render_children(node, output, depth.saturating_add(1));
+            self.push_rendered(output, "\n\n");
+            return;
+        }
+        match tag.as_str() {
+            "a" => {
+                let start = output.len();
+                self.render_children(node, output, depth.saturating_add(1));
+                let label = output.get(start..).unwrap_or_default().trim().to_owned();
+                if let Some(href) = attrs.get("href").and_then(Value::as_str) {
+                    let href = self.resolve_href(href);
+                    output.truncate(start);
+                    self.push_rendered(output, &format!("[{label}]({href})"));
+                }
+                self.push_rendered(output, " ");
+            }
+            "br" => self.push_rendered(output, "\n"),
+            "li" => {
+                self.push_rendered(
+                    output,
+                    &format!("{}- ", "  ".repeat(depth.saturating_sub(1))),
+                );
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, "\n");
+            }
+            "ul" | "ol" => {
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, "\n");
+            }
+            "blockquote" => {
+                let start = output.len();
+                self.render_children(node, output, depth.saturating_add(1));
+                let text = output.get(start..).unwrap_or_default().trim().to_owned();
+                output.truncate(start);
+                for line in text.lines() {
+                    self.push_rendered(output, &format!("> {line}\n"));
+                }
+                self.push_rendered(output, "\n");
+            }
+            "pre" => {
+                let raw = raw_text_descendant(node, self.source);
+                self.push_rendered(output, "```\n");
+                self.push_rendered(output, &raw);
+                self.push_rendered(output, "\n```\n\n");
+            }
+            "table" => {
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, "\n");
+            }
+            "tr" => {
+                self.push_rendered(output, "| ");
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, "\n");
+            }
+            "td" | "th" => {
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, " | ");
+            }
+            "p" | "div" | "section" | "article" | "main" | "nav" => {
+                self.render_children(node, output, depth.saturating_add(1));
+                self.push_rendered(output, "\n\n");
+            }
+            "title" => {}
+            _ => self.render_children(node, output, depth.saturating_add(1)),
+        }
+    }
+
+    fn render_children(&mut self, node: Node<'_>, output: &mut String, depth: usize) {
+        let mut cursor = node.walk();
+        let mut previous_end = node.start_byte();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            if previous_end < child.start_byte()
+                && self.source[previous_end..child.start_byte()]
+                    .iter()
+                    .all(u8::is_ascii_whitespace)
+            {
+                self.push_rendered(output, " ");
+            }
+            self.render_node(child, output, depth);
+            previous_end = child.end_byte();
+        }
+    }
+
+    fn collect_renderer_metadata(&mut self, tag: &str, attrs: &Map<String, Value>) {
+        if tag == "meta"
+            && let Some(key) = attrs
+                .get("name")
+                .or_else(|| attrs.get("property"))
+                .or_else(|| attrs.get("charset"))
+                .and_then(Value::as_str)
+        {
+            let value = attrs
+                .get("content")
+                .or_else(|| attrs.get("charset"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            self.metadata.insert(
+                key.to_ascii_lowercase(),
+                Value::String(bounded_string(value)),
+            );
+        }
+        if tag == "link"
+            && attrs.get("rel").and_then(Value::as_str).is_some_and(|rel| {
+                rel.split_ascii_whitespace()
+                    .any(|item| item.eq_ignore_ascii_case("canonical"))
+            })
+            && let Some(href) = attrs.get("href").and_then(Value::as_str)
+        {
+            self.metadata
+                .insert("canonical".to_owned(), Value::String(bounded_string(href)));
+        }
+    }
+
+    fn resolve_href(&self, href: &str) -> String {
+        if href.starts_with('#') || (href.starts_with('/') && !self.source_file.starts_with("http"))
+        {
+            return href.to_owned();
+        }
+        let Ok(source_url) = Url::parse(self.source_file) else {
+            return href.to_owned();
+        };
+        if !matches!(source_url.scheme(), "http" | "https") {
+            return href.to_owned();
+        }
+        let base = self
+            .base_href
+            .as_deref()
+            .and_then(|base| source_url.join(base).ok())
+            .unwrap_or(source_url);
+        base.join(href)
+            .map(|url| url.to_string())
+            .unwrap_or_else(|_| href.to_owned())
+    }
+
+    fn push_rendered(&mut self, output: &mut String, text: &str) {
+        if self.rendered_bytes >= MAX_RENDERED_BYTES {
+            return;
+        }
+        let remaining = MAX_RENDERED_BYTES.saturating_sub(self.rendered_bytes);
+        let text = truncate_bytes(text, remaining);
+        self.rendered_bytes = self.rendered_bytes.saturating_add(text.len());
+        output.push_str(&text);
+    }
+
+    fn add_diagnostic(&mut self, text: &str) {
+        if self.diagnostics.len() < MAX_DIAGNOSTICS {
+            self.diagnostics.push(text.to_owned());
+        }
+    }
+}
+
+fn element_tag_name<'a>(node: Node<'a>, source: &[u8]) -> (Option<String>, Option<Node<'a>>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(Node::is_named) {
+        if matches!(child.kind(), "start_tag" | "self_closing_tag") {
+            let mut tag_cursor = child.walk();
+            for tag_child in child.children(&mut tag_cursor).filter(Node::is_named) {
+                if tag_child.kind() == "tag_name" {
+                    return (
+                        Some(node_text(source, tag_child).to_ascii_lowercase()),
+                        Some(child),
+                    );
+                }
+            }
+            return (None, Some(child));
+        }
+    }
+    (None, None)
+}
+
+fn collect_attributes(start_tag: Option<Node<'_>>, source: &[u8]) -> Map<String, Value> {
+    let mut values = Vec::new();
+    let Some(start_tag) = start_tag else {
+        return Map::new();
+    };
+    let mut cursor = start_tag.walk();
+    for child in start_tag.children(&mut cursor).filter(Node::is_named) {
+        if child.kind() != "attribute" {
+            continue;
+        }
+        let mut name = None;
+        let mut value = None;
+        let mut inner = child.walk();
+        for part in child.children(&mut inner).filter(Node::is_named) {
+            match part.kind() {
+                "attribute_name" => name = Some(node_text(source, part).to_ascii_lowercase()),
+                "attribute_value" | "quoted_attribute_value" => {
+                    value = Some(
+                        decode_html_entities(node_text(source, part))
+                            .trim_matches(['"', '\''])
+                            .to_owned(),
+                    )
+                }
+                _ => {}
+            }
+        }
+        if let Some(name) = name.filter(|name| !name.is_empty()) {
+            values.push((name, bounded_string(value.as_deref().unwrap_or(""))));
+        }
+    }
+    values.sort_by(|left, right| left.0.cmp(&right.0));
+    values.truncate(MAX_ATTRIBUTES);
+    let mut output = Map::new();
+    for (name, value) in values {
+        output.insert(name, Value::String(value));
+    }
+    output
+}
+
+fn visible_text_for_node(node: Node<'_>, source: &[u8]) -> String {
+    let mut output = String::new();
+    append_visible_node_text(node, source, &mut output);
+    collapse_whitespace(&output)
+}
+
+fn append_visible_node_text(node: Node<'_>, source: &[u8], output: &mut String) {
+    if node.kind() == "comment"
+        || node.kind() == "doctype"
+        || node.kind() == "script_element"
+        || node.kind() == "style_element"
+    {
+        return;
+    }
+    if node.kind() == "element"
+        && element_tag_name(node, source)
+            .0
+            .is_some_and(|tag| is_hidden_tag(&tag.to_ascii_lowercase()))
+    {
+        return;
+    }
+    if node.kind() == "text" || node.kind() == "entity" {
+        output.push_str(&decode_html_entities(node_text(source, node)));
+        return;
+    }
+    let mut cursor = node.walk();
+    let mut previous_end = node.start_byte();
+    for child in node.children(&mut cursor).filter(Node::is_named) {
+        if previous_end < child.start_byte()
+            && source[previous_end..child.start_byte()]
+                .iter()
+                .all(u8::is_ascii_whitespace)
+        {
+            output.push(' ');
+        }
+        append_visible_node_text(child, source, output);
+        previous_end = child.end_byte();
+    }
+}
+
+fn raw_text_descendant(node: Node<'_>, source: &[u8]) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(Node::is_named) {
+        if child.kind() == "raw_text" {
+            return node_text(source, child);
+        }
+        let nested = raw_text_descendant(child, source);
+        if !nested.is_empty() {
+            return nested;
+        }
+    }
+    visible_text_for_node(node, source)
+}
+
+fn html_kind(tag: &str) -> &'static str {
+    match tag {
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => "heading",
+        "p" => "paragraph",
+        "ul" | "ol" => "list",
+        "li" => "list_item",
+        "blockquote" => "blockquote",
+        "pre" => "preformatted",
+        "code" => "code",
+        "table" => "table",
+        "tr" => "table_row",
+        "td" | "th" => "table_cell",
+        "main" | "article" | "section" | "nav" => "landmark",
+        "a" => "link",
+        "title" => "title",
+        "meta" => "metadata",
+        "link" => "resource_link",
+        "base" => "base_url",
+        _ => "element",
+    }
+}
+
+fn is_html_block_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "heading"
+            | "paragraph"
+            | "landmark"
+            | "list"
+            | "list_item"
+            | "blockquote"
+            | "preformatted"
+            | "table"
+            | "table_row"
+            | "table_cell"
+    )
+}
+
+fn heading_level(tag: &str) -> Option<usize> {
+    match tag {
+        "h1" => Some(1),
+        "h2" => Some(2),
+        "h3" => Some(3),
+        "h4" => Some(4),
+        "h5" => Some(5),
+        "h6" => Some(6),
+        _ => None,
+    }
+}
+
+fn is_hidden_tag(tag: &str) -> bool {
+    matches!(tag, "script" | "style" | "template" | "noscript")
+}
+
+fn is_external_url(raw: &str) -> bool {
+    raw.starts_with("//")
+        || Url::parse(raw)
+            .ok()
+            .is_some_and(|url| matches!(url.scheme(), "http" | "https" | "mailto"))
+}
+
+fn has_unsupported_scheme(raw: &str) -> bool {
+    raw.split_once(':').is_some_and(|(scheme, _)| {
+        !scheme.is_empty()
+            && scheme.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.')
+            })
+    })
+}
+
+fn is_supported_local_link(path: &Path) -> bool {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    matches!(
+        extension.as_str(),
+        "html"
+            | "htm"
+            | "md"
+            | "markdown"
+            | "mdx"
+            | "qmd"
+            | "skill"
+            | "txt"
+            | "rst"
+            | "yaml"
+            | "yml"
+            | "json"
+            | "docx"
+            | "xlsx"
+            | "pptx"
+            | "rtf"
+            | "pdf"
+            | "py"
+            | "rs"
+            | "ts"
+            | "tsx"
+            | "js"
+            | "jsx"
+            | "go"
+            | "java"
+            | "rb"
+            | "php"
+            | "c"
+            | "cpp"
+            | "h"
+            | "cs"
+            | "swift"
+            | "kt"
+            | "scala"
+            | "sql"
+    )
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut output = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !matches!(output.components().next_back(), Some(Component::RootDir)) {
+                    output.pop();
+                }
+            }
+            component => output.push(component.as_os_str()),
+        }
+    }
+    output
+}
+
+fn node_text(source: &[u8], node: Node<'_>) -> String {
+    let start = node.start_byte().min(source.len());
+    let end = node.end_byte().clamp(start, source.len());
+    String::from_utf8_lossy(&source[start..end]).into_owned()
+}
+
+fn bounded_string(value: &str) -> String {
+    truncate_bytes(value, MAX_ATTRIBUTE_BYTES)
+}
+
+fn bounded_label(value: &str) -> String {
+    let value = collapse_whitespace(value);
+    if value.is_empty() {
+        "HTML element".to_owned()
+    } else {
+        truncate_bytes(&value, 512)
+    }
+}
+
+fn truncate_bytes(value: &str, max: usize) -> String {
+    if value.len() <= max {
+        return value.to_owned();
+    }
+    let mut end = max;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    let mut output = String::new();
+    let mut pending_space = false;
+    for character in value.chars() {
+        if character.is_whitespace() {
+            pending_space = !output.is_empty();
+        } else {
+            if pending_space && !output.ends_with(['\n', ' ']) {
+                output.push(' ');
+            }
+            output.push(character);
+            pending_space = false;
+        }
+    }
+    output.trim().to_owned()
+}
+
+fn collapse_markdown(value: &str) -> String {
+    let mut lines = Vec::new();
+    let mut blank = false;
+    for raw in value.lines() {
+        let line = raw.trim_end();
+        if line.is_empty() {
+            if !blank {
+                lines.push(String::new());
+            }
+            blank = true;
+        } else {
+            lines.push(line.to_owned());
+            blank = false;
+        }
+    }
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+fn slugify(value: &str) -> String {
+    crate::normalize_id(value)
+}
+
+fn decode_html_entities(value: String) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut rest = value.as_str();
+    while let Some(index) = rest.find('&') {
+        output.push_str(&rest[..index]);
+        let after = &rest[index..];
+        let Some(end) = after.find(';') else {
+            output.push_str(after);
+            break;
+        };
+        let entity = &after[1..end];
+        let decoded = decode_entity(entity).unwrap_or_else(|| after[..end + 1].to_owned());
+        output.push_str(&decoded);
+        rest = &after[end + 1..];
+    }
+    if !rest.is_empty() && !rest.contains('&') {
+        output.push_str(rest);
+    }
+    output
+}
+
+fn decode_entity(entity: &str) -> Option<String> {
+    if let Some(hex) = entity
+        .strip_prefix("#x")
+        .or_else(|| entity.strip_prefix("#X"))
+    {
+        return u32::from_str_radix(hex, 16)
+            .ok()
+            .and_then(char::from_u32)
+            .map(|value| value.to_string());
+    }
+    if let Some(decimal) = entity.strip_prefix('#') {
+        return decimal
+            .parse::<u32>()
+            .ok()
+            .and_then(char::from_u32)
+            .map(|value| value.to_string());
+    }
+    let value = match entity {
+        "amp" => '&',
+        "lt" => '<',
+        "gt" => '>',
+        "quot" => '"',
+        "apos" => '\'',
+        "nbsp" => '\u{a0}',
+        "hellip" => '…',
+        "ndash" => '–',
+        "mdash" => '—',
+        "copy" => '©',
+        "reg" => '®',
+        "trade" => '™',
+        "laquo" => '«',
+        "raquo" => '»',
+        "bull" => '•',
+        "middot" => '·',
+        _ => return None,
+    };
+    Some(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::{normalize_html, parse};
+    use serde_json::Value;
+
+    #[test]
+    fn parser_is_pinned_and_renderer_skips_non_visible_elements() {
+        let source = br#"<html><head><title>A &amp; B</title><style>hide</style></head><body><main><h1 id="top">Hello</h1><p>World <a href="/next" rel="next">next</a></p><script>bad()</script><template>template secret</template><noscript>noscript secret</noscript></main></body></html>"#;
+        let normalized =
+            normalize_html("https://example.com/start.html", source).expect("normalize");
+        assert_eq!(normalized.title, "A & B", "{normalized:?}");
+        assert!(normalized.markdown.contains("# Hello"));
+        assert!(
+            normalized
+                .markdown
+                .contains("[next](https://example.com/next)"),
+            "{normalized:?}"
+        );
+        assert!(!normalized.markdown.contains("hide"));
+        assert!(!normalized.markdown.contains("bad()"));
+        assert!(!normalized.markdown.contains("template secret"));
+        assert!(!normalized.markdown.contains("noscript secret"));
+        assert!(
+            !normalized
+                .metadata
+                .get("visible_text")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .contains("template secret")
+        );
+    }
+
+    #[test]
+    fn malformed_html_is_recoverable() {
+        let tree = parse(b"<main><p>broken").expect("tree");
+        assert!(tree.root_node().has_error());
+    }
+}

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -21,6 +21,7 @@ pub mod frameworks;
 pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/5";
 mod go;
 mod groovy;
+mod html;
 mod ids;
 mod json_config;
 mod julia;
@@ -65,6 +66,7 @@ pub use frameworks::{
     FrameworkPackRegistryError, FrameworkRelation, RawDomainFact, RawFrameworkAnchor,
     RawFrameworkAnnotationFact, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact,
 };
+pub use html::{HtmlError, HtmlNormalization, normalize_html};
 pub use ids::{file_stem, make_id, normalize_id};
 pub use program::{TREE_SITTER_PROGRAM_PROVIDER_VERSION, TreeSitterSyntaxProvider};
 pub use project_evidence::{

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -18,7 +18,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/4";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/5";
 mod go;
 mod groovy;
 mod ids;

--- a/crates/compass-languages/src/markdown.rs
+++ b/crates/compass-languages/src/markdown.rs
@@ -1,185 +1,106 @@
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::sync::LazyLock;
 
+use crate::facts::stamp_source_range;
 use crate::{RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord};
-use regex::Regex;
 use serde_json::{Map, Value, json};
+use tree_sitter::{Node, Parser};
+use tree_sitter_md::{INLINE_LANGUAGE, LANGUAGE};
 
-use crate::{ExtractError, Extraction, file_stem, make_id};
+const FRONTMATTER_MAX_BYTES: usize = 64 * 1024;
+const MAX_BLOCKS: usize = 100_000;
+const MAX_LINKS: usize = 100_000;
+const MAX_DIAGNOSTICS: usize = 256;
+const MAX_METADATA_KEYS: usize = 256;
+const MAX_METADATA_STRING_BYTES: usize = 16 * 1024;
+const MAX_METADATA_ARRAY_ITEMS: usize = 256;
+const MAX_LABEL_CHARS: usize = 512;
 
-static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\[[^\]]*\]\(\s*<?([^\)\s>]+)>?(?:\s+[^\)]*)?\)"#)
-        .unwrap_or_else(|error| unreachable!("static Markdown link regex is invalid: {error}"))
-});
-static REFERENCE_DEFINITION: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"^\s{0,3}\[[^\]]+\]:\s*<?([^\s>]+)>?"#)
-        .unwrap_or_else(|error| unreachable!("static Markdown reference regex is invalid: {error}"))
-});
-static WIKILINK: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"\[\[([^\]|#]+)(?:[#|][^\]]*)?\]\]"#)
-        .unwrap_or_else(|error| unreachable!("static Markdown wikilink regex is invalid: {error}"))
-});
-static HEADING: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(#{1,6})\s+(.+)")
-        .unwrap_or_else(|error| unreachable!("static Markdown heading regex is invalid: {error}"))
-});
+/// Extract Markdown from bytes supplied by the caller.
+///
+/// The engine uses this path after its bounded source read. Keeping the source
+/// buffer here avoids a second filesystem read and lets every location remain
+/// relative to the exact bytes that were parsed.
+pub(crate) fn extract_source(
+    path: &Path,
+    source_file: &str,
+    source: &[u8],
+) -> Result<crate::Extraction, crate::ExtractError> {
+    let mut block_parser = Parser::new();
+    let block_language = LANGUAGE.into();
+    block_parser
+        .set_language(&block_language)
+        .map_err(|error| crate::ExtractError::MissingGrammar {
+            language: "markdown".to_owned(),
+            detail: error.to_string(),
+        })?;
+    let block_tree = block_parser
+        .parse(source, None)
+        .ok_or_else(|| crate::ExtractError::ParseCancelled(path.to_path_buf()))?;
 
-pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
-    let bytes = fs::read(path).map_err(|source| compass_files::FileError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let source = String::from_utf8_lossy(&bytes);
-    let source_file = path.to_string_lossy().into_owned();
-    let stem = file_stem(path);
-    let file_id = make_id(&[&source_file]);
+    let mut inline_parser = Parser::new();
+    let inline_language = INLINE_LANGUAGE.into();
+    inline_parser
+        .set_language(&inline_language)
+        .map_err(|error| crate::ExtractError::MissingGrammar {
+            language: "markdown_inline".to_owned(),
+            detail: error.to_string(),
+        })?;
+
+    let (metadata, frontmatter_diagnostic) = parse_frontmatter(source);
+    let stem = crate::file_stem(path);
+    let file_id = crate::make_id(&[source_file]);
     let mut state = State {
         path,
-        source_file,
+        source,
+        source_file: source_file.to_owned(),
         stem,
         file_id: file_id.clone(),
-        extraction: Extraction {
+        extraction: crate::Extraction {
             raw_calls: None,
-            ..Extraction::default()
+            ..crate::Extraction::default()
         },
         seen_nodes: HashSet::new(),
         heading_stack: Vec::new(),
         heading_occurrences: HashMap::new(),
+        heading_targets: HashMap::new(),
+        reference_definitions: HashMap::new(),
+        pending_links: Vec::new(),
+        unresolved_links: Vec::new(),
+        external_links: Vec::new(),
+        diagnostics: Vec::new(),
+        inline_parser,
+        next_block_index: 1,
     };
 
-    state.add_node(
-        file_id,
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or_default(),
-        1,
-        None,
-    );
-
-    let mut fence = None;
-    let mut byte_offset = 0;
-    for (index, line_text) in source.split_inclusive('\n').enumerate() {
-        let text = line_text
-            .strip_suffix('\n')
-            .unwrap_or(line_text)
-            .strip_suffix('\r')
-            .unwrap_or_else(|| line_text.strip_suffix('\n').unwrap_or(line_text));
-        let line = index + 1;
-        if let Some(open) = fence {
-            if closes_fence(text, open) {
-                fence = None;
-            }
-            byte_offset += line_text.len();
-            continue;
-        }
-        if let Some(open) = opens_fence(text) {
-            fence = Some(open);
-            byte_offset += line_text.len();
-            continue;
-        }
-
-        for captures in INLINE_LINK.captures_iter(text) {
-            let Some(whole) = captures.get(0) else {
-                continue;
-            };
-            if whole.start() > 0 && text.as_bytes().get(whole.start() - 1) == Some(&b'!') {
-                continue;
-            }
-            if let Some(target) = captures.get(1) {
-                state.add_link(
-                    target.as_str(),
-                    LinkSite {
-                        line,
-                        start_byte: byte_offset + whole.start(),
-                        end_byte: byte_offset + whole.end(),
-                        line_start: byte_offset,
-                    },
-                );
-            }
-        }
-        for captures in WIKILINK.captures_iter(text) {
-            let Some(whole) = captures.get(0) else {
-                continue;
-            };
-            if whole.start() > 0 && text.as_bytes().get(whole.start() - 1) == Some(&b'!') {
-                continue;
-            }
-            if let Some(target) = captures.get(1) {
-                state.add_link(
-                    target.as_str(),
-                    LinkSite {
-                        line,
-                        start_byte: byte_offset + whole.start(),
-                        end_byte: byte_offset + whole.end(),
-                        line_start: byte_offset,
-                    },
-                );
-            }
-        }
-        if let Some(captures) = REFERENCE_DEFINITION.captures(text)
-            && let (Some(whole), Some(target)) = (captures.get(0), captures.get(1))
-        {
-            state.add_link(
-                target.as_str(),
-                LinkSite {
-                    line,
-                    start_byte: byte_offset + whole.start(),
-                    end_byte: byte_offset + whole.end(),
-                    line_start: byte_offset,
-                },
-            );
-        }
-
-        let Some(captures) = HEADING.captures(text) else {
-            byte_offset += line_text.len();
-            continue;
-        };
-        let (Some(markers), Some(title)) = (captures.get(1), captures.get(2)) else {
-            continue;
-        };
-        let level = markers.as_str().len();
-        let title = title.as_str().trim();
-        while state
-            .heading_stack
-            .last()
-            .is_some_and(|(parent_level, _, _)| *parent_level >= level)
-        {
-            state.heading_stack.pop();
-        }
-        let qualified_base = state.heading_stack.last().map_or_else(
-            || title.to_owned(),
-            |(_, _, parent_scope)| format!("{parent_scope}::{title}"),
-        );
-        let occurrence = state
-            .heading_occurrences
-            .entry(qualified_base.clone())
-            .or_default();
-        *occurrence += 1;
-        let mut qualified_name = if *occurrence == 1 {
-            qualified_base
-        } else {
-            format!("{qualified_base}#{occurrence}")
-        };
-        if state.heading_stack.is_empty()
-            && path_file_name(state.path).is_some_and(|name| name == qualified_name)
-        {
-            qualified_name.push_str("::heading");
-        }
-        let mut id = make_id(&[&state.stem, &qualified_name]);
-        if id == state.file_id {
-            id = make_id(&[&state.source_file, "heading", &qualified_name]);
-        }
-        state.add_node(id.clone(), title, line, Some(&qualified_name));
-        let parent = state
-            .heading_stack
-            .last()
-            .map_or_else(|| state.file_id.clone(), |(_, id, _)| id.clone());
-        state.add_edge(parent, id.clone(), "contains", line);
-        state.heading_stack.push((level, id, qualified_name));
-        byte_offset += line_text.len();
+    state.add_root(file_id, metadata);
+    if let Some(diagnostic) = frontmatter_diagnostic {
+        state.add_diagnostic(diagnostic);
     }
+    if block_tree.root_node().has_error() {
+        state.add_diagnostic("Markdown parser recovered from malformed syntax".to_owned());
+        state.extraction.extensions.insert(
+            crate::EXTRACTION_QUALITY_EXTENSION.to_owned(),
+            json!(crate::EXTRACTION_QUALITY_PARTIAL),
+        );
+        state.extraction.extensions.insert(
+            crate::EXTRACTION_QUALITY_REASON_EXTENSION.to_owned(),
+            json!("markdown_parser_recovery"),
+        );
+    }
+
+    let root = block_tree.root_node();
+    let root_id = state.file_id.clone();
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor).filter(Node::is_named) {
+        match child.kind() {
+            "minus_metadata" | "plus_metadata" => {}
+            "section" => state.walk_section(child, Some(&root_id)),
+            _ => state.emit_block(child, Some(&root_id)),
+        }
+    }
+    state.scan_reference_definitions();
+    state.finalize_links();
 
     state
         .extraction
@@ -189,103 +110,822 @@ pub(crate) fn extract(path: &Path) -> Result<Extraction, ExtractError> {
         .extraction
         .extensions
         .insert("output_tokens".to_owned(), json!(0));
+    state.extraction.extensions.insert(
+        "markdown_block_count".to_owned(),
+        json!(state.next_block_index.saturating_sub(1)),
+    );
+    state.extraction.extensions.insert(
+        "markdown_link_count".to_owned(),
+        json!(state.pending_link_count()),
+    );
+    if !state.diagnostics.is_empty() {
+        state.extraction.extensions.insert(
+            "markdown_diagnostics".to_owned(),
+            Value::Array(state.diagnostics.into_iter().map(Value::String).collect()),
+        );
+    }
+    if !state.unresolved_links.is_empty() {
+        state.extraction.extensions.insert(
+            "markdown_unresolved_links".to_owned(),
+            Value::Array(state.unresolved_links),
+        );
+    }
+    if !state.external_links.is_empty() {
+        state.extraction.extensions.insert(
+            "markdown_external_links".to_owned(),
+            Value::Array(state.external_links),
+        );
+    }
     Ok(state.extraction)
 }
 
-fn path_file_name(path: &Path) -> Option<&str> {
-    path.file_name()?.to_str()
-}
-
-struct State<'path> {
+struct State<'source, 'path> {
     path: &'path Path,
+    source: &'source [u8],
     source_file: String,
     stem: String,
     file_id: String,
-    extraction: Extraction,
+    extraction: crate::Extraction,
     seen_nodes: HashSet<String>,
-    heading_stack: Vec<(usize, String, String)>,
+    heading_stack: Vec<HeadingFrame>,
     heading_occurrences: HashMap<String, usize>,
+    heading_targets: HashMap<String, Vec<String>>,
+    reference_definitions: HashMap<String, String>,
+    pending_links: Vec<PendingLink>,
+    unresolved_links: Vec<Value>,
+    external_links: Vec<Value>,
+    diagnostics: Vec<String>,
+    inline_parser: Parser,
+    next_block_index: usize,
+}
+
+#[derive(Clone)]
+struct HeadingFrame {
+    level: usize,
+    id: String,
+    qualified_name: String,
+}
+
+#[derive(Clone)]
+struct PendingLink {
+    raw: String,
+    reference_label: Option<String>,
+    owner_id: String,
+    site: LinkSite,
+    kind: &'static str,
 }
 
 #[derive(Clone, Copy)]
 struct LinkSite {
-    line: usize,
     start_byte: usize,
     end_byte: usize,
+    line: usize,
     line_start: usize,
 }
 
-impl State<'_> {
-    fn add_node(&mut self, id: String, label: &str, line: usize, qualified_name: Option<&str>) {
-        if !self.seen_nodes.insert(id.clone()) {
-            return;
-        }
+impl State<'_, '_> {
+    fn add_root(&mut self, id: String, metadata: Option<Map<String, Value>>) {
+        self.seen_nodes.insert(id.clone());
         let mut attributes = Map::new();
-        attributes.insert("label".to_owned(), Value::String(label.to_owned()));
-        if let Some(qualified_name) = qualified_name {
-            attributes.insert(
-                "qualified_name".to_owned(),
-                Value::String(qualified_name.to_owned()),
-            );
-        }
+        attributes.insert(
+            "label".to_owned(),
+            Value::String(
+                self.path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default()
+                    .to_owned(),
+            ),
+        );
         attributes.insert("file_type".to_owned(), Value::String("document".to_owned()));
         attributes.insert(
-            "source_file".to_owned(),
-            Value::String(self.source_file.clone()),
+            "document_kind".to_owned(),
+            Value::String("document".to_owned()),
         );
         attributes.insert(
-            "source_location".to_owned(),
-            Value::String(format!("L{line}")),
-        );
-        attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
-        self.extraction.nodes.push(NodeRecord { id, attributes });
-    }
-
-    fn add_edge(&mut self, source: String, target: String, relation: &str, line: usize) {
-        let mut attributes = Map::new();
-        attributes.insert("relation".to_owned(), Value::String(relation.to_owned()));
-        attributes.insert(
-            "confidence".to_owned(),
-            Value::String("EXTRACTED".to_owned()),
+            "document_format".to_owned(),
+            Value::String("markdown".to_owned()),
         );
         attributes.insert(
             "source_file".to_owned(),
             Value::String(self.source_file.clone()),
         );
-        attributes.insert(
-            "source_location".to_owned(),
-            Value::String(format!("L{line}")),
-        );
+        attributes.insert("source_location".to_owned(), Value::String("L1".to_owned()));
         attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
-        attributes.insert("weight".to_owned(), json!(1.0));
-        self.extraction.edges.push(EdgeRecord {
-            source,
-            target,
+        stamp_source_range(&mut attributes, self.source, 0, self.source.len());
+        if let Some(metadata) = metadata {
+            attributes.insert("document_metadata".to_owned(), Value::Object(metadata));
+        }
+        self.extraction.nodes.push(NodeRecord {
+            id: id.clone(),
             attributes,
         });
+        self.file_id = id;
     }
 
-    fn add_link(&mut self, raw: &str, site: LinkSite) {
-        let Some(target) = resolve_link(raw, self.path.parent().unwrap_or_else(|| Path::new("")))
-        else {
-            return;
-        };
-        let target_id = make_id(&[&target.to_string_lossy()]);
-        if target_id == self.file_id {
-            return;
+    fn add_diagnostic(&mut self, diagnostic: String) {
+        if self.diagnostics.len() < MAX_DIAGNOSTICS {
+            self.diagnostics.push(diagnostic);
         }
-        let relation = if is_documentable_source(&target) {
-            if !target.is_file() {
+    }
+
+    fn walk_section(&mut self, node: Node<'_>, inherited_parent: Option<&str>) {
+        let stack_len = self.heading_stack.len();
+        let mut parent = inherited_parent.map(str::to_owned);
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            match child.kind() {
+                "atx_heading" | "setext_heading" => {
+                    parent = Some(self.emit_heading(child, parent.as_deref()));
+                }
+                "section" => self.walk_section(child, parent.as_deref()),
+                "minus_metadata" | "plus_metadata" => {}
+                _ => self.emit_block(child, parent.as_deref()),
+            }
+        }
+        self.heading_stack.truncate(stack_len);
+    }
+
+    fn emit_heading(&mut self, node: Node<'_>, inherited_parent: Option<&str>) -> String {
+        let level = heading_level(node, self.source);
+        while self
+            .heading_stack
+            .last()
+            .is_some_and(|frame| frame.level >= level)
+        {
+            self.heading_stack.pop();
+        }
+        let raw_title = heading_title(node, self.source);
+        let (title, explicit_id) = split_explicit_heading_id(&raw_title);
+        let title = title.trim();
+        let qualified_base = self.heading_stack.last().map_or_else(
+            || title.to_owned(),
+            |parent| format!("{}::{title}", parent.qualified_name),
+        );
+        let occurrence = self
+            .heading_occurrences
+            .entry(qualified_base.clone())
+            .or_default();
+        *occurrence += 1;
+        let mut qualified_name = if *occurrence == 1 {
+            qualified_base
+        } else {
+            format!("{qualified_base}#{occurrence}")
+        };
+        if self.heading_stack.is_empty()
+            && self
+                .path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == qualified_name)
+        {
+            qualified_name.push_str("::heading");
+        }
+        let mut id = crate::make_id(&[&self.stem, &qualified_name]);
+        if id == self.file_id {
+            id = crate::make_id(&[&self.source_file, "heading", &qualified_name]);
+        }
+        let parent = self
+            .heading_stack
+            .last()
+            .map(|frame| frame.id.clone())
+            .or_else(|| inherited_parent.map(str::to_owned))
+            .or_else(|| Some(self.file_id.clone()));
+        let mut extra = Map::new();
+        extra.insert(
+            "qualified_name".to_owned(),
+            Value::String(qualified_name.clone()),
+        );
+        extra.insert("heading_level".to_owned(), json!(level));
+        extra.insert(
+            "heading_style".to_owned(),
+            Value::String(
+                if node.kind() == "setext_heading" {
+                    "setext"
+                } else {
+                    "atx"
+                }
+                .to_owned(),
+            ),
+        );
+        extra.insert(
+            "anchor_slug".to_owned(),
+            Value::String(slugify(explicit_id.as_deref().unwrap_or(title))),
+        );
+        if let Some(explicit_id) = explicit_id.as_deref() {
+            extra.insert(
+                "explicit_id".to_owned(),
+                Value::String(explicit_id.to_owned()),
+            );
+        }
+        let id = self.add_block_node(
+            id,
+            title,
+            "heading",
+            node.start_byte()..node.end_byte(),
+            parent.as_deref(),
+            extra,
+        );
+        self.register_heading_target(title, explicit_id.as_deref(), &id);
+        self.collect_inline_descendants(node, &id);
+        self.heading_stack.push(HeadingFrame {
+            level,
+            id: id.clone(),
+            qualified_name,
+        });
+        id
+    }
+
+    fn emit_block(&mut self, node: Node<'_>, parent: Option<&str>) {
+        let kind = node.kind();
+        match kind {
+            "section" => {
+                self.walk_section(node, parent);
                 return;
             }
-            "documents"
-        } else {
-            "references"
-        };
-        self.add_edge_range(self.file_id.clone(), target_id, relation, site);
+            "atx_heading" | "setext_heading" => {
+                self.emit_heading(node, parent);
+                return;
+            }
+            "inline" | "block_continuation" | "minus_metadata" | "plus_metadata" => return,
+            _ => {}
+        }
+        if self.next_block_index > MAX_BLOCKS {
+            self.add_diagnostic("Markdown block limit exceeded".to_owned());
+            return;
+        }
+        let text = node_text(self.source, node.start_byte(), node.end_byte());
+        let label = block_label(kind, &text);
+        let id = crate::make_id(&[
+            &self.source_file,
+            "markdown_block",
+            kind,
+            &self.next_block_index.to_string(),
+            &node.start_byte().to_string(),
+        ]);
+        let mut extra = Map::new();
+        extra.insert("block_index".to_owned(), json!(self.next_block_index));
+        if (kind == "fenced_code_block" || kind == "indented_code_block")
+            && let Some(info) = child_text(node, self.source, "info_string")
+        {
+            let info = compact_label(&info);
+            if !info.is_empty() {
+                extra.insert("language".to_owned(), Value::String(info));
+            }
+        }
+        if kind == "list_item" {
+            let checked = has_child_kind(node, "task_list_marker_checked");
+            let unchecked = has_child_kind(node, "task_list_marker_unchecked");
+            if checked || unchecked {
+                extra.insert("task".to_owned(), Value::Bool(true));
+                extra.insert("task_checked".to_owned(), Value::Bool(checked));
+            }
+        }
+        if kind == "pipe_table_header" {
+            extra.insert("table_role".to_owned(), Value::String("header".to_owned()));
+        } else if kind == "pipe_table_row" {
+            extra.insert("table_role".to_owned(), Value::String("row".to_owned()));
+        } else if kind == "pipe_table_cell" {
+            extra.insert("table_role".to_owned(), Value::String("cell".to_owned()));
+        }
+        let id = self.add_block_node(
+            id,
+            &label,
+            kind,
+            node.start_byte()..node.end_byte(),
+            parent,
+            extra,
+        );
+        if kind == "link_reference_definition" {
+            self.record_reference_definition(node, &id);
+        }
+        self.collect_inline_descendants(node, &id);
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            if !is_nested_block(child.kind()) {
+                continue;
+            }
+            self.emit_block(child, Some(&id));
+        }
     }
 
-    fn add_edge_range(&mut self, source: String, target: String, relation: &str, site: LinkSite) {
+    fn add_block_node(
+        &mut self,
+        id: String,
+        label: &str,
+        kind: &str,
+        range: std::ops::Range<usize>,
+        parent: Option<&str>,
+        mut extra: Map<String, Value>,
+    ) -> String {
+        if !self.seen_nodes.insert(id.clone()) {
+            return id;
+        }
+        let block_index = self.next_block_index;
+        self.next_block_index = self.next_block_index.saturating_add(1);
+        extra.insert("label".to_owned(), Value::String(bounded_label(label)));
+        extra.insert("file_type".to_owned(), Value::String("document".to_owned()));
+        extra.insert("document_kind".to_owned(), Value::String(kind.to_owned()));
+        extra.insert(
+            "source_file".to_owned(),
+            Value::String(self.source_file.clone()),
+        );
+        extra.insert(
+            "source_location".to_owned(),
+            Value::String(format!("L{}", self.line_at(range.start))),
+        );
+        extra.insert("block_index".to_owned(), json!(block_index));
+        extra.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
+        stamp_source_range(&mut extra, self.source, range.start, range.end);
+        self.extraction.nodes.push(NodeRecord {
+            id: id.clone(),
+            attributes: extra,
+        });
+        if let Some(parent) = parent {
+            self.add_relation(parent, &id, "contains", range.start, range.end);
+        }
+        id
+    }
+
+    fn collect_inline_descendants(&mut self, node: Node<'_>, owner_id: &str) {
+        if node.kind() == "inline" {
+            self.collect_inline_node(node, owner_id);
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            // A nested structural block gets its own owner when `emit_block`
+            // visits it. Do not walk through it here, or a link in a list item
+            // would be emitted once for every containing list/table/quote.
+            if is_structural_block_kind(child.kind()) {
+                continue;
+            }
+            self.collect_inline_descendants(child, owner_id);
+        }
+    }
+
+    fn collect_inline_node(&mut self, node: Node<'_>, owner_id: &str) {
+        let start = node.start_byte();
+        let end = node.end_byte().min(self.source.len());
+        if start >= end || end > self.source.len() {
+            return;
+        }
+        let inline_source = &self.source[start..end];
+        let Some(tree) = self.inline_parser.parse(inline_source, None) else {
+            self.add_diagnostic("Markdown inline parser was cancelled".to_owned());
+            return;
+        };
+        self.walk_inline_node(tree.root_node(), start, owner_id);
+        self.scan_reference_links(start, inline_source, owner_id);
+        self.scan_wikilinks(start, inline_source, owner_id);
+    }
+
+    fn walk_inline_node(&mut self, node: Node<'_>, base: usize, owner_id: &str) {
+        let kind = node.kind();
+        if kind == "image" {
+            return;
+        }
+        let link = match kind {
+            "inline_link" => child_text_at(node, self.source, base, "link_destination")
+                .map(|raw| (raw, None, "inline")),
+            "full_reference_link" => {
+                child_text_at(node, self.source, base, "link_label").map(|label| {
+                    (
+                        String::new(),
+                        Some(normalize_reference_label(&label)),
+                        "reference",
+                    )
+                })
+            }
+            "collapsed_reference_link" | "shortcut_link" => {
+                child_text_at(node, self.source, base, "link_text").map(|label| {
+                    (
+                        String::new(),
+                        Some(normalize_reference_label(&label)),
+                        "reference",
+                    )
+                })
+            }
+            "uri_autolink" | "email_autolink" => Some((
+                node_text(
+                    self.source,
+                    base + node.start_byte(),
+                    base + node.end_byte(),
+                ),
+                None,
+                "autolink",
+            )),
+            _ => None,
+        };
+        if let Some((raw, reference_label, link_kind)) = link {
+            let absolute_start = base.saturating_add(node.start_byte());
+            if link_kind == "reference" && self.is_reference_definition_at(absolute_start) {
+                return;
+            }
+            if self.pending_links.len() >= MAX_LINKS {
+                self.add_diagnostic("Markdown link limit exceeded".to_owned());
+                return;
+            }
+            let start = absolute_start;
+            let end = base.saturating_add(node.end_byte()).min(self.source.len());
+            self.pending_links.push(PendingLink {
+                raw,
+                reference_label,
+                owner_id: owner_id.to_owned(),
+                site: self.link_site(start, end),
+                kind: link_kind,
+            });
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(Node::is_named) {
+            self.walk_inline_node(child, base, owner_id);
+        }
+    }
+
+    fn is_reference_definition_at(&self, offset: usize) -> bool {
+        let line_start = self.line_start(offset);
+        let line_end = next_line(self.source, line_start).map_or(self.source.len(), |(_, line)| {
+            line_start.saturating_add(line.len())
+        });
+        parse_reference_definition(&self.source[line_start..line_end]).is_some()
+    }
+
+    fn scan_wikilinks(&mut self, base: usize, source: &[u8], owner_id: &str) {
+        let mut offset = 0;
+        while let Some(relative_start) = source[offset..].windows(2).position(|pair| pair == b"[[")
+        {
+            let start = offset + relative_start;
+            if start > 0 && source[start - 1] == b'!' {
+                offset = start.saturating_add(2);
+                continue;
+            }
+            let Some(relative_end) = source[start + 2..]
+                .windows(2)
+                .position(|pair| pair == b"]]")
+            else {
+                break;
+            };
+            let end = start + 2 + relative_end + 2;
+            let body = String::from_utf8_lossy(&source[start + 2..end - 2]);
+            let target = body
+                .split_once('|')
+                .map_or(body.as_ref(), |(target, _)| target)
+                .trim();
+            if !target.is_empty() && self.pending_links.len() < MAX_LINKS {
+                let absolute_start = base.saturating_add(start);
+                let absolute_end = base.saturating_add(end).min(self.source.len());
+                self.pending_links.push(PendingLink {
+                    raw: target.to_owned(),
+                    reference_label: None,
+                    owner_id: owner_id.to_owned(),
+                    site: self.link_site(absolute_start, absolute_end),
+                    kind: "wikilink",
+                });
+            }
+            offset = end;
+        }
+    }
+
+    fn scan_reference_links(&mut self, base: usize, source: &[u8], owner_id: &str) {
+        let mut offset = 0;
+        while let Some(relative_start) = source[offset..].iter().position(|byte| *byte == b'[') {
+            let start = offset.saturating_add(relative_start);
+            if start > 0 && source[start - 1] == b'!' {
+                offset = start.saturating_add(1);
+                continue;
+            }
+            let Some(relative_text_end) = source[start + 1..].iter().position(|byte| *byte == b']')
+            else {
+                break;
+            };
+            let text_end = start.saturating_add(1).saturating_add(relative_text_end);
+            let label_start = text_end.saturating_add(1);
+            if source.get(label_start) != Some(&b'[') {
+                offset = label_start;
+                continue;
+            }
+            let Some(relative_label_end) = source[label_start + 1..]
+                .iter()
+                .position(|byte| *byte == b']')
+            else {
+                break;
+            };
+            let label_end = label_start
+                .saturating_add(1)
+                .saturating_add(relative_label_end);
+            let text = String::from_utf8_lossy(&source[start + 1..text_end]);
+            let label = String::from_utf8_lossy(&source[label_start + 1..label_end]);
+            let label = if label.trim().is_empty() {
+                text.to_string()
+            } else {
+                label.to_string()
+            };
+            let absolute_start = base.saturating_add(start);
+            let absolute_end = base
+                .saturating_add(label_end.saturating_add(1))
+                .min(self.source.len());
+            if !label.trim().is_empty()
+                && !self.has_pending_site(absolute_start, absolute_end)
+                && self.pending_links.len() < MAX_LINKS
+            {
+                self.pending_links.push(PendingLink {
+                    raw: String::new(),
+                    reference_label: Some(normalize_reference_label(&label)),
+                    owner_id: owner_id.to_owned(),
+                    site: self.link_site(absolute_start, absolute_end),
+                    kind: "reference",
+                });
+            }
+            offset = label_end.saturating_add(1);
+        }
+    }
+
+    fn has_pending_site(&self, start: usize, end: usize) -> bool {
+        self.pending_links
+            .iter()
+            .any(|pending| pending.site.start_byte == start && pending.site.end_byte == end)
+    }
+
+    fn record_reference_definition(&mut self, node: Node<'_>, owner_id: &str) {
+        let Some(label) = child_text(node, self.source, "link_label") else {
+            return;
+        };
+        let Some(target) = child_text(node, self.source, "link_destination") else {
+            return;
+        };
+        let label = normalize_reference_label(&label);
+        if label.is_empty() {
+            return;
+        }
+        self.reference_definitions.insert(label, target.clone());
+        if self.pending_links.len() < MAX_LINKS {
+            self.pending_links.push(PendingLink {
+                raw: target,
+                reference_label: None,
+                owner_id: owner_id.to_owned(),
+                site: self.link_site(node.start_byte(), node.end_byte()),
+                kind: "reference_definition",
+            });
+        }
+    }
+
+    fn scan_reference_definitions(&mut self) {
+        let mut offset = 0;
+        let mut fence = None;
+        while let Some((line_end, line)) = next_line(self.source, offset) {
+            if let Some(open) = fence {
+                if closes_fence(line, open) {
+                    fence = None;
+                }
+                offset = line_end;
+                continue;
+            }
+            if let Some(open) = opens_fence(line) {
+                fence = Some(open);
+                offset = line_end;
+                continue;
+            }
+            if let Some((label, target, relative_start, relative_end)) =
+                parse_reference_definition(line)
+            {
+                let label = normalize_reference_label(&label);
+                if !label.is_empty() && !self.reference_definitions.contains_key(&label) {
+                    self.reference_definitions.insert(label, target.clone());
+                    if self.pending_links.len() < MAX_LINKS {
+                        let start = offset.saturating_add(relative_start);
+                        let end = offset.saturating_add(relative_end).min(self.source.len());
+                        let owner = self.owner_for_offset(start);
+                        self.pending_links.push(PendingLink {
+                            raw: target,
+                            reference_label: None,
+                            owner_id: owner,
+                            site: self.link_site(start, end),
+                            kind: "reference_definition",
+                        });
+                    }
+                }
+            }
+            offset = line_end;
+        }
+    }
+
+    fn owner_for_offset(&self, offset: usize) -> String {
+        let mut owner = self.file_id.clone();
+        let mut smallest_span = usize::MAX;
+        for node in &self.extraction.nodes {
+            if node.id == self.file_id {
+                continue;
+            }
+            let Some(start) = node
+                .attributes
+                .get("start_byte")
+                .and_then(Value::as_u64)
+                .and_then(|value| usize::try_from(value).ok())
+            else {
+                continue;
+            };
+            let Some(end) = node
+                .attributes
+                .get("end_byte")
+                .and_then(Value::as_u64)
+                .and_then(|value| usize::try_from(value).ok())
+            else {
+                continue;
+            };
+            if start <= offset && offset < end {
+                let span = end.saturating_sub(start);
+                if span < smallest_span {
+                    smallest_span = span;
+                    owner = node.id.clone();
+                }
+            }
+        }
+        owner
+    }
+
+    fn register_heading_target(&mut self, title: &str, explicit_id: Option<&str>, id: &str) {
+        let mut keys = vec![slugify(title)];
+        if let Some(explicit_id) = explicit_id {
+            keys.push(explicit_id.to_ascii_lowercase());
+            keys.push(slugify(explicit_id));
+        }
+        for key in keys.into_iter().filter(|key| !key.is_empty()) {
+            let targets = self.heading_targets.entry(key).or_default();
+            if !targets.contains(&id.to_owned()) {
+                targets.push(id.to_owned());
+            }
+        }
+    }
+
+    fn finalize_links(&mut self) {
+        let pending_links = std::mem::take(&mut self.pending_links);
+        for pending in pending_links {
+            let raw = pending
+                .reference_label
+                .as_ref()
+                .and_then(|label| self.reference_definitions.get(label))
+                .cloned()
+                .or_else(|| pending.reference_label.as_ref().map(|_| String::new()))
+                .unwrap_or(pending.raw.clone());
+            if raw.is_empty() {
+                self.add_unresolved(
+                    &pending,
+                    "missing_reference_definition",
+                    pending.reference_label.as_deref().unwrap_or_default(),
+                );
+                continue;
+            }
+            let raw = raw.trim().trim_matches('<').trim_matches('>');
+            if is_external_target(raw) {
+                self.external_links.push(json!({
+                    "source": pending.owner_id,
+                    "target": raw,
+                    "kind": pending.kind,
+                    "source_file": self.source_file,
+                    "start_byte": pending.site.start_byte,
+                    "end_byte": pending.site.end_byte,
+                    "start_line": pending.site.line,
+                    "end_line": self.line_at(pending.site.end_byte),
+                    "line_start": pending.site.line,
+                    "line_end": self.line_at(pending.site.end_byte),
+                    "column_start": pending.site.start_byte.saturating_sub(pending.site.line_start),
+                    "column_end": pending.site.end_byte.saturating_sub(self.line_start(pending.site.end_byte)),
+                }));
+                continue;
+            }
+            let (path_part, fragment) =
+                raw.split_once('#').map_or((raw, None), |(path, fragment)| {
+                    (path, Some(fragment.trim()))
+                });
+            let path_part = path_part
+                .split_once('?')
+                .map_or(path_part, |(path, _)| path)
+                .trim();
+            let target_path = if path_part.is_empty() {
+                lexical_normalize(self.path)
+            } else {
+                let mut target = PathBuf::from(path_part);
+                if target.extension().is_none() {
+                    target.set_extension("md");
+                }
+                if target.is_absolute() {
+                    target
+                } else {
+                    lexical_normalize(
+                        &self
+                            .path
+                            .parent()
+                            .unwrap_or_else(|| Path::new(""))
+                            .join(target),
+                    )
+                }
+            };
+            let same_file = lexical_normalize(self.path) == target_path;
+            if same_file {
+                if let Some(fragment) = fragment.filter(|fragment| !fragment.is_empty()) {
+                    let key = fragment.to_ascii_lowercase();
+                    let candidates = self
+                        .heading_targets
+                        .get(&key)
+                        .or_else(|| self.heading_targets.get(&slugify(fragment)));
+                    match candidates {
+                        Some(candidates) if candidates.len() == 1 => {
+                            if let Some(target_id) = candidates.first() {
+                                self.add_link_edge(
+                                    &pending,
+                                    target_id.clone(),
+                                    Some(("references", Some(fragment))),
+                                );
+                            }
+                        }
+                        Some(_) => self.add_unresolved(&pending, "ambiguous_fragment", fragment),
+                        None => self.add_unresolved(&pending, "missing_fragment", fragment),
+                    }
+                }
+                continue;
+            }
+            if is_documentable_source(&target_path) && !target_path.is_file() {
+                continue;
+            }
+            if !is_supported_local_link(&target_path) {
+                continue;
+            }
+            let target_id = crate::make_id(&[&target_path.to_string_lossy()]);
+            let relation = if is_documentable_source(&target_path) {
+                "documents"
+            } else {
+                "references"
+            };
+            self.add_link_edge(&pending, target_id, Some((relation, fragment)));
+        }
+    }
+
+    fn add_link_edge(
+        &mut self,
+        pending: &PendingLink,
+        target: String,
+        relation: Option<(&str, Option<&str>)>,
+    ) {
+        let (relation, fragment) = relation.unwrap_or(("references", None));
+        self.add_relation_with_site(
+            &pending.owner_id,
+            &target,
+            relation,
+            pending.site,
+            pending.kind,
+            fragment,
+        );
+    }
+
+    fn add_unresolved(&mut self, pending: &PendingLink, reason: &str, target: &str) {
+        if self.unresolved_links.len() >= MAX_DIAGNOSTICS {
+            return;
+        }
+        self.unresolved_links.push(json!({
+            "source": pending.owner_id,
+            "target": target,
+            "kind": pending.kind,
+            "reason": reason,
+            "source_file": self.source_file,
+            "start_byte": pending.site.start_byte,
+            "end_byte": pending.site.end_byte,
+            "start_line": pending.site.line,
+            "end_line": self.line_at(pending.site.end_byte),
+            "line_start": pending.site.line,
+            "line_end": self.line_at(pending.site.end_byte),
+            "column_start": pending.site.start_byte.saturating_sub(pending.site.line_start),
+            "column_end": pending.site.end_byte.saturating_sub(self.line_start(pending.site.end_byte)),
+        }));
+    }
+
+    fn add_relation(
+        &mut self,
+        source: &str,
+        target: &str,
+        relation: &str,
+        start: usize,
+        end: usize,
+    ) {
+        self.add_relation_with_site(
+            source,
+            target,
+            relation,
+            self.link_site(start, end),
+            "structural",
+            None,
+        );
+    }
+
+    fn add_relation_with_site(
+        &mut self,
+        source: &str,
+        target: &str,
+        relation: &str,
+        site: LinkSite,
+        link_kind: &str,
+        fragment: Option<&str>,
+    ) {
         let mut attributes = Map::new();
         attributes.insert("relation".to_owned(), Value::String(relation.to_owned()));
         attributes.insert(
@@ -301,105 +941,472 @@ impl State<'_> {
             Value::String(format!("L{}", site.line)),
         );
         attributes.insert("_origin".to_owned(), Value::String("artifact".to_owned()));
-        attributes.insert("start_byte".to_owned(), json!(site.start_byte));
-        attributes.insert("end_byte".to_owned(), json!(site.end_byte));
+        stamp_source_range(&mut attributes, self.source, site.start_byte, site.end_byte);
         attributes.insert("start_line".to_owned(), json!(site.line));
-        attributes.insert("end_line".to_owned(), json!(site.line));
-        attributes.insert(
-            "column_start".to_owned(),
-            json!(site.start_byte.saturating_sub(site.line_start)),
-        );
-        attributes.insert(
-            "column_end".to_owned(),
-            json!(site.end_byte.saturating_sub(site.line_start)),
-        );
+        attributes.insert("end_line".to_owned(), json!(self.line_at(site.end_byte)));
         attributes.insert("weight".to_owned(), json!(1.0));
+        if link_kind != "structural" {
+            attributes.insert("link_kind".to_owned(), Value::String(link_kind.to_owned()));
+        }
+        if let Some(fragment) = fragment.filter(|fragment| !fragment.is_empty()) {
+            attributes.insert("fragment".to_owned(), Value::String(fragment.to_owned()));
+        }
         self.extraction.edges.push(EdgeRecord {
-            source,
-            target,
+            source: source.to_owned(),
+            target: target.to_owned(),
             attributes,
         });
     }
+
+    fn link_site(&self, start: usize, end: usize) -> LinkSite {
+        let start = start.min(self.source.len());
+        let end = end.clamp(start, self.source.len());
+        LinkSite {
+            start_byte: start,
+            end_byte: end,
+            line: self.line_at(start),
+            line_start: self.line_start(start),
+        }
+    }
+
+    fn line_at(&self, offset: usize) -> usize {
+        self.source[..offset.min(self.source.len())]
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count()
+            .saturating_add(1)
+    }
+
+    fn line_start(&self, offset: usize) -> usize {
+        let prefix = &self.source[..offset.min(self.source.len())];
+        prefix
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |newline| newline.saturating_add(1))
+    }
+
+    fn pending_link_count(&self) -> usize {
+        self.extraction
+            .edges
+            .iter()
+            .filter(|edge| edge.attributes.get("link_kind").is_some())
+            .count()
+            .saturating_add(self.external_links.len())
+            .saturating_add(self.unresolved_links.len())
+    }
 }
 
-fn opens_fence(line: &str) -> Option<(u8, usize)> {
-    let bytes = line.as_bytes();
-    let indent = bytes.iter().take_while(|byte| **byte == b' ').count();
+fn parse_frontmatter(source: &[u8]) -> (Option<Map<String, Value>>, Option<String>) {
+    let Some((first_end, first_line)) = next_line(source, 0) else {
+        return (None, None);
+    };
+    if !is_frontmatter_delimiter(first_line, true) {
+        return (None, None);
+    }
+    if first_end > FRONTMATTER_MAX_BYTES {
+        return (
+            None,
+            Some("Markdown frontmatter exceeds the byte limit".to_owned()),
+        );
+    }
+    let mut offset = first_end;
+    while offset < source.len() && offset <= FRONTMATTER_MAX_BYTES {
+        let Some((line_end, line)) = next_line(source, offset) else {
+            break;
+        };
+        if is_frontmatter_delimiter(line, false) {
+            let yaml = &source[first_end..offset];
+            if yaml.len() > FRONTMATTER_MAX_BYTES {
+                return (
+                    None,
+                    Some("Markdown frontmatter exceeds the byte limit".to_owned()),
+                );
+            }
+            let yaml = String::from_utf8_lossy(yaml);
+            return match serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&yaml) {
+                Ok(value) => match yaml_metadata(&value) {
+                    Ok(metadata) => (Some(metadata), None),
+                    Err(diagnostic) => (None, Some(diagnostic.to_owned())),
+                },
+                Err(_) => (
+                    None,
+                    Some("Markdown frontmatter is not valid YAML".to_owned()),
+                ),
+            };
+        }
+        offset = line_end;
+    }
+    (
+        None,
+        Some("Markdown frontmatter has no bounded closing delimiter".to_owned()),
+    )
+}
+
+fn yaml_metadata(value: &serde_yaml_ng::Value) -> Result<Map<String, Value>, &'static str> {
+    let serde_yaml_ng::Value::Mapping(mapping) = value else {
+        return Err("Markdown frontmatter must be a mapping");
+    };
+    if mapping.len() > MAX_METADATA_KEYS {
+        return Err("Markdown frontmatter has too many keys");
+    }
+    let mut entries = Vec::with_capacity(mapping.len());
+    for (key, value) in mapping {
+        let serde_yaml_ng::Value::String(key) = key else {
+            return Err("Markdown frontmatter keys must be strings");
+        };
+        if key.len() > MAX_METADATA_STRING_BYTES {
+            return Err("Markdown frontmatter key exceeds the byte limit");
+        }
+        let json_value = match value {
+            serde_yaml_ng::Value::Null => Value::Null,
+            serde_yaml_ng::Value::Bool(value) => Value::Bool(*value),
+            serde_yaml_ng::Value::Number(value) => {
+                serde_json::to_value(value).map_err(|_| "Markdown frontmatter number is invalid")?
+            }
+            serde_yaml_ng::Value::String(value) => {
+                if value.len() > MAX_METADATA_STRING_BYTES {
+                    return Err("Markdown frontmatter value exceeds the byte limit");
+                }
+                Value::String(value.clone())
+            }
+            serde_yaml_ng::Value::Sequence(values) => {
+                if values.len() > MAX_METADATA_ARRAY_ITEMS {
+                    return Err("Markdown frontmatter array exceeds the item limit");
+                }
+                let mut output = Vec::with_capacity(values.len());
+                for value in values {
+                    let scalar = yaml_scalar(value)
+                        .ok_or("Markdown frontmatter arrays must contain scalars")?;
+                    output.push(scalar);
+                }
+                Value::Array(output)
+            }
+            serde_yaml_ng::Value::Mapping(_) | serde_yaml_ng::Value::Tagged(_) => {
+                return Err("Markdown frontmatter nested values are not supported");
+            }
+        };
+        entries.push((key.clone(), json_value));
+    }
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut output = Map::new();
+    for (key, value) in entries {
+        output.insert(key, value);
+    }
+    Ok(output)
+}
+
+fn yaml_scalar(value: &serde_yaml_ng::Value) -> Option<Value> {
+    match value {
+        serde_yaml_ng::Value::Null => Some(Value::Null),
+        serde_yaml_ng::Value::Bool(value) => Some(Value::Bool(*value)),
+        serde_yaml_ng::Value::Number(value) => serde_json::to_value(value).ok(),
+        serde_yaml_ng::Value::String(value) if value.len() <= MAX_METADATA_STRING_BYTES => {
+            Some(Value::String(value.clone()))
+        }
+        _ => None,
+    }
+}
+
+fn next_line(source: &[u8], start: usize) -> Option<(usize, &[u8])> {
+    if start >= source.len() {
+        return None;
+    }
+    let relative_end = source[start..]
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .map_or(source.len().saturating_sub(start), |offset| {
+            offset.saturating_add(1)
+        });
+    let end = start.saturating_add(relative_end);
+    Some((end, &source[start..end]))
+}
+
+fn opens_fence(line: &[u8]) -> Option<(u8, usize)> {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    let indent = line.iter().take_while(|byte| **byte == b' ').count();
     if indent > 3 {
         return None;
     }
-    let marker = *bytes.get(indent)?;
+    let marker = *line.get(indent)?;
     if !matches!(marker, b'`' | b'~') {
         return None;
     }
-    let length = bytes[indent..]
+    let length = line[indent..]
         .iter()
         .take_while(|byte| **byte == marker)
         .count();
-    if length < 3 || (marker == b'`' && bytes[indent + length..].contains(&b'`')) {
+    if length < 3 || (marker == b'`' && line[indent + length..].contains(&b'`')) {
         return None;
     }
     Some((marker, length))
 }
 
-fn closes_fence(line: &str, fence: (u8, usize)) -> bool {
-    let bytes = line.as_bytes();
-    let indent = bytes.iter().take_while(|byte| **byte == b' ').count();
-    if indent > 3 || bytes.get(indent) != Some(&fence.0) {
+fn closes_fence(line: &[u8], fence: (u8, usize)) -> bool {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    let indent = line.iter().take_while(|byte| **byte == b' ').count();
+    if indent > 3 || line.get(indent) != Some(&fence.0) {
         return false;
     }
-    let length = bytes[indent..]
+    let length = line[indent..]
         .iter()
         .take_while(|byte| **byte == fence.0)
         .count();
     length >= fence.1
-        && bytes[indent + length..]
+        && line[indent + length..]
             .iter()
             .all(|byte| byte.is_ascii_whitespace())
 }
 
-fn resolve_link(raw: &str, source_directory: &Path) -> Option<PathBuf> {
-    let target = raw.trim();
-    if target.is_empty() {
+fn parse_reference_definition(line: &[u8]) -> Option<(String, String, usize, usize)> {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    let mut start = 0;
+    while start < line.len() && line[start] == b' ' && start < 3 {
+        start += 1;
+    }
+    if line.get(start) != Some(&b'[') {
         return None;
     }
-    let target = target.split_once('#').map_or(target, |(head, _)| head);
-    let target = target
-        .split_once('?')
-        .map_or(target, |(head, _)| head)
-        .trim();
-    if target.is_empty() {
+    let label_end = line[start + 1..].iter().position(|byte| *byte == b']')? + start + 1;
+    let colon = label_end.saturating_add(1);
+    if line.get(colon) != Some(&b':') {
         return None;
     }
+    let mut target_start = colon.saturating_add(1);
+    while target_start < line.len() && line[target_start].is_ascii_whitespace() {
+        target_start += 1;
+    }
+    if target_start >= line.len() {
+        return None;
+    }
+    let (target_end, target) = if line[target_start] == b'<' {
+        let end = line[target_start + 1..]
+            .iter()
+            .position(|byte| *byte == b'>')?
+            + target_start
+            + 1;
+        (end.saturating_add(1), &line[target_start + 1..end])
+    } else {
+        let end = line[target_start..]
+            .iter()
+            .position(|byte| byte.is_ascii_whitespace())
+            .map_or(line.len(), |relative| target_start.saturating_add(relative));
+        (end, &line[target_start..end])
+    };
+    let label = String::from_utf8_lossy(&line[start + 1..label_end]).into_owned();
+    let target = String::from_utf8_lossy(target).into_owned();
+    Some((label, target, start, target_end))
+}
+
+fn is_frontmatter_delimiter(line: &[u8], allow_bom: bool) -> bool {
+    let line = if allow_bom {
+        line.strip_prefix(b"\xef\xbb\xbf").unwrap_or(line)
+    } else {
+        line
+    };
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    let mut end = line.len();
+    while end > 0 && matches!(line[end - 1], b' ' | b'\t') {
+        end = end.saturating_sub(1);
+    }
+    &line[..end] == b"---"
+}
+
+fn heading_level(node: Node<'_>, source: &[u8]) -> usize {
+    if node.kind() == "setext_heading" {
+        let mut cursor = node.walk();
+        return if node
+            .children(&mut cursor)
+            .any(|child| child.kind() == "setext_h1_underline")
+        {
+            1
+        } else {
+            2
+        };
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find_map(|child| child.kind().strip_prefix("atx_h")?.strip_suffix("_marker"))
+        .and_then(|level| level.parse::<usize>().ok())
+        .filter(|level| (1..=6).contains(level))
+        .unwrap_or_else(|| {
+            let line = node_text(source, node.start_byte(), node.end_byte());
+            line.trim_start()
+                .chars()
+                .take_while(|char| *char == '#')
+                .count()
+                .clamp(1, 6)
+        })
+}
+
+fn heading_title(node: Node<'_>, source: &[u8]) -> String {
+    if let Some(inline) = find_descendant_kind(node, "inline") {
+        return node_text(source, inline.start_byte(), inline.end_byte());
+    }
+    node_text(source, node.start_byte(), node.end_byte())
+}
+
+fn find_descendant_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(Node::is_named) {
+        if child.kind() == kind {
+            return Some(child);
+        }
+        if let Some(found) = find_descendant_kind(child, kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn child_text(node: Node<'_>, source: &[u8], kind: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == kind)
+        .map(|child| node_text(source, child.start_byte(), child.end_byte()))
+}
+
+fn child_text_at(node: Node<'_>, source: &[u8], base: usize, kind: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|child| child.kind() == kind)
+        .map(|child| {
+            node_text(
+                source,
+                base.saturating_add(child.start_byte()),
+                base.saturating_add(child.end_byte()),
+            )
+        })
+}
+
+fn has_child_kind(node: Node<'_>, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| child.kind() == kind)
+}
+
+fn node_text(source: &[u8], start: usize, end: usize) -> String {
+    let start = start.min(source.len());
+    let end = end.clamp(start, source.len());
+    String::from_utf8_lossy(&source[start..end]).into_owned()
+}
+
+fn block_label(kind: &str, text: &str) -> String {
+    match kind {
+        "list" => "list".to_owned(),
+        "list_item" => compact_label(text),
+        "pipe_table" | "pipe_table_header" | "pipe_table_row" | "pipe_table_cell" => {
+            kind.replace('_', " ")
+        }
+        "fenced_code_block" | "indented_code_block" => "code".to_owned(),
+        "block_quote" => "blockquote".to_owned(),
+        "thematic_break" => "thematic break".to_owned(),
+        "link_reference_definition" => "link definition".to_owned(),
+        "html_block" => "HTML block".to_owned(),
+        _ => compact_label(text),
+    }
+}
+
+fn compact_label(text: &str) -> String {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    bounded_label(&normalized)
+}
+
+fn bounded_label(text: &str) -> String {
+    let mut output = String::new();
+    for character in text.chars().take(MAX_LABEL_CHARS) {
+        output.push(character);
+    }
+    if text.chars().count() > MAX_LABEL_CHARS {
+        output.push('…');
+    }
+    output
+}
+
+fn split_explicit_heading_id(title: &str) -> (String, Option<String>) {
+    let Some(start) = title.rfind("{#") else {
+        return (title.to_owned(), None);
+    };
+    if !title.ends_with('}') || start + 3 >= title.len() {
+        return (title.to_owned(), None);
+    }
+    let candidate = &title[start + 2..title.len().saturating_sub(1)];
+    if candidate.is_empty()
+        || !candidate.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | ':' | '.')
+        })
+    {
+        return (title.to_owned(), None);
+    }
+    (
+        title[..start].trim_end().to_owned(),
+        Some(candidate.to_owned()),
+    )
+}
+
+fn slugify(text: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_dash = false;
+    for character in text.trim().chars().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            if pending_dash && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_dash = false;
+            slug.push(character);
+        } else if matches!(character, ' ' | '\t' | '-' | '_' | '.') {
+            pending_dash = true;
+        }
+    }
+    slug
+}
+
+fn normalize_reference_label(label: &str) -> String {
+    label
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn is_nested_block(kind: &str) -> bool {
+    is_structural_block_kind(kind)
+}
+
+fn is_structural_block_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "atx_heading"
+            | "block_quote"
+            | "fenced_code_block"
+            | "html_block"
+            | "indented_code_block"
+            | "link_reference_definition"
+            | "list"
+            | "list_item"
+            | "paragraph"
+            | "pipe_table"
+            | "pipe_table_cell"
+            | "pipe_table_header"
+            | "pipe_table_row"
+            | "section"
+            | "setext_heading"
+            | "thematic_break"
+    )
+}
+
+fn is_external_target(target: &str) -> bool {
     let lower = target.to_ascii_lowercase();
-    if target.contains("://")
+    target.contains("://")
         || lower.starts_with("mailto:")
         || lower.starts_with("tel:")
-        || lower.starts_with("//")
         || lower.starts_with("data:")
-    {
-        return None;
-    }
-    let mut target = PathBuf::from(target);
-    let suffix = target
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map_or_else(String::new, |extension| {
-            format!(".{extension}").to_ascii_lowercase()
-        });
-    let suffix = if suffix.is_empty() {
-        target.set_extension("md");
-        ".md"
-    } else {
-        suffix.as_str()
-    };
-    if !is_supported_local_link(suffix) {
-        return None;
-    }
-    if !target.is_absolute() {
-        target = source_directory.join(target);
-    }
-    Some(lexical_normalize(&target))
+        || lower.starts_with("//")
 }
 
 fn is_documentable_source(path: &Path) -> bool {
@@ -435,40 +1442,54 @@ fn is_documentable_source(path: &Path) -> bool {
         })
 }
 
-fn is_supported_local_link(suffix: &str) -> bool {
-    matches!(
-        suffix,
-        ".md"
-            | ".mdx"
-            | ".qmd"
-            | ".markdown"
-            | ".rst"
-            | ".txt"
-            | ".rs"
-            | ".py"
-            | ".js"
-            | ".jsx"
-            | ".ts"
-            | ".tsx"
-            | ".java"
-            | ".cs"
-            | ".go"
-            | ".c"
-            | ".cc"
-            | ".cpp"
-            | ".h"
-            | ".hpp"
-            | ".rb"
-            | ".php"
-            | ".swift"
-            | ".kt"
-            | ".kts"
-            | ".scala"
-            | ".dart"
-            | ".ex"
-            | ".exs"
-            | ".sql"
-    )
+fn is_supported_local_link(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "md" | "markdown"
+                    | "mdx"
+                    | "qmd"
+                    | "skill"
+                    | "rst"
+                    | "txt"
+                    | "html"
+                    | "htm"
+                    | "yaml"
+                    | "yml"
+                    | "json"
+                    | "docx"
+                    | "xlsx"
+                    | "pptx"
+                    | "rtf"
+                    | "pdf"
+                    | "rs"
+                    | "py"
+                    | "js"
+                    | "jsx"
+                    | "ts"
+                    | "tsx"
+                    | "java"
+                    | "cs"
+                    | "go"
+                    | "c"
+                    | "cc"
+                    | "cpp"
+                    | "h"
+                    | "hpp"
+                    | "rb"
+                    | "php"
+                    | "swift"
+                    | "kt"
+                    | "kts"
+                    | "scala"
+                    | "dart"
+                    | "ex"
+                    | "exs"
+                    | "sql"
+            )
+        })
 }
 
 fn lexical_normalize(path: &Path) -> PathBuf {

--- a/crates/compass-languages/src/markdown.rs
+++ b/crates/compass-languages/src/markdown.rs
@@ -65,12 +65,14 @@ pub(crate) fn extract_source(
         heading_occurrences: HashMap::new(),
         heading_targets: HashMap::new(),
         reference_definitions: HashMap::new(),
+        footnote_definitions: HashMap::new(),
         pending_links: Vec::new(),
         unresolved_links: Vec::new(),
         external_links: Vec::new(),
         diagnostics: Vec::new(),
         inline_parser,
         next_block_index: 1,
+        other_count: 0,
     };
 
     state.add_root(file_id, metadata);
@@ -100,6 +102,8 @@ pub(crate) fn extract_source(
         }
     }
     state.scan_reference_definitions();
+    state.scan_footnotes();
+    state.scan_other_constructs();
     state.finalize_links();
 
     state
@@ -118,6 +122,20 @@ pub(crate) fn extract_source(
         "markdown_link_count".to_owned(),
         json!(state.pending_link_count()),
     );
+    state.extraction.extensions.insert(
+        "markdown_footnote_count".to_owned(),
+        json!(
+            state
+                .footnote_definitions
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+        ),
+    );
+    state
+        .extraction
+        .extensions
+        .insert("markdown_other_count".to_owned(), json!(state.other_count));
     if !state.diagnostics.is_empty() {
         state.extraction.extensions.insert(
             "markdown_diagnostics".to_owned(),
@@ -151,12 +169,14 @@ struct State<'source, 'path> {
     heading_occurrences: HashMap<String, usize>,
     heading_targets: HashMap<String, Vec<String>>,
     reference_definitions: HashMap<String, String>,
+    footnote_definitions: HashMap<String, Vec<String>>,
     pending_links: Vec<PendingLink>,
     unresolved_links: Vec<Value>,
     external_links: Vec<Value>,
     diagnostics: Vec<String>,
     inline_parser: Parser,
     next_block_index: usize,
+    other_count: usize,
 }
 
 #[derive(Clone)]
@@ -710,6 +730,170 @@ impl State<'_, '_> {
         }
     }
 
+    fn scan_footnotes(&mut self) {
+        let mut offset = 0;
+        let mut fence = None;
+        while let Some((line_end, line)) = next_line(self.source, offset) {
+            if let Some(open) = fence {
+                if closes_fence(line, open) {
+                    fence = None;
+                }
+                offset = line_end;
+                continue;
+            }
+            if let Some(open) = opens_fence(line) {
+                fence = Some(open);
+                offset = line_end;
+                continue;
+            }
+            if let Some((label, relative_start, relative_end)) = parse_footnote_definition(line)
+                && self
+                    .footnote_definitions
+                    .values()
+                    .map(Vec::len)
+                    .sum::<usize>()
+                    < MAX_LINKS
+            {
+                let start = offset.saturating_add(relative_start);
+                let end = offset.saturating_add(relative_end).min(self.source.len());
+                let id = crate::make_id(&[
+                    &self.source_file,
+                    "markdown_footnote",
+                    &label,
+                    &start.to_string(),
+                ]);
+                let parent = self.owner_for_offset(start);
+                let mut extra = Map::new();
+                extra.insert("footnote_label".to_owned(), Value::String(label.clone()));
+                extra.insert(
+                    "footnote_role".to_owned(),
+                    Value::String("definition".to_owned()),
+                );
+                self.add_block_node(
+                    id.clone(),
+                    &format!("Footnote {label}"),
+                    "footnote_definition",
+                    start..end,
+                    Some(&parent),
+                    extra,
+                );
+                self.footnote_definitions.entry(label).or_default().push(id);
+            }
+            self.scan_footnote_references_in_line(offset, line);
+            offset = line_end;
+        }
+    }
+
+    fn scan_footnote_references_in_line(&mut self, offset: usize, line: &[u8]) {
+        let mut cursor = 0;
+        while let Some(relative_start) = line[cursor..].windows(2).position(|pair| pair == b"[^") {
+            let start = cursor.saturating_add(relative_start);
+            let Some(relative_end) = line[start.saturating_add(2)..]
+                .iter()
+                .position(|byte| *byte == b']')
+            else {
+                break;
+            };
+            let end = start
+                .saturating_add(2)
+                .saturating_add(relative_end)
+                .saturating_add(1);
+            if line.get(end) == Some(&b':') {
+                cursor = end.saturating_add(1);
+                continue;
+            }
+            let label =
+                String::from_utf8_lossy(&line[start.saturating_add(2)..end.saturating_sub(1)])
+                    .trim()
+                    .to_owned();
+            if !label.is_empty() && label.len() <= MAX_LABEL_CHARS {
+                let absolute_start = offset.saturating_add(start);
+                let absolute_end = offset.saturating_add(end).min(self.source.len());
+                if self.pending_links.len() < MAX_LINKS {
+                    self.pending_links.push(PendingLink {
+                        raw: label,
+                        reference_label: None,
+                        owner_id: self.owner_for_offset(absolute_start),
+                        site: self.link_site(absolute_start, absolute_end),
+                        kind: "footnote",
+                    });
+                }
+            }
+            cursor = end;
+        }
+    }
+
+    fn scan_other_constructs(&mut self) {
+        let extension = self
+            .path
+            .extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if extension != "mdx" && extension != "qmd" {
+            return;
+        }
+        let mut offset = 0;
+        let mut fence = None;
+        while let Some((line_end, line)) = next_line(self.source, offset) {
+            if let Some(open) = fence {
+                if closes_fence(line, open) {
+                    fence = None;
+                }
+                offset = line_end;
+                continue;
+            }
+            if let Some(open) = opens_fence(line) {
+                fence = Some(open);
+                offset = line_end;
+                continue;
+            }
+            let trimmed = line.trim_ascii();
+            let (other_kind, should_emit) = if extension == "qmd" {
+                (
+                    "quarto_directive",
+                    trimmed.starts_with(b":::") || trimmed.starts_with(b"{{<"),
+                )
+            } else {
+                (
+                    "mdx_construct",
+                    trimmed.starts_with(b"import ")
+                        || trimmed.starts_with(b"export ")
+                        || trimmed.starts_with(b"{")
+                        || (trimmed.starts_with(b"<")
+                            && trimmed.get(1).is_some_and(u8::is_ascii_uppercase)),
+                )
+            };
+            if should_emit && self.other_count < MAX_DIAGNOSTICS {
+                let start = offset;
+                let end = offset.saturating_add(line.len()).min(self.source.len());
+                let id = crate::make_id(&[
+                    &self.source_file,
+                    "markdown_other",
+                    other_kind,
+                    &start.to_string(),
+                ]);
+                let parent = self.owner_for_offset(start);
+                let mut extra = Map::new();
+                extra.insert(
+                    "other_kind".to_owned(),
+                    Value::String(other_kind.to_owned()),
+                );
+                extra.insert("source_syntax".to_owned(), Value::String(extension.clone()));
+                self.add_block_node(
+                    id,
+                    &compact_label(&String::from_utf8_lossy(line)),
+                    "other",
+                    start..end,
+                    Some(&parent),
+                    extra,
+                );
+                self.other_count = self.other_count.saturating_add(1);
+            }
+            offset = line_end;
+        }
+    }
+
     fn owner_for_offset(&self, offset: usize) -> String {
         let mut owner = self.file_id.clone();
         let mut smallest_span = usize::MAX;
@@ -761,6 +945,24 @@ impl State<'_, '_> {
     fn finalize_links(&mut self) {
         let pending_links = std::mem::take(&mut self.pending_links);
         for pending in pending_links {
+            if pending.kind == "footnote" {
+                match self.footnote_definitions.get(&pending.raw) {
+                    Some(candidates) if candidates.len() == 1 => {
+                        if let Some(target) = candidates.first() {
+                            self.add_link_edge(
+                                &pending,
+                                target.clone(),
+                                Some(("references", Some(&pending.raw))),
+                            );
+                        }
+                    }
+                    Some(_) => self.add_unresolved(&pending, "ambiguous_footnote", &pending.raw),
+                    None => {
+                        self.add_unresolved(&pending, "missing_footnote_definition", &pending.raw)
+                    }
+                }
+                continue;
+            }
             let raw = pending
                 .reference_label
                 .as_ref()
@@ -1022,6 +1224,12 @@ fn parse_frontmatter(source: &[u8]) -> (Option<Map<String, Value>>, Option<Strin
                     Some("Markdown frontmatter exceeds the byte limit".to_owned()),
                 );
             }
+            if yaml_contains_alias_or_tag(yaml) {
+                return (
+                    None,
+                    Some("Markdown frontmatter aliases and tags are not supported".to_owned()),
+                );
+            }
             let yaml = String::from_utf8_lossy(yaml);
             return match serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&yaml) {
                 Ok(value) => match yaml_metadata(&value) {
@@ -1040,6 +1248,54 @@ fn parse_frontmatter(source: &[u8]) -> (Option<Map<String, Value>>, Option<Strin
         None,
         Some("Markdown frontmatter has no bounded closing delimiter".to_owned()),
     )
+}
+
+fn yaml_contains_alias_or_tag(source: &[u8]) -> bool {
+    let mut quoted = None;
+    let mut escaped = false;
+    let mut index = 0;
+    while index < source.len() {
+        let byte = source[index];
+        if let Some(quote) = quoted {
+            if quote == b'"' && escaped {
+                escaped = false;
+            } else if quote == b'"' && byte == b'\\' {
+                escaped = true;
+            } else if quote == b'\'' && byte == b'\'' && source.get(index + 1) == Some(&b'\'') {
+                index = index.saturating_add(2);
+                continue;
+            } else if byte == quote {
+                quoted = None;
+            }
+            index = index.saturating_add(1);
+            continue;
+        }
+        if byte == b'\'' || byte == b'"' {
+            quoted = Some(byte);
+            index = index.saturating_add(1);
+            continue;
+        }
+        if byte == b'#' && (index == 0 || source[index - 1].is_ascii_whitespace()) {
+            index = source[index..]
+                .iter()
+                .position(|value| *value == b'\n')
+                .map_or(source.len(), |offset| index.saturating_add(offset));
+            continue;
+        }
+        if matches!(byte, b'&' | b'*' | b'!') {
+            let token_start = index == 0
+                || source[index - 1].is_ascii_whitespace()
+                || matches!(
+                    source[index - 1],
+                    b':' | b'[' | b']' | b',' | b'{' | b'}' | b'-'
+                );
+            if token_start {
+                return true;
+            }
+        }
+        index = index.saturating_add(1);
+    }
+    false
 }
 
 fn yaml_metadata(value: &serde_yaml_ng::Value) -> Result<Map<String, Value>, &'static str> {
@@ -1200,6 +1456,33 @@ fn parse_reference_definition(line: &[u8]) -> Option<(String, String, usize, usi
     Some((label, target, start, target_end))
 }
 
+fn parse_footnote_definition(line: &[u8]) -> Option<(String, usize, usize)> {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    let mut start = 0;
+    while start < line.len() && line[start] == b' ' && start < 3 {
+        start += 1;
+    }
+    if line.get(start..start.saturating_add(2)) != Some(b"[^") {
+        return None;
+    }
+    let label_end = line[start.saturating_add(2)..]
+        .iter()
+        .position(|byte| *byte == b']')?
+        .saturating_add(start)
+        .saturating_add(2);
+    if line.get(label_end.saturating_add(1)) != Some(&b':') {
+        return None;
+    }
+    let label = String::from_utf8_lossy(&line[start.saturating_add(2)..label_end])
+        .trim()
+        .to_owned();
+    if label.is_empty() || label.len() > MAX_LABEL_CHARS {
+        return None;
+    }
+    Some((label, start, line.len()))
+}
+
 fn is_frontmatter_delimiter(line: &[u8], allow_bom: bool) -> bool {
     let line = if allow_bom {
         line.strip_prefix(b"\xef\xbb\xbf").unwrap_or(line)
@@ -1304,6 +1587,8 @@ fn block_label(kind: &str, text: &str) -> String {
         "block_quote" => "blockquote".to_owned(),
         "thematic_break" => "thematic break".to_owned(),
         "link_reference_definition" => "link definition".to_owned(),
+        "footnote_definition" => "footnote".to_owned(),
+        "other" => "other Markdown construct".to_owned(),
         "html_block" => "HTML block".to_owned(),
         _ => compact_label(text),
     }
@@ -1384,6 +1669,7 @@ fn is_structural_block_kind(kind: &str) -> bool {
         "atx_heading"
             | "block_quote"
             | "fenced_code_block"
+            | "footnote_definition"
             | "html_block"
             | "indented_code_block"
             | "link_reference_definition"
@@ -1397,6 +1683,7 @@ fn is_structural_block_kind(kind: &str) -> bool {
             | "section"
             | "setext_heading"
             | "thematic_break"
+            | "other"
     )
 }
 

--- a/crates/compass-languages/src/registry.rs
+++ b/crates/compass-languages/src/registry.rs
@@ -466,7 +466,7 @@ const REGISTRY_CASES: &[RegistryCase] = &[
     ),
     registry_case!(
         "markdown",
-        RegistryMatcher::Extensions(&["md", "mdx", "qmd", "skill"]),
+        RegistryMatcher::Extensions(&["md", "markdown", "mdx", "qmd", "skill"]),
         LanguageSpec {
             name: "markdown",
             grammar: None,

--- a/crates/compass-languages/src/registry.rs
+++ b/crates/compass-languages/src/registry.rs
@@ -6,6 +6,7 @@ use crate::{AdapterProfile, AdapterRegistry};
 pub enum ExtractorKind {
     Generic,
     Markdown,
+    Html,
     JsonConfig,
     Terraform,
     PascalForm,
@@ -474,6 +475,17 @@ const REGISTRY_CASES: &[RegistryCase] = &[
         },
         "matrix/sample.md",
         "# Matrix\n"
+    ),
+    registry_case!(
+        "html",
+        RegistryMatcher::Extensions(&["html", "htm"]),
+        LanguageSpec {
+            name: "html",
+            grammar: Some("html"),
+            kind: ExtractorKind::Html
+        },
+        "matrix/sample.html",
+        "<main><h1>Matrix</h1></main>\n"
     ),
     registry_case!(
         "pascal",

--- a/crates/compass-languages/tests/html_coverage.rs
+++ b/crates/compass-languages/tests/html_coverage.rs
@@ -1,0 +1,183 @@
+#![allow(clippy::expect_used)]
+
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::path::Path;
+
+use compass_languages::{Engine, Registry};
+use serde_json::Value;
+
+#[test]
+fn html_emits_semantic_structure_metadata_and_link_provenance() -> Result<(), Box<dyn Error>> {
+    let source = br##"<!doctype html>
+<html><head>
+  <title>Guide &amp; API</title>
+  <meta name="description" content="A &amp; guide">
+  <base href="https://docs.example.test/guide/">
+  <link rel="canonical" href="https://docs.example.test/guide/index.html">
+  <style>.hidden { display: none }</style>
+</head><body>
+  <main id="intro"><h1>Guide</h1>
+    <p>Read <a href="#intro" rel="self">this section</a> or <a href="https://example.test/api">the API</a>.</p>
+    <nav><ul><li>Overview</li><li><a href="next.html">Next</a></li></ul></nav>
+    <blockquote>Quoted</blockquote>
+    <pre><code>const hidden = true;</code></pre>
+    <table><tr><th>Name</th><th>Value</th></tr><tr><td>A</td><td>1</td></tr></table>
+    <script>secret()</script><template>template secret</template><noscript>noscript secret</noscript>
+  </main>
+</body></html>"##;
+    let path = Path::new("docs/index.html");
+    let extraction = Engine::default().extract_source(path, source)?;
+    let root = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            node.attributes.get("document_kind") == Some(&Value::String("document".to_owned()))
+        })
+        .expect("HTML root");
+    assert_eq!(root.string("document_format"), "html");
+    assert_eq!(root.string("html_title"), "Guide & API");
+    assert!(root.string("html_visible_text").contains("Guide"));
+    assert!(!root.string("html_visible_text").contains("secret"));
+    assert_eq!(
+        root.string("html_canonical"),
+        "https://docs.example.test/guide/index.html"
+    );
+    assert_eq!(root.attributes["html_meta"]["description"], "A & guide");
+
+    let kinds = extraction
+        .nodes
+        .iter()
+        .filter_map(|node| node.attributes.get("document_kind").and_then(Value::as_str))
+        .collect::<BTreeSet<_>>();
+    for kind in [
+        "heading",
+        "paragraph",
+        "landmark",
+        "list",
+        "list_item",
+        "blockquote",
+        "preformatted",
+        "code",
+        "table",
+        "table_row",
+        "table_cell",
+        "link",
+    ] {
+        assert!(kinds.contains(kind), "missing HTML kind {kind}");
+    }
+    let paragraph_id = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            node.attributes.get("document_kind") == Some(&Value::String("paragraph".to_owned()))
+        })
+        .map(|node| node.id.clone())
+        .expect("paragraph owner");
+    assert!(
+        extraction
+            .edges
+            .iter()
+            .any(|edge| edge.attributes.get("link_kind")
+                == Some(&Value::String("anchor".to_owned()))
+                && edge.source == paragraph_id
+                && edge.attributes.get("fragment") == Some(&Value::String("intro".to_owned())))
+    );
+    assert!(
+        extraction
+            .extensions
+            .get("html_external_links")
+            .and_then(Value::as_array)
+            .is_some_and(|links| links
+                .iter()
+                .any(|link| link["target"] == "https://example.test/api"))
+    );
+    assert!(
+        extraction
+            .edges
+            .iter()
+            .any(|edge| edge.target == "docs_next_html")
+    );
+    assert!(
+        extraction
+            .edges
+            .iter()
+            .filter(|edge| edge.attributes.get("relation")
+                == Some(&Value::String("contains".to_owned())))
+            .all(|edge| edge.attributes.contains_key("start_byte")
+                && edge.attributes.contains_key("end_byte"))
+    );
+    Ok(())
+}
+
+#[test]
+fn html_extension_registry_is_structural_and_source_driven() -> Result<(), Box<dyn Error>> {
+    let html = Registry::resolve(Path::new("page.htm")).expect("HTML registry case");
+    assert_eq!(html.name, "html");
+    assert_eq!(html.kind, compass_languages::ExtractorKind::Html);
+    let combined = Engine::default().extract_source_combined(
+        Path::new("page.htm"),
+        "page.htm",
+        b"<main><h2>Source driven</h2></main>",
+    )?;
+    assert!(combined.program.is_none());
+    assert_eq!(combined.graph.nodes[0].string("document_format"), "html");
+    Ok(())
+}
+
+#[test]
+fn html_link_evidence_preserves_unsupported_and_remote_targets() -> Result<(), Box<dyn Error>> {
+    let local = Engine::default().extract_source(
+        Path::new("docs/index.html"),
+        br#"<p><a href="asset.bin">Binary asset</a></p>"#,
+    )?;
+    assert!(
+        local
+            .extensions
+            .get("html_unresolved_links")
+            .and_then(Value::as_array)
+            .is_some_and(|links| links.iter().any(|link| {
+                link["reason"] == "unsupported_local_suffix" && link["target"] == "docs/asset.bin"
+            }))
+    );
+
+    let remote = Engine::default().extract_source_combined(
+        Path::new("index.html"),
+        "https://example.test/start.html",
+        br#"<p><a href="next">Next</a></p>"#,
+    )?;
+    assert!(
+        remote
+            .graph
+            .extensions
+            .get("html_external_links")
+            .and_then(Value::as_array)
+            .is_some_and(|links| links.iter().any(|link| {
+                link["target"] == "https://example.test/next" && link["link_kind"] == "anchor"
+            }))
+    );
+    Ok(())
+}
+
+#[test]
+fn malformed_html_publishes_bounded_recovery_diagnostics() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("broken.html"),
+        b"<main><h1>Guide</h1><p>unclosed <a href=\"#missing\">link",
+    )?;
+    assert_eq!(
+        extraction
+            .extensions
+            .get("_compass_extraction_quality")
+            .and_then(Value::as_str),
+        Some("partial")
+    );
+    assert!(
+        extraction
+            .extensions
+            .get("html_diagnostics")
+            .and_then(Value::as_array)
+            .is_some_and(|diagnostics| !diagnostics.is_empty())
+    );
+    Ok(())
+}

--- a/crates/compass-languages/tests/markdown_coverage.rs
+++ b/crates/compass-languages/tests/markdown_coverage.rs
@@ -367,5 +367,61 @@ fn markdown_frontmatter_is_bounded_and_diagnosed_without_swallowing_body()
             .is_some_and(|message| message.contains("closing delimiter"))
     }));
     assert!(unclosed.nodes.iter().any(|node| node.label() == "Body"));
+
+    let unsafe_yaml = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b"---\ntitle: \"R&D\"\nbase: &shared value\ncopy: *shared\n---\n# Body\n",
+    )?;
+    let unsafe_diagnostics = unsafe_yaml
+        .extensions
+        .get("markdown_diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("missing alias diagnostic")?;
+    assert!(unsafe_diagnostics.iter().any(|value| {
+        value
+            .as_str()
+            .is_some_and(|message| message.contains("aliases and tags"))
+    }));
+    assert!(
+        !unsafe_yaml.nodes[0]
+            .attributes
+            .contains_key("document_metadata")
+    );
+    assert!(unsafe_yaml.nodes.iter().any(|node| node.label() == "Body"));
+    Ok(())
+}
+
+#[test]
+fn markdown_footnotes_and_mdx_quarto_constructs_remain_explicit() -> Result<(), Box<dyn Error>> {
+    let mdx = Engine::default().extract_source(
+        std::path::Path::new("guide.mdx"),
+        b"import Callout from './Callout.jsx'\n\n# Guide\n\nText[^note]\n\n<Callout>content</Callout>\n{value}\n\n[^note]: A bounded footnote.\n",
+    )?;
+    assert!(mdx.nodes.iter().any(|node| {
+        node.attributes.get("document_kind") == Some(&serde_json::json!("other"))
+            && node.attributes.get("other_kind") == Some(&serde_json::json!("mdx_construct"))
+    }));
+    assert!(mdx.nodes.iter().any(|node| {
+        node.attributes.get("document_kind") == Some(&serde_json::json!("footnote_definition"))
+            && node.attributes.get("footnote_label") == Some(&serde_json::json!("note"))
+    }));
+    assert!(mdx.edges.iter().any(|edge| {
+        edge.attributes.get("link_kind") == Some(&serde_json::json!("footnote"))
+            && edge.attributes.get("relation") == Some(&serde_json::json!("references"))
+    }));
+
+    let qmd = Engine::default().extract_source(
+        std::path::Path::new("report.qmd"),
+        b"::: {.callout-note}\nQuarto content\n:::\n\n{{< include shared.qmd >}}\n",
+    )?;
+    assert!(qmd.nodes.iter().any(|node| {
+        node.attributes.get("document_kind") == Some(&serde_json::json!("other"))
+            && node.attributes.get("other_kind") == Some(&serde_json::json!("quarto_directive"))
+    }));
+    assert!(
+        qmd.extensions["markdown_other_count"]
+            .as_u64()
+            .is_some_and(|count| count >= 2)
+    );
     Ok(())
 }

--- a/crates/compass-languages/tests/markdown_coverage.rs
+++ b/crates/compass-languages/tests/markdown_coverage.rs
@@ -351,5 +351,21 @@ fn markdown_frontmatter_is_bounded_and_diagnosed_without_swallowing_body()
             .is_some_and(|message| message.contains("frontmatter"))
     }));
     assert!(malformed.nodes.iter().any(|node| node.label() == "Body"));
+
+    let unclosed = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b"---\ntitle: still body\n# Body\n",
+    )?;
+    let unclosed_diagnostics = unclosed
+        .extensions
+        .get("markdown_diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("missing unclosed frontmatter diagnostic")?;
+    assert!(unclosed_diagnostics.iter().any(|value| {
+        value
+            .as_str()
+            .is_some_and(|message| message.contains("closing delimiter"))
+    }));
+    assert!(unclosed.nodes.iter().any(|node| node.label() == "Body"));
     Ok(())
 }

--- a/crates/compass-languages/tests/markdown_coverage.rs
+++ b/crates/compass-languages/tests/markdown_coverage.rs
@@ -82,7 +82,7 @@ fn markdown_extracts_heading_hierarchy_and_only_local_document_links() -> Result
                 == Some("references")
         })
         .collect::<Vec<_>>();
-    assert_eq!(references.len(), 9, "references={references:#?}");
+    assert_eq!(references.len(), 10, "references={references:#?}");
     assert!(references.iter().all(|edge| {
         edge.attributes
             .get("confidence")
@@ -100,7 +100,12 @@ fn markdown_extracts_heading_hierarchy_and_only_local_document_links() -> Result
                     == Some("contains")
             })
             .count(),
-        6
+        9
+    );
+    assert!(
+        references
+            .iter()
+            .all(|edge| edge.source != extraction.nodes[0].id)
     );
     assert_eq!(extraction.extensions["input_tokens"], 0);
     assert_eq!(extraction.extensions["output_tokens"], 0);
@@ -141,5 +146,210 @@ fn markdown_file_and_same_named_heading_have_distinct_identities() -> Result<(),
                 .and_then(serde_json::Value::as_str)
                 == Some("contains")
     }));
+    Ok(())
+}
+
+#[test]
+fn markdown_source_path_supports_frontmatter_blocks_and_section_links() -> Result<(), Box<dyn Error>>
+{
+    let path = std::path::Path::new("docs/guide.md");
+    let source = br#"---
+title: Guide
+tags: [rust, graph]
+draft: false
+---
+# Intro {#start}
+
+Setext heading
+---------------
+
+- [x] checked item
+  - nested item
+
+| Name | Value |
+| :--- | ---: |
+| alpha | `one` |
+
+```rust
+let hidden = "[not a link](ignored.md)";
+```
+
+[guide][reference]
+[reference]: ./reference.md
+[jump](#start)
+"#;
+
+    let extraction = Engine::default().extract_source(path, source)?;
+    let root = extraction
+        .nodes
+        .first()
+        .ok_or("missing Markdown document root")?;
+    assert_eq!(root.string("document_format"), "markdown");
+    assert_eq!(root.attributes["document_metadata"]["title"], "Guide");
+    assert_eq!(
+        root.attributes["document_metadata"]["tags"],
+        serde_json::json!(["rust", "graph"])
+    );
+
+    let kinds = extraction
+        .nodes
+        .iter()
+        .filter_map(|node| node.attributes.get("document_kind"))
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    for expected in [
+        "heading",
+        "list",
+        "list_item",
+        "pipe_table",
+        "pipe_table_header",
+        "pipe_table_row",
+        "pipe_table_cell",
+        "fenced_code_block",
+    ] {
+        assert!(kinds.contains(&expected), "missing {expected}: {kinds:?}");
+    }
+    assert!(extraction.nodes.iter().any(|node| {
+        node.attributes.get("heading_style") == Some(&serde_json::json!("setext"))
+            && node.attributes.get("heading_level") == Some(&serde_json::json!(2))
+    }));
+    assert!(!extraction.edges.iter().any(|edge| {
+        edge.attributes.get("link_kind") == Some(&serde_json::json!("inline"))
+            && edge.target.contains("ignored")
+    }));
+    let reference_edges = extraction
+        .edges
+        .iter()
+        .filter(|edge| edge.attributes.get("link_kind").is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(reference_edges.len(), 3);
+    assert!(reference_edges.iter().any(|edge| {
+        edge.attributes.get("link_kind") == Some(&serde_json::json!("reference_definition"))
+            && edge.attributes.get("relation") == Some(&serde_json::json!("references"))
+    }));
+    assert!(reference_edges.iter().any(|edge| {
+        edge.attributes.get("fragment") == Some(&serde_json::json!("start"))
+            && edge.target != root.id
+    }));
+    assert!(extraction.nodes.iter().all(|node| {
+        node.attributes
+            .get("start_byte")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|start| {
+                node.attributes
+                    .get("end_byte")
+                    .and_then(serde_json::Value::as_u64)
+                    .is_some_and(|end| start <= end && (end as usize) <= source.len())
+            })
+    }));
+
+    let combined = Engine::default().extract_source_combined(
+        std::path::Path::new("/workspace/docs/guide.md"),
+        "docs/guide.md",
+        source,
+    )?;
+    assert!(combined.program.is_none());
+    assert_eq!(
+        combined.graph.nodes[0].string("source_file"),
+        "docs/guide.md"
+    );
+    Ok(())
+}
+
+#[test]
+fn markdown_duplicate_fragments_are_explicitly_unresolved() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b"# Same\n\n## Same\n\n## Other\n\n[jump](#same)\n",
+    )?;
+    assert!(
+        !extraction
+            .edges
+            .iter()
+            .any(|edge| edge.attributes.get("link_kind") == Some(&serde_json::json!("inline")))
+    );
+    let unresolved = extraction
+        .extensions
+        .get("markdown_unresolved_links")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("missing unresolved Markdown link evidence")?;
+    assert!(unresolved.iter().any(|value| {
+        value.get("reason").and_then(serde_json::Value::as_str) == Some("ambiguous_fragment")
+    }));
+    Ok(())
+}
+
+#[test]
+fn markdown_links_are_owned_by_the_smallest_structural_block() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b"- [item](item.md)\n  - [nested](nested.md)\n\n> [quote](quote.md)\n",
+    )?;
+
+    let link_edges = extraction
+        .edges
+        .iter()
+        .filter(|edge| edge.attributes.get("link_kind").is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(link_edges.len(), 3);
+    for edge in link_edges {
+        let source = extraction
+            .nodes
+            .iter()
+            .find(|node| node.id == edge.source)
+            .ok_or("missing link owner")?;
+        assert_eq!(
+            source.attributes.get("document_kind"),
+            Some(&serde_json::json!("paragraph"))
+        );
+    }
+    let root_id = &extraction.nodes[0].id;
+    assert!(extraction.edges.iter().any(|edge| {
+        edge.source.as_str() == root_id.as_str()
+            && edge.attributes.get("relation") == Some(&serde_json::json!("contains"))
+    }));
+    assert!(extraction.nodes.iter().all(|node| {
+        !matches!(
+            node.attributes
+                .get("document_kind")
+                .and_then(serde_json::Value::as_str),
+            Some("block_continuation")
+                | Some("block_quote_marker")
+                | Some("link_destination")
+                | Some("list_marker_minus")
+        )
+    }));
+    Ok(())
+}
+
+#[test]
+fn markdown_frontmatter_is_bounded_and_diagnosed_without_swallowing_body()
+-> Result<(), Box<dyn Error>> {
+    let indented = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b" ---\ntitle: not metadata\n---\n# Body\n",
+    )?;
+    assert!(
+        !indented.nodes[0]
+            .attributes
+            .contains_key("document_metadata")
+    );
+    assert!(indented.nodes.iter().any(|node| node.label() == "Body"));
+
+    let malformed = Engine::default().extract_source(
+        std::path::Path::new("guide.md"),
+        b"---\ntitle: [unterminated\n---\n# Body\n",
+    )?;
+    let diagnostics = malformed
+        .extensions
+        .get("markdown_diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("missing frontmatter diagnostic")?;
+    assert!(diagnostics.iter().any(|value| {
+        value
+            .as_str()
+            .is_some_and(|message| message.contains("frontmatter"))
+    }));
+    assert!(malformed.nodes.iter().any(|node| node.label() == "Body"));
     Ok(())
 }

--- a/crates/compass-languages/tests/registry.rs
+++ b/crates/compass-languages/tests/registry.rs
@@ -18,9 +18,9 @@ fn registry_covers_every_python_dispatch_extension() -> Result<(), Box<dyn Error
         "kts", "scala", "php", "swift", "lua", "luau", "toc", "zig", "ps1", "psm1", "psd1", "ex",
         "exs", "mm", "jl", "f", "F", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "vue",
         "svelte", "astro", "dart", "v", "sv", "svh", "sql", "r", "md", "markdown", "mdx", "qmd",
-        "skill", "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk", "sh", "bash",
-        "json", "tf", "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx", "csproj",
-        "fsproj", "vbproj", "xaml", "razor", "cshtml", "cls", "trigger", "pl", "pm",
+        "skill", "html", "htm", "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk", "sh",
+        "bash", "json", "tf", "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx",
+        "csproj", "fsproj", "vbproj", "xaml", "razor", "cshtml", "cls", "trigger", "pl", "pm",
     ];
     for extension in ordinary {
         let path = directory.path().join(format!("sample.{extension}"));

--- a/crates/compass-languages/tests/registry.rs
+++ b/crates/compass-languages/tests/registry.rs
@@ -17,10 +17,10 @@ fn registry_covers_every_python_dispatch_extension() -> Result<(), Box<dyn Error
         "gradle", "c", "cpp", "cc", "cxx", "hpp", "cu", "cuh", "metal", "rb", "rake", "cs", "kt",
         "kts", "scala", "php", "swift", "lua", "luau", "toc", "zig", "ps1", "psm1", "psd1", "ex",
         "exs", "mm", "jl", "f", "F", "f90", "F90", "f95", "F95", "f03", "F03", "f08", "F08", "vue",
-        "svelte", "astro", "dart", "v", "sv", "svh", "sql", "r", "md", "mdx", "qmd", "skill",
-        "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk", "sh", "bash", "json", "tf",
-        "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx", "csproj", "fsproj",
-        "vbproj", "xaml", "razor", "cshtml", "cls", "trigger", "pl", "pm",
+        "svelte", "astro", "dart", "v", "sv", "svh", "sql", "r", "md", "markdown", "mdx", "qmd",
+        "skill", "pas", "pp", "dpr", "dpk", "lpr", "inc", "dfm", "lfm", "lpk", "sh", "bash",
+        "json", "tf", "tfvars", "hcl", "dm", "dme", "dmi", "dmm", "dmf", "sln", "slnx", "csproj",
+        "fsproj", "vbproj", "xaml", "razor", "cshtml", "cls", "trigger", "pl", "pm",
     ];
     for extension in ordinary {
         let path = directory.path().join(format!("sample.{extension}"));

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ workspace:
 | [Managed JDT integration](design/java-jdt-integration.md) | Planned Java semantic tooling, trust boundaries, phases, and acceptance criteria |
 | [Storage and history](design/storage-and-history.md) | Incremental artifacts and immutable historical realizations |
 | [Security and privacy](design/security-and-privacy.md) | Trust boundaries, credentials, and offline behavior |
+| [Document processing](design/document-processing.md) | Source-driven Markdown structure, metadata, links, and bounds |
 
 ### Work on the implementation
 
@@ -131,6 +132,7 @@ The [cookbook index](cookbook/README.md) routes to:
 | [Commands](reference/commands.md) | Command families, common inputs, output modes, and diagnostics |
 | [Configuration](reference/configuration.md) | Providers, environment, paths, and precedence |
 | [Outputs](reference/outputs.md) | `compass-out/`, graph JSON, query results, and history exports |
+| [Document formats](reference/document-formats.md) | Markdown fields, limits, and discovery versus extraction |
 | [Compatibility](reference/compatibility.md) | Compass contracts, hard cutovers, and portability |
 | [CompassQL 1](COMPASSQL.md) | Canonical language and runtime contract |
 | [CompassQL support](COMPASSQL_SUPPORT.md) | Checked syntax and feature matrix |

--- a/docs/design/document-processing.md
+++ b/docs/design/document-processing.md
@@ -1,0 +1,142 @@
+---
+meta:
+  contentType: Conceptual
+  title: Structural document processing
+  navLabel: Document Processing
+  category: Design
+  overview: How Compass turns Markdown bytes into bounded, deterministic graph evidence.
+  goal: Define the ownership, provenance, and cache rules for local text documents.
+  audience:
+    - Compass contributors
+    - technical evaluators
+  contentPlan:
+    - source-driven extraction
+    - Markdown structure and metadata
+    - links and ambiguity
+    - cache and security boundaries
+  openQuestions: []
+---
+
+# Structural document processing
+
+Compass treats a document as an ordered source artifact, not as a bag of
+extracted strings. The current structural implementation is Markdown-first:
+the same bounded bytes read by the build pipeline are parsed into a document
+root, structural blocks, and provenance-preserving relationships.
+
+> **Who this page is for:** contributors and integrators who need to understand
+> document graph facts.
+>
+> **You will learn:** what Markdown emits, how links resolve, and which limits
+> keep extraction local and bounded.
+>
+> **Prerequisites:** [Language architecture](language-architecture.md) and
+> [Graph model](../concepts/graph-model.md).
+
+## Ownership and data flow
+
+```text
+bounded source bytes
+        |
+        v
+compass-languages::Engine
+        |
+        +--> pinned Markdown block grammar
+        +--> pinned Markdown inline grammar
+        +--> bounded frontmatter decoder
+        |
+        v
+document root + structural blocks + link evidence
+        |
+        v
+compass-graph / compass-core publication
+```
+
+`Engine::extract_source` and the combined extraction path pass the already-read
+bytes to the Markdown producer. This avoids a second file read and preserves
+the caller's source-file identity for cache, repository-relative paths, and
+source ranges. The standalone compatibility path still accepts a `Path` and
+reads it once.
+
+The parser grammars are statically linked through the pinned `tree-sitter-md`
+crate. Markdown extraction does not download grammars, invoke Python, call a
+model, or follow a URL.
+
+## Markdown projection
+
+Every file has one root node with:
+
+- `document_format: "markdown"` and `document_kind: "document"`;
+- the source file and exact whole-document byte/line range;
+- deterministic `document_metadata` when bounded frontmatter is valid.
+
+The structural projection emits ordered nodes for headings, paragraphs, lists
+and list items, block quotes, thematic breaks, fenced and indented code,
+pipe-table containers/headers/rows/cells, HTML blocks, and reference
+definitions. Each node carries `document_kind`, `block_index`, source identity,
+and an exact byte range. Heading nodes additionally carry `heading_level`,
+`heading_style`, `qualified_name`, and a deterministic `anchor_slug`; headings
+with `{#explicit-id}` retain `explicit_id`.
+
+Nested blocks are represented by `contains` edges. Inline links are owned by
+the smallest containing structural block, so a link in a list item or table
+cell does not get attributed to the surrounding list or table as well. Parser
+helper nodes such as markers, destinations, and continuation tokens are never
+published as blocks.
+
+## Frontmatter policy
+
+Frontmatter is recognized only when the source begins with a whole-line `---`
+(an optional UTF-8 BOM is accepted) and a whole-line closing delimiter appears
+within 64 KiB. It is parsed with the workspace YAML implementation and only
+JSON-compatible scalars and bounded scalar arrays are published. Mappings,
+aliases, tags, oversized values, and arrays containing non-scalars produce a
+bounded diagnostic and do not become graph attributes. Keys are deterministic
+and capped at 256 entries; individual strings and arrays are bounded.
+
+Frontmatter is metadata, not visible Markdown body text. Body node ranges still
+point into the original bytes, including CRLF and non-UTF-8 input (labels use a
+lossy display representation while offsets remain byte offsets).
+
+## Link resolution
+
+Compass records external links as bounded `markdown_external_links` evidence
+without fetching them. Supported local links produce `references` edges, while
+links to an existing source document may use the `documents` relation. A
+fragment-only link resolves to a heading only when its slug or explicit ID is
+unique. Duplicate or missing fragments remain in `markdown_unresolved_links`
+with an explicit reason; extraction never selects the first same-named heading.
+
+Reference definitions and usages retain separate source sites. Wikilinks,
+autolinks, email links, inline links, and reference links carry a `link_kind`,
+line, byte range, source file, and extracted confidence. Images are not treated
+as document relationships, and links inside fenced code are inert.
+
+## Cache and trust boundaries
+
+Markdown file hashes include the raw frontmatter bytes. A metadata-only edit
+therefore invalidates structural and semantic cache entries just like a body
+edit. The legacy `body_content` helper remains available for callers that
+explicitly need the old body-only view; it is not used as the graph cache key.
+
+All parser work is bounded by the caller's source-read limits plus explicit
+frontmatter, block, link, metadata, and diagnostic caps. Inputs are never
+executed, fetched, or interpreted as configuration. Unknown graph attributes
+remain extensible, and consumers should preserve them.
+
+## Other document formats
+
+File discovery recognizes several document extensions, but recognition is not
+the same as structural extraction. HTML, DOCX, PPTX, RTF, and spreadsheet
+normalizers remain separate integration surfaces until they have their own
+bounded parser, exact locator policy, and qualification fixtures. See the
+[document format reference](../reference/document-formats.md) for the current
+matrix. Markdown links may point at those formats, but Compass does not fetch
+or execute a linked resource during Markdown extraction.
+
+## Related pages
+
+- [Document format reference](../reference/document-formats.md)
+- [Language architecture](language-architecture.md)
+- [Extraction pipeline](../implementation/extraction-pipeline.md)
+- [Graph model](../concepts/graph-model.md)

--- a/docs/design/document-processing.md
+++ b/docs/design/document-processing.md
@@ -4,14 +4,14 @@ meta:
   title: Structural document processing
   navLabel: Document Processing
   category: Design
-  overview: How Compass turns Markdown bytes into bounded, deterministic graph evidence.
+  overview: How Compass turns Markdown and HTML bytes into bounded, deterministic graph evidence.
   goal: Define the ownership, provenance, and cache rules for local text documents.
   audience:
     - Compass contributors
     - technical evaluators
   contentPlan:
     - source-driven extraction
-    - Markdown structure and metadata
+    - Markdown and HTML structure and metadata
     - links and ambiguity
     - cache and security boundaries
   openQuestions: []
@@ -41,9 +41,9 @@ bounded source bytes
         v
 compass-languages::Engine
         |
-        +--> pinned Markdown block grammar
-        +--> pinned Markdown inline grammar
-        +--> bounded frontmatter decoder
+        +--> pinned Markdown block/inline grammars
+        +--> pinned HTML grammar and shared renderer
+        +--> bounded frontmatter/entity/URL decoders
         |
         v
 document root + structural blocks + link evidence
@@ -58,9 +58,12 @@ the caller's source-file identity for cache, repository-relative paths, and
 source ranges. The standalone compatibility path still accepts a `Path` and
 reads it once.
 
-The parser grammars are statically linked through the pinned `tree-sitter-md`
-crate. Markdown extraction does not download grammars, invoke Python, call a
-model, or follow a URL.
+The Markdown grammars are statically linked through the pinned `tree-sitter-md`
+crate and HTML uses the exact pinned `tree-sitter-html` crate. The vendored
+language pack remains the owner for the general language registry; the direct
+HTML binding is deliberately parser-only because this release's pack build
+does not expose an HTML static loader. Neither path downloads a grammar at
+runtime, invokes Python, calls a model, or follows a URL.
 
 ## Markdown projection
 
@@ -112,6 +115,37 @@ autolinks, email links, inline links, and reference links carry a `link_kind`,
 line, byte range, source file, and extracted confidence. Images are not treated
 as document relationships, and links inside fenced code are inert.
 
+Footnote definitions and references are emitted as bounded
+`footnote_definition` nodes and `link_kind: "footnote"` relationships. Duplicate
+or missing footnote labels remain explicit unresolved evidence. MDX imports,
+JSX-like components, expressions, and Quarto directives are represented as
+bounded `other` blocks with an `other_kind` and `source_syntax` instead of being
+executed or silently discarded.
+
+## HTML projection and normalization
+
+HTML files (`.html` and `.htm`) use the same source-driven API as Markdown. The
+root has `document_format: "html"`; semantic nodes cover headings, paragraphs,
+lists/items, block quotes, preformatted/code blocks, tables/rows/cells,
+landmarks (`main`, `article`, `section`, and `nav`), anchors, title, metadata,
+resource links, and base URLs. Every node and relationship keeps an exact byte,
+line, and column range into the original HTML bytes.
+
+The HTML adapter decodes numeric and common named entities, preserves document
+order, and records bounded `html_title`, `html_meta`, `html_canonical`,
+`html_base_href`, and `html_visible_text` metadata. `script`, `style`,
+`template`, and `noscript` subtrees are never published. Anchor and resource
+links carry their `href`/`rel` provenance; same-file fragments resolve only to a
+unique `id`/`name`, while external and unsupported links remain evidence with
+an explicit reason. Relative links are resolved against a validated HTTP(S)
+source/base URL or a lexically normalized local path. Compass never fetches a
+discovered URL.
+
+`compass-ingest` calls `compass_languages::normalize_html` rather than using a
+regular-expression tag stripper. The renderer emits conservative Markdown
+block boundaries and links, so fetched webpages and local HTML files share the
+same visibility, entity, whitespace, and security rules.
+
 ## Cache and trust boundaries
 
 Markdown file hashes include the raw frontmatter bytes. A metadata-only edit
@@ -124,15 +158,22 @@ frontmatter, block, link, metadata, and diagnostic caps. Inputs are never
 executed, fetched, or interpreted as configuration. Unknown graph attributes
 remain extensible, and consumers should preserve them.
 
+## Structural and semantic coexistence
+
+Semantic refreshes are additive for Markdown and HTML. When a provider returns
+an updated concept for one of these files, Compass retains the byte-identical
+document, block, containment, and link subgraph produced by the local adapter;
+provider concepts and edges are published alongside it. A provider failure or
+partial response cannot replace a deterministic structural realization.
+
 ## Other document formats
 
 File discovery recognizes several document extensions, but recognition is not
-the same as structural extraction. HTML, DOCX, PPTX, RTF, and spreadsheet
-normalizers remain separate integration surfaces until they have their own
-bounded parser, exact locator policy, and qualification fixtures. See the
+the same as structural extraction. DOCX and XLSX retain their bounded media
+conversion surfaces; PPTX and RTF remain future format adapters. See the
 [document format reference](../reference/document-formats.md) for the current
-matrix. Markdown links may point at those formats, but Compass does not fetch
-or execute a linked resource during Markdown extraction.
+matrix. Markdown and HTML links may point at those formats, but Compass does
+not fetch or execute a linked resource during extraction.
 
 ## Related pages
 

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -135,6 +135,12 @@ It does not own:
 
 Compass disables runtime grammar downloads and dynamic loading. A grammar update changes grammar provenance and invalidates affected extraction caches without changing the universal evidence schema.
 
+Document adapters are a narrow exception to the general registry boundary:
+the pinned Markdown and HTML bindings are linked directly by
+`compass-languages` because the current vendored build subset does not expose
+those document loaders. They still use the same Tree-sitter ABI, source-driven
+Engine API, deterministic range policy, and no-runtime-download guarantee.
+
 ## How the layers differ
 
 The grammar pack, the historical CodeGraph kernel, and universal evidence solve

--- a/docs/reference/document-formats.md
+++ b/docs/reference/document-formats.md
@@ -17,7 +17,9 @@ alone.
 | Pipe tables | Table, header, row, and cell blocks | nested `contains` edges |
 | Reference definitions | Definition block and definition relationship | definition range |
 | Inline/reference/autolinks | Link relationship with `link_kind` | link-site range |
+| Footnotes | Bounded definition nodes and reference relationships | exact definition/reference ranges |
 | Wikilinks | Local link evidence with `link_kind: "wikilink"` | link-site range |
+| MDX / Quarto extensions | Bounded `other` blocks; no execution | exact source range |
 | Images | Ignored as document relationships | no fetch or edge |
 | Frontmatter | Bounded `document_metadata` map | root metadata; body offsets unchanged |
 | Malformed syntax | Recovered evidence plus bounded diagnostic | extraction quality extension |
@@ -38,6 +40,7 @@ applicable. Markdown-specific root extensions include:
 - `markdown_diagnostics`;
 - `markdown_unresolved_links`;
 - `markdown_external_links`.
+- `markdown_footnote_count` and `markdown_other_count`.
 
 These fields are extensible graph attributes. Consumers must preserve unknown
 attributes and must not parse stable IDs as path components.
@@ -57,20 +60,40 @@ resolve only to a unique heading slug or explicit ID. Ambiguous and missing
 fragments are explicit unresolved evidence. Unsupported local suffixes and
 missing document targets do not create invented nodes.
 
+## HTML
+
+| Construct | Current behavior | Provenance |
+| --- | --- | --- |
+| Title and headings | Title metadata/node; `h1`–`h6` heading nodes with levels | exact element range |
+| `main`/`article`/`section`/`nav` | Landmark nodes in source order | exact element range |
+| Paragraphs, lists/items, block quotes | Semantic nodes and `contains` edges | exact element range |
+| `pre`/`code` | Preformatted/code nodes; visible text excludes scripts | exact element range |
+| Tables, rows, cells | Table hierarchy including `th`/`td` | exact element range |
+| Anchors and resource links | `href`/`rel` attributes plus local/external evidence | link element range |
+| `meta`, canonical, base | Bounded root metadata and link evidence | element/link range |
+| Entities and whitespace | Decoded visible text; block order preserved | source-backed node ranges |
+| `script`, `style`, `template`, `noscript` | Entire subtree skipped | no graph node or link |
+| Malformed markup | Tree-sitter recovery plus bounded diagnostics | recovery/root range |
+
+HTML uses the exact pinned `tree-sitter-html` binding and the source-driven
+`Engine::extract_source` API. URL ingestion calls the same
+`compass_languages::normalize_html` renderer. Relative URLs are resolved
+lexically against the validated source/base URL, never fetched.
+
 ## Discovery versus structural extraction
 
 | Format | Discovery classification | Structural extractor in this release |
 | --- | --- | --- |
-| HTML / HTM | document | not yet a local language adapter |
+| HTML / HTM | document | structural Tree-sitter adapter and shared ingestion renderer |
 | DOCX | document/media | media conversion surface; no native block graph |
 | PPTX | not a general local document adapter | not yet |
 | RTF | not a general local document adapter | not yet |
 | XLSX | document/media | media conversion surface; no native block graph |
 | TXT / RST | document | generic/document fallback only |
 
-This distinction keeps product claims honest: future HTML, office, and rich
-text work must add bounded parsing, exact or explicitly normalized locators,
-security tests, and cache/version contracts before it becomes graph evidence.
+This distinction keeps product claims honest: future office and rich-text work
+must add bounded parsing, exact or explicitly normalized locators, security
+tests, and cache/version contracts before it becomes graph evidence.
 
 ## Related contracts
 

--- a/docs/reference/document-formats.md
+++ b/docs/reference/document-formats.md
@@ -1,0 +1,79 @@
+# Document format reference
+
+This page records the current deterministic document boundaries. A file can be
+discoverable without having a structural extractor; consumers should inspect
+the graph producer and diagnostics rather than infer support from an extension
+alone.
+
+## Markdown
+
+| Construct | Current behavior | Provenance |
+| --- | --- | --- |
+| ATX / Setext headings | Heading node, hierarchy, slug, optional explicit ID | exact node range |
+| Paragraphs and inline text | Paragraph block | exact node range |
+| Lists and task items | List/list-item blocks; `task_checked` when present | `contains` + exact ranges |
+| Block quotes and thematic breaks | Structural block | exact node range |
+| Fenced / indented code | Code block; fenced info string becomes `language` | exact node range |
+| Pipe tables | Table, header, row, and cell blocks | nested `contains` edges |
+| Reference definitions | Definition block and definition relationship | definition range |
+| Inline/reference/autolinks | Link relationship with `link_kind` | link-site range |
+| Wikilinks | Local link evidence with `link_kind: "wikilink"` | link-site range |
+| Images | Ignored as document relationships | no fetch or edge |
+| Frontmatter | Bounded `document_metadata` map | root metadata; body offsets unchanged |
+| Malformed syntax | Recovered evidence plus bounded diagnostic | extraction quality extension |
+
+Markdown is parsed from the caller-supplied bytes with statically linked
+Tree-sitter block and inline grammars. Supported source extensions are
+`.md`, `.markdown`, `.mdx`, `.qmd`, and `.skill`.
+
+### Stable fields
+
+Document and block nodes retain the common graph fields `id`, `label`,
+`file_type`, `document_kind`, `source_file`, `_origin`, `start_byte`,
+`end_byte`, `start_line`, `end_line`, `column_start`, and `column_end` where
+applicable. Markdown-specific root extensions include:
+
+- `markdown_block_count`;
+- `markdown_link_count`;
+- `markdown_diagnostics`;
+- `markdown_unresolved_links`;
+- `markdown_external_links`.
+
+These fields are extensible graph attributes. Consumers must preserve unknown
+attributes and must not parse stable IDs as path components.
+
+### Frontmatter limits
+
+- opening and closing delimiters must be whole lines within 64 KiB;
+- at most 256 metadata keys and 256 scalar-array items are published;
+- individual metadata keys and strings are capped at 16 KiB;
+- nested mappings, YAML tags/aliases, and non-scalar arrays are diagnosed and
+  omitted rather than projected as arbitrary graph data.
+
+### Link boundary
+
+External links are recorded as evidence but never fetched. Same-file fragments
+resolve only to a unique heading slug or explicit ID. Ambiguous and missing
+fragments are explicit unresolved evidence. Unsupported local suffixes and
+missing document targets do not create invented nodes.
+
+## Discovery versus structural extraction
+
+| Format | Discovery classification | Structural extractor in this release |
+| --- | --- | --- |
+| HTML / HTM | document | not yet a local language adapter |
+| DOCX | document/media | media conversion surface; no native block graph |
+| PPTX | not a general local document adapter | not yet |
+| RTF | not a general local document adapter | not yet |
+| XLSX | document/media | media conversion surface; no native block graph |
+| TXT / RST | document | generic/document fallback only |
+
+This distinction keeps product claims honest: future HTML, office, and rich
+text work must add bounded parsing, exact or explicitly normalized locators,
+security tests, and cache/version contracts before it becomes graph evidence.
+
+## Related contracts
+
+- [Structural document processing](../design/document-processing.md)
+- [Output reference](outputs.md)
+- [Compatibility](../../COMPATIBILITY.md)


### PR DESCRIPTION
## Summary

- Replace regex-oriented Markdown extraction with pinned, source-driven Tree-sitter block and inline parsing, bounded frontmatter, exact ranges, heading/list/table/code structure, footnotes, MDX/Quarto `other` evidence, and ambiguity-safe link provenance.
- Add a bounded structural HTML adapter for `.html`/`.htm` with headings, paragraphs, landmarks, lists, tables, code, metadata, canonical/base URLs, entity decoding, hidden-element filtering, exact ranges, link ownership, unresolved/external evidence, and malformed-input diagnostics.
- Reuse the same parser-backed HTML normalization for URL ingestion; it never fetches nested resources and keeps visible text/Markdown projection consistent with repository extraction.
- Preserve Markdown and HTML structure when semantic providers refresh documents, and make owned publication ordering deterministic across relocated roots.
- Update compatibility contracts, format/language architecture docs, changelog, advisor-plan status, and regression coverage.

The HTML adapter uses the pinned `tree-sitter-html` binding directly because the current vendored language-pack static subset does not expose an HTML loader; this exception is documented and remains fully static and offline.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --lib --bins --locked`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- targeted HTML/Markdown, ingest, files, core, and graph tests

The unrelated pre-existing viewer/store changes and untracked `3rd/` directory remain outside this branch commit.