### PR TITLE
Harden cold code graph build performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Restore sub-10-second cold builds for the pinned 3,105-file Django
+  qualification corpus by batching and compressing portable AST cache
+  publication, parallelizing independent resolver and graph-normalization
+  work, and avoiding redundant evidence, index, and serialization allocations
+  without changing valid graph facts or Program output. Partial-graph omission
+  diagnostics now use portable content-addressed edge identities instead of
+  transient raw positions.
 - Restore complete definition ranges for source navigation on universally
   extracted functions, methods, and containers while preserving exact
   identifier anchors in provenance. Ambiguous or non-containing scopes fall

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "toml 1.1.3+spec-1.1.0",
+ "zstd",
 ]
 
 [[package]]
@@ -1168,6 +1169,7 @@ dependencies = [
 name = "compass-languages"
 version = "0.2.1"
 dependencies = [
+ "ahash",
  "compass-files",
  "compass-ir",
  "compass-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ candle-transformers = "=0.9.2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 rmp-serde = "1.3.1"
+zstd = "0.13"
 sha2 = "0.10"
 sha1 = "0.10"
 md-5 = "0.10"

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -49,6 +49,36 @@ The release gate rejects:
 Local observations are diagnostic evidence. Promote a baseline only from a
 controlled Compass CI run with retained artifacts.
 
+## Django cold-build regression qualification
+
+The 0.2.1 code-graph performance hardening was qualified against Django commit
+`5e32c82a5a896e1d942cfc9dd9a2ebbe86741258`. Three isolated cold builds, each
+with a fresh output directory and no reusable cache entries, completed in
+9.31 seconds with internal phase profiling enabled and 9.04 and 9.06 seconds
+without profiling on the development runner. Every run published 3,105 files,
+80,961 nodes, 187,173 edges, 2,583 communities, 3,038 Program modules, and
+32,049 Program summaries. The canonical graph and Program SHA-256 digests were
+identical across all three runs.
+
+After rebasing the hardening onto Compass revision `347d9b1`, the default scan
+contract included the newly shipped deterministic HTML and Markdown adapters.
+On the local Django checkout at `957d0cee7167757ae221ffde59d2cf0a322e89c7`,
+that expanded the cold workload to 3,475 files, 82,654 nodes, 187,913 edges,
+and 3,379 communities. Three profiled fresh-output builds reported 10.39,
+10.60, and 10.37 seconds internally; after the first copied-binary launch,
+external wall times were 10.65 and 10.42 seconds. Two additional unprofiled
+runs completed in 10.55 and 10.67 seconds externally. All five runs produced
+the same graph and Program SHA-256 digests. The sub-10-second claim above
+therefore applies to the pinned 3,105-file corpus; the expanded 3,475-file
+default scan is a separate baseline rather than an equivalent workload.
+
+The qualification includes durable artifact publication. Storage throughput
+must be recorded separately when the output resides on a mounted volume: the
+same 277 MB graph can add several seconds when the volume is saturated, even
+when extraction and graph construction remain below their approved baseline.
+These local measurements are diagnostic evidence and do not replace a
+controlled CI baseline.
+
 ## Versioned history qualification
 
 Build a release binary, then measure a clean real repository:

--- a/crates/compass-cli/src/bin/compass.rs
+++ b/crates/compass-cli/src/bin/compass.rs
@@ -1,5 +1,9 @@
 use std::io::{self, IsTerminal, Write};
-use std::process::ExitCode;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+use std::process::{Command, ExitCode};
+
+const ALLOCATOR_CONFIGURED: &str = "COMPASS_INTERNAL_ALLOCATOR_CONFIGURED";
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -10,6 +14,30 @@ fn main() -> ExitCode {
         arguments.first().and_then(|argument| argument.to_str()),
         Some("extract" | "update")
     );
+    if one_shot_build
+        && std::env::var_os("MIMALLOC_PURGE_DELAY").is_none()
+        && std::env::var_os(ALLOCATOR_CONFIGURED).is_none()
+        && let Ok(executable) = std::env::current_exe()
+    {
+        let mut command = Command::new(executable);
+        command
+            .args(&arguments)
+            .env("MIMALLOC_PURGE_DELAY", "100")
+            .env(ALLOCATOR_CONFIGURED, "1");
+        #[cfg(unix)]
+        {
+            let _error = command.exec();
+        }
+        #[cfg(not(unix))]
+        if let Ok(status) = command.status() {
+            return ExitCode::from(
+                status
+                    .code()
+                    .and_then(|code| u8::try_from(code).ok())
+                    .unwrap_or(1),
+            );
+        }
+    }
     let events = match compass_cli::ide_contract::take_jsonl_events(&mut arguments) {
         Ok(enabled) => enabled,
         Err(error) => {

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -10,10 +10,12 @@ use compass_files::{
     Manifest, ManifestKind, detect, write_json_atomic, write_text_atomic,
 };
 use compass_graph::{
-    ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION, InventoryEvidence,
-    PublicationOmissions, PublicationOutcome, build_owned_with_tiebreaker as build_document,
-    canonical_edge_kind, canonical_raw_edge_sites, cluster, dedupe_nodes, extraction_from_v1,
-    graph_insights, label_communities_by_hub, normalize_document_v1_with_inventory_best_effort,
+    BuildEvidence, ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION,
+    InventoryEvidence, PublicationOmissions, PublicationOutcome,
+    build_owned_with_tiebreaker as build_document, canonical_edge_kind, canonical_raw_edge_sites,
+    cluster, dedupe_nodes, extraction_from_v1, graph_insights, label_communities_by_hub,
+    normalize_document_v1_with_evidence_best_effort_owned,
+    normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
     score_communities,
 };
@@ -34,12 +36,12 @@ use compass_model::provenance::{
 };
 use compass_model::{EdgeRecord, GraphDocument, NodeRecord};
 use compass_output::{
-    DetectionSummary, HtmlOptions, OutputError, ReportOptions, TokenCost, generate_report,
-    graph_view_model_document, write_html,
+    DetectionSummary, GraphViewModel, HtmlOptions, OutputError, ReportOptions, TokenCost,
+    generate_report, graph_view_model_document, write_html,
 };
 use compass_resolve::{
     apply_program_projection, collect_program_projection_sites, merge_decl_def_classes,
-    resolve_owned_with_root,
+    resolve_prevalidated_owned_with_root,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -934,10 +936,14 @@ fn build_graph_inner(
                         &program_sources,
                         &program_options,
                         &program_cache,
-                        &prepared,
+                        prepared,
                     )?;
-                    write_program(&program_output_dir, &program.canonical_bytes)?;
-                    let summary = ProgramBuildSummary::from_program(program, retain_artifacts);
+                    let (summary, canonical_bytes) =
+                        ProgramBuildSummary::from_program_with_canonical_bytes(
+                            program,
+                            retain_artifacts,
+                        );
+                    write_program(&program_output_dir, &canonical_bytes)?;
                     Ok::<_, CoreError>((summary, started.elapsed()))
                 })
                 .map_err(|error| CoreError::WorkerPool(error.to_string()))?,
@@ -1009,17 +1015,30 @@ fn build_graph_inner(
         );
     }
     profile_internal("portable AST ID remapping", &mut internal_started);
-    let ast_cache_started = Instant::now();
-    for (path, extraction) in ordered_paths.iter().zip(&mut ordered) {
-        if fresh_paths.contains(path) && extraction_has_cacheable_ast_facts(extraction) {
+    let ast_cache_sources = ordered_paths
+        .iter()
+        .zip(&ordered)
+        .filter(|(path, extraction)| {
+            fresh_paths.contains(*path) && extraction_has_cacheable_ast_facts(extraction)
+        })
+        .collect::<Vec<_>>();
+    let ast_cache_entries =
+        cache.encode_portable_ast_batch(&ast_cache_sources, |path, extraction| {
             let mut cache_entry = extraction.clone();
             prepare_portable_ast_cache_entry(&mut cache_entry, path, &root);
-            cache.save_portable_ast_batch(&[(path.clone(), cache_entry)])?;
-        }
-    }
-    cache.flush()?;
-    profile_internal_duration("AST cache publication", ast_cache_started.elapsed());
-    internal_started = Instant::now();
+            cache_entry
+        })?;
+    drop(ast_cache_sources);
+    let ast_cache_handle = std::thread::Builder::new()
+        .name("compass-ast-cache".to_owned())
+        .spawn(move || {
+            let started = Instant::now();
+            Cache::write_encoded_batch(&ast_cache_entries)?;
+            cache.flush()?;
+            Ok::<_, CoreError>(started.elapsed())
+        })
+        .map_err(|error| CoreError::WorkerPool(error.to_string()))?;
+    profile_internal("AST cache snapshot and dispatch", &mut internal_started);
     let read_source = |path: &PathBuf| read_source_text_with_limit(path, options.max_source_bytes);
     let read_cached_source = |path: &PathBuf| {
         (!fresh_paths.contains(path))
@@ -1035,10 +1054,21 @@ fn build_graph_inner(
     };
     fresh_source_text.extend(cached_source_text);
     let source_text = fresh_source_text;
+    drop(worker_pool);
+    drop(project_evidence);
+    drop(fresh_paths);
+    drop(ordered_paths);
+    drop(ast_id_remap);
+    drop(ast_root_marker);
     let program_projection_sites = collect_program_projection_sites(&ordered);
-    let mut resolved = resolve_owned_with_root(ordered, &source_text, &root);
+    let mut resolved = resolve_prevalidated_owned_with_root(ordered, &source_text, &root);
     profile_internal("cross-file resolution total", &mut internal_started);
     drop(source_text);
+    let ast_cache_elapsed = ast_cache_handle
+        .join()
+        .map_err(|_| CoreError::WorkerPanic("AST cache publication".to_owned()))??;
+    profile_internal_duration("AST cache publication worker", ast_cache_elapsed);
+    internal_started = Instant::now();
     let defer_program_join = options.force && !options.no_cluster && !has_program_artifacts;
     let mut program = if defer_program_join {
         None
@@ -1046,13 +1076,16 @@ fn build_graph_inner(
         join_program_worker(program_handle.take(), &mut timings)?
     };
     profile_internal("wait for Program analysis", &mut internal_started);
-    if let Some(program) = program.as_ref() {
+    if let Some(program) = program.as_mut()
+        && let Some(compiler_projection) = program.compiler_projection.take()
+    {
         apply_program_projection(
             &mut resolved,
             &program_projection_sites,
-            &program.compiler_projection,
+            &compiler_projection,
         );
     }
+    drop(program_projection_sites);
     profile_internal("Program graph projection", &mut internal_started);
     finalize_ast_extraction(&mut resolved, &root);
     profile_internal("AST finalization", &mut internal_started);
@@ -1407,24 +1440,47 @@ fn build_graph_inner(
         resolution: options.resolution,
         exclude_hubs_percentile: options.exclude_hubs,
     };
-    let ((previous, previous_elapsed), (current, cluster_elapsed)) = rayon::join(
-        || {
-            let started = Instant::now();
-            let previous = if std::env::var_os("COMPASS_HISTORY_BUILD").is_some() {
-                HashMap::new()
-            } else {
-                previous_communities(&output_dir.join("graph.json"))
-            };
-            (previous, started.elapsed())
-        },
-        || {
-            let started = Instant::now();
-            let current = cluster(&document, cluster_options);
-            (current, started.elapsed())
-        },
+    let configuration_digest = graph_configuration_digest(options, &output_dir)?;
+    let publication_inventory = detection_inventory(
+        &detection,
+        semantic,
+        &extraction_failures,
+        &extraction_partials,
+        &root,
     );
+    let publication_evidence = || -> Result<(BuildEvidence, Duration), CoreError> {
+        let started = Instant::now();
+        let mut evidence = BuildEvidence::from_document(&root, &document, configuration_digest)?;
+        evidence.include_inventory(publication_inventory)?;
+        evidence.build.source_commit.clone_from(&commit);
+        Ok((evidence, started.elapsed()))
+    };
+    let (((previous, previous_elapsed), (current, cluster_elapsed)), publication_evidence_result) =
+        rayon::join(
+            || {
+                rayon::join(
+                    || {
+                        let started = Instant::now();
+                        let previous = if std::env::var_os("COMPASS_HISTORY_BUILD").is_some() {
+                            HashMap::new()
+                        } else {
+                            previous_communities(&output_dir.join("graph.json"))
+                        };
+                        (previous, started.elapsed())
+                    },
+                    || {
+                        let started = Instant::now();
+                        let current = cluster(&document, cluster_options);
+                        (current, started.elapsed())
+                    },
+                )
+            },
+            publication_evidence,
+        );
     profile_internal_duration("load previous communities", previous_elapsed);
     profile_internal_duration("Louvain clustering", cluster_elapsed);
+    let (publication_evidence, evidence_elapsed) = publication_evidence_result?;
+    profile_internal_duration("parallel v1 evidence preparation", evidence_elapsed);
     internal_started = Instant::now();
     let communities = if previous.is_empty() {
         current
@@ -1436,70 +1492,6 @@ fn build_graph_inner(
     let labels = label_communities_by_hub(&document, &communities);
     profile_internal("community labeling", &mut internal_started);
 
-    let graph_output = ||
-     -> Result<
-        (
-            Duration,
-            PublicationOmissions,
-            usize,
-            usize,
-            Option<V1GraphDocument>,
-        ),
-        CoreError,
-    > {
-        let started = Instant::now();
-        let mut output_profile_started = Instant::now();
-        let configuration_digest = graph_configuration_digest(options, &output_dir)?;
-        let normalization_started = Instant::now();
-        let published = published_v1_document(
-            &document,
-            &communities,
-            &labels,
-            &root,
-            PublicationEvidence {
-                detection: &detection,
-                semantic,
-                extraction_failures: &extraction_failures,
-                extraction_partials: &extraction_partials,
-            },
-            configuration_digest,
-            commit.as_deref(),
-        )?;
-        profile_internal_duration(
-            "graph.json v1 normalization",
-            normalization_started.elapsed(),
-        );
-        if published.document.nodes.is_empty() {
-            return Err(CoreError::EmptyGraph);
-        }
-        let published_nodes = published.document.nodes.len();
-        let published_edges = published.document.links.len();
-        let serialization_started = Instant::now();
-        write_json_atomic(output_dir.join("graph.json"), &published.document, false)?;
-        profile_internal_duration(
-            "graph.json v1 serialization",
-            serialization_started.elapsed(),
-        );
-        profile_internal("graph.json v1 publication", &mut output_profile_started);
-        if options.purpose == BuildPurpose::Update {
-            write_text_atomic(
-                output_dir.join(".compass_root"),
-                &options.root.to_string_lossy(),
-            )?;
-            write_graph_overview_artifact(&document, &communities, &labels, &output_dir)?;
-            profile_internal(
-                "graph root marker and overview publication",
-                &mut output_profile_started,
-            );
-        }
-        Ok((
-            started.elapsed(),
-            published.omissions,
-            published_nodes,
-            published_edges,
-            retain_artifacts.then_some(published.document),
-        ))
-    };
     let graph_analyses = || -> Result<(bool, Duration, Option<Value>), CoreError> {
         let started = Instant::now();
         let analysis_compute_started = Instant::now();
@@ -1607,19 +1599,60 @@ fn build_graph_inner(
             retain_artifacts.then_some(analysis),
         ))
     };
-    let (graph_output_elapsed, analysis_result) = rayon::join(graph_output, graph_analyses);
-    let (graph_output_elapsed, omissions, published_nodes, published_edges, retained_document) =
-        graph_output_elapsed?;
+    let overview_output = || -> Result<(Duration, Option<GraphViewModel>), CoreError> {
+        let started = Instant::now();
+        let model = if options.purpose == BuildPurpose::Update {
+            write_text_atomic(
+                output_dir.join(".compass_root"),
+                &options.root.to_string_lossy(),
+            )?;
+            graph_overview_model(&document, &communities, &labels, &output_dir)?
+        } else {
+            None
+        };
+        Ok((started.elapsed(), model))
+    };
+    let (analysis_result, overview_result) = rayon::join(graph_analyses, overview_output);
     let (html_written, analysis_elapsed, retained_analysis) = analysis_result?;
-    profile_internal_duration("graph and overview publication", graph_output_elapsed);
+    let (overview_elapsed, overview_model) = overview_result?;
     profile_internal_duration(
         "parallel graph analyses and report publication",
         analysis_elapsed,
     );
+    profile_internal_duration(
+        "graph root marker and overview publication",
+        overview_elapsed,
+    );
+
+    let graph_output_started = Instant::now();
+    let mut output_profile_started = Instant::now();
+    let normalization_started = Instant::now();
+    let published = published_v1_document(document, &communities, &labels, publication_evidence)?;
+    profile_internal_duration(
+        "graph.json v1 normalization",
+        normalization_started.elapsed(),
+    );
+    if published.document.nodes.is_empty() {
+        return Err(CoreError::EmptyGraph);
+    }
+    let published_nodes = published.document.nodes.len();
+    let published_edges = published.document.links.len();
+    let omissions = published.omissions;
+    let serialization_started = Instant::now();
+    write_json_atomic(output_dir.join("graph.json"), &published.document, false)?;
+    if options.purpose == BuildPurpose::Update {
+        write_prepared_graph_overview(overview_model, &output_dir)?;
+    }
+    let serialization_elapsed = serialization_started.elapsed();
+    profile_internal_duration("graph.json v1 serialization", serialization_elapsed);
+    profile_internal("graph.json v1 publication", &mut output_profile_started);
+    let graph_output_elapsed = graph_output_started.elapsed();
+    let retained_document = retain_artifacts.then_some(published.document);
+    profile_internal_duration("graph publication", graph_output_elapsed);
     internal_started = Instant::now();
     timings.graph_assembly += stage_started.elapsed();
-    stage_started = Instant::now();
 
+    let publish_started = Instant::now();
     let mut manifest = prior_manifest;
     let (manifest_result, seals_result) = rayon::join(
         || {
@@ -1645,7 +1678,7 @@ fn build_graph_inner(
     );
     manifest_result?;
     seals_result?;
-    timings.publish = stage_started.elapsed();
+    timings.publish = publish_started.elapsed();
     if program.is_none() {
         program = join_program_worker(program_handle.take(), &mut timings)?;
     }
@@ -1744,31 +1777,42 @@ struct ProgramBuildSummary {
     artifact_documents_analyzed: usize,
     artifact_documents_reused: usize,
     conflicts: usize,
-    compiler_projection: compass_program::CompilerProjection,
+    compiler_projection: Option<compass_program::CompilerProjection>,
     analysis: Option<compass_analysis::AnalysisBundle>,
 }
 
 impl ProgramBuildSummary {
     fn from_program(program: ProgramBuild, retain_analysis: bool) -> Self {
+        Self::from_program_with_canonical_bytes(program, retain_analysis).0
+    }
+
+    fn from_program_with_canonical_bytes(
+        mut program: ProgramBuild,
+        retain_analysis: bool,
+    ) -> (Self, Vec<u8>) {
+        let canonical_bytes = std::mem::take(&mut program.canonical_bytes);
         let modules = program.analysis.program.modules.len();
         let summaries = program.analysis.summaries.len();
         let providers = program.analysis.program.providers.len();
         let analysis = retain_analysis.then_some(program.analysis);
-        Self {
-            seal: ArtifactSeal::from_bytes(&program.canonical_bytes),
-            modules,
-            summaries,
-            providers,
-            syntax_analyzed: program.syntax_analyzed,
-            syntax_reused: program.syntax_reused,
-            artifacts_loaded: program.artifacts_loaded,
-            artifacts_reused: program.artifacts_reused,
-            artifact_documents_analyzed: program.artifact_documents_analyzed,
-            artifact_documents_reused: program.artifact_documents_reused,
-            conflicts: program.conflicts,
-            compiler_projection: program.compiler_projection,
-            analysis,
-        }
+        (
+            Self {
+                seal: ArtifactSeal::from_bytes(&canonical_bytes),
+                modules,
+                summaries,
+                providers,
+                syntax_analyzed: program.syntax_analyzed,
+                syntax_reused: program.syntax_reused,
+                artifacts_loaded: program.artifacts_loaded,
+                artifacts_reused: program.artifacts_reused,
+                artifact_documents_analyzed: program.artifact_documents_analyzed,
+                artifact_documents_reused: program.artifact_documents_reused,
+                conflicts: program.conflicts,
+                compiler_projection: Some(program.compiler_projection),
+                analysis,
+            },
+            canonical_bytes,
+        )
     }
 }
 
@@ -3494,28 +3538,13 @@ fn graph_configuration_digest(
     Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
 }
 
-struct PublicationEvidence<'a> {
-    detection: &'a Detection,
-    semantic: Option<&'a SemanticLayer>,
-    extraction_failures: &'a BTreeMap<PathBuf, String>,
-    extraction_partials: &'a BTreeMap<PathBuf, String>,
-}
-
 fn published_v1_document(
-    document: &GraphDocument,
+    mut document: GraphDocument,
     communities: &compass_graph::Communities,
     labels: &BTreeMap<usize, String>,
-    root: &Path,
-    evidence: PublicationEvidence<'_>,
-    configuration_digest: String,
-    source_commit: Option<&str>,
+    evidence: BuildEvidence,
 ) -> Result<PublicationOutcome, CoreError> {
     let mut publication_profile_started = Instant::now();
-    let mut publication_source = document.clone();
-    profile_internal(
-        "graph publication source clone",
-        &mut publication_profile_started,
-    );
     let node_communities = communities
         .iter()
         .flat_map(|(community, members)| {
@@ -3524,7 +3553,7 @@ fn published_v1_document(
                 .map(move |member| (member.as_str(), *community))
         })
         .collect::<HashMap<_, _>>();
-    for node in &mut publication_source.nodes {
+    for node in &mut document.nodes {
         let Some(&community_index) = node_communities.get(node.id.as_str()) else {
             continue;
         };
@@ -3543,19 +3572,7 @@ fn published_v1_document(
         "graph publication community projection",
         &mut publication_profile_started,
     );
-    let published = normalize_document_v1_with_inventory_best_effort_owned(
-        publication_source,
-        root,
-        configuration_digest,
-        source_commit,
-        detection_inventory(
-            evidence.detection,
-            evidence.semantic,
-            evidence.extraction_failures,
-            evidence.extraction_partials,
-            root,
-        ),
-    )?;
+    let published = normalize_document_v1_with_evidence_best_effort_owned(document, evidence)?;
     profile_internal(
         "graph publication v1 boundary",
         &mut publication_profile_started,
@@ -3817,8 +3834,17 @@ pub(crate) fn write_graph_overview_artifact(
     labels: &BTreeMap<usize, String>,
     output_dir: &Path,
 ) -> Result<(), CoreError> {
-    let overview_path = output_dir.join(GRAPH_OVERVIEW_FILE);
-    let overview = graph_view_model_document(
+    let overview = graph_overview_model(document, communities, labels, output_dir)?;
+    write_prepared_graph_overview(overview, output_dir)
+}
+
+fn graph_overview_model(
+    document: &GraphDocument,
+    communities: &compass_graph::Communities,
+    labels: &BTreeMap<usize, String>,
+    output_dir: &Path,
+) -> Result<Option<GraphViewModel>, CoreError> {
+    Ok(graph_view_model_document(
         document,
         communities,
         output_dir.join("graph.json"),
@@ -3827,7 +3853,14 @@ pub(crate) fn write_graph_overview_artifact(
             node_limit: Some(GRAPH_OVERVIEW_NODE_LIMIT),
             ..HtmlOptions::default()
         },
-    )?;
+    )?)
+}
+
+fn write_prepared_graph_overview(
+    overview: Option<GraphViewModel>,
+    output_dir: &Path,
+) -> Result<(), CoreError> {
+    let overview_path = output_dir.join(GRAPH_OVERVIEW_FILE);
     if let Some(model) = overview {
         let graph_path = output_dir.join("graph.json");
         let source_graph_bytes = fs::metadata(&graph_path)

--- a/crates/compass-core/src/program.rs
+++ b/crates/compass-core/src/program.rs
@@ -76,20 +76,23 @@ pub(crate) fn build_program(
     sources: &[PathBuf],
     options: &BuildOptions,
     cache: &Cache,
-    prepared: &[PreparedSyntaxInput],
+    prepared: Vec<PreparedSyntaxInput>,
 ) -> Result<ProgramBuild, CoreError> {
     let mut internal_started = Instant::now();
     let artifacts = discover_artifacts(root, options)?;
+    let mut prepared_by_key = BTreeMap::new();
     let inputs = if artifacts.is_empty() && !prepared.is_empty() {
         let mut inputs = prepared
-            .iter()
+            .into_iter()
             .map(|input| {
                 let digest = hex_sha256(&input.bytes);
+                let cache_key = format!("{}:{digest}", input.source_file);
+                prepared_by_key.insert(cache_key.clone(), input.batch);
                 SourceInput {
-                    source_file: input.source_file.clone(),
-                    language: input.language.clone(),
-                    bytes: input.bytes.clone(),
-                    cache_key: format!("{}:{digest}", input.source_file),
+                    source_file: input.source_file,
+                    language: input.language,
+                    bytes: input.bytes,
+                    cache_key,
                     digest,
                 }
             })
@@ -101,16 +104,28 @@ pub(crate) fn build_program(
         });
         inputs
     } else {
+        for input in prepared {
+            let digest = hex_sha256(&input.bytes);
+            prepared_by_key.insert(format!("{}:{digest}", input.source_file), input.batch);
+        }
         read_sources(root, sources, options.max_source_bytes)?
     };
-    let source_digests = inputs
-        .iter()
-        .map(|input| (input.source_file.clone(), input.digest.clone()))
-        .collect::<BTreeMap<_, _>>();
-    let source_texts = inputs
-        .iter()
-        .map(|input| (input.source_file.clone(), input.bytes.clone()))
-        .collect::<BTreeMap<_, _>>();
+    let source_digests = if artifacts.is_empty() {
+        BTreeMap::new()
+    } else {
+        inputs
+            .iter()
+            .map(|input| (input.source_file.clone(), input.digest.clone()))
+            .collect::<BTreeMap<_, _>>()
+    };
+    let source_texts = if artifacts.is_empty() {
+        BTreeMap::new()
+    } else {
+        inputs
+            .iter()
+            .map(|input| (input.source_file.clone(), input.bytes.clone()))
+            .collect::<BTreeMap<_, _>>()
+    };
     profile_internal("Program input preparation", &mut internal_started);
 
     let syntax_kind = CacheKind::ProgramSyntax {
@@ -121,17 +136,8 @@ pub(crate) fn build_program(
     let mut missing = Vec::new();
     let mut syntax_reused = 0;
     let mut live_syntax_keys = BTreeSet::new();
-    let prepared = prepared
-        .iter()
-        .map(|input| {
-            (
-                format!("{}:{}", input.source_file, hex_sha256(&input.bytes)),
-                input.batch.clone(),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
     let mut prepared_fresh = Vec::new();
-    for input in &inputs {
+    for input in inputs {
         if !supports_program_syntax(&input.source_file) {
             continue;
         }
@@ -145,11 +151,11 @@ pub(crate) fn build_program(
             syntax_reused += 1;
             continue;
         }
-        if let Some(batch) = prepared.get(&input.cache_key) {
-            prepared_fresh.push((input.cache_key.clone(), batch.clone()));
+        if let Some(batch) = prepared_by_key.remove(&input.cache_key) {
+            prepared_fresh.push((input.cache_key, batch));
             continue;
         }
-        missing.push(input.clone());
+        missing.push(input);
     }
     let mut fresh = analyze_syntax(&missing, options.max_workers)?;
     fresh.extend(prepared_fresh);

--- a/crates/compass-files/Cargo.toml
+++ b/crates/compass-files/Cargo.toml
@@ -17,6 +17,7 @@ md-5.workspace = true
 rayon.workspace = true
 regex.workspace = true
 rmp-serde.workspace = true
+zstd.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -15,8 +15,12 @@ use crate::{FileError, StatHashIndex, file_hash, io_error, write_bytes_atomic, w
 /// Changes whenever cached extraction semantics change, even if the wire encoding does not.
 pub const AST_CACHE_VERSION: &str = "5";
 /// Portable cache encoding version used in the on-disk namespace.
-pub const CACHE_ENCODING_VERSION: u32 = 7;
+pub const CACHE_ENCODING_VERSION: u32 = 8;
 const MESSAGEPACK_EXTENSION: &str = "msgpack";
+const COMPRESSED_MESSAGEPACK_MAGIC: &[u8; 5] = b"CMPZ1";
+const COMPRESSED_MESSAGEPACK_HEADER_BYTES: usize = COMPRESSED_MESSAGEPACK_MAGIC.len() + 8;
+const MAX_DECOMPRESSED_CACHE_ENTRY_BYTES: usize = 256 * 1024 * 1024;
+const CACHE_COMPRESSION_LEVEL: i32 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CacheLayout {
@@ -124,6 +128,12 @@ struct SessionHash {
     size: u64,
     modified: Option<SystemTime>,
     value: String,
+}
+
+/// Opaque, compressed cache payload ready for atomic publication.
+pub struct EncodedCacheWrite {
+    destination: PathBuf,
+    bytes: Vec<u8>,
 }
 
 impl Cache {
@@ -236,12 +246,7 @@ impl Cache {
         fs::create_dir_all(&directory).map_err(|source| io_error(&directory, source))?;
         if deterministic_binary_kind(kind) {
             let destination = directory.join(format!("{key}.{MESSAGEPACK_EXTENSION}"));
-            let bytes = rmp_serde::to_vec_named(&on_disk).map_err(|source| {
-                FileError::MessagePackEncode {
-                    path: destination.clone(),
-                    source,
-                }
-            })?;
+            let bytes = encode_messagepack(&on_disk, &destination)?;
             write_cache_bytes(&destination, &bytes)
         } else {
             write_json_atomic(directory.join(format!("{key}.json")), &on_disk, false)
@@ -277,12 +282,7 @@ impl Cache {
             let mut on_disk = value.clone();
             relativize_source_files(&mut on_disk, root);
             if deterministic_binary_kind(kind) {
-                let bytes = rmp_serde::to_vec_named(&on_disk).map_err(|source| {
-                    FileError::MessagePackEncode {
-                        path: destination.clone(),
-                        source,
-                    }
-                })?;
+                let bytes = encode_messagepack(&on_disk, &destination)?;
                 write_cache_bytes(&destination, &bytes)
             } else {
                 write_json_atomic(destination, &on_disk, false)
@@ -319,11 +319,7 @@ impl Cache {
             ));
         }
         let write_job = |(destination, value): (PathBuf, &T)| {
-            let bytes =
-                rmp_serde::to_vec_named(value).map_err(|source| FileError::MessagePackEncode {
-                    path: destination.clone(),
-                    source,
-                })?;
+            let bytes = encode_messagepack(value, &destination)?;
             write_cache_bytes(&destination, &bytes)
         };
         if jobs.len() < 256 {
@@ -331,6 +327,46 @@ impl Cache {
         } else {
             jobs.into_par_iter().try_for_each(write_job)
         }
+    }
+
+    /// Prepare portable AST entries in parallel without retaining cloned typed
+    /// values after each entry has been compressed.
+    pub fn encode_portable_ast_batch<T, F>(
+        &mut self,
+        entries: &[(&PathBuf, &T)],
+        prepare: F,
+    ) -> Result<Vec<EncodedCacheWrite>, FileError>
+    where
+        T: Serialize + Sync,
+        F: Fn(&Path, &T) -> T + Sync,
+    {
+        let directory = self.directory(&CacheKind::Ast, None);
+        fs::create_dir_all(&directory).map_err(|source| io_error(&directory, source))?;
+        let mut jobs = Vec::with_capacity(entries.len());
+        for &(path, value) in entries {
+            let hash = self.content_hash(path)?;
+            let key = self.source_cache_key(path, &hash);
+            jobs.push((
+                directory.join(format!("{key}.{MESSAGEPACK_EXTENSION}")),
+                path,
+                value,
+            ));
+        }
+        jobs.into_par_iter()
+            .map(|(destination, path, value)| {
+                let prepared = prepare(path, value);
+                let bytes = encode_messagepack(&prepared, &destination)?;
+                Ok(EncodedCacheWrite { destination, bytes })
+            })
+            .collect()
+    }
+
+    /// Atomically publish cache payloads prepared by
+    /// [`Self::encode_portable_ast_batch`].
+    pub fn write_encoded_batch(entries: &[EncodedCacheWrite]) -> Result<(), FileError> {
+        entries
+            .par_iter()
+            .try_for_each(|entry| write_cache_bytes(&entry.destination, &entry.bytes))
     }
 
     /// Load a Program IR cache value by a caller-owned logical input key.
@@ -369,11 +405,7 @@ impl Cache {
             "{}.{MESSAGEPACK_EXTENSION}",
             logical_key_hash(logical_key)
         ));
-        let bytes =
-            rmp_serde::to_vec_named(value).map_err(|source| FileError::MessagePackEncode {
-                path: destination.clone(),
-                source,
-            })?;
+        let bytes = encode_messagepack(value, &destination)?;
         write_cache_bytes(&destination, &bytes)
     }
 
@@ -394,11 +426,7 @@ impl Cache {
                 "{}.{MESSAGEPACK_EXTENSION}",
                 logical_key_hash(logical_key)
             ));
-            let bytes =
-                rmp_serde::to_vec_named(value).map_err(|source| FileError::MessagePackEncode {
-                    path: destination.clone(),
-                    source,
-                })?;
+            let bytes = encode_messagepack(value, &destination)?;
             write_cache_bytes(&destination, &bytes)
         })
     }
@@ -579,10 +607,57 @@ fn load_json_value(
     Ok(Some(value))
 }
 
+fn encode_messagepack<T: Serialize>(value: &T, path: &Path) -> Result<Vec<u8>, FileError> {
+    let messagepack =
+        rmp_serde::to_vec_named(value).map_err(|source| FileError::MessagePackEncode {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if messagepack.len() > MAX_DECOMPRESSED_CACHE_ENTRY_BYTES {
+        return Err(FileError::CacheEntryTooLarge {
+            path: path.to_path_buf(),
+            size: messagepack.len(),
+            limit: MAX_DECOMPRESSED_CACHE_ENTRY_BYTES,
+        });
+    }
+    let compressed =
+        zstd::bulk::compress(&messagepack, CACHE_COMPRESSION_LEVEL).map_err(|source| {
+            FileError::CacheCompression {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+    let mut encoded =
+        Vec::with_capacity(COMPRESSED_MESSAGEPACK_HEADER_BYTES.saturating_add(compressed.len()));
+    encoded.extend_from_slice(COMPRESSED_MESSAGEPACK_MAGIC);
+    encoded.extend_from_slice(&(messagepack.len() as u64).to_le_bytes());
+    encoded.extend_from_slice(&compressed);
+    Ok(encoded)
+}
+
 fn decode_messagepack<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
-    let mut deserializer = rmp_serde::Deserializer::new(std::io::Cursor::new(bytes));
+    if bytes.len() < COMPRESSED_MESSAGEPACK_HEADER_BYTES
+        || &bytes[..COMPRESSED_MESSAGEPACK_MAGIC.len()] != COMPRESSED_MESSAGEPACK_MAGIC
+    {
+        return None;
+    }
+    let size_bytes: [u8; 8] = bytes
+        [COMPRESSED_MESSAGEPACK_MAGIC.len()..COMPRESSED_MESSAGEPACK_HEADER_BYTES]
+        .try_into()
+        .ok()?;
+    let size = usize::try_from(u64::from_le_bytes(size_bytes)).ok()?;
+    if size > MAX_DECOMPRESSED_CACHE_ENTRY_BYTES {
+        return None;
+    }
+    let messagepack =
+        zstd::bulk::decompress(&bytes[COMPRESSED_MESSAGEPACK_HEADER_BYTES..], size).ok()?;
+    if messagepack.len() != size {
+        return None;
+    }
+    let mut deserializer = rmp_serde::Deserializer::new(std::io::Cursor::new(&messagepack));
     let value = serde::Deserialize::deserialize(&mut deserializer).ok()?;
-    (deserializer.position() == u64::try_from(bytes.len()).unwrap_or(u64::MAX)).then_some(value)
+    (deserializer.position() == u64::try_from(messagepack.len()).unwrap_or(u64::MAX))
+        .then_some(value)
 }
 
 fn logical_key_hash(value: &str) -> String {
@@ -628,6 +703,44 @@ fn clear_cache_entries(directory: &Path) {
         } else if cache_extension(&path) {
             let _ = fs::remove_file(path);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use serde_json::json;
+
+    use super::{
+        COMPRESSED_MESSAGEPACK_HEADER_BYTES, COMPRESSED_MESSAGEPACK_MAGIC,
+        MAX_DECOMPRESSED_CACHE_ENTRY_BYTES, decode_messagepack, encode_messagepack,
+    };
+
+    #[test]
+    fn compressed_messagepack_round_trips_and_rejects_invalid_envelopes() {
+        let value = json!({
+            "source_file": "src/example.py",
+            "facts": vec!["repeated deterministic evidence"; 128],
+        });
+        let encoded = encode_messagepack(&value, Path::new("cache.msgpack"))
+            .unwrap_or_else(|_| std::process::abort());
+        assert!(encoded.starts_with(COMPRESSED_MESSAGEPACK_MAGIC));
+        assert_eq!(decode_messagepack(&encoded), Some(value));
+        assert_eq!(
+            decode_messagepack::<serde_json::Value>(b"not-a-cache"),
+            None
+        );
+
+        let mut oversized = Vec::with_capacity(COMPRESSED_MESSAGEPACK_HEADER_BYTES);
+        oversized.extend_from_slice(COMPRESSED_MESSAGEPACK_MAGIC);
+        oversized.extend_from_slice(
+            &(u64::try_from(MAX_DECOMPRESSED_CACHE_ENTRY_BYTES)
+                .unwrap_or(u64::MAX)
+                .saturating_add(1))
+            .to_le_bytes(),
+        );
+        assert_eq!(decode_messagepack::<serde_json::Value>(&oversized), None);
     }
 }
 

--- a/crates/compass-files/src/lib.rs
+++ b/crates/compass-files/src/lib.rs
@@ -52,6 +52,18 @@ pub enum FileError {
         #[source]
         source: rmp_serde::encode::Error,
     },
+    #[error("could not compress deterministic cache entry at {path}: {source}")]
+    CacheCompression {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("deterministic cache entry at {path} is {size} bytes, exceeding limit {limit}")]
+    CacheEntryTooLarge {
+        path: PathBuf,
+        size: usize,
+        limit: usize,
+    },
     #[error("file hash requires a regular file: {0}")]
     NotAFile(PathBuf),
     #[error("path is outside the scan root: {0}")]

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -25,7 +25,8 @@ pub use quarantine::{MAX_QUARANTINE_EXAMPLES, PublicationOmissions, PublicationO
 pub use v1::{
     BuildEvidence, InventoryEvidence, V1_PUBLICATION_SEMANTICS_VERSION, canonical_edge_kind,
     canonical_raw_edge_sites, extraction_from_v1, normalize_document_v1,
-    normalize_document_v1_with_inventory, normalize_document_v1_with_inventory_best_effort,
+    normalize_document_v1_with_evidence_best_effort_owned, normalize_document_v1_with_inventory,
+    normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, normalize_v1, normalize_v1_best_effort,
 };
 
@@ -266,10 +267,9 @@ fn build_from_owned_extraction(
         }
     }
     if source_edges.len() < 100_000 {
-        source_edges.sort_by_key(edge_occurrence_key);
+        source_edges.sort_by_cached_key(edge_occurrence_key);
     } else {
-        source_edges
-            .par_sort_by(|left, right| edge_occurrence_key(left).cmp(&edge_occurrence_key(right)));
+        source_edges.par_sort_by_cached_key(edge_occurrence_key);
     }
     profile_internal("graph edge cloning and sort", &mut profile_started);
     let normalize_edge = |mut edge: EdgeRecord| {

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -59,6 +59,12 @@ struct PreparedEdge {
     normalized: Result<EdgeRecord, (GraphError, String)>,
 }
 
+struct PreparedNode {
+    raw: RawNodeRecord,
+    raw_id: String,
+    normalized: Result<NodeRecord, GraphError>,
+}
+
 #[derive(Clone, Debug)]
 pub struct BuildEvidence {
     pub repository_root: PathBuf,
@@ -75,6 +81,34 @@ pub struct InventoryEvidence {
     pub producer: String,
     pub status: ExtractionStatus,
     pub reason: Option<String>,
+}
+
+trait AttributeRecord {
+    fn evidence_attributes(&self) -> &Map<String, Value>;
+}
+
+impl AttributeRecord for RawNodeRecord {
+    fn evidence_attributes(&self) -> &Map<String, Value> {
+        &self.attributes
+    }
+}
+
+impl AttributeRecord for RawEdgeRecord {
+    fn evidence_attributes(&self) -> &Map<String, Value> {
+        &self.attributes
+    }
+}
+
+impl AttributeRecord for compass_model::NodeRecord {
+    fn evidence_attributes(&self) -> &Map<String, Value> {
+        &self.attributes
+    }
+}
+
+impl AttributeRecord for compass_model::EdgeRecord {
+    fn evidence_attributes(&self) -> &Map<String, Value> {
+        &self.attributes
+    }
 }
 
 impl BuildEvidence {
@@ -95,15 +129,47 @@ impl BuildEvidence {
         extraction: &Extraction,
         configuration_digest: impl Into<String>,
     ) -> Result<Self, GraphError> {
+        Self::from_records(
+            repository_root,
+            &extraction.nodes,
+            &extraction.edges,
+            configuration_digest,
+        )
+    }
+
+    /// Derive publication evidence directly from an immutable analysis graph.
+    ///
+    /// This avoids cloning the complete graph merely to prepare file and build
+    /// metadata, and lets callers overlap evidence preparation with other
+    /// read-only graph analyses.
+    pub fn from_document(
+        repository_root: impl Into<PathBuf>,
+        document: &compass_model::GraphDocument,
+        configuration_digest: impl Into<String>,
+    ) -> Result<Self, GraphError> {
+        Self::from_records(
+            repository_root,
+            &document.nodes,
+            &document.links,
+            configuration_digest,
+        )
+    }
+
+    fn from_records<N: AttributeRecord, E: AttributeRecord>(
+        repository_root: impl Into<PathBuf>,
+        nodes: &[N],
+        edges: &[E],
+        configuration_digest: impl Into<String>,
+    ) -> Result<Self, GraphError> {
         let repository_root = repository_root.into();
         let mut paths = BTreeSet::new();
+        let mut seen_source_paths = HashSet::new();
         let mut external_reference_anchors = BTreeMap::<String, SourceAnchor>::new();
         let mut diagnostics = Vec::new();
-        for attributes in extraction
-            .nodes
+        for attributes in nodes
             .iter()
-            .map(|node| &node.attributes)
-            .chain(extraction.edges.iter().map(|edge| &edge.attributes))
+            .map(AttributeRecord::evidence_attributes)
+            .chain(edges.iter().map(AttributeRecord::evidence_attributes))
         {
             if let Some((path, anchor)) = external_reference_anchor(attributes, &repository_root)? {
                 external_reference_anchors
@@ -117,9 +183,16 @@ impl BuildEvidence {
             }
             for path in ["source_file", "origin_file"]
                 .into_iter()
-                .filter_map(|key| optional_source_path(attributes, key))
+                .filter_map(|key| {
+                    attributes
+                        .get(key)
+                        .and_then(Value::as_str)
+                        .filter(|path| !path.trim().is_empty())
+                })
             {
-                paths.insert(portable_path(&path, &repository_root)?);
+                if seen_source_paths.insert(path.to_owned()) {
+                    paths.insert(portable_path(path, &repository_root)?);
+                }
             }
         }
 
@@ -219,15 +292,16 @@ impl BuildEvidence {
             .collect::<HashMap<_, _>>();
         let mut coverage_file_ids = HashMap::<String, Option<String>>::new();
         let mut declared_coverage = BTreeSet::new();
-        for node in &extraction.nodes {
+        for node in nodes {
+            let attributes = node.evidence_attributes();
             if let Some(kind) =
-                optional_any_string(&node.attributes, &["symbol_kind", "type", "file_type"])
+                optional_any_string(attributes, &["symbol_kind", "type", "file_type"])
             {
                 declared_coverage.insert((
                     format!("node:{kind}"),
-                    coverage_producer(&node.attributes),
+                    coverage_producer(attributes),
                     coverage_file_id(
-                        &node.attributes,
+                        attributes,
                         &repository_root,
                         &published_file_ids,
                         &mut coverage_file_ids,
@@ -235,13 +309,14 @@ impl BuildEvidence {
                 ));
             }
         }
-        for edge in &extraction.edges {
-            if let Some(relation) = optional_string(&edge.attributes, "relation") {
+        for edge in edges {
+            let attributes = edge.evidence_attributes();
+            if let Some(relation) = optional_string(attributes, "relation") {
                 declared_coverage.insert((
                     format!("edge:{relation}"),
-                    coverage_producer(&edge.attributes),
+                    coverage_producer(attributes),
                     coverage_file_id(
-                        &edge.attributes,
+                        attributes,
                         &repository_root,
                         &published_file_ids,
                         &mut coverage_file_ids,
@@ -280,6 +355,42 @@ impl BuildEvidence {
         &mut self,
         inventory: impl IntoIterator<Item = InventoryEvidence>,
     ) -> Result<(), GraphError> {
+        let existing_files = self
+            .files
+            .iter()
+            .map(|file| {
+                (
+                    file.path.clone(),
+                    (file.content_digest.clone(), file.byte_size),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let inventory = inventory.into_iter().collect::<Vec<_>>();
+        let prepare = |item: InventoryEvidence| -> Result<
+            Option<(InventoryEvidence, String, String, u64)>,
+            GraphError,
+        > {
+            let path = portable_path(&item.path.to_string_lossy(), &self.repository_root)?;
+            let absolute = self.repository_root.join(&path);
+            if !absolute.is_file() {
+                return Ok(None);
+            }
+            let (content_digest, byte_size) = if let Some(existing) = existing_files.get(&path) {
+                existing.clone()
+            } else {
+                let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
+                    path: absolute,
+                    source,
+                })?;
+                (sha256_prefixed(&bytes), bytes.len() as u64)
+            };
+            Ok(Some((item, path, content_digest, byte_size)))
+        };
+        let prepared = if inventory.len() < 512 {
+            inventory.into_iter().map(prepare).collect::<Vec<_>>()
+        } else {
+            inventory.into_par_iter().map(prepare).collect::<Vec<_>>()
+        };
         let mut file_positions = self
             .files
             .iter()
@@ -295,23 +406,11 @@ impl BuildEvidence {
                     .push(index);
             }
         }
-        for item in inventory {
-            let path = portable_path(&item.path.to_string_lossy(), &self.repository_root)?;
-            let absolute = self.repository_root.join(&path);
-            if !absolute.is_file() {
+        for prepared in prepared {
+            let Some((item, path, content_digest, byte_size)) = prepared? else {
                 continue;
-            }
-            let existing_position = file_positions.get(&path).copied();
-            let (content_digest, byte_size) = if let Some(position) = existing_position {
-                let existing = &self.files[position];
-                (existing.content_digest.clone(), existing.byte_size)
-            } else {
-                let bytes = fs::read(&absolute).map_err(|source| GraphError::Read {
-                    path: absolute,
-                    source,
-                })?;
-                (sha256_prefixed(&bytes), bytes.len() as u64)
             };
+            let existing_position = file_positions.get(&path).copied();
             let record = FileRecord {
                 id: file_id(&path),
                 path: path.clone(),
@@ -599,14 +698,18 @@ fn normalize_v1_with_mode(
         sort_dedup_serialized(&mut evidence.diagnostics);
     }
     normalize_file_inventory(&mut evidence.files, &evidence.repository_root)?;
+    profile_v1("v1 file inventory normalization", &mut profile_started);
     let file_facts = published_file_facts(&evidence)?;
+    profile_v1("v1 published file facts", &mut profile_started);
     split_sourceless_placeholders(&mut extraction, &evidence.repository_root, &file_facts)?;
+    profile_v1("v1 sourceless placeholder split", &mut profile_started);
     let stub_wiring_sites = collect_stub_wiring_sites(
         &extraction.nodes,
         &extraction.edges,
         &evidence.repository_root,
         &file_facts,
     )?;
+    profile_v1("v1 stub wiring sites", &mut profile_started);
     resolve_or_drop_generic_symbols(
         &mut extraction,
         &mut evidence.diagnostics,
@@ -616,15 +719,49 @@ fn normalize_v1_with_mode(
         mode,
         &mut quarantine,
     )?;
-    profile_v1("v1 preparation", &mut profile_started);
+    profile_v1("v1 generic symbol resolution", &mut profile_started);
 
     if mode == PublicationMode::BestEffort && !canonical_raw_order {
         extraction.nodes.sort_by_cached_key(raw_node_sort_key);
     }
-    let mut id_remap = HashMap::with_capacity(extraction.nodes.len());
-    let mut nodes = HashMap::<String, NodeRecord>::with_capacity(extraction.nodes.len());
-    for mut raw in extraction.nodes {
+    let prepare_node = |mut raw: RawNodeRecord| {
         let raw_id = raw.id.clone();
+        let normalized = match raw.attributes.get(TRUSTED_NODE_RECORD).cloned() {
+            Some(value) => normalize_trusted_node(value, &raw_id),
+            None => normalize_node(
+                &mut raw,
+                &evidence.repository_root,
+                &file_facts,
+                stub_wiring_sites.get(&raw_id),
+            ),
+        };
+        PreparedNode {
+            raw,
+            raw_id,
+            normalized,
+        }
+    };
+    let prepared_nodes = if extraction.nodes.len() < 512 {
+        extraction
+            .nodes
+            .into_iter()
+            .map(prepare_node)
+            .collect::<Vec<_>>()
+    } else {
+        extraction
+            .nodes
+            .into_par_iter()
+            .map(prepare_node)
+            .collect::<Vec<_>>()
+    };
+    let mut id_remap = HashMap::with_capacity(prepared_nodes.len());
+    let mut nodes = HashMap::<String, NodeRecord>::with_capacity(prepared_nodes.len());
+    for prepared in prepared_nodes {
+        let PreparedNode {
+            raw,
+            raw_id,
+            normalized,
+        } = prepared;
         if id_remap.contains_key(&raw_id) {
             let error = raw_error(
                 &raw_id,
@@ -641,16 +778,6 @@ fn normalize_v1_with_mode(
             );
             continue;
         }
-        let trusted = raw.attributes.get(TRUSTED_NODE_RECORD).cloned();
-        let normalized = match trusted {
-            Some(value) => normalize_trusted_node(value, &raw_id),
-            None => normalize_node(
-                &mut raw,
-                &evidence.repository_root,
-                &file_facts,
-                stub_wiring_sites.get(&raw_id),
-            ),
-        };
         let node = match normalized {
             Ok(node) => node,
             Err(error) if mode == PublicationMode::BestEffort => {
@@ -710,216 +837,243 @@ fn normalize_v1_with_mode(
             .edges
             .sort_by_cached_key(|raw| raw_edge_sort_key(raw, &id_remap, &evidence.repository_root));
     }
-    let mut links = HashMap::<String, EdgeRecord>::with_capacity(extraction.edges.len());
-    for (index, raw) in extraction.edges.into_iter().enumerate() {
-        let prepared = prepare_edge(
-            raw,
-            index,
-            &id_remap,
-            &evidence.repository_root,
-            &file_facts,
-        );
-        let PreparedEdge {
-            index,
-            raw,
-            trusted,
-            normalized,
-        } = prepared;
-        let mut edge = match normalized {
-            Ok(edge) => edge,
-            Err((_error, reason)) if mode == PublicationMode::BestEffort => {
-                quarantine.omit_edge(
-                    &raw_edge_identity(&raw, index),
-                    &reason,
-                    best_effort_raw_anchor(&raw.attributes, &evidence.repository_root, &file_facts),
-                );
-                continue;
-            }
-            Err((error, _)) => return Err(error),
-        };
-        remap_provenance_candidates(&mut edge.evidence, &id_remap);
-        if !trusted
-            && edge.kind == EdgeKind::Tests
-            && let Some(source) = nodes.get_mut(&edge.source)
-        {
-            source.roles.push(NodeRole::Test);
-            sort_dedup_serialized(&mut source.roles);
+    // Preparation is record-local after deterministic raw ordering and node-ID
+    // remapping. Bounded parallel batches preserve indexed order without
+    // retaining raw and normalized copies of the complete edge inventory.
+    const PREPARED_EDGE_BATCH_SIZE: usize = 8_192;
+    let edge_count = extraction.edges.len();
+    let mut raw_edges = extraction.edges.into_iter().enumerate();
+    let mut links = HashMap::<String, EdgeRecord>::with_capacity(edge_count);
+    loop {
+        let batch = raw_edges
+            .by_ref()
+            .take(PREPARED_EDGE_BATCH_SIZE)
+            .collect::<Vec<_>>();
+        if batch.is_empty() {
+            break;
         }
-        if !trusted
-            && edge.kind == EdgeKind::Decorates
-            && nodes
-                .get(&edge.target)
-                .is_some_and(|node| matches!(node.kind, NodeKind::Annotation | NodeKind::Macro))
-            && nodes
+        let prepared_edges = batch
+            .into_par_iter()
+            .map(|(index, raw)| {
+                prepare_edge(
+                    raw,
+                    index,
+                    &id_remap,
+                    &evidence.repository_root,
+                    &file_facts,
+                )
+            })
+            .collect::<Vec<_>>();
+        for prepared in prepared_edges {
+            let PreparedEdge {
+                index,
+                raw,
+                trusted,
+                normalized,
+            } = prepared;
+            let mut edge = match normalized {
+                Ok(edge) => edge,
+                Err((_error, reason)) if mode == PublicationMode::BestEffort => {
+                    let identity = raw_edge_identity(&raw, &evidence.repository_root);
+                    let stable_reason = reason.replace(&format!("edge[{index}]"), &identity);
+                    quarantine.omit_edge(
+                        &identity,
+                        &stable_reason,
+                        best_effort_raw_anchor(
+                            &raw.attributes,
+                            &evidence.repository_root,
+                            &file_facts,
+                        ),
+                    );
+                    continue;
+                }
+                Err((error, _)) => return Err(error),
+            };
+            remap_provenance_candidates(&mut edge.evidence, &id_remap);
+            if !trusted
+                && edge.kind == EdgeKind::Tests
+                && let Some(source) = nodes.get_mut(&edge.source)
+            {
+                source.roles.push(NodeRole::Test);
+                sort_dedup_serialized(&mut source.roles);
+            }
+            if !trusted
+                && edge.kind == EdgeKind::Decorates
+                && nodes
+                    .get(&edge.target)
+                    .is_some_and(|node| matches!(node.kind, NodeKind::Annotation | NodeKind::Macro))
+                && nodes.get(&edge.source).is_some_and(|node| {
+                    !matches!(node.kind, NodeKind::Annotation | NodeKind::Macro)
+                })
+            {
+                std::mem::swap(&mut edge.source, &mut edge.target);
+                let id = edge_id(
+                    &edge.source,
+                    edge.kind,
+                    &edge.target,
+                    edge.relationship_site.as_ref(),
+                    edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
+                );
+                edge.id.clone_from(&id);
+                edge.key = id;
+            }
+            let source_kind = nodes
                 .get(&edge.source)
-                .is_some_and(|node| !matches!(node.kind, NodeKind::Annotation | NodeKind::Macro))
-        {
-            std::mem::swap(&mut edge.source, &mut edge.target);
-            let id = edge_id(
-                &edge.source,
-                edge.kind,
-                &edge.target,
-                edge.relationship_site.as_ref(),
-                edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
-            );
-            edge.id.clone_from(&id);
-            edge.key = id;
-        }
-        let source_kind = nodes
-            .get(&edge.source)
-            .map(|node| node.kind)
-            .unwrap_or(NodeKind::Variable);
-        let target_kind = nodes
-            .get(&edge.target)
-            .map(|node| node.kind)
-            .unwrap_or(NodeKind::Variable);
-        let target_is_constructible = nodes.get(&edge.target).is_some_and(|node| {
-            node.kind.is_constructible()
-                || (node.kind == NodeKind::EnumMember && node.language.as_deref() == Some("rust"))
-        });
-        let unresolved_wiring_site = [&edge.source, &edge.target]
-            .into_iter()
-            .filter_map(|id| nodes.get(id))
-            .filter(|node| is_unresolved_external_node(node))
-            .find_map(|node| {
-                node.evidence
-                    .iter()
-                    .find_map(|evidence| evidence.wiring_site.clone())
+                .map(|node| node.kind)
+                .unwrap_or(NodeKind::Variable);
+            let target_kind = nodes
+                .get(&edge.target)
+                .map(|node| node.kind)
+                .unwrap_or(NodeKind::Variable);
+            let target_is_constructible = nodes.get(&edge.target).is_some_and(|node| {
+                node.kind.is_constructible()
+                    || (node.kind == NodeKind::EnumMember
+                        && node.language.as_deref() == Some("rust"))
             });
-        if let Some(wiring_site) = unresolved_wiring_site {
-            edge.deferred = true;
-            if !edge.evidence.iter().any(|evidence| {
-                evidence.extractor == "compass.graph.external-placeholder"
-                    && evidence.rule.as_deref() == Some("external-symbol-placeholder")
-            }) {
-                edge.evidence.push(Provenance {
-                    origin: EvidenceOrigin::Heuristic,
-                    extractor: "compass.graph.external-placeholder".to_owned(),
-                    confidence: EvidenceConfidence::Inferred,
-                    rule: Some("external-symbol-placeholder".to_owned()),
-                    anchors: Vec::new(),
-                    wiring_site: Some(edge.relationship_site.clone().unwrap_or(wiring_site)),
-                    score: None,
-                    candidates: Vec::new(),
+            let unresolved_wiring_site = [&edge.source, &edge.target]
+                .into_iter()
+                .filter_map(|id| nodes.get(id))
+                .filter(|node| is_unresolved_external_node(node))
+                .find_map(|node| {
+                    node.evidence
+                        .iter()
+                        .find_map(|evidence| evidence.wiring_site.clone())
                 });
-                sort_dedup_serialized(&mut edge.evidence);
+            if let Some(wiring_site) = unresolved_wiring_site {
+                edge.deferred = true;
+                if !edge.evidence.iter().any(|evidence| {
+                    evidence.extractor == "compass.graph.external-placeholder"
+                        && evidence.rule.as_deref() == Some("external-symbol-placeholder")
+                }) {
+                    edge.evidence.push(Provenance {
+                        origin: EvidenceOrigin::Heuristic,
+                        extractor: "compass.graph.external-placeholder".to_owned(),
+                        confidence: EvidenceConfidence::Inferred,
+                        rule: Some("external-symbol-placeholder".to_owned()),
+                        anchors: Vec::new(),
+                        wiring_site: Some(edge.relationship_site.clone().unwrap_or(wiring_site)),
+                        score: None,
+                        candidates: Vec::new(),
+                    });
+                    sort_dedup_serialized(&mut edge.evidence);
+                }
             }
-        }
-        if !trusted && edge.kind == EdgeKind::TypeOf && source_kind.is_callable() {
-            edge.kind = EdgeKind::Returns;
-            edge.details = None;
-            let id = edge_id(
-                &edge.source,
-                edge.kind,
-                &edge.target,
-                edge.relationship_site.as_ref(),
-                edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
-            );
-            edge.id.clone_from(&id);
-            edge.key = id;
-        }
-        if !trusted && edge.kind == EdgeKind::Calls && target_is_constructible {
-            edge.kind = EdgeKind::Instantiates;
-            edge.details = None;
-            let id = edge_id(
-                &edge.source,
-                edge.kind,
-                &edge.target,
-                edge.relationship_site.as_ref(),
-                edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
-            );
-            edge.id.clone_from(&id);
-            edge.key = id;
-            evidence.diagnostics.push(GraphDiagnostic {
-                severity: DiagnosticSeverity::Info,
-                code: "normalized_constructor_call".to_owned(),
-                message: format!(
-                    "normalized calls endpoints {} -> {} to instantiates",
-                    source_kind.as_str(),
-                    target_kind.as_str()
-                ),
-                anchor: edge.relationship_site.clone(),
-                related_ids: vec![edge.source.clone(), edge.target.clone()],
-            });
-        }
-        if edge.source == edge.target && edge.kind != EdgeKind::Calls {
-            if mode == PublicationMode::BestEffort {
-                quarantine.omit_edge(
-                    &edge.id,
-                    &format!("unsupported {} self-loop", edge.kind.as_str()),
-                    edge.relationship_site.clone(),
+            if !trusted && edge.kind == EdgeKind::TypeOf && source_kind.is_callable() {
+                edge.kind = EdgeKind::Returns;
+                edge.details = None;
+                let id = edge_id(
+                    &edge.source,
+                    edge.kind,
+                    &edge.target,
+                    edge.relationship_site.as_ref(),
+                    edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
                 );
+                edge.id.clone_from(&id);
+                edge.key = id;
             }
-            evidence.diagnostics.push(GraphDiagnostic {
-                severity: DiagnosticSeverity::Warning,
-                code: "dropped_non_recursive_self_loop".to_owned(),
-                message: format!(
-                    "dropped impossible {} self-loop on {}",
-                    edge.kind.as_str(),
-                    edge.source
-                ),
-                anchor: edge.relationship_site,
-                related_ids: vec![edge.source],
-            });
-            continue;
-        }
-        if matches!(
-            edge.kind,
-            EdgeKind::Embeds | EdgeKind::Extends | EdgeKind::Implements
-        ) {
-            let valid = source_kind.is_type()
-                && match edge.kind {
-                    EdgeKind::Embeds | EdgeKind::Extends => target_kind.is_type(),
-                    EdgeKind::Implements => matches!(
-                        target_kind,
-                        NodeKind::Interface | NodeKind::Trait | NodeKind::Protocol
+            if !trusted && edge.kind == EdgeKind::Calls && target_is_constructible {
+                edge.kind = EdgeKind::Instantiates;
+                edge.details = None;
+                let id = edge_id(
+                    &edge.source,
+                    edge.kind,
+                    &edge.target,
+                    edge.relationship_site.as_ref(),
+                    edge.occurrence_rule.as_ref().map(OccurrenceRule::as_str),
+                );
+                edge.id.clone_from(&id);
+                edge.key = id;
+                evidence.diagnostics.push(GraphDiagnostic {
+                    severity: DiagnosticSeverity::Info,
+                    code: "normalized_constructor_call".to_owned(),
+                    message: format!(
+                        "normalized calls endpoints {} -> {} to instantiates",
+                        source_kind.as_str(),
+                        target_kind.as_str()
                     ),
-                    _ => false,
-                };
-            if !valid {
+                    anchor: edge.relationship_site.clone(),
+                    related_ids: vec![edge.source.clone(), edge.target.clone()],
+                });
+            }
+            if edge.source == edge.target && edge.kind != EdgeKind::Calls {
                 if mode == PublicationMode::BestEffort {
                     quarantine.omit_edge(
                         &edge.id,
-                        &format!(
-                            "invalid {} endpoints {} -> {}",
-                            edge.kind.as_str(),
-                            source_kind.as_str(),
-                            target_kind.as_str()
-                        ),
+                        &format!("unsupported {} self-loop", edge.kind.as_str()),
                         edge.relationship_site.clone(),
                     );
                 }
                 evidence.diagnostics.push(GraphDiagnostic {
                     severity: DiagnosticSeverity::Warning,
-                    code: "dropped_invalid_inheritance_target".to_owned(),
+                    code: "dropped_non_recursive_self_loop".to_owned(),
                     message: format!(
-                        "dropped invalid {} endpoints {} -> {}",
+                        "dropped impossible {} self-loop on {}",
                         edge.kind.as_str(),
-                        source_kind.as_str(),
-                        target_kind.as_str()
+                        edge.source
                     ),
                     anchor: edge.relationship_site,
-                    related_ids: vec![edge.source, edge.target],
+                    related_ids: vec![edge.source],
                 });
                 continue;
             }
-        }
-        if let Some(existing) = links.get_mut(&edge.id) {
-            let mut merged = existing.clone();
-            if let Err(error) = merge_normalized_edge(&mut merged, edge) {
-                if mode == PublicationMode::Strict {
-                    return Err(error);
+            if matches!(
+                edge.kind,
+                EdgeKind::Embeds | EdgeKind::Extends | EdgeKind::Implements
+            ) {
+                let valid = source_kind.is_type()
+                    && match edge.kind {
+                        EdgeKind::Embeds | EdgeKind::Extends => target_kind.is_type(),
+                        EdgeKind::Implements => matches!(
+                            target_kind,
+                            NodeKind::Interface | NodeKind::Trait | NodeKind::Protocol
+                        ),
+                        _ => false,
+                    };
+                if !valid {
+                    if mode == PublicationMode::BestEffort {
+                        quarantine.omit_edge(
+                            &edge.id,
+                            &format!(
+                                "invalid {} endpoints {} -> {}",
+                                edge.kind.as_str(),
+                                source_kind.as_str(),
+                                target_kind.as_str()
+                            ),
+                            edge.relationship_site.clone(),
+                        );
+                    }
+                    evidence.diagnostics.push(GraphDiagnostic {
+                        severity: DiagnosticSeverity::Warning,
+                        code: "dropped_invalid_inheritance_target".to_owned(),
+                        message: format!(
+                            "dropped invalid {} endpoints {} -> {}",
+                            edge.kind.as_str(),
+                            source_kind.as_str(),
+                            target_kind.as_str()
+                        ),
+                        anchor: edge.relationship_site,
+                        related_ids: vec![edge.source, edge.target],
+                    });
+                    continue;
                 }
-                quarantine.omit_edge(
-                    &existing.id,
-                    &error.to_string(),
-                    existing.relationship_site.clone(),
-                );
-                continue;
             }
-            *existing = merged;
-        } else {
-            links.insert(edge.id.clone(), edge);
+            if let Some(existing) = links.get_mut(&edge.id) {
+                let mut merged = existing.clone();
+                if let Err(error) = merge_normalized_edge(&mut merged, edge) {
+                    if mode == PublicationMode::Strict {
+                        return Err(error);
+                    }
+                    quarantine.omit_edge(
+                        &existing.id,
+                        &error.to_string(),
+                        existing.relationship_site.clone(),
+                    );
+                    continue;
+                }
+                *existing = merged;
+            } else {
+                links.insert(edge.id.clone(), edge);
+            }
         }
     }
     profile_v1("v1 edge normalization", &mut profile_started);
@@ -1006,8 +1160,8 @@ fn normalize_v1_with_mode(
             file_id.clone_from(published);
         }
     }
-    nodes.sort_by(|left, right| left.id.cmp(&right.id));
-    links.sort_by(|left, right| {
+    nodes.par_sort_unstable_by(|left, right| left.id.cmp(&right.id));
+    links.par_sort_unstable_by(|left, right| {
         (
             left.source.as_str(),
             left.kind.as_str(),
@@ -1317,11 +1471,14 @@ fn normalize_raw_sort_paths(value: &mut Value, repository_root: &Path) {
     object.extend(sorted);
 }
 
-fn raw_edge_identity(raw: &RawEdgeRecord, index: usize) -> String {
+fn raw_edge_identity(raw: &RawEdgeRecord, root: &Path) -> String {
     let relation =
         optional_string(&raw.attributes, "relation").unwrap_or_else(|| "<missing>".to_owned());
+    let mut attributes = Value::Object(raw.attributes.clone());
+    normalize_raw_sort_paths(&mut attributes, root);
+    let digest = Sha256::digest(serialized(&attributes).as_bytes());
     format!(
-        "edge[{index}] {} -[{relation}]-> {}",
+        "edge[sha256:{digest:x}] {} -[{relation}]-> {}",
         raw.source, raw.target
     )
 }
@@ -1584,18 +1741,20 @@ fn split_sourceless_placeholders(
                 && !node.attributes.contains_key("source_anchor")
         })
         .map(|node| node.id.clone())
-        .collect::<BTreeSet<_>>();
+        .collect::<HashSet<_>>();
     if sourceless.is_empty() {
         return Ok(());
     }
-    let node_attributes = extraction
+    let node_positions = extraction
         .nodes
         .iter()
-        .map(|node| (node.id.clone(), node.attributes.clone()))
+        .enumerate()
+        .map(|(index, node)| (node.id.as_str(), index))
         .collect::<HashMap<_, _>>();
     let mut scopes = HashMap::<String, BTreeSet<String>>::new();
     let mut inferred_kinds = HashMap::<(String, String), &'static str>::new();
-    for edge in &extraction.edges {
+    let mut edge_rewrites = Vec::<(usize, Option<String>, Option<String>)>::new();
+    for (edge_index, edge) in extraction.edges.iter().enumerate() {
         let source_is_sourceless = sourceless.contains(&edge.source);
         let target_is_sourceless = sourceless.contains(&edge.target);
         if !source_is_sourceless && !target_is_sourceless {
@@ -1604,27 +1763,35 @@ fn split_sourceless_placeholders(
         let Some(anchor) = raw_anchor(&edge.attributes, root, file_facts)? else {
             continue;
         };
-        for (endpoint, counterpart) in [(&edge.source, &edge.target), (&edge.target, &edge.source)]
-        {
-            if !sourceless.contains(endpoint) {
-                continue;
+        let source_scope = source_is_sourceless.then(|| {
+            let counterpart_attributes = node_positions
+                .get(edge.target.as_str())
+                .map(|&index| &extraction.nodes[index].attributes);
+            placeholder_scope_key(&edge.attributes, counterpart_attributes, &anchor)
+        });
+        let target_scope = target_is_sourceless.then(|| {
+            let counterpart_attributes = node_positions
+                .get(edge.source.as_str())
+                .map(|&index| &extraction.nodes[index].attributes);
+            placeholder_scope_key(&edge.attributes, counterpart_attributes, &anchor)
+        });
+        for (endpoint, scope) in [
+            (&edge.source, source_scope.as_ref()),
+            (&edge.target, target_scope.as_ref()),
+        ] {
+            if let Some(scope) = scope {
+                scopes
+                    .entry(endpoint.clone())
+                    .or_default()
+                    .insert(scope.clone());
             }
-            let counterpart_attributes = node_attributes.get(counterpart.as_str());
-            scopes
-                .entry(endpoint.clone())
-                .or_default()
-                .insert(placeholder_scope_key(
-                    &edge.attributes,
-                    counterpart_attributes,
-                    &anchor,
-                ));
         }
         if target_is_sourceless
             && let Some(kind) = inferred_external_target_kind(&edge.attributes)
-            && let Some(attributes) = node_attributes.get(&edge.target)
+            && let Some(&target_index) = node_positions.get(edge.target.as_str())
         {
-            let scope =
-                placeholder_scope_key(&edge.attributes, node_attributes.get(&edge.source), &anchor);
+            let attributes = &extraction.nodes[target_index].attributes;
+            let scope = target_scope.clone().unwrap_or_default();
             let qualified = optional_any_string(
                 attributes,
                 &["qualified_name", "qualifiedName", "name", "label"],
@@ -1639,7 +1806,9 @@ fn split_sourceless_placeholders(
                 })
                 .or_insert(kind);
         }
+        edge_rewrites.push((edge_index, source_scope, target_scope));
     }
+    drop(node_positions);
 
     let mut split_ids = HashMap::<String, BTreeMap<String, String>>::new();
     let mut expanded = Vec::with_capacity(extraction.nodes.len() + scopes.len());
@@ -1684,28 +1853,21 @@ fn split_sourceless_placeholders(
     }
     extraction.nodes = expanded;
 
-    for edge in &mut extraction.edges {
-        if !split_ids.contains_key(&edge.source) && !split_ids.contains_key(&edge.target) {
-            continue;
-        }
-        let Some(anchor) = raw_anchor(&edge.attributes, root, file_facts)? else {
-            continue;
-        };
+    for (edge_index, source_scope, target_scope) in edge_rewrites {
+        let edge = &mut extraction.edges[edge_index];
         let original_source = edge.source.clone();
         let original_target = edge.target.clone();
-        if let Some(clones) = split_ids.get(&original_source) {
-            let counterpart_attributes = node_attributes.get(&original_target);
-            let scope = placeholder_scope_key(&edge.attributes, counterpart_attributes, &anchor);
-            if let Some(clone_id) = clones.get(&scope) {
-                edge.source.clone_from(clone_id);
-            }
+        if let (Some(clones), Some(scope)) =
+            (split_ids.get(&original_source), source_scope.as_ref())
+            && let Some(clone_id) = clones.get(scope)
+        {
+            edge.source.clone_from(clone_id);
         }
-        if let Some(clones) = split_ids.get(&original_target) {
-            let counterpart_attributes = node_attributes.get(&original_source);
-            let scope = placeholder_scope_key(&edge.attributes, counterpart_attributes, &anchor);
-            if let Some(clone_id) = clones.get(&scope) {
-                edge.target.clone_from(clone_id);
-            }
+        if let (Some(clones), Some(scope)) =
+            (split_ids.get(&original_target), target_scope.as_ref())
+            && let Some(clone_id) = clones.get(scope)
+        {
+            edge.target.clone_from(clone_id);
         }
     }
     Ok(())
@@ -1875,7 +2037,7 @@ fn resolve_or_drop_generic_symbols(
             .filter(|edge| dropped.contains(&edge.source) || dropped.contains(&edge.target))
         {
             quarantine.omit_edge(
-                &raw_edge_identity(edge, 0),
+                &raw_edge_identity(edge, root),
                 "an endpoint node was quarantined",
                 best_effort_raw_anchor(&edge.attributes, root, file_facts),
             );
@@ -2250,6 +2412,15 @@ pub fn normalize_document_v1_with_inventory_best_effort_owned(
     normalize_v1_best_effort(extraction, evidence)
 }
 
+/// Publish an owned analysis document using evidence prepared from the same
+/// immutable document before ownership transfer.
+pub fn normalize_document_v1_with_evidence_best_effort_owned(
+    document: compass_model::GraphDocument,
+    evidence: BuildEvidence,
+) -> Result<PublicationOutcome, GraphError> {
+    normalize_v1_best_effort(document_extraction_owned(document), evidence)
+}
+
 fn document_publication_input(
     document: &compass_model::GraphDocument,
     repository_root: &Path,
@@ -2300,11 +2471,23 @@ fn document_publication_input_owned(
     // results. Leave raw-order canonicalization enabled so relocation and
     // repeated builds receive the same quarantine identities and diagnostics.
     let mut profile_started = Instant::now();
+    let extraction = document_extraction_owned(document);
+    profile_v1("v1 raw input transfer", &mut profile_started);
+    let mut evidence =
+        BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?;
+    profile_v1("v1 build evidence", &mut profile_started);
+    evidence.include_inventory(inventory)?;
+    profile_v1("v1 inventory enrichment", &mut profile_started);
+    evidence.build.source_commit = source_commit.map(str::to_owned);
+    Ok((extraction, evidence))
+}
+
+fn document_extraction_owned(document: compass_model::GraphDocument) -> Extraction {
     let mut extensions = Map::new();
     if let Some(diagnostics) = document.graph.get(TRUSTED_GRAPH_DIAGNOSTICS) {
         extensions.insert(TRUSTED_GRAPH_DIAGNOSTICS.to_owned(), diagnostics.clone());
     }
-    let extraction = Extraction {
+    Extraction {
         nodes: document
             .nodes
             .into_iter()
@@ -2324,15 +2507,7 @@ fn document_publication_input_owned(
             .collect(),
         extensions,
         ..Extraction::default()
-    };
-    profile_v1("v1 raw input transfer", &mut profile_started);
-    let mut evidence =
-        BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?;
-    profile_v1("v1 build evidence", &mut profile_started);
-    evidence.include_inventory(inventory)?;
-    profile_v1("v1 inventory enrichment", &mut profile_started);
-    evidence.build.source_commit = source_commit.map(str::to_owned);
-    Ok((extraction, evidence))
+    }
 }
 
 /// Project trusted v1 records back into flexible facts for incremental recomposition.

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -1287,6 +1287,39 @@ fn owned_best_effort_publication_sorts_before_assigning_diagnostic_positions()
 }
 
 #[test]
+fn canonical_raw_order_uses_content_addressed_omission_identities()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut source = extraction(root);
+    source.edges = [70_u64, 90]
+        .into_iter()
+        .map(|start| RawEdgeRecord {
+            source: "raw:a".to_owned(),
+            target: "raw:b".to_owned(),
+            attributes: Map::from_iter([
+                ("relation".to_owned(), json!(format!("unknown_{start}"))),
+                ("source_anchor".to_owned(), anchor(root, start)),
+            ]),
+        })
+        .collect();
+    source.extensions.insert(
+        "_compass_v1_canonical_raw_order".to_owned(),
+        Value::Bool(true),
+    );
+    let mut reversed = source.clone();
+    reversed.edges.reverse();
+
+    let left = normalize_v1_best_effort(source, build_evidence(root)?)?;
+    let right = normalize_v1_best_effort(reversed, build_evidence(root)?)?;
+
+    assert_eq!(left.document, right.document);
+    assert_eq!(left.omissions, right.omissions);
+    assert_eq!(left.omissions.edges, 2);
+    Ok(())
+}
+
+#[test]
 fn best_effort_diagnostic_positions_sort_by_published_endpoint_identity()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+ahash.workspace = true
 compass-ir = { path = "../compass-ir", version = "0.2.1" }
 compass-program = { path = "../compass-program", version = "0.2.1" }
 serde.workspace = true

--- a/crates/compass-languages/src/evidence/validate.rs
+++ b/crates/compass-languages/src/evidence/validate.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Component, Path};
 
+use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::model::{
@@ -149,22 +150,22 @@ pub fn validate_evidence(
         ));
     }
 
-    let declarations: BTreeMap<_, _> = batch
+    let declarations: AHashMap<_, _> = batch
         .declarations
         .iter()
         .map(|fact| (fact.id.as_str(), fact))
         .collect();
-    let scopes: BTreeMap<_, _> = batch
+    let scopes: AHashMap<_, _> = batch
         .scopes
         .iter()
         .map(|fact| (fact.id.as_str(), fact))
         .collect();
-    let bindings: BTreeMap<_, _> = batch
+    let bindings: AHashMap<_, _> = batch
         .bindings
         .iter()
         .map(|fact| (fact.id.as_str(), fact))
         .collect();
-    let occurrences: BTreeMap<_, _> = batch
+    let occurrences: AHashMap<_, _> = batch
         .occurrences
         .iter()
         .map(|fact| (fact.id.as_str(), fact))
@@ -291,10 +292,10 @@ fn validate_fact(
     fact: Fact<'_>,
     adapter_language: &str,
     capabilities: &BTreeSet<LanguageCapability>,
-    declarations: &BTreeMap<&str, &DeclarationFact>,
-    scopes: &BTreeMap<&str, &ScopeFact>,
-    bindings: &BTreeMap<&str, &BindingFact>,
-    occurrences: &BTreeMap<&str, &OccurrenceFact>,
+    declarations: &AHashMap<&str, &DeclarationFact>,
+    scopes: &AHashMap<&str, &ScopeFact>,
+    bindings: &AHashMap<&str, &BindingFact>,
+    occurrences: &AHashMap<&str, &OccurrenceFact>,
     limits: EvidenceLimits,
 ) -> Result<(), EvidenceError> {
     match fact {
@@ -664,7 +665,7 @@ fn require_reference<T>(
     owner_id: &str,
     kind: &str,
     target_id: &str,
-    index: &BTreeMap<&str, &T>,
+    index: &AHashMap<&str, &T>,
 ) -> Result<(), EvidenceError> {
     if target_id.is_empty() || !index.contains_key(target_id) {
         return Err(EvidenceError::new(
@@ -679,7 +680,7 @@ fn require_optional_reference<T>(
     owner_id: &str,
     kind: &str,
     target_id: Option<&str>,
-    index: &BTreeMap<&str, &T>,
+    index: &AHashMap<&str, &T>,
 ) -> Result<(), EvidenceError> {
     if let Some(target_id) = target_id {
         require_reference(owner_id, kind, target_id, index)?;

--- a/crates/compass-program/src/evidence.rs
+++ b/crates/compass-program/src/evidence.rs
@@ -63,22 +63,34 @@ pub struct EvidenceBatch {
 impl EvidenceBatch {
     pub fn canonicalized(&self) -> Self {
         let mut batch = self.clone();
-        batch.evidence.sort();
-        batch.evidence.dedup();
-        batch.modules.sort_by(|left, right| {
+        batch.canonicalize();
+        batch
+    }
+
+    /// Canonicalize an owned batch without cloning its complete Program IR.
+    #[must_use]
+    pub fn into_canonicalized(mut self) -> Self {
+        self.canonicalize();
+        self
+    }
+
+    fn canonicalize(&mut self) {
+        self.evidence.sort();
+        self.evidence.dedup();
+        self.modules.sort_by(|left, right| {
             left.source_file
                 .as_bytes()
                 .cmp(right.source_file.as_bytes())
         });
-        batch.facts.sort_by(|left, right| {
+        self.facts.sort_by(|left, right| {
             left.anchor.cmp(&right.anchor).then_with(|| {
                 left.evidence_id
                     .as_bytes()
                     .cmp(right.evidence_id.as_bytes())
             })
         });
-        batch.facts.dedup();
-        for coverage in batch.coverage.values_mut() {
+        self.facts.dedup();
+        for coverage in self.coverage.values_mut() {
             for state in coverage.values_mut() {
                 match state {
                     CoverageState::Complete => {}
@@ -91,7 +103,6 @@ impl EvidenceBatch {
                 }
             }
         }
-        batch
     }
 
     pub fn digest(&self) -> Result<String, compass_ir::IrError> {

--- a/crates/compass-program/src/merge.rs
+++ b/crates/compass-program/src/merge.rs
@@ -236,7 +236,7 @@ fn resolve_unique_syntax_calls(
 fn canonical_batches(batches: Vec<EvidenceBatch>) -> Result<Vec<EvidenceBatch>, MergeError> {
     let mut by_provider = BTreeMap::<String, EvidenceBatch>::new();
     for batch in batches {
-        let canonical = batch.canonicalized();
+        let canonical = batch.into_canonicalized();
         match by_provider.get(&canonical.descriptor.id) {
             Some(existing) if existing != &canonical => {
                 return Err(MergeError::ConflictingProvider(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1,14 +1,16 @@
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::time::Instant;
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use compass_languages::{
     BindingFact, CandidateRelation, DeclarationFact, EvidenceLimits, EvidenceRange,
     HierarchyConstraint, OccurrenceFact, ReceiverDispatchStrategy, RelationshipCandidate,
     SemanticEvidenceBatch, make_id, validate_evidence,
 };
 use compass_model::provenance::{NODE_PROVENANCE_ANCHOR_ATTRIBUTE, OCCURRENCE_RULE_ATTRIBUTE};
+use rayon::prelude::*;
 use serde_json::{Map, Value};
 
 use compass_languages::{RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord};
@@ -96,11 +98,11 @@ pub enum ResolutionDecision {
 }
 
 pub struct UniversalResolutionIndex {
-    declarations: BTreeMap<String, DeclarationFact>,
-    occurrences: BTreeMap<String, OccurrenceFact>,
-    bindings: BTreeMap<String, compass_languages::BindingFact>,
-    candidates: BTreeMap<String, RelationshipCandidate>,
-    scopes: BTreeMap<String, compass_languages::ScopeFact>,
+    declarations: AHashMap<String, DeclarationFact>,
+    occurrences: AHashMap<String, OccurrenceFact>,
+    bindings: AHashMap<String, compass_languages::BindingFact>,
+    candidates: AHashMap<String, RelationshipCandidate>,
+    scopes: AHashMap<String, compass_languages::ScopeFact>,
     definition_ranges: BTreeMap<String, EvidenceRange>,
     by_qualified: AHashMap<(String, String), Vec<String>>,
     by_module_name: AHashMap<(String, String, String), Vec<String>>,
@@ -140,16 +142,40 @@ impl UniversalResolutionIndex {
         root: &Path,
         limits: UniversalResolutionLimits,
     ) -> Result<Self, String> {
+        Self::new_with_inventory_owned_impl(batches, inventory_nodes, root, limits, true)
+    }
+
+    pub(crate) fn new_with_prevalidated_inventory_owned(
+        batches: Vec<SemanticEvidenceBatch>,
+        inventory_nodes: &[NodeRecord],
+        root: &Path,
+        limits: UniversalResolutionLimits,
+    ) -> Result<Self, String> {
+        Self::new_with_inventory_owned_impl(batches, inventory_nodes, root, limits, false)
+    }
+
+    fn new_with_inventory_owned_impl(
+        batches: Vec<SemanticEvidenceBatch>,
+        inventory_nodes: &[NodeRecord],
+        root: &Path,
+        limits: UniversalResolutionLimits,
+        validate_batches: bool,
+    ) -> Result<Self, String> {
         let mut profile_started = Instant::now();
         let go_module_path = read_go_module_path(root);
-        let mut declarations = BTreeMap::new();
-        let mut occurrences = BTreeMap::new();
-        let mut bindings = BTreeMap::new();
-        let mut candidates = BTreeMap::new();
-        let mut scopes = BTreeMap::new();
+        let mut declarations = AHashMap::new();
+        let mut occurrences = AHashMap::new();
+        let mut bindings = AHashMap::new();
+        let mut candidates = AHashMap::new();
+        let mut scopes = AHashMap::new();
+        if validate_batches {
+            batches.par_iter().try_for_each(|batch| {
+                validate_evidence(batch, EvidenceLimits::default())
+                    .map_err(|error| format!("invalid universal evidence: {error}"))
+            })?;
+        }
+        profile_internal("universal evidence validation", &mut profile_started);
         for batch in batches {
-            validate_evidence(&batch, EvidenceLimits::default())
-                .map_err(|error| format!("invalid universal evidence: {error}"))?;
             for fact in batch.declarations {
                 insert_unique(&mut declarations, fact.id.clone(), fact)?;
             }
@@ -166,10 +192,7 @@ impl UniversalResolutionIndex {
                 insert_unique(&mut scopes, fact.id.clone(), fact)?;
             }
         }
-        profile_internal(
-            "universal validation and fact collection",
-            &mut profile_started,
-        );
+        profile_internal("universal fact collection", &mut profile_started);
         let definition_ranges = unique_definition_ranges(&declarations, &scopes);
         for (name, count, limit) in [
             ("declarations", declarations.len(), limits.declarations),
@@ -501,7 +524,7 @@ impl UniversalResolutionIndex {
                 (id.as_str(), range)
             })
             .collect::<Vec<_>>();
-        ordered.sort_unstable_by(|(left_id, left_range), (right_id, right_range)| {
+        ordered.par_sort_unstable_by(|(left_id, left_range), (right_id, right_range)| {
             left_range
                 .map(|range| range.source_file.as_str())
                 .unwrap_or_default()
@@ -939,12 +962,14 @@ impl UniversalResolutionIndex {
             .iter()
             .enumerate()
             .map(|(index, node)| (node.id.clone(), index))
-            .collect::<BTreeMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let mut existing_nodes = nodes
             .iter()
             .map(|node| node.id.clone())
-            .collect::<BTreeSet<_>>();
-        for declaration in self.declarations.values() {
+            .collect::<AHashSet<_>>();
+        let mut declarations = self.declarations.values().collect::<Vec<_>>();
+        declarations.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+        for declaration in declarations {
             let graph_node_id = &graph_ids[&declaration.id];
             let definition_range = self.definition_ranges.get(&declaration.id);
             if let Some(index) = existing_positions.get(graph_node_id) {
@@ -975,7 +1000,7 @@ impl UniversalResolutionIndex {
         let inventory_kinds = nodes
             .iter()
             .map(|node| (node.id.clone(), node.string("symbol_kind")))
-            .collect::<BTreeMap<_, _>>();
+            .collect::<AHashMap<_, _>>();
         let mut external_positions = nodes
             .iter()
             .enumerate()
@@ -983,22 +1008,18 @@ impl UniversalResolutionIndex {
                 node.attributes.get("external").and_then(Value::as_bool) == Some(true)
             })
             .map(|(index, node)| (node.id.clone(), index))
-            .collect::<BTreeMap<_, _>>();
-        let mut emitted_edges = BTreeSet::new();
+            .collect::<AHashMap<_, _>>();
         let candidate_ids = self.candidate_ids();
         profile_internal("universal candidate ordering", &mut profile_started);
-        for candidate_id in candidate_ids {
+        let decisions = candidate_ids
+            .into_par_iter()
+            .map(|candidate_id| (candidate_id, self.resolve(candidate_id)))
+            .collect::<Vec<_>>();
+        profile_internal("universal candidate decisions", &mut profile_started);
+        let mut resolved_targets = Vec::with_capacity(decisions.len());
+        for (candidate_id, decision) in decisions {
             let candidate = &self.candidates[candidate_id];
-            let Some(source) = self
-                .declarations
-                .get(&candidate.source_declaration_id)
-                .map(|declaration| graph_ids[&declaration.id].clone())
-            else {
-                continue;
-            };
-            let (target, resolution_rule, target_kind, target_site) = match self
-                .resolve(candidate_id)
-            {
+            let (target, resolution_rule, target_kind, target_site) = match decision {
                 ResolutionDecision::Resolved {
                     declaration_id,
                     evidence,
@@ -1068,82 +1089,98 @@ impl UniversalResolutionIndex {
                 }
                 ResolutionDecision::Ambiguous { .. } | ResolutionDecision::Unresolved => continue,
             };
-            let (source, target) = if candidate.relation == CandidateRelation::Contains {
-                (source, target)
-            } else if self.occurrence(candidate).is_some_and(|occurrence| {
-                occurrence.role == compass_languages::SemanticRole::Receiver
-            }) {
-                (target, source)
-            } else {
-                (source, target)
-            };
-            let exact_target = candidate
-                .constraints
-                .exact_target_declaration_id
-                .as_deref()
-                .and_then(|id| self.declarations.get(id));
-            let relation = if self.occurrence(candidate).is_some_and(|occurrence| {
-                occurrence.role == compass_languages::SemanticRole::Receiver
-            }) {
-                "method"
-            } else if candidate.language == "go"
-                && candidate.relation == CandidateRelation::Calls
-                && target_kind
-                    .as_deref()
-                    .is_some_and(|kind| matches!(kind, "struct" | "interface" | "type_alias"))
-            {
-                "references"
-            } else {
-                relation_name(candidate.relation)
-            };
-            let site = self
-                .occurrence(candidate)
-                .map(|occurrence| &occurrence.range)
-                .or_else(|| exact_target.map(|target| &target.range))
-                .or_else(|| {
-                    matches!(
-                        candidate.relation,
-                        CandidateRelation::Contains | CandidateRelation::Owns
-                    )
-                    .then_some(target_site)
-                    .flatten()
-                })
-                .or_else(|| {
-                    self.declarations
-                        .get(&candidate.source_declaration_id)
-                        .map(|declaration| &declaration.range)
-                });
-            let Some(site) = site else { continue };
-            let key = (
-                source.clone(),
-                target.clone(),
-                relation.to_owned(),
-                site.source_file.clone(),
-                site.start_byte,
-                site.end_byte,
-                candidate.id.clone(),
-            );
-            if !emitted_edges.insert(key) || source == target {
-                continue;
-            }
-            edges.push(materialized_edge(
-                source,
+            resolved_targets.push((
+                candidate_id,
                 target,
-                relation,
-                candidate,
-                self.occurrence(candidate),
-                candidate
-                    .binding_id
-                    .as_deref()
-                    .and_then(|binding_id| self.bindings.get(binding_id)),
-                target_kind.as_deref(),
-                target_site.map(|range| range.source_file.as_str()),
-                site,
                 resolution_rule,
-                &candidate.language,
+                target_kind,
+                target_site,
             ));
         }
-        profile_internal("universal candidate resolution", &mut profile_started);
+        profile_internal("universal target projection", &mut profile_started);
+        let materialized = resolved_targets
+            .into_par_iter()
+            .filter_map(
+                |(candidate_id, target, resolution_rule, target_kind, target_site)| {
+                    let candidate = &self.candidates[candidate_id];
+                    let source = self
+                        .declarations
+                        .get(&candidate.source_declaration_id)
+                        .map(|declaration| graph_ids[&declaration.id].clone())?;
+                    let (source, target) = if candidate.relation == CandidateRelation::Contains {
+                        (source, target)
+                    } else if self.occurrence(candidate).is_some_and(|occurrence| {
+                        occurrence.role == compass_languages::SemanticRole::Receiver
+                    }) {
+                        (target, source)
+                    } else {
+                        (source, target)
+                    };
+                    let exact_target = candidate
+                        .constraints
+                        .exact_target_declaration_id
+                        .as_deref()
+                        .and_then(|id| self.declarations.get(id));
+                    let relation = if self.occurrence(candidate).is_some_and(|occurrence| {
+                        occurrence.role == compass_languages::SemanticRole::Receiver
+                    }) {
+                        "method"
+                    } else if candidate.language == "go"
+                        && candidate.relation == CandidateRelation::Calls
+                        && target_kind.as_deref().is_some_and(|kind| {
+                            matches!(kind, "struct" | "interface" | "type_alias")
+                        })
+                    {
+                        "references"
+                    } else {
+                        relation_name(candidate.relation)
+                    };
+                    let site = self
+                        .occurrence(candidate)
+                        .map(|occurrence| &occurrence.range)
+                        .or_else(|| exact_target.map(|target| &target.range))
+                        .or_else(|| {
+                            matches!(
+                                candidate.relation,
+                                CandidateRelation::Contains | CandidateRelation::Owns
+                            )
+                            .then_some(target_site)
+                            .flatten()
+                        })
+                        .or_else(|| {
+                            self.declarations
+                                .get(&candidate.source_declaration_id)
+                                .map(|declaration| &declaration.range)
+                        });
+                    let site = site?;
+                    // Candidate IDs are unique by construction and every candidate is
+                    // visited exactly once, so a second full edge-identity set cannot
+                    // remove duplicates here. Downstream graph publication still
+                    // performs its contract-level semantic edge coalescing.
+                    if source == target {
+                        return None;
+                    }
+                    Some(materialized_edge(
+                        source,
+                        target,
+                        relation,
+                        candidate,
+                        self.occurrence(candidate),
+                        candidate
+                            .binding_id
+                            .as_deref()
+                            .and_then(|binding_id| self.bindings.get(binding_id)),
+                        target_kind.as_deref(),
+                        target_site.map(|range| range.source_file.as_str()),
+                        site,
+                        resolution_rule,
+                        &candidate.language,
+                    ))
+                },
+            )
+            .collect::<Vec<_>>();
+        edges.extend(materialized);
+        profile_internal("universal edge materialization", &mut profile_started);
     }
 
     fn resolve_c3_receiver_dispatch(
@@ -2143,8 +2180,8 @@ fn declaration_basic_allowed(target: &DeclarationFact, candidate: &RelationshipC
 
 fn declaration_overloads<'a>(
     declarations: impl Iterator<Item = &'a DeclarationFact>,
-) -> BTreeMap<String, String> {
-    let mut groups = BTreeMap::<(String, String, String, String), Vec<&DeclarationFact>>::new();
+) -> AHashMap<String, String> {
+    let mut groups = AHashMap::<(String, String, String, String), Vec<&DeclarationFact>>::new();
     for declaration in declarations {
         groups
             .entry((
@@ -2156,7 +2193,7 @@ fn declaration_overloads<'a>(
             .or_default()
             .push(declaration);
     }
-    let mut overloads = BTreeMap::new();
+    let mut overloads = AHashMap::new();
     for declarations in groups.values_mut().filter(|group| group.len() > 1) {
         declarations.sort_by_key(|declaration| (declaration.range.start_byte, &declaration.id));
         for (position, declaration) in declarations.iter().enumerate() {
@@ -2192,15 +2229,15 @@ fn qualified_root(qualified: &str) -> &str {
 
 fn materialized_declaration_ids<'a>(
     declarations: impl Iterator<Item = &'a DeclarationFact>,
-) -> BTreeMap<String, String> {
-    let mut groups = BTreeMap::<String, Vec<&DeclarationFact>>::new();
+) -> AHashMap<String, String> {
+    let mut groups = AHashMap::<String, Vec<&DeclarationFact>>::new();
     for declaration in declarations {
         groups
             .entry(declaration.graph_node_id.clone())
             .or_default()
             .push(declaration);
     }
-    let mut ids = BTreeMap::new();
+    let mut ids = AHashMap::new();
     for (graph_node_id, declarations) in groups {
         if declarations.len() == 1 {
             ids.insert(declarations[0].id.clone(), graph_node_id);
@@ -2304,16 +2341,19 @@ fn read_go_module_path(root: &Path) -> Option<String> {
     })
 }
 
-fn insert_unique<T>(map: &mut BTreeMap<String, T>, id: String, value: T) -> Result<(), String> {
-    if map.insert(id.clone(), value).is_some() {
-        return Err(format!("duplicate universal evidence id {id:?}"));
+fn insert_unique<T>(map: &mut AHashMap<String, T>, id: String, value: T) -> Result<(), String> {
+    match map.entry(id) {
+        Entry::Occupied(entry) => Err(format!("duplicate universal evidence id {:?}", entry.key())),
+        Entry::Vacant(entry) => {
+            entry.insert(value);
+            Ok(())
+        }
     }
-    Ok(())
 }
 
 fn unique_definition_ranges(
-    declarations: &BTreeMap<String, DeclarationFact>,
-    scopes: &BTreeMap<String, compass_languages::ScopeFact>,
+    declarations: &AHashMap<String, DeclarationFact>,
+    scopes: &AHashMap<String, compass_languages::ScopeFact>,
 ) -> BTreeMap<String, EvidenceRange> {
     let mut ranges = BTreeMap::new();
     let mut ambiguous = BTreeSet::new();

--- a/crates/compass-resolve/src/frameworks/domain.rs
+++ b/crates/compass-resolve/src/frameworks/domain.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use ahash::AHashSet as HashSet;
 
 use compass_languages::{
     Extraction, FrameworkLimitError, FrameworkLimits, RawDomainFact, RawEdgeRecord,

--- a/crates/compass-resolve/src/frameworks/python.rs
+++ b/crates/compass-resolve/src/frameworks/python.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 
 use compass_languages::{FrameworkLimitError, FrameworkLimits, RawFrameworkFact, RawRouteFact};
 use serde_json::Value;

--- a/crates/compass-resolve/src/frameworks/routes.rs
+++ b/crates/compass-resolve/src/frameworks/routes.rs
@@ -1,6 +1,7 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::Path;
 
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use compass_languages::{
     Extraction, FrameworkLimitError, FrameworkLimits, RawEdgeRecord, RawFrameworkAnchor,
     RawFrameworkFact, RawFrameworkOrigin, RawNodeRecord, RawRouteFact, make_id,
@@ -113,14 +114,15 @@ pub fn publish_resolved_routes(
     extraction: &mut Extraction,
     routes: &[ResolvedRoute],
 ) -> Result<(), FrameworkResolutionError> {
-    let mut existing_nodes = extraction
+    let existing_nodes = extraction
         .nodes
         .iter()
-        .map(|node| node.id.clone())
+        .map(|node| node.id.as_str())
         .collect::<HashSet<_>>();
     let mut existing_edges = extraction
         .edges
         .iter()
+        .filter(|edge| edge.string("relation") == "routes_to")
         .map(|edge| {
             (
                 edge.source.clone(),
@@ -135,6 +137,10 @@ pub fn publish_resolved_routes(
             )
         })
         .collect::<HashSet<_>>();
+    let mut added_node_ids = HashSet::new();
+    let mut added_nodes = Vec::new();
+    let mut stage_roles = Vec::new();
+    let mut added_edges = Vec::new();
 
     for resolved in routes {
         let route = &resolved.route;
@@ -152,8 +158,8 @@ pub fn publish_resolved_routes(
             &route.anchor.end_line.to_string(),
             &route.anchor.end_column.to_string(),
         ]);
-        if existing_nodes.insert(route_id.clone()) {
-            extraction.nodes.push(RawNodeRecord {
+        if !existing_nodes.contains(route_id.as_str()) && added_node_ids.insert(route_id.clone()) {
+            added_nodes.push(RawNodeRecord {
                 id: route_id.clone(),
                 attributes: route_attributes(resolved),
             });
@@ -178,14 +184,20 @@ pub fn publish_resolved_routes(
             )) {
                 continue;
             }
-            mark_stage_role(&mut extraction.nodes, target, stage.role);
-            extraction.edges.push(RawEdgeRecord {
+            stage_roles.push((target.to_owned(), stage.role));
+            added_edges.push(RawEdgeRecord {
                 source: route_id.clone(),
                 target: target.to_owned(),
                 attributes: route_edge_attributes(resolved, stage),
             });
         }
     }
+    drop(existing_nodes);
+    extraction.nodes.extend(added_nodes);
+    for (target, role) in stage_roles {
+        mark_stage_role(&mut extraction.nodes, &target, role);
+    }
+    extraction.edges.extend(added_edges);
     Ok(())
 }
 

--- a/crates/compass-resolve/src/frameworks/target_index.rs
+++ b/crates/compass-resolve/src/frameworks/target_index.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use compass_languages::{Extraction, RawNodeRecord};
 use serde_json::Value;
 
@@ -38,12 +38,19 @@ impl<'a> FrameworkTargetIndex<'a> {
             .iter()
             .map(|node| (node.id.as_str(), node))
             .collect::<HashMap<_, _>>();
+        let target_ids = extraction
+            .nodes
+            .iter()
+            .filter(|node| !target_families(node).is_empty())
+            .map(|node| node.id.as_str())
+            .collect::<HashSet<_>>();
         let mut owners = HashMap::<&str, Vec<String>>::new();
         for edge in &extraction.edges {
             if !matches!(
                 edge.attributes.get("relation").and_then(Value::as_str),
                 Some("contains" | "method" | "defines")
-            ) {
+            ) || !target_ids.contains(edge.target.as_str())
+            {
                 continue;
             }
             if let Some(parent) = raw_by_id.get(edge.source.as_str()) {
@@ -75,6 +82,10 @@ impl<'a> FrameworkTargetIndex<'a> {
             by_module_terminal: HashMap::new(),
         };
         for node in &extraction.nodes {
+            let families = target_families(node);
+            if families.is_empty() {
+                continue;
+            }
             let qualified = normalize_reference(&node.string("qualified_name"));
             let signature_qualified = node
                 .attributes
@@ -107,8 +118,7 @@ impl<'a> FrameworkTargetIndex<'a> {
             normalized.dedup();
             let target_owners = owners.remove(node.id.as_str()).unwrap_or_default();
             let position = index.targets.len();
-            let families = target_families(node);
-            for family in families {
+            for &family in families {
                 index
                     .by_id
                     .entry((family, node.id.as_str()))
@@ -336,21 +346,24 @@ fn bounded_union_measured<'a>(
     (retained, truncated, examined)
 }
 
-fn target_families(node: &RawNodeRecord) -> Vec<TargetFamily> {
+fn target_families(node: &RawNodeRecord) -> &'static [TargetFamily] {
+    const ROUTE_CALLABLE: &[TargetFamily] = &[TargetFamily::Route, TargetFamily::Callable];
+    const ROUTE_TYPE: &[TargetFamily] = &[TargetFamily::Route, TargetFamily::Type];
+    const ROUTE: &[TargetFamily] = &[TargetFamily::Route];
+    const TYPE: &[TargetFamily] = &[TargetFamily::Type];
+    const DATABASE_TABLE: &[TargetFamily] = &[TargetFamily::DatabaseTable];
     let kind = node
         .attributes
         .get("symbol_kind")
         .or_else(|| node.attributes.get("type"))
         .and_then(Value::as_str);
     match kind {
-        Some("function" | "method") => vec![TargetFamily::Route, TargetFamily::Callable],
-        Some("class") => vec![TargetFamily::Route, TargetFamily::Type],
-        Some("component") => vec![TargetFamily::Route],
-        Some("struct" | "interface" | "trait" | "protocol" | "enum") => {
-            vec![TargetFamily::Type]
-        }
-        Some("database_table" | "table") => vec![TargetFamily::DatabaseTable],
-        _ => Vec::new(),
+        Some("function" | "method") => ROUTE_CALLABLE,
+        Some("class") => ROUTE_TYPE,
+        Some("component") => ROUTE,
+        Some("struct" | "interface" | "trait" | "protocol" | "enum") => TYPE,
+        Some("database_table" | "table") => DATABASE_TABLE,
+        _ => &[],
     }
 }
 

--- a/crates/compass-resolve/src/frameworks/typescript.rs
+++ b/crates/compass-resolve/src/frameworks/typescript.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::AHashMap as HashMap;
 use std::path::Path;
 
 use compass_languages::{Extraction, FrameworkLimits};

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -225,7 +225,14 @@ pub fn resolve_with_root(
             .framework_facts
             .extend(extraction.framework_facts.iter().cloned());
     }
-    finish_resolution(merged, language_facts, evidence_batches, sources, root)
+    finish_resolution(
+        merged,
+        language_facts,
+        evidence_batches,
+        sources,
+        root,
+        false,
+    )
 }
 
 /// Resolve a collection while transferring its node and edge buffers into the
@@ -237,10 +244,34 @@ pub fn resolve_owned_with_root(
     sources: &HashMap<String, String>,
     root: &Path,
 ) -> Extraction {
-    let language_facts = members::collect_language_call_facts_owned(&mut extractions);
+    resolve_owned_with_root_impl(&mut extractions, sources, root, false)
+}
+
+/// Resolve owned facts whose universal evidence was validated at its trust boundary.
+///
+/// This is the build-pipeline entry point: fresh evidence is validated before
+/// the language engine publishes it, and cached evidence is validated before
+/// cache acceptance. Cross-batch identities, aggregate limits, and all
+/// resolution ambiguity checks are still enforced here.
+#[must_use]
+pub fn resolve_prevalidated_owned_with_root(
+    mut extractions: Vec<Extraction>,
+    sources: &HashMap<String, String>,
+    root: &Path,
+) -> Extraction {
+    resolve_owned_with_root_impl(&mut extractions, sources, root, true)
+}
+
+fn resolve_owned_with_root_impl(
+    extractions: &mut Vec<Extraction>,
+    sources: &HashMap<String, String>,
+    root: &Path,
+    evidence_prevalidated: bool,
+) -> Extraction {
+    let language_facts = members::collect_language_call_facts_owned(extractions);
     let mut evidence_batches = Vec::new();
     let mut merged = Extraction::default();
-    for extraction in &mut extractions {
+    for extraction in extractions.iter_mut() {
         let universal = extraction.semantic_evidence.take();
         if universal.is_some() {
             let mut allowed = universal
@@ -280,8 +311,15 @@ pub fn resolve_owned_with_root(
             evidence_batches.push(batch);
         }
     }
-    drop(extractions);
-    finish_resolution(merged, language_facts, evidence_batches, sources, root)
+    extractions.clear();
+    finish_resolution(
+        merged,
+        language_facts,
+        evidence_batches,
+        sources,
+        root,
+        evidence_prevalidated,
+    )
 }
 
 fn universal_allowed_node_ids(extraction: &Extraction) -> HashSet<String> {
@@ -312,27 +350,51 @@ fn finish_resolution(
     evidence_batches: Vec<SemanticEvidenceBatch>,
     sources: &HashMap<String, String>,
     root: &Path,
+    evidence_prevalidated: bool,
 ) -> Extraction {
     let mut profile_started = Instant::now();
     let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    if let Err(error) = resolve_javascript_workspace_modules(&mut merged, &canonical_root) {
-        merged
-            .error
-            .get_or_insert_with(|| format!("JavaScript workspace resolution failed: {error}"));
+    let has_javascript = sources.keys().any(|source| {
+        let extension = extension(source);
+        matches!(
+            extension.as_str(),
+            "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts"
+        )
+    });
+    let has_csharp = sources
+        .keys()
+        .any(|source| matches!(extension(source).as_str(), "cs" | "razor" | "cshtml"));
+    let has_php = sources.keys().any(|source| extension(source) == "php");
+    if has_javascript {
+        if let Err(error) = resolve_javascript_workspace_modules(&mut merged, &canonical_root) {
+            merged
+                .error
+                .get_or_insert_with(|| format!("JavaScript workspace resolution failed: {error}"));
+        }
+        resolve_javascript_reexports(&mut merged);
     }
     profile_internal(
         "resolver JavaScript workspace modules",
         &mut profile_started,
     );
-    resolve_javascript_reexports(&mut merged);
     profile_internal("resolver JavaScript re-exports", &mut profile_started);
     if !evidence_batches.is_empty() {
-        match evidence::UniversalResolutionIndex::new_with_inventory_owned(
-            evidence_batches,
-            &merged.nodes,
-            &canonical_root,
-            evidence::UniversalResolutionLimits::default(),
-        ) {
+        let index = if evidence_prevalidated {
+            evidence::UniversalResolutionIndex::new_with_prevalidated_inventory_owned(
+                evidence_batches,
+                &merged.nodes,
+                &canonical_root,
+                evidence::UniversalResolutionLimits::default(),
+            )
+        } else {
+            evidence::UniversalResolutionIndex::new_with_inventory_owned(
+                evidence_batches,
+                &merged.nodes,
+                &canonical_root,
+                evidence::UniversalResolutionLimits::default(),
+            )
+        };
+        match index {
             Ok(index) => index.materialize(&mut merged.nodes, &mut merged.edges),
             Err(error) => {
                 if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
@@ -356,14 +418,20 @@ fn finish_resolution(
         &mut language_facts.calls,
     );
     profile_internal("resolver collision disambiguation", &mut profile_started);
-    resolve_javascript_workspace_symbols(&mut merged);
+    if has_javascript {
+        resolve_javascript_workspace_symbols(&mut merged);
+    }
     profile_internal(
         "resolver JavaScript workspace symbols",
         &mut profile_started,
     );
-    canonicalize_csharp_namespace_nodes(&mut merged);
+    if has_csharp {
+        canonicalize_csharp_namespace_nodes(&mut merged);
+    }
     profile_internal("resolver C# namespace normalization", &mut profile_started);
-    resolve_php_type_references(&mut merged, sources);
+    if has_php {
+        resolve_php_type_references(&mut merged, sources);
+    }
     profile_internal("resolver PHP types", &mut profile_started);
     rewire_unique_family_stubs(&mut merged);
     profile_internal("resolver family stubs", &mut profile_started);
@@ -940,6 +1008,9 @@ fn rewire_unique_family_stubs(extraction: &mut Extraction) {
                 .push((node.id.clone(), source));
         }
     }
+    if stubs.is_empty() {
+        return;
+    }
     let imports_by_source = extraction
         .edges
         .iter()
@@ -1186,7 +1257,7 @@ fn canonicalize_file_targets(extraction: &mut Extraction, root: &Path) {
     let node_ids = extraction
         .nodes
         .iter()
-        .map(|node| node.id.clone())
+        .map(|node| node.id.as_str())
         .collect::<HashSet<_>>();
     for node in &extraction.nodes {
         let source = string_attribute(node, "source_file");
@@ -1237,7 +1308,7 @@ fn canonicalize_file_targets(extraction: &mut Extraction, root: &Path) {
         })
         .collect::<HashMap<_, _>>();
     for edge in &mut extraction.edges {
-        if node_ids.contains(&edge.target) {
+        if node_ids.contains(edge.target.as_str()) {
             continue;
         }
         if let Some(target) = aliases.get(&edge.target) {
@@ -1256,41 +1327,66 @@ fn canonicalize_file_targets(extraction: &mut Extraction, root: &Path) {
 }
 
 fn rewire_unique_stub_nodes(extraction: &mut Extraction) {
+    let normalized_label = |node: &NodeRecord| {
+        node.label()
+            .trim()
+            .trim_matches(['(', ')'])
+            .trim_start_matches('.')
+            .chars()
+            .filter(char::is_ascii_alphanumeric)
+            .collect::<String>()
+    };
+    let stubs = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            string_attribute(node, "source_file").is_empty() && !is_canonical_external_symbol(node)
+        })
+        .filter_map(|node| {
+            let label = normalized_label(node);
+            (!label.is_empty()).then(|| (node.id.clone(), label))
+        })
+        .collect::<Vec<_>>();
+    if stubs.is_empty() {
+        return;
+    }
+    let needed_labels = stubs
+        .iter()
+        .map(|(_, label)| label.clone())
+        .collect::<HashSet<_>>();
+    let needed_folded = needed_labels
+        .iter()
+        .map(|label| label.to_ascii_lowercase())
+        .collect::<HashSet<_>>();
     let mut types = HashMap::<String, Vec<String>>::new();
     let mut types_ci = HashMap::<String, Vec<String>>::new();
     let mut callables = HashMap::<String, Vec<String>>::new();
     let mut source_by_id = HashMap::<String, String>::new();
-    let mut stubs = Vec::<(String, String)>::new();
     for node in &extraction.nodes {
-        let normalized_label = node
-            .label()
-            .trim()
-            .trim_matches(['(', ')'])
-            .trim_start_matches('.')
-            .to_owned();
-        let label = normalized_label
-            .chars()
-            .filter(char::is_ascii_alphanumeric)
-            .collect::<String>();
+        let source = string_attribute(node, "source_file");
+        if source.is_empty() {
+            continue;
+        }
+        let label = normalized_label(node);
         if label.is_empty() {
             continue;
         }
-        let source = string_attribute(node, "source_file");
+        let folded = label.to_ascii_lowercase();
+        if !needed_labels.contains(label.as_str()) && !needed_folded.contains(&folded) {
+            continue;
+        }
         source_by_id.insert(node.id.clone(), source.clone());
-        if source.is_empty() && !is_canonical_external_symbol(node) {
-            stubs.push((node.id.clone(), label));
-        } else if is_generic_call_target(node) {
+        if is_generic_call_target(node) && needed_labels.contains(label.as_str()) {
             callables.entry(label).or_default().push(node.id.clone());
         } else if is_type_like_definition(node) {
-            types
-                .entry(label.clone())
-                .or_default()
-                .push(node.id.clone());
-            if case_insensitive(&source) {
-                types_ci
-                    .entry(label.to_ascii_lowercase())
+            if needed_labels.contains(label.as_str()) {
+                types
+                    .entry(label.clone())
                     .or_default()
                     .push(node.id.clone());
+            }
+            if case_insensitive(&source) && needed_folded.contains(&folded) {
+                types_ci.entry(folded).or_default().push(node.id.clone());
             }
         }
     }
@@ -1497,6 +1593,7 @@ fn disambiguate_colliding_node_ids_with_calls(
     root: &Path,
     raw_calls: &mut [RawCall],
 ) {
+    let mut first_positions = HashMap::<String, usize>::new();
     let mut groups = HashMap::<String, Vec<usize>>::new();
     for (index, node) in extraction.nodes.iter().enumerate() {
         if matches!(
@@ -1506,9 +1603,17 @@ fn disambiguate_colliding_node_ids_with_calls(
             continue;
         }
         if !node.id.is_empty() {
-            groups.entry(node.id.clone()).or_default().push(index);
+            if let Some(&first) = first_positions.get(&node.id) {
+                groups
+                    .entry(node.id.clone())
+                    .or_insert_with(|| vec![first])
+                    .push(index);
+            } else {
+                first_positions.insert(node.id.clone(), index);
+            }
         }
     }
+    drop(first_positions);
     let mut remap = HashMap::<(String, String), String>::new();
     let mut ambiguous = HashSet::new();
     for (old_id, indexes) in &groups {
@@ -1669,6 +1774,25 @@ fn resolve_cross_file_calls_with_root(
 }
 
 fn resolve_cross_file_calls_with_root_calls(extraction: &mut Extraction, raw_calls: &[RawCall]) {
+    let eligible_calls = raw_calls.iter().filter(|raw| {
+        !raw.callee.is_empty()
+            && raw.is_member_call != Some(true)
+            && raw.extensions.get("is_mixin").and_then(Value::as_bool) != Some(true)
+    });
+    let mut call_families = AHashSet::new();
+    let mut has_unscoped_call = false;
+    let mut eligible_call_count = 0_usize;
+    for raw in eligible_calls {
+        eligible_call_count = eligible_call_count.saturating_add(1);
+        if let Some(family) = language_family(&raw.source_file) {
+            call_families.insert(family);
+        } else {
+            has_unscoped_call = true;
+        }
+    }
+    if eligible_call_count == 0 {
+        return;
+    }
     let mut profile_started = Instant::now();
     let mut exact = AHashMap::<String, Vec<String>>::new();
     let mut folded = AHashMap::<String, Vec<String>>::new();
@@ -1677,6 +1801,11 @@ fn resolve_cross_file_calls_with_root_calls(extraction: &mut Extraction, raw_cal
     let mut callable = AHashSet::<String>::new();
     for node in &extraction.nodes {
         let source = string_attribute(node, "source_file");
+        if !has_unscoped_call
+            && language_family(&source).is_some_and(|family| !call_families.contains(family))
+        {
+            continue;
+        }
         source_by_id.insert(node.id.clone(), source.clone());
         if node.attributes.get("_callable").and_then(Value::as_bool) == Some(true) {
             callable.insert(node.id.clone());
@@ -1723,6 +1852,9 @@ fn resolve_cross_file_calls_with_root_calls(extraction: &mut Extraction, raw_cal
     let mut existing = AHashSet::new();
     let mut call_like = AHashSet::new();
     for edge in &extraction.edges {
+        if !source_by_id.contains_key(&edge.source) {
+            continue;
+        }
         existing.insert((
             edge.source.clone(),
             edge.target.clone(),

--- a/crates/compass-resolve/src/members.rs
+++ b/crates/compass-resolve/src/members.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use compass_languages::{Extraction, RawCall, is_language_builtin_global, make_id};
 use compass_languages::{RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord};
 use serde_json::{Map, Value};
@@ -46,8 +47,17 @@ pub(crate) fn collect_language_call_facts_owned(
 }
 
 pub(crate) fn resolve_language_call_facts(facts: LanguageCallFacts, merged: &mut Extraction) {
+    if facts.calls.is_empty() {
+        return;
+    }
     let external_nodes = {
-        let indexes = Indexes::new(&merged.nodes, &merged.edges);
+        let (indexed_families, has_unscoped_calls) = indexed_families(&facts.calls, &facts.tables);
+        let indexes = Indexes::new(
+            &merged.nodes,
+            &merged.edges,
+            &indexed_families,
+            has_unscoped_calls,
+        );
         let mut existing = merged
             .edges
             .iter()
@@ -148,18 +158,29 @@ struct Indexes<'a> {
 }
 
 impl<'a> Indexes<'a> {
-    fn new(nodes: &'a [NodeRecord], edges: &[EdgeRecord]) -> Self {
+    fn new(
+        nodes: &'a [NodeRecord],
+        edges: &[EdgeRecord],
+        indexed_families: &HashSet<&'static str>,
+        has_unscoped_calls: bool,
+    ) -> Self {
         let nodes_by_id = nodes
             .iter()
+            .filter(|node| {
+                has_unscoped_calls
+                    || index_family(&node.string("source_file"))
+                        .is_none_or(|family| indexed_families.contains(family))
+            })
             .map(|node| (node.id.as_str(), node))
             .collect::<HashMap<_, _>>();
         let contained = edges
             .iter()
+            .filter(|edge| nodes_by_id.contains_key(edge.target.as_str()))
             .filter(|edge| relation(edge) == "contains")
             .map(|edge| edge.target.as_str())
             .collect::<HashSet<_>>();
         let mut types = HashMap::<String, Vec<String>>::new();
-        for node in nodes {
+        for node in nodes_by_id.values().copied() {
             if contained.contains(node.id.as_str()) && is_type_like(node) {
                 push_unique(&mut types, key(node.label()), &node.id);
             }
@@ -173,6 +194,11 @@ impl<'a> Indexes<'a> {
         let mut imports = HashMap::<String, HashSet<String>>::new();
         let mut bases = HashMap::<String, Vec<String>>::new();
         for edge in edges {
+            if !nodes_by_id.contains_key(edge.source.as_str())
+                && !nodes_by_id.contains_key(edge.target.as_str())
+            {
+                continue;
+            }
             let target_label = nodes_by_id
                 .get(edge.target.as_str())
                 .map(|node| node.label());
@@ -275,6 +301,42 @@ impl TypeTables {
             collect_table(extraction, "objc_type_table", &mut tables.objc);
         }
         tables
+    }
+}
+
+fn indexed_families(calls: &[RawCall], tables: &TypeTables) -> (HashSet<&'static str>, bool) {
+    let mut families = calls
+        .iter()
+        .filter_map(|call| index_family(&call.source_file))
+        .collect::<HashSet<_>>();
+    let has_unscoped = calls
+        .iter()
+        .any(|call| index_family(&call.source_file).is_none());
+    for (present, family) in [
+        (!tables.swift.is_empty(), "swift"),
+        (!tables.typescript.is_empty(), "javascript"),
+        (!tables.cpp.is_empty(), "cpp"),
+        (!tables.csharp.is_empty(), "csharp"),
+        (!tables.objc.is_empty(), "objc"),
+    ] {
+        if present {
+            families.insert(family);
+        }
+    }
+    (families, has_unscoped)
+}
+
+fn index_family(source: &str) -> Option<&'static str> {
+    match extension(source).as_str() {
+        "py" | "pyi" => Some("python"),
+        "rb" | "rake" => Some("ruby"),
+        "pas" | "pp" | "dpr" | "dpk" | "inc" => Some("pascal"),
+        "swift" => Some("swift"),
+        "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs" => Some("javascript"),
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx" | "cu" | "cuh" => Some("cpp"),
+        "cs" | "razor" | "cshtml" => Some("csharp"),
+        "m" | "mm" => Some("objc"),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

- replace the portable AST cache payload with a versioned MessagePack + zstd envelope and parallelize bounded cache encoding/publication
- remove redundant Program, evidence, graph, and normalization clones while using fast internal indexes behind deterministic sorted publication boundaries
- overlap independent Program analysis, resolver, clustering, and v1 evidence preparation work
- reduce framework-target and universal-evidence allocation overhead
- use portable content-addressed omission identities so clean, warm, rebuilt, and alternate-checkout output remains byte-identical
- tune the one-shot CLI allocator lifecycle and document the qualification evidence

## Why

The 0.2.1 Django cold code-graph build had regressed from roughly 10–12 seconds to about 40 seconds. This restores the pinned Django qualification workload to sub-10-second builds without weakening validation, ambiguity handling, resource bounds, provenance, or deterministic output.

## Performance evidence

On Django commit `5e32c82a5a896e1d942cfc9dd9a2ebbe86741258`, three isolated cold builds with fresh output and zero cache reuse completed in 9.31 seconds with internal profiling and 9.04/9.06 seconds without profiling. Each run published:

- 3,105 files
- 80,961 nodes
- 187,173 edges
- 2,583 communities
- 3,038 Program modules and 32,049 summaries

Graph and Program SHA-256 digests were identical across all runs.

Current `origin/main` also introduces deterministic HTML/Markdown extraction, expanding a second local Django workload from 3,105 to 3,475 files. On the rebased commit, five fresh-output runs remained byte-identical; repeated external wall times after the first copied-binary launch were 10.42–10.67 seconds. This expanded workload is recorded separately in `PERFORMANCE.md`.

As an optional diagnostic comparator on the same local checkout, Graphify 0.9.31 code-only cold extraction had a 48.27-second median. Compass remained about 4.6× faster while indexing the expanded file set and producing Program analysis.

## Correctness and validation

Run after rebasing directly onto current `origin/main`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-resolve -p compass-core -p compass-graph --locked`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `sh scripts/check_product_boundary.sh`

The fixture qualifier confirmed byte-identical clean, warm, forced-rebuild, restored, and alternate-checkout graphs.
