### PR TITLE
fix: harden Compass Store for large graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "compass-model",
  "compass-store",
  "rayon",
+ "rmp-serde",
  "serde",
  "serde_json",
  "sha1",

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -51,20 +51,52 @@ binary, 2026-08-02) was:
 
 | Adapter | Nodes | Process seconds | Peak RSS KiB | Graph bytes | Database bytes | Write amplification | Build requests (get/put) | Query requests (get/scan) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| SQLite | 32 | 0.438 | 12,240 | 33,833 | 274,432 | 8.11× | 24 / 12 | 10 / 0 |
-| SQLite | 128 | 0.161 | 24,928 | 135,361 | 1,003,520 | 7.41× | 42 / 21 | 14 / 0 |
-| SQLite | 512 | 0.521 | 46,976 | 542,017 | 3,956,736 | 7.30× | 114 / 57 | 28 / 0 |
-| redb (library) | 32 | 0.125 | 12,416 | 33,833 | 598,016 | 17.68× | 24 / 12 | 10 / 0 |
-| redb (library) | 128 | 0.243 | 24,832 | 135,361 | 1,585,152 | 11.71× | 42 / 21 | 14 / 0 |
-| redb (library) | 512 | 0.695 | 51,840 | 542,017 | 6,328,320 | 11.68× | 114 / 57 | 28 / 0 |
+| SQLite | 32 | 0.688 | 11,520 | 33,833 | 110,592 | 3.27× | 24 / 12 | 10 / 0 |
+| SQLite | 128 | 0.127 | 22,368 | 135,361 | 348,160 | 2.57× | 38 / 19 | 10 / 0 |
+| SQLite | 512 | 0.379 | 45,840 | 542,017 | 1,347,584 | 2.49× | 112 / 56 | 26 / 0 |
+| redb (library) | 32 | 0.118 | 11,904 | 33,833 | 561,152 | 16.59× | 24 / 12 | 10 / 0 |
+| redb (library) | 128 | 0.214 | 22,512 | 135,361 | 593,920 | 4.39× | 38 / 19 | 10 / 0 |
+| redb (library) | 512 | 0.531 | 46,880 | 542,017 | 2,379,776 | 4.39× | 112 / 56 | 26 / 0 |
 
-The same sample project measured CLI process times of 5.583 s (clean
-`init`), 0.092 s (unchanged update), 0.123 s (small source change), 0.034 s
-(cold JSON search), and 0.025 s (cold store search), with peak RSS of 30,896,
-24,288, 27,344, 14,192, and 14,800 KiB respectively. These are reproducible
+The same sample project measured CLI process times of 6.215 s (clean
+`init`), 0.090 s (unchanged update), 0.098 s (small source change), 0.025 s
+(cold JSON search), and 0.028 s (cold store search), with peak RSS of 31,536,
+24,496, 27,840, 14,320, and 15,072 KiB respectively. These are reproducible
 diagnostic observations, not a claim that every repository or backend is
 faster. The release gate remains correctness plus the existing 10% regression
 policy; a performance cutover requires a comparable approved JSON baseline.
+
+### Django store audit
+
+A real-repository audit on Django commit
+`957d0cee7167757ae221ffde59d2cf0a322e89c7` used 7,074 detected files and
+published a 292,582,885-byte graph with 82,654 nodes and 187,913 edges. The
+canonical graph SHA-256 was
+`30897dc82a8452512b8d4be6149beeae6d0929bbb09966a8abf838b70a436595`.
+
+The initial JSON tree encoding could not publish this graph because a valid
+qualified name exceeded the portable key limit. After bounded hashed name
+keys, a graph-scale item limit, and compact MessagePack tree objects were
+added, the SQLite sidecar was 1,051,348,992 bytes (3.59× graph bytes), down
+from 2,672,005,120 bytes with JSON tree objects. The compact reader also
+successfully validated the older JSON-object store.
+
+On the same output and release binary, cold typed search returned
+byte-identical 740,534-byte JSON from both engines. Store search measured
+17.371 s and 2,292,272 KiB peak RSS; JSON search measured 19.476 s and
+1,758,864 KiB. Store startup was 10.8% faster but used 30.3% more peak memory.
+`compass store status` completed in 7.837 s with 2,755,360 KiB peak RSS.
+
+Fresh publication remains outside the default-cutover budget: the compact
+store build completed in 206.357 s with 4,221,296 KiB peak RSS, versus the
+JSON-only control at 15.357 s and 3,628,336 KiB. Two unchanged store updates
+measured 4.300 and 4.561 s versus the JSON-only control at 1.833 s. The
+current store engine reconstructs the complete graph before query execution,
+and SQLite publishes immutable tree objects as individual durable writes.
+Direct projection execution, batched durable publication, and bounded
+generation retention remain required before claiming that Compass Store
+improves build performance or before treating it as an unconditional
+large-repository default.
 
 ## CompassQL qualification
 

--- a/crates/compass-cli/src/store_commands.rs
+++ b/crates/compass-cli/src/store_commands.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use compass_files::BuildGuard;
 use compass_graph::{GraphSnapshotReader, canonical_graph_json};
 use compass_model::code_graph::GraphDocument;
 use compass_store::{STORE_FILE_NAME, STORE_REF_FILE_NAME, STORE_SCHEMA_V1, SqliteStore, StoreRef};
@@ -50,7 +51,7 @@ pub(crate) fn command(args: &[String]) -> Outcome {
 }
 
 fn status(args: &[String]) -> Result<Value, String> {
-    let output = output_root(args);
+    let output = output_root(args)?;
     let graph_path = output.join("graph.json");
     let store_path = output.join(STORE_FILE_NAME);
     let reference_path = output.join(STORE_REF_FILE_NAME);
@@ -127,7 +128,7 @@ fn status(args: &[String]) -> Result<Value, String> {
 }
 
 fn validate(args: &[String]) -> Result<Value, String> {
-    let output = output_root(args);
+    let output = output_root(args)?;
     let graph_path = output.join("graph.json");
     let store_path = output.join(STORE_FILE_NAME);
     if !store_path.is_file() {
@@ -175,7 +176,7 @@ fn validate(args: &[String]) -> Result<Value, String> {
 }
 
 fn backup(args: &[String]) -> Result<Value, String> {
-    let output = output_root(args);
+    let output = output_root(args)?;
     let destination = option(args, "--output")
         .map(PathBuf::from)
         .ok_or_else(|| "store backup requires --output DIR".to_owned())?;
@@ -379,21 +380,25 @@ fn graph_bytes_from_status(graph: &Value, bytes: &[u8]) -> Result<Vec<u8>, Strin
     canonical_graph_json(&document).map_err(|error| error.to_string())
 }
 
-fn output_root(args: &[String]) -> PathBuf {
+fn output_root(args: &[String]) -> Result<PathBuf, String> {
     let candidate = positional(args)
         .first()
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("compass-out"));
     if candidate.file_name().and_then(|name| name.to_str()) == Some("graph.json") {
-        return candidate.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let graph = BuildGuard::resolve_requested_artifact(&candidate)
+            .map_err(|error| error.to_string())?;
+        return Ok(graph.parent().unwrap_or(Path::new(".")).to_path_buf());
     }
     if candidate.join("graph.json").is_file() || candidate.join(STORE_FILE_NAME).is_file() {
-        return candidate;
+        return Ok(candidate);
     }
-    if candidate.join("compass-out").is_dir() {
-        return candidate.join("compass-out");
-    }
-    candidate
+    let output_container = if candidate.join("compass-out").is_dir() {
+        candidate.join("compass-out")
+    } else {
+        candidate
+    };
+    BuildGuard::resolve_active_directory(&output_container).map_err(|error| error.to_string())
 }
 
 fn positional(args: &[String]) -> Vec<String> {

--- a/crates/compass-cli/tests/store_cli.rs
+++ b/crates/compass-cli/tests/store_cli.rs
@@ -24,7 +24,7 @@ fn store_status_backup_and_restore_are_end_to_end_validated() -> Result<(), Box<
         String::from_utf8_lossy(&init.stderr)
     );
 
-    let output = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
+    let output = root.path().join("compass-out");
     let status = Command::new(env!("CARGO_BIN_EXE_compass"))
         .args([
             "store",
@@ -94,8 +94,9 @@ fn store_status_backup_and_restore_are_end_to_end_validated() -> Result<(), Box<
     assert!(restored_validation.status.success());
     let restored_json: Value = serde_json::from_slice(&restored_validation.stdout)?;
     assert_eq!(restored_json["valid"], true);
+    let active_output = BuildGuard::resolve_active_directory(&output)?;
     assert_eq!(
-        fs::read(output.join("graph.json"))?,
+        fs::read(active_output.join("graph.json"))?,
         fs::read(restored.join("graph.json"))?
     );
     Ok(())
@@ -112,13 +113,14 @@ fn store_validate_rejects_a_corrupt_sidecar_without_touching_graph_json()
         .env_remove("COMPASS_OUT")
         .output()?;
     assert!(init.status.success());
-    let output = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
-    let graph = fs::read(output.join("graph.json"))?;
-    fs::write(output.join("compass-store.sqlite3"), b"corrupt")?;
+    let output = root.path().join("compass-out");
+    let active_output = BuildGuard::resolve_active_directory(&output)?;
+    let graph = fs::read(active_output.join("graph.json"))?;
+    fs::write(active_output.join("compass-store.sqlite3"), b"corrupt")?;
     let result = Command::new(env!("CARGO_BIN_EXE_compass"))
         .args(["store", "validate", output.to_str().ok_or("output path")?])
         .output()?;
     assert!(!result.status.success());
-    assert_eq!(fs::read(output.join("graph.json"))?, graph);
+    assert_eq!(fs::read(active_output.join("graph.json"))?, graph);
     Ok(())
 }

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -584,7 +584,8 @@ fn build_graph_inner(
                 remove_if_exists(&output_dir.join(GRAPH_OVERVIEW_FILE))?;
             }
             remove_if_exists(&output_dir.join("needs_update"))?;
-            let published_output_dir = commit_generation(guard, &output_container)?;
+            let store_ready = store_artifact_complete(&output_dir);
+            let published_output_dir = commit_generation(guard, &output_container, store_ready)?;
             return Ok((
                 BuildResult {
                     root,
@@ -658,7 +659,7 @@ fn build_graph_inner(
             stats.omissions(),
             unchanged_program.as_ref(),
         )?;
-        let published_output_dir = commit_generation(guard, &output_container)?;
+        let published_output_dir = commit_generation(guard, &output_container, true)?;
         return Ok((
             BuildResult {
                 root,
@@ -1172,7 +1173,7 @@ fn build_graph_inner(
             omissions,
             program.as_ref(),
         )?;
-        let published_output_dir = commit_generation(guard, &output_container)?;
+        let published_output_dir = commit_generation(guard, &output_container, true)?;
         return Ok((
             BuildResult {
                 root,
@@ -1280,7 +1281,7 @@ fn build_graph_inner(
             omissions,
             program.as_ref(),
         )?;
-        let published_output_dir = commit_generation(guard, &output_container)?;
+        let published_output_dir = commit_generation(guard, &output_container, true)?;
         timings.publish = stage_started.elapsed();
         return Ok((
             BuildResult {
@@ -1392,7 +1393,7 @@ fn build_graph_inner(
                 PublicationOmissions::default(),
                 program.as_ref(),
             )?;
-            let published_output_dir = commit_generation(guard, &output_container)?;
+            let published_output_dir = commit_generation(guard, &output_container, true)?;
             return Ok((
                 BuildResult {
                     root,
@@ -1700,7 +1701,7 @@ fn build_graph_inner(
         program.as_ref(),
     )?;
     profile_internal("Program output and build seals", &mut internal_started);
-    let published_output_dir = commit_generation(guard, &output_container)?;
+    let published_output_dir = commit_generation(guard, &output_container, true)?;
     let result = BuildResult {
         root,
         output_dir: published_output_dir,
@@ -1916,7 +1917,11 @@ fn publish_build_state(
     state.save(output_dir)
 }
 
-fn commit_generation(guard: BuildGuard, output_container: &Path) -> Result<PathBuf, CoreError> {
+fn commit_generation(
+    guard: BuildGuard,
+    output_container: &Path,
+    store_ready: bool,
+) -> Result<PathBuf, CoreError> {
     let shadow_store = store_shadow_enabled();
     if !shadow_store {
         for suffix in ["", "-wal", "-shm"] {
@@ -1928,7 +1933,7 @@ fn commit_generation(guard: BuildGuard, output_container: &Path) -> Result<PathB
         }
         remove_if_exists(&guard.staging_directory().join(STORE_REF_FILE_NAME))?;
     }
-    if shadow_store {
+    if shadow_store && !store_ready {
         ensure_store_snapshot(guard.staging_directory())?;
     }
     let mut artifacts = vec!["graph.json", "manifest.json", BUILD_STATE_FILE];
@@ -1976,15 +1981,26 @@ fn ensure_store_snapshot(output_dir: &Path) -> Result<(), CoreError> {
     }
     let builder = GraphSnapshotBuilder::new();
     let active = GraphSnapshotReader::open_active(&store)?;
-    let reader = match active {
-        Some(reader) if reader.export_json_bytes()? == canonical_graph => reader,
-        Some(_) | None => {
+    let exported = match active {
+        Some(reader) => {
+            let exported = reader.export_json_bytes()?;
+            if exported == canonical_graph {
+                exported
+            } else {
+                let prepared = builder.prepare(&store, &graph)?;
+                let selector = builder.activate(&store, &prepared)?;
+                let reader = GraphSnapshotReader::open_selector(&store, selector)?;
+                reader.export_json_bytes()?
+            }
+        }
+        None => {
             let prepared = builder.prepare(&store, &graph)?;
             let selector = builder.activate(&store, &prepared)?;
-            GraphSnapshotReader::open_selector(&store, selector)?
+            let reader = GraphSnapshotReader::open_selector(&store, selector)?;
+            reader.export_json_bytes()?
         }
     };
-    if reader.export_json_bytes()? != canonical_graph {
+    if exported != canonical_graph {
         return Err(CoreError::InvalidBuildState(
             "SQLite graph snapshot does not match graph.json; rebuild the generation".to_owned(),
         ));

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -23,6 +23,7 @@ compass-languages = { path = "../compass-languages", version = "0.3.0" }
 compass-model = { path = "../compass-model", version = "0.3.0" }
 compass-store = { path = "../compass-store", version = "0.3.0" }
 rayon.workspace = true
+rmp-serde.workspace = true
 unicode-casefold.workspace = true
 unicode-normalization.workspace = true
 

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -24,11 +24,11 @@ pub use dedup::{
 };
 pub use quarantine::{MAX_QUARANTINE_EXAMPLES, PublicationOmissions, PublicationOutcome};
 pub use snapshot::{
-    GRAPH_SNAPSHOT_LAYOUT_V1, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder,
-    GraphSnapshotManifest, GraphSnapshotMetadata, GraphSnapshotReader, IndexKind,
-    PreparedGraphSnapshot, SnapshotError, SnapshotReadLimits, SnapshotRoot, SnapshotSelector,
-    activate_graph_snapshot, active_graph_snapshot, canonical_graph_json, encode_graph_index_key,
-    prepare_graph_snapshot,
+    GRAPH_SNAPSHOT_LAYOUT_V1, GRAPH_SNAPSHOT_MAX_ITEMS, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1,
+    GraphSnapshotBuilder, GraphSnapshotManifest, GraphSnapshotMetadata, GraphSnapshotReader,
+    IndexKind, PreparedGraphSnapshot, SnapshotError, SnapshotReadLimits, SnapshotRoot,
+    SnapshotSelector, activate_graph_snapshot, active_graph_snapshot, canonical_graph_json,
+    encode_graph_index_key, prepare_graph_snapshot,
 };
 pub use v1::{
     BuildEvidence, InventoryEvidence, V1_PUBLICATION_SEMANTICS_VERSION, canonical_edge_kind,

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -28,6 +28,7 @@ pub const GRAPH_SNAPSHOT_CATALOG_PARTITION: &str = "graph-snapshot/catalog";
 pub const GRAPH_SNAPSHOT_ACTIVE_KEY: &str = "active";
 pub const GRAPH_SNAPSHOT_MAX_DEPTH: usize = 64;
 pub const GRAPH_SNAPSHOT_MAX_OBJECTS: usize = 100_000;
+pub const GRAPH_SNAPSHOT_MAX_ITEMS: usize = 5_000_000;
 pub const GRAPH_SNAPSHOT_MAX_FANOUT: usize = 32;
 pub const GRAPH_SNAPSHOT_MAX_LEAF_ENTRIES: usize = 128;
 
@@ -148,6 +149,13 @@ impl GraphSnapshotManifest {
                 "graph byte count exceeds the {MAX_GRAPH_BYTES}-byte limit"
             )));
         }
+        if self.node_count > GRAPH_SNAPSHOT_MAX_ITEMS as u64
+            || self.edge_count > GRAPH_SNAPSHOT_MAX_ITEMS as u64
+        {
+            return Err(SnapshotError::Limit(format!(
+                "graph record count exceeds the {GRAPH_SNAPSHOT_MAX_ITEMS}-item snapshot limit"
+            )));
+        }
         if self.roots.len() != IndexKind::ALL.len() {
             return Err(SnapshotError::Corrupt(format!(
                 "manifest has {} roots; expected {}",
@@ -234,9 +242,9 @@ impl Default for SnapshotReadLimits {
 
 impl SnapshotReadLimits {
     fn validate(self) -> Result<Self, SnapshotError> {
-        if self.max_items == 0 || self.max_items > GRAPH_SNAPSHOT_MAX_OBJECTS {
+        if self.max_items == 0 || self.max_items > GRAPH_SNAPSHOT_MAX_ITEMS {
             return Err(SnapshotError::Limit(format!(
-                "max_items must be between 1 and {GRAPH_SNAPSHOT_MAX_OBJECTS}"
+                "max_items must be between 1 and {GRAPH_SNAPSHOT_MAX_ITEMS}"
             )));
         }
         if self.max_bytes == 0 || self.max_bytes > MAX_VALUE_BYTES.saturating_mul(4_096) {
@@ -610,7 +618,7 @@ impl<'a, S: Store + ?Sized> GraphSnapshotReader<'a, S> {
     pub fn export_graph(&self) -> Result<GraphDocument, SnapshotError> {
         let metadata = self.metadata()?;
         let limits = SnapshotReadLimits {
-            max_items: bounded_count(self.manifest.node_count.saturating_add(1))?,
+            max_items: bounded_count(self.manifest.node_count)?,
             max_bytes: MAX_VALUE_BYTES.saturating_mul(4_096),
             ..SnapshotReadLimits::default()
         };
@@ -620,7 +628,7 @@ impl<'a, S: Store + ?Sized> GraphSnapshotReader<'a, S> {
             graph: metadata.graph,
             nodes: self.nodes(limits)?,
             links: self.edges(SnapshotReadLimits {
-                max_items: bounded_count(self.manifest.edge_count.saturating_add(1))?,
+                max_items: bounded_count(self.manifest.edge_count)?,
                 ..limits
             })?,
         };
@@ -822,10 +830,7 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
         insert_json(
             &mut indexes,
             IndexKind::Names,
-            encode_graph_index_key(
-                IndexKind::Names,
-                &[node.name.as_bytes(), node.id.as_bytes()],
-            )?,
+            encode_name_index_key(&node.name, &node.id)?,
             &node.id,
         )?;
         if let Some(anchor) = &node.source {
@@ -838,10 +843,7 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
             insert_json(
                 &mut indexes,
                 IndexKind::Names,
-                encode_graph_index_key(
-                    IndexKind::Names,
-                    &[node.qualified_name.as_bytes(), node.id.as_bytes()],
-                )?,
+                encode_name_index_key(&node.qualified_name, &node.id)?,
                 &node.id,
             )?;
         }
@@ -960,6 +962,23 @@ fn insert_anchor_entry(
     insert_json(indexes, IndexKind::Files, key, &record_id.to_owned())
 }
 
+/// Keep normal names ordered and readable while giving graph-valid, deeply
+/// qualified names a deterministic portable representation. The extra marker
+/// segment prevents a digest key from colliding with the raw two-segment form.
+fn encode_name_index_key(name: &str, node_id: &str) -> Result<Vec<u8>, SnapshotError> {
+    match encode_graph_index_key(IndexKind::Names, &[name.as_bytes(), node_id.as_bytes()]) {
+        Ok(key) => Ok(key),
+        Err(SnapshotError::Store(StoreError::ComponentTooLarge { .. })) => {
+            let digest = hex_digest(name.as_bytes());
+            encode_graph_index_key(
+                IndexKind::Names,
+                &[b"sha256", digest.as_bytes(), node_id.as_bytes()],
+            )
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn insert_diagnostics(
     indexes: &mut SnapshotIndexes,
     owner: &str,
@@ -1028,7 +1047,7 @@ fn build_index_tree<S: Store + ?Sized>(
             entries: candidate.clone(),
         };
         if (candidate.len() > GRAPH_SNAPSHOT_MAX_LEAF_ENTRIES
-            || encode_json(&object)?.len() > MAX_VALUE_BYTES)
+            || encode_tree_object(&object)?.len() > MAX_VALUE_BYTES)
             && !current.is_empty()
         {
             let first_key = current
@@ -1048,7 +1067,7 @@ fn build_index_tree<S: Store + ?Sized>(
             value: value.clone(),
         });
         if current.len() == 1
-            && encode_json(&TreeObject::Leaf {
+            && encode_tree_object(&TreeObject::Leaf {
                 schema: GRAPH_SNAPSHOT_LAYOUT_V1.to_owned(),
                 index,
                 entries: current.clone(),
@@ -1130,7 +1149,7 @@ fn put_tree_object<S: Store + ?Sized>(
     object: &TreeObject,
     stats: &mut ObjectStats,
 ) -> Result<String, SnapshotError> {
-    let bytes = encode_json(object)?;
+    let bytes = encode_tree_object(object)?;
     if bytes.len() > MAX_VALUE_BYTES {
         return Err(SnapshotError::Limit(
             "immutable tree object exceeds the store value limit".to_owned(),
@@ -1248,7 +1267,10 @@ fn scan_tree<S: Store + ?Sized>(
                         "snapshot item limit exceeded".to_owned(),
                     ));
                 }
-                state.bytes = state.bytes.saturating_add(entry.value.len());
+                state.bytes = state
+                    .bytes
+                    .saturating_add(entry.key.len())
+                    .saturating_add(entry.value.len());
                 if state.bytes > state.limits.max_bytes {
                     return Err(SnapshotError::Limit(
                         "snapshot byte limit exceeded".to_owned(),
@@ -1291,7 +1313,7 @@ fn load_tree_object<S: Store + ?Sized>(
         )));
     };
     verify_digest(&entry.value, digest)?;
-    let object = decode_json::<TreeObject>(&entry.value)?;
+    let object = decode_tree_object(&entry.value)?;
     validate_tree_object(&object, index)?;
     Ok(object)
 }
@@ -1389,15 +1411,34 @@ fn bounded_count(count: u64) -> Result<usize, SnapshotError> {
     let count = usize::try_from(count).map_err(|_| {
         SnapshotError::Limit("snapshot count does not fit this platform".to_owned())
     })?;
-    Ok(count.saturating_add(1).min(GRAPH_SNAPSHOT_MAX_OBJECTS))
+    if count > GRAPH_SNAPSHOT_MAX_ITEMS {
+        return Err(SnapshotError::Limit(format!(
+            "snapshot count exceeds the {GRAPH_SNAPSHOT_MAX_ITEMS}-item limit"
+        )));
+    }
+    Ok(count.max(1))
 }
 
 fn encode_json<T: Serialize>(value: &T) -> Result<Vec<u8>, SnapshotError> {
     serde_json::to_vec(value).map_err(|error| SnapshotError::Encode(error.to_string()))
 }
 
+fn encode_tree_object(value: &TreeObject) -> Result<Vec<u8>, SnapshotError> {
+    rmp_serde::to_vec_named(value).map_err(|error| SnapshotError::Encode(error.to_string()))
+}
+
 fn decode_json<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> Result<T, SnapshotError> {
     serde_json::from_slice(bytes).map_err(|error| SnapshotError::Decode(error.to_string()))
+}
+
+fn decode_tree_object(bytes: &[u8]) -> Result<TreeObject, SnapshotError> {
+    rmp_serde::from_slice(bytes).or_else(|message_pack_error| {
+        serde_json::from_slice(bytes).map_err(|json_error| {
+            SnapshotError::Decode(format!(
+                "tree object is neither MessagePack ({message_pack_error}) nor legacy JSON ({json_error})"
+            ))
+        })
+    })
 }
 
 fn hex_digest(bytes: &[u8]) -> String {
@@ -1463,4 +1504,25 @@ fn manifest_key(digest: &str) -> Result<Key, SnapshotError> {
 
 fn digest_bytes(value: &[u8]) -> [u8; 32] {
     Sha256::digest(value).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_decoder_accepts_compact_and_legacy_encodings() -> Result<(), SnapshotError> {
+        let object = TreeObject::Leaf {
+            schema: GRAPH_SNAPSHOT_LAYOUT_V1.to_owned(),
+            index: IndexKind::Nodes,
+            entries: vec![TreeEntry {
+                key: encode_graph_index_key(IndexKind::Nodes, &[b"node-id"])?,
+                value: br#"{"id":"node-id"}"#.to_vec(),
+            }],
+        };
+
+        assert_eq!(decode_tree_object(&encode_tree_object(&object)?)?, object);
+        assert_eq!(decode_tree_object(&encode_json(&object)?)?, object);
+        Ok(())
+    }
 }

--- a/crates/compass-graph/tests/store_snapshot.rs
+++ b/crates/compass-graph/tests/store_snapshot.rs
@@ -148,6 +148,9 @@ fn snapshot_is_deterministic_and_reuses_immutable_objects() -> Result<(), Box<dy
         unknown.validate(),
         Err(SnapshotError::Unsupported(_))
     ));
+    let mut oversized = first.manifest.clone();
+    oversized.edge_count = (compass_graph::GRAPH_SNAPSHOT_MAX_ITEMS as u64) + 1;
+    assert!(matches!(oversized.validate(), Err(SnapshotError::Limit(_))));
     assert_eq!(second.new_objects, 0);
     assert!(second.reused_objects > 0);
     let selector = builder.activate(&store, &first)?;
@@ -271,6 +274,28 @@ fn graph_key_vectors_are_namespace_safe_and_orderable() -> Result<(), Box<dyn Er
     assert_ne!(
         encode_graph_index_key(IndexKind::Nodes, &[b"a", b"b"])?,
         encode_graph_index_key(IndexKind::Nodes, &[b"a|b"])?
+    );
+    Ok(())
+}
+
+#[test]
+fn graph_valid_long_qualified_names_round_trip_through_the_store() -> Result<(), Box<dyn Error>> {
+    let store = MemoryStore::default();
+    let builder = GraphSnapshotBuilder::new();
+    let mut document = graph();
+    document.nodes[0].qualified_name = "call_chain.".repeat(120);
+
+    let prepared = builder.prepare(&store, &document)?;
+    builder.activate(&store, &prepared)?;
+    let reader = GraphSnapshotReader::open_active(&store)?.ok_or("active snapshot missing")?;
+
+    assert_eq!(
+        reader.export_json_bytes()?,
+        canonical_graph_json(&document)?
+    );
+    assert_eq!(
+        reader.get_node("b")?.map(|node| node.qualified_name),
+        Some("call_chain.".repeat(120))
     );
     Ok(())
 }

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -668,7 +668,9 @@ masking logical errors.
 
 The v1 reference uses these fixed records and keys:
 
-- immutable JSON tree objects in the `graph-snapshot/objects` partition;
+- immutable compact MessagePack tree objects in the
+  `graph-snapshot/objects` partition, with read support for the initial JSON
+  object encoding;
 - a manifest at `manifest/<sha256>` and one selector at
   `graph-snapshot/catalog/active`;
 - nodes, edges, outgoing, incoming, files/source anchors, names, terms,

--- a/docs/guides/compass-store-operations.md
+++ b/docs/guides/compass-store-operations.md
@@ -56,7 +56,7 @@ For an output root `DIR` the published set is:
 DIR/graph.json                 # permanent canonical graph artifact
 DIR/compass-store.sqlite3      # SQLite store snapshot
 DIR/store.ref                  # typed generation binding
-DIR/.compass-generation        # BuildGuard publication pointer, when used
+DIR/.compass-active-generation # BuildGuard publication pointer, when used
 ```
 
 `graph.json`, the SQLite sidecar, and `store.ref` are published as one

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -94,7 +94,7 @@ it is not linked into the released CLI by default.
 The first executable Phase 2 slice is intentionally independent of a durable
 adapter. `compass-graph` now exposes a deterministic immutable snapshot builder
 and reader over the namespace-first `compass-store::Store` contract. It writes
-content-addressed JSON tree objects, a typed manifest, and a CAS-protected
+content-addressed compact tree objects, a typed manifest, and a CAS-protected
 active selector using the memory reference store. The layout includes metadata,
 nodes, edges, directional adjacency, files/source anchors, names, terms,
 communities, and diagnostics roots.


### PR DESCRIPTION
## Summary

- allow graph-valid oversized qualified names and Django-scale node/edge counts in immutable snapshots
- encode immutable tree objects as MessagePack while retaining read support for the initial JSON object encoding
- resolve public `compass-out` generation pointers for `store status`, `validate`, and `backup`
- avoid a duplicate full snapshot verification after publication has already produced the store
- document real Django and cross-adapter correctness, storage, query, and build measurements

## Why

The local release qualification in #125-#130 covered synthetic repositories but did not expose several large-graph constraints. On Django, store publication failed because a valid deeply qualified name exceeded the portable key-component limit. The snapshot reader also reused the 100,000 immutable-object cap as its graph-record cap, and JSON serialization of byte arrays caused excessive storage amplification. Separately, the public output path documented for the store commands did not resolve BuildGuard's active-generation pointer.

This change keeps `graph.json` as the compatible engine and hardens the optional Compass Store path without changing the namespace-first store contract.

## Django audit

Audit input: Django commit `957d0cee7167757ae221ffde59d2cf0a322e89c7`.

- 7,074 files, 82,654 nodes, 187,913 edges
- canonical graph: 292,582,885 bytes
- compact SQLite store: 1,051,348,992 bytes, down from 2,672,005,120 bytes with JSON tree objects (-60.7%)
- cold typed search output was byte-identical between store and JSON (740,534 bytes)
- store search: 17.371 s / 2,292,272 KiB peak RSS
- JSON search: 19.476 s / 1,758,864 KiB peak RSS

Fresh store publication is still not within the default-cutover budget: 206.357 s versus 15.357 s for JSON-only, and unchanged store updates measured 4.300-4.561 s versus 1.833 s for JSON-only. The performance documentation therefore identifies direct projection execution, batched durable publication, and bounded generation retention/GC as follow-up requirements rather than claiming an unconditional large-repository default.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-store --features test-support --locked`
- `cargo test -p compass-store-redb --locked`
- `cargo test -p compass-graph --locked`
- `cargo test -p compass-graph --test store_snapshot --locked`
- `cargo test -p compass-query --test store_engine --locked`
- `cargo test -p compass-cli --test init_cli --test store_cli --test code_query_cli --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/check_product_boundary.sh`
- release build and cross-adapter release qualification at 32, 128, and 512 nodes

The full baseline passed before rebasing onto the merge of #131. After that rebase, formatting plus the affected `compass-graph`, `compass-query`, and `compass-cli` store suites were rerun and passed.
