### PR TITLE
Fix VS Code context graph actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   context submenus, resolve symbols without an initial prompt, and render only
   the nodes and relationships returned by context queries. The extension also
   adapts typed caller/callee query results when the selected Compass 0.3.0 CLI
-  cannot consume those source anchors through `call-graph`.
+  cannot consume those source anchors through `call-graph`, and now rejects
+  Compass CLI releases below 0.3.0 instead of accumulating legacy fallbacks.
 - Publish a validated `compass-store.sqlite3` namespace/partition/key snapshot
   and typed `store.ref` beside every current `graph.json` generation. Typed
   code-query commands now use the store by default when the selector agrees,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Make VS Code editor graph actions reliable and focused: project typed graph
   source anchors into cursor-based call resolution, consolidate duplicate
   context submenus, resolve symbols without an initial prompt, and render only
-  the nodes and relationships returned by context queries.
+  the nodes and relationships returned by context queries. The extension also
+  adapts typed caller/callee query results when the selected Compass 0.3.0 CLI
+  cannot consume those source anchors through `call-graph`.
 - Publish a validated `compass-store.sqlite3` namespace/partition/key snapshot
   and typed `store.ref` beside every current `graph.json` generation. Typed
   code-query commands now use the store by default when the selector agrees,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Make VS Code editor graph actions reliable and focused: project typed graph
+  source anchors into cursor-based call resolution, consolidate duplicate
+  context submenus, resolve symbols without an initial prompt, and render only
+  the nodes and relationships returned by context queries.
 - Publish a validated `compass-store.sqlite3` namespace/partition/key snapshot
   and typed `store.ref` beside every current `graph.json` generation. Typed
   code-query commands now use the store by default when the selector agrees,

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -18,6 +18,17 @@ Legacy Graphify names are intentionally unsupported. Existing Graphify state
 must be archived or removed before creating fresh Compass artifacts. See
 [`MIGRATION.md`](MIGRATION.md) for the hard-cutover procedure.
 
+## VS Code extension compatibility
+
+The Compass VS Code extension requires Compass CLI 0.3.0 or newer. Releases
+below 0.3.0 and 0.3.0 prereleases are unsupported even when they advertise an
+individual feature or contract used by the extension. The extension reports
+the minimum-version failure before activating repository workflows; it does
+not maintain command-specific fallbacks for older releases.
+
+Compass 0.3.0 itself remains supported. The extension adapts typed call-query
+results for the known nested-anchor limitation in that stable release.
+
 ## Compatibility evidence
 
 Compass changes are verified with native evidence:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,6 +48,11 @@ The matching VS Code extension requires a CLI that advertises both `graph` and
 `community_detail`. Upgrade Compass and the extension together; the extension
 does not fall back to the older non-drill-down graph workflow.
 
+Current VSIX builds require Compass CLI 0.3.0 or newer. If **Select Compass
+CLI** labels an installation unsupported, upgrade that CLI or select another
+detected installation. Releases below 0.3.0 and 0.3.0 prereleases cannot be
+activated, even if they advertise some current capabilities.
+
 ## Replace commands
 
 Replace Python and legacy executable invocations with `compass`:

--- a/crates/compass-analysis/src/universal_call_graph.rs
+++ b/crates/compass-analysis/src/universal_call_graph.rs
@@ -172,8 +172,8 @@ pub fn build_universal_call_graph(
                 call_sites: vec![UniversalCallSite {
                     source_file,
                     line,
-                    start_byte: None,
-                    end_byte: None,
+                    start_byte: edge.unsigned("start_byte"),
+                    end_byte: edge.unsigned("end_byte"),
                     evidence: Vec::new(),
                 }],
                 evidence_layer: "structural_graph",
@@ -411,8 +411,8 @@ fn structural_node(node: &NodeRecord) -> UniversalCallNode {
         file: nonempty(node.string("source_file")),
         start_line: line(node, "line_start"),
         end_line: line(node, "line_end"),
-        start_byte: None,
-        end_byte: None,
+        start_byte: line(node, "start_byte"),
+        end_byte: line(node, "end_byte"),
         graph_node_id: Some(node.id.clone()),
         unresolved: false,
         evidence_layer: "structural_graph",
@@ -449,11 +449,18 @@ fn resolve_structural_root(
                     node.file
                         .as_deref()
                         .is_some_and(|candidate| normalize_path(candidate) == normalized)
-                        && node.start_line.is_some_and(|start| start <= *line)
-                        && node.end_line.is_some_and(|end| *line <= end)
+                        && (node
+                            .start_byte
+                            .zip(node.end_byte)
+                            .is_some_and(|(start, end)| start <= *byte && *byte <= end)
+                            || (node.start_line.is_some_and(|start| start <= *line)
+                                && node.end_line.is_some_and(|end| *line <= end)))
                 })
                 .min_by_key(|node| {
                     (
+                        node.end_byte
+                            .unwrap_or(u64::MAX)
+                            .saturating_sub(node.start_byte.unwrap_or_default()),
                         node.end_line
                             .unwrap_or(u64::MAX)
                             .saturating_sub(node.start_line.unwrap_or_default()),

--- a/crates/compass-analysis/tests/universal_call_graph.rs
+++ b/crates/compass-analysis/tests/universal_call_graph.rs
@@ -118,6 +118,87 @@ fn source_resolution_selects_the_smallest_containing_callable()
 }
 
 #[test]
+fn graph_v1_source_anchors_resolve_the_cursor() -> Result<(), Box<dyn std::error::Error>> {
+    let graph = serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": true,
+        "graph": { "schema": "compass.graph/1" },
+        "nodes": [
+            {
+                "id": "root",
+                "kind": "function",
+                "name": "root",
+                "qualifiedName": "example::root",
+                "source": {
+                    "file": "src/lib.rs",
+                    "startByte": 100,
+                    "endByte": 220,
+                    "startLine": 10,
+                    "startColumn": 0,
+                    "endLine": 18,
+                    "endColumn": 1
+                }
+            },
+            {
+                "id": "callee",
+                "kind": "function",
+                "name": "callee",
+                "qualifiedName": "example::callee",
+                "source": {
+                    "file": "src/lib.rs",
+                    "startByte": 300,
+                    "endByte": 360,
+                    "startLine": 24,
+                    "startColumn": 0,
+                    "endLine": 28,
+                    "endColumn": 1
+                }
+            }
+        ],
+        "links": [{
+            "id": "root-calls-callee",
+            "key": "root-calls-callee",
+            "source": "root",
+            "target": "callee",
+            "kind": "calls",
+            "relationshipSite": {
+                "file": "src/lib.rs",
+                "startByte": 160,
+                "endByte": 168,
+                "startLine": 14,
+                "startColumn": 4,
+                "endLine": 14,
+                "endColumn": 12
+            }
+        }]
+    }))?;
+
+    let response = build_universal_call_graph(
+        &graph,
+        None,
+        &UniversalCallGraphRequest {
+            root: UniversalCallGraphRoot::SourcePosition {
+                file: "src/lib.rs".to_owned(),
+                byte: 165,
+                line: 14,
+            },
+            direction: CallGraphDirection::Callees,
+            depth: 1,
+            max_nodes: 20,
+            max_edges: 20,
+        },
+    )?;
+
+    assert_eq!(response.root_symbol, "root");
+    assert_eq!(response.nodes.len(), 2);
+    assert_eq!(response.edges.len(), 1);
+    assert_eq!(response.nodes[0].start_byte, Some(300));
+    assert_eq!(response.nodes[1].start_byte, Some(100));
+    assert_eq!(response.edges[0].call_sites[0].start_byte, Some(160));
+    Ok(())
+}
+
+#[test]
 fn declaration_only_ranges_keep_source_driven_languages_cursor_capable()
 -> Result<(), Box<dyn std::error::Error>> {
     for language in ["groovy", "zig", "r", "pascal", "dart"] {

--- a/crates/compass-model/src/document.rs
+++ b/crates/compass-model/src/document.rs
@@ -117,13 +117,27 @@ impl NodeRecord {
 
     #[must_use]
     pub fn unsigned(&self, key: &str) -> Option<u64> {
-        self.attributes.get(key).and_then(|value| {
-            value.as_u64().or_else(|| {
-                (key == "community")
-                    .then(|| value.as_object()?.get("id")?.as_u64())
-                    .flatten()
+        self.attributes
+            .get(key)
+            .and_then(|value| {
+                value.as_u64().or_else(|| {
+                    (key == "community")
+                        .then(|| value.as_object()?.get("id")?.as_u64())
+                        .flatten()
+                })
             })
-        })
+            .or_else(|| {
+                let source = self.attributes.get("source")?.as_object()?;
+                source
+                    .get(match key {
+                        "start_byte" => "startByte",
+                        "end_byte" => "endByte",
+                        "line_start" => "startLine",
+                        "line_end" => "endLine",
+                        _ => return None,
+                    })?
+                    .as_u64()
+            })
     }
 
     #[must_use]
@@ -238,6 +252,24 @@ impl EdgeRecord {
     #[must_use]
     pub fn boolean(&self, key: &str) -> Option<bool> {
         self.attributes.get(key).and_then(Value::as_bool)
+    }
+
+    #[must_use]
+    pub fn unsigned(&self, key: &str) -> Option<u64> {
+        self.attributes
+            .get(key)
+            .and_then(Value::as_u64)
+            .or_else(|| {
+                let site = self.attributes.get("relationshipSite")?.as_object()?;
+                site.get(match key {
+                    "start_byte" => "startByte",
+                    "end_byte" => "endByte",
+                    "line_start" => "startLine",
+                    "line_end" => "endLine",
+                    _ => return None,
+                })?
+                .as_u64()
+            })
     }
 
     #[must_use]
@@ -729,6 +761,8 @@ mod tests {
                     "name": "source",
                     "source": {
                         "file": "src/lib.rs",
+                        "startByte": 20,
+                        "endByte": 45,
                         "startLine": 2,
                         "startColumn": 3,
                         "endLine": 4,
@@ -759,6 +793,8 @@ mod tests {
                     "kind": "calls",
                     "relationshipSite": {
                         "file": "src/lib.rs",
+                        "startByte": 80,
+                        "endByte": 86,
                         "startLine": 8,
                         "startColumn": 9,
                         "endLine": 8,
@@ -769,10 +805,16 @@ mod tests {
         )?;
 
         assert_eq!(document.nodes[0].string("source_location"), "L2:3-L4:5");
+        assert_eq!(document.nodes[0].unsigned("start_byte"), Some(20));
+        assert_eq!(document.nodes[0].unsigned("end_byte"), Some(45));
+        assert_eq!(document.nodes[0].unsigned("line_start"), Some(2));
+        assert_eq!(document.nodes[0].unsigned("line_end"), Some(4));
         assert_eq!(document.nodes[0].string("community_name"), "Core");
         assert_eq!(document.nodes[1].string("wiring_file"), "src/caller.rs");
         assert_eq!(document.nodes[1].string("wiring_location"), "L11:7-L11:13");
         assert_eq!(document.links[0].string("source_location"), "L8:9-L8:15");
+        assert_eq!(document.links[0].unsigned("start_byte"), Some(80));
+        assert_eq!(document.links[0].unsigned("end_byte"), Some(86));
         Ok(())
     }
 

--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -45,9 +45,10 @@ use the same interaction against their exact commit.
 ## Calls and architecture
 
 Open an indexed source file and place the cursor anywhere inside a function or
-method. Right-click, choose **Compass Call Graph**, then choose **Show
-Callers**, **Show Callees**, or **Show Callers & Callees**. The same commands
-are available from the Command Palette.
+method. Right-click, choose **Compass**, then choose **Show Callers**, **Show
+Callees**, or **Show Callers & Callees**. The same commands are available from
+the Command Palette. The single Compass submenu also contains **Show Change
+Impact**, **Explore Related Symbols**, and **Show Node Trail**.
 
 Compass sends the relative file, UTF-8 cursor byte, and 1-based line to the
 language-neutral call-graph command. It selects the innermost callable range
@@ -66,6 +67,13 @@ in that direction. It does not prove that no runtime call exists.
 
 If Compass cannot resolve the cursor, move it inside the function or method
 body and retry. **Show Compass output** opens the local command diagnostics.
+
+Editor-context actions resolve the stable graph symbol from the active file,
+UTF-8 byte, and line rather than asking for a symbol name. Change impact and
+related-symbol actions open a focused graph containing only the returned
+neighborhood. Node trail uses the cursor symbol as its source, asks only for
+the destination, and opens the returned path instead of the repository-wide
+overview.
 
 Use **Open Architecture Flow** for the broader subsystem call-flow document,
 cross-community relationships, symbol lists, call tables, confidence, and

--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -6,7 +6,8 @@ Dev Container extension hosts. Browser-only `vscode.dev` is not supported.
 
 ## Set up
 
-1. Install Compass and confirm `compass --version` works on the workspace host.
+1. Install Compass CLI 0.3.0 or newer and confirm `compass --version` works on
+   the workspace host. Older releases and 0.3.0 prereleases are unsupported.
 2. Install the Compass VSIX.
 3. Open a trusted repository.
 4. The extension detects Compass on `PATH` and in common install locations.

--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -57,6 +57,11 @@ represented by Compass use the same editor workflow. If Program IR exists for
 the selected repository, Compass uses it only as an enrichment layer; it is not
 required to open a structural graph.
 
+With Compass CLI 0.3.0, the extension transparently resolves the same typed
+source anchor through a bounded CompassQL query and adapts the typed
+caller/callee results because that release cannot consume nested graph anchors
+in `call-graph`.
+
 In the graph tab, choose **Callers**, **Both**, or **Callees** to reload the
 root in another direction, or use an **Expand** action to trace a continuation.
 Resolved, inferred, ambiguous, and unresolved calls use distinct labels and

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Keep caller/callee actions compatible with an external Compass 0.3.0 CLI by
   resolving the cursor through bounded CompassQL and adapting typed call query
   results when that release's `call-graph` command rejects nested anchors.
+- Require Compass CLI 0.3.0 or newer. Older releases and 0.3.0 prereleases are
+  labeled unsupported and rejected before the extension activates workflows.
 
 ## 0.2.0
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -8,6 +8,9 @@
   graphs instead of loading the complete repository overview behind them.
 - Resolve caller/callee roots from current typed graph source anchors so the
   editor workflow works with `compass.graph/1` artifacts.
+- Keep caller/callee actions compatible with an external Compass 0.3.0 CLI by
+  resolving the cursor through bounded CompassQL and adapting typed call query
+  results when that release's `call-graph` command rejects nested anchors.
 
 ## 0.2.0
 

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Replace the duplicate Call Graph and Code Graph editor submenus with one
+  **Compass** menu whose actions resolve the symbol at the active cursor.
+- Render change-impact, related-symbol, and node-trail queries as focused result
+  graphs instead of loading the complete repository overview behind them.
+- Resolve caller/callee roots from current typed graph source anchors so the
+  editor workflow works with `compass.graph/1` artifacts.
+
 ## 0.2.0
 
 - Highlight complete source lines when opening a code-graph node, including the

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -81,7 +81,7 @@ guide opens and returns to that exact cursor when an action is selected.
 
 1. Open an indexed source file and place the cursor anywhere inside a function
    or method body.
-2. Right-click in the editor and choose **Compass Call Graph**.
+2. Right-click in the editor and choose **Compass**.
 3. Choose **Show Callers**, **Show Callees**, or **Show Callers & Callees**.
 4. In the graph tab, use **Callers**, **Both**, and **Callees** to switch
    direction without returning to the editor. Use an **Expand** action to trace
@@ -95,6 +95,12 @@ identifies structural-only or combined evidence and says when results are
 partial. An empty direction means that Compass found the function but has no
 represented relationship in that direction; it does not prove no runtime call
 exists.
+
+The same **Compass** editor menu includes **Show Change Impact**, **Explore
+Related Symbols**, and **Show Node Trail**. Compass resolves the graph identity
+at the cursor automatically. Impact and related-symbol results open as focused
+graphs containing only the returned nodes and relationships. Node trail uses
+the cursor as its source and asks only for the destination.
 
 Compass discovers the CLI automatically from the configured location, `PATH`,
 and common user-local install directories. When it is missing, **Set up

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,6 +6,9 @@ exports.
 
 ## Requirements
 
+The extension requires Compass CLI 0.3.0 or newer. Releases below 0.3.0 and
+0.3.0 prereleases are unsupported.
+
 If the `compass` CLI is missing, choose **Set up Compass** in the Compass
 activity bar. The onboarding page shows the exact official install command,
 opens a visible integrated terminal, runs it, and verifies the installed

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -96,6 +96,11 @@ partial. An empty direction means that Compass found the function but has no
 represented relationship in that direction; it does not prove no runtime call
 exists.
 
+When the selected CLI is Compass 0.3.0, the extension automatically uses the
+typed query contract for this workflow because that release's `call-graph`
+command cannot read nested `compass.graph/1` source anchors. You do not need to
+replace the CLI to use the rebuilt extension.
+
 The same **Compass** editor menu includes **Show Change Impact**, **Explore
 Related Symbols**, and **Show Node Trail**. Compass resolves the graph identity
 at the cursor automatically. Impact and related-symbol results open as focused

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -125,16 +125,6 @@
         "icon": "$(symbol-method)"
       },
       {
-        "command": "compass.showCodeCallers",
-        "title": "Compass: Show Typed Callers",
-        "icon": "$(references)"
-      },
-      {
-        "command": "compass.showCodeCallees",
-        "title": "Compass: Show Typed Callees",
-        "icon": "$(references)"
-      },
-      {
         "command": "compass.showCodeImpact",
         "title": "Compass: Show Change Impact",
         "icon": "$(pulse)"
@@ -167,12 +157,8 @@
     ],
     "submenus": [
       {
-        "id": "compass.callGraph",
-        "label": "Compass Call Graph"
-      },
-      {
         "id": "compass.codeGraph",
-        "label": "Compass Code Graph"
+        "label": "Compass"
       }
     ],
     "configuration": {
@@ -265,17 +251,12 @@
       ],
       "editor/context": [
         {
-          "submenu": "compass.callGraph",
-          "when": "resourceScheme == file",
-          "group": "navigation@90"
-        },
-        {
           "submenu": "compass.codeGraph",
           "when": "resourceScheme == file",
-          "group": "navigation@91"
+          "group": "navigation@90"
         }
       ],
-      "compass.callGraph": [
+      "compass.codeGraph": [
         {
           "command": "compass.openCallers",
           "group": "1_direction@1"
@@ -287,16 +268,6 @@
         {
           "command": "compass.openCallersAndCallees",
           "group": "1_direction@3"
-        }
-      ],
-      "compass.codeGraph": [
-        {
-          "command": "compass.showCodeCallers",
-          "group": "1_calls@1"
-        },
-        {
-          "command": "compass.showCodeCallees",
-          "group": "1_calls@2"
         },
         {
           "command": "compass.showCodeImpact",
@@ -340,7 +311,7 @@
           {
             "id": "compass.calls",
             "title": "Trace calls from the editor",
-            "description": "Place the cursor inside a function, right-click, choose **Compass Call Graph**, then select callers, callees, or both.",
+            "description": "Place the cursor inside a function, right-click, choose **Compass**, then select callers, callees, or both.",
             "media": { "markdown": "README.md" },
             "completionEvents": [
               "onCommand:compass.openCallers",

--- a/editors/vscode/src/cli/compatibility.test.ts
+++ b/editors/vscode/src/cli/compatibility.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { CapabilityReport } from "./contracts";
-import { COMPASS_REQUIREMENTS, compatibilityIssue } from "./compatibility";
+import {
+  COMPASS_REQUIREMENTS,
+  compatibilityIssue,
+  isSupportedCompassVersion
+} from "./compatibility";
 
 const compatible: CapabilityReport = {
   schema: "compass.ide.capabilities/1",
-  compass_version: "0.1.4",
+  compass_version: "0.3.0",
   contracts: {
     graph_viewer: "compass.viewer.graph/1",
     progress: "compass.ide.progress/1"
@@ -16,6 +20,30 @@ const compatible: CapabilityReport = {
 };
 
 describe("compatibilityIssue", () => {
+  it("rejects Compass releases and prereleases below 0.3.0", () => {
+    for (const version of [
+      "0.1.9",
+      "0.2.99",
+      "0.3.0-beta.1",
+      "00.3.0",
+      "999999999999999999999.0.0",
+      "invalid"
+    ]) {
+      expect(compatibilityIssue(
+        { ...compatible, compass_version: version },
+        undefined,
+        COMPASS_REQUIREMENTS.graph
+      )).toContain("requires Compass CLI 0.3.0 or newer");
+    }
+  });
+
+  it("accepts stable 0.3.0 and later semantic versions", () => {
+    expect(isSupportedCompassVersion("0.3.0")).toBe(true);
+    expect(isSupportedCompassVersion("0.3.0+build.7")).toBe(true);
+    expect(isSupportedCompassVersion("0.3.1-beta.1")).toBe(true);
+    expect(isSupportedCompassVersion("1.0.0")).toBe(true);
+  });
+
   it("explains a failed capability negotiation instead of running an unsupported command", () => {
     expect(compatibilityIssue(
       undefined,

--- a/editors/vscode/src/cli/compatibility.ts
+++ b/editors/vscode/src/cli/compatibility.ts
@@ -1,5 +1,7 @@
 import type { CapabilityReport } from "./contracts";
 
+export const MINIMUM_COMPASS_VERSION = "0.3.0";
+
 export type CapabilityRequirement = {
   workflow: string;
   features?: readonly string[];
@@ -61,6 +63,8 @@ export function compatibilityIssue(
     const detail = negotiationError ? ` Capability negotiation failed: ${negotiationError}` : "";
     return `The installed Compass CLI cannot ${requirement.workflow} with this extension.${detail}`;
   }
+  const versionIssue = minimumCompassVersionIssue(report.compass_version);
+  if (versionIssue) return versionIssue;
   for (const feature of requirement.features ?? []) {
     if (report.features[feature] !== true) {
       return `Compass CLI ${report.compass_version} does not advertise the '${feature}' feature required to ${requirement.workflow}.`;
@@ -75,4 +79,28 @@ export function compatibilityIssue(
     }
   }
   return undefined;
+}
+
+export function minimumCompassVersionIssue(version: string): string | undefined {
+  return isSupportedCompassVersion(version)
+    ? undefined
+    : `Compass CLI ${version || "(version unavailable)"} is unsupported. `
+      + `This extension requires Compass CLI ${MINIMUM_COMPASS_VERSION} or newer.`;
+}
+
+export function isSupportedCompassVersion(version: string): boolean {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+    version.trim()
+  );
+  if (!match) return false;
+  const current = [Number(match[1]), Number(match[2]), Number(match[3])];
+  if (current.some((value) => !Number.isSafeInteger(value))) return false;
+  const minimum = [0, 3, 0];
+  for (let index = 0; index < minimum.length; index += 1) {
+    const value = current[index] ?? 0;
+    const required = minimum[index] ?? 0;
+    if (value > required) return true;
+    if (value < required) return false;
+  }
+  return match[4] === undefined;
 }

--- a/editors/vscode/src/cli/runtime.test.ts
+++ b/editors/vscode/src/cli/runtime.test.ts
@@ -7,7 +7,7 @@ import type { RepositorySession } from "../workspace/repositorySession";
 
 const capabilities: CapabilityReport = {
   schema: "compass.ide.capabilities/1",
-  compass_version: "0.1.7",
+  compass_version: "0.3.0",
   contracts: {
     progress: "compass.ide.progress/1",
     graph_viewer: "compass.viewer.graph/1",
@@ -37,7 +37,7 @@ const missing: CompassDiscovery = {
 
 const installation: CompassInstallation = {
   executable: "/home/dev/.local/bin/compass",
-  version: "0.1.7",
+  version: "0.3.0",
   source: "common"
 };
 
@@ -84,7 +84,7 @@ describe("CompassRuntime", () => {
     expect(runtime.discovery).toMatchObject({
       kind: "found",
       executable: installation.executable,
-      version: "0.1.7",
+      version: "0.3.0",
       installations: [installation]
     });
     expect(listener).toHaveBeenCalledOnce();
@@ -109,6 +109,30 @@ describe("CompassRuntime", () => {
     await expect(runtime.activate(installation)).rejects.toThrow(
       "does not advertise the 'history' feature"
     );
+    expect(persistCliPath).not.toHaveBeenCalled();
+    expect(processes.executablePath).toBe("compass");
+    expect(repository.capabilities).toBeUndefined();
+    expect(runtime.discovery).toBe(missing);
+  });
+
+  it("rejects Compass versions below 0.3.0 without mutating runtime state", async () => {
+    const processes = new CompassProcessManager("compass");
+    const repository = session();
+    const persistCliPath = vi.fn(async () => {});
+    const runtime = new CompassRuntime(missing, {
+      processes,
+      sessions: () => [repository],
+      persistCliPath,
+      createCandidateProcesses: () => ({
+        runJson: vi.fn(async () => ({
+          ...capabilities,
+          compass_version: "0.2.9"
+        }))
+      }) as never
+    });
+
+    await expect(runtime.activate({ ...installation, version: "0.2.9" }))
+      .rejects.toThrow("requires Compass CLI 0.3.0 or newer");
     expect(persistCliPath).not.toHaveBeenCalled();
     expect(processes.executablePath).toBe("compass");
     expect(repository.capabilities).toBeUndefined();
@@ -144,12 +168,12 @@ describe("CompassRuntime", () => {
     const previous: CompassDiscovery = {
       kind: "found",
       executable: "/opt/compass",
-      version: "0.1.6",
+      version: "0.3.1",
       installations: [
         { ...installation, version: undefined },
         {
           executable: "/opt/compass",
-          version: "0.1.6",
+          version: "0.3.1",
           source: "path"
         }
       ],
@@ -166,7 +190,7 @@ describe("CompassRuntime", () => {
 
     const activated = await runtime.activate({ ...installation, version: undefined });
 
-    expect(activated.installation.version).toBe("0.1.7");
+    expect(activated.installation.version).toBe("0.3.0");
     expect(runtime.discovery.installations.map((item) => item.executable)).toEqual([
       installation.executable,
       "/opt/compass"

--- a/editors/vscode/src/cli/selection.test.ts
+++ b/editors/vscode/src/cli/selection.test.ts
@@ -7,16 +7,16 @@ describe("compassSelectionItems", () => {
     const discovery: CompassDiscovery = {
       kind: "found",
       executable: "/home/dev/.local/bin/compass",
-      version: "0.1.5",
+      version: "0.2.9",
       installations: [
         {
           executable: "/home/dev/.local/bin/compass",
-          version: "0.1.5",
+          version: "0.2.9",
           source: "common"
         },
         {
           executable: "/home/dev/.cargo/bin/compass",
-          version: "0.2.0-beta.1",
+          version: "0.3.0",
           source: "path"
         }
       ],
@@ -25,12 +25,12 @@ describe("compassSelectionItems", () => {
 
     expect(compassSelectionItems(discovery)).toEqual([
       expect.objectContaining({
-        label: "$(terminal) Compass 0.1.5",
-        description: "Current selection",
+        label: "$(terminal) Compass 0.2.9",
+        description: "Unsupported — requires 0.3.0+",
         detail: "/home/dev/.local/bin/compass"
       }),
       expect.objectContaining({
-        label: "$(terminal) Compass 0.2.0-beta.1",
+        label: "$(terminal) Compass 0.3.0",
         description: "Detected on PATH",
         detail: "/home/dev/.cargo/bin/compass"
       }),

--- a/editors/vscode/src/cli/selection.ts
+++ b/editors/vscode/src/cli/selection.ts
@@ -3,6 +3,10 @@ import type {
   CompassInstallation,
   CompassInstallationSource
 } from "./discovery";
+import {
+  MINIMUM_COMPASS_VERSION,
+  isSupportedCompassVersion
+} from "./compatibility";
 
 export type CompassSelectionItem = {
   label: string;
@@ -23,9 +27,11 @@ export function compassSelectionItems(
     label: installation.version
       ? `$(terminal) Compass ${installation.version}`
       : "$(terminal) Compass (version unavailable)",
-    description: installation.executable === activeExecutable
-      ? "Current selection"
-      : sourceLabel(installation.source),
+    description: installation.version && !isSupportedCompassVersion(installation.version)
+      ? `Unsupported — requires ${MINIMUM_COMPASS_VERSION}+`
+      : installation.executable === activeExecutable
+        ? "Current selection"
+        : sourceLabel(installation.source),
     detail: installation.executable,
     installation
   }));

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import * as vscode from "vscode";
 import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 import {
@@ -22,6 +23,9 @@ import {
   type CodeQueryRequest
 } from "./views/codeQueryClient";
 import { CallGraphPanel } from "./views/callGraphPanel";
+import { callGraphRootArguments } from "./views/callGraphArguments";
+import { runCallGraph } from "./views/callGraphClient";
+import { utf8ByteAt } from "./views/cursorByte";
 import { openCallGraphGuidePanel } from "./views/callGraphGuidePanel";
 import { openArchitecturePanel } from "./views/architecturePanel";
 import { openQueryPanel } from "./views/queryPanel";
@@ -323,6 +327,48 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (candidate?.trim()) return candidate.trim();
     }
     const editor = vscode.window.activeTextEditor;
+    const session = registry.forEditor(editor);
+    if (editor && session) {
+      if (!await ensureCompatible(session, COMPASS_REQUIREMENTS.calls)) return undefined;
+      if (session.graphState !== "available") {
+        const action = await vscode.window.showInformationMessage(
+          "Build the Compass code graph before resolving the symbol under the cursor.",
+          "Rebuild with Compass"
+        );
+        if (action === "Rebuild with Compass") {
+          await vscode.commands.executeCommand("compass.update", session.id);
+        }
+        return undefined;
+      }
+      const relativePath = path.relative(session.root, editor.document.uri.fsPath);
+      if (
+        path.isAbsolute(relativePath)
+        || relativePath === ".."
+        || relativePath.startsWith(`..${path.sep}`)
+      ) {
+        void vscode.window.showErrorMessage(
+          "The active editor is outside the selected Compass repository."
+        );
+        return undefined;
+      }
+      const relative = relativePath.split(path.sep).join("/");
+      try {
+        const response = await runCallGraph(
+          session,
+          callGraphRootArguments({
+            file: relative,
+            byte: utf8ByteAt(editor.document, editor.selection.active),
+            line: editor.selection.active.line + 1
+          }, "both", 1)
+        );
+        return response.rootSymbol;
+      } catch (error) {
+        void vscode.window.showErrorMessage(
+          `Compass could not resolve a symbol at the cursor: ${message(error)}`
+        );
+        return undefined;
+      }
+    }
     const range = editor?.document.getWordRangeAtPosition(editor.selection.active);
     const word = editor && range ? editor.document.getText(range) : "";
     return vscode.window.showInputBox({
@@ -342,7 +388,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
     const session = await selectRepository(repositoryId);
     if (!session) return;
-    if (!await ensureCompatible(session, COMPASS_REQUIREMENTS.graph)) return;
+    if (!await ensureCompatible(session, COMPASS_REQUIREMENTS.query)) return;
     if (session.graphState !== "available") {
       const action = await vscode.window.showInformationMessage(
         "Build the Compass code graph before running code queries.",
@@ -356,7 +402,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const controller = new AbortController();
     try {
       const result = await runCodeQuery(session, request, controller.signal);
-      await GraphPanel.open(context, session, output, result);
+      await GraphPanel.open(
+        context,
+        session,
+        output,
+        result,
+        codeQueryTitle(request, result.nodes)
+      );
     } catch (error) {
       const detail = message(error);
       if (codeQueryRequiresRebuild(detail)) {
@@ -431,27 +483,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (query) await runAndOpenCodeQuery({ operation: "search", query });
     }),
     vscode.commands.registerCommand("compass.showCodeCallers", async (value?: unknown) => {
-      const symbol = await selectedSymbol(value, "Show Compass callers");
-      if (symbol) await runAndOpenCodeQuery({ operation: "callers", symbol });
+      if (value !== undefined) {
+        const symbol = await selectedSymbol(value, "Show Compass callers");
+        if (symbol) await runAndOpenCodeQuery({ operation: "callers", symbol });
+        return;
+      }
+      await openCallGraph("callers");
     }),
     vscode.commands.registerCommand("compass.showCodeCallees", async (value?: unknown) => {
-      const symbol = await selectedSymbol(value, "Show Compass callees");
-      if (symbol) await runAndOpenCodeQuery({ operation: "callees", symbol });
+      if (value !== undefined) {
+        const symbol = await selectedSymbol(value, "Show Compass callees");
+        if (symbol) await runAndOpenCodeQuery({ operation: "callees", symbol });
+        return;
+      }
+      await openCallGraph("callees");
     }),
     vscode.commands.registerCommand("compass.showCodeImpact", async (value?: unknown) => {
       const symbol = await selectedSymbol(value, "Show Compass impact");
       if (symbol) await runAndOpenCodeQuery({ operation: "impact", symbol });
     }),
-    vscode.commands.registerCommand("compass.exploreCode", async () => {
-      const input = await vscode.window.showInputBox({
-        title: "Explore related Compass symbols",
-        prompt: "Enter symbol IDs or names separated by commas",
-        validateInput: (value) => value.split(",").some((item) => item.trim())
-          ? undefined
-          : "Enter at least one symbol"
-      });
-      const symbols = input?.split(",").map((item) => item.trim()).filter(Boolean);
-      if (symbols?.length) await runAndOpenCodeQuery({ operation: "explore", symbols });
+    vscode.commands.registerCommand("compass.exploreCode", async (value?: unknown) => {
+      const symbol = await selectedSymbol(value, "Explore related Compass symbols");
+      if (symbol) await runAndOpenCodeQuery({ operation: "explore", symbols: [symbol] });
     }),
     vscode.commands.registerCommand("compass.showNodeTrail", async () => {
       const source = await selectedSymbol(undefined, "Compass node trail source");
@@ -506,6 +559,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await vscode.commands.executeCommand("compass.selectCli");
       }
     });
+  }
+}
+
+function codeQueryTitle(
+  request: CodeQueryRequest,
+  nodes: readonly { id: string; name: string }[]
+): string {
+  const label = (symbol: string) =>
+    nodes.find((node) => node.id === symbol)?.name ?? symbol;
+  switch (request.operation) {
+    case "search":
+      return `Compass Search — ${request.query}`;
+    case "callers":
+      return `Compass Callers — ${label(request.symbol)}`;
+    case "callees":
+      return `Compass Callees — ${label(request.symbol)}`;
+    case "impact":
+      return `Compass Change Impact — ${label(request.symbol)}`;
+    case "explore":
+      return `Compass Related Symbols — ${request.symbols.map(label).join(", ")}`;
+    case "node":
+      return `Compass Node Trail — ${label(request.source)} to ${label(request.target)}`;
   }
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -23,8 +23,7 @@ import {
   type CodeQueryRequest
 } from "./views/codeQueryClient";
 import { CallGraphPanel } from "./views/callGraphPanel";
-import { callGraphRootArguments } from "./views/callGraphArguments";
-import { runCallGraph } from "./views/callGraphClient";
+import { runCallGraphAtCursor } from "./views/callGraphClient";
 import { utf8ByteAt } from "./views/cursorByte";
 import { openCallGraphGuidePanel } from "./views/callGraphGuidePanel";
 import { openArchitecturePanel } from "./views/architecturePanel";
@@ -353,13 +352,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
       const relative = relativePath.split(path.sep).join("/");
       try {
-        const response = await runCallGraph(
+        const response = await runCallGraphAtCursor(
           session,
-          callGraphRootArguments({
+          {
             file: relative,
             byte: utf8ByteAt(editor.document, editor.selection.active),
             line: editor.selection.active.line + 1
-          }, "both", 1)
+          },
+          "both",
+          1
         );
         return response.rootSymbol;
       } catch (error) {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 import {
   COMPASS_REQUIREMENTS,
   compatibilityIssue,
+  minimumCompassVersionIssue,
   type CapabilityRequirement
 } from "./cli/compatibility";
 import { CapabilityReportSchema } from "./cli/contracts";
@@ -59,6 +60,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           ["capabilities", "--format", "json"],
           CapabilityReportSchema
         );
+        session.capabilityError = minimumCompassVersionIssue(
+          session.capabilities.compass_version
+        );
+        if (session.capabilityError) output.warn(session.capabilityError);
       } catch (error) {
         session.capabilityError = message(error);
         output.warn(`Capability negotiation failed for ${executable}: ${session.capabilityError}`);
@@ -147,6 +152,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }
     if (!installation) return;
+    if (installation.version) {
+      const versionIssue = minimumCompassVersionIssue(installation.version);
+      if (versionIssue) {
+        void vscode.window.showErrorMessage(versionIssue);
+        return;
+      }
+    }
 
     if (
       runtime.discovery.kind === "found"

--- a/editors/vscode/src/test/fake-bin/compass
+++ b/editors/vscode/src/test/fake-bin/compass
@@ -3,7 +3,7 @@ const command = process.argv[2];
 if (command === "capabilities") {
   process.stdout.write(JSON.stringify({
     schema: "compass.ide.capabilities/1",
-    compass_version: "0.1.4-test",
+    compass_version: "0.3.0",
     contracts: {
       graph_viewer: "compass.viewer.graph/1",
       callflow_viewer: "compass.viewer.callflow/1",

--- a/editors/vscode/src/views/callGraphArguments.ts
+++ b/editors/vscode/src/views/callGraphArguments.ts
@@ -1,6 +1,6 @@
 import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 
-type CallGraphRoot = {
+export type CallGraphRoot = {
   file: string;
   byte: number;
   line: number;

--- a/editors/vscode/src/views/callGraphClient.test.ts
+++ b/editors/vscode/src/views/callGraphClient.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { runCallGraph } from "./callGraphClient";
+
+describe("callGraphClient", () => {
+  it("returns the stable cursor root and forwards bounded graph arguments", async () => {
+    const signal = new AbortController().signal;
+    const runJson = vi.fn().mockResolvedValue({
+      schema: "compass.call_graph/1",
+      rootSymbol: "sha256:root",
+      direction: "both",
+      depth: 1,
+      nodes: [],
+      edges: [],
+      truncated: false,
+      continuations: [],
+      coverage: {
+        resolved: 0,
+        inferred: 0,
+        ambiguous: 0,
+        unresolved: 0,
+        evidenceLayer: "structural_graph",
+        partial: true,
+        limitations: [],
+        warning: "Structural graph"
+      }
+    });
+    const session = {
+      root: "/repo",
+      graphPath: "/repo/compass-out/graph.json",
+      processes: { runJson }
+    };
+
+    const response = await runCallGraph(
+      session as never,
+      [
+        "--file", "src/lib.rs", "--byte", "120", "--line", "8",
+        "--direction", "both", "--depth", "1"
+      ],
+      signal
+    );
+
+    expect(response.rootSymbol).toBe("sha256:root");
+    expect(runJson.mock.calls[0]?.[1]).toEqual([
+      "call-graph",
+      "--file", "src/lib.rs", "--byte", "120", "--line", "8",
+      "--direction", "both", "--depth", "1",
+      "--max-nodes", "500",
+      "--max-edges", "1000",
+      "--graph", "/repo/compass-out/graph.json",
+      "--format", "json"
+    ]);
+    expect(runJson.mock.calls[0]?.[3]).toBe(signal);
+  });
+});

--- a/editors/vscode/src/views/callGraphClient.test.ts
+++ b/editors/vscode/src/views/callGraphClient.test.ts
@@ -1,5 +1,79 @@
 import { describe, expect, it, vi } from "vitest";
-import { runCallGraph } from "./callGraphClient";
+import { runCallGraph, runCallGraphAtCursor } from "./callGraphClient";
+
+const source = {
+  file: "crates/globset/src/glob.rs",
+  startByte: 4695,
+  endByte: 4802,
+  startLine: 147,
+  startColumn: 4,
+  endLine: 149,
+  endColumn: 5
+};
+const evidence = {
+  layer: "structural_graph",
+  origin: "ast",
+  extractor: "compass.languages.rust.universal",
+  confidence: "exact",
+  anchor: source,
+  rule: null,
+  wiringSite: null,
+  resolution: "exact"
+};
+const limits = {
+  maxDepth: 8,
+  maxNodes: 500,
+  maxEdges: 1000,
+  maxPaths: 100,
+  maxCandidates: 20,
+  maxSourceBytes: 1_048_576,
+  maxResponseBytes: 8_388_608
+};
+
+function queryResponse(operation: "callers" | "callees") {
+  const root = {
+    id: "sha256:method",
+    kind: "method",
+    roles: [],
+    name: ".is_match_candidate()",
+    qualifiedName: "globset::glob::GlobMatcher::is_match_candidate",
+    language: "rust",
+    framework: null,
+    source,
+    details: null,
+    evidence: [evidence]
+  };
+  const related = {
+    ...root,
+    id: operation === "callers" ? "sha256:caller" : "sha256:callee",
+    name: operation === "callers" ? ".is_match()" : "is_match",
+    qualifiedName: operation === "callers"
+      ? "globset::glob::GlobMatcher::is_match"
+      : "globset::pathutil::is_match"
+  };
+  const caller = operation === "callers" ? related : root;
+  const callee = operation === "callees" ? related : root;
+  return {
+    schema: "compass.query/1",
+    operation,
+    results: [],
+    nodes: [root, related],
+    edges: [{
+      id: `${caller.id}:${callee.id}`,
+      source: caller.id,
+      target: callee.id,
+      kind: "calls",
+      relationshipSite: source,
+      details: null,
+      evidence: [evidence]
+    }],
+    files: [],
+    paths: [],
+    diagnostics: [],
+    limits,
+    truncated: false
+  };
+}
 
 describe("callGraphClient", () => {
   it("returns the stable cursor root and forwards bounded graph arguments", async () => {
@@ -50,5 +124,88 @@ describe("callGraphClient", () => {
       "--format", "json"
     ]);
     expect(runJson.mock.calls[0]?.[3]).toBe(signal);
+  });
+
+  it("falls back to a typed cursor lookup for Compass 0.3.0 graphs", async () => {
+    const runJson = vi.fn()
+      .mockResolvedValueOnce({
+        schema: "compass.cql.result/1",
+        columns: [],
+        rows: [{
+          "n.id": { type: "string", value: "sha256:method" },
+          "n.kind": { type: "string", value: "method" },
+          "n.source": {
+            type: "map",
+            value: {
+              file: { type: "string", value: "crates/globset/src/glob.rs" },
+              startByte: { type: "integer", value: 4695 },
+              endByte: { type: "integer", value: 4802 },
+              startLine: { type: "integer", value: 147 },
+              startColumn: { type: "integer", value: 4 },
+              endLine: { type: "integer", value: 149 },
+              endColumn: { type: "integer", value: 5 }
+            }
+          }
+        }],
+        profile: null,
+        explain: null
+      })
+      .mockResolvedValueOnce(queryResponse("callers"))
+      .mockResolvedValueOnce(queryResponse("callees"));
+    const session = {
+      root: "/repo",
+      graphPath: "/repo/compass-out/graph.json",
+      processes: { runJson },
+      capabilities: { compass_version: "0.3.0" }
+    };
+
+    const response = await runCallGraphAtCursor(
+      session as never,
+      {
+        file: "crates/globset/src/glob.rs",
+        byte: 4707,
+        line: 147
+      },
+      "both",
+      1
+    );
+
+    expect(response.rootSymbol).toBe("sha256:method");
+    expect(response.nodes.map((node) => node.id)).toEqual([
+      "sha256:callee",
+      "sha256:caller",
+      "sha256:method"
+    ]);
+    expect(response.edges).toHaveLength(2);
+    expect(response.direction).toBe("both");
+    expect(response.coverage).toEqual(expect.objectContaining({
+      resolved: 2,
+      evidenceLayer: "structural_graph",
+      partial: true
+    }));
+    expect(runJson).toHaveBeenCalledTimes(3);
+    expect(runJson.mock.calls[0]?.[1]).toEqual([
+      "query",
+      "--cql",
+      expect.stringContaining("n.source.startByte <= 4707"),
+      "--param",
+      "file=crates/globset/src/glob.rs",
+      "--timeout-ms",
+      "5000",
+      "--max-rows",
+      "64",
+      "--graph",
+      "/repo/compass-out/graph.json",
+      "--format",
+      "json"
+    ]);
+    expect(runJson.mock.calls[1]?.[1]?.slice(0, 2)).toEqual([
+      "callers",
+      "sha256:method"
+    ]);
+    expect(runJson.mock.calls[2]?.[1]?.slice(0, 2)).toEqual([
+      "callees",
+      "sha256:method"
+    ]);
   });
 });

--- a/editors/vscode/src/views/callGraphClient.ts
+++ b/editors/vscode/src/views/callGraphClient.ts
@@ -1,9 +1,47 @@
 import {
   CallGraphResponseSchema,
+  type CallDirection,
   type CallGraphResponse
 } from "@compass/viewer/contracts/callGraph";
+import { z } from "zod";
+import { buildCqlArgs } from "../commands/queryArguments";
 import type { RepositorySession } from "../workspace/repositorySession";
-import { callGraphCommandArguments } from "./callGraphArguments";
+import { runCodeQuery } from "./codeQueryClient";
+import {
+  callGraphCommandArguments,
+  callGraphExpansionArguments,
+  callGraphRootArguments,
+  type CallGraphRoot
+} from "./callGraphArguments";
+import { codeQueryCallGraph } from "./codeQueryCallGraph";
+
+const CqlStringSchema = z.strictObject({
+  type: z.literal("string"),
+  value: z.string()
+});
+const CqlIntegerSchema = z.strictObject({
+  type: z.literal("integer"),
+  value: z.number().int().nonnegative()
+});
+const CursorQuerySchema = z.object({
+  schema: z.literal("compass.cql.result/1"),
+  rows: z.array(z.strictObject({
+    "n.id": CqlStringSchema,
+    "n.kind": CqlStringSchema,
+    "n.source": z.strictObject({
+      type: z.literal("map"),
+      value: z.strictObject({
+        file: CqlStringSchema,
+        startByte: CqlIntegerSchema,
+        endByte: CqlIntegerSchema,
+        startLine: CqlIntegerSchema,
+        startColumn: CqlIntegerSchema,
+        endLine: CqlIntegerSchema,
+        endColumn: CqlIntegerSchema
+      })
+    })
+  }))
+});
 
 export async function runCallGraph(
   session: RepositorySession,
@@ -15,5 +53,139 @@ export async function runCallGraph(
     callGraphCommandArguments(request, session.graphPath),
     CallGraphResponseSchema,
     signal
+  );
+}
+
+export async function runCallGraphAtCursor(
+  session: RepositorySession,
+  root: CallGraphRoot,
+  direction: CallDirection,
+  depth: number,
+  signal?: AbortSignal
+): Promise<CallGraphResponse> {
+  if (requiresTypedFallback(session)) {
+    const symbol = await resolveCursorSymbol(session, root, signal);
+    if (!symbol) throw missingCursorError(root);
+    return runTypedCallGraph(session, symbol, direction, signal);
+  }
+  try {
+    return await runCallGraph(
+      session,
+      callGraphRootArguments(root, direction, depth),
+      signal
+    );
+  } catch (error) {
+    if (!message(error).includes("no callable graph node matches")) throw error;
+    let symbol: string | undefined;
+    try {
+      symbol = await resolveCursorSymbol(session, root, signal);
+    } catch (fallbackError) {
+      throw new Error(
+        `${message(error)} Compatibility lookup failed: ${message(fallbackError)}`
+      );
+    }
+    if (!symbol) throw error;
+    return runCallGraphForSymbol(
+      session,
+      symbol,
+      direction,
+      depth,
+      signal
+    );
+  }
+}
+
+export async function runCallGraphForSymbol(
+  session: RepositorySession,
+  symbol: string,
+  direction: CallDirection,
+  depth: number,
+  signal?: AbortSignal
+): Promise<CallGraphResponse> {
+  if (requiresTypedFallback(session)) {
+    return runTypedCallGraph(session, symbol, direction, signal);
+  }
+  try {
+    return await runCallGraph(
+      session,
+      callGraphExpansionArguments(symbol, direction, depth),
+      signal
+    );
+  } catch (error) {
+    if (!message(error).includes("no callable graph node matches")) throw error;
+    return runTypedCallGraph(session, symbol, direction, signal);
+  }
+}
+
+async function runTypedCallGraph(
+  session: RepositorySession,
+  symbol: string,
+  direction: CallDirection,
+  signal?: AbortSignal
+): Promise<CallGraphResponse> {
+  const operations = direction === "both"
+    ? ["callers", "callees"] as const
+    : [direction] as const;
+  const responses = await Promise.all(operations.map((operation) =>
+    runCodeQuery(session, { operation, symbol }, signal)
+  ));
+  return codeQueryCallGraph(symbol, direction, responses);
+}
+
+async function resolveCursorSymbol(
+  session: RepositorySession,
+  root: CallGraphRoot,
+  signal?: AbortSignal
+): Promise<string | undefined> {
+  if (!Number.isSafeInteger(root.byte) || root.byte < 0) {
+    throw new Error("The cursor byte must be a non-negative safe integer.");
+  }
+  if (!Number.isSafeInteger(root.line) || root.line < 1) {
+    throw new Error("The cursor line must be a positive safe integer.");
+  }
+  const query = [
+    "MATCH (n)",
+    "WHERE n.source.file = $file",
+    `AND ((n.source.startByte <= ${root.byte} AND n.source.endByte >= ${root.byte})`,
+    `OR (n.source.startLine <= ${root.line} AND n.source.endLine >= ${root.line}))`,
+    "AND n.kind IN ['function', 'method', 'constructor', 'procedure', 'subroutine']",
+    "RETURN n.id, n.kind, n.source"
+  ].join(" ");
+  const result = await session.processes.runJson(
+    session.root,
+    buildCqlArgs({
+      query,
+      params: { file: root.file },
+      timeoutMs: 5000,
+      maxRows: 64,
+      graph: session.graphPath
+    }),
+    CursorQuerySchema,
+    signal
+  );
+  return result.rows
+    .filter((row) => row["n.source"].value.file.value === root.file)
+    .sort((left, right) => {
+      const leftSource = left["n.source"].value;
+      const rightSource = right["n.source"].value;
+      return (leftSource.endByte.value - leftSource.startByte.value)
+        - (rightSource.endByte.value - rightSource.startByte.value)
+        || (leftSource.endLine.value - leftSource.startLine.value)
+        - (rightSource.endLine.value - rightSource.startLine.value)
+        || left["n.id"].value.localeCompare(right["n.id"].value);
+    })[0]?.["n.id"].value;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requiresTypedFallback(session: RepositorySession): boolean {
+  return /^0\.3\.0(?:\D|$)/.test(session.capabilities?.compass_version ?? "");
+}
+
+function missingCursorError(root: CallGraphRoot): Error {
+  return new Error(
+    `error: no callable graph node matches ${root.file}:${root.byte} (line ${root.line})`
   );
 }

--- a/editors/vscode/src/views/callGraphClient.ts
+++ b/editors/vscode/src/views/callGraphClient.ts
@@ -1,0 +1,19 @@
+import {
+  CallGraphResponseSchema,
+  type CallGraphResponse
+} from "@compass/viewer/contracts/callGraph";
+import type { RepositorySession } from "../workspace/repositorySession";
+import { callGraphCommandArguments } from "./callGraphArguments";
+
+export async function runCallGraph(
+  session: RepositorySession,
+  request: readonly string[],
+  signal?: AbortSignal
+): Promise<CallGraphResponse> {
+  return session.processes.runJson(
+    session.root,
+    callGraphCommandArguments(request, session.graphPath),
+    CallGraphResponseSchema,
+    signal
+  );
+}

--- a/editors/vscode/src/views/callGraphContributions.test.ts
+++ b/editors/vscode/src/views/callGraphContributions.test.ts
@@ -18,26 +18,30 @@ const manifest = JSON.parse(
 };
 
 describe("call graph editor contributions", () => {
-  it("contributes one editor submenu with caller, callee, and combined actions", () => {
+  it("contributes one Compass editor submenu with cursor-aware graph actions", () => {
     expect(manifest.contributes.commands).toContainEqual(expect.objectContaining({
       command: "compass.openCallGraphGuide",
       title: "Compass: Call Graph Guide"
     }));
     expect(manifest.contributes.submenus).toContainEqual({
-      id: "compass.callGraph",
-      label: "Compass Call Graph"
+      id: "compass.codeGraph",
+      label: "Compass"
     });
-    expect(manifest.contributes.menus["editor/context"]).toContainEqual({
-      submenu: "compass.callGraph",
+    expect(manifest.contributes.menus["editor/context"]).toEqual([{
+      submenu: "compass.codeGraph",
       when: "resourceScheme == file",
       group: "navigation@90"
-    });
+    }]);
     expect(
-      manifest.contributes.menus["compass.callGraph"]?.map((item) => item.command)
+      manifest.contributes.menus["compass.codeGraph"]?.map((item) => item.command)
     ).toEqual([
       "compass.openCallers",
       "compass.openCallees",
-      "compass.openCallersAndCallees"
+      "compass.openCallersAndCallees",
+      "compass.showCodeImpact",
+      "compass.exploreCode",
+      "compass.showNodeTrail"
     ]);
+    expect(manifest.contributes.submenus).toHaveLength(1);
   });
 });

--- a/editors/vscode/src/views/callGraphPanel.ts
+++ b/editors/vscode/src/views/callGraphPanel.ts
@@ -1,14 +1,10 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import * as vscode from "vscode";
-import { CallGraphResponseSchema } from "@compass/viewer/contracts/callGraph";
 import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 import type { RepositorySession } from "../workspace/repositorySession";
-import {
-  callGraphCommandArguments,
-  callGraphExpansionArguments,
-  callGraphRootArguments
-} from "./callGraphArguments";
+import { callGraphExpansionArguments, callGraphRootArguments } from "./callGraphArguments";
+import { runCallGraph } from "./callGraphClient";
 import { utf8ByteAt } from "./cursorByte";
 import { openGraphSource } from "./sourceNavigation";
 
@@ -20,12 +16,15 @@ export class CallGraphPanel {
     output: vscode.OutputChannel,
     initialDirection: CallDirection = "both"
   ): Promise<void> {
-    const relative = path.relative(session.root, editor.document.uri.fsPath)
-      .split(path.sep)
-      .join("/");
-    if (relative.startsWith("../")) {
+    const relativePath = path.relative(session.root, editor.document.uri.fsPath);
+    if (
+      path.isAbsolute(relativePath)
+      || relativePath === ".."
+      || relativePath.startsWith(`..${path.sep}`)
+    ) {
       throw new Error("The active editor is outside the selected Compass repository.");
     }
+    const relative = relativePath.split(path.sep).join("/");
     const byte = utf8ByteAt(editor.document, editor.selection.active);
     const line = editor.selection.active.line + 1;
     const panel = vscode.window.createWebviewPanel(
@@ -91,13 +90,7 @@ export class CallGraphPanel {
       const abort = () => controller.abort();
       panelController.signal.addEventListener("abort", abort, { once: true });
       try {
-        const graphArgs = callGraphCommandArguments(rootArgs, session.graphPath);
-        const graph = await session.processes.runJson(
-          session.root,
-          graphArgs,
-          CallGraphResponseSchema,
-          controller.signal
-        );
+        const graph = await runCallGraph(session, rootArgs, controller.signal);
         if (generation !== rootGeneration || controller.signal.aborted) return;
         await panel.webview.postMessage({
           type,

--- a/editors/vscode/src/views/callGraphPanel.ts
+++ b/editors/vscode/src/views/callGraphPanel.ts
@@ -3,8 +3,7 @@ import path from "node:path";
 import * as vscode from "vscode";
 import type { CallDirection } from "@compass/viewer/contracts/callGraph";
 import type { RepositorySession } from "../workspace/repositorySession";
-import { callGraphExpansionArguments, callGraphRootArguments } from "./callGraphArguments";
-import { runCallGraph } from "./callGraphClient";
+import { runCallGraphAtCursor, runCallGraphForSymbol } from "./callGraphClient";
 import { utf8ByteAt } from "./cursorByte";
 import { openGraphSource } from "./sourceNavigation";
 
@@ -50,7 +49,7 @@ export class CallGraphPanel {
       if (message?.type === "ready" || message?.type === "retry") {
         rootGeneration += 1;
         await send(
-          callGraphRootArguments({ file: relative, byte, line }, direction, 2),
+          { kind: "cursor", direction, depth: 2 },
           "hydrateCallGraph",
           rootGeneration
         );
@@ -59,7 +58,7 @@ export class CallGraphPanel {
         direction = message.direction;
         rootGeneration += 1;
         await send(
-          callGraphRootArguments({ file: relative, byte, line }, direction, 2),
+          { kind: "cursor", direction, depth: 2 },
           "hydrateCallGraph",
           rootGeneration
         );
@@ -67,10 +66,15 @@ export class CallGraphPanel {
         output.show(true);
       } else if (message?.type === "expand"
         && typeof message.symbol === "string"
-        && ["callers", "callees", "both"].includes(message.direction)
+        && isDirection(message.direction)
         && Number.isInteger(message.depth)) {
         await send(
-          callGraphExpansionArguments(message.symbol, message.direction, message.depth),
+          {
+            kind: "symbol",
+            symbol: message.symbol,
+            direction: message.direction,
+            depth: message.depth
+          },
           "mergeCallGraph",
           rootGeneration
         );
@@ -80,7 +84,16 @@ export class CallGraphPanel {
     });
 
     async function send(
-      rootArgs: string[],
+      request: {
+        kind: "cursor";
+        direction: CallDirection;
+        depth: number;
+      } | {
+        kind: "symbol";
+        symbol: string;
+        direction: CallDirection;
+        depth: number;
+      },
       type: "hydrateCallGraph" | "mergeCallGraph",
       generation: number
     ): Promise<void> {
@@ -90,7 +103,21 @@ export class CallGraphPanel {
       const abort = () => controller.abort();
       panelController.signal.addEventListener("abort", abort, { once: true });
       try {
-        const graph = await runCallGraph(session, rootArgs, controller.signal);
+        const graph = request.kind === "cursor"
+          ? await runCallGraphAtCursor(
+            session,
+            { file: relative, byte, line },
+            request.direction,
+            request.depth,
+            controller.signal
+          )
+          : await runCallGraphForSymbol(
+            session,
+            request.symbol,
+            request.direction,
+            request.depth,
+            controller.signal
+          );
         if (generation !== rootGeneration || controller.signal.aborted) return;
         await panel.webview.postMessage({
           type,

--- a/editors/vscode/src/views/codeQueryCallGraph.ts
+++ b/editors/vscode/src/views/codeQueryCallGraph.ts
@@ -1,0 +1,129 @@
+import {
+  CallGraphResponseSchema,
+  type CallDirection,
+  type CallEdge,
+  type CallGraphResponse,
+  type CallNode
+} from "@compass/viewer/contracts/callGraph";
+import type {
+  CodeEvidenceRecord,
+  CodeQueryEdge,
+  CodeQueryResponse
+} from "@compass/viewer/contracts/codeQuery";
+
+export function codeQueryCallGraph(
+  rootSymbol: string,
+  direction: CallDirection,
+  responses: readonly CodeQueryResponse[]
+): CallGraphResponse {
+  const queryNodes = new Map(
+    responses.flatMap((response) => response.nodes).map((node) => [node.id, node])
+  );
+  const queryEdges = new Map(
+    responses
+      .flatMap((response) => response.edges)
+      .filter((edge) => edge.kind === "calls")
+      .map((edge) => [edge.id, edge])
+  );
+  const nodes = [...queryNodes.values()].map((node): CallNode => ({
+    id: node.id,
+    symbol: node.id,
+    name: node.name,
+    file: node.source?.file ?? null,
+    startLine: node.source?.startLine ?? null,
+    endLine: node.source?.endLine ?? null,
+    startByte: node.source?.startByte ?? null,
+    endByte: node.source?.endByte ?? null,
+    graphNodeId: node.id,
+    unresolved: false,
+    evidenceLayer: evidenceLayer(node.evidence)
+  })).sort((left, right) => left.id.localeCompare(right.id));
+  const edges = [...queryEdges.values()].map((edge) => callEdge(edge, queryNodes))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const limitations = [
+    "typed_query_fallback",
+    ...responses.flatMap((response) => response.diagnostics.map((item) => item.code))
+  ].filter((value, index, values) => values.indexOf(value) === index).sort();
+  const response = {
+    schema: "compass.call_graph/1" as const,
+    rootSymbol,
+    direction,
+    depth: 1,
+    nodes,
+    edges,
+    truncated: responses.some((item) => item.truncated),
+    continuations: continuations(rootSymbol, responses),
+    coverage: {
+      resolved: edges.filter((edge) => edge.resolution === "resolved").length,
+      inferred: edges.filter((edge) => edge.resolution === "inferred").length,
+      ambiguous: edges.filter((edge) => edge.resolution === "ambiguous").length,
+      unresolved: edges.filter((edge) => edge.resolution === "unresolved").length,
+      evidenceLayer: evidenceLayer(responses.flatMap((item) => [
+        ...item.nodes.flatMap((node) => node.evidence),
+        ...item.edges.flatMap((edge) => edge.evidence)
+      ])),
+      partial: true,
+      limitations,
+      warning: "Showing typed call relationships because source-position call graph lookup is unavailable in the selected Compass CLI."
+    }
+  };
+  return CallGraphResponseSchema.parse(response);
+}
+
+function callEdge(
+  edge: CodeQueryEdge,
+  nodes: Map<string, CodeQueryResponse["nodes"][number]>
+): CallEdge {
+  const resolution = callResolution(edge.evidence);
+  const site = edge.relationshipSite;
+  return {
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    callee: nodes.get(edge.target)?.name ?? edge.target,
+    resolution,
+    confidence: resolution === "resolved" ? "EXTRACTED" : resolution.toUpperCase(),
+    callSites: site ? [{
+      sourceFile: site.file,
+      line: site.startLine,
+      startByte: site.startByte,
+      endByte: site.endByte,
+      evidence: [...new Set(edge.evidence.map((item) => item.rule ?? item.extractor))].sort()
+    }] : [],
+    evidenceLayer: evidenceLayer(edge.evidence)
+  };
+}
+
+function callResolution(evidence: readonly CodeEvidenceRecord[]): CallEdge["resolution"] {
+  if (evidence.some((item) => item.resolution === "unresolved")) return "unresolved";
+  if (evidence.some((item) => item.resolution === "ambiguous"
+    || item.confidence === "ambiguous")) return "ambiguous";
+  if (evidence.some((item) => item.confidence === "inferred")) return "inferred";
+  return "resolved";
+}
+
+function evidenceLayer(
+  evidence: readonly CodeEvidenceRecord[]
+): "structural_graph" | "program_ir" | "combined" {
+  const structural = evidence.some((item) => item.layer === "structural_graph");
+  const program = evidence.some((item) => item.layer === "program_ir");
+  return structural && program ? "combined" : program ? "program_ir" : "structural_graph";
+}
+
+function continuations(
+  rootSymbol: string,
+  responses: readonly CodeQueryResponse[]
+): CallGraphResponse["continuations"] {
+  const values = responses.flatMap((response) => response.nodes
+    .filter((node) => node.id !== rootSymbol)
+    .map((node) => ({
+      symbol: node.id,
+      direction: response.operation === "callers" ? "callers" as const : "callees" as const,
+      nextDepth: 2
+    })));
+  return [...new Map(values.map((item) => [
+    `${item.symbol}:${item.direction}`,
+    item
+  ])).values()].sort((left, right) => left.symbol.localeCompare(right.symbol)
+    || left.direction.localeCompare(right.direction));
+}

--- a/editors/vscode/src/views/codeQueryGraph.test.ts
+++ b/editors/vscode/src/views/codeQueryGraph.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { CodeQueryResponse } from "@compass/viewer/contracts/codeQuery";
+import { codeQueryGraphViewModel } from "./codeQueryGraph";
+
+const anchor = {
+  file: "src/lib.rs",
+  startByte: 10,
+  endByte: 30,
+  startLine: 2,
+  startColumn: 0,
+  endLine: 4,
+  endColumn: 1
+};
+const evidence = {
+  layer: "structural_graph" as const,
+  origin: "ast" as const,
+  extractor: "compass.languages.rust.universal",
+  confidence: "exact" as const,
+  anchor,
+  rule: null,
+  wiringSite: null,
+  resolution: "exact" as const,
+  candidates: []
+};
+const result: CodeQueryResponse = {
+  schema: "compass.query/1",
+  operation: "callers",
+  results: [],
+  nodes: [
+    {
+      id: "caller",
+      kind: "function",
+      roles: [],
+      name: "caller",
+      qualifiedName: "example::caller",
+      language: "rust",
+      framework: null,
+      source: anchor,
+      details: { type: "symbol", data: { signature: "fn caller()", modifiers: [] } },
+      evidence: [evidence]
+    },
+    {
+      id: "root",
+      kind: "function",
+      roles: [],
+      name: "root",
+      qualifiedName: "example::root",
+      language: "rust",
+      framework: null,
+      source: { ...anchor, startByte: 40, endByte: 70, startLine: 6, endLine: 9 },
+      details: { type: "symbol", data: { signature: "fn root()", modifiers: [] } },
+      evidence: [evidence]
+    }
+  ],
+  edges: [{
+    id: "caller-root",
+    source: "caller",
+    target: "root",
+    kind: "calls",
+    relationshipSite: anchor,
+    details: { type: "call", data: { dispatch: "static" } },
+    evidence: [evidence]
+  }],
+  files: [],
+  paths: [],
+  diagnostics: [],
+  limits: {
+    maxDepth: 8,
+    maxNodes: 500,
+    maxEdges: 1000,
+    maxPaths: 100,
+    maxCandidates: 20,
+    maxSourceBytes: 1_048_576,
+    maxResponseBytes: 8_388_608
+  },
+  truncated: false
+};
+
+describe("focused code query graph", () => {
+  it("renders only returned query nodes and relationships", () => {
+    const model = codeQueryGraphViewModel(result, "Callers of example::root");
+
+    expect(model.title).toBe("Callers of example::root");
+    expect(model.stats).toEqual({
+      nodes: 2,
+      edges: 1,
+      communities: 1,
+      aggregated: false
+    });
+    expect(model.nodes.map((node) => node.id)).toEqual(["caller", "root"]);
+    expect(model.nodes[0]).toEqual(expect.objectContaining({
+      label: "caller",
+      kind: "function",
+      language: "rust",
+      signature: "fn caller()",
+      degree: 1,
+      source: anchor,
+      codeEvidence: [evidence]
+    }));
+    expect(model.edges).toEqual([expect.objectContaining({
+      id: "caller-root",
+      source: "caller",
+      target: "root",
+      relation: "calls",
+      confidence: "extracted",
+      relationshipSite: anchor,
+      codeEvidence: [evidence]
+    })]);
+  });
+
+  it("keeps an empty query result focused instead of substituting the overview", () => {
+    const model = codeQueryGraphViewModel(
+      { ...result, nodes: [], edges: [], diagnostics: [{
+        code: "no_match",
+        message: "No symbol matched root",
+        nodeId: null,
+        path: null
+      }] },
+      "Callers"
+    );
+
+    expect(model.nodes).toEqual([]);
+    expect(model.edges).toEqual([]);
+    expect(model.stats.communities).toBe(0);
+  });
+});

--- a/editors/vscode/src/views/codeQueryGraph.ts
+++ b/editors/vscode/src/views/codeQueryGraph.ts
@@ -1,0 +1,84 @@
+import type {
+  CodeQueryEdge,
+  CodeQueryNode,
+  CodeQueryResponse
+} from "@compass/viewer/contracts/codeQuery";
+import type {
+  GraphEdge,
+  GraphNode,
+  GraphViewModel
+} from "@compass/viewer/contracts/graph";
+
+const QUERY_COMMUNITY = 0;
+
+export function codeQueryGraphViewModel(
+  result: CodeQueryResponse,
+  title: string
+): GraphViewModel {
+  const nodeIds = new Set(result.nodes.map((node) => node.id));
+  const edges = result.edges
+    .filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
+    .map(graphEdge);
+  const degrees = new Map<string, number>();
+  for (const edge of edges) {
+    degrees.set(edge.source, (degrees.get(edge.source) ?? 0) + 1);
+    degrees.set(edge.target, (degrees.get(edge.target) ?? 0) + 1);
+  }
+  const nodes = result.nodes.map((node) => graphNode(node, degrees.get(node.id) ?? 0));
+  return {
+    schema: "compass.viewer.graph/1",
+    title,
+    stats: {
+      nodes: nodes.length,
+      edges: edges.length,
+      communities: nodes.length > 0 ? 1 : 0,
+      aggregated: false
+    },
+    nodes,
+    edges,
+    communities: nodes.length > 0
+      ? [{ id: QUERY_COMMUNITY, label: "Query result", color: "#6f7bf7", hidden: false }]
+      : [],
+    hyperedges: []
+  };
+}
+
+function graphNode(node: CodeQueryNode, degree: number): GraphNode {
+  const signature = node.details?.type === "symbol"
+    ? node.details.data.signature ?? undefined
+    : undefined;
+  return {
+    id: node.id,
+    label: node.name,
+    kind: node.kind,
+    community: QUERY_COMMUNITY,
+    communityName: "Query result",
+    degree,
+    ...(node.language ? { language: node.language } : {}),
+    ...(signature ? { signature } : {}),
+    ...(node.source ? { source: node.source } : {}),
+    codeEvidence: node.evidence
+  };
+}
+
+function graphEdge(edge: CodeQueryEdge): GraphEdge {
+  const edgeConfidence = confidence(edge);
+  return {
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    relation: edge.kind,
+    ...(edge.relationshipSite ? { relationshipSite: edge.relationshipSite } : {}),
+    ...(edge.details ? { details: edge.details } : {}),
+    ...(edgeConfidence ? { confidence: edgeConfidence } : {}),
+    codeEvidence: edge.evidence
+  };
+}
+
+function confidence(
+  edge: CodeQueryEdge
+): GraphEdge["confidence"] {
+  if (edge.evidence.some((item) => item.confidence === "ambiguous")) return "ambiguous";
+  if (edge.evidence.some((item) => item.confidence === "inferred")) return "inferred";
+  return edge.evidence.length > 0 ? "extracted" : undefined;
+}

--- a/editors/vscode/src/views/graphPanel.ts
+++ b/editors/vscode/src/views/graphPanel.ts
@@ -19,6 +19,7 @@ import { CurrentGraphSnapshot } from "./graphSnapshot";
 import { openGraphSource } from "./sourceNavigation";
 import { graphStaticLoadingMarkup } from "../webviews/graphLoadingMarkup";
 import { codeQueryRequiresRebuild, runCodeQuery } from "./codeQueryClient";
+import { codeQueryGraphViewModel } from "./codeQueryGraph";
 
 const LARGE_GRAPH_BYTES = 8 * 1024 * 1024;
 
@@ -27,11 +28,14 @@ export class GraphPanel {
     context: vscode.ExtensionContext,
     session: RepositorySession,
     output: vscode.OutputChannel,
-    queryResult?: CodeQueryResponse
+    queryResult?: CodeQueryResponse,
+    queryTitle?: string
   ): Promise<GraphPanel> {
     const panel = vscode.window.createWebviewPanel(
       "compass.graph",
-      `Compass Graph — ${vscode.workspace.asRelativePath(session.root)}`,
+      queryTitle
+        ? `${queryTitle} — ${vscode.workspace.asRelativePath(session.root)}`
+        : `Compass Graph — ${vscode.workspace.asRelativePath(session.root)}`,
       vscode.ViewColumn.Active,
       {
         enableScripts: true,
@@ -39,7 +43,14 @@ export class GraphPanel {
         localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist")]
       }
     );
-    const graph = new GraphPanel(context, session, panel, output, queryResult);
+    const graph = new GraphPanel(
+      context,
+      session,
+      panel,
+      output,
+      queryResult,
+      queryTitle
+    );
     await graph.initialize();
     return graph;
   }
@@ -56,7 +67,8 @@ export class GraphPanel {
     private readonly session: RepositorySession,
     private readonly panel: vscode.WebviewPanel,
     private readonly output: vscode.OutputChannel,
-    queryResult?: CodeQueryResponse
+    queryResult?: CodeQueryResponse,
+    private queryTitle?: string
   ) {
     this.queryResult = queryResult;
   }
@@ -106,6 +118,12 @@ export class GraphPanel {
 
   private async hydrate(): Promise<void> {
     try {
+      if (this.queryResult && this.queryTitle) {
+        await this.publishOverview(
+          codeQueryGraphViewModel(this.queryResult, this.queryTitle)
+        );
+        return;
+      }
       const nodeLimit = vscode.workspace
         .getConfiguration("compass")
         .get("graphNodeLimit", 5000);
@@ -222,7 +240,7 @@ export class GraphPanel {
   }
 
   private async publishOverview(model: GraphViewModel): Promise<void> {
-    this.overview = this.withRepositoryTitle(model);
+    this.overview = this.queryTitle ? model : this.withRepositoryTitle(model);
     this.communityCache.clear();
     await this.panel.webview.postMessage({
       type: "hydrateGraph",
@@ -251,7 +269,13 @@ export class GraphPanel {
         this.controller.signal
       );
       this.queryResult = result;
-      await this.publishQueryResult(result);
+      if (this.queryTitle) {
+        this.queryTitle = queryResultTitle(operation, symbol);
+        this.panel.title = `${this.queryTitle} — ${vscode.workspace.asRelativePath(this.session.root)}`;
+        await this.publishOverview(codeQueryGraphViewModel(result, this.queryTitle));
+      } else {
+        await this.publishQueryResult(result);
+      }
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       this.output.appendLine(`[code-query] ${detail}`);
@@ -325,4 +349,14 @@ export class GraphPanel {
 </body>
 </html>`;
   }
+}
+
+function queryResultTitle(
+  operation: "callers" | "callees" | "impact",
+  symbol: string
+): string {
+  const label = operation === "callers"
+    ? "Callers"
+    : operation === "callees" ? "Callees" : "Impact";
+  return `Compass ${label} — ${symbol}`;
 }

--- a/editors/vscode/src/webviews/callGraphGuide.tsx
+++ b/editors/vscode/src/webviews/callGraphGuide.tsx
@@ -93,7 +93,7 @@ function CallGraphGuide() {
             <h2 id="call-guide-how">Three moves from code to context</h2>
           </div>
           <span className="call-guide-shortcut">
-            Right-click <ArrowRightIcon aria-hidden="true" /> Compass Call Graph
+            Right-click <ArrowRightIcon aria-hidden="true" /> Compass
           </span>
         </div>
 
@@ -109,7 +109,7 @@ function CallGraphGuide() {
           <li className="call-guide-step-menu">
             <span className="call-guide-step-number">02</span>
             <div>
-              <h3>Open Compass Call Graph</h3>
+              <h3>Open Compass</h3>
               <p>Right-click in the editor and open the Compass submenu.</p>
             </div>
             <ContextMenuPreview />
@@ -238,11 +238,11 @@ function ContextMenuPreview() {
     <div
       className="call-guide-menu-preview"
       role="img"
-      aria-label="Compass Call Graph editor context menu with callers, callees, and both"
+      aria-label="Compass editor context menu with callers, callees, and both"
     >
       <div className="call-guide-menu-parent">
         <NetworkIcon aria-hidden="true" />
-        <span>Compass Call Graph</span>
+        <span>Compass</span>
         <ChevronRightIcon aria-hidden="true" />
       </div>
       <div className="call-guide-submenu">


### PR DESCRIPTION
## What changed

- consolidate the duplicate VS Code editor context submenus into one **Compass** menu
- make callers, callees, impact, related-symbol, and node-trail actions resolve the symbol under the active cursor
- render typed query responses as focused graphs instead of reopening the full repository graph
- project `compass.graph/1` node and relationship byte anchors into universal call-graph resolution
- keep the rebuilt VSIX compatible with stable Compass 0.3.0 by resolving typed cursor anchors with bounded CompassQL and adapting `callers`/`callees` query responses into the call-graph panel contract
- require Compass CLI 0.3.0 or newer; older releases and 0.3.0 prereleases are explicitly labeled unsupported and rejected before workflows activate
- add regression coverage and update compatibility, migration, and VS Code documentation

## Root cause

The VS Code extension exposed overlapping legacy call-graph and typed-query menus. Typed actions prompted for graph IDs because they did not resolve the cursor first, while `GraphPanel` always hydrated the repository overview even when a focused query response was available.

Universal call-graph conversion also ignored the typed graph's nested byte anchors, so cursor lookup could fail even when the callable contained the cursor. The VSIX uses an external Compass CLI, however, so fixing that Rust projection alone did not repair users running the released 0.3.0 binary. In 0.3.0, `call-graph` rejects both the valid source position and the valid stable symbol ID because typed nodes are filtered before root selection. The typed `callers` and `callees` commands correctly return those relationships.

Compatibility previously depended only on individual capability flags and versioned contracts, allowing much older CLIs to appear selectable and encouraging command-specific fallbacks. A centralized semantic-version gate now establishes 0.3.0 as the minimum supported CLI.

## User impact

Editor context actions now start from the code under the cursor, return only the requested neighborhood or path, and share a single predictable menu. Caller/callee views work with stable Compass 0.3.0; users do not need an unreleased CLI binary. Direction changes and graph expansion use the same compatibility path.

Compass releases below 0.3.0 and 0.3.0 prereleases are no longer supported. Detected old installations are labeled unsupported, manual/selected old installations are rejected, runtime activation remains unchanged on rejection, and an automatically detected old CLI puts the Workspace view into an incompatible state. Existing command IDs remain registered for compatibility.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test call_graph_cli --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `npm run typecheck:js`
- `npm run test:js` (125 viewer, 113 extension, and 72 browser tests)
- `npm run build -w editors/vscode`
- `node scripts/check_viewer_assets.mjs`
- `npm run package -w editors/vscode`
- `npm run smoke:vsix -w editors/vscode`
- verified the patched CLI resolves `crates/printer/src/standard.rs:2000` against the existing ripgrep graph built with Compass 0.3.0 (78 nodes, 86 edges); the released 0.3.0 CLI reproduces the source-position failure
- ran the actual extension client through `/Users/haipingfu/.cargo/bin/compass` 0.3.0 against the active ripgrep generation at `crates/globset/src/glob.rs:4707` (line 147); it resolved `sha256:f08ee742cca796e63e58e04ae7ac6dbd8401899dc502d2c38fd47a72b56de8ab` and returned both directions with at least 3 nodes and 2 edges

## Check not completed

The VS Code extension-host runner did not reach the test suite in this environment: the downloaded macOS test application exposed an unexpected executable layout, and the compatibility retry was terminated before test execution. The extension unit suites, real-process client check, browser tests, production build, VSIX packaging, and VSIX archive smoke test all passed.
