### PR TITLE
feat: qualify Compass Store local release contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Qualify the local `compass-store` release contract: versioned store and
+  graph-snapshot envelopes, namespace-first addressing, SQLite backup/restore,
+  `compass store status|validate|backup|restore`, explicit rebuild tooling, and
+  canonical JSON/typed-query/CompassQL differential evidence. `graph.json`
+  remains permanent; redb is a library-only adapter and PostgreSQL/DynamoDB
+  remain deferred.
 - Publish a validated `compass-store.sqlite3` namespace/partition/key snapshot
   and typed `store.ref` beside every current `graph.json` generation. Typed
   code-query commands now use the store by default when the selector agrees,

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -57,6 +57,45 @@ selection never requires opening a database. The SQLite file and reference are
 internal realizations of the backend-neutral `compass-store` contract, not a
 stable SQL schema or pointer format that consumers may query directly.
 
+## Compass Store release contract
+
+The first supported local store line is `0.3.x`. Its logical machine formats
+are versioned independently:
+
+| Contract | Major | Support in `0.3.x` |
+| --- | --- | --- |
+| Graph JSON | `compass.graph/1` | Permanent compatible engine; direct input, publication, inspection, interchange, recovery, and deterministic export |
+| Common key-value API | `compass.store/1` | Supported by the local SQLite adapter and the library-only redb adapter |
+| Immutable graph snapshot | `compass.store.graph-snapshot/1` | Same-major reopen and validation |
+| Store reference | `compass.store.ref/1` | Required to bind the selected snapshot to `graph.json` |
+| Backup bundle | `compass.store.backup/1` | Validated by `compass store restore` into a new directory |
+
+Patch releases may reopen a matching major. Unknown majors, pre-release
+physical files, mismatched adapters, and invalid references fail explicitly and
+must be rebuilt; they are never silently treated as empty data. The SQLite
+tables/WAL, redb file, object-key spellings, and query-index caches remain
+rebuildable implementation details. See the [store operations guide](docs/guides/compass-store-operations.md)
+and [migration notes](MIGRATION.md).
+
+The CLI currently selects SQLite for a validated local sidecar.
+`compass-store-redb` is a separate library adapter used by conformance and
+qualification tests; it is not a CLI or packaging dependency. PostgreSQL and
+DynamoDB are future adapters, not supported release backends. No local store
+command accepts cloud credentials, endpoints, or TLS configuration.
+
+Published locations are `DIR/graph.json`, `DIR/compass-store.sqlite3`, and
+`DIR/store.ref` under the selected `--out DIR` (default `compass-out/`).
+`compass store status|validate|backup|restore` are the supported operational
+surface. Backups are digest-bound directories and restores never overwrite an
+existing destination. General object GC and service quotas are deferred; the
+local API still enforces bounded values, scans, graph sizes, and request work.
+
+The hard-cut boundary is the sidecar and all disposable indexes. When a
+physical format is invalid or outside the support window, preserve
+`graph.json`, run `scripts/rebuild_compass_store.sh`, or select `--engine json`.
+The JSON engine does not require a database and is not a migration fallback
+scheduled for removal.
+
 Markdown graph extraction is a structural, extensible projection. New
 document/block attributes and bounded diagnostic extensions may appear without
 changing node identity; consumers must preserve unknown attributes, edge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "compass-store-qualification"
+version = "0.3.0"
+dependencies = [
+ "compass-cypher",
+ "compass-graph",
+ "compass-model",
+ "compass-query",
+ "compass-store",
+ "compass-store-redb",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+]
+
+[[package]]
 name = "compass-store-redb"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/compass-history",
     "crates/compass-store",
     "crates/compass-store-redb",
+    "crates/compass-store-qualification",
     "crates/compass-transcribe",
     "crates/compass-whisper",
     "vendor/compass-tree-sitter-language-pack",

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,6 +35,46 @@ graphify://... MCP resources     -> compass://...
 
 Compass does not fall back to the old names.
 
+## Compass Store sidecar upgrades
+
+The `0.3.x` line supports the logical majors `compass.store/1`,
+`compass.store.graph-snapshot/1`, and `compass.store.ref/1`. A patch release
+can reopen and validate a same-major SQLite sidecar. Unknown majors, a missing
+or corrupt `store.ref`, and redb or prototype files are rebuildable hard cuts;
+they are not migrated in place.
+
+Check an output before upgrading or collecting support evidence:
+
+```bash
+compass store status compass-out --format json
+compass store validate compass-out --format json
+```
+
+Create and verify a rollback bundle before a planned upgrade:
+
+```bash
+compass store backup compass-out --output /safe/compass-store-backup
+compass store restore --from /safe/compass-store-backup --into /safe/compass-out-check
+compass store validate /safe/compass-out-check --format json
+```
+
+If validation fails after an upgrade, retain `graph.json` and rebuild the
+sidecar from source:
+
+```bash
+scripts/rebuild_compass_store.sh . --out compass-out --compass compass
+```
+
+The script preserves existing sidecars in a timestamped rollback directory,
+restores them if `compass update --force` fails, and never replaces the JSON
+artifact. A normal `compass update --force` is also sufficient when the old
+sidecar has already been removed. If only `graph.json` is available, use
+`--engine json`; no database is required to inspect or query that artifact.
+
+Downgrades must validate the output with the target binary. Do not reuse a
+newer physical SQLite/redb file merely because its filename matches. Rebuild
+when the target binary reports an unsupported major or adapter.
+
 ## Regenerate HTML graph exports
 
 Current Compass releases use the shared graph workbench for `graph.html` and

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -24,6 +24,48 @@ Compare a proposed change with a previously approved Compass result captured on
 the same runner and corpus. A median regression above 10% requires explicit
 review and evidence explaining the tradeoff.
 
+## Compass Store release qualification
+
+The local store release harness records the adapter's build/query timings,
+peak child RSS, graph and database bytes, request/byte counters, write
+amplification, immutable-object reuse, GC state, and JSON/typed-query/
+CompassQL differential results. It also measures a small real CLI workflow:
+clean build, unchanged update, one-file update, and cold JSON/store search.
+Run it from a checkout with the required external target directory:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-store-<checkout> \
+  scripts/qualify_compass_store_release.sh
+```
+
+The default graph sizes are 32, 128, and 512 generated nodes. Raw JSON and
+CSV observations are written below the selected target directory and must not
+be committed. Set `COMPASS_STORE_QUALIFICATION_SKIP_GATES=1` only for a local
+measurement rerun; a release run also executes adapter conformance, snapshot,
+query, CLI, CompassQL, product-boundary, packaging, and fixture gates. The
+release harness reports GC as `discovery-only` because general retention and
+deletion are not shipped in the local store.
+
+One macOS development-run observation (Apple Silicon, Rust 1.97.1, release
+binary, 2026-08-02) was:
+
+| Adapter | Nodes | Process seconds | Peak RSS KiB | Graph bytes | Database bytes | Write amplification | Build requests (get/put) | Query requests (get/scan) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| SQLite | 32 | 0.438 | 12,240 | 33,833 | 274,432 | 8.11× | 24 / 12 | 10 / 0 |
+| SQLite | 128 | 0.161 | 24,928 | 135,361 | 1,003,520 | 7.41× | 42 / 21 | 14 / 0 |
+| SQLite | 512 | 0.521 | 46,976 | 542,017 | 3,956,736 | 7.30× | 114 / 57 | 28 / 0 |
+| redb (library) | 32 | 0.125 | 12,416 | 33,833 | 598,016 | 17.68× | 24 / 12 | 10 / 0 |
+| redb (library) | 128 | 0.243 | 24,832 | 135,361 | 1,585,152 | 11.71× | 42 / 21 | 14 / 0 |
+| redb (library) | 512 | 0.695 | 51,840 | 542,017 | 6,328,320 | 11.68× | 114 / 57 | 28 / 0 |
+
+The same sample project measured CLI process times of 5.583 s (clean
+`init`), 0.092 s (unchanged update), 0.123 s (small source change), 0.034 s
+(cold JSON search), and 0.025 s (cold store search), with peak RSS of 30,896,
+24,288, 27,344, 14,192, and 14,800 KiB respectively. These are reproducible
+diagnostic observations, not a claim that every repository or backend is
+faster. The release gate remains correctness plus the existing 10% regression
+policy; a performance cutover requires a comparable approved JSON baseline.
+
 ## CompassQL qualification
 
 CompassQL measures compile/plan latency, indexed fixed matches, one-hop and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,22 @@ Compass parses untrusted project content and graph files. Its default structural
   executable so the managed command path remains accurate.
 
 Include the selected options and endpoint type in reports about these features. Never include live credentials.
+
+## Store boundary
+
+`graph.json`, `store.ref`, backup manifests, SQLite files, and future adapter
+objects are untrusted input. Compass validates schema majors, bounded sizes,
+content digests, active selectors, canonical JSON export, and reference
+bindings before exposing a store snapshot. `compass store restore` is
+fail-closed, restores only into a new destination, and removes an incomplete
+destination on validation failure. Stop writers before copying a redb file;
+the SQLite backup command checkpoints WAL for this purpose.
+
+The namespace is an isolation and lifecycle key, not an authorization
+mechanism. A future hosted adapter must add authentication, authorization,
+TLS, audit logging, quotas, and tenant-scoped GC outside the common contract.
+The local release has no cloud endpoint, credential, or TLS setting and does
+not link cloud SDKs into the CLI. Never attach a store database or raw backup
+to a public issue: it can disclose repository names, paths, source anchors,
+and graph structure. Share a sanitized `compass store status --format json`
+response instead.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -31,3 +31,28 @@ Follow [SECURITY.md](SECURITY.md) and use [GitHub private vulnerability reportin
 ## Support boundaries
 
 The project doesn't offer guaranteed response times, private implementation consulting, or support for modified binaries and unsupported releases. Community members may still help when a question includes enough public information to reproduce the behavior.
+
+## Store troubleshooting
+
+For a local output, collect:
+
+```bash
+compass store status compass-out --format json
+compass store validate compass-out --format json
+```
+
+If the graph is valid and only the sidecar fails, use the JSON engine while
+rebuilding:
+
+```bash
+compass search "symbol" --graph compass-out/graph.json --engine json --format json
+scripts/rebuild_compass_store.sh . --out compass-out --compass compass
+```
+
+Back up before any repair and restore into a new directory. Do not edit SQLite
+tables, copy a redb file while it is open for writing, or report a failed
+validation as an empty graph. Include the Compass version, platform, schema
+identifiers, sanitized status/validation output, and exact command. Remove
+databases, backup bundles, private source, credentials, `.env` files, and
+machine-specific paths from public reports. PostgreSQL, DynamoDB, and cloud
+store endpoints are not supported in this local release.

--- a/crates/compass-cli/assets/compass-skill/references/command-reference.md
+++ b/crates/compass-cli/assets/compass-skill/references/command-reference.md
@@ -36,6 +36,12 @@ whether a Compass capability is covered by the installed skill. Run
   parallel or reciprocal relationships.
 - `compass check-update`: report whether watched semantic changes left a pending
   refresh marker.
+- `compass store status|validate`: inspect and validate the local SQLite graph
+  sidecar without changing graph meaning.
+- `compass store backup`: checkpoint and copy a validated local generation into
+  a new backup directory with a signed-by-digest manifest.
+- `compass store restore`: validate that manifest, graph export, selector, and
+  sidecar before restoring into a new or empty output directory.
 
 These are read-only unless a missing historical realization must be materialized.
 An `--at REV` query can therefore create local history-store artifacts even

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -82,6 +82,7 @@ const GROUPS: &[Group] = &[
             "cache-check",
             "merge-chunks",
             "merge-semantic",
+            "store",
         ],
     },
     Group {
@@ -164,6 +165,17 @@ const PAGES: &[Page] = &[
         "Incrementally refresh the local knowledge graph",
         ["compass update [PATH] [OPTIONS]"],
         "Arguments:\n  [PATH]                       Project directory to scan [default: saved root or .]\n\nOptions:\n  --program-artifact <PATH>    Add an offline program-evidence artifact; repeatable\n  --no-program                Build only the structural graph; omit program.json\n  --out <DIR>                  Write artifacts below this directory\n  --force                      Rebuild even when inputs appear unchanged\n  --no-cluster                 Skip community detection\n  --no-viz                     Skip graph.html generation\n  --no-gitignore               Ignore .gitignore rules while scanning\n  --exclude <PATTERN>          Exclude a glob pattern; repeatable\n  --resolution <NUMBER>        Community-detection resolution [default: 1.0]\n  --exclude-hubs <NUMBER>      Exclude high-degree hubs from clustering\n  --timing                     Print stage timings\n\nExamples:\n  compass update\n  compass update ./services/api --force --timing\n  compass update ./services/api --no-program --no-cluster\n  compass update --program-artifact index.scip\n\nTips:\n  Use `compass watch` to refresh the graph whenever project files change."
+    ),
+    page!(
+        "store",
+        "Validate, back up, and restore the local graph store",
+        [
+            "compass store status [PATH] [--format text|json]",
+            "compass store validate [PATH] [--format text|json]",
+            "compass store backup [PATH] --output DIR [--format text|json]",
+            "compass store restore --from DIR --into DIR [--format text|json]"
+        ],
+        "Options:\n  [PATH]                   Project or compass-out directory [default: compass-out]\n  --output DIR             New backup directory\n  --from DIR               Backup directory to restore\n  --into DIR               New output directory for a restore\n  --format <text|json>     Output format [default: text]\n\nExamples:\n  compass store status --format json\n  compass store validate compass-out\n  compass store backup compass-out --output /safe/backups/project\n  compass store restore --from /safe/backups/project --into restored-out\n\nNotes:\n  Backup and restore are SQLite local operations. Stop writers before backup; restore only into a new or empty output directory. A stale or corrupt sidecar remains rebuildable with `compass update --force`. The optional redb adapter is library-only and is not selected by this command."
     ),
     page!(
         "extract",
@@ -1047,7 +1059,7 @@ mod tests {
     #[test]
     fn catalog_has_unique_complete_public_roots() {
         let roots = root_commands();
-        assert_eq!(roots.len(), 45);
+        assert_eq!(roots.len(), 46);
         for root in roots {
             let matches = PAGES.iter().filter(|page| page.path == root).count();
             assert_eq!(matches, 1, "{root}");

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -23,6 +23,7 @@ mod result_commands;
 mod semantic_commands;
 mod semantic_diff_commands;
 mod semantic_diff_render;
+mod store_commands;
 mod upgrade_commands;
 
 use std::collections::HashMap;
@@ -367,6 +368,7 @@ pub fn run(frontend: Frontend, arguments: impl IntoIterator<Item = OsString>) ->
         "merge-chunks" => semantic_commands::command_merge_chunks(frontend, &args),
         "merge-semantic" => semantic_commands::command_merge_semantic(frontend, &args),
         "provider" => provider_commands::command_provider(frontend, &args),
+        "store" => store_commands::command(&args),
         "save-result" => result_commands::command_save_result(frontend, &args),
         "reflect" => result_commands::command_reflect(frontend, &args),
         "check-update" => integration_commands::command_check_update(frontend, &args),

--- a/crates/compass-cli/src/store_commands.rs
+++ b/crates/compass-cli/src/store_commands.rs
@@ -1,0 +1,453 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use compass_graph::{GraphSnapshotReader, canonical_graph_json};
+use compass_model::code_graph::GraphDocument;
+use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, STORE_SCHEMA_V1, SqliteStore, StoreRef};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::Outcome;
+
+const BACKUP_SCHEMA_V1: &str = "compass.store.backup/1";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BackupManifest {
+    schema: String,
+    store_schema: String,
+    adapter: String,
+    graph_digest: String,
+    store_digest: String,
+    snapshot_id: String,
+    manifest_digest: String,
+    store_reference: StoreRef,
+}
+
+pub(crate) fn command(args: &[String]) -> Outcome {
+    let operation = args.first().map(String::as_str).unwrap_or("status");
+    let result = match operation {
+        "status" => status(args),
+        "validate" => validate(args),
+        "backup" => backup(args),
+        "restore" => restore(args),
+        _ => Err("usage: compass store <status|validate|backup|restore> [OPTIONS]".to_owned()),
+    };
+    match result {
+        Ok(value) => match option(args, "--format").unwrap_or("text") {
+            "json" => match serde_json::to_string_pretty(&value) {
+                Ok(output) => Outcome::success(output),
+                Err(error) => Outcome::failure(format!("error: {error}")),
+            },
+            "text" => Outcome::success(render_text(&value)),
+            value => Outcome::failure(format!(
+                "error: --format must be text or json (found {value})"
+            )),
+        },
+        Err(error) => Outcome::failure(format!("error: {error}")),
+    }
+}
+
+fn status(args: &[String]) -> Result<Value, String> {
+    let output = output_root(args);
+    let graph_path = output.join("graph.json");
+    let store_path = output.join(STORE_FILE_NAME);
+    let reference_path = output.join(STORE_REF_FILE_NAME);
+    let graph = if graph_path.is_file() {
+        let bytes = fs::read(&graph_path).map_err(|error| format!("read graph.json: {error}"))?;
+        let document = GraphDocument::load(&graph_path).map_err(|error| error.to_string())?;
+        Some(graph_status(&bytes, &document))
+    } else {
+        None
+    };
+
+    let store = if store_path.is_file() {
+        match SqliteStore::open_read_only(&store_path) {
+            Ok(store) => match validate_store(&store, graph.as_ref(), &graph_path) {
+                Ok((reference, snapshot_id, manifest_digest)) => Some(json!({
+                    "present": true,
+                    "valid": true,
+                    "bytes": fs::metadata(&store_path).map(|metadata| metadata.len()).unwrap_or(0),
+                    "sha256": digest_file(&store_path)?,
+                    "adapter": "sqlite",
+                    "storeSchema": STORE_SCHEMA_V1,
+                    "snapshotId": snapshot_id,
+                    "manifestDigest": manifest_digest,
+                    "reference": reference,
+                })),
+                Err(error) => Some(json!({
+                    "present": true,
+                    "valid": false,
+                    "adapter": "sqlite",
+                    "error": error,
+                })),
+            },
+            Err(error) => Some(json!({
+                "present": true,
+                "valid": false,
+                "adapter": "sqlite",
+                "error": error.to_string(),
+            })),
+        }
+    } else {
+        None
+    };
+
+    let reference = if reference_path.is_file() {
+        let bytes =
+            fs::read(&reference_path).map_err(|error| format!("read store.ref: {error}"))?;
+        match serde_json::from_slice::<StoreRef>(&bytes) {
+            Ok(reference) => match reference.validate() {
+                Ok(()) => json!({ "present": true, "valid": true, "value": reference }),
+                Err(error) => json!({
+                    "present": true,
+                    "valid": false,
+                    "error": error.to_string(),
+                }),
+            },
+            Err(error) => json!({
+                "present": true,
+                "valid": false,
+                "error": error.to_string(),
+            }),
+        }
+    } else {
+        json!({ "present": false })
+    };
+
+    Ok(json!({
+        "schema": "compass.store.status/1",
+        "output": output,
+        "graphJson": graph.unwrap_or_else(|| json!({ "present": false })),
+        "store": store.unwrap_or_else(|| json!({ "present": false })),
+        "storeRef": reference,
+        "rebuildCommand": "compass update --force",
+    }))
+}
+
+fn validate(args: &[String]) -> Result<Value, String> {
+    let output = output_root(args);
+    let graph_path = output.join("graph.json");
+    let store_path = output.join(STORE_FILE_NAME);
+    if !store_path.is_file() {
+        return Err(format!(
+            "store sidecar is missing: {}",
+            store_path.display()
+        ));
+    }
+    let graph = if graph_path.is_file() {
+        let bytes = fs::read(&graph_path).map_err(|error| format!("read graph.json: {error}"))?;
+        let document = GraphDocument::load(&graph_path).map_err(|error| error.to_string())?;
+        Some(graph_status(&bytes, &document))
+    } else {
+        None
+    };
+    let store = SqliteStore::open_read_only(&store_path).map_err(|error| error.to_string())?;
+    let (reference, snapshot_id, manifest_digest) =
+        validate_store(&store, graph.as_ref(), &graph_path)?;
+    let reference_path = output.join(STORE_REF_FILE_NAME);
+    if !reference_path.is_file() {
+        return Err(format!(
+            "store.ref is missing: {}",
+            reference_path.display()
+        ));
+    }
+    let on_disk: StoreRef = serde_json::from_slice(
+        &fs::read(&reference_path).map_err(|error| format!("read store.ref: {error}"))?,
+    )
+    .map_err(|error| format!("decode store.ref: {error}"))?;
+    on_disk.validate().map_err(|error| error.to_string())?;
+    if on_disk != reference {
+        return Err("store.ref does not match the active SQLite snapshot".to_owned());
+    }
+    Ok(json!({
+        "schema": "compass.store.validation/1",
+        "valid": true,
+        "output": output,
+        "graphJson": graph.unwrap_or_else(|| json!({ "present": false })),
+        "adapter": "sqlite",
+        "storeSchema": STORE_SCHEMA_V1,
+        "snapshotId": snapshot_id,
+        "manifestDigest": manifest_digest,
+        "storeReference": reference,
+    }))
+}
+
+fn backup(args: &[String]) -> Result<Value, String> {
+    let output = output_root(args);
+    let destination = option(args, "--output")
+        .map(PathBuf::from)
+        .ok_or_else(|| "store backup requires --output DIR".to_owned())?;
+    if destination.exists() {
+        return Err(format!(
+            "backup destination already exists: {}",
+            destination.display()
+        ));
+    }
+    let graph_path = output.join("graph.json");
+    let store_path = output.join(STORE_FILE_NAME);
+    let reference_path = output.join(STORE_REF_FILE_NAME);
+    let graph_bytes = fs::read(&graph_path).map_err(|error| format!("read graph.json: {error}"))?;
+    let graph = GraphDocument::load(&graph_path).map_err(|error| error.to_string())?;
+    let reference_bytes =
+        fs::read(&reference_path).map_err(|error| format!("read store.ref: {error}"))?;
+    let reference: StoreRef = serde_json::from_slice(&reference_bytes)
+        .map_err(|error| format!("decode store.ref: {error}"))?;
+    reference.validate().map_err(|error| error.to_string())?;
+    let store = SqliteStore::open(&store_path).map_err(|error| error.to_string())?;
+    let graph_value = graph_status(&graph_bytes, &graph);
+    let (_, snapshot_id, manifest_digest) =
+        validate_store(&store, Some(&graph_value), &graph_path)?;
+    if reference.snapshot_id != snapshot_id || reference.manifest_digest != manifest_digest {
+        return Err("store.ref does not match the active snapshot".to_owned());
+    }
+
+    fs::create_dir_all(&destination)
+        .map_err(|error| format!("create backup destination: {error}"))?;
+    let result = (|| {
+        store
+            .backup_to(destination.join(STORE_FILE_NAME))
+            .map_err(|error| error.to_string())?;
+        fs::copy(&graph_path, destination.join("graph.json"))
+            .map_err(|error| format!("copy graph.json: {error}"))?;
+        fs::copy(&reference_path, destination.join(STORE_REF_FILE_NAME))
+            .map_err(|error| format!("copy store.ref: {error}"))?;
+        let manifest = BackupManifest {
+            schema: BACKUP_SCHEMA_V1.to_owned(),
+            store_schema: STORE_SCHEMA_V1.to_owned(),
+            adapter: "sqlite".to_owned(),
+            graph_digest: digest(&graph_bytes),
+            store_digest: digest_file(&destination.join(STORE_FILE_NAME))?,
+            snapshot_id,
+            manifest_digest,
+            store_reference: reference,
+        };
+        fs::write(
+            destination.join("manifest.json"),
+            serde_json::to_vec_pretty(&manifest).map_err(|error| error.to_string())?,
+        )
+        .map_err(|error| format!("write backup manifest: {error}"))?;
+        Ok::<_, String>(manifest)
+    })();
+    match result {
+        Ok(manifest) => Ok(json!({
+            "schema": BACKUP_SCHEMA_V1,
+            "backup": destination,
+            "manifest": manifest,
+        })),
+        Err(error) => {
+            let _ = fs::remove_dir_all(&destination);
+            Err(error)
+        }
+    }
+}
+
+fn restore(args: &[String]) -> Result<Value, String> {
+    let source = option(args, "--from")
+        .map(PathBuf::from)
+        .ok_or_else(|| "store restore requires --from DIR".to_owned())?;
+    let destination = option(args, "--into")
+        .map(PathBuf::from)
+        .ok_or_else(|| "store restore requires --into DIR".to_owned())?;
+    if destination.exists()
+        && fs::read_dir(&destination)
+            .map_err(|error| format!("inspect restore destination: {error}"))?
+            .next()
+            .is_some()
+    {
+        return Err(format!(
+            "restore destination must be new or empty: {}",
+            destination.display()
+        ));
+    }
+    let manifest: BackupManifest = serde_json::from_slice(
+        &fs::read(source.join("manifest.json"))
+            .map_err(|error| format!("read backup manifest: {error}"))?,
+    )
+    .map_err(|error| format!("decode backup manifest: {error}"))?;
+    if manifest.schema != BACKUP_SCHEMA_V1
+        || manifest.store_schema != STORE_SCHEMA_V1
+        || manifest.adapter != "sqlite"
+    {
+        return Err("backup uses an unsupported Compass store format".to_owned());
+    }
+    manifest
+        .store_reference
+        .validate()
+        .map_err(|error| error.to_string())?;
+    let graph_bytes = fs::read(source.join("graph.json"))
+        .map_err(|error| format!("read backup graph.json: {error}"))?;
+    if digest(&graph_bytes) != manifest.graph_digest {
+        return Err("backup graph digest does not match manifest".to_owned());
+    }
+    let graph_path = source.join("graph.json");
+    let graph = GraphDocument::load(&graph_path).map_err(|error| error.to_string())?;
+    let backup_store = source.join(STORE_FILE_NAME);
+    let store = SqliteStore::open_read_only(&backup_store).map_err(|error| error.to_string())?;
+    validate_store(
+        &store,
+        Some(&graph_status(&graph_bytes, &graph)),
+        &graph_path,
+    )?;
+    if digest_file(&backup_store)? != manifest.store_digest {
+        return Err("backup store digest does not match manifest".to_owned());
+    }
+    let backup_reference: StoreRef = serde_json::from_slice(
+        &fs::read(source.join(STORE_REF_FILE_NAME))
+            .map_err(|error| format!("read backup store.ref: {error}"))?,
+    )
+    .map_err(|error| format!("decode backup store.ref: {error}"))?;
+    if backup_reference != manifest.store_reference {
+        return Err("backup store.ref does not match manifest".to_owned());
+    }
+
+    fs::create_dir_all(&destination)
+        .map_err(|error| format!("create restore destination: {error}"))?;
+    let result = (|| {
+        SqliteStore::restore_from(&backup_store, destination.join(STORE_FILE_NAME))
+            .map_err(|error| error.to_string())?;
+        fs::write(destination.join("graph.json"), &graph_bytes)
+            .map_err(|error| format!("restore graph.json: {error}"))?;
+        fs::copy(
+            source.join(STORE_REF_FILE_NAME),
+            destination.join(STORE_REF_FILE_NAME),
+        )
+        .map_err(|error| format!("restore store.ref: {error}"))?;
+        validate(&["validate".to_owned(), destination.display().to_string()])?;
+        Ok::<_, String>(())
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_dir_all(&destination);
+        return Err(error);
+    }
+    Ok(json!({
+        "schema": "compass.store.restore/1",
+        "restored": destination,
+        "snapshotId": manifest.snapshot_id,
+        "graphDigest": manifest.graph_digest,
+    }))
+}
+
+fn validate_store(
+    store: &SqliteStore,
+    graph: Option<&Value>,
+    graph_path: &Path,
+) -> Result<(StoreRef, String, String), String> {
+    let reader = GraphSnapshotReader::open_active(store)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "active immutable graph snapshot is missing".to_owned())?;
+    let manifest = reader.manifest();
+    let exported = reader
+        .export_json_bytes()
+        .map_err(|error| error.to_string())?;
+    if let Some(graph) = graph {
+        let graph_bytes =
+            fs::read(graph_path).map_err(|error| format!("read graph.json: {error}"))?;
+        let expected = graph_bytes_from_status(graph, &graph_bytes)?;
+        if exported != expected {
+            return Err("store export is not byte-identical to graph.json".to_owned());
+        }
+    }
+    let reference = store
+        .snapshot_reference()
+        .map_err(|error| error.to_string())?;
+    let manifest_digest = reference.manifest_digest.clone();
+    Ok((reference, manifest.snapshot_id.clone(), manifest_digest))
+}
+
+fn graph_status(bytes: &[u8], graph: &GraphDocument) -> Value {
+    json!({
+        "present": true,
+        "bytes": bytes.len(),
+        "sha256": digest(bytes),
+        "nodes": graph.nodes.len(),
+        "edges": graph.links.len(),
+    })
+}
+
+fn graph_bytes_from_status(graph: &Value, bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let expected = graph
+        .get("sha256")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "graph status is missing its digest".to_owned())?;
+    if expected != digest(bytes) {
+        return Err("graph status digest changed during validation".to_owned());
+    }
+    let document = serde_json::from_slice::<GraphDocument>(bytes)
+        .map_err(|error| format!("decode graph.json: {error}"))?;
+    canonical_graph_json(&document).map_err(|error| error.to_string())
+}
+
+fn output_root(args: &[String]) -> PathBuf {
+    let candidate = positional(args)
+        .first()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("compass-out"));
+    if candidate.file_name().and_then(|name| name.to_str()) == Some("graph.json") {
+        return candidate.parent().unwrap_or(Path::new(".")).to_path_buf();
+    }
+    if candidate.join("graph.json").is_file() || candidate.join(STORE_FILE_NAME).is_file() {
+        return candidate;
+    }
+    if candidate.join("compass-out").is_dir() {
+        return candidate.join("compass-out");
+    }
+    candidate
+}
+
+fn positional(args: &[String]) -> Vec<String> {
+    let value_options = ["--format", "--output", "--from", "--into"];
+    let mut values = Vec::new();
+    let mut skip = false;
+    for argument in args.iter().skip(1) {
+        if skip {
+            skip = false;
+        } else if value_options.contains(&argument.as_str()) {
+            skip = true;
+        } else if !argument.starts_with("--") {
+            values.push(argument.clone());
+        }
+    }
+    values
+}
+
+fn option<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+    args.iter().enumerate().find_map(|(index, argument)| {
+        if argument == name {
+            args.get(index + 1).map(String::as_str)
+        } else {
+            argument
+                .strip_prefix(name)
+                .and_then(|value| value.strip_prefix('='))
+        }
+    })
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn digest_file(path: &Path) -> Result<String, String> {
+    Ok(digest(&fs::read(path).map_err(|error| {
+        format!("read {}: {error}", path.display())
+    })?))
+}
+
+fn render_text(value: &Value) -> String {
+    let schema = value
+        .get("schema")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let output = value
+        .get("output")
+        .or_else(|| value.get("backup"))
+        .or_else(|| value.get("restored"))
+        .map(Value::to_string)
+        .unwrap_or_default();
+    let valid = value.get("valid").and_then(Value::as_bool);
+    match valid {
+        Some(valid) => format!("{schema}: valid={valid} {output}"),
+        None => format!("{schema}: {output}"),
+    }
+}

--- a/crates/compass-cli/tests/store_cli.rs
+++ b/crates/compass-cli/tests/store_cli.rs
@@ -1,0 +1,124 @@
+use std::error::Error;
+use std::fs;
+use std::process::Command;
+
+use compass_files::BuildGuard;
+use serde_json::Value;
+
+#[test]
+fn store_status_backup_and_restore_are_end_to_end_validated() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    fs::write(
+        root.path().join("main.rs"),
+        "fn main() { println!(\"ok\"); }\n",
+    )?;
+    let init = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["init", ".", "--yes"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        init.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let output = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
+    let status = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args([
+            "store",
+            "status",
+            output.to_str().ok_or("output path")?,
+            "--format",
+            "json",
+        ])
+        .output()?;
+    assert!(
+        status.status.success(),
+        "status: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: Value = serde_json::from_slice(&status.stdout)?;
+    assert_eq!(status_json["schema"], "compass.store.status/1");
+    assert_eq!(status_json["store"]["valid"], true);
+
+    let backup = root.path().join("backup");
+    let backup_result = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args([
+            "store",
+            "backup",
+            output.to_str().ok_or("output path")?,
+            "--output",
+            backup.to_str().ok_or("backup path")?,
+            "--format",
+            "json",
+        ])
+        .output()?;
+    assert!(
+        backup_result.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&backup_result.stdout),
+        String::from_utf8_lossy(&backup_result.stderr)
+    );
+    assert!(backup.join("manifest.json").is_file());
+
+    let restored = root.path().join("restored");
+    let restore_result = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args([
+            "store",
+            "restore",
+            "--from",
+            backup.to_str().ok_or("backup path")?,
+            "--into",
+            restored.to_str().ok_or("restore path")?,
+            "--format",
+            "json",
+        ])
+        .output()?;
+    assert!(
+        restore_result.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&restore_result.stdout),
+        String::from_utf8_lossy(&restore_result.stderr)
+    );
+    let restored_validation = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args([
+            "store",
+            "validate",
+            restored.to_str().ok_or("restore path")?,
+            "--format",
+            "json",
+        ])
+        .output()?;
+    assert!(restored_validation.status.success());
+    let restored_json: Value = serde_json::from_slice(&restored_validation.stdout)?;
+    assert_eq!(restored_json["valid"], true);
+    assert_eq!(
+        fs::read(output.join("graph.json"))?,
+        fs::read(restored.join("graph.json"))?
+    );
+    Ok(())
+}
+
+#[test]
+fn store_validate_rejects_a_corrupt_sidecar_without_touching_graph_json()
+-> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    fs::write(root.path().join("main.rs"), "fn main() {}\n")?;
+    let init = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["init", ".", "--yes"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(init.status.success());
+    let output = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
+    let graph = fs::read(output.join("graph.json"))?;
+    fs::write(output.join("compass-store.sqlite3"), b"corrupt")?;
+    let result = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["store", "validate", output.to_str().ok_or("output path")?])
+        .output()?;
+    assert!(!result.status.success());
+    assert_eq!(fs::read(output.join("graph.json"))?, graph);
+    Ok(())
+}

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "compass-store-qualification"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+description = "Internal release qualification harness for Compass Store adapters"
+publish = false
+
+[[bin]]
+name = "compass-store-qualification"
+path = "src/main.rs"
+
+[dependencies]
+compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
+compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-query = { path = "../compass-query", version = "0.3.0" }
+compass-store = { path = "../compass-store", version = "0.3.0" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.0" }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/compass-store-qualification/src/main.rs
+++ b/crates/compass-store-qualification/src/main.rs
@@ -1,0 +1,521 @@
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use compass_cypher::{CompileLimits, CompileRequest, ParameterTypes, Parameters, compile};
+use compass_graph::{GraphSnapshotBuilder, GraphSnapshotReader, canonical_graph_json};
+use compass_model::code_graph::{CODE_GRAPH_SCHEMA_V1, EdgeKind, GraphDocument};
+use compass_model::identity::{edge_id, file_id};
+use compass_model::provenance::{EvidenceConfidence, EvidenceOrigin, Provenance, SourceAnchor};
+use compass_model::query_contract::{CodeQueryLimits, SearchRequest};
+use compass_model::{
+    EdgeRecord as LegacyEdgeRecord, Graph, GraphDocument as LegacyGraphDocument,
+    NodeRecord as LegacyNodeRecord,
+};
+use compass_query::{
+    EngineSelection, QueryLimits as CompassQlLimits, QueryRequest as CompassQlRequest, execute,
+    open_with_engine, open_with_store,
+};
+use compass_store::{
+    Entry, Key, KeyRange, NamespaceId, PartitionKey, ScanCursor, ScanLimits, ScanPage, Store,
+    StoreCapabilities, StoreError, WriteCondition,
+};
+use compass_store_redb::RedbStore;
+use serde::Serialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+const REPORT_SCHEMA: &str = "compass.store.release-qualification/1";
+const MAX_NODES: usize = 100_000;
+
+#[derive(Default)]
+struct Counters {
+    get_requests: AtomicU64,
+    scan_requests: AtomicU64,
+    put_requests: AtomicU64,
+    delete_requests: AtomicU64,
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CounterSnapshot {
+    get_requests: u64,
+    scan_requests: u64,
+    put_requests: u64,
+    delete_requests: u64,
+    bytes_read: u64,
+    bytes_written: u64,
+}
+
+impl Counters {
+    fn snapshot(&self) -> CounterSnapshot {
+        CounterSnapshot {
+            get_requests: self.get_requests.load(Ordering::Relaxed),
+            scan_requests: self.scan_requests.load(Ordering::Relaxed),
+            put_requests: self.put_requests.load(Ordering::Relaxed),
+            delete_requests: self.delete_requests.load(Ordering::Relaxed),
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            bytes_written: self.bytes_written.load(Ordering::Relaxed),
+        }
+    }
+}
+
+struct CountingStore<S> {
+    inner: S,
+    counters: Counters,
+}
+
+impl<S> CountingStore<S> {
+    fn new(inner: S) -> Self {
+        Self {
+            inner,
+            counters: Counters::default(),
+        }
+    }
+}
+
+impl<S: Store> Store for CountingStore<S> {
+    fn capabilities(&self) -> StoreCapabilities {
+        self.inner.capabilities()
+    }
+
+    fn get(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+    ) -> Result<Option<Entry>, StoreError> {
+        self.counters.get_requests.fetch_add(1, Ordering::Relaxed);
+        let entry = self.inner.get(namespace, partition, key)?;
+        if let Some(entry) = &entry {
+            self.counters
+                .bytes_read
+                .fetch_add(entry.value.len() as u64, Ordering::Relaxed);
+        }
+        Ok(entry)
+    }
+
+    fn scan(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        range: &KeyRange,
+        limits: ScanLimits,
+        cursor: Option<&ScanCursor>,
+    ) -> Result<ScanPage, StoreError> {
+        self.counters.scan_requests.fetch_add(1, Ordering::Relaxed);
+        let page = self
+            .inner
+            .scan(namespace, partition, range, limits, cursor)?;
+        self.counters
+            .bytes_read
+            .fetch_add(page.bytes_read as u64, Ordering::Relaxed);
+        Ok(page)
+    }
+
+    fn put(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+        value: &[u8],
+        condition: WriteCondition,
+    ) -> Result<Entry, StoreError> {
+        self.counters.put_requests.fetch_add(1, Ordering::Relaxed);
+        self.counters
+            .bytes_written
+            .fetch_add(value.len() as u64, Ordering::Relaxed);
+        self.inner.put(namespace, partition, key, value, condition)
+    }
+
+    fn delete(
+        &self,
+        namespace: &NamespaceId,
+        partition: &PartitionKey,
+        key: &Key,
+        condition: WriteCondition,
+    ) -> Result<bool, StoreError> {
+        self.counters
+            .delete_requests
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.delete(namespace, partition, key, condition)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReleaseReport {
+    schema: &'static str,
+    adapter: &'static str,
+    nodes: usize,
+    edges: usize,
+    graph_bytes: usize,
+    graph_digest: String,
+    snapshot_id: String,
+    manifest_digest: String,
+    canonical_json_equal: bool,
+    compassql_equal: bool,
+    build_seconds: f64,
+    query_seconds: f64,
+    database_bytes: u64,
+    write_amplification: f64,
+    build_requests: CounterSnapshot,
+    query_requests: CounterSnapshot,
+    query_results: usize,
+    new_objects: u64,
+    reused_objects: u64,
+    gc: Value,
+}
+
+fn main() -> Result<(), String> {
+    let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+    let adapter = option(&arguments, "--adapter").unwrap_or("sqlite");
+    let nodes = option(&arguments, "--nodes")
+        .unwrap_or("128")
+        .parse::<usize>()
+        .map_err(|_| "--nodes must be a positive integer".to_owned())?;
+    if nodes == 0 || nodes > MAX_NODES {
+        return Err(format!("--nodes must be between 1 and {MAX_NODES}"));
+    }
+    let output = option(&arguments, "--output").map(PathBuf::from);
+    let report = match adapter {
+        "sqlite" => run_sqlite(nodes)?,
+        "redb" => run_redb(nodes)?,
+        value => return Err(format!("--adapter must be sqlite or redb (found {value})")),
+    };
+    let encoded = serde_json::to_vec_pretty(&report).map_err(|error| error.to_string())?;
+    if let Some(output) = output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        fs::write(output, encoded).map_err(|error| error.to_string())?;
+    } else {
+        println!("{}", String::from_utf8_lossy(&encoded));
+    }
+    Ok(())
+}
+
+fn run_sqlite(nodes: usize) -> Result<ReleaseReport, String> {
+    let directory = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let path = directory.path().join("compass-store.sqlite3");
+    let store = compass_store::SqliteStore::open(&path).map_err(|error| error.to_string())?;
+    run_with_store("sqlite", nodes, directory, path, store)
+}
+
+fn run_redb(nodes: usize) -> Result<ReleaseReport, String> {
+    let directory = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let path = directory.path().join(compass_store_redb::REDB_FILE_NAME);
+    let store = RedbStore::open(&path).map_err(|error| error.to_string())?;
+    run_with_store("redb", nodes, directory, path, store)
+}
+
+fn run_with_store<S: Store>(
+    adapter: &'static str,
+    nodes: usize,
+    directory: TempDir,
+    store_path: PathBuf,
+    store: S,
+) -> Result<ReleaseReport, String> {
+    let graph = graph(nodes)?;
+    let canonical = canonical_graph_json(&graph).map_err(|error| error.to_string())?;
+    let graph_path = directory.path().join("graph.json");
+    fs::write(&graph_path, &canonical).map_err(|error| error.to_string())?;
+    let counted = CountingStore::new(store);
+    let build_started = Instant::now();
+    let prepared = GraphSnapshotBuilder::new()
+        .prepare(&counted, &graph)
+        .map_err(|error| error.to_string())?;
+    GraphSnapshotBuilder::new()
+        .activate(&counted, &prepared)
+        .map_err(|error| error.to_string())?;
+    let build_seconds = build_started.elapsed().as_secs_f64();
+    let build_requests = counted.counters.snapshot();
+    let reader = GraphSnapshotReader::open_active(&counted)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "active snapshot is missing".to_owned())?;
+    let exported = reader
+        .export_json_bytes()
+        .map_err(|error| error.to_string())?;
+    if exported != canonical {
+        return Err("store export differs from canonical graph JSON".to_owned());
+    }
+
+    let query_started = Instant::now();
+    let store_engine = open_with_store(
+        &counted,
+        &graph_path,
+        None,
+        &directory.path().join("store-query-cache"),
+    )
+    .map_err(|error| error.to_string())?;
+    let json_engine = open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("json-query-cache"),
+        EngineSelection::Json,
+    )
+    .map_err(|error| error.to_string())?;
+    let request = SearchRequest {
+        query: "symbol".to_owned(),
+        limits: CodeQueryLimits::default(),
+    };
+    let store_response = store_engine
+        .search(request.clone())
+        .map_err(|error| error.to_string())?;
+    let json_response = json_engine
+        .search(request)
+        .map_err(|error| error.to_string())?;
+    let canonical_results = serde_json::to_value(&store_response)
+        .map_err(|error| error.to_string())?
+        == serde_json::to_value(&json_response).map_err(|error| error.to_string())?;
+    let store_document =
+        serde_json::from_slice::<GraphDocument>(&exported).map_err(|error| error.to_string())?;
+    let store_graph = compassql_graph(&store_document)?;
+    let json_graph = compassql_graph(&graph)?;
+    let compassql_equal = run_compassql(&store_graph, &json_graph)?;
+    let query_seconds = query_started.elapsed().as_secs_f64();
+    let query_requests = subtract(build_requests.clone(), counted.counters.snapshot());
+    drop(store_engine);
+    drop(json_engine);
+    drop(counted);
+    let database_bytes = fs::metadata(&store_path)
+        .map_err(|error| error.to_string())?
+        .len();
+    let write_amplification = database_bytes as f64 / canonical.len() as f64;
+    Ok(ReleaseReport {
+        schema: REPORT_SCHEMA,
+        adapter,
+        nodes: graph.nodes.len(),
+        edges: graph.links.len(),
+        graph_bytes: canonical.len(),
+        graph_digest: digest(&canonical),
+        snapshot_id: prepared.manifest.snapshot_id,
+        manifest_digest: prepared.manifest_digest,
+        canonical_json_equal: canonical_results,
+        compassql_equal,
+        build_seconds,
+        query_seconds,
+        database_bytes,
+        write_amplification,
+        build_requests,
+        query_requests,
+        query_results: store_response.results.len(),
+        new_objects: prepared.new_objects,
+        reused_objects: prepared.reused_objects,
+        gc: json!({
+            "mode": "discovery-only",
+            "executed": false,
+            "supported": false,
+            "reason": "retention and deletion are deferred until the Phase 8 control plane",
+        }),
+    })
+}
+
+fn compassql_graph(document: &GraphDocument) -> Result<Graph, String> {
+    let nodes = document
+        .nodes
+        .iter()
+        .map(|node| {
+            let mut attributes = serde_json::Map::new();
+            attributes.insert("label".to_owned(), Value::String(node.name.clone()));
+            attributes.insert(
+                "kind".to_owned(),
+                Value::String(node.kind.as_str().to_owned()),
+            );
+            attributes.insert(
+                "qualified_name".to_owned(),
+                Value::String(node.qualified_name.clone()),
+            );
+            attributes.insert("file_type".to_owned(), Value::String("function".to_owned()));
+            LegacyNodeRecord {
+                id: node.id.clone(),
+                attributes,
+            }
+        })
+        .collect();
+    let links = document
+        .links
+        .iter()
+        .map(|edge| {
+            let mut attributes = serde_json::Map::new();
+            attributes.insert(
+                "relation".to_owned(),
+                Value::String(edge.kind.as_str().to_owned()),
+            );
+            attributes.insert(
+                "kind".to_owned(),
+                Value::String(edge.kind.as_str().to_owned()),
+            );
+            attributes.insert(
+                "confidence".to_owned(),
+                Value::String("EXTRACTED".to_owned()),
+            );
+            LegacyEdgeRecord {
+                source: edge.source.clone(),
+                target: edge.target.clone(),
+                attributes,
+            }
+        })
+        .collect();
+    Graph::from_document(LegacyGraphDocument {
+        directed: document.directed,
+        multigraph: document.multigraph,
+        graph: serde_json::Map::new(),
+        nodes,
+        links,
+        extras: BTreeMap::new(),
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn run_compassql(store_graph: &Graph, json_graph: &Graph) -> Result<bool, String> {
+    let source = "MATCH (n:Function) RETURN n.id AS id ORDER BY id";
+    let parameter_types = ParameterTypes::new();
+    let store_schema = store_graph.schema_fingerprint();
+    let compiled = compile(CompileRequest {
+        source_name: "store-release-qualification.cypher",
+        source,
+        parameter_types: &parameter_types,
+        schema: &store_schema,
+        limits: CompileLimits::default(),
+    })
+    .map_err(|error| error.to_string())?;
+    let parameters = Parameters::new();
+    let store_result = execute(CompassQlRequest {
+        compiled: &compiled,
+        graph: store_graph,
+        parameters: &parameters,
+        limits: CompassQlLimits::interactive(),
+        cancellation: &AtomicBool::new(false),
+    })
+    .map_err(|error| error.to_string())?;
+    let json_result = execute(CompassQlRequest {
+        compiled: &compiled,
+        graph: json_graph,
+        parameters: &parameters,
+        limits: CompassQlLimits::interactive(),
+        cancellation: &AtomicBool::new(false),
+    })
+    .map_err(|error| error.to_string())?;
+    Ok(
+        serde_json::to_value(store_result).map_err(|error| error.to_string())?
+            == serde_json::to_value(json_result).map_err(|error| error.to_string())?,
+    )
+}
+
+fn subtract(before: CounterSnapshot, after: CounterSnapshot) -> CounterSnapshot {
+    CounterSnapshot {
+        get_requests: after.get_requests.saturating_sub(before.get_requests),
+        scan_requests: after.scan_requests.saturating_sub(before.scan_requests),
+        put_requests: after.put_requests.saturating_sub(before.put_requests),
+        delete_requests: after.delete_requests.saturating_sub(before.delete_requests),
+        bytes_read: after.bytes_read.saturating_sub(before.bytes_read),
+        bytes_written: after.bytes_written.saturating_sub(before.bytes_written),
+    }
+}
+
+fn graph(nodes: usize) -> Result<GraphDocument, String> {
+    let anchor = SourceAnchor {
+        file: "src/release_qualification.rs".to_owned(),
+        start_byte: 0,
+        end_byte: 1,
+        start_line: 1,
+        start_column: 0,
+        end_line: 1,
+        end_column: 1,
+    };
+    let evidence = Provenance {
+        origin: EvidenceOrigin::Ast,
+        extractor: "compass.store.release-qualification".to_owned(),
+        confidence: EvidenceConfidence::Exact,
+        rule: None,
+        anchors: vec![anchor.clone()],
+        wiring_site: None,
+        score: None,
+        candidates: Vec::new(),
+    };
+    let evidence = serde_json::to_value(&evidence).map_err(|error| error.to_string())?;
+    let anchor_value = serde_json::to_value(&anchor).map_err(|error| error.to_string())?;
+    let mut node_values = Vec::with_capacity(nodes);
+    for index in 0..nodes {
+        node_values.push(json!({
+            "id": format!("node-{index:08}"),
+            "kind": "function",
+            "name": format!("symbol_{index}"),
+            "qualifiedName": format!("symbol::{index}"),
+            "source": anchor_value.clone(),
+            "evidence": [evidence.clone()],
+            "coverage": [],
+            "diagnostics": [],
+        }));
+    }
+    let mut edge_values = Vec::with_capacity(nodes.saturating_sub(1));
+    for index in 1..nodes {
+        let source = format!("node-{index_minus_one:08}", index_minus_one = index - 1);
+        let target = format!("node-{index:08}");
+        let id = edge_id(&source, EdgeKind::Calls, &target, Some(&anchor), None);
+        edge_values.push(json!({
+            "id": id.clone(),
+            "key": id,
+            "source": source,
+            "target": target,
+            "kind": "calls",
+            "relationshipSite": anchor_value.clone(),
+            "evidence": [evidence.clone()],
+            "diagnostics": [],
+        }));
+    }
+    let value = json!({
+        "directed": true,
+        "multigraph": true,
+        "graph": {
+            "schema": CODE_GRAPH_SCHEMA_V1,
+            "build": {
+                "builderVersion": "release-qualification",
+                "schemaFingerprint": "release-qualification",
+                "sourceTreeDigest": "release-qualification",
+                "configurationDigest": "release-qualification",
+                "generationId": "release-qualification",
+            },
+            "files": [{
+                "id": file_id("src/release_qualification.rs"),
+                "path": "src/release_qualification.rs",
+                "language": "rust",
+                "contentDigest": "sha256:release-qualification",
+                "byteSize": 1,
+                "generated": false,
+                "extractionStatus": "extracted",
+                "extractorVersions": ["compass.store.release-qualification"]
+            }],
+            "coverage": [],
+            "diagnostics": [],
+        },
+        "nodes": node_values,
+        "links": edge_values,
+    });
+    serde_json::from_value(value).map_err(|error| format!("qualification graph: {error}"))
+}
+
+fn option<'a>(arguments: &'a [String], name: &str) -> Option<&'a str> {
+    arguments.iter().enumerate().find_map(|(index, argument)| {
+        if argument == name {
+            arguments.get(index + 1).map(String::as_str)
+        } else {
+            argument
+                .strip_prefix(name)
+                .and_then(|value| value.strip_prefix('='))
+        }
+    })
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}

--- a/crates/compass-store-redb/src/lib.rs
+++ b/crates/compass-store-redb/src/lib.rs
@@ -131,6 +131,90 @@ impl RedbStore {
         self.read_only
     }
 
+    /// Copy a validated redb database to a new backup path.
+    ///
+    /// Callers should stop application writers before invoking this method.
+    /// The copied database is reopened read-only and its schema is validated
+    /// before the method returns.
+    pub fn backup_to(&self, destination: impl AsRef<Path>) -> Result<(), StoreError> {
+        if !self.read_only {
+            return Err(StoreError::Unsupported(
+                "redb backup requires a read-only reopen after writers close".to_owned(),
+            ));
+        }
+        let destination = destination.as_ref();
+        if destination == self.path {
+            return Err(StoreError::InvalidFormat(
+                "redb backup destination must differ from the live store".to_owned(),
+            ));
+        }
+        if destination.exists() {
+            return Err(StoreError::InvalidFormat(format!(
+                "redb backup destination already exists: {}",
+                destination.display()
+            )));
+        }
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                operation: "create_redb_backup_parent",
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::copy(&self.path, destination).map_err(|source| StoreError::Io {
+            operation: "copy_redb_backup",
+            path: destination.to_path_buf(),
+            source,
+        })?;
+        if let Err(error) =
+            Self::open_read_only(destination).and_then(|store| store.verify_schema())
+        {
+            let _ = fs::remove_file(destination);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    /// Restore a validated redb backup into a new path without overwriting it.
+    pub fn restore_from(
+        backup: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
+    ) -> Result<(), StoreError> {
+        let backup = backup.as_ref();
+        let destination = destination.as_ref();
+        if backup == destination {
+            return Err(StoreError::InvalidFormat(
+                "redb restore destination must differ from the backup".to_owned(),
+            ));
+        }
+        if destination.exists() {
+            return Err(StoreError::InvalidFormat(format!(
+                "redb restore destination already exists: {}",
+                destination.display()
+            )));
+        }
+        Self::open_read_only(backup)?.verify_schema()?;
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                operation: "create_redb_restore_parent",
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::copy(backup, destination).map_err(|source| StoreError::Io {
+            operation: "copy_redb_restore",
+            path: destination.to_path_buf(),
+            source,
+        })?;
+        if let Err(error) =
+            Self::open_read_only(destination).and_then(|store| store.verify_schema())
+        {
+            let _ = fs::remove_file(destination);
+            return Err(error);
+        }
+        Ok(())
+    }
+
     fn initialize_schema(&self) -> Result<(), StoreError> {
         self.with_write(|transaction| {
             let mut metadata = transaction

--- a/crates/compass-store-redb/tests/redb_store.rs
+++ b/crates/compass-store-redb/tests/redb_store.rs
@@ -159,6 +159,7 @@ fn redb_database_file_can_be_backed_up_after_reopen() -> Result<(), Box<dyn Erro
     let namespace = NamespaceId::new(b"tenant")?;
     let partition = PartitionKey::new(b"records")?;
     let key = Key::new(b"one")?;
+    let restored_path = directory.path().join("restored.redb");
     {
         let store = RedbStore::open(&path)?;
         store.put(
@@ -169,12 +170,24 @@ fn redb_database_file_can_be_backed_up_after_reopen() -> Result<(), Box<dyn Erro
             WriteCondition::Missing,
         )?;
     }
-    fs::copy(&path, &backup)?;
+    RedbStore::open_read_only(&path)?.backup_to(&backup)?;
     let restored = RedbStore::open_read_only(&backup)?;
     let restored_entry = restored
         .get(&namespace, &partition, &key)?
         .ok_or("restored redb value is missing")?;
     assert_eq!(restored_entry.value, b"value");
+    RedbStore::restore_from(&backup, &restored_path)?;
+    assert_eq!(
+        RedbStore::open_read_only(&restored_path)?
+            .get(&namespace, &partition, &key)?
+            .ok_or("restored redb copy is missing")?
+            .value,
+        b"value"
+    );
+    let corrupt = directory.path().join("corrupt.redb");
+    fs::copy(&backup, &corrupt)?;
+    fs::write(&corrupt, b"not a redb database")?;
+    assert!(RedbStore::restore_from(&corrupt, directory.path().join("rejected.redb")).is_err());
     Ok(())
 }
 

--- a/crates/compass-store/src/lib.rs
+++ b/crates/compass-store/src/lib.rs
@@ -679,6 +679,90 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Copy a validated, checkpointed SQLite store to a new backup path.
+    ///
+    /// The destination must not be the live store. The copy is reopened and
+    /// validated before this method returns so callers never receive a backup
+    /// that only looked complete at the filesystem level.
+    pub fn backup_to(&self, destination: impl AsRef<Path>) -> Result<(), StoreError> {
+        let destination = destination.as_ref();
+        if destination == self.path {
+            return Err(StoreError::InvalidFormat(
+                "store backup destination must differ from the live store".to_owned(),
+            ));
+        }
+        if destination.exists() {
+            return Err(StoreError::InvalidFormat(format!(
+                "store backup destination already exists: {}",
+                destination.display()
+            )));
+        }
+        self.checkpoint()?;
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                operation: "create_store_backup_parent",
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::copy(&self.path, destination).map_err(|source| StoreError::Io {
+            operation: "copy_store_backup",
+            path: destination.to_path_buf(),
+            source,
+        })?;
+        let validation =
+            Self::open_read_only(destination).and_then(|store| store.validate_snapshot());
+        if let Err(error) = validation {
+            let _ = fs::remove_file(destination);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    /// Restore a validated SQLite backup into a new path.
+    ///
+    /// Restores intentionally refuse to overwrite an existing path. A caller
+    /// that needs replacement must move the old generation aside first, which
+    /// preserves a recoverable rollback copy.
+    pub fn restore_from(
+        backup: impl AsRef<Path>,
+        destination: impl AsRef<Path>,
+    ) -> Result<(), StoreError> {
+        let backup = backup.as_ref();
+        let destination = destination.as_ref();
+        if backup == destination {
+            return Err(StoreError::InvalidFormat(
+                "store restore destination must differ from the backup".to_owned(),
+            ));
+        }
+        if destination.exists() {
+            return Err(StoreError::InvalidFormat(format!(
+                "store restore destination already exists: {}",
+                destination.display()
+            )));
+        }
+        Self::open_read_only(backup)?.validate_snapshot()?;
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).map_err(|source| StoreError::Io {
+                operation: "create_store_restore_parent",
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::copy(backup, destination).map_err(|source| StoreError::Io {
+            operation: "copy_store_restore",
+            path: destination.to_path_buf(),
+            source,
+        })?;
+        let validation =
+            Self::open_read_only(destination).and_then(|store| store.validate_snapshot());
+        if let Err(error) = validation {
+            let _ = fs::remove_file(destination);
+            return Err(error);
+        }
+        Ok(())
+    }
+
     /// Return bounded manifest keys that are not selected by either the
     /// payload snapshot or the immutable graph-index selector.  This is a
     /// discovery API only; Phase 8 owns retention policy and deletion.
@@ -1775,13 +1859,17 @@ pub mod test_support {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
+    use std::fs;
+    use std::sync::Arc;
+    use std::thread;
 
     use rusqlite::Connection;
     use sha2::{Digest, Sha256};
 
     use super::{
-        Key, KeyRange, MemoryStore, NamespaceId, PartitionKey, ScanLimits, SqliteStore, Store,
-        StoreError, VersionToken, WriteCondition, decode_key_segments, encode_key_segments,
+        GRAPH_SCHEMA_V1, Key, KeyRange, MemoryStore, NamespaceId, PartitionKey, ScanLimits,
+        SqliteStore, Store, StoreError, VersionToken, WriteCondition, decode_key_segments,
+        encode_key_segments,
     };
 
     #[test]
@@ -1864,6 +1952,43 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_serializes_concurrent_conditional_writers() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let store = Arc::new(SqliteStore::open(directory.path().join("store.sqlite3"))?);
+        let namespace = NamespaceId::new("tenant")?;
+        let partition = PartitionKey::new("records")?;
+        let key = Key::new("active")?;
+        let mut writers = Vec::new();
+        for index in 0..8_u8 {
+            let store = Arc::clone(&store);
+            let namespace = namespace.clone();
+            let partition = partition.clone();
+            let key = key.clone();
+            writers.push(thread::spawn(move || {
+                store.put(
+                    &namespace,
+                    &partition,
+                    &key,
+                    &[index],
+                    WriteCondition::Missing,
+                )
+            }));
+        }
+        let mut winners = 0;
+        let mut conflicts = 0;
+        for writer in writers {
+            match writer.join().map_err(|_| "SQLite writer thread panicked")? {
+                Ok(_) => winners += 1,
+                Err(StoreError::Conflict) => conflicts += 1,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        assert_eq!(winners, 1);
+        assert_eq!(conflicts, 7);
+        Ok(())
+    }
+
+    #[test]
     fn snapshots_reopen_and_verify_digest() -> Result<(), Box<dyn Error>> {
         let directory = tempfile::tempdir()?;
         let path = directory.path().join("store.sqlite3");
@@ -1893,6 +2018,35 @@ mod tests {
         let synchronous =
             connection.query_row("PRAGMA synchronous", [], |row| row.get::<_, i64>(0))?;
         assert_eq!(synchronous, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn backup_and_restore_validate_the_complete_sqlite_file() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("source.sqlite3");
+        let backup = directory.path().join("backup.sqlite3");
+        let restored = directory.path().join("restored.sqlite3");
+        let bytes = br#"{"graph":{"schema":"compass.graph/1"},"nodes":[],"links":[]}"#;
+        {
+            let store = SqliteStore::open(&source)?;
+            store.publish_snapshot(bytes, GRAPH_SCHEMA_V1, 0, 0)?;
+            store.backup_to(&backup)?;
+        }
+        SqliteStore::restore_from(&backup, &restored)?;
+        assert_eq!(
+            SqliteStore::open_read_only(&restored)?.read_snapshot()?.1,
+            bytes
+        );
+
+        let corrupt = directory.path().join("corrupt.sqlite3");
+        fs::copy(&backup, &corrupt)?;
+        let connection = Connection::open(&corrupt)?;
+        connection.execute("DELETE FROM kv", [])?;
+        drop(connection);
+        assert!(
+            SqliteStore::restore_from(&corrupt, directory.path().join("rejected.sqlite3")).is_err()
+        );
         Ok(())
     }
 
@@ -1984,6 +2138,15 @@ mod tests {
         )?;
         assert_eq!(page.entries[0].key, vec![0, 1]);
         assert!(page.next.is_some());
+        Ok(())
+    }
+
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn sqlite_passes_the_shared_adapter_conformance_contract() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let store = SqliteStore::open(directory.path().join("store.sqlite3"))?;
+        super::test_support::assert_store_contract(&store)?;
         Ok(())
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ to yours:
 - [Set up a coding assistant](guides/assistant-setup.md)
 - [Use versioned graph history](guides/versioned-history.md)
 - [Operate watch, serve, hooks, and providers](guides/operations.md)
+- [Operate the Compass Store](guides/compass-store-operations.md)
 - [Solve a concrete problem](cookbook/README.md)
 - [Look up commands and contracts](reference/commands.md)
 
@@ -92,6 +93,7 @@ workspace:
 | [Assistant setup](guides/assistant-setup.md) | A native Compass skill installed at the right scope |
 | [Versioned history](guides/versioned-history.md) | Immutable graphs and diffs for exact Git commits |
 | [Operations](guides/operations.md) | Safe operation of long-running and optional surfaces |
+| [Compass Store operations](guides/compass-store-operations.md) | Store health, backup, restore, rebuild, and release qualification |
 
 ### Understand the design
 

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -1,15 +1,15 @@
 # Compass store and graph-engine design
 
-**Status:** Architecture reference. The initial local slice, Phase 2 memory
-snapshot layout, Phase 3 SQLite shadow-publication slice, local Phase 4
-snapshot-backed query routing, and the optional Phase 5 redb adapter slice are
-shipped: the `compass-store` contract, SQLite/redb adapters, dual graph
-publication, typed query-engine selection, deterministic immutable graph
-indexes, selector-CAS reference protocol, WAL/redb durability, reopen
-validation, canonical graph.json differential checks, and cross-engine
-typed-query checks are implemented. PostgreSQL, DynamoDB, remote operation,
-bounded streaming plans, general garbage collection, and performance claims
-remain follow-on work.
+**Status:** Architecture reference plus the local `0.3.x` release contract.
+The initial local slice, Phase 2 memory snapshot layout, Phase 3 SQLite
+shadow-publication slice, local Phase 4 snapshot-backed query routing, the
+optional Phase 5 redb adapter, and the Phase 9 local operational surface are
+implemented. This includes the namespace-first common contract, versioned
+logical envelopes, SQLite backup/restore, explicit rebuild tooling, release
+qualification reports, canonical JSON/typed-query/CompassQL differential
+checks, and packaging boundaries. `graph.json` remains permanent and
+compatible. PostgreSQL, DynamoDB, hosted credentials/TLS, general garbage
+collection, and service quotas remain future work.
 
 Each generated sidecar now contains both a validated graph payload retained for
 compatibility and the Phase 2 content-addressed graph indexes used by the
@@ -17,6 +17,11 @@ current store engine. The sidecar is prepared and checkpointed in the
 unpublished BuildGuard generation; only the filesystem generation switch
 publishes it. `graph.json` remains a permanent compatible engine and is never
 removed or made dependent on SQLite.
+
+The first support window is `0.3.x`: matching logical majors may be reopened
+by patch releases, while physical adapter files and disposable indexes remain
+rebuildable. The exact operator procedures and file-level backup bundle are in
+the [Compass Store operations guide](../guides/compass-store-operations.md).
 
 > **Who this page is for:** maintainers of graph publication and queries,
 > storage-adapter authors, cloud-service implementers, and reviewers of the

--- a/docs/guides/compass-store-operations.md
+++ b/docs/guides/compass-store-operations.md
@@ -1,0 +1,181 @@
+# Compass Store operations
+
+This guide describes the local `compass-store` release contract and the
+operational procedures that keep a published graph coherent. It is the
+runbook for `compass-out` owners, package maintainers, and future service
+adapter authors.
+
+## Release boundary
+
+Compass addresses every value as:
+
+```text
+(namespace, partition, key) -> opaque value
+```
+
+The namespace is the first isolation boundary. A partition is the required
+locality/sharding boundary inside that namespace, and ordered scans never cross
+it. The graph realization uses the namespace `compass.current.graph.v1` and
+keeps catalog, immutable objects, and the active selector in separate
+partitions. The contract is deliberately smaller than SQL, redb, PostgreSQL,
+or DynamoDB so the same behavior can be implemented by all of them.
+
+The first local release declares these logical, machine-readable formats:
+
+| Format | Identifier | Role | Upgrade policy |
+| --- | --- | --- | --- |
+| Graph document | `compass.graph/1` | Canonical `graph.json`, interchange, inspection, and recovery | Permanent compatible engine; unknown majors fail |
+| Store contract | `compass.store/1` | Namespace/partition/key values, limits, conditional writes, scans, and typed errors | Major changes require a new adapter contract |
+| Graph snapshot | `compass.store.graph-snapshot/1` | Immutable manifests, content digests, ordered index roots, and selector state | Same-major patch upgrades only in the first window |
+| Store reference | `compass.store.ref/1` | Binds `graph.json`, store snapshot, adapter, and generation digests | Validate before a store query |
+| Backup bundle | `compass.store.backup/1` | `manifest.json`, graph, reference, and a validated adapter copy | Restore only into a new directory |
+
+The SQLite table layout, redb file layout, WAL/SHM files, object-key spelling,
+and query-index cache are implementation details. They must not be queried or
+edited directly. A physical-format change is a hard cut: remove the sidecar,
+run the rebuild procedure, and retain the unchanged `graph.json`.
+
+## Current backend matrix
+
+| Backend | Local CLI | Credentials/network | Platforms | Status |
+| --- | --- | --- | --- | --- |
+| SQLite | Default sidecar `compass-store.sqlite3` | None; local file only | macOS, Linux, Windows | Released local adapter |
+| redb | Explicit Rust adapter `compass-store-redb` | None; local file only | CI-supported native platforms | Library/conformance adapter; not selected by the CLI |
+| PostgreSQL | No released CLI adapter | Would require an explicit endpoint, credentials, TLS, and bounded client | Future service profile | Deferred |
+| DynamoDB | No released CLI adapter | Would require an explicit AWS boundary, credentials, TLS, retries, and quotas | Future service profile | Deferred |
+
+No cloud SDK, endpoint, credential, or TLS setting is read by the local store
+path. A future remote adapter must expose those concerns outside the common
+contract and pass the same conformance and differential suites.
+
+## Files and durability
+
+For an output root `DIR` the published set is:
+
+```text
+DIR/graph.json                 # permanent canonical graph artifact
+DIR/compass-store.sqlite3      # SQLite store snapshot
+DIR/store.ref                  # typed generation binding
+DIR/.compass-generation        # BuildGuard publication pointer, when used
+```
+
+`graph.json`, the SQLite sidecar, and `store.ref` are published as one
+generation. The sidecar uses WAL during preparation and is checkpointed before
+the generation switch. Readers open the active immutable snapshot and remain
+pinned to it. A failed or interrupted update must leave the previous coherent
+generation selected. The query-code index beneath the requested cache root is
+disposable and may be deleted at any time.
+
+The store contract bounds namespace, partition, key, value, scan, and graph
+sizes. Those limits are correctness limits, not hints: exceeding one produces
+a typed failure and must never be reported as an empty result. Local quotas
+are therefore enforced by the API and available disk space; service adapters
+will add explicit tenant and request quotas later.
+
+## Health and recovery commands
+
+Run these commands from the Compass checkout or with an installed binary:
+
+```bash
+compass store status compass-out --format json
+compass store validate compass-out --format json
+```
+
+`status` is read-only and reports graph, sidecar, selector, schema, byte size,
+and digest state. `validate` fails unless the sidecar, active snapshot,
+`store.ref`, and canonical JSON export all agree. A failed validation does not
+modify any artifact.
+
+To create a self-contained backup:
+
+```bash
+compass store backup compass-out --output /safe/path/compass-store-backup
+```
+
+The destination must not already exist. The command checkpoints SQLite, copies
+the validated database, copies `graph.json` and `store.ref`, and writes a
+digest-bound `manifest.json`. Keep the bundle on storage with equivalent or
+better access controls; it contains project structure and source anchors.
+
+Restore only into a new or empty directory:
+
+```bash
+compass store restore \
+  --from /safe/path/compass-store-backup \
+  --into /recovered/compass-out
+compass store validate /recovered/compass-out --format json
+```
+
+Restore validates every digest and snapshot before publication. It removes an
+incomplete destination on failure and never overwrites an existing output.
+After restore, use `--engine json` if only the graph file is available; the
+JSON engine does not require a database.
+
+## Rebuild and upgrade policy
+
+The first supported upgrade window is the `0.3.x` release line for the logical
+format majors above. Patch releases may reopen and validate a matching
+same-major SQLite store. Unknown majors, pre-release prototypes, a missing or
+invalid `store.ref`, and physical files from another adapter are not migrated
+in place.
+
+Rebuild a sidecar from the current graph without replacing the JSON artifact:
+
+```bash
+scripts/rebuild_compass_store.sh . --out compass-out --compass compass
+```
+
+The script moves existing sidecars into a timestamped rollback directory,
+runs `compass update --force`, and restores the old sidecars if the update
+fails. On success it leaves the backup for an operator to review and remove
+according to local retention policy. The graph file is never deleted by the
+script. If source is available, a normal `compass update --force` is the
+preferred rebuild; if only `graph.json` is available, use the JSON engine or
+import it through a separately reviewed adapter tool.
+
+Downgrades must preserve `graph.json` and run `compass store validate` after
+the target binary starts. Do not copy a newer physical sidecar over an older
+binary and do not make an invalid sidecar look healthy by editing its bytes.
+
+## Backup, GC, and retention
+
+The local backup procedure is a file-level snapshot after writers close or the
+SQLite WAL is checkpointed. Filesystem snapshots may be used by operators, but
+the bundle manifest and validation command remain the portability boundary.
+Redb backups use the library adapter's read-only reopen rule; they are not
+currently exposed by the CLI.
+
+General graph-object garbage collection and retention leases are not in the
+local release. The qualification report records GC as discovery-only. Keep
+backup generations until restore has been exercised, then apply an explicit
+operator retention policy; never delete a directory that is the active
+BuildGuard generation. A future multi-tenant service must add namespace-scoped
+leases, quotas, and an auditable GC plan before advertising deletion.
+
+## Incident checklist
+
+1. Stop concurrent writers and copy the entire output directory to protected
+   storage.
+2. Run `compass store status --format json`; save only the sanitized response.
+3. Run `compass store validate --format json` and record the typed error.
+4. If the graph is valid but the sidecar is not, use the rebuild script or
+   `--engine json`; do not edit SQLite tables.
+5. If both are damaged, restore a validated backup into a new directory and
+   compare the graph digest before switching consumers.
+6. Report Compass version, platform, schema identifiers, and bounded command
+   output. Do not attach databases, credentials, private source, or raw
+   provider responses unless the security process explicitly requests them.
+
+## Qualification entry point
+
+The release harness creates a deterministic typed graph and exercises both
+embedded adapters, canonical JSON export, typed search, CompassQL, request and
+byte counters, database size, write amplification, and the explicit GC status:
+
+```bash
+scripts/qualify_compass_store_release.sh
+```
+
+The script writes all raw observations beneath the selected target directory;
+those files are release evidence, not repository artifacts. Re-run it on the
+release commit after the native gates and packaging checks complete.

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -1,11 +1,10 @@
 # Executable Compass store implementation plan
 
-**Status:** In progress. Phases 0–4 and the local Phase 5 redb adapter slice
-are implemented. The typed query path now accepts any common-contract store
-adapter, while the local CLI remains SQLite/JSON-only until packaging policy
-selects another backend. Bounded projection execution, remote adapters,
-fault-injected crash qualification, general garbage collection, and measured
-performance claims remain follow-on work.
+**Status:** Phase 9 local release slice in progress. Phases 0–5 and the local
+Phase 9 operational/qualification work are implemented in this worktree. The
+CLI publishes SQLite plus permanent `graph.json`; redb is a library-only
+adapter. PostgreSQL, DynamoDB, hosted operation, general garbage collection,
+and service quotas remain explicitly deferred until their phases are complete.
 
 > **Who this page is for:** implementers and reviewers delivering
 > `compass-store`, store-backed graph snapshots, backend adapters, and the
@@ -38,6 +37,12 @@ At completion, Compass has:
 - adapter conformance, cross-engine differential tests, fault injection,
   garbage collection, backup, and recovery coverage; and
 - measured performance evidence before any release claim.
+
+The current local release boundary is intentionally smaller than the eventual
+cloud program: logical formats are versioned and validated, while physical
+adapter files and query caches can be rebuilt. See the [operations guide](../guides/compass-store-operations.md)
+for locations, backups, restore, quotas, recovery, and the first `0.3.x`
+upgrade window.
 
 ## Shipped initial slice in this branch
 
@@ -1038,6 +1043,30 @@ performance, packaging, and operational evidence.
 8. Add release-visible changes to `CHANGELOG.md` and user actions to
    `MIGRATION.md`.
 
+### Local `0.3.x` implementation in this phase
+
+The local release work closes the first support window without claiming cloud
+readiness:
+
+- `compass store status|validate|backup|restore` validates the co-published
+  SQLite generation and writes digest-bound backup bundles;
+- `scripts/rebuild_compass_store.sh` provides an explicit, rollback-preserving
+  hard-cut rebuild path;
+- `compass-store-qualification` and
+  `scripts/qualify_compass_store_release.sh` measure SQLite/redb graph sizes,
+  peak RSS, bytes, request counts, database size, write amplification, GC
+  state, and CLI clean/no-change/small-change/cold-query behavior;
+- the harness compares canonical JSON, typed query responses, and CompassQL
+  results and runs the adapter, corruption, concurrency, snapshot, packaging,
+  and product-boundary gates; and
+- the operations, compatibility, migration, security, support, and
+  configuration references declare SQLite as the local CLI backend, redb as a
+  library-only adapter, and PostgreSQL/DynamoDB as deferred service phases.
+
+The generated qualification directory is external evidence and is never
+committed. Run the harness again on the final release commit after all docs and
+release metadata have settled.
+
 ### Release acceptance criteria
 
 - Canonical JSON exported from every released engine is byte-identical for the
@@ -1138,5 +1167,6 @@ without inspecting backend internals:
 - [Compatibility policy](../../COMPATIBILITY.md)
 - [Performance qualification](../../PERFORMANCE.md)
 
-**Next step:** begin Phase 0 with an API/encoding review and land the memory
-reference implementation before adding any database dependency.
+**Next step:** after the local release is accepted, start the separately scoped
+PostgreSQL service adapter only with endpoint, credential, TLS, quota, lease,
+and tenant-isolation evidence. Do not widen the local CLI backend implicitly.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -652,6 +652,29 @@ Managed integration/update probe.
 - `COMPASS_OUT` can change the default output root for several compatible
   command families; explicit `--out` is clearer in automation.
 
+## Store health and recovery
+
+```text
+compass store status [OUTPUT] [--format text|json]
+compass store validate [OUTPUT] [--format text|json]
+compass store backup [OUTPUT] --output BACKUP_DIR [--format text|json]
+compass store restore --from BACKUP_DIR --into OUTPUT [--format text|json]
+```
+
+`status` is read-only and reports graph, SQLite sidecar, selector, schema, and
+digest state. `validate` requires a matching `compass-store.sqlite3`, active
+snapshot, and `store.ref`; a mismatch is an error, never an empty graph.
+`backup` creates a new digest-bound directory after checkpointing SQLite.
+`restore` validates that bundle and writes only to a new or empty destination.
+The commands currently operate on the local SQLite adapter. The redb adapter is
+library-only, and PostgreSQL/DynamoDB are future backends.
+
+`graph.json` remains a complete engine. If a sidecar is unavailable or being
+rebuilt, use `--engine json` with typed query commands. The explicit rebuild
+runbook is [`scripts/rebuild_compass_store.sh`](../../scripts/rebuild_compass_store.sh);
+the detailed durability, backup, GC, quota, and recovery policy is in the
+[Compass Store operations guide](../guides/compass-store-operations.md).
+
 ## IDE and graph-inspection commands
 
 ```text

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,6 +54,35 @@ compass update . --out custom-output
 
 Do not point two concurrent writers at one output directory.
 
+## Compass Store configuration
+
+The local build publishes a co-located store under the selected output root:
+
+```text
+DIR/graph.json
+DIR/compass-store.sqlite3
+DIR/store.ref
+```
+
+`DIR` is `compass-out/` by default and can be set with `--out DIR` or the
+documented `COMPASS_OUT` fallback. The CLI's default store engine is SQLite;
+`--engine json` explicitly uses the permanent JSON engine and `--engine store`
+requires a validated sidecar. The `compass-store-redb` crate is a separate
+library adapter and is not a CLI setting. PostgreSQL and DynamoDB are deferred
+service adapters, so no endpoint, credential, TLS, or cloud SDK configuration
+is read by local store commands.
+
+SQLite uses a local WAL-backed file and checkpoints it before publication and
+backup. Do not run two writers against one output root. Query indexes beneath
+the cache root are disposable and may be deleted; the graph, sidecar, and
+`store.ref` must be kept together. Use `compass store status|validate` for
+health, `compass store backup` for a digest-bound copy, and `compass store
+restore` into a new directory for recovery. The store API enforces bounded
+namespace, partition, key, value, scan, and graph sizes. General object GC and
+hosted quotas are deferred; local disk availability remains an operational
+limit. See the [store operations guide](../guides/compass-store-operations.md)
+for the support window and rebuild procedure.
+
 ## Build configuration
 
 Initialize a reviewable repository scope with:

--- a/scripts/qualify_compass_store_release.sh
+++ b/scripts/qualify_compass_store_release.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+compass_root=$(cd "$script_dir/.." && pwd)
+target_dir=${CARGO_TARGET_DIR:-/Volumes/Workspace/crabbuild-target/compass-store-phase9}
+output_dir=${COMPASS_STORE_QUALIFICATION_OUTPUT:-$target_dir/compass-store-release-qualification-$(date -u +%Y%m%dT%H%M%SZ)}
+sizes=${COMPASS_STORE_QUALIFICATION_SIZES:-"32 128 512"}
+measure="$script_dir/measure_process.py"
+
+usage() {
+  echo "usage: $0 [--output DIR] [--sizes 'N N ...']" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || usage
+      output_dir=$2
+      shift 2
+      ;;
+    --sizes)
+      [[ $# -ge 2 ]] || usage
+      sizes=$2
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[ ! -d /Volumes/Workspace || ! -w /Volumes/Workspace ]]; then
+  echo "error: /Volumes/Workspace must be mounted and writable" >&2
+  exit 1
+fi
+mkdir -p "$target_dir"
+if [[ ! -w "$target_dir" ]]; then
+  echo "error: target directory is not writable: $target_dir" >&2
+  exit 1
+fi
+if [[ -e "$output_dir" ]]; then
+  echo "error: qualification output already exists; choose a new --output directory: $output_dir" >&2
+  exit 1
+fi
+mkdir -p "$output_dir"
+
+export CARGO_TARGET_DIR="$target_dir"
+cargo build --release --locked -p compass-cli --bin compass
+cargo build --release --locked -p compass-store-qualification --bin compass-store-qualification
+compass_bin="$target_dir/release/compass"
+qualification_bin="$target_dir/release/compass-store-qualification"
+
+if [[ ${COMPASS_STORE_QUALIFICATION_SKIP_GATES:-0} != 1 ]]; then
+  cargo test -p compass-store --features test-support --locked
+  cargo test -p compass-store-redb --locked
+  cargo test -p compass-graph --test store_snapshot --locked
+  cargo test -p compass-query --test store_engine --locked
+  cargo test -p compass-query --test opencypher_tck --locked
+  cargo test -p compass-cli --test store_cli --locked
+  cargo test -p compass-cli --test compass_product --locked
+  python3 "$compass_root/scripts/check_compassql_support.py"
+  sh "$compass_root/scripts/check_product_boundary.sh"
+  sh "$compass_root/scripts/test_release_scripts.sh"
+  "$compass_root/scripts/qualify_code_graph_v1.sh" --fixtures-only
+fi
+
+mkdir -p "$output_dir/store" "$output_dir/cli"
+printf 'adapter,nodes,seconds,peak_rss_kib,graph_bytes,database_bytes,write_amplification,build_requests,query_requests,canonical_json_equal,compassql_equal,gc_executed,gc_supported\n' \
+  > "$output_dir/store/metrics.csv"
+
+for adapter in sqlite redb; do
+  for nodes in $sizes; do
+    if ! [[ "$nodes" =~ ^[1-9][0-9]*$ ]]; then
+      echo "error: invalid graph size: $nodes" >&2
+      exit 2
+    fi
+    raw="$output_dir/store/${adapter}-${nodes}.json"
+    metrics=$(python3 "$measure" "$raw" -- \
+      "$qualification_bin" --adapter "$adapter" --nodes "$nodes")
+    IFS=, read -r seconds peak_rss_kib <<<"$metrics"
+    python3 - "$raw" "$adapter" "$nodes" "$seconds" "$peak_rss_kib" \
+      "$output_dir/store/metrics.csv" <<'PY'
+import csv
+import json
+import sys
+
+raw, adapter, nodes, seconds, peak, csv_path = sys.argv[1:]
+with open(raw, encoding="utf-8") as stream:
+    report = json.load(stream)
+with open(csv_path, "a", newline="", encoding="utf-8") as stream:
+    csv.writer(stream).writerow([
+        adapter,
+        int(nodes),
+        seconds,
+        int(peak),
+        report["graphBytes"],
+        report["databaseBytes"],
+        report["writeAmplification"],
+        json.dumps(report["buildRequests"], sort_keys=True, separators=(",", ":")),
+        json.dumps(report["queryRequests"], sort_keys=True, separators=(",", ":")),
+        report["canonicalJsonEqual"],
+        report["compassqlEqual"],
+        report["gc"]["executed"],
+        report["gc"]["supported"],
+    ])
+if not report["canonicalJsonEqual"] or not report["compassqlEqual"]:
+    raise SystemExit(f"{adapter}/{nodes}: differential qualification failed")
+PY
+  done
+done
+
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/compass-store-release.XXXXXX")
+cleanup() {
+  rm -rf -- "$work_root"
+}
+trap cleanup EXIT HUP INT TERM
+project="$work_root/project"
+mkdir -p "$project/src"
+printf 'pub fn symbol_zero() -> usize { 0 }\n' > "$project/src/lib.rs"
+printf 'pub fn symbol_one() -> usize { super::symbol_zero() + 1 }\n' > "$project/src/other.rs"
+
+measure_cli() {
+  local name=$1
+  shift
+  local raw="$output_dir/cli/${name}.stdout"
+  local metrics="$output_dir/cli/${name}.metrics"
+  python3 "$measure" "$raw" -- "$@" > "$metrics"
+}
+
+measure_cli clean_build "$compass_bin" init "$project" --yes
+measure_cli no_change_build "$compass_bin" update "$project" --no-program --no-viz
+printf '\npub fn symbol_two() -> usize { 2 }\n' >> "$project/src/lib.rs"
+measure_cli small_change_build "$compass_bin" update "$project" --no-program --no-viz
+graph="$project/compass-out/graph.json"
+measure_cli cold_query_json "$compass_bin" search symbol --graph "$graph" --engine json --format json
+measure_cli cold_query_store "$compass_bin" search symbol --graph "$graph" --engine store --format json
+
+python3 - "$output_dir" "$compass_root" "$compass_bin" <<'PY'
+import csv
+import json
+import pathlib
+import subprocess
+import sys
+
+output, root, binary = map(pathlib.Path, sys.argv[1:])
+metrics = output / "store" / "metrics.csv"
+rows = list(csv.DictReader(metrics.open(encoding="utf-8")))
+for row in rows:
+    assert row["canonical_json_equal"] == "True", row
+    assert row["compassql_equal"] == "True", row
+    assert row["gc_executed"] == "False", row
+    assert row["gc_supported"] == "False", row
+
+reports = {}
+for path in (output / "store").glob("*.json"):
+    report = json.loads(path.read_text(encoding="utf-8"))
+    reports.setdefault(report["nodes"], {})[report["adapter"]] = report
+for nodes, engines in reports.items():
+    assert set(engines) == {"sqlite", "redb"}, (nodes, engines)
+    assert engines["sqlite"]["graphDigest"] == engines["redb"]["graphDigest"], nodes
+    assert engines["sqlite"]["snapshotId"] == engines["redb"]["snapshotId"], nodes
+    assert engines["sqlite"]["manifestDigest"] == engines["redb"]["manifestDigest"], nodes
+
+cli = output / "cli"
+for name in ["clean_build", "no_change_build", "small_change_build", "cold_query_json", "cold_query_store"]:
+    metric = (cli / f"{name}.metrics").read_text(encoding="utf-8").strip()
+    seconds, peak = metric.split(",")
+    assert float(seconds) >= 0, name
+    assert int(peak) > 0, name
+assert (cli / "cold_query_json.stdout").read_bytes()
+assert (cli / "cold_query_store.stdout").read_bytes()
+
+commit = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+summary = {
+    "schema": "compass.store.release-summary/1",
+    "commit": commit,
+    "compassBinary": str(binary),
+    "storeMetrics": str(metrics),
+    "cliMetrics": str(cli),
+    "reports": sorted(str(path.relative_to(output)) for path in (output / "store").glob("*.json")),
+    "graphDigests": {
+        str(nodes): engines["sqlite"]["graphDigest"]
+        for nodes, engines in sorted(reports.items())
+    },
+}
+(output / "release-summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+with (output / "release-summary.md").open("w", encoding="utf-8") as stream:
+    stream.write("# Compass Store release qualification\n\n")
+    stream.write(f"Commit: `{commit}`\n\n")
+    stream.write("Store adapters produced byte-identical graph digests, snapshot IDs, and manifest digests for every requested size. Both typed search and CompassQL differential checks passed. Raw observations are in `store/metrics.csv`; CLI build/query observations are in `cli/*.metrics`.\n")
+PY
+
+echo "Compass Store release qualification written to $output_dir"

--- a/scripts/rebuild_compass_store.sh
+++ b/scripts/rebuild_compass_store.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "usage: rebuild_compass_store.sh PROJECT_ROOT [--out OUTPUT] [--compass BINARY]" >&2
+    exit 2
+}
+
+project=${1:-}
+[ -n "$project" ] || usage
+shift
+output=
+binary=${COMPASS_BIN:-compass}
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --out)
+            [ "$#" -ge 2 ] || usage
+            output=$2
+            shift 2
+            ;;
+        --compass)
+            [ "$#" -ge 2 ] || usage
+            binary=$2
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+project=$(CDPATH= cd -- "$project" && pwd)
+if [ -z "$output" ]; then
+    output=${COMPASS_OUT:-$project/compass-out}
+fi
+mkdir -p "$(dirname -- "$output")"
+output=$(CDPATH= cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")
+
+if [ ! -f "$output/graph.json" ]; then
+    echo "error: graph.json is required before rebuilding the store: $output/graph.json" >&2
+    exit 1
+fi
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+backup="$output/store-rebuild-backup-$timestamp-$$"
+mkdir -p "$backup"
+moved=0
+restore_on_failure() {
+    if [ "$moved" -eq 1 ]; then
+        for name in compass-store.sqlite3 store.ref compass-store.redb \
+            compass-store.sqlite3-wal compass-store.sqlite3-shm
+        do
+            if [ -f "$backup/$name" ] && [ ! -e "$output/$name" ]; then
+                mv "$backup/$name" "$output/$name"
+            fi
+        done
+    fi
+}
+trap restore_on_failure EXIT HUP INT TERM
+
+for name in compass-store.sqlite3 store.ref compass-store.redb \
+    compass-store.sqlite3-wal compass-store.sqlite3-shm
+do
+    if [ -e "$output/$name" ]; then
+        mv "$output/$name" "$backup/$name"
+        moved=1
+    fi
+done
+
+if ! "$binary" update "$project" --out "$output" --force; then
+    echo "error: store rebuild failed; the previous sidecar remains in $backup" >&2
+    exit 1
+fi
+
+trap - EXIT HUP INT TERM
+echo "rebuilt Compass store at $output"
+echo "previous sidecar backup: $backup"

--- a/scripts/test_release_scripts.sh
+++ b/scripts/test_release_scripts.sh
@@ -91,6 +91,12 @@ do
     test "$(tar -tzf "$archive" | grep -Ec "(^|/)$binary_name$")" -eq 1
 done
 
+if tar -tzf "$test_root/dist-aarch64-apple-darwin/compass-aarch64-apple-darwin.tar.gz" \
+    | grep -Eiq '(^|/)(graph\.json|compass-store\.(sqlite3|redb)|store\.ref|\.compass|credentials|\.env)(/|$|\.)'; then
+    echo "release archive contains local store state or credentials" >&2
+    exit 1
+fi
+
 release_dir="$test_root/release"
 mkdir -p "$release_dir" "$test_root/fake-bin"
 cp "$test_root/dist-aarch64-apple-darwin/"* "$release_dir/"
@@ -165,4 +171,5 @@ fi
 test ! -e "$test_root/checksum-must-fail/compass"
 mv "$test_root/good.sha256" "$release_dir/compass-aarch64-apple-darwin.tar.gz.sha256"
 
+"$repo_root/scripts/tests/test_store_release.sh"
 echo "release script tests passed"

--- a/scripts/tests/test_store_release.sh
+++ b/scripts/tests/test_store_release.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+
+project="$test_root/project"
+output="$project/compass-out"
+mkdir -p "$output"
+printf '%s\n' '{"graph":{"schema":"compass.graph/1"},"nodes":[],"links":[]}' > "$output/graph.json"
+printf 'old-sqlite\n' > "$output/compass-store.sqlite3"
+printf 'old-reference\n' > "$output/store.ref"
+
+cat > "$test_root/fake-compass" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "$FAKE_COMPASS_FAIL" = 1 ]; then
+    exit 17
+fi
+test "$1" = update
+shift
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --out) output=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf 'new-sqlite\n' > "$output/compass-store.sqlite3"
+printf 'new-reference\n' > "$output/store.ref"
+EOF
+chmod +x "$test_root/fake-compass"
+
+FAKE_COMPASS_FAIL=0 sh "$repo_root/scripts/rebuild_compass_store.sh" "$project" --compass "$test_root/fake-compass" > "$test_root/success.txt"
+backup=$(sed -n 's/^previous sidecar backup: //p' "$test_root/success.txt")
+test -n "$backup"
+test "$(cat "$output/compass-store.sqlite3")" = new-sqlite
+test "$(cat "$backup/compass-store.sqlite3")" = old-sqlite
+test "$(cat "$backup/store.ref")" = old-reference
+
+printf 'replacement-sqlite\n' > "$output/compass-store.sqlite3"
+printf 'replacement-reference\n' > "$output/store.ref"
+if FAKE_COMPASS_FAIL=1 sh "$repo_root/scripts/rebuild_compass_store.sh" \
+    "$project" --compass "$test_root/fake-compass" > "$test_root/failure.txt" 2>&1; then
+    echo "expected failed rebuild" >&2
+    exit 1
+fi
+test "$(cat "$output/compass-store.sqlite3")" = replacement-sqlite
+test "$(cat "$output/store.ref")" = replacement-reference
+
+echo "store release script tests passed"


### PR DESCRIPTION
## What changed

Implements the next Compass Store phase as a local 0.3.x release slice while keeping `graph.json` permanent and byte-compatible:

- adds namespace/partition/key/value store operations and SQLite backup/restore validation;
- adds `compass store status|validate|backup|restore` with versioned JSON envelopes;
- adds explicit rebuild tooling that never deletes or rewrites `graph.json`;
- adds a rebuildable release qualification binary and harness for SQLite and redb;
- qualifies typed query and CompassQL results against the canonical JSON engine;
- documents formats, support window, backend/platform policy, durability, recovery, GC/quotas, security, migration, and performance evidence;
- keeps redb library-only for this slice; cloud backends remain deferred until endpoint/auth/TLS/tenant/quota contracts are specified;
- hardens release archive checks so local store state and credentials cannot ship.

## Compatibility and operations

- `graph.json` remains the permanent interchange/fallback engine.
- `compass.store/1`, graph snapshots, refs, and backup manifests are versioned and fail closed on unknown/corrupt data.
- The supported upgrade window is same-major 0.3.x; physical sidecars are rebuildable via `compass update --force` or `scripts/rebuild_compass_store.sh`.
- Backup/restore validates graph, snapshot, manifest, ref, and store digests before publication.

## Verification

- `cargo fmt --all -- --check`
- full workspace clippy and `cargo test --workspace --lib --bins --locked`
- store/redb conformance, backup/restore, concurrent-writer, graph snapshot, typed query, CompassQL TCK, CLI, product-boundary, release-script, and fixture qualification gates
- workspace crate packaging plus archive leak scan; CLI dependency tree has no redb/cloud dependency
- committed-tree release qualification at sizes 32/128/512 for SQLite and redb: `/Volumes/Workspace/crabbuild-target/compass-store-phase9/qualification-final-a2829c4`
- all cross-engine canonical JSON, snapshot/manifest digests, typed query, and CompassQL comparisons passed; backup/rebuild and release packaging checks passed

The release evidence is intentionally kept outside the repository target tree.
