### PR TITLE
Improve assistant setup experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Make `compass install` setup more seamless: recognize host directories and
+  instruction files during agent detection, show and preflight every dry-run
+  destination, provide host-specific activation actions, reject ineffective
+  strict-mode or unsupported scope combinations, bootstrap missing graphs on
+  first broad use, and replace the Codex no-op hook with a bounded graph-first
+  search guard.
 - Make Markdown extraction source-driven and structurally parsed with pinned
   block and inline grammars. Publish bounded frontmatter metadata, headings,
   nested blocks, tables, code fences, reference definitions, exact link sites,

--- a/README.md
+++ b/README.md
@@ -273,7 +273,9 @@ compass install --user --format json
 
 The skill teaches assistants to use an existing Compass graph as the first
 navigation layer, request a focused subgraph, and open only the source files
-needed to verify an answer. Installation does not build a graph.
+needed to verify an answer. Installation does not build a graph; on the first
+repository-wide architecture, dependency, history, or impact question, the
+assistant can run the local deterministic build and continue automatically.
 
 ```text
 architecture question

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,5 +43,8 @@ Compass parses untrusted project content and graph files. Its default structural
 - Neo4j and FalkorDB pushes connect to external databases
 - URL acquisition and Google Workspace extraction access configured external services
 - PostgreSQL extraction connects to the supplied database server
+- Assistant setup can register local command hooks. Review generated hook files
+  before trusting them in the host, and reinstall after moving the Compass
+  executable so the managed command path remains accurate.
 
 Include the selected options and endpoint type in reports about these features. Never include live credentials.

--- a/crates/compass-cli/assets/compass-integrations/agents-md.md
+++ b/crates/compass-cli/assets/compass-integrations/agents-md.md
@@ -1,8 +1,10 @@
 ## compass
 
 When `compass-out/graph.json` exists, use the Compass knowledge graph as the
-first navigation layer. If it is absent, ask before running `compass update .`
-unless the current task already requires building the graph.
+first navigation layer. If it is absent and the task needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue. Skip the build for a narrow task that already identifies the
+files to edit or when the user asked not to create generated files.
 
 Rules:
 
@@ -12,7 +14,7 @@ Rules:
 - Use `compass affected "<symbol>"` for change-review scope
 - Read `compass-out/GRAPH_REPORT.md` for broad architecture
 - Navigate `compass-out/wiki/index.md` when the wiki exists
-- Run `compass update .` after code changes
+- Run `compass update .` after code changes unless the user prohibited generated files
 - Verify important graph conclusions in the cited source
 - Treat missing paths and inferred edges as uncertain evidence, not proof
 - Keep explicit `--graph`, `--at`, provider, and output selections unchanged

--- a/crates/compass-cli/assets/compass-integrations/antigravity-rules.md
+++ b/crates/compass-cli/assets/compass-integrations/antigravity-rules.md
@@ -1,8 +1,10 @@
 ## compass
 
 When `compass-out/graph.json` exists, use the Compass knowledge graph as the
-first navigation layer. If it is absent, ask before running `compass update .`
-unless the current task already requires building the graph.
+first navigation layer. If it is absent and the task needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue. Skip the build for a narrow task that already identifies the
+files to edit or when the user asked not to create generated files.
 
 Rules:
 
@@ -12,7 +14,7 @@ Rules:
 - Use `compass affected "<symbol>"` for change-review scope
 - Read `compass-out/GRAPH_REPORT.md` for broad architecture
 - Navigate `compass-out/wiki/index.md` when the wiki exists
-- Run `compass update .` after code changes
+- Run `compass update .` after code changes unless the user prohibited generated files
 - Verify important graph conclusions in the cited source
 - Treat missing paths and inferred edges as uncertain evidence, not proof
 - Keep explicit `--graph`, `--at`, provider, and output selections unchanged

--- a/crates/compass-cli/assets/compass-integrations/claude-md.md
+++ b/crates/compass-cli/assets/compass-integrations/claude-md.md
@@ -1,8 +1,10 @@
 ## compass
 
 When `compass-out/graph.json` exists, use the Compass knowledge graph as the
-first navigation layer. If it is absent, ask before running `compass update .`
-unless the current task already requires building the graph.
+first navigation layer. If it is absent and the task needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue. Skip the build for a narrow task that already identifies the
+files to edit or when the user asked not to create generated files.
 
 Rules:
 
@@ -12,7 +14,7 @@ Rules:
 - Use `compass affected "<symbol>"` for change-review scope
 - Read `compass-out/GRAPH_REPORT.md` for broad architecture
 - Navigate `compass-out/wiki/index.md` when the wiki exists
-- Run `compass update .` after code changes
+- Run `compass update .` after code changes unless the user prohibited generated files
 - Verify important graph conclusions in the cited source
 - Treat missing paths and inferred edges as uncertain evidence, not proof
 - Keep explicit `--graph`, `--at`, provider, and output selections unchanged

--- a/crates/compass-cli/assets/compass-integrations/gemini-md.md
+++ b/crates/compass-cli/assets/compass-integrations/gemini-md.md
@@ -1,8 +1,10 @@
 ## compass
 
 When `compass-out/graph.json` exists, use the Compass knowledge graph as the
-first navigation layer. If it is absent, ask before running `compass update .`
-unless the current task already requires building the graph.
+first navigation layer. If it is absent and the task needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue. Skip the build for a narrow task that already identifies the
+files to edit or when the user asked not to create generated files.
 
 Rules:
 
@@ -12,7 +14,7 @@ Rules:
 - Use `compass affected "<symbol>"` for change-review scope
 - Read `compass-out/GRAPH_REPORT.md` for broad architecture
 - Navigate `compass-out/wiki/index.md` when the wiki exists
-- Run `compass update .` after code changes
+- Run `compass update .` after code changes unless the user prohibited generated files
 - Verify important graph conclusions in the cited source
 - Treat missing paths and inferred edges as uncertain evidence, not proof
 - Keep explicit `--graph`, `--at`, provider, and output selections unchanged

--- a/crates/compass-cli/assets/compass-integrations/kiro-steering.md
+++ b/crates/compass-cli/assets/compass-integrations/kiro-steering.md
@@ -1,8 +1,10 @@
 ## compass
 
 When `compass-out/graph.json` exists, use the Compass knowledge graph as the
-first navigation layer. If it is absent, ask before running `compass update .`
-unless the current task already requires building the graph.
+first navigation layer. If it is absent and the task needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue. Skip the build for a narrow task that already identifies the
+files to edit or when the user asked not to create generated files.
 
 Rules:
 
@@ -12,7 +14,7 @@ Rules:
 - Use `compass affected "<symbol>"` for change-review scope
 - Read `compass-out/GRAPH_REPORT.md` for broad architecture
 - Navigate `compass-out/wiki/index.md` when the wiki exists
-- Run `compass update .` after code changes
+- Run `compass update .` after code changes unless the user prohibited generated files
 - Verify important graph conclusions in the cited source
 - Treat missing paths and inferred edges as uncertain evidence, not proof
 - Keep explicit `--graph`, `--at`, provider, and output selections unchanged

--- a/crates/compass-cli/assets/compass-skill/SKILL.md
+++ b/crates/compass-cli/assets/compass-skill/SKILL.md
@@ -49,6 +49,16 @@ or global graph must preserve repository origin. If a command fails to load the
 selected graph, stop and diagnose that selection instead of answering from a
 different graph.
 
+When the current project graph is absent and the request needs repository-wide
+architecture, dependency, history, or impact evidence, run `compass update .`
+once and continue with the query workflow. Do not interrupt the user for routine
+confirmation: this is a local deterministic build into `compass-out/`. Skip the
+build for a narrow task that already identifies the files to edit, when the user
+asked not to create generated files, or when repository guidance requires a
+different build command. After a successful first build, run the focused query;
+the new graph does not need a freshness check. Read `GRAPH_REPORT.md` as well
+when the request needs repository-wide architecture context.
+
 ## Fast path: use an existing graph
 
 When `compass-out/graph.json` exists and the user asks a natural-language
@@ -100,11 +110,11 @@ access. Semantic providers, URL ingestion, repository cloning, database pushes,
 and HTTP serving may use the network; do not start them unless the request
 requires them.
 
-After modifying project code, run `compass update .` unless the repository gives
-a more specific Compass instruction. If the refresh fails, report the failure
-and do not describe the graph as current. Confirm the expected graph and report
-exist after a successful build; an old file surviving a failed command is not a
-successful refresh.
+After modifying project code, run `compass update .` unless the user asked not
+to create generated files or the repository gives a more specific Compass
+instruction. If the refresh fails, report the failure and do not describe the
+graph as current. Confirm the expected graph and report exist after a successful
+build; an old file surviving a failed command is not a successful refresh.
 
 Community naming is a separate semantic operation. Use `compass label` only when
 the user wants human-readable community labels and accepts provider use. Use

--- a/crates/compass-cli/assets/compass-skill/references/hooks.md
+++ b/crates/compass-cli/assets/compass-skill/references/hooks.md
@@ -60,8 +60,11 @@ changes.
 `--strict` is a Claude Code project PreToolUse behavior. It blocks the first raw
 read in a session until a Compass query has oriented the agent; it is not a
 global security sandbox and does not apply uniformly across platforms.
-`hook-check` and `hook-guard` are installed adapter commands. Do not run or
-script them directly unless diagnosing generated configuration.
+Codex project setup installs a bounded `hook-guard search` PreToolUse command;
+review and trust its exact definition through Codex `/hooks` before relying on
+it. `hook-check` remains a compatibility probe for older Compass-generated
+configuration. Do not run or script either command directly unless diagnosing
+generated configuration.
 
 After project installation, report which files were created or modified and
 which should be added to version control. Uninstall must leave unrelated files,

--- a/crates/compass-cli/src/install_commands.rs
+++ b/crates/compass-cli/src/install_commands.rs
@@ -179,14 +179,6 @@ fn command_install_compass(args: &[String]) -> Outcome {
         Ok(scope) => scope,
         Err(error) => return Outcome::failure(error),
     };
-    let _scope_lock = if request.dry_run {
-        None
-    } else {
-        match InstallLock::acquire(scope.root()) {
-            Ok(lock) => Some(lock),
-            Err(error) => return Outcome::failure(error),
-        }
-    };
     let detected = if request.platforms.is_empty() && !request.all {
         detect_agents(&registry, &scope)
     } else {
@@ -207,6 +199,25 @@ fn command_install_compass(args: &[String]) -> Outcome {
     } else {
         match registry.canonicalize(&request.platforms) {
             Ok(values) => values,
+            Err(error) => return Outcome::failure(error),
+        }
+    };
+    if request.strict && !scope.is_project() {
+        return Outcome::failure(
+            "error: --strict requires project scope because it installs a project hook".to_owned(),
+        );
+    }
+    if request.strict && !selected.iter().any(|platform| platform == "claude") {
+        return Outcome::failure(
+            "error: --strict currently requires the Claude platform; add `--platform claude`"
+                .to_owned(),
+        );
+    }
+    let _scope_lock = if request.dry_run {
+        None
+    } else {
+        match InstallLock::acquire(scope.root()) {
+            Ok(lock) => Some(lock),
             Err(error) => return Outcome::failure(error),
         }
     };
@@ -259,13 +270,34 @@ fn command_install_compass(args: &[String]) -> Outcome {
     let output = scope.root().join("compass-out");
     let graph_exists = compass_files::BuildGuard::resolve_artifact(&output, "graph.json")
         .is_ok_and(|path| path.is_file());
-    let mut next_actions = Vec::new();
-    if !graph_exists && scope.is_project() {
-        next_actions
-            .push("Run `compass update .` to build the project knowledge graph.".to_owned());
-    }
-    next_actions
-        .push("Restart or reload active coding-agent sessions to discover the skill.".to_owned());
+    let ready_consumers = results
+        .iter()
+        .filter(|result| {
+            matches!(
+                result.status,
+                InstallStatus::Installed | InstallStatus::Updated | InstallStatus::Current
+            )
+        })
+        .flat_map(|result| result.consumers.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let successful = !ready_consumers.is_empty();
+    let incomplete = results.iter().any(|result| {
+        matches!(
+            result.status,
+            InstallStatus::Skipped | InstallStatus::Failed
+        )
+    });
+    let has_failures = results
+        .iter()
+        .any(|result| result.status == InstallStatus::Failed);
+    let next_actions = install_next_actions(
+        &scope,
+        &ready_consumers,
+        graph_exists,
+        request.dry_run,
+        incomplete,
+        has_failures,
+    );
     let report = InstallReport {
         schema: 1,
         scope: scope.kind(),
@@ -280,18 +312,6 @@ fn command_install_compass(args: &[String]) -> Outcome {
         Ok(output) => output,
         Err(error) => return Outcome::failure(error),
     };
-    let successful = report.results.iter().any(|result| {
-        matches!(
-            result.status,
-            InstallStatus::Installed | InstallStatus::Updated | InstallStatus::Current
-        )
-    });
-    let incomplete = report.results.iter().any(|result| {
-        matches!(
-            result.status,
-            InstallStatus::Skipped | InstallStatus::Failed
-        )
-    });
     let failed = (!request.dry_run && !successful) || (request.require_all && incomplete);
     Outcome {
         code: u8::from(failed),
@@ -301,6 +321,59 @@ fn command_install_compass(args: &[String]) -> Outcome {
         stderr_trailing_newline: true,
         html_output: None,
     }
+}
+
+fn install_next_actions(
+    scope: &InstallScope,
+    ready_consumers: &BTreeSet<String>,
+    graph_exists: bool,
+    dry_run: bool,
+    incomplete: bool,
+    has_failures: bool,
+) -> Vec<String> {
+    if dry_run {
+        if has_failures {
+            return vec![
+                "Resolve the reported preflight failures, then rerun `compass install --dry-run`."
+                    .to_owned(),
+            ];
+        }
+        return vec![
+            "Review the plan, then rerun without `--dry-run` to install these targets.".to_owned(),
+        ];
+    }
+    if ready_consumers.is_empty() {
+        return vec![
+            "Resolve the reported installation failures, then rerun `compass install`.".to_owned(),
+        ];
+    }
+    let mut actions = Vec::new();
+    if incomplete {
+        actions.push(
+            "Review skipped or failed targets above; configured targets are ready to activate."
+                .to_owned(),
+        );
+    }
+    if !graph_exists && scope.is_project() {
+        actions.push(
+            "Run `compass update .` now, or ask the configured assistant an architecture question to build the project graph on first use."
+                .to_owned(),
+        );
+    }
+    if scope.is_project() && ready_consumers.contains("codex") {
+        actions.push(
+            "In Codex, open `/hooks` and trust the Compass project hook before relying on graph-first search guidance."
+                .to_owned(),
+        );
+    }
+    if ready_consumers.contains("gemini") {
+        actions.push("In Gemini CLI, run `/skills reload` to activate Compass now.".to_owned());
+    }
+    actions.push(
+        "Start a new coding-agent session, or use its skill reload command, then ask a codebase question."
+            .to_owned(),
+    );
+    actions
 }
 
 fn migrate_legacy_codex_skill(scope: &InstallScope, dry_run: bool) -> Option<TargetResult> {
@@ -372,12 +445,28 @@ fn execute_skill_target(
         consumers.iter().next().cloned().unwrap_or_default()
     };
     if request.dry_run {
+        let paths = planned_target_paths(scope, Some(&destination), &consumers);
+        let preflight = validate_skill_destination(&destination, scope.root())
+            .and_then(|()| require_owned_or_absent(&destination))
+            .and_then(|()| {
+                consumers
+                    .iter()
+                    .try_for_each(|consumer| preflight_agent_adapter(scope, consumer))
+            });
         return TargetResult {
             id,
             consumers,
-            status: InstallStatus::Skipped,
-            paths: vec![destination],
-            reason: Some("dry run: no files were changed".to_owned()),
+            status: if preflight.is_ok() {
+                InstallStatus::Skipped
+            } else {
+                InstallStatus::Failed
+            },
+            paths,
+            reason: Some(
+                preflight.err().unwrap_or_else(|| {
+                    "dry run: target is ready; no files were changed".to_owned()
+                }),
+            ),
             rollback: None,
         };
     }
@@ -715,6 +804,20 @@ fn adapter_paths_for(scope: &InstallScope, consumers: &BTreeSet<String>) -> Vec<
     paths
 }
 
+fn planned_target_paths(
+    scope: &InstallScope,
+    skill_destination: Option<&Path>,
+    consumers: &BTreeSet<String>,
+) -> Vec<PathBuf> {
+    skill_destination
+        .into_iter()
+        .map(Path::to_path_buf)
+        .chain(adapter_paths_for(scope, consumers))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
 fn uninstall_paths_for(scope: &InstallScope, consumers: &BTreeSet<String>) -> Vec<PathBuf> {
     let mut paths = adapter_paths_for(scope, consumers);
     if scope.is_project() {
@@ -879,13 +982,40 @@ fn execute_adapter_target(
     consumer: &str,
 ) -> TargetResult {
     let consumers = BTreeSet::from([consumer.to_owned()]);
-    if request.dry_run {
+    let planned_paths = planned_target_paths(scope, None, &consumers);
+    if planned_paths.is_empty() {
         return TargetResult {
             id: consumer.to_owned(),
             consumers,
-            status: InstallStatus::Skipped,
+            status: InstallStatus::Failed,
             paths: Vec::new(),
-            reason: Some("dry run: no files were changed".to_owned()),
+            reason: Some(format!(
+                "error: {consumer} has no {}-scoped Compass installation target",
+                if scope.is_project() {
+                    "project"
+                } else {
+                    "user"
+                }
+            )),
+            rollback: None,
+        };
+    }
+    if request.dry_run {
+        let preflight = preflight_agent_adapter(scope, consumer);
+        return TargetResult {
+            id: consumer.to_owned(),
+            consumers,
+            status: if preflight.is_ok() {
+                InstallStatus::Skipped
+            } else {
+                InstallStatus::Failed
+            },
+            paths: planned_paths,
+            reason: Some(
+                preflight.err().unwrap_or_else(|| {
+                    "dry run: target is ready; no files were changed".to_owned()
+                }),
+            ),
             rollback: None,
         };
     }
@@ -2508,11 +2638,11 @@ fn install_codex_hook(root: &Path, lines: &mut Vec<String>) -> Result<(), String
         .filter(|value| !is_compass_hook(value))
         .collect::<Vec<_>>();
     let executable = compass_executable();
-    values.push(json!({"matcher":"Bash","hooks":[{"type":"command","command":format!("{executable} hook-check")}]}));
+    values.push(json!({"matcher":"Bash","hooks":[{"type":"command","command":format!("{executable} hook-guard search")}]}));
     hooks.insert("PreToolUse".to_owned(), Value::Array(values));
     write_json_object(path, &document)?;
     lines.push(format!(
-        "  .codex/hooks.json  ->  PreToolUse hook registered ({executable} hook-check)"
+        "  .codex/hooks.json  ->  PreToolUse graph-first search guard registered ({executable} hook-guard search)"
     ));
     Ok(())
 }
@@ -3797,6 +3927,7 @@ fn is_compass_hook(value: &Value) -> bool {
     matches!(
         (matcher, managed_command_suffix(command).as_deref()),
         ("Bash", Some("hook-check"))
+            | ("Bash", Some("hook-guard search"))
             | ("Bash|Grep", Some("hook-guard search"))
             | ("Read|Glob", Some("hook-guard read"))
             | ("Read|Glob", Some("hook-guard read --strict"))

--- a/crates/compass-cli/src/install_commands/detect.rs
+++ b/crates/compass-cli/src/install_commands/detect.rs
@@ -21,7 +21,7 @@ pub(super) fn detect_agents(
             }
         }
         for relative in agent.config_paths {
-            if valid_config_file(&scope.root().join(relative)) {
+            if valid_detection_path(&scope.root().join(relative)) {
                 evidence.push(format!("config:{relative}"));
             }
         }
@@ -42,14 +42,19 @@ pub(super) fn detect_agents(
     detected
 }
 
-fn valid_config_file(path: &std::path::Path) -> bool {
-    let Ok(content) = std::fs::read_to_string(path) else {
+fn valid_detection_path(path: &std::path::Path) -> bool {
+    if path.is_dir() {
+        return true;
+    }
+    if !path.is_file() {
         return false;
-    };
+    }
     match path.extension().and_then(|extension| extension.to_str()) {
-        Some("json") => serde_json::from_str::<serde_json::Value>(&content).is_ok(),
-        Some("toml") => toml::from_str::<toml::Value>(&content).is_ok(),
-        _ => false,
+        Some("json") => std::fs::read_to_string(path)
+            .is_ok_and(|content| serde_json::from_str::<serde_json::Value>(&content).is_ok()),
+        Some("toml") => std::fs::read_to_string(path)
+            .is_ok_and(|content| toml::from_str::<toml::Value>(&content).is_ok()),
+        _ => true,
     }
 }
 
@@ -71,4 +76,35 @@ fn executable_on_path(name: &str) -> bool {
             .iter()
             .any(|extension| directory.join(format!("{name}{extension}")).is_file())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_detection_path;
+
+    #[test]
+    fn detection_accepts_host_directories_and_valid_configuration_files()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let directory = tempfile::tempdir()?;
+        let host = directory.path().join(".kiro");
+        std::fs::create_dir(&host)?;
+        assert!(valid_detection_path(&host));
+
+        let markdown = directory.path().join("copilot-instructions.md");
+        std::fs::write(&markdown, "# Copilot\n")?;
+        assert!(valid_detection_path(&markdown));
+
+        let json = directory.path().join("settings.json");
+        std::fs::write(&json, "{}")?;
+        assert!(valid_detection_path(&json));
+        std::fs::write(&json, "{invalid")?;
+        assert!(!valid_detection_path(&json));
+
+        let toml = directory.path().join("config.toml");
+        std::fs::write(&toml, "model = \"test\"\n")?;
+        assert!(valid_detection_path(&toml));
+        std::fs::write(&toml, "model = [")?;
+        assert!(!valid_detection_path(&toml));
+        Ok(())
+    }
 }

--- a/crates/compass-cli/src/install_commands/registry.rs
+++ b/crates/compass-cli/src/install_commands/registry.rs
@@ -216,7 +216,7 @@ fn descriptors() -> Vec<AgentDescriptor> {
         AgentDescriptor::shared(
             "copilot",
             &["vscode"],
-            &["copilot", "code"],
+            &["copilot"],
             &[".github/copilot-instructions.md"],
             "https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills",
         ),

--- a/crates/compass-cli/tests/install_cli.rs
+++ b/crates/compass-cli/tests/install_cli.rs
@@ -56,7 +56,6 @@ const GLOBAL_PLATFORMS: &[&str] = &[
     "agents",
     "devin",
     "gemini",
-    "cursor",
 ];
 
 #[test]
@@ -76,6 +75,7 @@ fn project_codex_install_creates_native_compass_skill() -> Result<(), Box<dyn Er
     assert!(body.contains("references/command-reference.md"));
     assert!(body.contains("references/labeling.md"));
     assert!(body.contains("references/security-and-boundaries.md"));
+    assert!(body.contains("run `compass update .`\nonce and continue"));
     assert_native(&body);
     assert!(skill.with_file_name(".compass_version").is_file());
     assert!(
@@ -91,6 +91,20 @@ fn project_codex_install_creates_native_compass_skill() -> Result<(), Box<dyn Er
             .len(),
         15
     );
+    let hooks: serde_json::Value =
+        serde_json::from_slice(&fs::read(fixture.project.join(".codex/hooks.json"))?)?;
+    let hooks = hooks["hooks"]["PreToolUse"]
+        .as_array()
+        .ok_or("Codex PreToolUse hooks")?;
+    assert!(hooks.iter().any(|hook| {
+        hook["matcher"] == "Bash"
+            && hook["hooks"][0]["command"]
+                .as_str()
+                .is_some_and(|command| command.ends_with(" hook-guard search"))
+    }));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("hook-check"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("/hooks"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("new coding-agent session"));
     Ok(())
 }
 
@@ -379,6 +393,12 @@ fn plain_install_detects_agents_and_deduplicates_the_shared_skill() -> Result<()
     )?;
     fs::create_dir(fixture.project.join(".gemini"))?;
     fs::write(fixture.project.join(".gemini/settings.json"), "{}")?;
+    fs::create_dir(fixture.project.join(".kiro"))?;
+    fs::create_dir_all(fixture.project.join(".github"))?;
+    fs::write(
+        fixture.project.join(".github/copilot-instructions.md"),
+        "# Existing Copilot instructions\n",
+    )?;
 
     let output = fixture.run(&["install", "--format", "json"])?;
     assert_success("automatic multi-agent install", &output);
@@ -386,6 +406,8 @@ fn plain_install_detects_agents_and_deduplicates_the_shared_skill() -> Result<()
     assert_eq!(report["scope"], "project");
     assert!(report["detected"]["codex"].is_array());
     assert!(report["detected"]["gemini"].is_array());
+    assert!(report["detected"]["kiro"].is_array());
+    assert!(report["detected"]["copilot"].is_array());
 
     let skill = fixture.project.join(".agents/skills/compass/SKILL.md");
     assert!(skill.is_file());
@@ -394,12 +416,18 @@ fn plain_install_detects_agents_and_deduplicates_the_shared_skill() -> Result<()
     let manifest: serde_json::Value =
         serde_json::from_slice(&fs::read(skill.with_file_name(".compass-install.json"))?)?;
     let consumers = manifest["consumers"].as_array().ok_or("consumers")?;
-    for expected in ["agents", "codex", "gemini"] {
+    for expected in ["agents", "codex", "copilot", "gemini"] {
         assert!(
             consumers.iter().any(|value| value == expected),
             "missing consumer {expected}"
         );
     }
+    assert!(
+        fixture
+            .project
+            .join(".kiro/skills/compass/SKILL.md")
+            .is_file()
+    );
     Ok(())
 }
 
@@ -418,6 +446,34 @@ fn repeated_platforms_share_one_package_and_dry_run_is_read_only() -> Result<(),
     ])?;
     assert_success("dry run", &dry_run);
     assert!(!tree_contains_compass_skill(&fixture.project)?);
+    let report: serde_json::Value = serde_json::from_slice(&dry_run.stdout)?;
+    assert_eq!(
+        report["next_actions"],
+        serde_json::json!([
+            "Review the plan, then rerun without `--dry-run` to install these targets."
+        ])
+    );
+    let planned = report["results"]
+        .as_array()
+        .ok_or("dry-run results")?
+        .iter()
+        .flat_map(|result| result["paths"].as_array().into_iter().flatten())
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    for expected in [
+        ".agents/skills/compass/SKILL.md",
+        ".codex/hooks.json",
+        "AGENTS.md",
+        ".claude/skills/compass/SKILL.md",
+        ".claude/CLAUDE.md",
+        ".claude/settings.json",
+        "CLAUDE.md",
+    ] {
+        assert!(
+            planned.iter().any(|path| path.ends_with(expected)),
+            "dry run omitted {expected}: {planned:?}"
+        );
+    }
 
     let output = fixture.run(&[
         "install",
@@ -440,6 +496,39 @@ fn repeated_platforms_share_one_package_and_dry_run_is_read_only() -> Result<(),
             .count(),
         1
     );
+    let next_actions = report["next_actions"].as_array().ok_or("next actions")?;
+    assert!(next_actions.iter().any(|action| {
+        action
+            .as_str()
+            .is_some_and(|action| action.contains("/hooks"))
+    }));
+    assert!(next_actions.iter().any(|action| {
+        action
+            .as_str()
+            .is_some_and(|action| action.contains("/skills reload"))
+    }));
+    assert!(next_actions.iter().any(|action| {
+        action
+            .as_str()
+            .is_some_and(|action| action.contains("new coding-agent session"))
+    }));
+    Ok(())
+}
+
+#[test]
+fn install_rejects_unsupported_scope_and_platform_combinations() -> Result<(), Box<dyn Error>> {
+    let fixture = InstallFixture::new()?;
+    let unsupported = fixture.run(&["install", "--project", "--platform", "codex", "--strict"])?;
+    assert!(!unsupported.status.success());
+    assert!(String::from_utf8_lossy(&unsupported.stderr).contains("requires the Claude platform"));
+
+    let user_scope = fixture.run(&["install", "--user", "--platform", "claude", "--strict"])?;
+    assert!(!user_scope.status.success());
+    assert!(String::from_utf8_lossy(&user_scope.stderr).contains("requires project scope"));
+
+    let cursor_user = fixture.run(&["install", "--user", "--platform", "cursor"])?;
+    assert!(!cursor_user.status.success());
+    assert!(String::from_utf8_lossy(&cursor_user.stdout).contains("no user-scoped"));
     Ok(())
 }
 

--- a/docs/guides/assistant-setup.md
+++ b/docs/guides/assistant-setup.md
@@ -12,7 +12,7 @@ verification, and safe removal.
 >
 > **Prerequisites:** the `compass` executable installed.
 >
-> **Completion time:** 5–10 minutes.
+> **Completion time:** about 2 minutes, plus the first graph build.
 
 ## What the integration does
 
@@ -35,7 +35,10 @@ open only the source files needed to verify the answer
 It does not give Compass permission to run arbitrary external actions. It
 provides task instructions and, where the platform supports them, helper
 integration files. Installation does not build `compass-out/`; the report
-recommends `compass update .` when a project graph is absent.
+offers the exact build and activation actions when a project graph is absent.
+For a repository-wide architecture, dependency, history, or impact question,
+the installed guidance lets the assistant run the local deterministic first
+build and continue without another setup exchange.
 
 ## Recommended setup
 
@@ -47,6 +50,17 @@ Inside Git, Compass resolves the repository root, detects supported agents, and
 always includes the portable Agent Skills target. Outside Git, it uses user
 scope. The report lists detection evidence, every destination, and reload or
 graph-build actions.
+
+That is the normal setup path. You do not need to identify an agent, copy a
+skill directory, edit an instruction file, or build a graph before running it.
+Inside a repository this command creates project-scoped, reviewable files; use
+`compass install --user` instead when you want personal configuration only.
+
+Confirm that your intended host, such as `codex` or `gemini`, appears under
+`Selected` in the report. If the report selects only `agents`, the portable
+skill was installed but no host-specific adapter was detected. Rerun with an
+explicit target, for example `compass install --platform codex` or
+`compass install --platform gemini`.
 
 ## Global or project scope
 
@@ -61,6 +75,10 @@ Use user scope when:
 - this is your personal tool configuration;
 - many repositories should use the same skill;
 - you do not want generated assistant files committed per repository.
+
+Some rule-only adapters, including Cursor, are project-scoped because Compass
+does not invent an undocumented user-level destination. The installer fails
+explicitly when a selected platform has no target for the requested scope.
 
 ### Project installation
 
@@ -111,6 +129,11 @@ compass install --all --dry-run
 destinations differ by platform and scope; use installer output as the source
 of truth instead of copying paths from another tool.
 
+Detection accepts valid host configuration files, existing host directories,
+and platform-specific executables. A generic editor executable alone is not
+treated as proof that its AI assistant is installed. Use `--platform` when you
+want a target that is not detected automatically.
+
 Explicit platform selection bypasses detection. `--all` selects every registry
 entry and conflicts with `--platform`. For CI, add `--require-all` and
 `--format json` when skipped or failed targets must fail the job.
@@ -120,12 +143,12 @@ entry and conflicts with `--platform`. For CI, add `--require-all` and
 Representative project-scoped destinations include:
 
 ```text
-Codex       .agents/skills/compass/SKILL.md
-Gemini      .agents/skills/compass/SKILL.md
+Codex       .agents/skills/compass/SKILL.md + AGENTS.md + .codex/hooks.json
+Gemini      .agents/skills/compass/SKILL.md + GEMINI.md + .gemini/settings.json
 OpenCode    .agents/skills/compass/SKILL.md
 Copilot     .agents/skills/compass/SKILL.md
 Agents      .agents/skills/compass/SKILL.md
-Claude      .claude/skills/compass/SKILL.md
+Claude      .claude/skills/compass/SKILL.md + CLAUDE.md + .claude/settings.json
 Kiro        .kiro/skills/compass/SKILL.md
 Cline       .cline/skills/compass/SKILL.md
 Cursor      Cursor-specific project integration
@@ -157,7 +180,7 @@ COMPASS_HOOK_STRICT=0 your-assistant-command
 Strict mode:
 
 - requires project scope;
-- applies only where the platform's hook mechanism supports it;
+- currently requires the Claude platform;
 - is not a security sandbox;
 - should be explained to repository contributors before adoption.
 
@@ -178,16 +201,31 @@ Check:
 - no machine-specific path or credential was written;
 - platform-specific syntax matches the selected assistant.
 
-### Exercise the workflow
+For Codex project installs, open `/hooks` in Codex and review the exact Compass
+hook before trusting it. Codex skips new or changed project command hooks until
+they are trusted. The Compass hook reads bounded tool metadata and adds a short
+graph-first reminder before matching raw searches; it does not execute a graph
+build or change the proposed command. Hook trust activates the hook only; start
+a new Codex session to ensure the newly installed skill and `AGENTS.md` guidance
+are discovered.
 
-In a project with a graph:
+For Gemini CLI, run `/skills reload` to activate a new skill in the current
+session. For other hosts, start a new session or use the host's skill reload
+operation when it provides one. The install report prints these actions.
+
+### Exercise first use
+
+In a project without a graph:
 
 1. ask the assistant a broad architecture question;
-2. confirm it reads `compass-out/GRAPH_REPORT.md` or runs a focused query;
-3. ask a narrow implementation question;
-4. confirm it verifies graph results in source;
-5. check that it does not treat inferred/ambiguous edges as unquestionable
-   runtime truth.
+2. confirm the assistant—not the installer—runs one local `compass update .`;
+3. confirm it runs a focused query and uses `compass-out/GRAPH_REPORT.md` for
+   repository-wide context;
+4. confirm it verifies graph results in source.
+
+When a graph already exists, the assistant should query it directly, open only
+the source needed to verify the result, and avoid treating inferred or ambiguous
+edges as unquestionable runtime truth.
 
 ### Verify idempotence
 
@@ -259,7 +297,8 @@ Before answering architecture questions:
 2. run compass query for the focused question;
 3. verify graph claims in source.
 
-After modifying source files, run compass update .
+After modifying source files, run compass update . unless the user prohibited
+generated files.
 ```
 
 Avoid:
@@ -279,6 +318,8 @@ Avoid:
 | Existing instructions changed | Inspect the diff; uninstall managed content and reapply after resolving ownership |
 | Strict mode blocks unexpectedly | Set `COMPASS_HOOK_STRICT=0` for the session, then review the project hook |
 | Assistant ignores the graph | Confirm it discovers the installed skill and that `compass-out/` exists |
+| Codex hook is skipped | Open `/hooks`, review the project hook source, and trust its current definition |
+| Gemini does not see a new skill | Run `/skills reload` or start a new Gemini CLI session |
 | Assistant over-trusts the graph | Strengthen instructions to verify source and qualify provenance |
 | Upgrade leaves stale content | Rerun install with the same scope/platform and review managed files |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -473,13 +473,19 @@ workflows.
 
 ```text
 compass install
-  [--project]
+  [--project | --user]
   [--strict]
-  [--platform P | P]
+  [--platform P ... | --all]
+  [--dry-run]
+  [--require-all]
+  [--format text|json]
 ```
 
 Run `compass install --help` for the version's platform list. `--strict`
-requires a supported project-scoped hook target.
+requires a project-scoped Claude target. With no explicit platform, Compass
+detects agents and also installs the portable Agent Skills package. Dry-run
+output includes the complete skill and adapter path plan and performs read-only
+preflight checks.
 
 ### `uninstall`
 
@@ -515,8 +521,9 @@ compass hook [install|uninstall|status]
 compass hook-check
 ```
 
-Managed integration probe installed for supported assistants. It is normally
-invoked by generated integration configuration rather than by a person.
+Managed integration probe invoked by older Compass-generated integration
+configuration. Current contextual integrations use `hook-guard`; people do not
+normally invoke this command directly.
 
 ### `hook-guard`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -307,6 +307,11 @@ COMPASS_HOOK_STRICT
 Reinstall hooks after moving/upgrading the binary so embedded invocation paths
 remain correct.
 
+Codex project hooks are not active until their exact definition is reviewed and
+trusted in Codex. After `compass install --project --platform codex`, use
+`/hooks` to review the bounded `hook-guard search` command. New or changed hook
+content requires review again.
+
 ## Assistant configuration
 
 ```bash


### PR DESCRIPTION
## Summary

- make `compass install` detect agent configuration directories and instruction files more reliably while avoiding generic VS Code false positives
- make dry-run plans complete and outcome-aware, with preflight diagnostics and platform-specific activation guidance
- replace the Codex no-op hook with the bounded graph-first search guard supported by current Codex hooks
- let the installed skill bootstrap a missing local graph for broad questions while respecting narrow tasks and no-generated-files requests
- reject ineffective strict-mode and unsupported scope combinations instead of reporting misleading success
- update assistant setup, command, configuration, security, README, and changelog documentation

## Why

The existing installer had strong ownership and rollback mechanics, but first-use activation still required users to infer whether their host was detected, which files were planned, how to reload the skill, and whether hooks were active. Codex also installed a no-op hook, and some unsupported combinations silently did nothing.

This change makes the default setup flow explicit, deterministic, and usable out of the box without weakening Compass's local-first or transaction-safety boundaries.

## User impact

A normal project setup remains:

```bash
compass install
```

The report now explains what was selected, every planned or changed path, how to activate Codex or Gemini, and how to build or bootstrap the first graph. Existing unowned or modified files remain protected.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-cli --test install_cli --locked` — 22 passed
- `cargo clippy -p compass-cli --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `cargo test -p compass-cli --test help_cli --test coverage_paths --locked`
- `sh scripts/check_product_boundary.sh`
- two independent forward tests of first-use skill behavior and installer activation UX

The generic skill-creator validator could not start because its Python environment lacks `yaml`; Compass's stricter build-time embedded-skill validation ran successfully during the Rust builds.
