### PR TITLE
feat: publish durable SQLite graph snapshots

### DIFF
--- a/crates/compass-cli/tests/init_cli.rs
+++ b/crates/compass-cli/tests/init_cli.rs
@@ -5,7 +5,10 @@ use std::io::Cursor;
 use std::process::{Command, Stdio};
 
 use compass_files::{BuildGuard, ProjectConfig};
+use compass_graph::{GraphSnapshotReader, canonical_graph_json};
 use compass_model::GraphDocument;
+use compass_model::code_graph::GraphDocument as CodeGraphDocument;
+use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef};
 use serde_json::Value;
 
 #[test]
@@ -44,6 +47,77 @@ fn init_persists_scope_and_builds_only_matching_files() -> Result<(), Box<dyn Er
     )?)?;
     assert!(graph.nodes.iter().any(|node| node.label() == "included()"));
     assert!(!graph.nodes.iter().any(|node| node.label() == "excluded()"));
+    Ok(())
+}
+
+#[test]
+fn init_and_update_publish_a_durable_graph_snapshot_alongside_json() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    fs::create_dir(root.path().join("src"))?;
+    fs::write(root.path().join("src/lib.rs"), "pub fn initial() {}\n")?;
+    let init = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["init", ".", "--yes"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        init.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let output_root = root.path().join("compass-out");
+    let active = BuildGuard::resolve_active_directory(&output_root)?;
+    let graph_path = active.join("graph.json");
+    let store = SqliteStore::open_read_only(active.join(STORE_FILE_NAME))?;
+    let graph = CodeGraphDocument::load(&graph_path)?;
+    let reader = GraphSnapshotReader::open_active(&store)?.ok_or("missing active snapshot")?;
+    assert_eq!(reader.export_json_bytes()?, canonical_graph_json(&graph)?);
+    let reference: StoreRef = serde_json::from_slice(&fs::read(active.join(STORE_REF_FILE_NAME))?)?;
+    assert_eq!(reference, store.snapshot_reference()?);
+
+    fs::write(root.path().join("src/lib.rs"), "pub fn changed() {}\n")?;
+    let update = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["update", ".", "--no-viz"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        update.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&update.stdout),
+        String::from_utf8_lossy(&update.stderr)
+    );
+    let active = BuildGuard::resolve_active_directory(&output_root)?;
+    assert!(active.join("graph.json").is_file());
+    assert!(active.join(STORE_FILE_NAME).is_file());
+    assert!(active.join(STORE_REF_FILE_NAME).is_file());
+    assert!(!active.join(".compass-build-incomplete").exists());
+    Ok(())
+}
+
+#[test]
+fn shadow_switch_can_disable_store_artifacts_without_disabling_json() -> Result<(), Box<dyn Error>>
+{
+    let root = tempfile::tempdir()?;
+    fs::write(root.path().join("main.rs"), "fn main() {}\n")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["update", ".", "--no-viz"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .env("COMPASS_STORE_SHADOW", "0")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let active = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
+    assert!(active.join("graph.json").is_file());
+    assert!(!active.join(STORE_FILE_NAME).exists());
+    assert!(!active.join(STORE_REF_FILE_NAME).exists());
     Ok(())
 }
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -11,9 +11,10 @@ use compass_files::{
 };
 use compass_graph::{
     BuildEvidence, ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION,
-    InventoryEvidence, PublicationOmissions, PublicationOutcome,
-    build_owned_with_tiebreaker as build_document, canonical_edge_kind, canonical_raw_edge_sites,
-    cluster, dedupe_nodes, extraction_from_v1, graph_insights, label_communities_by_hub,
+    GraphSnapshotBuilder, GraphSnapshotReader, InventoryEvidence, PublicationOmissions,
+    PublicationOutcome, build_owned_with_tiebreaker as build_document, canonical_edge_kind,
+    canonical_graph_json, canonical_raw_edge_sites, cluster, dedupe_nodes, extraction_from_v1,
+    graph_insights, label_communities_by_hub,
     normalize_document_v1_with_evidence_best_effort_owned,
     normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
@@ -320,6 +321,8 @@ pub enum CoreError {
     ProgramIr(#[from] compass_ir::IrError),
     #[error(transparent)]
     Store(#[from] compass_store::StoreError),
+    #[error(transparent)]
+    Snapshot(#[from] compass_graph::SnapshotError),
     #[error("invalid Program IR input: {0}")]
     InvalidProgramInput(String),
     #[error("invalid completed-build state: {0}")]
@@ -1859,10 +1862,15 @@ fn publish_build_state(
     omissions: PublicationOmissions,
     program: Option<&ProgramBuildSummary>,
 ) -> Result<(), CoreError> {
-    ensure_store_snapshot(output_dir)?;
+    let shadow_store = store_shadow_enabled();
+    if shadow_store {
+        ensure_store_snapshot(output_dir)?;
+    }
     let mut required = vec![output_dir.join(OUTPUT_STATS_FILE)];
-    required.push(output_dir.join(STORE_FILE_NAME));
-    required.push(output_dir.join(STORE_REF_FILE_NAME));
+    if shadow_store {
+        required.push(output_dir.join(STORE_FILE_NAME));
+        required.push(output_dir.join(STORE_REF_FILE_NAME));
+    }
     match options.purpose {
         BuildPurpose::Update => {
             required.push(output_dir.join(".compass_root"));
@@ -1909,14 +1917,24 @@ fn publish_build_state(
 }
 
 fn commit_generation(guard: BuildGuard, output_container: &Path) -> Result<PathBuf, CoreError> {
-    ensure_store_snapshot(guard.staging_directory())?;
-    let mut artifacts = vec![
-        "graph.json",
-        "manifest.json",
-        BUILD_STATE_FILE,
-        STORE_FILE_NAME,
-        STORE_REF_FILE_NAME,
-    ];
+    let shadow_store = store_shadow_enabled();
+    if !shadow_store {
+        for suffix in ["", "-wal", "-shm"] {
+            remove_if_exists(
+                &guard
+                    .staging_directory()
+                    .join(format!("{STORE_FILE_NAME}{suffix}")),
+            )?;
+        }
+        remove_if_exists(&guard.staging_directory().join(STORE_REF_FILE_NAME))?;
+    }
+    if shadow_store {
+        ensure_store_snapshot(guard.staging_directory())?;
+    }
+    let mut artifacts = vec!["graph.json", "manifest.json", BUILD_STATE_FILE];
+    if shadow_store {
+        artifacts.extend([STORE_FILE_NAME, STORE_REF_FILE_NAME]);
+    }
     if guard.staging_directory().join("program.json").is_file() {
         artifacts.push("program.json");
     }
@@ -1941,26 +1959,52 @@ fn ensure_store_snapshot(output_dir: &Path) -> Result<(), CoreError> {
             graph.graph.schema
         )));
     }
+    let canonical_graph = canonical_graph_json(&graph)?;
     let store_path = output_dir.join(STORE_FILE_NAME);
-    if let Ok(store) = SqliteStore::open_read_only(&store_path)
-        && let Ok((manifest, existing)) = store.read_snapshot()
-        && existing == graph_bytes
-        && manifest.node_count == graph.nodes.len() as u64
-        && manifest.edge_count == graph.links.len() as u64
-    {
-        write_store_ref(output_dir, &store)?;
-        return Ok(());
-    }
     let store = SqliteStore::open(&store_path)?;
-    store.publish_snapshot(
-        &graph_bytes,
-        GRAPH_SCHEMA_V1,
-        graph.nodes.len(),
-        graph.links.len(),
-    )?;
+    if !store.read_snapshot().is_ok_and(|(manifest, existing)| {
+        existing == graph_bytes
+            && manifest.node_count == graph.nodes.len() as u64
+            && manifest.edge_count == graph.links.len() as u64
+    }) {
+        store.publish_snapshot(
+            &graph_bytes,
+            GRAPH_SCHEMA_V1,
+            graph.nodes.len(),
+            graph.links.len(),
+        )?;
+    }
+    let builder = GraphSnapshotBuilder::new();
+    let active = GraphSnapshotReader::open_active(&store)?;
+    let reader = match active {
+        Some(reader) if reader.export_json_bytes()? == canonical_graph => reader,
+        Some(_) | None => {
+            let prepared = builder.prepare(&store, &graph)?;
+            let selector = builder.activate(&store, &prepared)?;
+            GraphSnapshotReader::open_selector(&store, selector)?
+        }
+    };
+    if reader.export_json_bytes()? != canonical_graph {
+        return Err(CoreError::InvalidBuildState(
+            "SQLite graph snapshot does not match graph.json; rebuild the generation".to_owned(),
+        ));
+    }
     store.validate_snapshot()?;
-    write_store_ref(output_dir, &store)?;
+    store.checkpoint()?;
+    let reference = write_store_ref(output_dir, &store)?;
+    store.record_retention_metadata(&reference, compass_store::MAX_SCAN_ITEMS)?;
+    store.checkpoint()?;
     Ok(())
+}
+
+fn store_shadow_enabled() -> bool {
+    let Ok(value) = std::env::var("COMPASS_STORE_SHADOW") else {
+        return true;
+    };
+    !matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "off" | "no" | "disabled"
+    )
 }
 
 fn write_store_ref(output_dir: &Path, store: &SqliteStore) -> Result<StoreRef, CoreError> {
@@ -3875,20 +3919,25 @@ fn topology_is_unchanged(existing: &GraphDocument, candidate: &GraphDocument) ->
 }
 
 fn update_artifacts_complete(output_dir: &Path) -> bool {
-    [
+    let mut required = vec![
         "graph.json",
-        STORE_FILE_NAME,
-        STORE_REF_FILE_NAME,
         "GRAPH_REPORT.md",
         ".compass_labels.json",
         ".compass_root",
         GRAPH_OVERVIEW_FILE,
-    ]
-    .into_iter()
-    .all(|name| output_dir.join(name).is_file())
+    ];
+    if store_shadow_enabled() {
+        required.extend([STORE_FILE_NAME, STORE_REF_FILE_NAME]);
+    }
+    required
+        .into_iter()
+        .all(|name| output_dir.join(name).is_file())
 }
 
 fn store_artifact_complete(output_dir: &Path) -> bool {
+    if !store_shadow_enabled() {
+        return true;
+    }
     let path = output_dir.join(STORE_FILE_NAME);
     let reference_path = output_dir.join(STORE_REF_FILE_NAME);
     let Ok(reference_bytes) = fs::read(reference_path) else {

--- a/crates/compass-core/tests/code_graph_v1_determinism.rs
+++ b/crates/compass-core/tests/code_graph_v1_determinism.rs
@@ -7,6 +7,7 @@ use compass_core::{
     BuildOptions, BuildPurpose, SemanticLayer, build_graph_with_semantic, build_local_graph,
 };
 use compass_files::{Cache, CacheKind, CacheOptions};
+use compass_graph::{GraphSnapshotReader, canonical_graph_json};
 use compass_languages::Extraction;
 use compass_model::code_graph::{
     EdgeKind, GraphDocument, NodeDetails, NodeKind, NodeRole, RouteStage,
@@ -179,6 +180,20 @@ fn build_publishes_a_reopenable_store_snapshot_matching_graph_json() -> Result<(
     assert_eq!(manifest.edge_count, graph.links.len() as u64);
     assert_eq!(store.validate_snapshot()?.snapshot_id, manifest.snapshot_id);
     assert_eq!(reference, store.snapshot_reference()?);
+    let retention = store
+        .retention_metadata()?
+        .ok_or("missing retention metadata")?;
+    assert_eq!(retention.active_manifest_digest, reference.manifest_digest);
+    let reader =
+        GraphSnapshotReader::open_active(&store)?.ok_or("missing active graph snapshot")?;
+    assert_eq!(reader.export_json_bytes()?, canonical_graph_json(&graph)?);
+    assert_eq!(reference.snapshot_id, reader.selector().snapshot_id);
+    assert_eq!(reference.manifest_digest, reader.selector().manifest_digest);
+    assert!(
+        store
+            .discover_orphan_manifests(Default::default())?
+            .is_empty()
+    );
     Ok(())
 }
 

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -27,7 +27,8 @@ pub use snapshot::{
     GRAPH_SNAPSHOT_LAYOUT_V1, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder,
     GraphSnapshotManifest, GraphSnapshotMetadata, GraphSnapshotReader, IndexKind,
     PreparedGraphSnapshot, SnapshotError, SnapshotReadLimits, SnapshotRoot, SnapshotSelector,
-    activate_graph_snapshot, active_graph_snapshot, encode_graph_index_key, prepare_graph_snapshot,
+    activate_graph_snapshot, active_graph_snapshot, canonical_graph_json, encode_graph_index_key,
+    prepare_graph_snapshot,
 };
 pub use v1::{
     BuildEvidence, InventoryEvidence, V1_PUBLICATION_SEMANTICS_VERSION, canonical_edge_kind,

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -9,7 +9,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use compass_model::code_graph::{
-    CODE_GRAPH_SCHEMA_V1, EdgeRecord, GraphDiagnostic, GraphDocument, GraphMetadata, NodeRecord,
+    CODE_GRAPH_SCHEMA_V1, EdgeRecord, FileRecord, GraphDiagnostic, GraphDocument, GraphMetadata,
+    NodeRecord,
 };
 use compass_model::validate_code_graph;
 use compass_store::{
@@ -408,6 +409,14 @@ pub fn prepare_graph_snapshot<S: Store + ?Sized>(
     GraphSnapshotBuilder::new().prepare(store, graph)
 }
 
+/// Encode a graph using the same deterministic normalization used by a store
+/// snapshot.  Publication and shadow verification use this helper instead of
+/// comparing source-order JSON bytes, so equivalent graph records have one
+/// stable identity across adapters.
+pub fn canonical_graph_json(graph: &GraphDocument) -> Result<Vec<u8>, SnapshotError> {
+    encode_json(&canonical_document(graph)?)
+}
+
 pub fn activate_graph_snapshot<S: Store + ?Sized>(
     store: &S,
     prepared: &PreparedGraphSnapshot,
@@ -509,15 +518,48 @@ impl<'a, S: Store + ?Sized> GraphSnapshotReader<'a, S> {
     }
 
     pub fn metadata(&self) -> Result<GraphSnapshotMetadata, SnapshotError> {
-        let key = encode_graph_index_key(IndexKind::Metadata, &[])?;
-        let value = self
-            .lookup(IndexKind::Metadata, &key)?
+        let entries = self.scan_entries(
+            IndexKind::Metadata,
+            None,
+            SnapshotReadLimits {
+                max_items: GRAPH_SNAPSHOT_MAX_OBJECTS,
+                max_bytes: MAX_VALUE_BYTES.saturating_mul(4_096),
+                max_objects: GRAPH_SNAPSHOT_MAX_OBJECTS,
+                ..SnapshotReadLimits::default()
+            },
+        )?;
+        let base_key = encode_graph_index_key(IndexKind::Metadata, &[])?;
+        let base = entries
+            .iter()
+            .find(|entry| entry.key == base_key)
             .ok_or_else(|| SnapshotError::Corrupt("metadata index entry is missing".to_owned()))?;
-        let record = decode_json::<MetadataRecord>(&value)?;
+        let record = decode_json::<MetadataRecord>(&base.value)?;
+        let mut graph = record.graph;
+        for entry in entries {
+            let segments = decode_key_segments(&entry.key).map_err(SnapshotError::from)?;
+            let Some(kind) = segments.get(1).map(Vec::as_slice) else {
+                continue;
+            };
+            match kind {
+                b"file" => graph.files.push(decode_json::<FileRecord>(&entry.value)?),
+                b"coverage" => graph.coverage.push(decode_json::<
+                    compass_model::code_graph::CoverageRecord,
+                >(&entry.value)?),
+                b"diagnostic" => graph
+                    .diagnostics
+                    .push(decode_json::<GraphDiagnostic>(&entry.value)?),
+                _ => {
+                    return Err(SnapshotError::Corrupt(
+                        "metadata index contains an unknown supplement".to_owned(),
+                    ));
+                }
+            }
+        }
+        graph.files.sort_by(|left, right| left.id.cmp(&right.id));
         Ok(GraphSnapshotMetadata {
             directed: record.directed,
             multigraph: record.multigraph,
-            graph: record.graph,
+            graph,
         })
     }
 
@@ -654,10 +696,28 @@ impl<'a, S: Store + ?Sized> GraphSnapshotReader<'a, S> {
             limits,
             objects: 0,
             bytes: 0,
-            values: Vec::new(),
+            entries: Vec::new(),
         };
         scan_tree(self.store, index, &root, prefix, &mut state, 0)?;
-        Ok(state.values)
+        Ok(state.entries.into_iter().map(|entry| entry.value).collect())
+    }
+
+    fn scan_entries(
+        &self,
+        index: IndexKind,
+        prefix: Option<&[u8]>,
+        limits: SnapshotReadLimits,
+    ) -> Result<Vec<TreeEntry>, SnapshotError> {
+        let limits = limits.validate()?;
+        let root = self.root(index)?.digest.clone();
+        let mut state = ScanState {
+            limits,
+            objects: 0,
+            bytes: 0,
+            entries: Vec::new(),
+        };
+        scan_tree(self.store, index, &root, prefix, &mut state, 0)?;
+        Ok(state.entries)
     }
 }
 
@@ -703,10 +763,14 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
         .into_iter()
         .map(|index| (index, BTreeMap::new()))
         .collect::<BTreeMap<_, _>>();
+    let mut metadata_graph = graph.graph.clone();
+    metadata_graph.files.clear();
+    metadata_graph.coverage.clear();
+    metadata_graph.diagnostics.clear();
     let metadata = MetadataRecord {
         directed: graph.directed,
         multigraph: graph.multigraph,
-        graph: graph.graph.clone(),
+        graph: metadata_graph,
     };
     insert_json(
         &mut indexes,
@@ -714,6 +778,39 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
         encode_graph_index_key(IndexKind::Metadata, &[])?,
         &metadata,
     )?;
+    for file in &graph.graph.files {
+        insert_json(
+            &mut indexes,
+            IndexKind::Metadata,
+            encode_graph_index_key(IndexKind::Metadata, &[b"file", file.id.as_bytes()])?,
+            file,
+        )?;
+    }
+    for (ordinal, coverage) in graph.graph.coverage.iter().enumerate() {
+        let ordinal = format!("{ordinal:08}");
+        insert_json(
+            &mut indexes,
+            IndexKind::Metadata,
+            encode_graph_index_key(IndexKind::Metadata, &[b"coverage", ordinal.as_bytes()])?,
+            coverage,
+        )?;
+    }
+    for (ordinal, diagnostic) in graph.graph.diagnostics.iter().enumerate() {
+        let ordinal = format!("{ordinal:08}");
+        insert_json(
+            &mut indexes,
+            IndexKind::Metadata,
+            encode_graph_index_key(
+                IndexKind::Metadata,
+                &[
+                    b"diagnostic",
+                    ordinal.as_bytes(),
+                    diagnostic.code.as_bytes(),
+                ],
+            )?,
+            diagnostic,
+        )?;
+    }
 
     for node in &graph.nodes {
         insert_json(
@@ -1118,7 +1215,7 @@ struct ScanState {
     limits: SnapshotReadLimits,
     objects: usize,
     bytes: usize,
-    values: Vec<Vec<u8>>,
+    entries: Vec<TreeEntry>,
 }
 
 fn scan_tree<S: Store + ?Sized>(
@@ -1146,7 +1243,7 @@ fn scan_tree<S: Store + ?Sized>(
                 {
                     continue;
                 }
-                if state.values.len() >= state.limits.max_items {
+                if state.entries.len() >= state.limits.max_items {
                     return Err(SnapshotError::Limit(
                         "snapshot item limit exceeded".to_owned(),
                     ));
@@ -1157,7 +1254,7 @@ fn scan_tree<S: Store + ?Sized>(
                         "snapshot byte limit exceeded".to_owned(),
                     ));
                 }
-                state.values.push(entry.value);
+                state.entries.push(entry);
             }
         }
         TreeObject::Branch { children, .. } => {

--- a/crates/compass-graph/tests/store_snapshot.rs
+++ b/crates/compass-graph/tests/store_snapshot.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use compass_graph::{
     GraphSnapshotBuilder, GraphSnapshotReader, IndexKind, SnapshotError, SnapshotReadLimits,
-    active_graph_snapshot, encode_graph_index_key,
+    active_graph_snapshot, canonical_graph_json, encode_graph_index_key,
 };
 use compass_model::code_graph::{
     BuildMetadata, EdgeKind, EdgeRecord, ExtractionStatus, FileRecord, GraphDocument, NodeKind,
@@ -249,6 +249,11 @@ fn sqlite_adapter_round_trips_the_same_snapshot_contract() -> Result<(), Box<dyn
     );
     assert_eq!(reader.outgoing("a", limits(4))?.len(), 2);
     assert_eq!(reader.manifest().snapshot_id, prepared.manifest.snapshot_id);
+    assert_eq!(reader.export_json_bytes()?, canonical_graph_json(&graph())?);
+    let reference = reopened.snapshot_reference()?;
+    assert_eq!(reference.snapshot_id, prepared.manifest.snapshot_id);
+    assert_eq!(reference.manifest_digest, prepared.manifest_digest);
+    assert_eq!(reference.graph_digest, prepared.manifest.graph_digest);
     Ok(())
 }
 

--- a/crates/compass-store/src/lib.rs
+++ b/crates/compass-store/src/lib.rs
@@ -26,6 +26,7 @@ use sha2::{Digest, Sha256};
 pub const STORE_SCHEMA_V1: &str = "compass.store/1";
 pub const GRAPH_SNAPSHOT_SCHEMA_V1: &str = "compass.store.graph-snapshot/1";
 pub const STORE_REF_SCHEMA_V1: &str = "compass.store.ref/1";
+pub const STORE_RETENTION_SCHEMA_V1: &str = "compass.store.retention/1";
 pub const GRAPH_SCHEMA_V1: &str = "compass.graph/1";
 pub const STORE_FILE_NAME: &str = "compass-store.sqlite3";
 pub const STORE_REF_FILE_NAME: &str = "store.ref";
@@ -42,9 +43,15 @@ const GRAPH_NAMESPACE: &[u8] = b"compass.current.graph.v1";
 const CATALOG_PARTITION: &[u8] = b"catalog";
 const OBJECT_PARTITION: &[u8] = b"object";
 const ACTIVE_KEY: &[u8] = b"active";
+const GRAPH_SNAPSHOT_CATALOG_PARTITION: &[u8] = b"graph-snapshot/catalog";
+const GRAPH_SNAPSHOT_OBJECT_PARTITION: &[u8] = b"graph-snapshot/objects";
 const MANIFEST_PREFIX: &[u8] = b"manifest/";
 const CHUNK_PREFIX: &[u8] = b"chunk/";
 const CHUNK_BYTES: usize = MAX_VALUE_BYTES - 1_024;
+const GRAPH_SNAPSHOT_LAYOUT_V1: &str = "compass.store.graph-index/1";
+const GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1: &str = "compass.store.graph-selector/1";
+const GRAPH_SNAPSHOT_ACTIVE_KEY: &[u8] = b"active";
+const RETENTION_METADATA_KEY: &str = "retention.v1";
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
@@ -404,6 +411,35 @@ pub struct StoreRef {
     pub graph_digest: String,
 }
 
+/// Bounded, backend-neutral maintenance state. It records what a future
+/// garbage collector may retain without embedding a path, clock value, or
+/// deletion policy in the graph snapshot contract.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RetentionMetadata {
+    pub schema: String,
+    pub active_snapshot_id: String,
+    pub active_manifest_digest: String,
+    pub orphan_scan_limit: u32,
+}
+
+impl RetentionMetadata {
+    pub fn validate(&self) -> Result<(), StoreError> {
+        if self.schema != STORE_RETENTION_SCHEMA_V1 {
+            return Err(StoreError::InvalidFormat(format!(
+                "expected retention schema {STORE_RETENTION_SCHEMA_V1}"
+            )));
+        }
+        validate_digest("retention snapshot", &self.active_snapshot_id)?;
+        validate_digest("retention manifest", &self.active_manifest_digest)?;
+        if self.orphan_scan_limit == 0 || self.orphan_scan_limit as usize > MAX_SCAN_ITEMS {
+            return Err(StoreError::InvalidFormat(format!(
+                "retention orphan scan limit must be between 1 and {MAX_SCAN_ITEMS}"
+            )));
+        }
+        Ok(())
+    }
+}
+
 impl StoreRef {
     pub fn validate(&self) -> Result<(), StoreError> {
         if self.schema != STORE_REF_SCHEMA_V1 {
@@ -478,6 +514,7 @@ impl SqliteStore {
             &path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
         )?;
+        configure_read_only_connection(&connection)?;
         verify_schema(&connection)?;
         Ok(Self {
             path,
@@ -600,8 +637,149 @@ impl SqliteStore {
         self.read_snapshot().map(|(manifest, _)| manifest)
     }
 
+    /// Flush all acknowledged WAL frames before a filesystem generation is
+    /// committed.  The main database file is the only authoritative artifact
+    /// named by `BuildGuard`; checkpointing makes it self-contained for copy,
+    /// backup, and recovery operations.
+    pub fn checkpoint(&self) -> Result<(), StoreError> {
+        if self.read_only {
+            return Err(StoreError::Unsupported(
+                "cannot checkpoint a read-only store".to_owned(),
+            ));
+        }
+        let connection = self.connection()?;
+        connection.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        Ok(())
+    }
+
+    /// Return bounded manifest keys that are not selected by either the
+    /// payload snapshot or the immutable graph-index selector.  This is a
+    /// discovery API only; Phase 8 owns retention policy and deletion.
+    pub fn discover_orphan_manifests(&self, limits: ScanLimits) -> Result<Vec<String>, StoreError> {
+        let namespace = NamespaceId::graph();
+        let object = PartitionKey::new(OBJECT_PARTITION)?;
+        let page = self.scan(
+            &namespace,
+            &object,
+            &KeyRange {
+                start_inclusive: Some(MANIFEST_PREFIX.to_vec()),
+                end_exclusive: Some(b"manifest0".to_vec()),
+            },
+            limits,
+            None,
+        )?;
+        if page.next.is_some() {
+            return Err(StoreError::InvalidScanLimit(
+                "orphan manifest discovery exceeds the supplied bounded page".to_owned(),
+            ));
+        }
+        let mut active = BTreeMap::new();
+        if let Some(entry) = self.get(
+            &namespace,
+            &PartitionKey::new(CATALOG_PARTITION)?,
+            &Key::new(ACTIVE_KEY)?,
+        )? {
+            let manifest = serde_json::from_slice::<SnapshotManifest>(&entry.value)
+                .map_err(|error| StoreError::Corrupt(format!("active manifest: {error}")))?;
+            validate_manifest(&manifest)?;
+            active.insert(manifest.snapshot_id, ());
+        }
+        if let Some(entry) = self.get(
+            &namespace,
+            &PartitionKey::new(GRAPH_SNAPSHOT_CATALOG_PARTITION)?,
+            &Key::new(GRAPH_SNAPSHOT_ACTIVE_KEY)?,
+        )? {
+            let selector =
+                serde_json::from_slice::<GraphSnapshotSelector>(&entry.value).map_err(|error| {
+                    StoreError::Corrupt(format!("graph snapshot selector: {error}"))
+                })?;
+            if selector.schema != GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1 {
+                return Err(StoreError::InvalidFormat(
+                    "selected graph snapshot uses an unsupported format; rebuild the store"
+                        .to_owned(),
+                ));
+            }
+            validate_digest("snapshot selector manifest", &selector.manifest_digest)?;
+            active.insert(selector.manifest_digest, ());
+        }
+        let mut orphans = Vec::new();
+        for entry in page.entries {
+            let Some(digest) = entry
+                .key
+                .strip_prefix(MANIFEST_PREFIX)
+                .and_then(|value| std::str::from_utf8(value).ok())
+            else {
+                continue;
+            };
+            if digest.len() == 64
+                && digest.as_bytes().iter().all(u8::is_ascii_hexdigit)
+                && !active.contains_key(digest)
+            {
+                orphans.push(digest.to_owned());
+            }
+        }
+        Ok(orphans)
+    }
+
+    /// Record the active graph snapshot and the bounded maintenance budget
+    /// used by orphan discovery. The value is operational metadata and does
+    /// not participate in graph identity.
+    pub fn record_retention_metadata(
+        &self,
+        reference: &StoreRef,
+        orphan_scan_limit: usize,
+    ) -> Result<RetentionMetadata, StoreError> {
+        if self.read_only {
+            return Err(StoreError::Unsupported(
+                "cannot update retention metadata through a read-only store".to_owned(),
+            ));
+        }
+        reference.validate()?;
+        let orphan_scan_limit = u32::try_from(orphan_scan_limit).map_err(|_| {
+            StoreError::InvalidScanLimit("retention scan limit does not fit u32".to_owned())
+        })?;
+        let metadata = RetentionMetadata {
+            schema: STORE_RETENTION_SCHEMA_V1.to_owned(),
+            active_snapshot_id: reference.snapshot_id.clone(),
+            active_manifest_digest: reference.manifest_digest.clone(),
+            orphan_scan_limit,
+        };
+        metadata.validate()?;
+        let bytes = serde_json::to_vec(&metadata)
+            .map_err(|error| StoreError::Corrupt(format!("retention metadata encode: {error}")))?;
+        let connection = self.connection()?;
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES(?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![RETENTION_METADATA_KEY, bytes],
+        )?;
+        Ok(metadata)
+    }
+
+    pub fn retention_metadata(&self) -> Result<Option<RetentionMetadata>, StoreError> {
+        let connection = self.connection()?;
+        let bytes = connection
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![RETENTION_METADATA_KEY],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()?;
+        bytes
+            .map(|bytes| {
+                let metadata = serde_json::from_slice::<RetentionMetadata>(&bytes)
+                    .map_err(|error| StoreError::Corrupt(format!("retention metadata: {error}")))?;
+                metadata.validate()?;
+                Ok(metadata)
+            })
+            .transpose()
+    }
+
     /// Return the typed reference for the currently selected snapshot.
     pub fn snapshot_reference(&self) -> Result<StoreRef, StoreError> {
+        if let Some(reference) = self.graph_snapshot_reference()? {
+            return Ok(reference);
+        }
         let (manifest, _) = self.read_snapshot()?;
         let manifest_bytes = serde_json::to_vec(&manifest)
             .map_err(|error| StoreError::Corrupt(format!("manifest encode: {error}")))?;
@@ -617,6 +795,61 @@ impl SqliteStore {
         };
         reference.validate()?;
         Ok(reference)
+    }
+
+    fn graph_snapshot_reference(&self) -> Result<Option<StoreRef>, StoreError> {
+        let namespace = NamespaceId::graph();
+        let catalog = PartitionKey::new(GRAPH_SNAPSHOT_CATALOG_PARTITION)?;
+        let active = Key::new(GRAPH_SNAPSHOT_ACTIVE_KEY)?;
+        let Some(entry) = self.get(&namespace, &catalog, &active)? else {
+            return Ok(None);
+        };
+        let selector: GraphSnapshotSelector = serde_json::from_slice(&entry.value)
+            .map_err(|error| StoreError::Corrupt(format!("graph snapshot selector: {error}")))?;
+        if selector.schema != GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1 {
+            return Err(StoreError::InvalidFormat(
+                "selected graph snapshot uses an unsupported format; rebuild the store".to_owned(),
+            ));
+        }
+        validate_digest("snapshot selector", &selector.snapshot_id)?;
+        validate_digest("snapshot selector manifest", &selector.manifest_digest)?;
+        let object = PartitionKey::new(GRAPH_SNAPSHOT_OBJECT_PARTITION)?;
+        let manifest_key = Key::new(format!("manifest/{}", selector.manifest_digest))?;
+        let Some(manifest_entry) = self.get(&namespace, &object, &manifest_key)? else {
+            return Err(StoreError::Corrupt(
+                "selected graph snapshot manifest is missing".to_owned(),
+            ));
+        };
+        if digest(&manifest_entry.value) != selector_digest(&selector.manifest_digest)? {
+            return Err(StoreError::Corrupt(
+                "selected graph snapshot manifest digest does not match".to_owned(),
+            ));
+        }
+        let manifest: GraphSnapshotManifest = serde_json::from_slice(&manifest_entry.value)
+            .map_err(|error| StoreError::Corrupt(format!("graph snapshot manifest: {error}")))?;
+        if manifest.schema != GRAPH_SNAPSHOT_LAYOUT_V1
+            || manifest.graph_schema != GRAPH_SCHEMA_V1
+            || manifest.snapshot_id != selector.snapshot_id
+        {
+            return Err(StoreError::InvalidFormat(
+                "selected graph snapshot uses an unsupported or mismatched format; rebuild the store"
+                    .to_owned(),
+            ));
+        }
+        validate_digest("graph snapshot graph", &manifest.graph_digest)?;
+        let manifest_digest = hex_digest(&manifest_entry.value);
+        let reference = StoreRef {
+            schema: STORE_REF_SCHEMA_V1.to_owned(),
+            store_schema: STORE_SCHEMA_V1.to_owned(),
+            adapter: "sqlite".to_owned(),
+            store_id: "sqlite-local-v1".to_owned(),
+            namespace: String::from_utf8_lossy(GRAPH_NAMESPACE).into_owned(),
+            snapshot_id: selector.snapshot_id,
+            manifest_digest,
+            graph_digest: manifest.graph_digest,
+        };
+        reference.validate()?;
+        Ok(Some(reference))
     }
 
     fn connection(&self) -> Result<MutexGuard<'_, Connection>, StoreError> {
@@ -1232,9 +1465,17 @@ fn hex_digest(value: &[u8]) -> String {
 
 fn configure_connection(connection: &Connection) -> Result<(), StoreError> {
     connection.execute_batch(
-        "PRAGMA journal_mode=DELETE;
+        "PRAGMA journal_mode=WAL;
          PRAGMA synchronous=FULL;
          PRAGMA foreign_keys=ON;
+         PRAGMA busy_timeout=5000;",
+    )?;
+    Ok(())
+}
+
+fn configure_read_only_connection(connection: &Connection) -> Result<(), StoreError> {
+    connection.execute_batch(
+        "PRAGMA foreign_keys=ON;
          PRAGMA busy_timeout=5000;",
     )?;
     Ok(())
@@ -1270,10 +1511,58 @@ fn verify_schema(connection: &Connection) -> Result<(), StoreError> {
         .optional()?;
     if schema.as_deref() != Some(STORE_SCHEMA_V1) {
         return Err(StoreError::InvalidFormat(format!(
-            "expected metadata schema {STORE_SCHEMA_V1}"
+            "expected metadata schema {STORE_SCHEMA_V1}; remove the store and rebuild it"
         )));
     }
     Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphSnapshotSelector {
+    schema: String,
+    snapshot_id: String,
+    manifest_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphSnapshotManifest {
+    schema: String,
+    snapshot_id: String,
+    graph_schema: String,
+    graph_digest: String,
+}
+
+fn validate_digest(component: &'static str, value: &str) -> Result<(), StoreError> {
+    if value.len() != 64 || !value.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err(StoreError::Corrupt(format!(
+            "{component} is not a SHA-256 hex digest"
+        )));
+    }
+    Ok(())
+}
+
+fn selector_digest(value: &str) -> Result<[u8; 32], StoreError> {
+    validate_digest("manifest digest", value)?;
+    let mut output = [0_u8; 32];
+    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_digit(pair[0]).ok_or_else(|| {
+            StoreError::Corrupt("manifest digest contains a non-hex character".to_owned())
+        })?;
+        let low = hex_digit(pair[1]).ok_or_else(|| {
+            StoreError::Corrupt("manifest digest contains a non-hex character".to_owned())
+        })?;
+        output[index] = (high << 4) | low;
+    }
+    Ok(output)
+}
+
+fn hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
 }
 
 fn manifest_key(snapshot_id: &str) -> Vec<u8> {
@@ -1325,6 +1614,9 @@ fn validate_manifest(manifest: &SnapshotManifest) -> Result<(), StoreError> {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
+
+    use rusqlite::Connection;
+    use sha2::{Digest, Sha256};
 
     use super::{
         Key, KeyRange, MemoryStore, NamespaceId, PartitionKey, ScanLimits, SqliteStore, Store,
@@ -1424,10 +1716,60 @@ mod tests {
             let store = SqliteStore::open(&path)?;
             let manifest = store.publish_snapshot(bytes, "compass.graph/1", 1, 0)?;
             assert_eq!(manifest.payload_bytes, bytes.len() as u64);
+            store.checkpoint()?;
         }
         let store = SqliteStore::open_read_only(&path)?;
         let (_, loaded) = store.read_snapshot()?;
         assert_eq!(loaded, bytes);
+        let copied_path = directory.path().join("copied.sqlite3");
+        std::fs::copy(&path, &copied_path)?;
+        let copied = SqliteStore::open_read_only(&copied_path)?;
+        assert_eq!(copied.read_snapshot()?.1, bytes);
+        let connection = Connection::open(&path)?;
+        let journal_mode =
+            connection.query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0))?;
+        assert_eq!(journal_mode, "wal");
+        let synchronous =
+            connection.query_row("PRAGMA synchronous", [], |row| row.get::<_, i64>(0))?;
+        assert_eq!(synchronous, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn orphan_manifest_discovery_is_bounded_and_does_not_delete_data() -> Result<(), Box<dyn Error>>
+    {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("store.sqlite3");
+        let first = br#"{"graph":{"schema":"compass.graph/1"},"nodes":[1],"links":[]}"#;
+        let second = br#"{"graph":{"schema":"compass.graph/1"},"nodes":[2],"links":[]}"#;
+        let store = SqliteStore::open(&path)?;
+        store.publish_snapshot(first, "compass.graph/1", 1, 0)?;
+        store.publish_snapshot(second, "compass.graph/1", 1, 0)?;
+        let reference = store.snapshot_reference()?;
+        let retention = store.record_retention_metadata(&reference, 16)?;
+        assert_eq!(store.retention_metadata()?, Some(retention));
+        let orphans = store.discover_orphan_manifests(ScanLimits::default())?;
+        let first_digest = format!("{:x}", Sha256::digest(first));
+        assert_eq!(orphans, vec![first_digest]);
+        assert_eq!(store.read_snapshot()?.1, second);
+        Ok(())
+    }
+
+    #[test]
+    fn stale_schema_reports_rebuild_instruction() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let path = directory.path().join("store.sqlite3");
+        let connection = Connection::open(&path)?;
+        connection.execute_batch(
+            "CREATE TABLE metadata(key TEXT PRIMARY KEY NOT NULL, value BLOB NOT NULL);
+             INSERT INTO metadata(key, value) VALUES('schema', 'compass.store/0');",
+        )?;
+        drop(connection);
+        let error = match SqliteStore::open(&path) {
+            Ok(_) => return Err("stale schema unexpectedly opened".into()),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("rebuild"));
         Ok(())
     }
 

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -1,17 +1,19 @@
 # Compass store and graph-engine design
 
-**Status:** Architecture reference. The initial local slice and the Phase 2
-memory snapshot layout are shipped: the `compass-store` contract, SQLite
-adapter, dual graph publication, typed query-engine selection, deterministic
-immutable graph indexes, and selector-CAS reference protocol are implemented.
-SQLite publication still contains the validated JSON payload; persistent
-streamed store publication remains the next phase.
+**Status:** Architecture reference. The initial local slice, Phase 2 memory
+snapshot layout, and the Phase 3 SQLite shadow-publication slice are shipped:
+the `compass-store` contract, SQLite adapter, dual graph publication, typed
+query-engine selection, deterministic immutable graph indexes, selector-CAS
+reference protocol, WAL durability, reopen validation, and canonical
+graph.json differential checks are implemented. redb, PostgreSQL, DynamoDB,
+remote operation, general garbage collection, and performance claims remain
+follow-on work.
 
-The initial sidecar stores the validated graph payload as immutable,
-content-addressed chunks and keeps the existing query index disposable. The
-Phase 2 graph layer now also provides a backend-neutral memory implementation
-of the final index shape for qualification and future adapters. It is not yet
-the persistent SQLite publication path.
+Each generated sidecar now contains both the validated graph payload used by
+the current store engine and the Phase 2 content-addressed graph indexes. The
+sidecar is prepared and checkpointed in the unpublished BuildGuard generation;
+only the filesystem generation switch publishes it. `graph.json` remains a
+permanent compatible engine and is never removed or made dependent on SQLite.
 
 > **Who this page is for:** maintainers of graph publication and queries,
 > storage-adapter authors, cloud-service implementers, and reviewers of the
@@ -679,11 +681,12 @@ logical identity. A prepared snapshot writes no active selector. Activation is
 one conditional write, allowing readers that already opened an older selector
 to finish against that immutable realization.
 
-This reference is intentionally not the Phase 3 persistent path: the existing
-SQLite sidecar continues to store the validated JSON payload and the CLI still
-keeps `graph.json` as a permanent compatible engine. The next phase maps these
-same objects and selectors to durable SQLite publication and reopen/recovery
-tests without changing the logical contract.
+The Phase 3 local adapter maps these same objects and selectors to durable
+SQLite. It validates the active selector and canonical export after reopen,
+publishes a typed `store.ref`, checkpoints WAL frames before the generation
+switch, and reports bounded unreachable manifest candidates without deleting
+them. A malformed or stale store fails the unpublished build and leaves the
+previous generation and its JSON engine readable.
 
 ### Structural sharing and incremental update
 
@@ -743,6 +746,12 @@ If the filesystem commit fails, the prepared snapshot is an orphan. If the
 database later becomes unavailable, the published `graph.json` remains a
 usable complete engine. No best-effort sequence of “update database, then
 replace JSON” is allowed to expose two different current graphs.
+
+The Phase 3 local implementation uses `compass-store.sqlite3` inside the
+staged generation. SQLite runs in WAL/FULL mode; the writer checkpoints before
+the generation switch, then writes `store.ref` and bounded retention metadata.
+`COMPASS_STORE_SHADOW=0` is an internal diagnosis switch that removes store
+artifacts from the staged generation while retaining the JSON publication.
 
 ### Store-native or cloud publication
 
@@ -888,19 +897,15 @@ binary comparisons. Conditional updates include the observed `version` in the
 transaction and require the observed version to match. Put-if-absent uses the
 primary-key constraint and verifies the existing digest on conflict.
 
-The initial generated sidecar uses the rollback journal, full synchronous
-durability, a bounded busy timeout, bounded values, and explicit transactions.
-Rollback-journal mode is intentional while each build generation is represented
-by one portable SQLite file; a WAL adapter must stage and publish its `-wal`
-and `-shm` state together before it can replace this mode. Whether
-`WITHOUT ROWID` is retained must be benchmarked on Compass workloads; SQLite's
-own documentation recommends measuring this optimization rather than assuming
-it always wins.
-
-For a future WAL adapter, backups must include committed WAL state. The current
-rollback-journal sidecar is self-contained. File creation, permissions,
-symlink handling, corruption recovery, and atomic replacement reuse
-`compass-files` primitives rather than new weaker helpers.
+The generated sidecar uses WAL, full synchronous durability, a bounded busy
+timeout, bounded values, and explicit transactions. The publication path calls
+an explicit WAL checkpoint before `BuildGuard` seals the generation, so the
+main database file is self-contained for copy and recovery. File creation,
+permissions, symlink handling, corruption recovery, and atomic replacement
+reuse `compass-files` primitives rather than new weaker helpers. Whether
+`WITHOUT ROWID` remains the best physical choice is still a benchmark question;
+SQLite's own documentation recommends measuring this optimization rather than
+assuming it always wins.
 
 ### redb
 

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -1,10 +1,10 @@
 # Executable Compass store implementation plan
 
-**Status:** In progress. Phase 0, Phase 1, and the initial local portion of
-Phases 3–4 are implemented. This branch adds the Phase 2 backend-neutral
-memory snapshot/index slice; persistent SQLite streamed publication and the
-remaining cross-engine qualification work are executable follow-on phases and
-are not implied to be shipped.
+**Status:** In progress. Phases 0–2 and the local Phase 3 SQLite
+shadow-publication slice are implemented. The branch also retains the initial
+Phase 4 typed query-engine selection. Remote adapters, fault-injected crash
+qualification, general garbage collection, and measured performance claims
+remain follow-on work.
 
 > **Who this page is for:** implementers and reviewers delivering
 > `compass-store`, store-backed graph snapshots, backend adapters, and the
@@ -50,11 +50,11 @@ and is independently mergeable:
   service adapter can implement the same trait later.
 - Every committed local generation contains `graph.json`,
   `compass-store.sqlite3`, and a typed `store.ref`. The store contains
-  immutable, digest-addressed graph chunks and manifests plus one
-  CAS-protected active selector. The payload is byte-identical to the
-  published JSON and is validated before the build state is sealed; the
-  reference is checked against the selected manifest before a store query
-  runs.
+  immutable, digest-addressed graph chunks and manifests plus the Phase 2
+  graph-index trees and CAS-protected selector. WAL is checkpointed before the
+  BuildGuard generation switch; canonical store export is compared with
+  `graph.json` before sealing; the reference is checked against the selected
+  graph snapshot before a store query runs.
 - Typed code-query opening chooses the store by default when the sidecar is
   present, keeps `graph.json` as a complete engine, and supports explicit
   `--engine default|json|store`. Omitting `--engine` selects the store for a
@@ -77,10 +77,9 @@ Acceptance criteria for this slice are deliberately concrete:
    store selection fails with a typed error and a present malformed `store.ref`
    fails closed.
 
-The initial local slice above does not claim streamed graph indexes,
-redb/PostgreSQL/DynamoDB adapters, remote retry semantics, general garbage
-collection, or a measured performance improvement. Those remain the follow-on
-phases below.
+The initial local slice above does not claim redb/PostgreSQL/DynamoDB adapters,
+remote retry semantics, general garbage collection, or a measured performance
+improvement. Those remain the follow-on phases below.
 
 ## Phase 2 memory-layout slice shipped in this branch
 
@@ -97,16 +96,18 @@ identity, graph counts, and the complete typed graph before returning data. It
 provides bounded point reads, ordered node/edge scans, directional adjacency,
 and canonical JSON export. Repeated builds are idempotent and report immutable
 object reuse; prepared content never becomes active until the selector CAS.
-The permanent `graph.json` engine and the existing SQLite payload sidecar are
-unchanged.
+The permanent `graph.json` engine remains unchanged. Phase 3 persists these
+same objects in the SQLite sidecar and verifies their canonical export before
+the generation is sealed.
 
 The slice's acceptance evidence is in
 `crates/compass-graph/tests/store_snapshot.rs`: deterministic identity across
 record insertion order and operational generation IDs, immutable object reuse,
 selector-before-commit behavior, bounded reads, directional multiplicity, key
-vectors, and fail-closed tamper detection. Full `JsonGraphEngine` versus
-streaming store-engine differential tests, persistent SQLite publication, and
-measured performance claims remain the explicit Phase 3/4 gates below.
+vectors, and fail-closed tamper detection. Persistent SQLite publication and
+CLI generation checks are covered by the Phase 3 tests below; full
+`JsonGraphEngine` versus streaming store-engine differential qualification and
+measured performance claims remain follow-on work.
 
 ## Program rules
 
@@ -456,14 +457,15 @@ This is still an unpublished internal format. If the layout is insufficient,
 change its major or discard it; do not add a migration reader merely to retain
 test data. Phase 3 must not begin until cross-engine equivalence is complete.
 
-## Phase 3: Add SQLite and shadow local publication
+## Phase 3: Add SQLite and shadow local publication (implemented local slice)
 
 ### Context and objective
 
 SQLite is the first persistent adapter and exercises reopen, filesystem,
-locking, crash, and durability behavior. Local builds initially write the
-store snapshot in shadow mode while JSON remains the read path. This isolates
-write/publication risk from query-routing risk.
+locking, crash, and durability behavior. Local builds write the store snapshot
+in shadow mode while the JSON artifact remains a permanent independent engine;
+the existing typed query selection may already prefer the store. This isolates
+write/publication risk from the broader remote-adapter work.
 
 ### Prerequisite inputs
 
@@ -489,18 +491,22 @@ write/publication risk from query-routing risk.
    from `compass-files`.
 4. Run the complete adapter conformance suite against a newly created and a
    reopened database.
-5. Add crash/fault tests at transaction begin, content write, commit,
-   manifest write, validation, and filesystem generation switch.
+5. Add reopen/durability, WAL checkpoint, orphan-discovery, stale-format, and
+   generation-publication tests. Fault-injected crash qualification remains a
+   release gate for the larger Phase 3 evidence set.
 6. Define a typed, versioned `store.ref` containing store identity, namespace,
    snapshot ID, manifest digest, and graph digest but no machine-specific
    absolute path.
 7. During `init` and `update`, prepare the SQLite snapshot and stage
    `store.ref` with `graph.json` and other output artifacts. The filesystem
    generation switch is the only local commit.
-8. Keep all queries on `JsonGraphEngine`; shadow verification opens the store
-   snapshot and compares graph identity before publication.
+8. Keep `graph.json` as a permanent compatible engine. The existing typed
+   query path may select the store by default, while publication always opens
+   the store snapshot and compares canonical graph identity before commit.
 9. Add an explicit internal switch to disable shadow storage for diagnosis.
-   It is not a promise to remove JSON.
+   `COMPASS_STORE_SHADOW=0` disables store creation while leaving JSON
+   publication and query compatibility intact; it is not a promise to remove
+   JSON.
 10. Add bounded orphan discovery and retention metadata, but defer general GC
     to Phase 8.
 
@@ -522,18 +528,20 @@ write/publication risk from query-routing risk.
 
 ### Acceptance criteria
 
-- the initial adapter's `cargo test -p compass-store --locked` passes the
-  shared conformance suite after reopen and under injected busy/interrupt
-  failures; a split adapter must retain the same command-level evidence.
+- the initial adapter's `cargo test -p compass-store --locked` passes
+  namespace/CAS/scan conformance, WAL reopen durability, orphan discovery,
+  and stale-format checks; injected busy/interrupt qualification remains a
+  separate release gate.
 - `compass init` and `compass update` CLI integration tests assert successful
   exit, `graph.json`, `store.ref`, complete manifest, and no visible partial
   generation.
-- Shadow comparison covers all fixture graphs and rejects publication on any
-  mismatch.
-- In a shadow-only deployment before Phase 4, no default query reads SQLite, so
-  deleting the new database cannot affect the published JSON engine. The
-  current branch's initial slice has intentionally advanced the typed
-  code-query path to the Phase 4 default-selection behavior described above.
+- Shadow comparison covers the published core fixture and CLI init/update
+  generations and rejects publication on any canonical mismatch.
+- The permanent `graph.json` engine remains independently readable when the
+  store is missing or corrupt, and `COMPASS_STORE_SHADOW=0` keeps JSON
+  publication complete. The current branch's initial typed query selection may
+  prefer the store by default, while explicit JSON selection remains
+  independent of the sidecar.
 - The old disposable query SQLite cache may be hard-cut or rebuilt, but the
   new durable snapshot store uses a different format identity and location.
 


### PR DESCRIPTION
## Summary

- Persist Phase 2 immutable graph snapshots and indexes in the SQLite sidecar during `init` and `update`.
- Use WAL with full synchronous durability, checkpoint before the BuildGuard generation switch, and validate/reopen the active snapshot before publication.
- Compare canonical SQLite export with `graph.json`, publish a typed `store.ref`, record bounded retention metadata, and discover orphan manifests without deleting them.
- Keep `graph.json` as the permanent compatible engine; `COMPASS_STORE_SHADOW=0` disables sidecar publication while preserving JSON output.
- Add reopen, durability, orphan, stale-format, core publication, and CLI init/update regression coverage plus updated Phase 3 documentation.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --lib --bins --locked --quiet`
- focused `compass-store`, `compass-graph`, `compass-core`, `compass-query`, and `compass-cli` tests
- targeted Clippy with `-D warnings`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`

The qualification gate passed all scale ceilings, deterministic rebuild comparisons, alternate checkout checks, and semantic assertions.