### PR TITLE
Document Compass Store architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,9 +65,11 @@ workspace:
 5. [Extraction pipeline](implementation/extraction-pipeline.md)
 6. [Universal evidence implementation](implementation/universal-evidence.md)
 7. [Query engine](implementation/query-engine.md)
-8. [Semantic pipeline](implementation/semantic-pipeline.md)
-9. [Extending Compass](implementation/extending-compass.md)
-10. [Contributing](../CONTRIBUTING.md)
+8. [Planned Compass store design](design/compass-store.md)
+9. [Compass store implementation plan](implementation/compass-store-plan.md)
+10. [Semantic pipeline](implementation/semantic-pipeline.md)
+11. [Extending Compass](implementation/extending-compass.md)
+12. [Contributing](../CONTRIBUTING.md)
 
 ## Documentation map
 
@@ -101,6 +103,7 @@ workspace:
 | [Managed language analyzers](design/managed-language-analyzers.md) | Planned compiler, indexer, and language-server enrichment across languages |
 | [Managed JDT integration](design/java-jdt-integration.md) | Planned Java semantic tooling, trust boundaries, phases, and acceptance criteria |
 | [Storage and history](design/storage-and-history.md) | Incremental artifacts and immutable historical realizations |
+| [Compass store](design/compass-store.md) | Planned namespace/partition/key contract, graph engines, snapshot schema, and database mappings |
 | [Security and privacy](design/security-and-privacy.md) | Trust boundaries, credentials, and offline behavior |
 
 ### Work on the implementation
@@ -112,6 +115,7 @@ workspace:
 | [Universal evidence](implementation/universal-evidence.md) | Language contracts, crate boundaries, resolution, and qualification |
 | [Code-graph parity qualification](implementation/code-graph-parity-qualification.md) | Pinned real-repository Graphify comparison and open quality gaps |
 | [Query engine](implementation/query-engine.md) | Discovery queries, traversal, and CompassQL |
+| [Compass store plan](implementation/compass-store-plan.md) | Executable phases and acceptance criteria for local and cloud database engines |
 | [Semantic pipeline](implementation/semantic-pipeline.md) | Optional provider-backed extraction |
 | [Extending Compass](implementation/extending-compass.md) | Adding languages, relations, integrations, and commands |
 

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -1,0 +1,1189 @@
+# Compass store and graph-engine design
+
+**Status:** Planned. This document defines a target architecture and is not
+evidence that a store-backed graph engine has shipped.
+
+> **Who this page is for:** maintainers of graph publication and queries,
+> storage-adapter authors, cloud-service implementers, and reviewers of the
+> `compass-store` contract.
+>
+> **You will learn:** the portable namespace/partition/key contract, the
+> store-independent graph layout, how `graph.json` remains supported, the
+> atomic publication and recovery rules, and how SQLite, redb, PostgreSQL, and
+> DynamoDB map onto the same semantics.
+>
+> **Prerequisites:** [Design principles](principles.md),
+> [Storage and history](storage-and-history.md), and
+> [Query engine](../implementation/query-engine.md).
+>
+> **Reading time:** 25–35 minutes.
+
+## Decision summary
+
+Compass will introduce a backend-neutral crate named `compass-store`. Its
+smallest address is always:
+
+```text
+(namespace, partition, key) -> value
+```
+
+The ordering is intentional. A caller first receives a handle scoped to one
+namespace. Operations on that handle then require one partition and one key,
+or a bounded key range within one partition. No portable operation can scan an
+entire tenant, silently cross partitions, or issue raw backend queries.
+
+The portable correctness envelope is deliberately smaller than the union of
+database features:
+
+- strongly consistent point reads;
+- ordered, bounded scans inside exactly one partition;
+- durable single-key writes;
+- put-if-absent and compare-and-swap on one address;
+- immutable, idempotent content writes; and
+- explicit limits, deadlines, cursors, and typed failures.
+
+Graph snapshots are built above this key-value contract as immutable,
+content-addressed ordered indexes. Publication writes all immutable content
+first and commits only one small selector with compare-and-swap. Compass does
+not require a transaction spanning graph partitions.
+
+`graph.json` is not deprecated and will not be replaced. It remains a complete
+and compatible graph engine for local files, interchange, inspection, and
+recovery. Store-backed engines and the JSON engine implement the same graph
+read contract and must return equivalent public results. `graph.json` is not
+forced to pretend to be a mutable key-value database.
+
+The new internal database format does not need to read disposable query caches
+or unpublished storage prototypes. Those can be rebuilt. This freedom does
+not permit a silent change to `compass.graph/1`, CLI output, CompassQL,
+relationship meaning, stable IDs, or deterministic ordering.
+
+## Goals
+
+The design must:
+
+1. improve incremental graph-build and cold-query performance without loading
+   or rewriting one complete JSON document for every operation;
+2. preserve the existing typed graph and query contracts independently of the
+   selected engine;
+3. support embedded local databases and remote managed databases through one
+   deliberately small contract;
+4. provide namespace isolation suitable for a future multi-tenant Compass
+   service;
+5. keep all scans, values, retries, memory, network responses, and maintenance
+   work bounded;
+6. preserve deterministic identities, ordering, directions, multiplicity,
+   source anchors, provenance, and unknown graph attributes where the public
+   graph contract allows them;
+7. publish coherent snapshots without relying on cross-partition or
+   distributed transactions;
+8. make interrupted builds, partial remote writes, conflicts, corruption, and
+   throttling distinguishable and recoverable; and
+9. retain Compass's native, offline local path with no credentials, remote
+   service, vector database, or runtime download.
+
+## Non-goals
+
+This design does not:
+
+- make SQL, DynamoDB expressions, or a backend query language public Compass
+  contracts;
+- promise that every backend has identical latency, cost, backup, or
+  operational behavior;
+- make a namespace string an authorization mechanism by itself;
+- require a transaction across namespaces or partitions;
+- merge working-tree storage with immutable Git-history identity;
+- remove `graph.json`, make it a temporary migration path, or require a
+  database to read an explicitly supplied JSON graph;
+- put backend-specific connection configuration into `compass-model` or the
+  graph schema; or
+- claim a performance improvement before the repository's performance gates
+  measure it.
+
+## Vocabulary
+
+| Term | Meaning |
+| --- | --- |
+| Store | An implementation of the `compass-store` key-value contract. |
+| Namespace | The first isolation and lifecycle boundary, normally one tenant, repository, data plane, and schema major. |
+| Partition | A required locality and sharding key inside one namespace. All ordered scans stay within it. |
+| Key | An opaque, ordered byte string unique inside one namespace and partition. |
+| Entry | A value plus integrity metadata and an opaque compare-and-swap version. |
+| Graph engine | A reader of one selected immutable graph snapshot. JSON and store-backed implementations are peers. |
+| Snapshot | A complete immutable graph realization with typed index roots and validation evidence. |
+| Active selector | The one small mutable record that makes a prepared store snapshot current. |
+| Content object | An immutable, hash-addressed tree node, record block, or manifest. |
+| Accelerator | A disposable backend-specific index that can improve speed but cannot define graph meaning. |
+
+## Architectural boundaries
+
+```text
+CLI / MCP / reports / CompassQL / graph algorithms
+                       |
+                       v
+          compass-query graph read contract
+                       |
+          +------------+-------------+
+          |                          |
+          v                          v
+  JSON graph engine          store graph engine
+  compass.graph/1            manifests + ordered indexes
+          |                          |
+     graph.json                 compass-store
+                                     |
+                  +------------------+------------------+
+                  |          |             |            |
+                SQLite      redb       PostgreSQL    DynamoDB
+```
+
+Ownership follows the existing workspace boundaries:
+
+- `compass-model` owns graph records, graph validation, and public graph
+  meaning;
+- `compass-store` owns backend-neutral addresses, operations, limits,
+  consistency, errors, and the adapter conformance suite;
+- backend adapter crates own connections and physical schemas;
+- `compass-graph` owns deterministic graph-to-snapshot index construction;
+- `compass-core` owns build and publication orchestration;
+- `compass-query` owns the graph-engine read contract and query planning; and
+- `compass-output` owns deterministic `graph.json` export and other renderers.
+
+The core crate name is `compass-store`. Heavy or platform-specific clients do
+not become features of that crate. Planned adapters are separate packages such
+as `compass-store-sqlite`, `compass-store-redb`,
+`compass-store-postgres`, and `compass-store-dynamodb`. This keeps a local
+binary from acquiring a cloud SDK merely because the shared contract exists.
+
+## Two contracts, not one leaky abstraction
+
+There are two intentional abstraction levels.
+
+### The key-value store contract
+
+The low-level contract stores opaque bytes at a
+`(namespace, partition, key)` address. It knows nothing about nodes, edges,
+CompassQL, files, or graph schema versions.
+
+### The graph-engine contract
+
+The high-level contract opens one validated graph snapshot and provides
+bounded graph operations: metadata lookup, node and edge lookup, ordered
+iteration, outgoing and incoming adjacency, text candidates, and community
+membership. It knows nothing about SQL tables or DynamoDB expressions.
+
+The store-backed graph engine maps those graph operations to immutable ordered
+indexes above `compass-store`. The JSON graph engine maps them to a validated
+`GraphDocument` and disposable local indexes. This separation is what lets
+`graph.json` stay a real engine rather than an emulated database.
+
+## Engine and materialization profiles
+
+Supporting the JSON engine does not require every store-backed build to rewrite
+a complete JSON file. The application layer can expose three explicit
+profiles:
+
+| Profile | Published graph engines | Intended use |
+| --- | --- | --- |
+| `json` | `graph.json` | Existing local/interchange behavior, direct inspection, and database-free operation |
+| `store` | Store snapshot; deterministic JSON export available on demand | Maximum incremental-build and cold-query benefit |
+| `dual` | Store snapshot and co-published `graph.json` | Migration, differential qualification, local recovery, and users requiring both artifacts |
+
+`JsonGraphEngine` is compiled, tested, and supported in all product profiles
+that accept JSON input, even when one particular build did not materialize a
+JSON file. A store snapshot can always stream a canonical `graph.json` export;
+an existing `graph.json` can be imported into a new prepared store snapshot
+after full validation.
+
+The existing `init` and `update` output contract remains `json` or `dual` until
+a separately reviewed CLI/configuration change introduces `store` as an
+explicit choice. The implementation plan begins with `dual`; it does not
+silently stop creating an artifact that callers currently expect.
+
+This distinction is essential to honest performance claims. A dual build must
+still encode and write all nodes and edges to JSON, so it has an unavoidable
+linear materialization floor. Structural sharing can reduce graph-index work
+and later query startup, but only the explicit store profile can avoid the
+full-file rewrite. Benchmarks report `json`, `store`, and `dual` separately.
+
+## Portable key-value contract
+
+### Address model
+
+The full physical identity of a value is:
+
+```text
+StoreAddress {
+    namespace: NamespaceId,
+    partition: PartitionKey,
+    key: Key,
+}
+```
+
+All three components are non-empty opaque byte strings. The contract compares
+keys as unsigned bytes in ascending lexicographic order. It does not apply a
+locale, Unicode normalization, database collation, or natural-number sort.
+
+Callers do not repeatedly pass a namespace to every operation. The root store
+creates a `NamespaceStore` after authorization and configuration have selected
+one namespace:
+
+```text
+Store::scope(namespace) -> NamespaceStore
+NamespaceStore::get(partition, key)
+NamespaceStore::scan(partition, range, limits, cursor)
+NamespaceStore::put(partition, key, value, condition)
+NamespaceStore::delete(partition, key, condition)
+```
+
+The scoped handle prevents accidental cross-namespace reads. In a service, the
+handle must be constructed from authenticated server-side identity, never
+from an untrusted request field alone.
+
+### Namespace identity
+
+A namespace is the isolation, quota, backup, encryption-policy, and garbage-
+collection boundary. The canonical descriptor includes:
+
+```text
+tenant identity
+repository or project identity
+data plane: working | history | derived
+logical schema major
+optional deployment realm
+```
+
+The physical `NamespaceId` is derived from the canonical descriptor with a
+versioned, length-prefixed encoding and a cryptographic digest. Display names,
+repository paths, credentials, and secrets are not stored in the ID. A catalog
+entry inside the namespace may retain validated, non-secret descriptive
+metadata.
+
+Working graphs, historical realizations, and disposable derived data use
+different namespaces even if one physical backend hosts all three. Sharing a
+backend does not merge their identity or retention rules.
+
+### Partition semantics
+
+A partition is mandatory on every data operation. It has three jobs:
+
+1. bound scans and failure impact;
+2. express storage locality that all supported backends can implement; and
+3. give the graph layer an explicit sharding control for cloud workloads.
+
+The contract has no `scan_namespace` method. Administrative namespace
+enumeration, migration, and garbage collection operate from explicit
+manifests or a privileged maintenance API with separate limits and auditing.
+
+### Key encoding
+
+Application code must not concatenate user-controlled strings with separators.
+`compass-store` provides one canonical key builder with:
+
+- a one-byte encoding major;
+- a one-byte record kind;
+- length-prefixed byte segments;
+- fixed-width big-endian unsigned integers where numeric order matters;
+- explicit path normalization performed by the owning domain before encoding;
+- a maximum segment count and nesting depth; and
+- test vectors shared by every adapter.
+
+Prefix and range construction uses the encoded representation. Backends must
+store and compare it as binary data, not text. A new incompatible encoding
+uses a new major and a different namespace.
+
+### Proposed portable limits
+
+Phase 0 must freeze exact values with executable conformance tests. The target
+v1 envelope is intentionally conservative enough for embedded and managed
+stores:
+
+| Item | Proposed maximum |
+| --- | ---: |
+| Namespace ID | 128 bytes |
+| Partition key | 256 bytes |
+| Key | 1,024 bytes |
+| Value | 256 KiB |
+| Version token | 64 bytes |
+| Cursor | 4 KiB |
+| Requested page | 1,000 entries and 1 MiB, whichever comes first |
+| Key segments | 32 |
+
+An adapter may support larger values, but portable graph code cannot rely on
+that. Oversize content is deterministically chunked above the store layer.
+Limit exhaustion returns a typed limit error; it never becomes an empty page
+or a missing value.
+
+### Operation surface
+
+The normative semantic surface is small:
+
+```text
+capabilities() -> StoreCapabilities
+get(GetRequest) -> Entry | Missing
+scan(ScanRequest) -> ScanPage
+put(PutRequest { condition }) -> WriteResult
+delete(DeleteRequest { condition }) -> DeleteResult
+```
+
+All requests carry an explicit operation budget or deadline supplied by the
+application boundary. `scan` also carries item and byte limits. Adapters may
+offer bulk helpers, but helpers split work into these operations and cannot
+invent stronger atomicity.
+
+The canonical Rust API is asynchronous so a remote adapter never blocks an
+executor thread by contract. The trait uses object-safe returned futures
+rather than requiring backend types in callers. Embedded adapters may return
+immediately ready futures. `compass-store` does not create a runtime; the CLI,
+service, or test harness owns execution.
+
+### Entries and versions
+
+A successful read returns:
+
+```text
+Entry {
+    key,
+    value,
+    version: opaque backend-issued token,
+    digest: sha256(value),
+}
+```
+
+The version exists only for conditional mutation. Callers may compare tokens
+for equality but cannot parse, order, persist across migrations, or derive
+meaning from them. The digest provides end-to-end corruption detection and
+idempotence; it is not a substitute for authorization.
+
+### Write conditions
+
+Every mutable write declares one condition:
+
+| Condition | Required behavior |
+| --- | --- |
+| `Any` | Replace the value at exactly one address. Restricted to operational data that is explicitly last-writer-wins. |
+| `Missing` | Succeed only when the address is absent. |
+| `Version(token)` | Succeed only when the current opaque version matches. |
+
+Content-addressed objects use a stricter helper, `put_immutable`:
+
+- an absent address receives the value;
+- an existing address with the same digest is an idempotent success; and
+- an existing address with a different digest is a corruption/conflict error.
+
+The graph layer never uses unconditional replacement for manifests, snapshot
+content, or active selectors.
+
+### Read consistency
+
+Strong reads are mandatory for active selectors, leases, publication state,
+and compare-and-swap. A backend that cannot provide a strong point read for
+these records cannot implement the v1 contract.
+
+An adapter may advertise eventual reads for immutable content as an optional
+optimization. The store graph engine may use them only after a strongly read
+manifest has selected the content, and it must verify content digests. A
+temporarily absent immutable object is `Unavailable` and may be retried within
+budget; it is not `NotFound` evidence that the manifest is valid.
+
+### Ordered scans and cursors
+
+A scan names exactly one namespace, one partition, and one half-open key
+range. Results are strictly ascending by unsigned key bytes and contain no
+duplicates within one cursor sequence.
+
+Each returned page includes:
+
+```text
+entries
+next_cursor or end
+items_read
+bytes_read
+consistency used
+```
+
+A cursor is opaque, versioned, integrity-protected, and bound to the
+namespace, partition, requested range, consistency, and adapter instance. It
+must fail as `InvalidCursor` or `StaleCursor`; it must not silently restart.
+Portable callers do not persist cursors as durable Compass artifacts.
+
+Snapshot graph indexes are immutable, so page-to-page mutation cannot change
+their contents. Scans of mutable operational partitions use backend snapshot
+facilities where available or document their weaker page boundary; no graph
+correctness may depend on a mutable multi-page scan.
+
+### Atomicity boundary
+
+The only required atomic unit is one address. A backend may advertise a
+larger atomic batch, but portable publication cannot require it.
+
+This rule is central to portability. SQLite and PostgreSQL can commit large
+transactions, redb serializes write transactions, and DynamoDB offers bounded
+transactional operations with different constraints. Compass instead gets
+cross-record coherence from immutability plus one active-selector CAS.
+
+### Errors and retry policy
+
+`compass-store` errors are typed and preserve actionable backend context
+without exposing credentials or full values:
+
+| Error | Meaning and retry rule |
+| --- | --- |
+| `NotFound` | The exact address is absent after a valid strong read. Not retryable by default. |
+| `Conflict` | A condition or immutable-value check failed. Return to orchestration; never blind-retry CAS. |
+| `LimitExceeded` | A key, value, page, response, or budget limit was reached. Never treat as empty. |
+| `InvalidCursor` / `StaleCursor` | Cursor validation or lifetime failed. Restart only under explicit caller policy. |
+| `Corrupt` | Digest, envelope, ordering, or backend invariant failed. Quarantine and recover. |
+| `Throttled` | Backend rejected capacity. Retry only idempotent operations with bounded jitter and deadline. |
+| `Unavailable` | Transient backend or replication failure. Bounded retry is permitted for reads and immutable writes. |
+| `DeadlineExceeded` | The request budget expired. Do not continue work in the background. |
+| `Unauthorized` | Namespace or backend access was denied. Never retry as transient. |
+| `Unsupported` | The requested consistency or capability is unavailable. Fail before partial work. |
+| `Internal` | Adapter invariant failed. Include a safe diagnostic ID and source chain. |
+
+Retry classification belongs to the common contract, while delay and attempt
+counts belong to application policy. Every retryable write must be idempotent.
+
+### Capabilities
+
+An adapter reports validated capabilities at open time:
+
+```text
+limits
+strong point reads
+ordered partition scans
+conditional single-key writes
+durability mode
+optional atomic batch size
+optional eventual immutable reads
+optional disposable accelerator kinds
+backend and format identifiers
+```
+
+Required v1 capabilities are not negotiable. Optional capabilities can improve
+performance but must have a portable path with identical observable results.
+Configuration is rejected before publication if an adapter cannot meet the
+requested durability or consistency.
+
+### Configuration and adapter selection
+
+`compass-store` defines only backend-neutral open requirements: requested
+durability, consistency, operation limits, store identity, and namespace
+scope. It does not define one universal connection string whose query
+parameters grow to contain every backend option.
+
+Each adapter owns a typed configuration and a `StoreFactory` implementation:
+
+```text
+SQLite:     contained database path, busy timeout, durability
+redb:       contained database path, durability, writer-queue bound
+PostgreSQL: endpoint reference, database/schema, pool bounds, TLS, secret ref
+DynamoDB:   region, endpoint policy, table, capacity/retry policy, secret ref
+```
+
+Configuration files contain credential references, not secret values. CLI or
+service wiring chooses a compiled adapter explicitly, opens it, validates its
+reported capabilities, and only then scopes it to an authorized namespace.
+Store factories and configurations remain outside graph models and snapshot
+manifests. A snapshot is therefore movable between conforming adapters through
+the graph-level copy/export path without embedding the source backend's DSN,
+file path, account, or region.
+
+## Value envelopes and schema evolution
+
+Every non-trivial stored value has a small binary envelope:
+
+```text
+magic
+envelope major and minor
+record kind
+codec identifier
+uncompressed length
+payload digest
+payload bytes
+```
+
+Readers bound compressed and uncompressed sizes before allocation. Codecs are
+explicit and deterministic; no backend decides compression independently.
+Unknown major versions fail. Unknown minor fields are retained or skipped only
+when the typed record contract permits it.
+
+There are three different versions and they must not be conflated:
+
+- the store envelope version describes bytes;
+- the graph-snapshot layout version describes indexes and manifests; and
+- `compass.graph/1` describes public graph meaning and JSON representation.
+
+Changing an internal envelope does not imply a graph-schema change. Changing
+graph meaning requires the existing public compatibility process even if no
+database table changes.
+
+## Store-backed graph snapshot
+
+### Logical structure
+
+A store snapshot is an immutable manifest pointing to content-addressed
+ordered-map roots:
+
+```text
+ActiveSelector / local store.ref
+              |
+              v
+      SnapshotManifest
+       /    |    |    \
+ nodes   edges  outgoing  incoming  ...
+   |       |       |         |
+ immutable ordered index nodes, addressed by digest
+              |
+       canonical graph records
+```
+
+The initial implementation should reuse the workspace's proven Prolly-tree
+ideas where their contract fits. The key-value layer itself remains a normal
+store; tree construction, graph key encodings, and structural sharing belong
+to the graph repository above it.
+
+### Physical partitions
+
+The graph layer reserves versioned partition families:
+
+| Partition family | Contents | Mutation rule |
+| --- | --- | --- |
+| `catalog` | Active selector, namespace descriptor, format marker | Selector uses CAS; descriptor is immutable |
+| `manifest/<shard>` | Snapshot manifests keyed by snapshot ID | Immutable |
+| `object/<shard>` | Tree nodes and record blocks keyed by content digest | Immutable |
+| `lease/<shard>` | Bounded reader/build leases | Conditional mutable records |
+| `gc/<shard>` | Checkpoints and bounded maintenance state | Conditional mutable records |
+| `derived/<shard>` | Disposable accelerators keyed by snapshot and format | Replaceable; never authoritative |
+
+`<shard>` is derived from leading digest bits with a versioned function. It is
+not chosen from source order, repository path, or a sequential counter. The
+shard count is recorded in the layout version and cannot vary silently across
+writers.
+
+### Snapshot manifest
+
+The typed manifest contains at least:
+
+```text
+schema: compass.store.graph-snapshot/1
+snapshot_id
+graph_schema: compass.graph/1
+canonical_encoding_version
+build_fingerprint
+source_identity and working-tree state
+created_by implementation identity
+counts and bounded-size summaries
+roots for every required logical index
+root digests and aggregate snapshot digest
+optional graph_json_sha256
+validation/completion evidence
+```
+
+`snapshot_id` is derived from meaning-affecting canonical content, not wall
+clock time, database sequence values, host paths, or operational timings. The
+manifest may contain operational metadata outside the identity projection,
+but that metadata cannot affect graph equivalence.
+
+The manifest is small enough for one portable value. If the root registry can
+outgrow the value limit, it becomes its own immutable tree and the manifest
+stores only the registry root.
+
+### Required logical indexes
+
+The v1 snapshot needs these authoritative ordered maps:
+
+| Index | Canonical logical key | Value |
+| --- | --- | --- |
+| Graph metadata | fixed key | typed metadata record |
+| Nodes by ID | node ID | complete typed node record or content reference |
+| Edges by ID | edge ID | complete typed edge record or content reference |
+| Outgoing edges | source ID, edge kind, target ID, edge ID | edge ID/reference |
+| Incoming edges | target ID, edge kind, source ID, edge ID | edge ID/reference |
+| Files/source anchors | normalized file identity, range, record kind, record ID | node/edge reference |
+| Names | normalized lookup name, node kind, qualified name, node ID | node ID and stable projection |
+| Text postings | normalized term, node ID | deterministic term statistics |
+| Communities | community identity, member order, node ID | member projection |
+| Diagnostics | severity, stable diagnostic identity | diagnostic projection |
+
+The edge indexes include `edge ID` even when endpoints and kind match. That
+preserves multigraph multiplicity. They preserve semantic direction and never
+swap endpoints to improve locality. Full records preserve relationship sites,
+occurrence rules, evidence, details, weight, context, deferred state, and
+diagnostics.
+
+Text normalization and scoring are versioned Compass semantics implemented in
+Rust. A backend FTS index may produce candidates only if differential tests
+prove the same result ordering and tie-breaking. Backend relevance scores are
+not public graph meaning.
+
+### Deterministic construction
+
+Snapshot construction follows a canonical stream:
+
+1. validate the typed graph document and all bounds;
+2. sort records by their public canonical identities;
+3. derive every logical index entry with versioned encoders;
+4. reject duplicate keys unless the index explicitly aggregates them;
+5. build content-defined immutable ordered trees;
+6. write tree objects with `put_immutable`;
+7. construct and validate the manifest; and
+8. derive the snapshot ID from its canonical identity projection.
+
+Parallel extraction and tree building are allowed, but the emitted objects and
+roots must not depend on task completion order, thread count, host, locale, or
+backend.
+
+### Structural sharing and incremental update
+
+An update compares the new canonical index streams with the prior roots. Tree
+nodes whose content is unchanged retain the same digest and are not rewritten.
+Changed records rewrite only affected paths and content-defined neighbor
+chunks. Deleted records disappear from new roots but remain reachable from an
+older retained snapshot until garbage collection.
+
+Incremental build state remains evidence, not authority. A reused record still
+passes current validation and participates in deterministic index
+construction. A cache miss can cost time but cannot change graph meaning.
+
+## Publication protocols
+
+### Common prepare sequence
+
+All publication modes begin with:
+
+1. observe the current selected snapshot and its version, if one exists;
+2. build and validate the candidate graph;
+3. write immutable content objects idempotently;
+4. write the immutable snapshot manifest;
+5. re-read required roots and verify digests, counts, and completion evidence;
+6. prepare all non-store artifacts; and
+7. perform exactly one mode-specific commit action.
+
+Failure before the commit leaves only unreachable immutable objects. They are
+safe to retry and later collect.
+
+### Local artifact-set publication
+
+For `compass init` and `compass update`, the existing filesystem build guard
+remains the coordinator for a coherent local output generation. A dual-profile
+generation contains:
+
+```text
+staged generation/
+  graph.json
+  reports and viewer artifacts
+  store.ref -> immutable snapshot ID + manifest digest + store identity
+```
+
+The store snapshot is fully prepared but does not independently become
+current. The filesystem generation switch atomically publishes `graph.json`,
+its reports, and `store.ref` together. A reader opening that generation may
+choose either the JSON engine or the referenced store engine and must observe
+the same graph.
+
+A JSON-profile generation follows the existing artifact publication without a
+store reference. A store-profile generation stages `store.ref` plus reports
+derived from that immutable snapshot and deliberately omits eager JSON
+materialization; its export command can create JSON as a new coherent artifact
+without changing the selected snapshot.
+
+If the filesystem commit fails, the prepared snapshot is an orphan. If the
+database later becomes unavailable, the published `graph.json` remains a
+usable complete engine. No best-effort sequence of “update database, then
+replace JSON” is allowed to expose two different current graphs.
+
+### Store-native or cloud publication
+
+A deployment without a filesystem artifact set commits by conditionally
+replacing one `ActiveSelector` in `catalog`:
+
+```text
+CAS(observed selector version -> candidate snapshot ID and manifest digest)
+```
+
+A conflict means another writer won. The losing writer does not overwrite the
+winner, does not reinterpret the candidate as active, and reports a typed
+publication conflict. It may rebuild from the newly active roots under an
+explicit orchestration decision.
+
+Readers strongly read the selector, validate the manifest digest, then open
+only immutable roots. A reader that already opened an older snapshot can
+finish against it while a new selector is published.
+
+### Dual-output equivalence
+
+When a build emits both engines, publication validation must prove:
+
+- equal graph schema and build fingerprint;
+- equal node and edge counts;
+- equal canonical graph digest;
+- equal sampled and then fully streamed record identities in qualification;
+  and
+- byte-identical `graph.json` output to the canonical JSON renderer for the
+  same validated graph.
+
+The store engine is not allowed to “fix” or omit data that the JSON engine
+contains. Differences fail publication.
+
+## Graph-engine read contract
+
+The graph read abstraction is immutable and snapshot-scoped. Its conceptual
+surface is:
+
+```text
+metadata()
+get_node(id)
+get_edge(id)
+scan_nodes(range, limits, cursor)
+scan_edges(range, limits, cursor)
+outgoing(node, edge_filter, limits, cursor)
+incoming(node, edge_filter, limits, cursor)
+lookup_name(query, filters, limits, cursor)
+search_terms(query, filters, limits, cursor)
+community_members(community, limits, cursor)
+export_graph_json(writer, limits)
+```
+
+Every sequence has stable ordering and explicit bounds. “All nodes” remains a
+bounded streaming operation, not a request to allocate the full graph. Query
+planners may request projections so an engine need not decode unused large
+fields.
+
+The graph read contract is asynchronous and supports bounded page/stream
+delivery because a store engine may cross a network. It does not create an
+executor or expose backend futures in public query results. The JSON engine can
+complete local operations immediately, while CLI and service application
+layers own runtime, cancellation, and overall command deadlines.
+
+`JsonGraphEngine` validates `compass.graph/1` using `compass-model`. It may use
+the existing content-addressed binary and FTS caches, but those remain
+disposable and JSON remains authoritative for that engine.
+
+`StoreGraphEngine` validates the selector or `store.ref`, manifest, index
+roots, envelopes, and record contracts. It performs point reads and ordered
+tree walks through a scoped `NamespaceStore`. It must not downcast to a
+specific adapter for correctness.
+
+CompassQL, traversal, impact, reports, MCP, and CLI layers consume the graph
+read contract. They do not select SQL tables or DynamoDB indexes.
+
+## Query planning and accelerators
+
+The first portable plan should use:
+
+- direct node and edge ID lookup;
+- outgoing and incoming ordered indexes for traversal;
+- name and kind indexes for structural discovery;
+- deterministic term postings for text candidates; and
+- bounded record projection and batched point reads.
+
+Each query budget accounts for objects read, decoded bytes, result rows,
+frontier size, traversal depth, and elapsed time. Crossing a limit returns a
+limit error or an explicitly marked partial-result contract where the public
+command already permits partial results.
+
+SQLite FTS, PostgreSQL text search, redb-local caches, or another service can
+be registered as disposable accelerators. Each accelerator is keyed by
+snapshot ID and its own format version. It is safe to delete and rebuild. A
+miss, corrupt accelerator, or unsupported backend falls back to the portable
+plan within the same declared budget.
+
+Accelerator qualification compares full ordered results, scores, truncation,
+and diagnostics against the portable implementation. Faster but observably
+different results do not qualify.
+
+## Backend mappings
+
+These mappings are adapter designs, not leaked public schema. An adapter may
+change its physical representation if it still passes the contract and its
+own format migration policy.
+
+| Contract concept | SQLite | redb | PostgreSQL | DynamoDB |
+| --- | --- | --- | --- | --- |
+| Deployment | Embedded file | Embedded file | Remote or local service | Managed remote service |
+| Namespace + partition | Leading binary primary-key columns | Leading composite-key segments | Leading `bytea` primary-key columns | Encoded together as table partition key |
+| Key order | Binary primary-key order | Byte-key table order | Binary `bytea` order | Table sort-key order |
+| Strong read | Read transaction | Read transaction | Primary/qualifying synchronous path | Consistent base-table read |
+| Conditional write | Transaction plus row/version predicate | Write transaction plus version check | Unique constraint/conditional update | Conditional expression |
+| Publication commit | One selector-row CAS or filesystem generation switch | One selector-key CAS or filesystem generation switch | One selector-row CAS | One selector-item CAS |
+| Optional acceleration | FTS/derived tables | Derived local tables | Derived indexes/text search | Derived items or separately qualified service |
+
+Only the contract column meanings are portable. For example, availability of a
+large SQL transaction in one adapter does not raise the common atomicity
+boundary.
+
+### SQLite
+
+The reference local adapter uses one database per configured local store and a
+binary primary key:
+
+```sql
+CREATE TABLE kv (
+    namespace  BLOB    NOT NULL,
+    partition  BLOB    NOT NULL,
+    key        BLOB    NOT NULL,
+    value      BLOB    NOT NULL,
+    digest     BLOB    NOT NULL,
+    version    INTEGER NOT NULL,
+    PRIMARY KEY (namespace, partition, key)
+) WITHOUT ROWID;
+```
+
+A separate metadata table records the adapter format, store identity,
+creation state, and migration state. Ordered scans specify all three leading
+primary-key components and use binary comparisons. Conditional updates include
+the observed `version` in the `WHERE` clause and require exactly one affected
+row. Put-if-absent uses the primary-key constraint and verifies the existing
+digest on conflict.
+
+WAL mode, full synchronous durability, a bounded busy timeout, bounded
+prepared statements, and explicit transactions follow the repository's
+existing local durability posture. Whether `WITHOUT ROWID` is retained must
+be benchmarked on Compass workloads; SQLite's own documentation recommends
+measuring this optimization rather than assuming it always wins.
+
+Backups must include committed WAL state. File creation, permissions, symlink
+handling, corruption recovery, and atomic replacement reuse `compass-files`
+primitives rather than new weaker helpers.
+
+### redb
+
+The redb adapter stores a composite binary address whose encoding preserves
+the contract's namespace, partition, and key ordering. Read transactions
+provide stable local snapshots. Writes map conditional operations to one
+redb write transaction and commit before success is returned.
+
+redb permits one write transaction at a time, so the adapter uses bounded
+write queues or reports backpressure; graph construction must not spawn an
+unbounded number of waiting writers. Large immutable batches are chunked,
+committed, and safe to retry because no chunk becomes active before the final
+selector CAS.
+
+Table names, database files, and durability configuration are adapter-private.
+The conformance suite, not matching the SQLite schema, establishes
+compatibility.
+
+### PostgreSQL
+
+The reference mapping uses binary columns and the same composite primary key:
+
+```sql
+CREATE TABLE compass_kv (
+    namespace  bytea  NOT NULL,
+    partition  bytea  NOT NULL,
+    key        bytea  NOT NULL,
+    value      bytea  NOT NULL,
+    digest     bytea  NOT NULL,
+    version    bigint NOT NULL,
+    PRIMARY KEY (namespace, partition, key)
+);
+```
+
+Point reads and ordered range scans always constrain `namespace` and
+`partition`. Put-if-absent uses the unique primary key. Compare-and-swap uses a
+conditional update on the observed version, returning the new version only if
+one row changed. PostgreSQL documents `INSERT ... ON CONFLICT` as an atomic
+insert-or-update primitive, but Compass still implements its narrower explicit
+conditions and reports conflicts rather than giving all writes last-writer-
+wins behavior.
+
+The adapter uses a bounded connection pool, statement timeouts, response byte
+limits, TLS policy, scoped database credentials, and cancellation. A future
+service may add database/schema isolation or row-level security, but those are
+defense in depth; application authorization still produces a namespace-scoped
+handle.
+
+Table partitioning and replicas are deployment choices. An authoritative
+active-selector read cannot be routed to a replica whose consistency is too
+weak for the contract.
+
+### DynamoDB
+
+The DynamoDB adapter maps one Compass address to one table item:
+
+```text
+PK = versioned binary encoding(namespace, partition)
+SK = key
+V  = value envelope
+D  = digest
+R  = compare-and-swap version
+```
+
+DynamoDB groups items with the same partition key and orders them by sort key,
+which directly matches one-partition scans. The adapter uses base-table Query
+with strongly consistent reads for authoritative data, handles the service's
+pagination internally, and binds Compass cursors to the complete request.
+Global secondary indexes are not authoritative selector paths because their
+reads are eventually consistent.
+
+Put-if-absent and compare-and-swap use conditional expressions. A conditional
+failure becomes `Conflict`, not a generic outage. Values stay within the
+portable envelope and below the service item limit after all attributes are
+included. Graph content is digest-sharded across partition keys so a large
+repository does not make one hot partition.
+
+The adapter bounds retries, exponential backoff with jitter, consumed
+capacity, response bytes, and total deadline. Throttling is surfaced distinctly
+when the budget is exhausted. Tests use a controlled local implementation or
+protocol mock, never real credentials or a production table.
+
+### Additional adapters
+
+Any database can qualify if it implements the common contract. An adapter
+must not weaken ordering, turn a consistency failure into absence, drop
+unknown bytes, or hide a limit behind truncation. A backend without ordered
+partition scans may build an adapter-private ordered index only if it can
+provide the exact semantics durably and within bounds.
+
+Adapter-specific features belong behind capability flags. A graph engine that
+requires one optional feature is not portable and must supply a portable plan
+before adoption.
+
+## Adapter conformance suite
+
+`compass-store` owns a reusable test suite executed against every adapter. At
+minimum it covers:
+
+- namespace and partition isolation;
+- unsigned byte ordering, prefix edges, empty and maximum keys;
+- point-read and missing-value behavior;
+- exact page limits, continuation, invalid cursors, and no duplicates;
+- put-if-absent races and compare-and-swap races;
+- idempotent immutable writes and mismatched-value detection;
+- reopen durability after successful acknowledgement;
+- interruption before, during, and after commit;
+- value, key, cursor, response, and deadline limits;
+- corruption and malformed envelope detection;
+- retry classification, throttling, cancellation, and safe diagnostics;
+- capability rejection before writes;
+- concurrent readers during publication; and
+- deterministic behavior across repeated runs.
+
+The suite supplies logical tests plus a backend fault-injection interface. A
+backend cannot qualify from happy-path CRUD tests alone.
+
+## Garbage collection, leases, and retention
+
+Immutable publication makes orphaned content expected. Garbage collection is
+mark-and-sweep, rooted at:
+
+- active selectors;
+- filesystem `store.ref` records for retained local generations;
+- retained historical realization roots;
+- explicit pins; and
+- unexpired reader or build leases.
+
+The mark phase traverses bounded manifests and tree roots. It records a
+versioned checkpoint so remote runs can resume. The sweep phase visits explicit
+digest shards with page and delete budgets. Objects younger than a safety
+window are not collected. A conditional delete verifies that the object and
+retention state did not change since marking.
+
+GC never infers liveness from “the newest timestamp,” never requires an
+unbounded namespace scan in a user query, and never rewrites a published
+snapshot. Operational indexes may accelerate enumeration, but the root set
+remains explicit.
+
+## Recovery and backup
+
+Recovery is ordered by authority:
+
+1. validate the selected snapshot reference;
+2. validate its manifest and roots;
+3. use a coherent backend backup or an alternate retained snapshot if the
+   store is corrupt;
+4. for local artifact generations, open the co-published `graph.json` engine;
+5. rebuild disposable indexes or the store snapshot from validated JSON or
+   source; and
+6. publish a new generation rather than editing an immutable snapshot.
+
+A missing object reachable from a committed manifest is corruption or
+incomplete replication, not an empty graph. A dangling prepared manifest is
+an orphan, not current data.
+
+Backup procedures are backend-specific but must capture the selector and all
+content it can reach coherently. Restore validates every root before making a
+selector active. Cloud backup and disaster-recovery objectives are deployment
+policy and cannot be inferred from the key-value API.
+
+## Multi-tenancy and security
+
+The future cloud design uses defense in depth:
+
+- authentication and authorization select an internal namespace descriptor;
+- callers receive a namespace-scoped store handle, not raw database access;
+- quotas apply per tenant, namespace, build, operation, and response;
+- database credentials are scoped to the service, rotated, and never encoded
+  into keys or diagnostics;
+- remote endpoints, TLS, timeouts, and credential sources are explicit
+  configuration;
+- local Compass remains offline by default and never contacts a backend unless
+  the user selected it;
+- untrusted stored bytes pass size, envelope, digest, graph-record, path, and
+  source-anchor validation before rendering;
+- namespace IDs are safe opaque identifiers, not accepted authorization
+  claims;
+- backend logs and metrics redact values, source text, credentials, and
+  sensitive repository paths; and
+- administrative enumeration, migration, backup, and GC use separate
+  privileged APIs and audit trails.
+
+Encryption at rest is normally provided by the selected backend and deployment.
+Application-level value encryption can be added later, but its key identifier,
+rotation, and range-query implications require a separate versioned design.
+
+## Observability
+
+The common layer emits structured, low-cardinality measurements:
+
+- operation kind, adapter kind, result class, and consistency;
+- duration and retry count;
+- requested and returned items/bytes;
+- throttle and deadline counts;
+- cache/accelerator outcome;
+- objects reused versus written during build;
+- snapshot preparation and selector-CAS duration;
+- query objects read, decoded bytes, and frontier peak; and
+- GC objects marked, retained, swept, and deferred.
+
+Namespace IDs, keys, graph record IDs, query text, values, and source paths are
+not metric labels. A diagnostic may include a short safe correlation ID and
+bounded hashes where policy permits.
+
+## Performance qualification
+
+The design predicts improvements; it does not assert them. Qualification must
+measure at least:
+
+- clean `compass init` wall time and peak memory;
+- no-change and small-change `compass update` time, bytes read, and bytes
+  written;
+- cold engine-open time and memory;
+- point lookup, name search, one-hop traversal, multi-hop bounded traversal,
+  impact, and representative CompassQL latency;
+- concurrent readers during an update;
+- JSON export time and byte equivalence;
+- database size, temporary publication amplification, and GC work;
+- local SQLite and redb at small, medium, and large graph sizes; and
+- PostgreSQL and DynamoDB request count, transferred bytes, throttling, and
+  estimated cost under controlled workloads.
+
+Measurements include engine-open and index-build time. A benchmark that starts
+after a full graph has already been deserialized cannot support a cold-query
+claim. Results and thresholds belong in `PERFORMANCE.md` before a release makes
+performance claims.
+
+## Compatibility and migration policy
+
+### What may hard-cut
+
+Before a store format is released as durable user or cloud data, Compass may:
+
+- replace its physical adapter schema;
+- invalidate and rebuild store snapshots;
+- discard old disposable query caches;
+- change unpublished namespace or key encodings; and
+- require regeneration from source or validated `graph.json`.
+
+The implementation plan should prefer a clean hard cut over permanent support
+for a prototype. Unknown store and snapshot majors fail explicitly.
+
+### What remains compatible
+
+The following are not waived:
+
+- `graph.json` remains an available, validated graph engine;
+- the existing `compass.graph/1` contract changes only through its normal
+  compatibility process;
+- public CLI arguments, streams, exits, output schemas, CompassQL semantics,
+  MCP schemas, and stable graph IDs remain compatible unless separately
+  versioned and documented;
+- deterministic JSON export remains available from a store snapshot;
+- relationship direction, multiplicity, anchors, provenance, and diagnostics
+  survive round trips; and
+- historical realizations already published remain immutable.
+
+When a durable store format is first declared public, its schema identifier,
+supported upgrade window, backup procedure, and migration tooling must be
+added to `COMPATIBILITY.md` and `MIGRATION.md`.
+
+## Rejected alternatives
+
+### Replace `graph.json` with SQLite
+
+Rejected. It breaks a useful inspection and interchange engine, creates a
+forced migration, and couples public graph access to one database. Store
+snapshots instead coexist with deterministic JSON export.
+
+### Define the common API as SQL
+
+Rejected. SQL syntax, collation, isolation, indexes, and query planners do not
+map faithfully to redb or DynamoDB. Raw SQL would leak backend behavior into
+graph meaning.
+
+### Require cross-partition transactions
+
+Rejected. It selects for a subset of backends and makes cloud scale and
+failure semantics unnecessarily expensive. Immutable preparation plus one CAS
+provides the needed publication atomicity.
+
+### One namespace for all repositories and data planes
+
+Rejected. It weakens tenant isolation, makes quotas and deletion ambiguous,
+and increases blast radius. The namespace is the first explicit boundary.
+
+### Backend-native indexes as graph authority
+
+Rejected. SQLite FTS, PostgreSQL search, and DynamoDB secondary indexes differ
+in scoring and consistency. They are useful accelerators only after
+differential qualification.
+
+### Serialize the complete graph as one database value
+
+Rejected. It retains the rewrite, memory, and item-size problems of one large
+JSON file while losing JSON's portability and inspectability.
+
+## Open decisions to close in Phase 0
+
+Before implementation proceeds beyond the reference memory store, maintainers
+must freeze:
+
+1. the exact v1 byte limits and key test vectors;
+2. the async trait representation and cancellation/deadline type;
+3. the content digest and deterministic codec set;
+4. the ordered-tree implementation and chunking parameters;
+5. namespace descriptor inputs and local store location policy;
+6. the exact graph-read projection and cursor contracts;
+7. the portable text normalization and ranking rules; and
+8. whether filesystem `store.ref` is embedded in the existing manifest or is a
+   separate typed artifact.
+
+Each decision must land with tests and a compatibility assessment. None should
+be left to the first backend adapter to decide implicitly.
+
+## External implementation references
+
+- [SQLite documentation](https://sqlite.org/docs.html), including WAL and
+  `WITHOUT ROWID` guidance
+- [redb API documentation](https://docs.rs/redb/latest/redb/)
+- [PostgreSQL `INSERT ... ON CONFLICT`](https://www.postgresql.org/docs/current/sql-insert.html)
+  and [transaction isolation](https://www.postgresql.org/docs/current/transaction-iso.html)
+- [DynamoDB partition and sort keys](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.Partitions.html),
+  [Query semantics](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html),
+  and [service constraints](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Constraints.html)
+
+These links explain backend behavior. The normative Compass contract is this
+document plus its conformance tests, not a backend's superset of features.
+
+## Related pages
+
+- [Executable Compass store plan](../implementation/compass-store-plan.md)
+- [Storage and history](storage-and-history.md)
+- [System architecture](architecture.md)
+- [Query engine](../implementation/query-engine.md)
+- [Compatibility policy](../../COMPATIBILITY.md)
+- [Performance qualification](../../PERFORMANCE.md)
+
+**Next step:** execute
+[Phase 0 of the implementation plan](../implementation/compass-store-plan.md#phase-0-freeze-the-contract-and-build-the-reference-store)
+to turn the planned semantics into tested Rust contracts.

--- a/docs/design/storage-and-history.md
+++ b/docs/design/storage-and-history.md
@@ -288,6 +288,7 @@ Lease appears stuck?
 
 ## Related pages
 
+- [Planned Compass store and graph-engine design](compass-store.md)
 - [Versioned graph history](../guides/versioned-history.md)
 - [History crate tour](../implementation/workspace-tour.md)
 - [Output reference](../reference/outputs.md)

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -1,0 +1,1017 @@
+# Executable Compass store implementation plan
+
+**Status:** Planned. No phase is shipped merely because it appears here.
+
+> **Who this page is for:** implementers and reviewers delivering
+> `compass-store`, store-backed graph snapshots, backend adapters, and the
+> future cloud storage boundary.
+>
+> **You will learn:** the mergeable phases, exact ownership boundaries,
+> deliverables, verification, failure tests, compatibility decisions, and
+> acceptance criteria for each phase.
+>
+> **Prerequisites:** read the complete
+> [Compass store and graph-engine design](../design/compass-store.md),
+> [Workspace tour](workspace-tour.md),
+> [Extending Compass](extending-compass.md), and
+> [Compatibility policy](../../COMPATIBILITY.md).
+>
+> **Reading time:** 30–40 minutes.
+
+## Outcome
+
+At completion, Compass has:
+
+- a backend-neutral `compass-store` crate whose first boundary is a scoped
+  namespace and whose complete address is `(namespace, partition, key)`;
+- a permanent `JsonGraphEngine` for `graph.json`;
+- a `StoreGraphEngine` using immutable content-addressed graph snapshots;
+- SQLite and redb embedded adapters;
+- PostgreSQL and DynamoDB remote adapters;
+- atomic local and store-native publication;
+- bounded graph reads that do not require full JSON deserialization;
+- adapter conformance, cross-engine differential tests, fault injection,
+  garbage collection, backup, and recovery coverage; and
+- measured performance evidence before any release claim.
+
+## Program rules
+
+Every phase follows these rules independently:
+
+1. **Keep phases mergeable.** A phase must leave the default branch usable and
+   tested. Feature flags or internal configuration may hide unfinished paths,
+   but an incomplete path must fail explicitly rather than silently change
+   engines.
+2. **Preserve JSON.** `graph.json` remains a supported engine and canonical
+   export. No phase may call it “legacy,” “fallback pending removal,” or
+   “deprecated.”
+3. **Hard-cut only internal formats.** Unreleased store schemas, namespace
+   encodings, and disposable query caches may be invalidated and rebuilt.
+   Public graph, CLI, CompassQL, MCP, and historical contracts need their
+   normal compatibility process.
+4. **Prove semantics before speed.** Cross-engine graph equivalence and
+   adapter conformance land before query routing or performance claims.
+5. **Bound all work.** Every API and test covers item, byte, depth, frontier,
+   response, deadline, retry, and concurrency limits relevant to it.
+6. **Keep local operation native.** Default builds and tests require no cloud
+   account, service credentials, Python, vector database, or live network.
+7. **Test the lowest owner.** Store semantics live in `compass-store`, graph
+   layout in `compass-graph`, publication in `compass-core` and
+   `compass-files`, query behavior in `compass-query`, and public command
+   effects in `compass-cli`.
+8. **Use one target directory per checkout.** Every compiling Cargo command
+   sets `CARGO_TARGET_DIR` under `/Volumes/Workspace/crabbuild-target` as
+   required by `AGENTS.md`.
+
+## Phase dependency map
+
+```text
+Phase 0  portable store contract + memory reference
+   |
+   +--> Phase 1  graph-engine read boundary + permanent JSON engine
+   |       |
+   |       v
+   +--> Phase 2  immutable graph snapshot layout + memory store engine
+                   |
+                   v
+               Phase 3  SQLite adapter + shadow local publication
+                   |
+                   v
+               Phase 4  store-backed query routing and local cutover
+                 /   \
+                v     v
+          Phase 5     Phase 6
+             redb     PostgreSQL
+                         |
+                         v
+                      Phase 7
+                      DynamoDB
+                 \       |       /
+                  \      v      /
+                   Phase 8
+             multi-tenant operations
+                         |
+                         v
+                      Phase 9
+             qualification and release
+```
+
+Phases 5 and 6 can proceed independently after Phase 4. Phase 7 can begin
+after the conformance harness and graph layout are stable, but it should not be
+declared production-ready before the remote operational patterns in Phase 6
+have been exercised.
+
+## Shared definition of done
+
+A phase is complete only when:
+
+- its acceptance criteria are represented by automated tests or a checked
+  qualification artifact;
+- unknown major versions and unsupported capabilities fail explicitly;
+- failure and interruption paths clean up or leave only unreachable immutable
+  content;
+- deterministic result ordering is asserted, not inferred;
+- public errors are typed, bounded, actionable, and free of secrets;
+- relevant docs identify behavior as available only after the implementation
+  lands;
+- `git diff` and `git status --short` contain no unrelated or generated noise;
+  and
+- the implementer reports which repository baseline and surface-specific gates
+  ran, and why any applicable gate did not run.
+
+The normal final Rust baseline is:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo fmt --all -- --check
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo clippy --workspace --lib --bins --locked -- -D warnings
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo test --workspace --lib --bins --locked
+```
+
+Use the actual unique checkout name. Verify `/Volumes/Workspace` is mounted and
+writable before running Cargo; do not fall back to a local `target/`.
+
+## Phase 0: Freeze the contract and build the reference store
+
+### Context and objective
+
+There is no safe backend work until address encoding, ordering, limits,
+consistency, conditional writes, cursor behavior, and error semantics are
+executable. This phase creates the lowest-level contract without graph logic or
+database dependencies. A deterministic in-memory implementation is the
+reference model used by every later adapter.
+
+### Owned surfaces
+
+- new `crates/compass-store/` package;
+- root workspace membership and workspace dependency wiring;
+- `compass-store` unit and public-contract tests; and
+- no changes to CLI behavior or generated artifacts.
+
+### Work
+
+1. Create `compass-store` with `#![forbid(unsafe_code)]` and the workspace lint
+   policy.
+2. Define bounded newtypes for `NamespaceId`, `PartitionKey`, `Key`, `Value`,
+   `VersionToken`, and `Cursor`.
+3. Freeze the versioned, length-prefixed binary key encoding and checked-in
+   golden vectors, including binary zeroes, maximum lengths, and prefix
+   boundaries.
+4. Freeze the portable v1 maxima proposed by the design. Record why each fits
+   all four planned adapters.
+5. Define object-safe asynchronous `Store`, namespace-scoped
+   `NamespaceStore`, and backend-neutral `StoreFactory` requirements. The
+   crate must not create or require one specific async runtime or a universal
+   connection-string format.
+6. Implement `get`, ordered one-partition `scan`, conditional `put`,
+   conditional `delete`, and `put_immutable` semantics.
+7. Define `StoreCapabilities`, operation budgets/deadlines, read consistency,
+   page accounting, and the complete typed error taxonomy.
+8. Implement a deterministic memory store with fault injection, clock
+   injection, and controllable conflicts. It must model semantics, not attempt
+   to model SQLite or DynamoDB latency.
+9. Build a reusable adapter conformance module. Adapter crates must be able to
+   invoke it without copying tests.
+10. Add property tests for ordering and encode/decode round trips with bounded
+    generators. Seed failures must be reproducible.
+11. Add crate-level documentation stating that namespaces are isolation
+    identifiers but not authorization claims.
+
+### Required tests
+
+- namespace A cannot read, scan, overwrite, or delete namespace B;
+- partitions with identical keys remain isolated;
+- keys are returned in unsigned lexicographic byte order;
+- page item and byte ceilings stop before overflow and produce a valid cursor;
+- resuming a cursor returns every matching entry exactly once;
+- a cursor fails when reused with another range, partition, namespace,
+  consistency, or store identity;
+- concurrent `Missing` writes have exactly one winner;
+- concurrent `Version` writes have exactly one winner per observed version;
+- `put_immutable` accepts identical retries and rejects different bytes;
+- limits fail before allocation or mutation;
+- deadline and cancellation stop work without a detached mutation;
+- errors redact values, keys, source text, and credentials; and
+- unsupported capabilities fail before any write.
+
+### Acceptance criteria
+
+- `cargo test -p compass-store --locked` passes and includes all required
+  conformance behaviors.
+- `cargo clippy -p compass-store --all-targets --all-features --locked -- -D warnings`
+  passes.
+- Golden key vectors are identical on Linux, macOS, and Windows CI.
+- A public API review confirms that no method scans a whole namespace, exposes
+  raw SQL/backend expressions, promises cross-partition atomicity, or accepts
+  unbounded values.
+- The memory store passes the complete conformance suite under at least two
+  deterministic fault schedules.
+- No existing Compass command or file output changes in this phase.
+
+### Exit and rollback
+
+The output is a new unused contract crate, so rollback is removal of the crate
+and workspace entry. Do not preserve an inadequate encoding for compatibility;
+change it before Phase 2 and update golden vectors with an explicit review.
+
+## Phase 1: Introduce the graph-engine boundary and preserve JSON
+
+### Context and objective
+
+Current query paths open `graph.json` and build in-memory lookup and adjacency
+structures. Before a store engine exists, consumers need one immutable graph
+read boundary. This phase moves current behavior behind that boundary while
+keeping JSON results, files, and command behavior unchanged.
+
+### Prerequisite inputs
+
+- Phase 0's bounded key/value vocabulary is available, but the JSON engine
+  does not depend on a store backend.
+- Existing `compass-model::GraphDocument` validation and query tests are the
+  behavioral oracle.
+
+### Owned surfaces
+
+- `compass-query` graph snapshot/read traits and planner inputs;
+- a JSON implementation wrapping existing load, validation, binary cache, and
+  FTS behavior;
+- narrow wiring in `compass-cli` and `compass-mcp`; and
+- query-engine implementation documentation.
+
+### Work
+
+1. Inventory every graph consumer: typed search, code search, traversal,
+   impact, affected, CompassQL, reports, MCP resources/tools, viewer export,
+   clustering, and tests.
+2. Define an immutable `GraphEngine`/`GraphSnapshot` contract with bounded
+   metadata, point lookup, ordered scans, incoming/outgoing adjacency, name and
+   text candidates, community membership, projections, and JSON export. Its
+   object-safe asynchronous/page surface must work for local and remote
+   engines without owning an executor.
+3. Define engine-independent cursors and result accounting where feasible. If
+   a cursor is engine-specific, make it opaque, request-bound, and explicitly
+   non-portable.
+4. Implement `JsonGraphEngine` using the current strict graph validation and
+   disposable content cache. Preserve its path size checks and corruption
+   behavior.
+5. Refactor each query family to use the graph snapshot rather than reaching
+   into JSON-specific indexes. Do not change query algorithms in the same
+   step unless required for bounded streaming.
+6. Preserve deterministic tie-breaking and every current public diagnostic.
+7. Add a test-only recording engine that asserts query budgets, projection
+   use, range direction, and absence of unbounded calls.
+8. Keep direct `--graph <path.json>` and equivalent library entry points on
+   `JsonGraphEngine`.
+
+### Required tests
+
+- every existing query fixture produces byte-for-byte equal JSON output and
+  equivalent human output before and after the refactor;
+- graph open still rejects oversize, malformed, invalid-major, and invalid
+  cross-reference inputs;
+- directed traversal and reverse traversal request the correct index direction;
+- multiedges remain distinct and preserve edge IDs and source anchors;
+- a limit error is not converted to an empty result;
+- query ordering is stable across repeated runs; and
+- opening an explicit JSON file never requires a database.
+
+### Acceptance criteria
+
+- Existing `compass-query`, `compass-cypher`, `compass-cli`, and `compass-mcp`
+  contract tests pass without approved snapshot changes.
+- `cargo test -p compass-cypher --test tck --locked`,
+  `cargo test -p compass-query --test opencypher_tck --locked`, and
+  `python3 scripts/check_compassql_support.py` pass.
+- The recording engine proves every public query supplies finite item/byte and
+  traversal limits.
+- `graph.json` remains the only default engine and all public CLI output is
+  unchanged in this phase.
+- Documentation names `JsonGraphEngine` as permanent supported behavior.
+
+### Exit and rollback
+
+Because the JSON implementation preserves the old semantics, rollback can
+restore direct JSON types without data migration. Do not proceed if the new
+trait requires a full graph allocation by definition; that would prevent the
+later store engine from improving cold-query memory.
+
+## Phase 2: Implement the immutable snapshot layout in memory
+
+### Context and objective
+
+This phase proves graph encoding, ordered indexes, structural sharing, and
+publication semantics against the memory store before database behavior can
+hide logical mistakes. It introduces `StoreGraphEngine` but does not publish a
+user database.
+
+### Prerequisite inputs
+
+- Phase 0 supplies the store contract and conformance model.
+- Phase 1 supplies the graph read contract and JSON oracle.
+- The design document supplies the manifest and required logical indexes.
+
+### Owned surfaces
+
+- `compass-graph` snapshot builder and canonical graph-index encoders;
+- `compass-query` store graph engine;
+- `compass-model` only for new typed internal snapshot records whose ownership
+  review confirms they are shared graph contracts; and
+- cross-engine fixtures and differential tests.
+
+### Work
+
+1. Freeze `compass.store.graph-snapshot/1`, `SnapshotManifest`, root registry,
+   value envelope, content digest, and snapshot identity projection.
+2. Implement deterministic graph key encoders with golden vectors for nodes,
+   edges, incoming/outgoing adjacency, files, names, terms, communities, and
+   diagnostics.
+3. Integrate or implement the immutable ordered-map tree. Freeze content-
+   defined chunking parameters and enforce maximum fanout, depth, object size,
+   decoded size, and traversal reads.
+4. Stream canonical `GraphDocument` records into every required index. Reject
+   duplicate logical keys and invalid references before publishing a manifest.
+5. Use `put_immutable` for all content and manifest objects.
+6. Implement manifest validation, root verification, and a prepared-snapshot
+   result that is not active by construction.
+7. Implement the selector-CAS protocol in the memory store and concurrent
+   reader semantics.
+8. Implement `StoreGraphEngine` point reads, ordered iteration, adjacency,
+   search candidates, projections, and streaming JSON export.
+9. Add incremental rebuild from prior roots and measure object reuse in test
+   fixtures for no-change, one-node, one-edge, rename, and delete updates.
+10. Add full differential tests between `JsonGraphEngine` and
+    `StoreGraphEngine` over generated bounded graphs as well as repository
+    fixtures.
+
+### Required tests
+
+- identical validated graphs produce identical snapshot IDs and roots across
+  repeated builds and insertion orders;
+- operational timestamps, thread count, and host paths do not change snapshot
+  identity;
+- every logical graph field survives store-to-JSON round trip;
+- outgoing and incoming indexes preserve direction;
+- duplicate endpoint/kind edges preserve multiplicity through edge IDs;
+- missing/corrupt tree objects fail as corruption or unavailable, never empty;
+- a reader opened before selector CAS completes on the old snapshot;
+- a reader opened after CAS observes only the new complete snapshot;
+- two concurrent publishers produce one selector winner;
+- no-change update writes no new content objects after idempotence checks;
+- small updates reuse unchanged tree objects; and
+- an interrupted prepare never becomes active.
+
+### Acceptance criteria
+
+- The memory-backed store engine passes every Phase 1 graph-engine contract
+  test.
+- Canonical JSON exported by both engines is byte-identical for all fixtures
+  and bounded generated graphs.
+- A checked qualification report records structural-sharing ratios for the
+  five update cases; ratios are evidence, not yet release promises.
+- Tree reads fail before exceeding configured depth, object, byte, or result
+  limits.
+- The snapshot layout has an explicit unknown-major failure test and no
+  backend-specific field.
+- `./scripts/qualify_code_graph_v1.sh --fixtures-only` passes.
+
+### Exit and rollback
+
+This is still an unpublished internal format. If the layout is insufficient,
+change its major or discard it; do not add a migration reader merely to retain
+test data. Phase 3 must not begin until cross-engine equivalence is complete.
+
+## Phase 3: Add SQLite and shadow local publication
+
+### Context and objective
+
+SQLite is the first persistent adapter and exercises reopen, filesystem,
+locking, crash, and durability behavior. Local builds initially write the
+store snapshot in shadow mode while JSON remains the read path. This isolates
+write/publication risk from query-routing risk.
+
+### Prerequisite inputs
+
+- Phase 0's adapter conformance harness;
+- Phase 2's immutable snapshot builder; and
+- the existing `BuildGuard` generation publication primitive.
+
+### Owned surfaces
+
+- new `compass-store-sqlite` crate;
+- local store path and file lifecycle in `compass-files`;
+- snapshot preparation and `store.ref` staging in `compass-core`; and
+- CLI contract tests for `init` and `update` side effects.
+
+### Work
+
+1. Implement the SQLite physical schema, binary ordering, metadata/format
+   table, conditional writes, ordered scans, and capability report.
+2. Configure WAL, full synchronous durability, bounded busy timeout, bounded
+   statement inputs/results, and coherent close/checkpoint behavior.
+3. Reuse atomic path, containment, permissions, symlink, and recovery helpers
+   from `compass-files`.
+4. Run the complete adapter conformance suite against a newly created and a
+   reopened database.
+5. Add crash/fault tests at transaction begin, content write, commit,
+   manifest write, validation, and filesystem generation switch.
+6. Define a typed, versioned `store.ref` containing store identity, namespace,
+   snapshot ID, manifest digest, and graph digest but no machine-specific
+   absolute path.
+7. During `init` and `update`, prepare the SQLite snapshot and stage
+   `store.ref` with `graph.json` and other output artifacts. The filesystem
+   generation switch is the only local commit.
+8. Keep all queries on `JsonGraphEngine`; shadow verification opens the store
+   snapshot and compares graph identity before publication.
+9. Add an explicit internal switch to disable shadow storage for diagnosis.
+   It is not a promise to remove JSON.
+10. Add bounded orphan discovery and retention metadata, but defer general GC
+    to Phase 8.
+
+### Required tests
+
+- creation, reopen, write, read, scan, CAS, and delete pass conformance;
+- acknowledged writes survive process reopen under the configured durability;
+- copying or recovering SQLite accounts for WAL state;
+- an interrupted database write cannot change the active filesystem
+  generation;
+- an interrupted filesystem switch leaves the prior generation readable;
+- published `graph.json` and `store.ref` select equal graph digests;
+- a store database missing or corrupt after publication does not make the
+  co-published JSON unreadable;
+- concurrent local updates produce a guarded conflict rather than mixed
+  artifacts;
+- local paths cannot escape through symlinks or untrusted namespace text; and
+- stale/unreleased SQLite formats fail with a rebuild instruction.
+
+### Acceptance criteria
+
+- `cargo test -p compass-store-sqlite --locked` passes the shared conformance
+  suite after reopen and under injected busy/interrupt failures.
+- `compass init` and `compass update` CLI integration tests assert successful
+  exit, `graph.json`, `store.ref`, complete manifest, and no visible partial
+  generation.
+- Shadow comparison covers all fixture graphs and rejects publication on any
+  mismatch.
+- No default query reads SQLite yet, so a user can delete the new database and
+  continue using the published JSON engine.
+- The old disposable query SQLite cache may be hard-cut or rebuilt, but the
+  new durable snapshot store uses a different format identity and location.
+
+### Exit and rollback
+
+Disable shadow writes and remove unpublished databases. Existing
+`graph.json` generations remain valid. Do not attempt to repair a partially
+published store by rewriting its immutable objects; rebuild a new snapshot.
+
+## Phase 4: Route local queries to the store engine
+
+### Context and objective
+
+After shadow publication proves equivalence and durability, local readers can
+prefer the co-published store snapshot. The goal is faster cold open and
+bounded memory without changing public query results. JSON remains selectable
+and is used whenever the caller explicitly supplies a JSON graph.
+
+### Prerequisite inputs
+
+- Phase 3 has qualification evidence from real local build generations.
+- Every current query family is already behind the Phase 1 graph read contract.
+
+### Owned surfaces
+
+- engine selection in `compass-core` and thin CLI/MCP wiring;
+- store-aware plans and projection batching in `compass-query`;
+- query cache lifecycle; and
+- performance and differential qualification.
+
+### Work
+
+1. Define deterministic engine selection:
+   - explicit JSON path selects `JsonGraphEngine`;
+   - a validated active generation with a valid `store.ref` selects
+     `StoreGraphEngine` by default;
+   - an explicit `--engine json|store` diagnostic option may override the
+     default where the command surface review approves it.
+2. Validate `store.ref`, store identity, namespace, snapshot ID, manifest
+   digest, and graph digest before executing a query.
+3. Make store query plans use projections, bounded point-read batches, ordered
+   adjacency ranges, and finite traversal frontiers.
+4. Port deterministic name/text ranking to portable indexes. Keep SQLite FTS
+   only as a disposable, differential-tested accelerator.
+5. Make corruption and unavailability actionable. An automatic switch to JSON
+   is permitted only before results are emitted, only when the selected local
+   generation proves digest equivalence, and only with an explicit diagnostic.
+6. Remove assumptions that opening a current graph loads every node and edge.
+7. Add engine identity to safe diagnostics and telemetry, not to public result
+   meaning.
+8. Benchmark complete cold command latency, including engine open and any
+   accelerator build.
+9. Define a typed storage/materialization profile at the application boundary:
+   `json`, `store`, or `dual`. Preserve the existing output profile by default;
+   expose `store` only through a separately reviewed CLI/configuration change.
+   Store-only generations must support bounded deterministic JSON export.
+
+### Required tests
+
+- every public query produces the same ordered machine output under JSON and
+  SQLite store engines;
+- human output differs only by an approved diagnostic when engine recovery is
+  exercised;
+- partial results from one engine are never combined with retry results from
+  another;
+- an explicit JSON input never opens the default store;
+- stale `store.ref`, wrong namespace, wrong digest, missing object, corrupt
+  envelope, unsupported major, and store timeout each have distinct tests;
+- query item, byte, frontier, depth, and deadline limits are enforced on store
+  plans;
+- current graph updates do not invalidate readers already pinned to the prior
+  immutable snapshot; and
+- accelerator deletion changes latency only, not ordered results;
+- `json` publishes the existing artifact set without requiring a database;
+- `dual` publishes equal JSON and store snapshots in one generation; and
+- `store` avoids full JSON materialization but can export byte-identical
+  canonical JSON on demand.
+
+### Acceptance criteria
+
+- Cross-engine differential tests cover typed search, code search, traversal,
+  impact, affected, CompassQL, MCP, and JSON export.
+- CompassQL TCK, OpenCypher TCK, CLI product tests, product-boundary check, and
+  fixture-only code-graph qualification pass.
+- `PERFORMANCE.md` contains reproducible before/after commands and results for
+  cold open, peak RSS, common queries, no-change update, and small-change
+  update, with `json`, `store`, and `dual` measured separately.
+- The default switches to store only if correctness is equal and agreed
+  performance thresholds are met; otherwise shadow mode remains available
+  without blocking later adapter development.
+- Documentation clearly states that `graph.json` is a compatible permanent
+  engine, not a deprecated fallback.
+
+### Exit and rollback
+
+Engine selection can return to JSON without converting data because each local
+generation still contains it. Keep store databases as disposable/unselected or
+rebuild them. A rollback must not remove the graph read abstraction.
+
+## Phase 5: Add the redb embedded adapter
+
+### Context and objective
+
+redb provides a second local implementation with different concurrency and
+physical-storage behavior. Its purpose is both a usable embedded option and a
+test that the common contract did not accidentally become SQLite-shaped.
+
+### Prerequisite inputs
+
+- Phase 0 conformance and Phase 2 graph differential suites are stable.
+- Phase 4 engine selection can name a backend without changing graph meaning.
+
+### Owned surfaces
+
+- new `compass-store-redb` crate;
+- explicit local backend configuration and help; and
+- adapter-specific durability, contention, and reopen tests.
+
+### Work
+
+1. Add redb as a pinned workspace dependency after dependency-policy review.
+2. Implement the composite binary address encoding, read transactions,
+   conditional write transactions, ordered scans, versions, and capabilities.
+3. Bound the single-writer queue and expose backpressure rather than allowing
+   unbounded waiting tasks.
+4. Map commit durability and process reopen to the common acknowledgement
+   contract.
+5. Run graph snapshot construction and every query family through redb.
+6. Add backend selection without changing namespace, manifest, graph-index, or
+   JSON contracts.
+7. Document file backup and recovery separately from SQLite.
+
+### Required tests
+
+- conformance under create, reopen, contention, and injected commit failure;
+- byte ordering across composite namespace/partition/key boundaries;
+- bounded single-writer backpressure and cancellation;
+- reader snapshot stability during selector publication; and
+- full graph/query differential coverage against JSON and SQLite.
+
+### Acceptance criteria
+
+- redb passes the unmodified shared adapter conformance suite, including
+  deterministic fault schedules and reopen tests.
+- Memory, SQLite, and redb produce identical graph snapshot IDs, logical roots,
+  JSON exports, and ordered query results for the same graph.
+- A stress test proves writer backpressure remains within configured task and
+  memory bounds.
+- No redb type appears in `compass-store`, `compass-model`, public graph
+  schemas, or query result contracts.
+- The local binary does not include redb unless packaging/product policy
+  intentionally selects or exposes it.
+
+### Exit and rollback
+
+Remove the optional adapter and its configuration. The store and graph formats
+remain usable through SQLite and JSON, so there is no graph migration.
+
+## Phase 6: Add the PostgreSQL remote adapter
+
+### Context and objective
+
+PostgreSQL proves that the contract works across a network, connection pool,
+server transactions, cancellation, and multiple service workers. This phase
+does not yet ship a multi-tenant Compass cloud product; it produces a hardened
+remote adapter and controlled service-boundary tests.
+
+### Prerequisite inputs
+
+- Store and graph contracts are stable through Phase 4.
+- Security review has defined endpoint, TLS, and credential configuration.
+- CI can provide an isolated disposable PostgreSQL service without real
+  credentials or persistent user data.
+
+### Owned surfaces
+
+- new `compass-store-postgres` crate;
+- backend-neutral remote connection configuration at an application boundary;
+- local mock/disposable-service integration tests; and
+- security, operations, and adapter documentation.
+
+### Work
+
+1. Add a bounded asynchronous PostgreSQL client and pool after dependency and
+   feature review.
+2. Implement the binary composite primary key, format metadata, point reads,
+   constrained ordered scans, conditional insert/update/delete, and versions.
+3. Set connection, acquisition, statement, response, and total operation
+   deadlines. Wire cancellation so expired work does not continue unnoticed.
+4. Enforce TLS and endpoint policy appropriate to the configured deployment.
+   Redact DSNs, credentials, query values, and repository identifiers.
+5. Run schema installation/migration through an explicit administrative path;
+   ordinary graph callers cannot create arbitrary tables or schemas.
+6. Exercise concurrent publisher CAS from multiple processes and readers
+   pinned before/after publication.
+7. Test connection loss after request send and before response. Immutable
+   retries verify digest; CAS returns an indeterminate-safe diagnostic unless
+   the selector can be strongly reread and resolved.
+8. Validate namespace isolation in application handles and, where configured,
+   database permissions or row-level security as defense in depth.
+9. Record request counts, bytes, pool wait, query time, retries, and conflict
+   rates with low-cardinality metrics.
+
+### Required tests
+
+- schema creation is restricted to the administrative path;
+- CAS races from separate connections have exactly one winner;
+- ordered scans survive service page boundaries without gaps or duplicates;
+- connection acquisition, statement, response, and total deadlines each
+  terminate with the correct error;
+- an ambiguous connection failure is resolved by a strong reread or reported
+  without an unsafe retry;
+- primary and permitted replica routes meet the requested consistency; and
+- namespace and cursor replay attacks fail without information disclosure.
+
+### Acceptance criteria
+
+- PostgreSQL passes the shared conformance suite against a disposable local CI
+  service, including reopen, concurrent processes, cancellation, and injected
+  connection failures.
+- Tests prove every normal statement constrains namespace and partition; no
+  unbounded table scan is available to graph callers.
+- Two authenticated test principals cannot cross namespace boundaries through
+  point reads, scans, cursors, diagnostics, or maintenance APIs.
+- Store and JSON engines have identical query and export results.
+- Secrets do not appear in snapshots, errors, logs, metric labels, or test
+  artifacts.
+- Default local Compass packaging and operation still require no PostgreSQL
+  client configuration or network.
+
+### Exit and rollback
+
+Remove or disable the remote adapter. Immutable snapshots remain exportable to
+JSON before teardown. Because the physical schema is adapter-private, no other
+backend must read PostgreSQL tables directly.
+
+## Phase 7: Add the DynamoDB adapter
+
+### Context and objective
+
+DynamoDB exercises the strictest partition-first deployment: exact partition
+key locality, paginated Query, conditional writes, capacity throttling, item
+limits, and eventually consistent secondary indexes. The adapter must use the
+base table's strong-read path for authoritative records and must not require
+global transactions.
+
+### Prerequisite inputs
+
+- Phase 0 limits fit DynamoDB key and item constraints with measured envelope
+  overhead.
+- Phase 2 digest sharding avoids sequential or repository-wide hot partitions.
+- Phase 6 has established remote cancellation, retry, and secret-handling
+  patterns.
+
+### Owned surfaces
+
+- new `compass-store-dynamodb` crate;
+- AWS endpoint, region, credential-source, retry, and capacity configuration at
+  the application boundary;
+- protocol mocks or a controlled local DynamoDB implementation; and
+- cloud cost/capacity qualification artifacts.
+
+### Work
+
+1. Add only the required AWS SDK features after dependency-size and build-time
+   review. Keep the adapter out of default local packages unless selected.
+2. Encode `PK = (namespace, partition)` and `SK = key` with checked limits and
+   golden test vectors.
+3. Implement strongly consistent GetItem and base-table Query, conditional
+   PutItem/UpdateItem/DeleteItem, digest verification, and opaque versions.
+4. Translate one Compass page across service 1 MiB pages without exceeding the
+   caller's byte/item/deadline budget. Protect and bind continuation cursors.
+5. Handle throttling with bounded exponential backoff and jitter. Surface
+   exhausted throttling separately from not found and conflict.
+6. Prohibit authoritative selector or manifest reads through an eventually
+   consistent global secondary index.
+7. Measure partition distribution for large and adversarial graph fixtures.
+   Revise the unreleased shard function if hot keys appear.
+8. Model ambiguous network outcomes: reread immutable content by digest; reread
+   selectors strongly and compare the intended snapshot before reporting the
+   final outcome.
+9. Add request, byte, consumed-capacity, retry, throttle, and projected-cost
+   reporting without high-cardinality identifiers.
+10. Test only against controlled local resources or mocks in normal CI. A
+    separately authorized qualification environment may run non-default cloud
+    tests with synthetic data.
+
+### Required tests
+
+- item encoding reaches every portable length boundary without crossing a
+  service key or item limit;
+- service pagination maps to Compass pages without gaps, duplicates, false
+  completion, or byte-budget overflow;
+- conditional failures map to `Conflict`, throttling to `Throttled`, and an
+  absent strong read to `NotFound`;
+- retries stop at the request deadline and never repeat a non-idempotent write;
+- a global secondary index cannot be selected for an authoritative read;
+- hot-partition fixtures exercise the documented shard calculation; and
+- ambiguous request outcomes resolve through strong selector or digest reads.
+
+### Acceptance criteria
+
+- The adapter passes the same conformance suite as memory, SQLite, redb, and
+  PostgreSQL, with service pagination and throttling explicitly exercised.
+- No value can exceed the portable limit after envelope and DynamoDB attribute
+  overhead.
+- Authoritative reads request strong consistency and tests fail if routed
+  through an eventual-only index.
+- Synthetic large graphs distribute content across the documented shard
+  envelope; the report includes the hottest partition and request count.
+- A throttled or partially paginated scan never returns a false complete page.
+- Credentials and endpoints remain optional and explicit; offline Compass
+  tests and structural extraction never contact AWS.
+
+### Exit and rollback
+
+Disable the adapter and export retained snapshots through the graph engine
+before deleting deployment tables under a separately authorized operational
+procedure. Never put table deletion into ordinary Compass rollback code.
+
+## Phase 8: Add multi-tenant operations, retention, and recovery
+
+### Context and objective
+
+Passing CRUD conformance is insufficient for a cloud service. This phase adds
+the backend-neutral control plane: authenticated namespace scoping, quotas,
+leases, garbage collection, backup validation, recovery, and safe
+observability. It runs over PostgreSQL and DynamoDB and remains usable for
+embedded maintenance.
+
+### Prerequisite inputs
+
+- At least one embedded and one remote adapter have passed conformance and
+  graph differential qualification.
+- Product/security owners have defined tenant, project, repository, and data-
+  retention identities.
+
+### Owned surfaces
+
+- a service/application crate chosen by architecture review, not
+  `compass-store` itself;
+- namespace catalog and authorization integration;
+- build/reader leases and active-selector orchestration;
+- portable root-based GC and restore validation; and
+- security, privacy, operations, and support documentation.
+
+### Work
+
+1. Derive namespace IDs server-side from authenticated tenant, repository,
+   data-plane, realm, and schema-major descriptors.
+2. Issue namespace-scoped handles after authorization. Remove raw namespace
+   selection from user-controlled graph/query requests.
+3. Enforce quotas for concurrent builds, stored bytes, snapshots, query
+   objects/bytes/frontier/time, response size, and backend capacity.
+4. Implement versioned build and reader leases with bounded renewal and
+   explicit expiry. A crashed worker cannot hold data forever.
+5. Implement mark-and-sweep GC rooted at active selectors, retained local
+   references, pins, history roots, and unexpired leases. Use checkpoints,
+   safety windows, shard budgets, and conditional deletion.
+6. Add namespace deletion as a separately authorized, auditable, resumable
+   workflow. It must enumerate explicit manifests/checkpoints rather than run
+   an unbounded synchronous request.
+7. Implement backend-specific coherent backup procedures and a common restore
+   validator that checks selector, manifest, all roots, digests, graph schema,
+   and completion evidence before activation.
+8. Exercise disaster recovery into a new store identity and namespace. Opaque
+   old version tokens and cursors must not be reused.
+9. Add low-cardinality metrics, structured audit records, correlation IDs,
+   redaction tests, and per-tenant cost attribution without source disclosure.
+10. Threat-model confused deputy, namespace collision, cursor replay, quota
+    bypass, malicious stored values, hot partitions, credential exposure, and
+    cross-tenant accelerators.
+
+### Required tests
+
+- authenticated tenant A cannot derive or use tenant B's scoped handle;
+- namespace display names and repository paths cannot alter physical identity
+  through encoding ambiguity;
+- quota exhaustion produces a typed limit result and no background overrun;
+- expired leases stop protecting data, while live readers remain protected;
+- GC preserves every reachable object and eventually removes only eligible
+  orphans under deterministic fault schedules;
+- interrupted GC and namespace deletion resume from bounded checkpoints;
+- restore refuses missing, corrupt, wrong-major, wrong-namespace, and
+  incomplete snapshots;
+- accelerator data never crosses snapshot or namespace boundaries;
+- audit and metrics contain no source, values, credentials, raw keys, or
+  sensitive paths; and
+- a compromised/untrusted stored envelope cannot force an oversized
+  allocation or unsafe path.
+
+### Acceptance criteria
+
+- Security review signs off on namespace authorization, credentials, remote
+  endpoint policy, cursor integrity, quotas, redaction, and deletion.
+- `SECURITY.md` and security/privacy design docs describe all new trust,
+  credential, network, storage, and disclosure boundaries.
+- GC fault tests prove no reachable-object deletion across every supported
+  adapter.
+- A documented backup/restore drill succeeds for SQLite, PostgreSQL, and
+  DynamoDB qualification environments and produces equal canonical JSON.
+- Service load tests demonstrate bounded resources during tenant concurrency,
+  throttling, worker crashes, and large responses.
+- Local Compass remains usable without enabling or configuring any service
+  surface.
+
+### Exit and rollback
+
+Stop accepting new remote publications, retain selectors and leases, export or
+back up reachable snapshots, then disable the service control plane. Data
+deletion requires its explicit audited workflow and is never implied by code
+rollback.
+
+## Phase 9: Qualify, document, and release the storage contract
+
+### Context and objective
+
+This phase converts implemented behavior into a supported product contract.
+Until it completes, store formats may still hard-cut and performance remains a
+development observation. Release requires compatibility, migration, security,
+performance, packaging, and operational evidence.
+
+### Prerequisite inputs
+
+- All adapters intended for the release have passed conformance.
+- Local store-backed queries have passed full JSON differential testing.
+- Cloud operations are included only if Phase 8 is complete for that surface.
+
+### Owned surfaces
+
+- `COMPATIBILITY.md`, `MIGRATION.md`, `CHANGELOG.md`, `PERFORMANCE.md`,
+  `SECURITY.md`, `SUPPORT.md`, command/configuration/output references, and
+  operations guides;
+- packaging, install, upgrade, and downgrade tests; and
+- release qualification artifacts.
+
+### Work
+
+1. Declare exactly which store envelope, graph-snapshot layout, adapter
+   physical formats, and configuration surfaces are public and which remain
+   rebuildable implementation details.
+2. Decide the first supported upgrade window. Provide migration or explicit
+   rebuild tooling for formats now declared durable.
+3. Document backend selection, locations/endpoints, credentials, TLS,
+   durability, backup, restore, GC, quotas, and recovery.
+4. Document that `graph.json` remains supported for direct input, publication,
+   interchange, inspection, recovery, and deterministic export.
+5. Run clean/no-change/small-change builds and complete cold-query benchmarks
+   at documented graph sizes. Include peak memory, bytes, request counts,
+   database size, write amplification, and GC.
+6. Run all cross-engine differential, adapter conformance, crash, corruption,
+   concurrency, namespace isolation, and restore suites on the release commit.
+7. Validate packaging does not accidentally include cloud SDKs, credentials,
+   or local database files in unrelated distributions.
+8. Add release-visible changes to `CHANGELOG.md` and user actions to
+   `MIGRATION.md`.
+
+### Release acceptance criteria
+
+- Canonical JSON exported from every released engine is byte-identical for the
+  release qualification corpus.
+- All public query and CompassQL outputs are equal across JSON and released
+  store engines.
+- `PERFORMANCE.md` contains reproducible evidence for each performance claim;
+  regressions outside agreed budgets block the default cutover.
+- `COMPATIBILITY.md` lists supported store/snapshot majors, backend/platform
+  support, hard-cut boundaries, and the permanent JSON engine.
+- Backup and restore procedures have been executed, not only reviewed.
+- The repository native baseline and every applicable surface gate pass on the
+  release commit.
+- No generated graph, `.compass/` state, database, credentials, private source,
+  or machine-specific path is committed.
+
+### Release gates
+
+In addition to targeted crate tests, run:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo test -p compass-cli --test compass_product --locked
+sh scripts/check_product_boundary.sh
+
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo test -p compass-cypher --test tck --locked
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo test -p compass-query --test opencypher_tck --locked
+python3 scripts/check_compassql_support.py
+
+./scripts/qualify_code_graph_v1.sh --fixtures-only
+```
+
+Run repository qualification on external repositories only under
+`/Volumes/Workspace/Github` and treat them as read-only, following
+`AGENTS.md`.
+
+### Exit and rollback
+
+Before public format declaration, rollback may rebuild store state and route
+local queries to JSON. After declaration, use the documented migration and
+support policy; do not silently invalidate durable cloud or user data. Query
+cutover can still return to the co-published JSON engine without changing
+public graph meaning.
+
+## Work-package checklist
+
+Every pull request implementing part of a phase should include this information
+in its description:
+
+```text
+Phase and bounded work package:
+Owning crate(s):
+Contract/version affected:
+Failure modes added or changed:
+Limits enforced:
+JSON equivalence evidence:
+Adapter conformance evidence:
+Performance evidence or “no claim”:
+Compatibility decision: hard cut | rebuildable | public-compatible
+Security/network/credential impact:
+Targeted checks run:
+Baseline/gates run or reason omitted:
+Rollback path:
+```
+
+Do not combine a store encoding change, a query semantic change, and a public
+CLI change in one work package unless the phase cannot be made coherent any
+other way.
+
+## Final system acceptance
+
+The program is complete only when a reviewer can demonstrate this sequence
+without inspecting backend internals:
+
+1. build one graph and publish a coherent JSON plus store generation;
+2. query both engines and obtain equal ordered outputs;
+3. interrupt an update at each publication boundary and retain the old graph;
+4. complete an update and keep an already-open reader on its old snapshot;
+5. reopen every embedded backend and recover every remote backend from a
+   coherent backup;
+6. race two publishers and observe one active-selector winner;
+7. exhaust scan, query, retry, throttle, and quota budgets without false empty
+   results or background overruns;
+8. attempt cross-namespace access and receive denial without information
+   disclosure;
+9. remove disposable accelerators and obtain the same results; and
+10. export deterministic `compass.graph/1` JSON from every store backend.
+
+## Related pages
+
+- [Compass store and graph-engine design](../design/compass-store.md)
+- [Storage and history](../design/storage-and-history.md)
+- [Extraction pipeline](extraction-pipeline.md)
+- [Query engine](query-engine.md)
+- [Workspace tour](workspace-tour.md)
+- [Compatibility policy](../../COMPATIBILITY.md)
+- [Performance qualification](../../PERFORMANCE.md)
+
+**Next step:** begin Phase 0 with an API/encoding review and land the memory
+reference implementation before adding any database dependency.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,6 +152,23 @@ The items below have committed design or implementation-plan evidence. They are
 not listed in the current public command surface unless explicitly moved to
 Available now.
 
+### Backend-neutral graph storage
+
+Goal: add a `compass-store` contract that improves incremental build and
+bounded query performance locally while supporting a future cloud deployment.
+The planned boundary is namespace first, then partition and ordered key-value
+operations, with SQLite, redb, PostgreSQL, and DynamoDB adapters required to
+pass the same conformance suite.
+
+Store-backed immutable graph snapshots will coexist with a permanent,
+compatible `graph.json` engine. The plan does not deprecate JSON or make a
+remote database necessary for native local extraction and queries.
+
+Evidence:
+
+- [Compass store and graph-engine design](design/compass-store.md)
+- [Executable Compass store implementation plan](implementation/compass-store-plan.md)
+
 ### Compass Guard: architecture governance
 
 Goal: build a production CI architecture-governance product on CompassQL and


### PR DESCRIPTION
## Summary

- define the planned `compass-store` namespace/partition/key contract
- specify immutable graph snapshots, atomic publication, query boundaries, and backend mappings for SQLite, redb, PostgreSQL, and DynamoDB
- preserve `graph.json` as a permanent compatible engine with explicit JSON, store, and dual materialization profiles
- add a ten-phase implementation plan with self-contained context, tests, acceptance criteria, rollback paths, cloud tenancy, recovery, and release qualification
- link the design from the documentation index, storage design, and roadmap

## Motivation

The current graph artifact and query cache model requires complete JSON materialization and whole-graph loading on important paths. This design establishes a portable storage boundary that can improve incremental builds and bounded queries locally while remaining suitable for a future cloud Compass deployment.

The document is explicitly marked **Planned**. It does not claim that a store-backed engine has shipped or weaken existing public graph, CLI, CompassQL, MCP, or JSON contracts.

## Impact

Documentation only. No runtime behavior, dependency, schema, or generated artifact changes are included.

## Validation

- `git diff --check`
- local Markdown link validation for all changed pages
- trailing-whitespace validation for the new documents
- reviewed the branch diff to confirm it contains only the five intended documentation files

Rust tests were not run because this pull request changes documentation only.
