### PR TITLE
Release Compass 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-02
+
 - Restore sub-10-second cold builds for the pinned 3,105-file Django
   qualification corpus by batching and compressing portable AST cache
   publication, parallelizing independent resolver and graph-normalization

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "regex",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "compass-core",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,28 +35,28 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.2.1" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-program = { path = "../compass-program", version = "0.2.1" }
-compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
-compass-cargo = { path = "../compass-cargo", version = "0.2.1" }
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.2.1" }
-compass-global = { path = "../compass-global", version = "0.2.1" }
-compass-history = { path = "../compass-history", version = "0.2.1" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.1" }
-compass-ingest = { path = "../compass-ingest", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-mcp = { path = "../compass-mcp", version = "0.2.1" }
-compass-output = { path = "../compass-output", version = "0.2.1" }
-compass-postgres = { path = "../compass-postgres", version = "0.2.1" }
-compass-prs = { path = "../compass-prs", version = "0.2.1" }
-compass-query = { path = "../compass-query", version = "0.2.1" }
-compass-reflect = { path = "../compass-reflect", version = "0.2.1" }
-compass-semantic = { path = "../compass-semantic", version = "0.2.1" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.2.1" }
+compass-core = { path = "../compass-core", version = "0.3.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-program = { path = "../compass-program", version = "0.3.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
+compass-global = { path = "../compass-global", version = "0.3.0" }
+compass-history = { path = "../compass-history", version = "0.3.0" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.0" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.0" }
+compass-output = { path = "../compass-output", version = "0.3.0" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.0" }
+compass-prs = { path = "../compass-prs", version = "0.3.0" }
+compass-query = { path = "../compass-query", version = "0.3.0" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.0" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.0" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.0" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-program = { path = "../compass-program", version = "0.2.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-program = { path = "../compass-program", version = "0.3.0" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,15 +24,15 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.2.1" }
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
-compass-history = { path = "../compass-history", version = "0.2.1" }
-compass-output = { path = "../compass-output", version = "0.2.1" }
-compass-reflect = { path = "../compass-reflect", version = "0.2.1" }
-compass-resolve = { path = "../compass-resolve", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-history = { path = "../compass-history", version = "0.3.0" }
+compass-output = { path = "../compass-output", version = "0.3.0" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.0" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.0" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.2.1" }
+compass-media = { path = "../compass-media", version = "0.3.0" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,8 +19,8 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 rayon.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-program = { path = "../compass-program", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-program = { path = "../compass-program", version = "0.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,12 +19,12 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.2.1" }
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-prs = { path = "../compass-prs", version = "0.2.1" }
-compass-query = { path = "../compass-query", version = "0.2.1" }
+compass-core = { path = "../compass-core", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-prs = { path = "../compass-prs", version = "0.3.0" }
+compass-query = { path = "../compass-query", version = "0.3.0" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,12 +20,12 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
-compass-history = { path = "../compass-history", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-query = { path = "../compass-query", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-history = { path = "../compass-history", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-query = { path = "../compass-query", version = "0.3.0" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
 protobuf.workspace = true
 scip.workspace = true
 serde.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-files = { path = "../compass-files", version = "0.2.1" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -18,10 +18,10 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -29,9 +29,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.2.1" }
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
-compass-program = { path = "../compass-program", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-program = { path = "../compass-program", version = "0.3.0" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-graph = { path = "../compass-graph", version = "0.2.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.2.1" }
-compass-history = { path = "../compass-history", version = "0.2.1" }
-compass-ir = { path = "../compass-ir", version = "0.2.1" }
-compass-model = { path = "../compass-model", version = "0.2.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
+compass-history = { path = "../compass-history", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.2.1" }
-compass-program = { path = "../compass-program", version = "0.2.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-program = { path = "../compass-program", version = "0.3.0" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.2.1" }
-compass-media = { path = "../compass-media", version = "0.2.1" }
+compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-media = { path = "../compass-media", version = "0.3.0" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.2.1", path = "../compass-ingest" }
-compass-whisper = { version = "0.2.1", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.0", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.0", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "regex",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -925,6 +925,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "toml 1.1.3+spec-1.1.0",
+ "zstd",
 ]
 
 [[package]]
@@ -948,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -960,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -973,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -991,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1003,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1023,9 +1024,10 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
+ "compass-languages",
  "regex",
  "serde_json",
  "sha1",
@@ -1040,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1050,8 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
+ "ahash",
  "compass-files",
  "compass-ir",
  "compass-program",
@@ -1068,14 +1071,17 @@ dependencies = [
  "toml 1.1.3+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-dm",
+ "tree-sitter-html",
+ "tree-sitter-md",
  "unicode-casefold",
  "unicode-normalization",
  "unicode-properties",
+ "url",
 ]
 
 [[package]]
 name = "compass-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "compass-core",
@@ -1094,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1104,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1116,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1137,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1151,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1165,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1178,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1197,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1211,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1228,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1249,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1263,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "compass-ingest",
  "rubato",
@@ -4415,10 +4421,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "try-lock"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.2.1", path = "../crates/compass-model" }
-compass-cli = { version = "0.2.1", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.2.1", path = "../crates/compass-cypher" }
-compass-files = { version = "0.2.1", path = "../crates/compass-files" }
-compass-graph = { version = "0.2.1", path = "../crates/compass-graph" }
-compass-languages = { version = "0.2.1", path = "../crates/compass-languages" }
-compass-output = { version = "0.2.1", path = "../crates/compass-output" }
-compass-query = { version = "0.2.1", path = "../crates/compass-query" }
-compass-semantic = { version = "0.2.1", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.2.1", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.0", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.0", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.0", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.0", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.0", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.0", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.0", path = "../crates/compass-output" }
+compass-query = { version = "0.3.0", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.0", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.0", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1599,7 +1599,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.2.1"
+    "producerVersion": "compass-languages/0.3.0"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- sync the release branch from the latest `origin/main` (`c8390c5`)
- bump the Rust workspace, fuzz harness, lockfiles, VS Code extension, and qualification producer identity to `0.3.0`
- promote the current Unreleased highlights into the dated 0.3.0 changelog

## Validation

- `cargo fmt --all -- --check`
- product-boundary and release-script tests
- Compass CLI product contract: 5 passed
- fixture-only code-graph qualification: deterministic byte comparisons and semantic assertions passed
- workspace Clippy with `-D warnings`
- workspace library/binary tests: all passed
- fuzz manifest `cargo check --offline`
- verified local aarch64 macOS release archive, version/help, licenses, and SHA-256

## Release plan

After merge, tag `compass-v0.3.0` to build and publish the six macOS/Linux/Windows archives, checksums, installers, and generated GitHub release notes.