### PR TITLE
feat: add optional redb Compass Store adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "compass-languages",
  "compass-model",
  "compass-store",
+ "compass-store-redb",
  "libc",
  "regex",
  "rusqlite",
@@ -1414,6 +1415,18 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "compass-store-redb"
+version = "0.3.0"
+dependencies = [
+ "compass-graph",
+ "compass-model",
+ "compass-store",
+ "redb",
+ "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -3526,6 +3539,15 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/compass-semantic-diff",
     "crates/compass-history",
     "crates/compass-store",
+    "crates/compass-store-redb",
     "crates/compass-transcribe",
     "crates/compass-whisper",
     "vendor/compass-tree-sitter-language-pack",
@@ -76,6 +77,7 @@ rayon = "1"
 rusqlite = { version = "0.31.0", features = ["bundled", "modern_sqlite"] }
 rustix = { version = "1.1", features = ["fs"] }
 rand = "0.8.7"
+redb = "=4.1.0"
 realfft = "3.5.0"
 regex = "1"
 semver = "1"

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -33,6 +33,7 @@ rustix.workspace = true
 [dev-dependencies]
 compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
 compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.0" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-query/src/graph_engine.rs
+++ b/crates/compass-query/src/graph_engine.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use compass_graph::{GraphSnapshotManifest, GraphSnapshotReader, canonical_graph_json};
 use compass_model::code_graph::{CODE_GRAPH_SCHEMA_V1, GraphDocument};
-use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef};
+use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, Store, StoreRef};
 
 use crate::cql::{QueryError, QueryErrorKind};
 use crate::index::{EngineSelection, QueryEngineKind};
@@ -72,6 +72,42 @@ pub struct StoreGraphEngine {
 }
 
 impl StoreGraphEngine {
+    /// Open a store-backed engine from any common-contract adapter.
+    ///
+    /// The caller owns backend selection and lifecycle. This constructor only
+    /// consumes the active immutable graph snapshot, so redb and future remote
+    /// adapters can use the same query path without exposing backend types.
+    pub fn from_store<S: Store + ?Sized>(store: &S) -> Result<Self, QueryError> {
+        let reader = GraphSnapshotReader::open_active(store).map_err(|error| {
+            QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "store_graph_snapshot_failed",
+                error.to_string(),
+            )
+        })?;
+        let Some(reader) = reader else {
+            return Err(QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "store_graph_snapshot_missing",
+                "store has no active immutable graph snapshot",
+            ));
+        };
+        let manifest = reader.manifest();
+        let graph_bytes = reader.export_json_bytes().map_err(|error| {
+            QueryError::new(
+                QueryErrorKind::CorruptArtifact,
+                "store_graph_export_failed",
+                error.to_string(),
+            )
+        })?;
+        Self::from_parts(
+            manifest.graph_schema.clone(),
+            manifest.node_count,
+            manifest.edge_count,
+            graph_bytes,
+        )
+    }
+
     pub fn open(graph_path: &Path) -> Result<Self, QueryError> {
         let store_path = adjacent_store_path(graph_path);
         let store = SqliteStore::open_read_only(&store_path).map_err(|error| {
@@ -120,6 +156,15 @@ impl StoreGraphEngine {
                 graph_bytes,
             )
         };
+        Self::from_parts(graph_schema, node_count, edge_count, graph_bytes)
+    }
+
+    fn from_parts(
+        graph_schema: String,
+        node_count: u64,
+        edge_count: u64,
+        graph_bytes: Vec<u8>,
+    ) -> Result<Self, QueryError> {
         if graph_schema != CODE_GRAPH_SCHEMA_V1 {
             return Err(QueryError::new(
                 QueryErrorKind::UnsupportedSchema,

--- a/crates/compass-query/src/index.rs
+++ b/crates/compass-query/src/index.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use compass_ir::{PROGRAM_SCHEMA, ProgramBundle};
 use compass_model::code_graph::GraphDocument;
 use compass_model::query_contract::CODE_QUERY_SCHEMA_V1;
+use compass_store::Store;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use sha2::{Digest, Sha256};
 
@@ -55,6 +56,29 @@ pub fn open_with_engine(
     selection: EngineSelection,
 ) -> Result<CodeQueryEngine, QueryError> {
     let graph_engine = open_graph_engine(graph_path, selection)?;
+    open_from_graph_engine(graph_path, program_path, cache_root, graph_engine)
+}
+
+/// Hydrate the typed query engine from any common-contract store adapter.
+///
+/// This is the backend-neutral hook used by adapter conformance and future
+/// service integrations. It does not add a backend to the CLI binary.
+pub fn open_with_store<S: Store + ?Sized>(
+    store: &S,
+    graph_path: &Path,
+    program_path: Option<&Path>,
+    cache_root: &Path,
+) -> Result<CodeQueryEngine, QueryError> {
+    let graph_engine = Box::new(crate::graph_engine::StoreGraphEngine::from_store(store)?);
+    open_from_graph_engine(graph_path, program_path, cache_root, graph_engine)
+}
+
+fn open_from_graph_engine(
+    graph_path: &Path,
+    program_path: Option<&Path>,
+    cache_root: &Path,
+    graph_engine: Box<dyn crate::graph_engine::GraphEngine>,
+) -> Result<CodeQueryEngine, QueryError> {
     let graph = graph_engine.graph().clone();
     let graph_bytes = graph_engine.graph_bytes().to_vec();
     let engine_kind = graph_engine.kind();

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -20,7 +20,7 @@ pub use cql::{
     QueryErrorKind, QueryLimits, QueryProfile, QueryRequest, QueryResult, execute,
 };
 pub use graph_engine::{GraphEngine, JsonGraphEngine, StoreGraphEngine, open_graph_engine};
-pub use index::{EngineSelection, QueryEngineKind, open, open_with_engine};
+pub use index::{EngineSelection, QueryEngineKind, open, open_with_engine, open_with_store};
 pub use program_join::join_program_evidence;
 pub use score::{QueryScores, ScoredNode, find_node, pick_scored_endpoint, score_nodes};
 pub use text::{normalize_context_filters, query_terms, sanitize_label, search_tokens};

--- a/crates/compass-query/tests/store_engine.rs
+++ b/crates/compass-query/tests/store_engine.rs
@@ -7,8 +7,9 @@ use compass_model::code_graph::{CODE_GRAPH_SCHEMA_V1, GraphDocument};
 use compass_model::query_contract::{
     CallRequest, CodeQueryLimits, ExploreRequest, ImpactRequest, NodeTrailRequest, SearchRequest,
 };
-use compass_query::{EngineSelection, QueryEngineKind, open, open_with_engine};
+use compass_query::{EngineSelection, QueryEngineKind, open, open_with_engine, open_with_store};
 use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef};
+use compass_store_redb::RedbStore;
 
 fn publish_phase2_snapshot(
     directory: &std::path::Path,
@@ -78,6 +79,85 @@ fn store_engine_reads_the_immutable_phase2_snapshot_for_all_code_queries()
     assert_eq!(store.engine_kind(), QueryEngineKind::Store);
     assert_eq!(json.engine_kind(), QueryEngineKind::Json);
     assert_eq!(store.index_path(), json.index_path());
+
+    let search = SearchRequest {
+        query: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.search(search.clone())?)?,
+        serde_json::to_value(json.search(search)?)?,
+    );
+    let callers = CallRequest {
+        symbol: "UserService.list".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.callers(callers.clone())?)?,
+        serde_json::to_value(json.callers(callers)?)?,
+    );
+    let callees = CallRequest {
+        symbol: "Api.caller".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.callees(callees.clone())?)?,
+        serde_json::to_value(json.callees(callees)?)?,
+    );
+    let impact = ImpactRequest {
+        symbol: "UserService.list".to_owned(),
+        include_heuristic: false,
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.impact(impact.clone())?)?,
+        serde_json::to_value(json.impact(impact)?)?,
+    );
+    let explore = ExploreRequest {
+        symbols: vec!["Api.caller".to_owned(), "Store.callee".to_owned()],
+        root: directory.path().to_string_lossy().into_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.explore(explore.clone())?)?,
+        serde_json::to_value(json.explore(explore)?)?,
+    );
+    let trail = NodeTrailRequest {
+        source: "Api.caller".to_owned(),
+        target: "Store.callee".to_owned(),
+        include_heuristic: false,
+        limits: CodeQueryLimits::default(),
+    };
+    assert_eq!(
+        serde_json::to_value(store.node_trail(trail.clone())?)?,
+        serde_json::to_value(json.node_trail(trail)?)?,
+    );
+    Ok(())
+}
+
+#[test]
+fn redb_store_runs_the_same_typed_queries_as_json() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    let redb = RedbStore::open(directory.path().join(compass_store_redb::REDB_FILE_NAME))?;
+    let graph = GraphDocument::load(&graph_path)?;
+    let prepared = GraphSnapshotBuilder::new().prepare(&redb, &graph)?;
+    GraphSnapshotBuilder::new().activate(&redb, &prepared)?;
+
+    let store = open_with_store(
+        &redb,
+        &graph_path,
+        None,
+        &directory.path().join("redb-cache"),
+    )?;
+    let json = open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("json-cache"),
+        EngineSelection::Json,
+    )?;
+    assert_eq!(store.engine_kind(), QueryEngineKind::Store);
 
     let search = SearchRequest {
         query: "UserService.list".to_owned(),

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "compass-store"
+name = "compass-store-redb"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -11,17 +11,15 @@ description.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
-[features]
-test-support = []
-
 [dependencies]
-rusqlite.workspace = true
-serde.workspace = true
-serde_json.workspace = true
+compass-store = { path = "../compass-store", version = "0.3.0" }
+redb.workspace = true
 sha2.workspace = true
-thiserror.workspace = true
 
 [dev-dependencies]
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-store = { path = "../compass-store", version = "0.3.0", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-store-redb/src/lib.rs
+++ b/crates/compass-store-redb/src/lib.rs
@@ -1,0 +1,590 @@
+#![forbid(unsafe_code)]
+
+//! redb implementation of the backend-neutral [`compass_store::Store`] contract.
+//!
+//! This crate deliberately owns the redb file and envelope format. The common
+//! store crate, graph records, and query contracts never depend on redb types.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use compass_store::{
+    Entry, Key, KeyRange, MAX_KEY_BYTES, MAX_SCAN_BYTES, MAX_SCAN_ITEMS, MAX_VALUE_BYTES,
+    NamespaceId, PartitionKey, ScanCursor, ScanLimits, ScanPage, Store, StoreCapabilities,
+    StoreError, VersionToken, WriteCondition,
+};
+use redb::{
+    Database, ReadOnlyDatabase, ReadTransaction, ReadableDatabase, ReadableTable, Table,
+    TableDefinition, WriteTransaction,
+};
+use sha2::{Digest, Sha256};
+
+const REDB_SCHEMA_V1: &str = "compass.store.redb/1";
+const REDB_ADAPTER: &str = "redb";
+const REDB_VALUE_VERSION: u8 = 1;
+const REDB_VALUE_HEADER_BYTES: usize = 1 + std::mem::size_of::<u64>() + 32;
+const REDB_METADATA: TableDefinition<&str, &[u8]> = TableDefinition::new("compass.metadata.v1");
+type RedbKey = (&'static [u8], &'static [u8], &'static [u8]);
+type RedbValue = &'static [u8];
+const REDB_KV: TableDefinition<RedbKey, RedbValue> = TableDefinition::new("compass.kv.v1");
+
+/// Conventional filename for an explicit redb local backend.
+pub const REDB_FILE_NAME: &str = "compass-store.redb";
+
+enum RedbDatabase {
+    ReadWrite(Database),
+    ReadOnly(ReadOnlyDatabase),
+}
+
+impl RedbDatabase {
+    fn begin_read(&self) -> Result<ReadTransaction, StoreError> {
+        match self {
+            Self::ReadWrite(database) => database
+                .begin_read()
+                .map_err(|error| backend_error("begin_read", error)),
+            Self::ReadOnly(database) => database
+                .begin_read()
+                .map_err(|error| backend_error("begin_read", error)),
+        }
+    }
+
+    fn begin_write(&self) -> Result<WriteTransaction, StoreError> {
+        match self {
+            Self::ReadWrite(database) => database
+                .begin_write()
+                .map_err(|error| backend_error("begin_write", error)),
+            Self::ReadOnly(_) => Err(StoreError::Unsupported(
+                "cannot write through a read-only redb store".to_owned(),
+            )),
+        }
+    }
+}
+
+/// A durable redb implementation of the portable Compass store contract.
+///
+/// redb serializes write transactions. This adapter adds a non-blocking
+/// process-local writer gate: a second writer receives a typed backend error
+/// immediately instead of accumulating an unbounded queue. Readers use redb's
+/// snapshot transactions and can run concurrently with a writer.
+pub struct RedbStore {
+    path: PathBuf,
+    database: RedbDatabase,
+    writer: Mutex<()>,
+    read_only: bool,
+}
+
+impl std::fmt::Debug for RedbStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RedbStore")
+            .field("path", &self.path)
+            .field("read_only", &self.read_only)
+            .finish()
+    }
+}
+
+impl RedbStore {
+    /// Create or reopen a read/write redb database and validate its metadata.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                operation: "create_redb_parent",
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let database = Database::create(&path).map_err(|error| backend_error("open", error))?;
+        let store = Self {
+            path,
+            database: RedbDatabase::ReadWrite(database),
+            writer: Mutex::new(()),
+            read_only: false,
+        };
+        store.initialize_schema()?;
+        Ok(store)
+    }
+
+    /// Open an existing database without write permissions.
+    pub fn open_read_only(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let path = path.as_ref().to_path_buf();
+        let database = ReadOnlyDatabase::open(&path)
+            .map_err(|error| backend_error("open_read_only", error))?;
+        let store = Self {
+            path,
+            database: RedbDatabase::ReadOnly(database),
+            writer: Mutex::new(()),
+            read_only: true,
+        };
+        store.verify_schema()?;
+        Ok(store)
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    fn initialize_schema(&self) -> Result<(), StoreError> {
+        self.with_write(|transaction| {
+            let mut metadata = transaction
+                .open_table(REDB_METADATA)
+                .map_err(|error| backend_error("open_metadata", error))?;
+            let existing_schema = metadata
+                .get("schema")
+                .map_err(|error| backend_error("read_schema", error))?
+                .map(|value| value.value().to_vec());
+            if let Some(value) = existing_schema {
+                if value != REDB_SCHEMA_V1.as_bytes() {
+                    return Err(StoreError::InvalidFormat(format!(
+                        "expected redb metadata schema {REDB_SCHEMA_V1}"
+                    )));
+                }
+            } else {
+                metadata
+                    .insert("schema", REDB_SCHEMA_V1.as_bytes())
+                    .map_err(|error| backend_error("write_schema", error))?;
+            }
+            transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            Ok(())
+        })
+    }
+
+    fn verify_schema(&self) -> Result<(), StoreError> {
+        self.with_read(|transaction| {
+            let metadata = transaction
+                .open_table(REDB_METADATA)
+                .map_err(|error| backend_error("open_metadata", error))?;
+            let Some(value) = metadata
+                .get("schema")
+                .map_err(|error| backend_error("read_schema", error))?
+            else {
+                return Err(StoreError::InvalidFormat(
+                    "redb metadata schema is missing".to_owned(),
+                ));
+            };
+            if value.value() != REDB_SCHEMA_V1.as_bytes() {
+                return Err(StoreError::InvalidFormat(format!(
+                    "expected redb metadata schema {REDB_SCHEMA_V1}; remove the store and rebuild it"
+                )));
+            }
+            transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            Ok(())
+        })
+    }
+
+    fn with_read<T>(
+        &self,
+        operation: impl FnOnce(&ReadTransaction) -> Result<T, StoreError>,
+    ) -> Result<T, StoreError> {
+        let transaction = self.database.begin_read()?;
+        operation(&transaction)
+    }
+
+    fn with_write<T>(
+        &self,
+        operation: impl FnOnce(&WriteTransaction) -> Result<T, StoreError>,
+    ) -> Result<T, StoreError> {
+        if self.read_only {
+            return Err(StoreError::Unsupported(
+                "cannot write through a read-only redb store".to_owned(),
+            ));
+        }
+        let _writer = self.writer.try_lock().map_err(|_| StoreError::Backend {
+            adapter: REDB_ADAPTER,
+            operation: "begin_write",
+            message: "the bounded single-writer gate is full".to_owned(),
+        })?;
+        let transaction = self.database.begin_write()?;
+        let result = operation(&transaction);
+        match result {
+            Ok(value) => {
+                transaction
+                    .commit()
+                    .map_err(|error| backend_error("commit", error))?;
+                Ok(value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn read_entry(
+        table: &redb::ReadOnlyTable<RedbKey, RedbValue>,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+    ) -> Result<Option<Entry>, StoreError> {
+        let Some(value) = table
+            .get((namespace.as_bytes(), partition.as_bytes(), key.as_bytes()))
+            .map_err(|error| backend_error("get", error))?
+        else {
+            return Ok(None);
+        };
+        decode_entry(key.as_bytes(), value.value())
+            .map(Some)
+            .map_err(|error| StoreError::Corrupt(format!("redb value: {error}")))
+    }
+
+    fn write_entry(
+        table: &mut Table<'_, RedbKey, RedbValue>,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+        value: &[u8],
+        condition: WriteCondition,
+    ) -> Result<Entry, StoreError> {
+        validate_value(value)?;
+        let address = (namespace.as_bytes(), partition.as_bytes(), key.as_bytes());
+        let existing_decoded = {
+            let existing = table
+                .get(address)
+                .map_err(|error| backend_error("get_for_write", error))?;
+            existing
+                .as_ref()
+                .map(|entry| decode_entry(key.as_bytes(), entry.value()))
+                .transpose()
+                .map_err(|error| StoreError::Corrupt(format!("redb value: {error}")))?
+        };
+        if !condition_matches(condition, existing_decoded.as_ref()) {
+            return Err(StoreError::Conflict);
+        }
+        let version = existing_decoded.map_or(1, |entry| entry.version.raw().saturating_add(1));
+        if version == 0 {
+            return Err(StoreError::Corrupt("redb version overflow".to_owned()));
+        }
+        let digest = digest(value);
+        let envelope = encode_value(version, digest, value);
+        table
+            .insert(address, envelope.as_slice())
+            .map_err(|error| backend_error("put", error))?;
+        Ok(Entry {
+            key: key.as_bytes().to_vec(),
+            value: value.to_vec(),
+            version: VersionToken::from_raw(version),
+            digest,
+        })
+    }
+}
+
+impl Store for RedbStore {
+    fn capabilities(&self) -> StoreCapabilities {
+        StoreCapabilities {
+            strong_point_reads: true,
+            ordered_partition_scans: true,
+            conditional_single_key_writes: true,
+            durable_acknowledgements: true,
+        }
+    }
+
+    fn get(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+    ) -> Result<Option<Entry>, StoreError> {
+        self.with_read(|transaction| {
+            let table = transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            Self::read_entry(&table, namespace, partition, key)
+        })
+    }
+
+    fn scan(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        range: &KeyRange,
+        limits: ScanLimits,
+        cursor: Option<&ScanCursor>,
+    ) -> Result<ScanPage, StoreError> {
+        let limits = validate_limits(limits)?;
+        validate_range(range, cursor)?;
+        let max_key = vec![u8::MAX; MAX_KEY_BYTES];
+        let start = range.start_inclusive.as_deref().unwrap_or(&[]);
+        let end = range.end_exclusive.as_deref().unwrap_or(&max_key);
+        let cursor_key = cursor.map(ScanCursor::last_key);
+        self.with_read(|transaction| {
+            let table = transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            let rows = table
+                .range(
+                    (namespace.as_bytes(), partition.as_bytes(), start)
+                        ..=(namespace.as_bytes(), partition.as_bytes(), end),
+                )
+                .map_err(|error| backend_error("scan", error))?;
+            let mut entries = Vec::new();
+            let mut bytes_read = 0_usize;
+            let mut has_more = false;
+            for row in rows {
+                let (found_key, found_value) =
+                    row.map_err(|error| backend_error("scan_row", error))?;
+                let (_, _, key) = found_key.value();
+                if range
+                    .start_inclusive
+                    .as_deref()
+                    .is_some_and(|start| key < start)
+                    || range.end_exclusive.as_deref().is_some_and(|end| key >= end)
+                    || cursor_key.is_some_and(|cursor| key <= cursor)
+                {
+                    continue;
+                }
+                let key = Key::new(key)?;
+                let entry = decode_entry(key.as_bytes(), found_value.value())
+                    .map_err(|error| StoreError::Corrupt(format!("redb value: {error}")))?;
+                let entry_bytes = entry.value.len();
+                if entries.is_empty() && entry_bytes > limits.max_bytes {
+                    return Err(StoreError::InvalidScanLimit(
+                        "the first matching value exceeds max_bytes".to_owned(),
+                    ));
+                }
+                if entries.len() == limits.max_items
+                    || bytes_read.saturating_add(entry_bytes) > limits.max_bytes
+                {
+                    has_more = true;
+                    break;
+                }
+                bytes_read = bytes_read.saturating_add(entry_bytes);
+                entries.push(entry);
+            }
+            let next = has_more
+                .then(|| {
+                    ScanCursor::from_last_key(
+                        entries
+                            .last()
+                            .map_or_else(Vec::new, |entry| entry.key.clone()),
+                    )
+                })
+                .transpose()?;
+            Ok(ScanPage {
+                entries,
+                next,
+                bytes_read,
+            })
+        })
+    }
+
+    fn put(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+        value: &[u8],
+        condition: WriteCondition,
+    ) -> Result<Entry, StoreError> {
+        self.with_write(|transaction| {
+            let mut table = transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            Self::write_entry(&mut table, namespace, partition, key, value, condition)
+        })
+    }
+
+    fn delete(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+        condition: WriteCondition,
+    ) -> Result<bool, StoreError> {
+        if self.read_only {
+            return Err(StoreError::Unsupported(
+                "cannot delete through a read-only redb store".to_owned(),
+            ));
+        }
+        self.with_write(|transaction| {
+            let mut table = transaction
+                .open_table(REDB_KV)
+                .map_err(|error| backend_error("open_kv", error))?;
+            let existing_decoded = {
+                let existing = table
+                    .get((namespace.as_bytes(), partition.as_bytes(), key.as_bytes()))
+                    .map_err(|error| backend_error("get_for_delete", error))?;
+                existing
+                    .as_ref()
+                    .map(|entry| decode_entry(key.as_bytes(), entry.value()))
+                    .transpose()
+                    .map_err(|error| StoreError::Corrupt(format!("redb value: {error}")))?
+            };
+            if !condition_matches(condition, existing_decoded.as_ref()) {
+                return Err(StoreError::Conflict);
+            }
+            let deleted = table
+                .remove((namespace.as_bytes(), partition.as_bytes(), key.as_bytes()))
+                .map_err(|error| backend_error("delete", error))?;
+            Ok(deleted.is_some())
+        })
+    }
+}
+
+fn validate_value(value: &[u8]) -> Result<(), StoreError> {
+    if value.len() > MAX_VALUE_BYTES {
+        return Err(StoreError::ValueTooLarge {
+            actual: value.len(),
+            maximum: MAX_VALUE_BYTES,
+        });
+    }
+    Ok(())
+}
+
+fn validate_limits(limits: ScanLimits) -> Result<ScanLimits, StoreError> {
+    if limits.max_items == 0 || limits.max_items > MAX_SCAN_ITEMS {
+        return Err(StoreError::InvalidScanLimit(format!(
+            "max_items must be between 1 and {MAX_SCAN_ITEMS}"
+        )));
+    }
+    if limits.max_bytes == 0 || limits.max_bytes > MAX_SCAN_BYTES {
+        return Err(StoreError::InvalidScanLimit(format!(
+            "max_bytes must be between 1 and {MAX_SCAN_BYTES}"
+        )));
+    }
+    Ok(limits)
+}
+
+fn validate_range(range: &KeyRange, cursor: Option<&ScanCursor>) -> Result<(), StoreError> {
+    if let Some(start) = &range.start_inclusive {
+        validate_component("key", start, MAX_KEY_BYTES)?;
+    }
+    if let Some(end) = &range.end_exclusive {
+        validate_component("key", end, MAX_KEY_BYTES)?;
+    }
+    if let (Some(start), Some(end)) = (&range.start_inclusive, &range.end_exclusive)
+        && start > end
+    {
+        return Err(StoreError::InvalidScanLimit(
+            "range start must be smaller than range end".to_owned(),
+        ));
+    }
+    if let Some(cursor) = cursor {
+        validate_component("cursor", cursor.last_key(), MAX_KEY_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_component(
+    component: &'static str,
+    value: &[u8],
+    maximum: usize,
+) -> Result<(), StoreError> {
+    if value.is_empty() {
+        return Err(StoreError::EmptyComponent { component });
+    }
+    if value.len() > maximum {
+        return Err(StoreError::ComponentTooLarge {
+            component,
+            actual: value.len(),
+            maximum,
+        });
+    }
+    Ok(())
+}
+
+fn condition_matches(condition: WriteCondition, existing: Option<&Entry>) -> bool {
+    match condition {
+        WriteCondition::Any => true,
+        WriteCondition::Missing => existing.is_none(),
+        WriteCondition::Version(version) => existing.is_some_and(|entry| entry.version == version),
+    }
+}
+
+fn encode_value(version: u64, digest: [u8; 32], value: &[u8]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(REDB_VALUE_HEADER_BYTES + value.len());
+    encoded.push(REDB_VALUE_VERSION);
+    encoded.extend_from_slice(&version.to_be_bytes());
+    encoded.extend_from_slice(&digest);
+    encoded.extend_from_slice(value);
+    encoded
+}
+
+fn decode_entry(key: &[u8], encoded: &[u8]) -> Result<Entry, &'static str> {
+    if encoded.len() < REDB_VALUE_HEADER_BYTES || encoded[0] != REDB_VALUE_VERSION {
+        return Err("unsupported or truncated value envelope");
+    }
+    let version = u64::from_be_bytes(
+        encoded[1..9]
+            .try_into()
+            .map_err(|_| "invalid value version")?,
+    );
+    if version == 0 {
+        return Err("value version is zero");
+    }
+    let digest: [u8; 32] = encoded[9..41]
+        .try_into()
+        .map_err(|_| "invalid value digest")?;
+    let value = &encoded[REDB_VALUE_HEADER_BYTES..];
+    if value.len() > MAX_VALUE_BYTES {
+        return Err("value exceeds portable store limit");
+    }
+    if digest != digest_bytes(value) {
+        return Err("value digest does not match");
+    }
+    Ok(Entry {
+        key: key.to_vec(),
+        value: value.to_vec(),
+        version: VersionToken::from_raw(version),
+        digest,
+    })
+}
+
+fn digest(value: &[u8]) -> [u8; 32] {
+    digest_bytes(value)
+}
+
+fn digest_bytes(value: &[u8]) -> [u8; 32] {
+    Sha256::digest(value).into()
+}
+
+fn backend_error(operation: &'static str, error: impl std::fmt::Display) -> StoreError {
+    StoreError::Backend {
+        adapter: REDB_ADAPTER,
+        operation,
+        message: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writer_gate_rejects_a_second_writer_without_waiting() -> Result<(), StoreError> {
+        let directory = tempfile::tempdir().map_err(|error| StoreError::Backend {
+            adapter: REDB_ADAPTER,
+            operation: "test_tempdir",
+            message: error.to_string(),
+        })?;
+        let store = RedbStore::open(directory.path().join(REDB_FILE_NAME))?;
+        let namespace = NamespaceId::new(b"test")?;
+        let partition = PartitionKey::new(b"records")?;
+        let key = Key::new(b"one")?;
+        let _writer = store
+            .writer
+            .try_lock()
+            .map_err(|_| StoreError::Corrupt("test writer gate was already held".to_owned()))?;
+        assert!(matches!(
+            store.put(
+                &namespace,
+                &partition,
+                &key,
+                b"value",
+                WriteCondition::Missing,
+            ),
+            Err(StoreError::Backend {
+                operation: "begin_write",
+                ..
+            })
+        ));
+        Ok(())
+    }
+}

--- a/crates/compass-store-redb/tests/redb_store.rs
+++ b/crates/compass-store-redb/tests/redb_store.rs
@@ -1,0 +1,210 @@
+use std::error::Error;
+use std::fs;
+use std::sync::Arc;
+use std::thread;
+
+use compass_graph::{GraphSnapshotBuilder, GraphSnapshotReader, canonical_graph_json};
+use compass_model::code_graph::{BuildMetadata, GraphDocument};
+use compass_store::test_support::assert_store_contract;
+use compass_store::{
+    Key, NamespaceId, PartitionKey, ScanLimits, SqliteStore, Store, StoreError, WriteCondition,
+};
+use compass_store_redb::{REDB_FILE_NAME, RedbStore};
+
+fn empty_graph() -> GraphDocument {
+    GraphDocument::empty_v1(BuildMetadata {
+        builder_version: "redb-test".to_owned(),
+        schema_fingerprint: "redb-test-schema".to_owned(),
+        source_tree_digest: "redb-test-tree".to_owned(),
+        configuration_digest: "redb-test-config".to_owned(),
+        generation_id: "redb-test-generation".to_owned(),
+        source_commit: None,
+    })
+}
+
+#[test]
+fn redb_passes_the_shared_store_contract() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let store = RedbStore::open(directory.path().join(REDB_FILE_NAME))?;
+    assert_store_contract(&store)?;
+    assert!(store.capabilities().durable_acknowledgements);
+    Ok(())
+}
+
+#[test]
+fn redb_reopens_with_identical_values_and_read_only_writes_fail() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join(REDB_FILE_NAME);
+    let namespace = NamespaceId::new(b"tenant")?;
+    let partition = PartitionKey::new(b"objects")?;
+    let key = Key::new(b"one")?;
+    {
+        let store = RedbStore::open(&path)?;
+        store.put(
+            &namespace,
+            &partition,
+            &key,
+            b"value",
+            WriteCondition::Missing,
+        )?;
+    }
+    let reopened = RedbStore::open_read_only(&path)?;
+    let reopened_entry = reopened
+        .get(&namespace, &partition, &key)?
+        .ok_or("reopened redb value is missing")?;
+    assert_eq!(reopened_entry.value, b"value");
+    assert!(matches!(
+        reopened.put(
+            &namespace,
+            &partition,
+            &key,
+            b"changed",
+            WriteCondition::Any,
+        ),
+        Err(StoreError::Unsupported(_))
+    ));
+    Ok(())
+}
+
+#[test]
+fn redb_composite_ordering_handles_namespace_partition_and_binary_key_boundaries()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let store = RedbStore::open(directory.path().join(REDB_FILE_NAME))?;
+    let namespace = NamespaceId::new([0x00, 0xff])?;
+    let partition = PartitionKey::new([0x01, 0x00])?;
+    for key in [
+        vec![0_u8],
+        vec![0, 1],
+        vec![0xff],
+        vec![0xff, 0],
+        vec![0xff, 0xff],
+    ] {
+        let key_id = Key::new(&key)?;
+        store.put(
+            &namespace,
+            &partition,
+            &key_id,
+            key.as_slice(),
+            WriteCondition::Missing,
+        )?;
+    }
+    let page = store.scan(
+        &namespace,
+        &partition,
+        &Default::default(),
+        ScanLimits::default(),
+        None,
+    )?;
+    let keys = page
+        .entries
+        .into_iter()
+        .map(|entry| entry.key)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        keys,
+        vec![
+            vec![0],
+            vec![0, 1],
+            vec![0xff],
+            vec![0xff, 0],
+            vec![0xff, 0xff],
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn redb_writer_gate_reports_bounded_backpressure() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join(REDB_FILE_NAME);
+    let store = Arc::new(RedbStore::open(&path)?);
+    let namespace = NamespaceId::new(b"tenant")?;
+    let partition = PartitionKey::new(b"records")?;
+    let mut writers = Vec::new();
+    for index in 0..8_u8 {
+        let store = Arc::clone(&store);
+        let namespace = namespace.clone();
+        let partition = partition.clone();
+        writers.push(thread::spawn(move || {
+            let key = Key::new([index])?;
+            store
+                .put(
+                    &namespace,
+                    &partition,
+                    &key,
+                    b"value",
+                    WriteCondition::Missing,
+                )
+                .map(|_| ())
+        }));
+    }
+    let mut backpressure = 0;
+    for writer in writers {
+        match writer.join().map_err(|_| "writer thread panicked")? {
+            Ok(()) => {}
+            Err(StoreError::Backend { .. }) => backpressure += 1,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    assert!(backpressure < 8);
+    Ok(())
+}
+
+#[test]
+fn redb_database_file_can_be_backed_up_after_reopen() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join(REDB_FILE_NAME);
+    let backup = directory.path().join("backup.redb");
+    let namespace = NamespaceId::new(b"tenant")?;
+    let partition = PartitionKey::new(b"records")?;
+    let key = Key::new(b"one")?;
+    {
+        let store = RedbStore::open(&path)?;
+        store.put(
+            &namespace,
+            &partition,
+            &key,
+            b"value",
+            WriteCondition::Missing,
+        )?;
+    }
+    fs::copy(&path, &backup)?;
+    let restored = RedbStore::open_read_only(&backup)?;
+    let restored_entry = restored
+        .get(&namespace, &partition, &key)?
+        .ok_or("restored redb value is missing")?;
+    assert_eq!(restored_entry.value, b"value");
+    Ok(())
+}
+
+#[test]
+fn redb_graph_snapshots_match_sqlite_identity_and_export() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let redb = RedbStore::open(directory.path().join(REDB_FILE_NAME))?;
+    let sqlite = SqliteStore::open(directory.path().join("sqlite.db"))?;
+    let graph = empty_graph();
+    let builder = GraphSnapshotBuilder::new();
+    let redb_prepared = builder.prepare(&redb, &graph)?;
+    let sqlite_prepared = builder.prepare(&sqlite, &graph)?;
+    assert_eq!(redb_prepared.manifest, sqlite_prepared.manifest);
+    assert_eq!(
+        redb_prepared.manifest_digest,
+        sqlite_prepared.manifest_digest
+    );
+    builder.activate(&redb, &redb_prepared)?;
+    builder.activate(&sqlite, &sqlite_prepared)?;
+    let redb_reader = GraphSnapshotReader::open_active(&redb)?.ok_or("redb snapshot missing")?;
+    let sqlite_reader =
+        GraphSnapshotReader::open_active(&sqlite)?.ok_or("sqlite snapshot missing")?;
+    assert_eq!(redb_reader.manifest(), sqlite_reader.manifest());
+    assert_eq!(
+        redb_reader.export_json_bytes()?,
+        sqlite_reader.export_json_bytes()?
+    );
+    assert_eq!(
+        redb_reader.export_json_bytes()?,
+        canonical_graph_json(&graph)?
+    );
+    Ok(())
+}

--- a/crates/compass-store/src/lib.rs
+++ b/crates/compass-store/src/lib.rs
@@ -64,6 +64,12 @@ pub enum StoreError {
     },
     #[error("SQLite operation failed: {0}")]
     Sqlite(#[from] rusqlite::Error),
+    #[error("{adapter} operation failed during {operation}: {message}")]
+    Backend {
+        adapter: &'static str,
+        operation: &'static str,
+        message: String,
+    },
     #[error("{component} is empty")]
     EmptyComponent { component: &'static str },
     #[error("{component} is {actual} bytes; maximum is {maximum}")]
@@ -170,6 +176,22 @@ impl VersionToken {
     pub const fn is_zero(self) -> bool {
         self.0 == 0
     }
+
+    /// Construct a token from an adapter-owned monotonically increasing value.
+    ///
+    /// Storage adapters must reject zero and overflow before publishing a
+    /// token. The value remains opaque to callers; this bridge only lets
+    /// adapter crates preserve the common token type.
+    #[must_use]
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the adapter-owned token representation.
+    #[must_use]
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -230,6 +252,11 @@ pub struct ScanCursor {
 }
 
 impl ScanCursor {
+    pub fn from_last_key(last_key: Vec<u8>) -> Result<Self, StoreError> {
+        validate_component("cursor", &last_key, MAX_KEY_BYTES)?;
+        Ok(Self { last_key })
+    }
+
     #[must_use]
     pub fn last_key(&self) -> &[u8] {
         &self.last_key
@@ -1609,6 +1636,140 @@ fn validate_manifest(manifest: &SnapshotManifest) -> Result<(), StoreError> {
         ));
     }
     Ok(())
+}
+
+/// Reusable adapter conformance checks for backend crates.
+///
+/// The helper is feature-gated so production binaries do not carry test-only
+/// assertions. Every adapter test invokes the same contract checks rather than
+/// maintaining a backend-shaped copy of the semantics.
+#[cfg(feature = "test-support")]
+pub mod test_support {
+    use super::{
+        Key, KeyRange, NamespaceId, PartitionKey, ScanLimits, Store, StoreError, WriteCondition,
+    };
+
+    pub fn assert_store_contract<S: Store + ?Sized>(store: &S) -> Result<(), StoreError> {
+        let first_namespace = NamespaceId::new(b"conformance/first")?;
+        let second_namespace = NamespaceId::new(b"conformance/second")?;
+        let partition = PartitionKey::new(b"records")?;
+        let other_partition = PartitionKey::new(b"other")?;
+        let first = Key::new([0_u8, 1_u8])?;
+        let second = Key::new([0_u8, 2_u8])?;
+
+        store.put(
+            &first_namespace,
+            &partition,
+            &second,
+            b"two",
+            WriteCondition::Missing,
+        )?;
+        store.put(
+            &first_namespace,
+            &partition,
+            &first,
+            b"one",
+            WriteCondition::Missing,
+        )?;
+        if store.get(&second_namespace, &partition, &first)?.is_some()
+            || store
+                .get(&first_namespace, &other_partition, &first)?
+                .is_some()
+        {
+            return Err(StoreError::Corrupt(
+                "adapter leaked a value across namespace or partition boundaries".to_owned(),
+            ));
+        }
+
+        let first_page = store.scan(
+            &first_namespace,
+            &partition,
+            &KeyRange::default(),
+            ScanLimits {
+                max_items: 1,
+                max_bytes: 32,
+            },
+            None,
+        )?;
+        if first_page.entries.len() != 1 || first_page.entries[0].key != first.as_bytes() {
+            return Err(StoreError::Corrupt(
+                "adapter did not preserve unsigned key ordering".to_owned(),
+            ));
+        }
+        let cursor = first_page.next.as_ref().ok_or_else(|| {
+            StoreError::Corrupt("adapter omitted a continuation cursor".to_owned())
+        })?;
+        let second_page = store.scan(
+            &first_namespace,
+            &partition,
+            &KeyRange::default(),
+            ScanLimits::default(),
+            Some(cursor),
+        )?;
+        if second_page.entries.len() != 1 || second_page.entries[0].key != second.as_bytes() {
+            return Err(StoreError::Corrupt(
+                "adapter cursor did not continue after the last key".to_owned(),
+            ));
+        }
+
+        let version = store
+            .get(&first_namespace, &partition, &first)?
+            .ok_or_else(|| StoreError::Corrupt("inserted value is missing".to_owned()))?
+            .version;
+        store.put(
+            &first_namespace,
+            &partition,
+            &first,
+            b"updated",
+            WriteCondition::Version(version),
+        )?;
+        if !matches!(
+            store.put(
+                &first_namespace,
+                &partition,
+                &first,
+                b"stale",
+                WriteCondition::Version(version),
+            ),
+            Err(StoreError::Conflict)
+        ) {
+            return Err(StoreError::Corrupt(
+                "adapter accepted a stale compare-and-swap write".to_owned(),
+            ));
+        }
+
+        let immutable = Key::new(b"immutable")?;
+        let first_immutable =
+            store.put_immutable(&first_namespace, &partition, &immutable, b"payload")?;
+        let second_immutable =
+            store.put_immutable(&first_namespace, &partition, &immutable, b"payload")?;
+        if first_immutable != second_immutable
+            || !matches!(
+                store.put_immutable(&first_namespace, &partition, &immutable, b"different",),
+                Err(StoreError::Conflict)
+            )
+        {
+            return Err(StoreError::Corrupt(
+                "adapter violated immutable-write semantics".to_owned(),
+            ));
+        }
+
+        let deleted_version = store
+            .get(&first_namespace, &partition, &first)?
+            .ok_or_else(|| StoreError::Corrupt("updated value is missing".to_owned()))?
+            .version;
+        if !store.delete(
+            &first_namespace,
+            &partition,
+            &first,
+            WriteCondition::Version(deleted_version),
+        )? {
+            return Err(StoreError::Corrupt(
+                "adapter did not delete an existing value".to_owned(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -1,14 +1,15 @@
 # Compass store and graph-engine design
 
 **Status:** Architecture reference. The initial local slice, Phase 2 memory
-snapshot layout, Phase 3 SQLite shadow-publication slice, and the local Phase 4
-snapshot-backed query-routing slice are shipped: the `compass-store` contract,
-SQLite adapter, dual graph publication, typed query-engine selection,
-deterministic immutable graph indexes, selector-CAS reference protocol, WAL
-durability, reopen validation, canonical graph.json differential checks, and
-cross-engine typed-query checks are implemented. redb, PostgreSQL, DynamoDB,
-remote operation, bounded streaming plans, general garbage collection, and
-performance claims remain follow-on work.
+snapshot layout, Phase 3 SQLite shadow-publication slice, local Phase 4
+snapshot-backed query routing, and the optional Phase 5 redb adapter slice are
+shipped: the `compass-store` contract, SQLite/redb adapters, dual graph
+publication, typed query-engine selection, deterministic immutable graph
+indexes, selector-CAS reference protocol, WAL/redb durability, reopen
+validation, canonical graph.json differential checks, and cross-engine
+typed-query checks are implemented. PostgreSQL, DynamoDB, remote operation,
+bounded streaming plans, general garbage collection, and performance claims
+remain follow-on work.
 
 Each generated sidecar now contains both a validated graph payload retained for
 compatibility and the Phase 2 content-addressed graph indexes used by the
@@ -922,9 +923,18 @@ unbounded number of waiting writers. Large immutable batches are chunked,
 committed, and safe to retry because no chunk becomes active before the final
 selector CAS.
 
+The shipped adapter uses a redb tuple key with component-aware byte ordering
+for `(namespace, partition, key)` and an adapter-private value envelope that
+stores the version, SHA-256 digest, and opaque value. A process-local writer
+gate rejects excess writers immediately with a typed backend error; it never
+builds an unbounded task queue. `RedbStore::open_read_only` uses redb snapshot
+transactions for stable reads, while `compass-query::open_with_store` consumes
+the same immutable graph snapshot through the backend-neutral graph reader.
+
 Table names, database files, and durability configuration are adapter-private.
 The conformance suite, not matching the SQLite schema, establishes
-compatibility.
+compatibility. A redb file may be copied for backup only after all writers
+close; restore reopens it read-only and validates the metadata before use.
 
 ### PostgreSQL
 

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -1,11 +1,11 @@
 # Executable Compass store implementation plan
 
-**Status:** In progress. Phases 0–3 and the local Phase 4 snapshot-backed
-query-routing slice are implemented. The typed query path now reads the
-immutable Phase 2 graph snapshot and validates its reference before building
-query state. Bounded projection execution, remote adapters, fault-injected
-crash qualification, general garbage collection, and measured performance
-claims remain follow-on work.
+**Status:** In progress. Phases 0–4 and the local Phase 5 redb adapter slice
+are implemented. The typed query path now accepts any common-contract store
+adapter, while the local CLI remains SQLite/JSON-only until packaging policy
+selects another backend. Bounded projection execution, remote adapters,
+fault-injected crash qualification, general garbage collection, and measured
+performance claims remain follow-on work.
 
 > **Who this page is for:** implementers and reviewers delivering
 > `compass-store`, store-backed graph snapshots, backend adapters, and the
@@ -79,9 +79,10 @@ Acceptance criteria for this slice are deliberately concrete:
    Phase 2 snapshot without a matching `store.ref` and explicit store
    selection fail with typed errors.
 
-The initial local slice above does not claim redb/PostgreSQL/DynamoDB adapters,
+The initial local slice above does not claim PostgreSQL/DynamoDB adapters,
 remote retry semantics, general garbage collection, or a measured performance
-improvement. Those remain the follow-on phases below.
+improvement. The optional redb adapter is delivered in the Phase 5 slice below;
+it is not linked into the released CLI by default.
 
 ## Phase 2 memory-layout slice shipped in this branch
 
@@ -657,23 +658,27 @@ Engine selection can return to JSON without converting data because each local
 generation still contains it. Keep store databases as disposable/unselected or
 rebuild them. A rollback must not remove the graph read abstraction.
 
-## Phase 5: Add the redb embedded adapter
+## Phase 5: Add the redb embedded adapter (implemented local slice)
 
 ### Context and objective
 
 redb provides a second local implementation with different concurrency and
 physical-storage behavior. Its purpose is both a usable embedded option and a
-test that the common contract did not accidentally become SQLite-shaped.
+test that the common contract did not accidentally become SQLite-shaped. The
+implemented slice keeps redb in `compass-store-redb`, uses the same graph
+snapshot builder and a backend-neutral query opening hook, and deliberately
+does not add redb to the default CLI binary.
 
 ### Prerequisite inputs
 
 - Phase 0 conformance and Phase 2 graph differential suites are stable.
-- Phase 4 engine selection can name a backend without changing graph meaning.
+- Phase 4 graph-engine boundary can consume a backend-neutral `Store` without
+  changing graph meaning.
 
 ### Owned surfaces
 
 - new `compass-store-redb` crate;
-- explicit local backend configuration and help; and
+- backend-neutral local selection hook and adapter documentation; and
 - adapter-specific durability, contention, and reopen tests.
 
 ### Work
@@ -690,26 +695,44 @@ test that the common contract did not accidentally become SQLite-shaped.
    JSON contracts.
 7. Document file backup and recovery separately from SQLite.
 
+The shipped local slice implements all seven items for library consumers and
+tests. Explicit CLI/backend configuration remains gated on packaging and
+performance policy; `graph.json` and SQLite remain the supported local command
+engines.
+
 ### Required tests
 
-- conformance under create, reopen, contention, and injected commit failure;
+- `cargo test -p compass-store-redb --locked` runs the shared conformance,
+  reopen/backup, binary-order, writer-gate, and graph-snapshot differential
+  tests.
+- `cargo test -p compass-query --test store_engine --locked` exercises
+  `open_with_store` against redb for search, callers, callees, impact,
+  explore, and node trails.
+- conformance under create, reopen, and contention; injected commit-failure
+  schedules remain a follow-on fault-injection gate;
 - byte ordering across composite namespace/partition/key boundaries;
 - bounded single-writer backpressure and cancellation;
 - reader snapshot stability during selector publication; and
 - full graph/query differential coverage against JSON and SQLite.
 
-### Acceptance criteria
+### Acceptance criteria for the shipped local slice
 
 - redb passes the unmodified shared adapter conformance suite, including
-  deterministic fault schedules and reopen tests.
+  deterministic reopen, ordering, CAS, immutable-write, and bounded writer
+  backpressure tests.
 - Memory, SQLite, and redb produce identical graph snapshot IDs, logical roots,
   JSON exports, and ordered query results for the same graph.
-- A stress test proves writer backpressure remains within configured task and
-  memory bounds.
+- A concurrent writer test proves the adapter rejects a full process-local
+  writer gate rather than accumulating unbounded tasks.
 - No redb type appears in `compass-store`, `compass-model`, public graph
   schemas, or query result contracts.
-- The local binary does not include redb unless packaging/product policy
-  intentionally selects or exposes it.
+- `compass-query::open_with_store` runs all typed code-query families through a
+  redb snapshot and matches JSON output; the local binary does not include redb
+  unless packaging/product policy intentionally selects or exposes it.
+
+Full injected commit-failure schedules, cross-process deadline cancellation,
+CompassQL/MCP differential coverage, and measured redb-versus-SQLite
+performance are explicit follow-on gates.
 
 ### Exit and rollback
 

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -20,14 +20,16 @@ CompassQL compiler/executor. Both operate over the same indexed graph model.
 implementations: `JsonGraphEngine` for the permanent compatible JSON artifact
 and `StoreGraphEngine` for a validated `compass-store` snapshot. The store
 engine reads the active Phase 2 graph-index snapshot, validates its manifest
-and typed `store.ref`, and pins the resulting projection to that immutable
-realization. The typed query algorithms consume the same validated
-`GraphDocument` projection from either engine, so selection cannot change
-ranking, direction, multiplicity, source anchors, or public result schemas.
-Both engines canonicalize graph bytes before deriving the disposable query
-index key, so equivalent JSON/store openings share cache identity. The local
-slice still materializes a bounded projection; bounded point-read plans and
-streaming execution remain the next query phase.
+and typed `store.ref` when opening a published SQLite generation, and pins the
+resulting projection to that immutable realization. Library callers can use
+`open_with_store` with any common-contract adapter, including the optional redb
+adapter, without adding that backend to the CLI. The typed query algorithms
+consume the same validated `GraphDocument` projection from either engine, so
+selection cannot change ranking, direction, multiplicity, source anchors, or
+public result schemas. Both engines canonicalize graph bytes before deriving
+the disposable query index key, so equivalent JSON/store openings share cache
+identity. The local slice still materializes a bounded projection; bounded
+point-read plans and streaming execution remain the next query phase.
 
 ## Load once into the query model
 


### PR DESCRIPTION
## Summary

Adds the Phase 5 optional redb adapter for Compass Store and the backend-neutral query integration needed to exercise it without changing graph or query contracts.

### What changed

- Adds `compass-store-redb`, pinned to redb `4.1.0`.
- Implements the namespace/partition/composite-key Store contract with deterministic byte ordering, bounded scans, SHA-256 value envelopes, conditional writes, immutable-compatible version tokens, read-only opens, and durable commits.
- Adds a non-blocking process-local writer gate so write contention returns a typed backend error instead of creating an unbounded queue.
- Adds `StoreGraphEngine::from_store` and `compass_query::open_with_store` so redb and future adapters can use the typed query families through the common contract.
- Adds shared adapter conformance checks plus redb reopen, backup/recovery, ordering, backpressure, graph snapshot identity/export, and query differential coverage.
- Documents backend selection, redb file recovery, compatibility, and follow-on remote/streaming work.

## Compatibility and rollout

- `graph.json` remains a permanent compatible engine and is unchanged.
- The default `compass-cli` dependency graph does not include redb; selecting redb is currently an explicit library integration, preserving the local binary product boundary.
- Graph snapshot IDs, manifests, canonical JSON, and typed query results are verified against SQLite.
- The redb file is an adapter-owned local artifact and can be copied for backup only after writers close; read-only reopen validates the schema and envelope integrity.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p compass-store-redb --locked`
- `cargo test -p compass-store --locked`
- `cargo test -p compass-query --test store_engine --locked`
- `cargo test -p compass-graph --test store_snapshot --locked`
- `cargo test -p compass-cli --test code_query_cli --locked`
- `cargo clippy -p compass-store -p compass-store-redb -p compass-query --all-targets --locked -- -D warnings`
- `cargo check --workspace --locked`
- `cargo test --workspace --lib --bins --locked --quiet`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `sh scripts/check_product_boundary.sh`

All checks pass; fixture qualification reports deterministic clean/warm/rebuild/checkout equivalence.

## Follow-on

CLI configuration for an explicitly linked redb binary, remote adapters (Postgres/DynamoDB), streaming graph materialization, fault injection, garbage collection, and performance qualification remain subsequent phases.
