### PR TITLE
feat: route queries through immutable graph snapshots

### DIFF
--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -23,6 +23,7 @@ compass-model = { path = "../compass-model", version = "0.3.0" }
 compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
 compass-ir = { path = "../compass-ir", version = "0.3.0" }
 compass-store = { path = "../compass-store", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -30,7 +31,6 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
 compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
 compass-languages = { path = "../compass-languages", version = "0.3.0" }
 tempfile.workspace = true

--- a/crates/compass-query/src/graph_engine.rs
+++ b/crates/compass-query/src/graph_engine.rs
@@ -8,6 +8,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use compass_graph::{GraphSnapshotManifest, GraphSnapshotReader, canonical_graph_json};
 use compass_model::code_graph::{CODE_GRAPH_SCHEMA_V1, GraphDocument};
 use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef};
 
@@ -38,8 +39,14 @@ impl JsonGraphEngine {
                 error.to_string(),
             )
         })?;
-        let graph_bytes = fs::read(path).map_err(|error| io_error("read_graph", error))?;
         validate_graph_schema(&graph)?;
+        let graph_bytes = canonical_graph_json(&graph).map_err(|error| {
+            QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "graph_canonicalization_failed",
+                error.to_string(),
+            )
+        })?;
         Ok(Self { graph, graph_bytes })
     }
 }
@@ -74,22 +81,50 @@ impl StoreGraphEngine {
                 error.to_string(),
             )
         })?;
-        validate_store_ref(graph_path, &store)?;
-        let (manifest, graph_bytes) = store.read_snapshot().map_err(|error| {
+        let active = GraphSnapshotReader::open_active(&store).map_err(|error| {
             QueryError::new(
                 QueryErrorKind::CorruptArtifact,
-                "store_snapshot_failed",
+                "store_graph_snapshot_failed",
                 error.to_string(),
             )
         })?;
-        if manifest.graph_schema != CODE_GRAPH_SCHEMA_V1 {
+        let (graph_schema, node_count, edge_count, graph_bytes) = if let Some(reader) = active {
+            let manifest = reader.manifest();
+            let graph_bytes = reader.export_json_bytes().map_err(|error| {
+                QueryError::new(
+                    QueryErrorKind::CorruptArtifact,
+                    "store_graph_export_failed",
+                    error.to_string(),
+                )
+            })?;
+            validate_store_ref(graph_path, &store, Some(manifest))?;
+            (
+                manifest.graph_schema.clone(),
+                manifest.node_count,
+                manifest.edge_count,
+                graph_bytes,
+            )
+        } else {
+            let (manifest, graph_bytes) = store.read_snapshot().map_err(|error| {
+                QueryError::new(
+                    QueryErrorKind::CorruptArtifact,
+                    "store_snapshot_failed",
+                    error.to_string(),
+                )
+            })?;
+            validate_store_ref(graph_path, &store, None)?;
+            (
+                manifest.graph_schema,
+                manifest.node_count,
+                manifest.edge_count,
+                graph_bytes,
+            )
+        };
+        if graph_schema != CODE_GRAPH_SCHEMA_V1 {
             return Err(QueryError::new(
                 QueryErrorKind::UnsupportedSchema,
                 "unsupported_graph_schema",
-                format!(
-                    "expected {CODE_GRAPH_SCHEMA_V1}, found {}",
-                    manifest.graph_schema
-                ),
+                format!("expected {CODE_GRAPH_SCHEMA_V1}, found {}", graph_schema),
             ));
         }
         let graph = serde_json::from_slice::<GraphDocument>(&graph_bytes).map_err(|error| {
@@ -106,15 +141,20 @@ impl StoreGraphEngine {
                 error.to_string(),
             )
         })?;
-        if manifest.node_count != graph.nodes.len() as u64
-            || manifest.edge_count != graph.links.len() as u64
-        {
+        if node_count != graph.nodes.len() as u64 || edge_count != graph.links.len() as u64 {
             return Err(QueryError::new(
                 QueryErrorKind::CorruptArtifact,
                 "store_manifest_counts_mismatch",
                 "store manifest counts do not match the decoded graph",
             ));
         }
+        let graph_bytes = canonical_graph_json(&graph).map_err(|error| {
+            QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "store_graph_canonicalization_failed",
+                error.to_string(),
+            )
+        })?;
         Ok(Self { graph, graph_bytes })
     }
 }
@@ -172,12 +212,23 @@ fn validate_graph_schema(graph: &GraphDocument) -> Result<(), QueryError> {
     Ok(())
 }
 
-fn validate_store_ref(graph_path: &Path, store: &SqliteStore) -> Result<(), QueryError> {
+fn validate_store_ref(
+    graph_path: &Path,
+    store: &SqliteStore,
+    graph_snapshot: Option<&GraphSnapshotManifest>,
+) -> Result<(), QueryError> {
     let reference_path = graph_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join(STORE_REF_FILE_NAME);
     if !reference_path.is_file() {
+        if graph_snapshot.is_some() {
+            return Err(QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "store_ref_missing",
+                "store.ref is required for an immutable graph snapshot",
+            ));
+        }
         return Ok(());
     }
     let size = fs::metadata(&reference_path)
@@ -217,6 +268,16 @@ fn validate_store_ref(graph_path: &Path, store: &SqliteStore) -> Result<(), Quer
             QueryErrorKind::CorruptArtifact,
             "store_ref_mismatch",
             "store.ref does not describe the selected store snapshot",
+        ));
+    }
+    if let Some(manifest) = graph_snapshot
+        && (reference.snapshot_id != manifest.snapshot_id
+            || reference.graph_digest != manifest.graph_digest)
+    {
+        return Err(QueryError::new(
+            QueryErrorKind::CorruptArtifact,
+            "store_ref_snapshot_mismatch",
+            "store.ref does not describe the active immutable graph snapshot",
         ));
     }
     Ok(())

--- a/crates/compass-query/tests/store_engine.rs
+++ b/crates/compass-query/tests/store_engine.rs
@@ -2,10 +2,30 @@ mod support;
 
 use std::fs;
 
+use compass_graph::GraphSnapshotBuilder;
 use compass_model::code_graph::{CODE_GRAPH_SCHEMA_V1, GraphDocument};
-use compass_model::query_contract::{CodeQueryLimits, SearchRequest};
+use compass_model::query_contract::{
+    CallRequest, CodeQueryLimits, ExploreRequest, ImpactRequest, NodeTrailRequest, SearchRequest,
+};
 use compass_query::{EngineSelection, QueryEngineKind, open, open_with_engine};
-use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore};
+use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef};
+
+fn publish_phase2_snapshot(
+    directory: &std::path::Path,
+    graph_path: &std::path::Path,
+) -> Result<SqliteStore, Box<dyn std::error::Error>> {
+    let store = SqliteStore::open(directory.join(STORE_FILE_NAME))?;
+    let graph = GraphDocument::load(graph_path)?;
+    let prepared = GraphSnapshotBuilder::new().prepare(&store, &graph)?;
+    GraphSnapshotBuilder::new().activate(&store, &prepared)?;
+    let reference = store.snapshot_reference()?;
+    fs::write(
+        directory.join(STORE_REF_FILE_NAME),
+        serde_json::to_vec(&reference)?,
+    )?;
+    store.checkpoint()?;
+    Ok(store)
+}
 
 #[test]
 fn default_query_open_prefers_store_and_matches_json_results()
@@ -36,10 +56,197 @@ fn default_query_open_prefers_store_and_matches_json_results()
         serde_json::to_value(store_engine.search(request.clone())?)?,
         serde_json::to_value(json_engine.search(request)?)?,
     );
+    assert_eq!(store_engine.index_path(), json_engine.index_path());
 
     drop(store_engine);
     let reopened = open_with_engine(&graph_path, None, &cache, EngineSelection::Store)?;
     assert_eq!(reopened.engine_kind(), QueryEngineKind::Store);
+    Ok(())
+}
+
+#[test]
+fn store_engine_reads_the_immutable_phase2_snapshot_for_all_code_queries()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    publish_phase2_snapshot(directory.path(), &graph_path)?;
+
+    let cache = directory.path().join("cache");
+    let store = open_with_engine(&graph_path, None, &cache, EngineSelection::Store)?;
+    let json = open_with_engine(&graph_path, None, &cache, EngineSelection::Json)?;
+    assert_eq!(store.engine_kind(), QueryEngineKind::Store);
+    assert_eq!(json.engine_kind(), QueryEngineKind::Json);
+    assert_eq!(store.index_path(), json.index_path());
+
+    let search = SearchRequest {
+        query: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.search(search.clone())?)?,
+        serde_json::to_value(json.search(search)?)?,
+    );
+    let callers = CallRequest {
+        symbol: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.callers(callers.clone())?)?,
+        serde_json::to_value(json.callers(callers)?)?,
+    );
+    let callees = CallRequest {
+        symbol: "Api.caller".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.callees(callees.clone())?)?,
+        serde_json::to_value(json.callees(callees)?)?,
+    );
+    let impact = ImpactRequest {
+        symbol: "UserService.list".to_owned(),
+        include_heuristic: false,
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.impact(impact.clone())?)?,
+        serde_json::to_value(json.impact(impact)?)?,
+    );
+    let explore = ExploreRequest {
+        symbols: vec!["Api.caller".to_owned(), "Store.callee".to_owned()],
+        root: directory.path().to_string_lossy().into_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.explore(explore.clone())?)?,
+        serde_json::to_value(json.explore(explore)?)?,
+    );
+    let trail = NodeTrailRequest {
+        source: "Api.caller".to_owned(),
+        target: "Store.callee".to_owned(),
+        include_heuristic: false,
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.node_trail(trail.clone())?)?,
+        serde_json::to_value(json.node_trail(trail)?)?,
+    );
+    Ok(())
+}
+
+#[test]
+fn phase2_snapshot_is_authoritative_over_the_legacy_payload_selector()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    let store = SqliteStore::open(directory.path().join(STORE_FILE_NAME))?;
+    store.publish_snapshot(b"not the phase2 graph", CODE_GRAPH_SCHEMA_V1, 0, 0)?;
+    drop(store);
+    publish_phase2_snapshot(directory.path(), &graph_path)?;
+
+    let engine = open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("cache"),
+        EngineSelection::Store,
+    )?;
+    let response = engine.search(SearchRequest {
+        query: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    })?;
+    assert!(response.results.iter().any(|hit| hit.node_id == "n:list"));
+    Ok(())
+}
+
+#[test]
+fn active_phase2_snapshot_requires_a_matching_store_reference()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    publish_phase2_snapshot(directory.path(), &graph_path)?;
+    fs::remove_file(directory.path().join(STORE_REF_FILE_NAME))?;
+
+    let error = match open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("cache"),
+        EngineSelection::Store,
+    ) {
+        Ok(_) => return Err("active snapshot opened without store.ref".into()),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), "store_ref_missing");
+    Ok(())
+}
+
+#[test]
+fn active_phase2_snapshot_rejects_a_stale_store_reference() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    publish_phase2_snapshot(directory.path(), &graph_path)?;
+    let reference_path = directory.path().join(STORE_REF_FILE_NAME);
+    let mut reference: StoreRef = serde_json::from_slice(&fs::read(&reference_path)?)?;
+    reference.graph_digest = "0".repeat(64);
+    fs::write(reference_path, serde_json::to_vec(&reference)?)?;
+
+    let error = match open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("cache"),
+        EngineSelection::Store,
+    ) {
+        Ok(_) => return Err("stale store.ref was accepted".into()),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), "store_ref_mismatch");
+    Ok(())
+}
+
+#[test]
+fn opened_store_reader_remains_pinned_when_the_active_selector_changes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    let store = publish_phase2_snapshot(directory.path(), &graph_path)?;
+    let cache = directory.path().join("cache");
+    let old = open_with_engine(&graph_path, None, &cache, EngineSelection::Store)?;
+
+    let mut updated = GraphDocument::load(&graph_path)?;
+    updated.nodes[0].qualified_name = "UserService.renamed".to_owned();
+    fs::write(&graph_path, serde_json::to_vec(&updated)?)?;
+    let prepared = GraphSnapshotBuilder::new().prepare(&store, &updated)?;
+    GraphSnapshotBuilder::new().activate(&store, &prepared)?;
+    fs::write(
+        directory.path().join(STORE_REF_FILE_NAME),
+        serde_json::to_vec(&store.snapshot_reference()?)?,
+    )?;
+
+    let current = open_with_engine(&graph_path, None, &cache, EngineSelection::Store)?;
+    let old_response = old.search(SearchRequest {
+        query: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    })?;
+    let current_response = current.search(SearchRequest {
+        query: "UserService.renamed".to_owned(),
+        limits: CodeQueryLimits::default(),
+    })?;
+    assert!(
+        old_response
+            .results
+            .iter()
+            .any(|hit| hit.node_id == "n:list")
+    );
+    assert!(
+        current_response
+            .results
+            .iter()
+            .any(|hit| hit.node_id == "n:list")
+    );
     Ok(())
 }
 

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -1,19 +1,21 @@
 # Compass store and graph-engine design
 
 **Status:** Architecture reference. The initial local slice, Phase 2 memory
-snapshot layout, and the Phase 3 SQLite shadow-publication slice are shipped:
-the `compass-store` contract, SQLite adapter, dual graph publication, typed
-query-engine selection, deterministic immutable graph indexes, selector-CAS
-reference protocol, WAL durability, reopen validation, and canonical
-graph.json differential checks are implemented. redb, PostgreSQL, DynamoDB,
-remote operation, general garbage collection, and performance claims remain
-follow-on work.
+snapshot layout, Phase 3 SQLite shadow-publication slice, and the local Phase 4
+snapshot-backed query-routing slice are shipped: the `compass-store` contract,
+SQLite adapter, dual graph publication, typed query-engine selection,
+deterministic immutable graph indexes, selector-CAS reference protocol, WAL
+durability, reopen validation, canonical graph.json differential checks, and
+cross-engine typed-query checks are implemented. redb, PostgreSQL, DynamoDB,
+remote operation, bounded streaming plans, general garbage collection, and
+performance claims remain follow-on work.
 
-Each generated sidecar now contains both the validated graph payload used by
-the current store engine and the Phase 2 content-addressed graph indexes. The
-sidecar is prepared and checkpointed in the unpublished BuildGuard generation;
-only the filesystem generation switch publishes it. `graph.json` remains a
-permanent compatible engine and is never removed or made dependent on SQLite.
+Each generated sidecar now contains both a validated graph payload retained for
+compatibility and the Phase 2 content-addressed graph indexes used by the
+current store engine. The sidecar is prepared and checkpointed in the
+unpublished BuildGuard generation; only the filesystem generation switch
+publishes it. `graph.json` remains a permanent compatible engine and is never
+removed or made dependent on SQLite.
 
 > **Who this page is for:** maintainers of graph publication and queries,
 > storage-adapter authors, cloud-service implementers, and reviewers of the

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -1,10 +1,11 @@
 # Executable Compass store implementation plan
 
-**Status:** In progress. Phases 0–2 and the local Phase 3 SQLite
-shadow-publication slice are implemented. The branch also retains the initial
-Phase 4 typed query-engine selection. Remote adapters, fault-injected crash
-qualification, general garbage collection, and measured performance claims
-remain follow-on work.
+**Status:** In progress. Phases 0–3 and the local Phase 4 snapshot-backed
+query-routing slice are implemented. The typed query path now reads the
+immutable Phase 2 graph snapshot and validates its reference before building
+query state. Bounded projection execution, remote adapters, fault-injected
+crash qualification, general garbage collection, and measured performance
+claims remain follow-on work.
 
 > **Who this page is for:** implementers and reviewers delivering
 > `compass-store`, store-backed graph snapshots, backend adapters, and the
@@ -67,15 +68,16 @@ Acceptance criteria for this slice are deliberately concrete:
    lexicographic scans/cursors, CAS, immutable retry, snapshot validation, and
    reopen tests.
 2. `cargo test -p compass-query --test store_engine --locked` proves default
-   store selection, explicit JSON selection, explicit-store failure, reopen,
-   and JSON-equivalent search results.
+   store selection, immutable Phase 2 snapshot authority, explicit JSON
+   selection, reference failures, pinned readers, cache identity, and
+   JSON-equivalent typed query results.
 3. The core publication regression test proves the sidecar is present,
    reopenable, digest-valid, and byte-identical to `graph.json` after a local
    build.
 4. Deleting or corrupting the sidecar never changes the JSON artifact; default
-   query opening falls back only when the sidecar is absent, while explicit
-   store selection fails with a typed error and a present malformed `store.ref`
-   fails closed.
+   query opening falls back only when the sidecar is absent, while an active
+   Phase 2 snapshot without a matching `store.ref` and explicit store
+   selection fail with typed errors.
 
 The initial local slice above does not claim redb/PostgreSQL/DynamoDB adapters,
 remote retry semantics, general garbage collection, or a measured performance
@@ -551,14 +553,17 @@ Disable shadow writes and remove unpublished databases. Existing
 `graph.json` generations remain valid. Do not attempt to repair a partially
 published store by rewriting its immutable objects; rebuild a new snapshot.
 
-## Phase 4: Route local queries to the store engine
+## Phase 4: Route local queries to the store engine (implemented local slice)
 
 ### Context and objective
 
 After shadow publication proves equivalence and durability, local readers can
-prefer the co-published store snapshot. The goal is faster cold open and
-bounded memory without changing public query results. JSON remains selectable
-and is used whenever the caller explicitly supplies a JSON graph.
+prefer the co-published store snapshot. The local slice now reads the
+immutable Phase 2 snapshot, validates the active selector and `store.ref`, and
+compares every typed code-query operation with the JSON engine. The query
+algorithms still materialize a bounded `GraphDocument`; projection/streaming
+execution and performance qualification remain follow-on work. JSON remains
+selectable and is used whenever the caller explicitly supplies a JSON graph.
 
 ### Prerequisite inputs
 
@@ -599,6 +604,12 @@ and is used whenever the caller explicitly supplies a JSON graph.
    expose `store` only through a separately reviewed CLI/configuration change.
    Store-only generations must support bounded deterministic JSON export.
 
+The shipped local slice implements items 1–2 for the typed code-query path,
+uses canonical graph bytes for shared disposable-index identity, and pins an
+opened reader to the immutable snapshot it selected. Items 3, 6, 8, and 9
+remain the next streaming/performance slice; the broader CompassQL and MCP
+engine plumbing remains explicitly gated on that work.
+
 ### Required tests
 
 - every public query produces the same ordered machine output under JSON and
@@ -620,18 +631,23 @@ and is used whenever the caller explicitly supplies a JSON graph.
 - `store` avoids full JSON materialization but can export byte-identical
   canonical JSON on demand.
 
-### Acceptance criteria
+### Acceptance criteria for the shipped local slice
 
-- Cross-engine differential tests cover typed search, code search, traversal,
-  impact, affected, CompassQL, MCP, and JSON export.
-- CompassQL TCK, OpenCypher TCK, CLI product tests, product-boundary check, and
-  fixture-only code-graph qualification pass.
-- `PERFORMANCE.md` contains reproducible before/after commands and results for
-  cold open, peak RSS, common queries, no-change update, and small-change
-  update, with `json`, `store`, and `dual` measured separately.
-- The default switches to store only if correctness is equal and agreed
-  performance thresholds are met; otherwise shadow mode remains available
-  without blocking later adapter development.
+- `compass-query` differential tests cover typed search, callers, callees,
+  impact, explore, node trails, explicit JSON isolation, stale references,
+  immutable snapshot authority, and reader pinning.
+- The default typed query path selects the immutable store snapshot only when
+  its active selector and `store.ref` validate; malformed or missing references
+  fail closed, while explicit JSON remains independent.
+- The disposable query index uses one canonical graph identity for JSON and
+  store openings, so equivalent engines share cache state and ordered results.
+- Existing CompassQL TCK, OpenCypher TCK, CLI product tests, product-boundary
+  check, and fixture-only code-graph qualification remain green.
+
+Full cross-engine differential coverage for CompassQL/MCP, bounded projection
+plans, and `PERFORMANCE.md` cold-open/RSS/query measurements are explicit
+follow-on gates before claiming a streaming performance improvement or adding
+additional storage profiles.
 - Documentation clearly states that `graph.json` is a compatible permanent
   engine, not a deprecated fallback.
 

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -18,12 +18,16 @@ CompassQL compiler/executor. Both operate over the same indexed graph model.
 
 `compass-query` exposes an immutable `GraphEngine` boundary with two supported
 implementations: `JsonGraphEngine` for the permanent compatible JSON artifact
-and `StoreGraphEngine` for a validated `compass-store` snapshot. The typed
-query algorithms consume the same validated `GraphDocument` projection from
-either engine, so selection cannot change ranking, direction, multiplicity,
-source anchors, or public result schemas. The store implementation is the
-seam for the planned bounded projection/streaming reads; its current local
-slice materializes the validated projection while preserving that contract.
+and `StoreGraphEngine` for a validated `compass-store` snapshot. The store
+engine reads the active Phase 2 graph-index snapshot, validates its manifest
+and typed `store.ref`, and pins the resulting projection to that immutable
+realization. The typed query algorithms consume the same validated
+`GraphDocument` projection from either engine, so selection cannot change
+ranking, direction, multiplicity, source anchors, or public result schemas.
+Both engines canonicalize graph bytes before deriving the disposable query
+index key, so equivalent JSON/store openings share cache identity. The local
+slice still materializes a bounded projection; bounded point-read plans and
+streaming execution remain the next query phase.
 
 ## Load once into the query model
 
@@ -50,14 +54,16 @@ it.
 
 The typed `search`, `callers`, `callees`, `impact`, `explore`, and `node`
 commands open through `compass_query::open`. The default selector looks for a
-validated `compass-store.sqlite3` sidecar and optional `store.ref` beside the
-requested graph and reads its content-addressed snapshot; if no sidecar exists,
-it opens `graph.json`. A present reference is checked against the store
-identity, manifest, and graph digest before query state is created. `--engine
-json` always uses the compatible JSON engine, while `--engine store` requires a
-readable store and reports corruption or absence explicitly. The query index
-remains disposable and keyed by the snapshot bytes, so JSON and store openings
-share the same cache identity and deterministic result path.
+validated `compass-store.sqlite3` sidecar beside the requested graph. A sidecar
+with an active Phase 2 selector must also have a matching `store.ref`; if no
+sidecar exists, the permanent `graph.json` engine is used. A present reference
+is checked against store identity, snapshot ID, manifest digest, and graph
+digest before query state is created. `--engine json` always uses the
+compatible JSON engine without opening the database, while `--engine store`
+requires a readable, referenced store and reports corruption or absence
+explicitly. The query index remains disposable and keyed by canonical snapshot
+bytes, so JSON and store openings share the same cache identity and
+deterministic result path.
 
 ## Focused discovery path
 


### PR DESCRIPTION
## Summary

- Route `StoreGraphEngine` through the active Phase 2 immutable graph-index snapshot.
- Validate the active selector and `store.ref` identity (including snapshot ID and graph digest) before creating query state.
- Canonicalize JSON and store graph bytes so equivalent engines share the disposable query-index cache identity.
- Keep `graph.json` as an explicit, permanent compatible engine; `--engine json` never opens SQLite.
- Add differential and failure-mode coverage for all typed code-query operations, legacy-payload precedence, stale/missing references, and pinned readers.
- Update the Compass Store and query-engine implementation documentation with the shipped local Phase 4 slice and follow-on streaming/performance work.

The local store reader still materializes a bounded `GraphDocument`; projection/streaming execution and measured performance claims remain a subsequent phase.

## Verification

Passed:

- `cargo test -p compass-query --test store_engine --locked`
- `cargo test -p compass-query --test code_query_scale --locked`
- `cargo test -p compass-cli --test code_query_cli --locked`
- `cargo clippy -p compass-query -p compass-cli -p compass-core --all-targets --locked -- -D warnings`
- `cargo check --workspace --locked`
- `sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-store-phase4 ./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `cargo fmt --all -- --check`
- `git diff --check`

The warm `cargo test --workspace --lib --bins --locked --quiet` run passed all preceding crates but hit an unrelated existing `compass-whisper` test failure (`timing.rs:76` subtraction overflow in `fallback_ladder_and_word_timestamps_run_on_a_bounded_clip`).
