### PR TITLE
Fix versioned graph diff semantics and queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Make versioned graph comparisons meaning-aware: source-coordinate shifts,
+  clustering/layout metadata, and anchor-derived edge identities no longer
+  appear as graph-wide structural changes. Historical queries now read only
+  sealed graph roots plus document metadata on a cold cache miss, while exact
+  record diffs remain lossless and profile compatibility remains mandatory.
 - Replace sticky graph-edge tooltips in the shared viewer and VS Code with a
   theme-aware relationship card that shows direction, confidence, evidence,
   and source location, with explicit cleanup on edge, canvas, drag, and zoom

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -63,7 +63,7 @@ pub(crate) fn load_graph_at(
     let cache_key = serde_json::json!({
         "schema": "compass.history.graph_query_key/1",
         "realization": preferred.id.to_string(),
-        "projection_version": 3,
+        "projection_version": 1,
     });
     let document = cache
         .read(DerivedCacheNamespace::Viewer, &cache_key, 256 * 1024 * 1024)

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -63,7 +63,7 @@ pub(crate) fn load_graph_at(
     let cache_key = serde_json::json!({
         "schema": "compass.history.graph_query_key/1",
         "realization": preferred.id.to_string(),
-        "projection_version": 2,
+        "projection_version": 3,
     });
     let document = cache
         .read(DerivedCacheNamespace::Viewer, &cache_key, 256 * 1024 * 1024)
@@ -73,10 +73,11 @@ pub(crate) fn load_graph_at(
     let document = match document {
         Some(document) => document,
         None => {
-            let artifacts = history
-                .artifacts(&preferred.id)
+            let reader = history
+                .reader(&preferred.id)
                 .map_err(|error| error.to_string())?;
-            let document = artifacts.artifacts.document;
+            let document = compass_output::historical_graph_document(&reader)
+                .map_err(|error| error.to_string())?;
             if let Ok(value) = serde_json::to_value(&document)
                 && let Ok(bytes) = compass_history::canonical_json_bytes(&value)
             {
@@ -996,37 +997,6 @@ fn write_exact_diff<W: Write>(
     Ok(sink.counts)
 }
 
-#[derive(Default, serde::Serialize)]
-struct RecordChangeCounts {
-    added: u64,
-    removed: u64,
-    changed: u64,
-}
-
-#[derive(Default, serde::Serialize)]
-struct ChangeCounts {
-    nodes: RecordChangeCounts,
-    edges: RecordChangeCounts,
-    hyperedges: RecordChangeCounts,
-}
-
-impl ChangeSink for ChangeCounts {
-    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
-        let counts = match change.record {
-            compass_history::RecordKind::Node => &mut self.nodes,
-            compass_history::RecordKind::Edge => &mut self.edges,
-            compass_history::RecordKind::Hyperedge => &mut self.hyperedges,
-            _ => return Ok(()),
-        };
-        match change.change {
-            ChangeKind::Added => counts.added += 1,
-            ChangeKind::Removed => counts.removed += 1,
-            ChangeKind::Changed => counts.changed += 1,
-        }
-        Ok(())
-    }
-}
-
 fn execute_verify(repository: &Repository, args: &[String]) -> Result<String, CommandFailure> {
     let mut target = None;
     let mut format = "text";
@@ -1169,17 +1139,8 @@ fn execute_change_counts(
         .ok_or_else(|| runtime(format!("parent revision {parent} is not materialized")))?;
     let previous_reader = history.reader(&previous.id).map_err(runtime)?;
     let current_reader = history.reader(&current.id).map_err(runtime)?;
-    let mut counts = ChangeCounts::default();
-    previous_reader
-        .diff_records(
-            &current_reader,
-            &[
-                compass_history::RecordKind::Node,
-                compass_history::RecordKind::Edge,
-                compass_history::RecordKind::Hyperedge,
-            ],
-            &mut counts,
-        )
+    let counts = previous_reader
+        .structural_change_counts(&current_reader)
         .map_err(runtime)?;
     serde_json::to_string(&serde_json::json!({
         "schema": "compass.history.change_counts/1",

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -135,7 +135,7 @@ fn execute(args: &[String]) -> Result<CommandOutput, CommandError> {
                 )
                 .map_err(runtime)?;
             direct.cancel_attribute_only_dependency_churn();
-            direct.normalize_graph_delta();
+            direct.normalize_graph_delta().map_err(runtime)?;
             let snapshots = HistorySnapshots {
                 old: old_reader,
                 new: new_reader,
@@ -451,6 +451,13 @@ struct DirectChanges {
     nodes: Vec<String>,
     dependencies: Vec<DependencyDelta>,
     graph_delta: GraphDelta,
+    edge_identity_changes: Vec<EdgeIdentityChange>,
+}
+
+struct EdgeIdentityChange {
+    change: ChangeKind,
+    delta: GraphEdgeDelta,
+    value: serde_json::Value,
 }
 
 impl DirectChanges {
@@ -492,7 +499,8 @@ impl DirectChanges {
         });
     }
 
-    fn normalize_graph_delta(&mut self) {
+    fn normalize_graph_delta(&mut self) -> Result<(), HistoryError> {
+        self.normalize_edge_identity_changes()?;
         let sort_nodes = |nodes: &mut Vec<GraphNodeDelta>| {
             for node in nodes.iter_mut() {
                 node.changed_fields.sort();
@@ -534,66 +542,87 @@ impl DirectChanges {
         sort_edges(&mut self.graph_delta.added_edges);
         sort_edges(&mut self.graph_delta.removed_edges);
         sort_edges(&mut self.graph_delta.changed_edges);
-        let mut balances = std::collections::BTreeMap::<(String, String, String), i64>::new();
-        for edge in &self.graph_delta.added_edges {
-            *balances
-                .entry((
-                    edge.source.clone(),
-                    edge.relation.clone(),
-                    edge.target.clone(),
-                ))
-                .or_default() += 1;
-        }
-        for edge in &self.graph_delta.removed_edges {
-            *balances
-                .entry((
-                    edge.source.clone(),
-                    edge.relation.clone(),
-                    edge.target.clone(),
-                ))
-                .or_default() -= 1;
-        }
-        let removed_before = self.graph_delta.removed_edges.len();
-        self.graph_delta.added_edges.retain(|edge| {
-            let key = (
-                edge.source.clone(),
-                edge.relation.clone(),
-                edge.target.clone(),
+        Ok(())
+    }
+
+    fn normalize_edge_identity_changes(&mut self) -> Result<(), HistoryError> {
+        type Topology = (String, String, String);
+        type ProjectionGroups = std::collections::BTreeMap<Vec<u8>, Vec<EdgeIdentityChange>>;
+        let mut groups =
+            std::collections::BTreeMap::<Topology, (ProjectionGroups, ProjectionGroups)>::new();
+        for change in self.edge_identity_changes.drain(..) {
+            let topology = (
+                change.delta.source.clone(),
+                change.delta.relation.clone(),
+                change.delta.target.clone(),
             );
-            let Some(balance) = balances.get_mut(&key) else {
-                return true;
-            };
-            if *balance > 0 {
-                *balance -= 1;
-                true
+            let projected =
+                compass_history::structural_graph_projection(RecordKind::Edge, &change.value);
+            let projection = canonical_json_bytes(&projected)?;
+            let projections = groups.entry(topology).or_default();
+            let target = if change.change == ChangeKind::Added {
+                &mut projections.0
             } else {
-                false
-            }
-        });
-        self.graph_delta.removed_edges.retain(|edge| {
-            let key = (
-                edge.source.clone(),
-                edge.relation.clone(),
-                edge.target.clone(),
-            );
-            let Some(balance) = balances.get_mut(&key) else {
-                return true;
+                &mut projections.1
             };
-            if *balance < 0 {
-                *balance += 1;
-                true
-            } else {
-                false
-            }
-        });
-        let cancelled = removed_before.saturating_sub(self.graph_delta.removed_edges.len());
-        if cancelled > 0 {
-            *self
-                .graph_delta
-                .collapsed_attribute_changes
-                .entry("edge_identity".to_owned())
-                .or_default() += cancelled;
+            target.entry(projection).or_default().push(change);
         }
+        for (mut added, mut removed) in groups.into_values() {
+            let projections = added
+                .keys()
+                .chain(removed.keys())
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>();
+            let mut unmatched_added = Vec::new();
+            let mut unmatched_removed = Vec::new();
+            for projection in projections {
+                let mut added_records = added.remove(&projection).unwrap_or_default();
+                let mut removed_records = removed.remove(&projection).unwrap_or_default();
+                added_records.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
+                removed_records.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
+                let unchanged = added_records.len().min(removed_records.len());
+                if unchanged > 0 {
+                    *self
+                        .graph_delta
+                        .collapsed_attribute_changes
+                        .entry("edge_identity".to_owned())
+                        .or_default() += unchanged;
+                }
+                unmatched_added.extend(added_records.into_iter().skip(unchanged));
+                unmatched_removed.extend(removed_records.into_iter().skip(unchanged));
+            }
+            unmatched_added.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
+            unmatched_removed.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
+            let changed = usize::from(unmatched_added.len() == 1 && unmatched_removed.len() == 1);
+            for (added, removed) in unmatched_added
+                .iter()
+                .take(changed)
+                .zip(unmatched_removed.iter().take(changed))
+            {
+                let fields = meaningful_graph_fields(
+                    RecordKind::Edge,
+                    Some(&removed.value),
+                    Some(&added.value),
+                    &mut self.graph_delta.collapsed_attribute_changes,
+                );
+                let mut delta = added.delta.clone();
+                delta.changed_fields = fields;
+                self.graph_delta.changed_edges.push(delta);
+            }
+            self.graph_delta.added_edges.extend(
+                unmatched_added
+                    .into_iter()
+                    .skip(changed)
+                    .map(|change| change.delta),
+            );
+            self.graph_delta.removed_edges.extend(
+                unmatched_removed
+                    .into_iter()
+                    .skip(changed)
+                    .map(|change| change.delta),
+            );
+        }
+        Ok(())
     }
 }
 
@@ -602,14 +631,17 @@ impl ChangeSink for DirectChanges {
         match change.record {
             RecordKind::Node => {
                 if let Some(node_id) = change.key.first() {
-                    self.nodes.push(node_id.clone());
                     match change.change {
-                        ChangeKind::Added => self.graph_delta.added_nodes.push(graph_node_delta(
-                            node_id,
-                            change.new.as_ref(),
-                            Vec::new(),
-                        )),
+                        ChangeKind::Added => {
+                            self.nodes.push(node_id.clone());
+                            self.graph_delta.added_nodes.push(graph_node_delta(
+                                node_id,
+                                change.new.as_ref(),
+                                Vec::new(),
+                            ));
+                        }
                         ChangeKind::Removed => {
+                            self.nodes.push(node_id.clone());
                             self.graph_delta.removed_nodes.push(graph_node_delta(
                                 node_id,
                                 change.old.as_ref(),
@@ -618,11 +650,13 @@ impl ChangeSink for DirectChanges {
                         }
                         ChangeKind::Changed => {
                             let fields = meaningful_graph_fields(
+                                RecordKind::Node,
                                 change.old.as_ref(),
                                 change.new.as_ref(),
                                 &mut self.graph_delta.collapsed_attribute_changes,
                             );
                             if !fields.is_empty() {
+                                self.nodes.push(node_id.clone());
                                 self.graph_delta.changed_nodes.push(graph_node_delta(
                                     node_id,
                                     change.new.as_ref().or(change.old.as_ref()),
@@ -640,24 +674,28 @@ impl ChangeSink for DirectChanges {
                 let key = change.key.get(3).map(String::as_str).unwrap_or_default();
                 let value = change.new.as_ref().or(change.old.as_ref());
                 match change.change {
-                    ChangeKind::Added => self.graph_delta.added_edges.push(graph_edge_delta(
-                        source,
-                        target,
-                        relation,
-                        key,
-                        value,
-                        Vec::new(),
-                    )),
-                    ChangeKind::Removed => self.graph_delta.removed_edges.push(graph_edge_delta(
-                        source,
-                        target,
-                        relation,
-                        key,
-                        value,
-                        Vec::new(),
-                    )),
+                    ChangeKind::Added | ChangeKind::Removed => {
+                        let Some(value) = value.cloned() else {
+                            return Err(HistoryError::InvalidArtifacts(
+                                "edge identity change has no record value".to_owned(),
+                            ));
+                        };
+                        self.edge_identity_changes.push(EdgeIdentityChange {
+                            change: change.change,
+                            delta: graph_edge_delta(
+                                source,
+                                target,
+                                relation,
+                                key,
+                                Some(&value),
+                                Vec::new(),
+                            ),
+                            value,
+                        });
+                    }
                     ChangeKind::Changed => {
                         let fields = meaningful_graph_fields(
+                            RecordKind::Edge,
                             change.old.as_ref(),
                             change.new.as_ref(),
                             &mut self.graph_delta.collapsed_attribute_changes,
@@ -795,10 +833,15 @@ fn nested_string(value: &serde_json::Value, path: &[&str]) -> Option<String> {
 }
 
 fn meaningful_graph_fields(
+    record: RecordKind,
     old: Option<&serde_json::Value>,
     new: Option<&serde_json::Value>,
     collapsed: &mut std::collections::BTreeMap<String, usize>,
 ) -> Vec<String> {
+    let projected_old =
+        old.map(|value| compass_history::structural_graph_projection(record, value));
+    let projected_new =
+        new.map(|value| compass_history::structural_graph_projection(record, value));
     let mut keys = std::collections::BTreeSet::new();
     if let Some(object) = old.and_then(serde_json::Value::as_object) {
         keys.extend(object.keys().cloned());
@@ -811,27 +854,15 @@ fn meaningful_graph_fields(
         if old.and_then(|value| value.get(&key)) == new.and_then(|value| value.get(&key)) {
             continue;
         }
-        if is_graph_churn_field(&key) {
+        let projected_old_field = projected_old.as_ref().and_then(|value| value.get(&key));
+        let projected_new_field = projected_new.as_ref().and_then(|value| value.get(&key));
+        if projected_old_field == projected_new_field {
             *collapsed.entry(key).or_default() += 1;
         } else {
             meaningful.push(key);
         }
     }
     meaningful
-}
-
-fn is_graph_churn_field(field: &str) -> bool {
-    matches!(
-        field,
-        "community"
-            | "line_start"
-            | "line_end"
-            | "source_location"
-            | "source_hash"
-            | "start_byte"
-            | "end_byte"
-            | "column"
-    )
 }
 
 enum CommandError {
@@ -992,6 +1023,7 @@ mod tests {
                 },
             ],
             graph_delta: GraphDelta::default(),
+            edge_identity_changes: Vec::new(),
         };
         changes.cancel_attribute_only_dependency_churn();
         assert_eq!(changes.dependencies.len(), 1);
@@ -999,25 +1031,35 @@ mod tests {
     }
 
     #[test]
-    fn graph_edge_identity_churn_preserves_only_net_multigraph_multiplicity() {
-        let edge = |key: &str| GraphEdgeDelta {
-            source: "caller".to_owned(),
-            target: "target".to_owned(),
-            relation: "calls".to_owned(),
-            key: key.to_owned(),
-            source_file: "example.rs".to_owned(),
-            changed_fields: Vec::new(),
-        };
-        let mut changes = DirectChanges {
-            nodes: Vec::new(),
-            dependencies: Vec::new(),
-            graph_delta: GraphDelta {
-                added_edges: vec![edge("new-1"), edge("new-2")],
-                removed_edges: vec![edge("old-1")],
-                ..GraphDelta::default()
-            },
-        };
-        changes.normalize_graph_delta();
+    fn graph_edge_identity_churn_preserves_only_net_multigraph_multiplicity()
+    -> Result<(), HistoryError> {
+        let mut changes = DirectChanges::default();
+        for (change, key) in [
+            (ChangeKind::Removed, "old-1"),
+            (ChangeKind::Added, "new-1"),
+            (ChangeKind::Added, "new-2"),
+        ] {
+            let value = serde_json::json!({
+                "source": "caller",
+                "target": "target",
+                "relation": "calls",
+                "confidence": "extracted",
+                "relationshipSite": {"file": "example.rs", "startLine": 1}
+            });
+            changes.change(GraphChange {
+                record: RecordKind::Edge,
+                change,
+                key: vec![
+                    "caller".to_owned(),
+                    "target".to_owned(),
+                    "calls".to_owned(),
+                    key.to_owned(),
+                ],
+                old: (change == ChangeKind::Removed).then_some(value.clone()),
+                new: (change == ChangeKind::Added).then_some(value),
+            })?;
+        }
+        changes.normalize_graph_delta()?;
         assert_eq!(changes.graph_delta.added_edges.len(), 1);
         assert!(changes.graph_delta.removed_edges.is_empty());
         assert_eq!(
@@ -1027,5 +1069,78 @@ mod tests {
                 .get("edge_identity"),
             Some(&1)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn edge_attribute_change_survives_anchor_derived_identity_churn() -> Result<(), HistoryError> {
+        let mut changes = DirectChanges::default();
+        for (change, key, confidence, line) in [
+            (ChangeKind::Removed, "old", "inferred", 10),
+            (ChangeKind::Added, "new", "extracted", 11),
+        ] {
+            let value = serde_json::json!({
+                "source": "caller",
+                "target": "target",
+                "relation": "calls",
+                "confidence": confidence,
+                "relationshipSite": {"file": "example.rs", "startLine": line}
+            });
+            changes.change(GraphChange {
+                record: RecordKind::Edge,
+                change,
+                key: vec![
+                    "caller".to_owned(),
+                    "target".to_owned(),
+                    "calls".to_owned(),
+                    key.to_owned(),
+                ],
+                old: (change == ChangeKind::Removed).then_some(value.clone()),
+                new: (change == ChangeKind::Added).then_some(value),
+            })?;
+        }
+        changes.normalize_graph_delta()?;
+
+        assert!(changes.graph_delta.added_edges.is_empty());
+        assert!(changes.graph_delta.removed_edges.is_empty());
+        assert_eq!(changes.graph_delta.changed_edges.len(), 1);
+        assert_eq!(
+            changes.graph_delta.changed_edges[0].changed_fields,
+            ["confidence"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn nested_source_coordinate_churn_does_not_mark_a_node_changed() -> Result<(), HistoryError> {
+        let mut changes = DirectChanges::default();
+        changes.change(GraphChange {
+            record: RecordKind::Node,
+            change: ChangeKind::Changed,
+            key: vec!["api::serve".to_owned()],
+            old: Some(serde_json::json!({
+                "id": "api::serve",
+                "kind": "function",
+                "name": "serve",
+                "source": {"file": "src/api.rs", "startLine": 10, "endLine": 12}
+            })),
+            new: Some(serde_json::json!({
+                "id": "api::serve",
+                "kind": "function",
+                "name": "serve",
+                "source": {"file": "src/api.rs", "startLine": 11, "endLine": 13}
+            })),
+        })?;
+
+        assert!(changes.nodes.is_empty());
+        assert!(changes.graph_delta.changed_nodes.is_empty());
+        assert_eq!(
+            changes
+                .graph_delta
+                .collapsed_attribute_changes
+                .get("source"),
+            Some(&1)
+        );
+        Ok(())
     }
 }

--- a/crates/compass-cli/src/semantic_diff_commands.rs
+++ b/crates/compass-cli/src/semantic_diff_commands.rs
@@ -128,14 +128,9 @@ fn execute(args: &[String]) -> Result<CommandOutput, CommandError> {
             let old_reader = resolved.history.reader(&resolved.old.id).map_err(runtime)?;
             let new_reader = resolved.history.reader(&resolved.new.id).map_err(runtime)?;
             old_reader
-                .diff_records(
-                    &new_reader,
-                    &[RecordKind::Node, RecordKind::Edge],
-                    &mut direct,
-                )
+                .structural_diff(&new_reader, &mut direct)
                 .map_err(runtime)?;
-            direct.cancel_attribute_only_dependency_churn();
-            direct.normalize_graph_delta().map_err(runtime)?;
+            direct.normalize_graph_delta();
             let snapshots = HistorySnapshots {
                 old: old_reader,
                 new: new_reader,
@@ -451,56 +446,10 @@ struct DirectChanges {
     nodes: Vec<String>,
     dependencies: Vec<DependencyDelta>,
     graph_delta: GraphDelta,
-    edge_identity_changes: Vec<EdgeIdentityChange>,
-}
-
-struct EdgeIdentityChange {
-    change: ChangeKind,
-    delta: GraphEdgeDelta,
-    value: serde_json::Value,
 }
 
 impl DirectChanges {
-    fn cancel_attribute_only_dependency_churn(&mut self) {
-        let mut directions = std::collections::BTreeMap::<(String, String, String), i64>::new();
-        for delta in &self.dependencies {
-            let balance = directions
-                .entry((
-                    delta.source.clone(),
-                    delta.target.clone(),
-                    delta.relation.clone(),
-                ))
-                .or_default();
-            match delta.change {
-                ChangeDirection::Added => *balance += 1,
-                ChangeDirection::Removed => *balance -= 1,
-            }
-        }
-        self.dependencies.retain(|delta| {
-            let key = (
-                delta.source.clone(),
-                delta.target.clone(),
-                delta.relation.clone(),
-            );
-            let Some(balance) = directions.get_mut(&key) else {
-                return true;
-            };
-            match delta.change {
-                ChangeDirection::Added if *balance > 0 => {
-                    *balance -= 1;
-                    true
-                }
-                ChangeDirection::Removed if *balance < 0 => {
-                    *balance += 1;
-                    true
-                }
-                _ => false,
-            }
-        });
-    }
-
-    fn normalize_graph_delta(&mut self) -> Result<(), HistoryError> {
-        self.normalize_edge_identity_changes()?;
+    fn normalize_graph_delta(&mut self) {
         let sort_nodes = |nodes: &mut Vec<GraphNodeDelta>| {
             for node in nodes.iter_mut() {
                 node.changed_fields.sort();
@@ -542,87 +491,6 @@ impl DirectChanges {
         sort_edges(&mut self.graph_delta.added_edges);
         sort_edges(&mut self.graph_delta.removed_edges);
         sort_edges(&mut self.graph_delta.changed_edges);
-        Ok(())
-    }
-
-    fn normalize_edge_identity_changes(&mut self) -> Result<(), HistoryError> {
-        type Topology = (String, String, String);
-        type ProjectionGroups = std::collections::BTreeMap<Vec<u8>, Vec<EdgeIdentityChange>>;
-        let mut groups =
-            std::collections::BTreeMap::<Topology, (ProjectionGroups, ProjectionGroups)>::new();
-        for change in self.edge_identity_changes.drain(..) {
-            let topology = (
-                change.delta.source.clone(),
-                change.delta.relation.clone(),
-                change.delta.target.clone(),
-            );
-            let projected =
-                compass_history::structural_graph_projection(RecordKind::Edge, &change.value);
-            let projection = canonical_json_bytes(&projected)?;
-            let projections = groups.entry(topology).or_default();
-            let target = if change.change == ChangeKind::Added {
-                &mut projections.0
-            } else {
-                &mut projections.1
-            };
-            target.entry(projection).or_default().push(change);
-        }
-        for (mut added, mut removed) in groups.into_values() {
-            let projections = added
-                .keys()
-                .chain(removed.keys())
-                .cloned()
-                .collect::<std::collections::BTreeSet<_>>();
-            let mut unmatched_added = Vec::new();
-            let mut unmatched_removed = Vec::new();
-            for projection in projections {
-                let mut added_records = added.remove(&projection).unwrap_or_default();
-                let mut removed_records = removed.remove(&projection).unwrap_or_default();
-                added_records.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
-                removed_records.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
-                let unchanged = added_records.len().min(removed_records.len());
-                if unchanged > 0 {
-                    *self
-                        .graph_delta
-                        .collapsed_attribute_changes
-                        .entry("edge_identity".to_owned())
-                        .or_default() += unchanged;
-                }
-                unmatched_added.extend(added_records.into_iter().skip(unchanged));
-                unmatched_removed.extend(removed_records.into_iter().skip(unchanged));
-            }
-            unmatched_added.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
-            unmatched_removed.sort_by(|left, right| left.delta.key.cmp(&right.delta.key));
-            let changed = usize::from(unmatched_added.len() == 1 && unmatched_removed.len() == 1);
-            for (added, removed) in unmatched_added
-                .iter()
-                .take(changed)
-                .zip(unmatched_removed.iter().take(changed))
-            {
-                let fields = meaningful_graph_fields(
-                    RecordKind::Edge,
-                    Some(&removed.value),
-                    Some(&added.value),
-                    &mut self.graph_delta.collapsed_attribute_changes,
-                );
-                let mut delta = added.delta.clone();
-                delta.changed_fields = fields;
-                self.graph_delta.changed_edges.push(delta);
-            }
-            self.graph_delta.added_edges.extend(
-                unmatched_added
-                    .into_iter()
-                    .skip(changed)
-                    .map(|change| change.delta),
-            );
-            self.graph_delta.removed_edges.extend(
-                unmatched_removed
-                    .into_iter()
-                    .skip(changed)
-                    .map(|change| change.delta),
-            );
-        }
-        Ok(())
     }
 }
 
@@ -674,24 +542,25 @@ impl ChangeSink for DirectChanges {
                 let key = change.key.get(3).map(String::as_str).unwrap_or_default();
                 let value = change.new.as_ref().or(change.old.as_ref());
                 match change.change {
-                    ChangeKind::Added | ChangeKind::Removed => {
-                        let Some(value) = value.cloned() else {
-                            return Err(HistoryError::InvalidArtifacts(
-                                "edge identity change has no record value".to_owned(),
-                            ));
-                        };
-                        self.edge_identity_changes.push(EdgeIdentityChange {
-                            change: change.change,
-                            delta: graph_edge_delta(
-                                source,
-                                target,
-                                relation,
-                                key,
-                                Some(&value),
-                                Vec::new(),
-                            ),
+                    ChangeKind::Added => {
+                        self.graph_delta.added_edges.push(graph_edge_delta(
+                            source,
+                            target,
+                            relation,
+                            key,
                             value,
-                        });
+                            Vec::new(),
+                        ));
+                    }
+                    ChangeKind::Removed => {
+                        self.graph_delta.removed_edges.push(graph_edge_delta(
+                            source,
+                            target,
+                            relation,
+                            key,
+                            value,
+                            Vec::new(),
+                        ));
                     }
                     ChangeKind::Changed => {
                         let fields = meaningful_graph_fields(
@@ -1004,109 +873,48 @@ mod tests {
     }
 
     #[test]
-    fn dependency_attribute_churn_is_not_reported_as_a_semantic_change() {
-        let delta = |change| DependencyDelta {
-            source: "caller".to_owned(),
-            target: "target".to_owned(),
-            relation: "calls".to_owned(),
-            change,
-            evidence: Vec::new(),
-        };
-        let mut changes = DirectChanges {
-            nodes: Vec::new(),
-            dependencies: vec![
-                delta(ChangeDirection::Removed),
-                delta(ChangeDirection::Added),
-                DependencyDelta {
-                    target: "new-target".to_owned(),
-                    ..delta(ChangeDirection::Added)
-                },
-            ],
-            graph_delta: GraphDelta::default(),
-            edge_identity_changes: Vec::new(),
-        };
-        changes.cancel_attribute_only_dependency_churn();
-        assert_eq!(changes.dependencies.len(), 1);
-        assert_eq!(changes.dependencies[0].target, "new-target");
-    }
-
-    #[test]
-    fn graph_edge_identity_churn_preserves_only_net_multigraph_multiplicity()
-    -> Result<(), HistoryError> {
+    fn structural_parallel_edge_changes_all_reach_the_semantic_delta() -> Result<(), HistoryError> {
         let mut changes = DirectChanges::default();
-        for (change, key) in [
-            (ChangeKind::Removed, "old-1"),
-            (ChangeKind::Added, "new-1"),
-            (ChangeKind::Added, "new-2"),
-        ] {
-            let value = serde_json::json!({
-                "source": "caller",
-                "target": "target",
-                "relation": "calls",
-                "confidence": "extracted",
-                "relationshipSite": {"file": "example.rs", "startLine": 1}
-            });
+        for index in 0..2 {
             changes.change(GraphChange {
                 record: RecordKind::Edge,
-                change,
+                change: ChangeKind::Changed,
                 key: vec![
                     "caller".to_owned(),
                     "target".to_owned(),
                     "calls".to_owned(),
-                    key.to_owned(),
+                    format!("new-{index}"),
                 ],
-                old: (change == ChangeKind::Removed).then_some(value.clone()),
-                new: (change == ChangeKind::Added).then_some(value),
-            })?;
-        }
-        changes.normalize_graph_delta()?;
-        assert_eq!(changes.graph_delta.added_edges.len(), 1);
-        assert!(changes.graph_delta.removed_edges.is_empty());
-        assert_eq!(
-            changes
-                .graph_delta
-                .collapsed_attribute_changes
-                .get("edge_identity"),
-            Some(&1)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn edge_attribute_change_survives_anchor_derived_identity_churn() -> Result<(), HistoryError> {
-        let mut changes = DirectChanges::default();
-        for (change, key, confidence, line) in [
-            (ChangeKind::Removed, "old", "inferred", 10),
-            (ChangeKind::Added, "new", "extracted", 11),
-        ] {
-            let value = serde_json::json!({
+                old: Some(serde_json::json!({
+                    "source": "caller",
+                    "target": "target",
+                    "relation": "calls",
+                    "confidence": "inferred",
+                    "context": index,
+                    "relationshipSite": {"file": "example.rs", "startLine": 10 + index}
+                })),
+                new: Some(serde_json::json!({
                 "source": "caller",
                 "target": "target",
                 "relation": "calls",
-                "confidence": confidence,
-                "relationshipSite": {"file": "example.rs", "startLine": line}
-            });
-            changes.change(GraphChange {
-                record: RecordKind::Edge,
-                change,
-                key: vec![
-                    "caller".to_owned(),
-                    "target".to_owned(),
-                    "calls".to_owned(),
-                    key.to_owned(),
-                ],
-                old: (change == ChangeKind::Removed).then_some(value.clone()),
-                new: (change == ChangeKind::Added).then_some(value),
+                    "confidence": "extracted",
+                    "context": index,
+                    "relationshipSite": {"file": "example.rs", "startLine": 20 + index}
+                })),
             })?;
         }
-        changes.normalize_graph_delta()?;
+        changes.normalize_graph_delta();
 
         assert!(changes.graph_delta.added_edges.is_empty());
         assert!(changes.graph_delta.removed_edges.is_empty());
-        assert_eq!(changes.graph_delta.changed_edges.len(), 1);
-        assert_eq!(
-            changes.graph_delta.changed_edges[0].changed_fields,
-            ["confidence"]
+        assert_eq!(changes.graph_delta.changed_edges.len(), 2);
+        assert!(changes.dependencies.is_empty());
+        assert!(
+            changes
+                .graph_delta
+                .changed_edges
+                .iter()
+                .all(|edge| { edge.changed_fields == ["confidence"] })
         );
         Ok(())
     }

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -1573,6 +1573,146 @@ fn query_path_and_explain_read_the_selected_materialized_commit()
 }
 
 #[test]
+fn change_counts_report_structure_instead_of_shifted_source_coordinates()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("service.rs"), "pub fn first() {}\n")?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "old"])?;
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let profile = current_history_profile()?;
+    let old_commit = repository.resolve("HEAD")?;
+    let publish = |commit: compass_history::CommitId,
+                   fingerprint: char,
+                   line: u64,
+                   edge_key: &str|
+     -> Result<(), Box<dyn std::error::Error>> {
+        let document: GraphDocument = serde_json::from_value(json!({
+            "directed": true,
+            "multigraph": true,
+            "nodes": [
+                {
+                    "id": "caller",
+                    "label": "caller",
+                    "source": {"file": "service.rs", "startLine": line, "endLine": line}
+                },
+                {
+                    "id": "callee",
+                    "label": "callee",
+                    "source": {"file": "service.rs", "startLine": line + 1, "endLine": line + 1}
+                }
+            ],
+            "links": [{
+                "source": "caller",
+                "target": "callee",
+                "relation": "calls",
+                "key": edge_key,
+                "relationshipSite": {
+                    "file": "service.rs",
+                    "startLine": line,
+                    "endLine": line
+                }
+            }]
+        }))?;
+        history.publish(PublishRequest {
+            commit: commit.clone(),
+            parents: repository.parents(&commit)?,
+            profile: profile.clone(),
+            fingerprint: std::iter::repeat_n(fingerprint, 64)
+                .collect::<String>()
+                .parse::<ExtractionFingerprint>()?,
+            artifacts: GraphArtifacts {
+                document,
+                program: None,
+                analysis: None,
+                labels: None,
+                manifest: None,
+                authoritative_sidecars: BTreeMap::new(),
+            },
+            completion: CompletionEvidence {
+                extraction_succeeded: true,
+                allow_partial: false,
+                semantic_files_expected: 0,
+                semantic_files_completed: 0,
+                failed_chunks: 0,
+            },
+            make_preferred: true,
+        })?;
+        Ok(())
+    };
+    publish(old_commit, 'a', 1, "edge-at-line-1")?;
+
+    std::fs::write(
+        directory.path().join("service.rs"),
+        "// inserted comment\npub fn first() {}\n",
+    )?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "shift"])?;
+    publish(repository.resolve("HEAD")?, 'b', 2, "edge-at-line-2")?;
+    drop(history);
+
+    let output = run(
+        env!("CARGO_BIN_EXE_compass"),
+        directory.path(),
+        &["history", "change-counts", "HEAD", "--format=json"],
+    )?;
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(output["schema"], "compass.history.change_counts/1");
+    assert_eq!(
+        output["counts"],
+        json!({
+            "nodes": {"added": 0, "removed": 0, "changed": 0},
+            "edges": {"added": 0, "removed": 0, "changed": 0},
+            "hyperedges": {"added": 0, "removed": 0, "changed": 0}
+        })
+    );
+
+    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
+    let current_commit = repository.resolve("HEAD")?;
+    let preferred = history
+        .preferred(&current_commit)?
+        .ok_or("missing preferred realization")?;
+    let current = history.artifacts(&preferred.id)?;
+    let mut incompatible_profile = profile;
+    incompatible_profile.insert("comparison_fixture", "incompatible")?;
+    history.publish(PublishRequest {
+        commit: current_commit.clone(),
+        parents: repository.parents(&current_commit)?,
+        profile: incompatible_profile,
+        fingerprint: std::iter::repeat_n('c', 64)
+            .collect::<String>()
+            .parse::<ExtractionFingerprint>()?,
+        artifacts: current.artifacts,
+        completion: current.completion,
+        make_preferred: true,
+    })?;
+    drop(history);
+    let incompatible = run(
+        env!("CARGO_BIN_EXE_compass"),
+        directory.path(),
+        &["history", "change-counts", "HEAD", "--format=json"],
+    )?;
+    assert_eq!(incompatible.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&incompatible.stderr).contains("different history build profiles")
+    );
+    Ok(())
+}
+
+#[test]
 fn missing_code_only_commit_is_built_on_first_query() -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     git(directory.path(), &["init", "--quiet"])?;

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -1306,6 +1306,42 @@ fn diff_emits_semantic_text_json_html_and_rejects_removed_flags()
     assert!(envelope["findings"].is_array());
     assert!(envelope["source_changes"].is_array());
     assert!(envelope["graph_delta"].is_object());
+    assert_eq!(
+        envelope["graph_delta"]["added_nodes"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        envelope["graph_delta"]["removed_nodes"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
+    assert_eq!(
+        envelope["graph_delta"]["changed_nodes"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
+    assert_eq!(
+        envelope["graph_delta"]["added_edges"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        envelope["graph_delta"]["removed_edges"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        envelope["graph_delta"]["changed_edges"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
     assert!(envelope.get("changes").is_none());
 
     let html_output = run(
@@ -1592,8 +1628,7 @@ fn change_counts_report_structure_instead_of_shifted_source_coordinates()
     let old_commit = repository.resolve("HEAD")?;
     let publish = |commit: compass_history::CommitId,
                    fingerprint: char,
-                   line: u64,
-                   edge_key: &str|
+                   line: u64|
      -> Result<(), Box<dyn std::error::Error>> {
         let document: GraphDocument = serde_json::from_value(json!({
             "directed": true,
@@ -1614,7 +1649,6 @@ fn change_counts_report_structure_instead_of_shifted_source_coordinates()
                 "source": "caller",
                 "target": "callee",
                 "relation": "calls",
-                "key": edge_key,
                 "relationshipSite": {
                     "file": "service.rs",
                     "startLine": line,
@@ -1648,7 +1682,7 @@ fn change_counts_report_structure_instead_of_shifted_source_coordinates()
         })?;
         Ok(())
     };
-    publish(old_commit, 'a', 1, "edge-at-line-1")?;
+    publish(old_commit, 'a', 1)?;
 
     std::fs::write(
         directory.path().join("service.rs"),
@@ -1656,7 +1690,7 @@ fn change_counts_report_structure_instead_of_shifted_source_coordinates()
     )?;
     git(directory.path(), &["add", "service.rs"])?;
     git(directory.path(), &["commit", "--quiet", "-m", "shift"])?;
-    publish(repository.resolve("HEAD")?, 'b', 2, "edge-at-line-2")?;
+    publish(repository.resolve("HEAD")?, 'b', 2)?;
     drop(history);
 
     let output = run(

--- a/crates/compass-history/src/artifacts.rs
+++ b/crates/compass-history/src/artifacts.rs
@@ -1626,7 +1626,7 @@ fn analysis_key(parts: &[&[u8]]) -> Vec<u8> {
         .finish()
 }
 
-fn metadata_key(parts: &[&[u8]]) -> Vec<u8> {
+pub(crate) fn metadata_key(parts: &[&[u8]]) -> Vec<u8> {
     parts
         .iter()
         .fold(

--- a/crates/compass-history/src/diff.rs
+++ b/crates/compass-history/src/diff.rs
@@ -152,18 +152,104 @@ impl RealizationReader<'_> {
         &self,
         new: &RealizationReader<'_>,
     ) -> Result<StructuralChangeCounts, HistoryError> {
-        if self.published.version.build_profile != new.published.version.build_profile {
+        let mut sink = StructuralCountSink::default();
+        self.structural_diff(new, &mut sink)?;
+        Ok(sink.counts)
+    }
+
+    /// Stream meaning-oriented graph changes from the Prolly roots.
+    ///
+    /// This is the canonical classification interface for versioned graph views. It preserves
+    /// topology, direction, relation, multiplicity, provenance, and explicit compatibility edge
+    /// keys while collapsing source-coordinate, clustering, presentation, and anchor-derived edge
+    /// identity churn. Exact storage changes remain available through [`Self::diff_records`].
+    pub fn structural_diff(
+        &self,
+        new: &RealizationReader<'_>,
+        sink: &mut dyn ChangeSink,
+    ) -> Result<(), HistoryError> {
+        if !std::ptr::eq(self.store, new.store) {
             return Err(HistoryError::OperationalState(
-                "cannot compare structural counts for different history build profiles".to_owned(),
+                "cannot diff readers from different history stores".to_owned(),
             ));
         }
-        let mut sink = StructuralChangeSink::default();
-        self.diff_records(
-            new,
-            &[RecordKind::Node, RecordKind::Edge, RecordKind::Hyperedge],
-            &mut sink,
-        )?;
-        sink.finish()
+        if self.published.version.build_profile != new.published.version.build_profile {
+            return Err(HistoryError::OperationalState(
+                "cannot compare structural graphs for different history build profiles".to_owned(),
+            ));
+        }
+        let mut projection = StructuralChangeSink::new(sink);
+        for (record, old, new) in [
+            (
+                RecordKind::Node,
+                &self.published.version.nodes_root,
+                &new.published.version.nodes_root,
+            ),
+            (
+                RecordKind::Edge,
+                &self.published.version.edges_root,
+                &new.published.version.edges_root,
+            ),
+            (
+                RecordKind::Hyperedge,
+                &self.published.version.hyperedges_root,
+                &new.published.version.hyperedges_root,
+            ),
+        ] {
+            self.diff_structural_root(record, old, new, &mut projection)?;
+        }
+        projection.finish()
+    }
+
+    fn diff_structural_root(
+        &self,
+        record: RecordKind,
+        old: &StoredTree,
+        new: &StoredTree,
+        sink: &mut StructuralChangeSink<'_>,
+    ) -> Result<(), HistoryError> {
+        if old == new {
+            return Ok(());
+        }
+        for difference in self.prolly.stream_diff(&self.tree(old), &self.tree(new))? {
+            let difference = difference?;
+            let (change, raw_key, old, new, identity) = match difference {
+                Diff::Added { key, val } => {
+                    let value = decode_stored_value(&val)?;
+                    let identity = edge_identity(record, &key, &value.schema)?;
+                    (ChangeKind::Added, key, None, Some(value.payload), identity)
+                }
+                Diff::Removed { key, val } => {
+                    let value = decode_stored_value(&val)?;
+                    let identity = edge_identity(record, &key, &value.schema)?;
+                    (
+                        ChangeKind::Removed,
+                        key,
+                        Some(value.payload),
+                        None,
+                        identity,
+                    )
+                }
+                Diff::Changed { key, old, new } => (
+                    ChangeKind::Changed,
+                    key,
+                    Some(decode_value(&old)?),
+                    Some(decode_value(&new)?),
+                    EdgeIdentity::Derived,
+                ),
+            };
+            sink.change(
+                GraphChange {
+                    record,
+                    change,
+                    key: display_key(record, &raw_key)?,
+                    old,
+                    new,
+                },
+                identity,
+            )?;
+        }
+        Ok(())
     }
 
     fn diff_root(
@@ -206,29 +292,45 @@ impl RealizationReader<'_> {
 
 type EdgeTopology = (String, String, String);
 
-#[derive(Default)]
-struct EdgeIdentityChanges {
-    added: BTreeMap<Vec<u8>, u64>,
-    removed: BTreeMap<Vec<u8>, u64>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EdgeIdentity {
+    Derived,
+    ExplicitCompatibility,
 }
 
 #[derive(Default)]
-struct StructuralChangeSink {
-    counts: StructuralChangeCounts,
+struct EdgeIdentityChanges {
+    added: BTreeMap<Vec<u8>, Vec<GraphChange>>,
+    removed: BTreeMap<Vec<u8>, Vec<GraphChange>>,
+}
+
+struct ProjectedIdentityChange {
+    projection: Vec<u8>,
+    change: GraphChange,
+}
+
+struct StructuralChangeSink<'a> {
+    sink: &'a mut dyn ChangeSink,
     // Prolly edge keys are ordered by topology then occurrence, so only one topology group needs
     // to be retained while the exact diff streams.
     edge_identity_changes: Option<(EdgeTopology, EdgeIdentityChanges)>,
 }
 
-impl StructuralChangeSink {
-    fn finish(mut self) -> Result<StructuralChangeCounts, HistoryError> {
-        self.flush_edge_identity_changes();
-        Ok(self.counts)
+impl<'a> StructuralChangeSink<'a> {
+    fn new(sink: &'a mut dyn ChangeSink) -> Self {
+        Self {
+            sink,
+            edge_identity_changes: None,
+        }
     }
 
-    fn flush_edge_identity_changes(&mut self) {
+    fn finish(mut self) -> Result<(), HistoryError> {
+        self.flush_edge_identity_changes()
+    }
+
+    fn flush_edge_identity_changes(&mut self) -> Result<(), HistoryError> {
         let Some((_, changes)) = self.edge_identity_changes.take() else {
-            return;
+            return Ok(());
         };
         let projections = changes
             .added
@@ -236,36 +338,59 @@ impl StructuralChangeSink {
             .chain(changes.removed.keys())
             .cloned()
             .collect::<BTreeSet<_>>();
-        let added = changes.added.values().copied().sum::<u64>();
-        let removed = changes.removed.values().copied().sum::<u64>();
-        let unchanged = projections
+        let mut added = changes.added;
+        let mut removed = changes.removed;
+        let mut unmatched_added = Vec::new();
+        let mut unmatched_removed = Vec::new();
+        for projection in projections {
+            let mut added_records = added.remove(&projection).unwrap_or_default();
+            let mut removed_records = removed.remove(&projection).unwrap_or_default();
+            sort_identity_changes(&mut added_records);
+            sort_identity_changes(&mut removed_records);
+            let unchanged = added_records.len().min(removed_records.len());
+            unmatched_added.extend(added_records.into_iter().skip(unchanged).map(|change| {
+                ProjectedIdentityChange {
+                    projection: projection.clone(),
+                    change,
+                }
+            }));
+            unmatched_removed.extend(removed_records.into_iter().skip(unchanged).map(|change| {
+                ProjectedIdentityChange {
+                    projection: projection.clone(),
+                    change,
+                }
+            }));
+        }
+        sort_projected_identity_changes(&mut unmatched_added);
+        sort_projected_identity_changes(&mut unmatched_removed);
+        let changed = unmatched_added.len().min(unmatched_removed.len());
+        for (added, removed) in unmatched_added
             .iter()
-            .map(|projection| {
-                changes
-                    .added
-                    .get(projection)
-                    .copied()
-                    .unwrap_or_default()
-                    .min(changes.removed.get(projection).copied().unwrap_or_default())
-            })
-            .sum::<u64>();
-        let unmatched_added = added.saturating_sub(unchanged);
-        let unmatched_removed = removed.saturating_sub(unchanged);
-        let changed = unmatched_added.min(unmatched_removed);
-        self.counts.edges.changed = self.counts.edges.changed.saturating_add(changed);
-        self.counts.edges.added = self
-            .counts
-            .edges
-            .added
-            .saturating_add(unmatched_added.saturating_sub(changed));
-        self.counts.edges.removed = self
-            .counts
-            .edges
-            .removed
-            .saturating_add(unmatched_removed.saturating_sub(changed));
+            .take(changed)
+            .zip(unmatched_removed.iter().take(changed))
+        {
+            self.sink.change(GraphChange {
+                record: RecordKind::Edge,
+                change: ChangeKind::Changed,
+                key: added.change.key.clone(),
+                old: removed.change.old.clone(),
+                new: added.change.new.clone(),
+            })?;
+        }
+        for change in unmatched_added.into_iter().skip(changed) {
+            self.sink.change(change.change)?;
+        }
+        for change in unmatched_removed.into_iter().skip(changed) {
+            self.sink.change(change.change)?;
+        }
+        Ok(())
     }
 
-    fn edge_identity_change(&mut self, change: &GraphChange) -> Result<(), HistoryError> {
+    fn edge_identity_change(
+        &mut self,
+        change: &GraphChange,
+        identity: EdgeIdentity,
+    ) -> Result<(), HistoryError> {
         let [source, target, relation, ..] = change.key.as_slice() else {
             return Err(HistoryError::InvalidKey(
                 "edge change has no source, target, and relation".to_owned(),
@@ -279,6 +404,9 @@ impl StructuralChangeSink {
         .ok_or_else(|| {
             HistoryError::InvalidArtifacts("edge identity change has no record value".to_owned())
         })?;
+        if identity == EdgeIdentity::ExplicitCompatibility {
+            return self.sink.change(change.clone());
+        }
         let projection = structural_projection(RecordKind::Edge, value)?;
         let topology = (source.clone(), target.clone(), relation.clone());
         if self
@@ -286,7 +414,7 @@ impl StructuralChangeSink {
             .as_ref()
             .is_some_and(|(current, _)| current != &topology)
         {
-            self.flush_edge_identity_changes();
+            self.flush_edge_identity_changes()?;
         }
         let (_, changes) = self
             .edge_identity_changes
@@ -296,45 +424,79 @@ impl StructuralChangeSink {
         } else {
             &mut changes.removed
         };
-        let count = counts.entry(projection).or_default();
-        *count = count.saturating_add(1);
+        counts.entry(projection).or_default().push(change.clone());
+        Ok(())
+    }
+
+    fn change(&mut self, change: GraphChange, identity: EdgeIdentity) -> Result<(), HistoryError> {
+        match (change.record, change.change) {
+            (RecordKind::Node | RecordKind::Hyperedge, ChangeKind::Added | ChangeKind::Removed) => {
+                self.sink.change(change)?;
+            }
+            (RecordKind::Edge, ChangeKind::Added | ChangeKind::Removed) => {
+                self.edge_identity_change(&change, identity)?;
+            }
+            (RecordKind::Node | RecordKind::Edge | RecordKind::Hyperedge, ChangeKind::Changed)
+                if meaningful_record_changed(&change)? =>
+            {
+                self.sink.change(change)?;
+            }
+            _ => {}
+        }
         Ok(())
     }
 }
 
-impl ChangeSink for StructuralChangeSink {
+fn sort_identity_changes(changes: &mut [GraphChange]) {
+    changes.sort_by(|left, right| left.key.cmp(&right.key));
+}
+
+fn sort_projected_identity_changes(changes: &mut [ProjectedIdentityChange]) {
+    changes.sort_by(|left, right| {
+        left.projection
+            .cmp(&right.projection)
+            .then_with(|| left.change.key.cmp(&right.change.key))
+    });
+}
+
+fn edge_identity(
+    record: RecordKind,
+    raw_key: &[u8],
+    schema: &str,
+) -> Result<EdgeIdentity, HistoryError> {
+    if record != RecordKind::Edge || schema != "compass.edge" {
+        return Ok(EdgeIdentity::Derived);
+    }
+    let segments =
+        decode_segments(raw_key).map_err(|error| HistoryError::InvalidKey(error.to_string()))?;
+    Ok(
+        if segments.get(5).and_then(|segment| segment.first()) == Some(&1) {
+            EdgeIdentity::ExplicitCompatibility
+        } else {
+            EdgeIdentity::Derived
+        },
+    )
+}
+
+#[derive(Default)]
+struct StructuralCountSink {
+    counts: StructuralChangeCounts,
+}
+
+impl ChangeSink for StructuralCountSink {
     fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
-        match (change.record, change.change) {
-            (RecordKind::Node, ChangeKind::Added) => {
-                self.counts.nodes.added = self.counts.nodes.added.saturating_add(1);
-            }
-            (RecordKind::Node, ChangeKind::Removed) => {
-                self.counts.nodes.removed = self.counts.nodes.removed.saturating_add(1);
-            }
-            (RecordKind::Node, ChangeKind::Changed) => {
-                if meaningful_record_changed(&change)? {
-                    self.counts.nodes.changed = self.counts.nodes.changed.saturating_add(1);
-                }
-            }
-            (RecordKind::Edge, ChangeKind::Added | ChangeKind::Removed) => {
-                self.edge_identity_change(&change)?;
-            }
-            (RecordKind::Edge, ChangeKind::Changed) => {
-                if meaningful_record_changed(&change)? {
-                    self.counts.edges.changed = self.counts.edges.changed.saturating_add(1);
-                }
-            }
-            (RecordKind::Hyperedge, ChangeKind::Added) => {
-                self.counts.hyperedges.added = self.counts.hyperedges.added.saturating_add(1);
-            }
-            (RecordKind::Hyperedge, ChangeKind::Removed) => {
-                self.counts.hyperedges.removed = self.counts.hyperedges.removed.saturating_add(1);
-            }
-            (RecordKind::Hyperedge, ChangeKind::Changed) => {
-                self.counts.hyperedges.changed = self.counts.hyperedges.changed.saturating_add(1);
-            }
-            _ => {}
-        }
+        let counts = match change.record {
+            RecordKind::Node => &mut self.counts.nodes,
+            RecordKind::Edge => &mut self.counts.edges,
+            RecordKind::Hyperedge => &mut self.counts.hyperedges,
+            _ => return Ok(()),
+        };
+        let count = match change.change {
+            ChangeKind::Added => &mut counts.added,
+            ChangeKind::Removed => &mut counts.removed,
+            ChangeKind::Changed => &mut counts.changed,
+        };
+        *count = count.saturating_add(1);
         Ok(())
     }
 }
@@ -421,9 +583,21 @@ fn ignored_structural_field(record: RecordKind, field: &str, root: bool) -> bool
         || (root && record == RecordKind::Edge && matches!(field, "id" | "key"))
 }
 
-fn decode_value(bytes: &[u8]) -> Result<Value, HistoryError> {
+struct StoredValue {
+    schema: String,
+    payload: Value,
+}
+
+fn decode_stored_value(bytes: &[u8]) -> Result<StoredValue, HistoryError> {
     let envelope = VersionedValue::from_bytes(bytes)?;
-    serde_json::from_slice(&envelope.payload).map_err(HistoryError::from)
+    Ok(StoredValue {
+        schema: envelope.schema,
+        payload: serde_json::from_slice(&envelope.payload)?,
+    })
+}
+
+fn decode_value(bytes: &[u8]) -> Result<Value, HistoryError> {
+    Ok(decode_stored_value(bytes)?.payload)
 }
 
 fn display_key(record: RecordKind, key: &[u8]) -> Result<Vec<String>, HistoryError> {
@@ -508,5 +682,19 @@ mod tests {
             .push_str("node-id")
             .finish();
         assert!(display_key(RecordKind::Node, &edge).is_err());
+    }
+
+    #[test]
+    fn edge_identity_uses_the_value_schema_not_discriminator_shape() -> Result<(), HistoryError> {
+        let key = edge_key("source", "target", "calls", true, Some(&[1, b'k']));
+        assert_eq!(
+            edge_identity(RecordKind::Edge, &key, "compass.edge")?,
+            EdgeIdentity::ExplicitCompatibility
+        );
+        assert_eq!(
+            edge_identity(RecordKind::Edge, &key, "compass.graph.edge.v1")?,
+            EdgeIdentity::Derived
+        );
+        Ok(())
     }
 }

--- a/crates/compass-history/src/diff.rs
+++ b/crates/compass-history/src/diff.rs
@@ -1,6 +1,8 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use prolly::{Diff, VersionedValue, decode_segments};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::keys::{EDGE_KIND, HYPEREDGE_KIND, KEY_SCHEMA_V1, NODE_KIND};
 use crate::{HistoryError, RealizationReader, StoredTree};
@@ -38,6 +40,22 @@ pub struct GraphChange {
 
 pub trait ChangeSink {
     fn change(&mut self, change: GraphChange) -> Result<(), HistoryError>;
+}
+
+/// Bounded counts for one structural record family.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct RecordChangeCounts {
+    pub added: u64,
+    pub removed: u64,
+    pub changed: u64,
+}
+
+/// Meaning-oriented graph counts that exclude source-coordinate and clustering churn.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct StructuralChangeCounts {
+    pub nodes: RecordChangeCounts,
+    pub edges: RecordChangeCounts,
+    pub hyperedges: RecordChangeCounts,
 }
 
 impl RealizationReader<'_> {
@@ -124,6 +142,30 @@ impl RealizationReader<'_> {
         Ok(())
     }
 
+    /// Count structural graph changes without treating relocated source anchors as topology.
+    ///
+    /// Unlike [`Self::diff_records`], this projection is intended for graph-version UI and
+    /// summary queries. Exact record diffs remain available through `diff_records`. Both
+    /// realizations must use the same build profile so extractor or configuration changes never
+    /// masquerade as repository changes.
+    pub fn structural_change_counts(
+        &self,
+        new: &RealizationReader<'_>,
+    ) -> Result<StructuralChangeCounts, HistoryError> {
+        if self.published.version.build_profile != new.published.version.build_profile {
+            return Err(HistoryError::OperationalState(
+                "cannot compare structural counts for different history build profiles".to_owned(),
+            ));
+        }
+        let mut sink = StructuralChangeSink::default();
+        self.diff_records(
+            new,
+            &[RecordKind::Node, RecordKind::Edge, RecordKind::Hyperedge],
+            &mut sink,
+        )?;
+        sink.finish()
+    }
+
     fn diff_root(
         &self,
         record: RecordKind,
@@ -160,6 +202,223 @@ impl RealizationReader<'_> {
         }
         Ok(())
     }
+}
+
+type EdgeTopology = (String, String, String);
+
+#[derive(Default)]
+struct EdgeIdentityChanges {
+    added: BTreeMap<Vec<u8>, u64>,
+    removed: BTreeMap<Vec<u8>, u64>,
+}
+
+#[derive(Default)]
+struct StructuralChangeSink {
+    counts: StructuralChangeCounts,
+    // Prolly edge keys are ordered by topology then occurrence, so only one topology group needs
+    // to be retained while the exact diff streams.
+    edge_identity_changes: Option<(EdgeTopology, EdgeIdentityChanges)>,
+}
+
+impl StructuralChangeSink {
+    fn finish(mut self) -> Result<StructuralChangeCounts, HistoryError> {
+        self.flush_edge_identity_changes();
+        Ok(self.counts)
+    }
+
+    fn flush_edge_identity_changes(&mut self) {
+        let Some((_, changes)) = self.edge_identity_changes.take() else {
+            return;
+        };
+        let projections = changes
+            .added
+            .keys()
+            .chain(changes.removed.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let added = changes.added.values().copied().sum::<u64>();
+        let removed = changes.removed.values().copied().sum::<u64>();
+        let unchanged = projections
+            .iter()
+            .map(|projection| {
+                changes
+                    .added
+                    .get(projection)
+                    .copied()
+                    .unwrap_or_default()
+                    .min(changes.removed.get(projection).copied().unwrap_or_default())
+            })
+            .sum::<u64>();
+        let unmatched_added = added.saturating_sub(unchanged);
+        let unmatched_removed = removed.saturating_sub(unchanged);
+        let changed = unmatched_added.min(unmatched_removed);
+        self.counts.edges.changed = self.counts.edges.changed.saturating_add(changed);
+        self.counts.edges.added = self
+            .counts
+            .edges
+            .added
+            .saturating_add(unmatched_added.saturating_sub(changed));
+        self.counts.edges.removed = self
+            .counts
+            .edges
+            .removed
+            .saturating_add(unmatched_removed.saturating_sub(changed));
+    }
+
+    fn edge_identity_change(&mut self, change: &GraphChange) -> Result<(), HistoryError> {
+        let [source, target, relation, ..] = change.key.as_slice() else {
+            return Err(HistoryError::InvalidKey(
+                "edge change has no source, target, and relation".to_owned(),
+            ));
+        };
+        let value = match change.change {
+            ChangeKind::Added => change.new.as_ref(),
+            ChangeKind::Removed => change.old.as_ref(),
+            ChangeKind::Changed => None,
+        }
+        .ok_or_else(|| {
+            HistoryError::InvalidArtifacts("edge identity change has no record value".to_owned())
+        })?;
+        let projection = structural_projection(RecordKind::Edge, value)?;
+        let topology = (source.clone(), target.clone(), relation.clone());
+        if self
+            .edge_identity_changes
+            .as_ref()
+            .is_some_and(|(current, _)| current != &topology)
+        {
+            self.flush_edge_identity_changes();
+        }
+        let (_, changes) = self
+            .edge_identity_changes
+            .get_or_insert_with(|| (topology, EdgeIdentityChanges::default()));
+        let counts = if change.change == ChangeKind::Added {
+            &mut changes.added
+        } else {
+            &mut changes.removed
+        };
+        let count = counts.entry(projection).or_default();
+        *count = count.saturating_add(1);
+        Ok(())
+    }
+}
+
+impl ChangeSink for StructuralChangeSink {
+    fn change(&mut self, change: GraphChange) -> Result<(), HistoryError> {
+        match (change.record, change.change) {
+            (RecordKind::Node, ChangeKind::Added) => {
+                self.counts.nodes.added = self.counts.nodes.added.saturating_add(1);
+            }
+            (RecordKind::Node, ChangeKind::Removed) => {
+                self.counts.nodes.removed = self.counts.nodes.removed.saturating_add(1);
+            }
+            (RecordKind::Node, ChangeKind::Changed) => {
+                if meaningful_record_changed(&change)? {
+                    self.counts.nodes.changed = self.counts.nodes.changed.saturating_add(1);
+                }
+            }
+            (RecordKind::Edge, ChangeKind::Added | ChangeKind::Removed) => {
+                self.edge_identity_change(&change)?;
+            }
+            (RecordKind::Edge, ChangeKind::Changed) => {
+                if meaningful_record_changed(&change)? {
+                    self.counts.edges.changed = self.counts.edges.changed.saturating_add(1);
+                }
+            }
+            (RecordKind::Hyperedge, ChangeKind::Added) => {
+                self.counts.hyperedges.added = self.counts.hyperedges.added.saturating_add(1);
+            }
+            (RecordKind::Hyperedge, ChangeKind::Removed) => {
+                self.counts.hyperedges.removed = self.counts.hyperedges.removed.saturating_add(1);
+            }
+            (RecordKind::Hyperedge, ChangeKind::Changed) => {
+                self.counts.hyperedges.changed = self.counts.hyperedges.changed.saturating_add(1);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+fn meaningful_record_changed(change: &GraphChange) -> Result<bool, HistoryError> {
+    let old = change.old.as_ref().ok_or_else(|| {
+        HistoryError::InvalidArtifacts("changed graph record has no old value".to_owned())
+    })?;
+    let new = change.new.as_ref().ok_or_else(|| {
+        HistoryError::InvalidArtifacts("changed graph record has no new value".to_owned())
+    })?;
+    Ok(structural_projection(change.record, old)? != structural_projection(change.record, new)?)
+}
+
+fn structural_projection(record: RecordKind, value: &Value) -> Result<Vec<u8>, HistoryError> {
+    let projected = structural_graph_projection(record, value);
+    crate::canonical_json_bytes(&projected)
+}
+
+/// Remove source-coordinate, clustering, and presentation fields from a graph record.
+///
+/// This is the shared meaning projection used by structural history summaries. It does not alter
+/// the stored record or the exact diff contract.
+pub fn structural_graph_projection(record: RecordKind, value: &Value) -> Value {
+    project_value(record, value, true)
+}
+
+fn project_value(record: RecordKind, value: &Value, root: bool) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| project_value(record, value, false))
+                .collect(),
+        ),
+        Value::Object(values) => Value::Object(project_object(record, values, root)),
+        _ => value.clone(),
+    }
+}
+
+fn project_object(
+    record: RecordKind,
+    values: &Map<String, Value>,
+    root: bool,
+) -> Map<String, Value> {
+    values
+        .iter()
+        .filter(|(key, _)| !ignored_structural_field(record, key, root))
+        .map(|(key, value)| (key.clone(), project_value(record, value, false)))
+        .collect()
+}
+
+fn ignored_structural_field(record: RecordKind, field: &str, root: bool) -> bool {
+    matches!(
+        field,
+        "anchor"
+            | "anchors"
+            | "color"
+            | "community"
+            | "communityName"
+            | "community_name"
+            | "endByte"
+            | "endColumn"
+            | "endLine"
+            | "end_byte"
+            | "end_column"
+            | "line_end"
+            | "line_start"
+            | "norm_label"
+            | "relationshipSite"
+            | "relationship_site"
+            | "sourceDigest"
+            | "source_file"
+            | "source_hash"
+            | "source_location"
+            | "startByte"
+            | "startColumn"
+            | "startLine"
+            | "start_byte"
+            | "start_column"
+            | "wiringSite"
+            | "wiring_site"
+    ) || (root && record == RecordKind::Node && field == "source")
+        || (root && record == RecordKind::Edge && matches!(field, "id" | "key"))
 }
 
 fn decode_value(bytes: &[u8]) -> Result<Value, HistoryError> {

--- a/crates/compass-history/src/graph_read.rs
+++ b/crates/compass-history/src/graph_read.rs
@@ -1,8 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use compass_model::{EdgeRecord, NodeRecord};
 use prolly::decode_segments;
-use serde_json::Value;
+use serde::Deserialize;
+use serde_json::{Map, Value};
 
 use crate::{
     HistoryError, MAX_AUTHORITATIVE_BYTES, MAX_KEY_BYTES, MAX_RECORD_VALUE_BYTES,
@@ -11,6 +12,14 @@ use crate::{
 
 /// Receives the graph-only projection of a sealed realization.
 pub trait GraphRecordSink {
+    fn document_metadata(
+        &mut self,
+        directed: bool,
+        multigraph: bool,
+        graph: Map<String, Value>,
+        extras: BTreeMap<String, Value>,
+    ) -> Result<(), HistoryError>;
+
     fn node_attribute(
         &mut self,
         node_id: String,
@@ -29,6 +38,21 @@ impl RealizationReader<'_> {
     /// Scan only analysis, node, and edge roots for a historical graph view.
     pub fn scan_graph(&self, sink: &mut dyn GraphRecordSink) -> Result<(), HistoryError> {
         let mut total_bytes = 0_u64;
+        let metadata = self.published.version.metadata_root.to_tree();
+        let document_key = crate::artifacts::metadata_key(&[b"document"]);
+        let document_bytes = self.prolly.get(&metadata, &document_key)?.ok_or_else(|| {
+            HistoryError::InvalidArtifacts("missing document metadata".to_owned())
+        })?;
+        account(&document_key, &document_bytes, &mut total_bytes)?;
+        let document: GraphDocumentMetadata =
+            crate::artifacts::decode_typed(&document_bytes, "compass.metadata.document")?;
+        sink.document_metadata(
+            document.directed,
+            document.multigraph,
+            document.graph,
+            document.extras,
+        )?;
+
         let mut pending_analysis = HashSet::<String>::new();
         let analysis = self.published.version.analysis_root.to_tree();
         let mut analysis_count = 0_u64;
@@ -132,6 +156,14 @@ impl RealizationReader<'_> {
         }
         require_count("edges", self.published.version.edge_count, edge_count)
     }
+}
+
+#[derive(Deserialize)]
+struct GraphDocumentMetadata {
+    directed: bool,
+    multigraph: bool,
+    graph: Map<String, Value>,
+    extras: BTreeMap<String, Value>,
 }
 
 fn account(key: &[u8], value: &[u8], total: &mut u64) -> Result<(), HistoryError> {

--- a/crates/compass-history/src/lib.rs
+++ b/crates/compass-history/src/lib.rs
@@ -28,7 +28,10 @@ pub use cache::{
 };
 pub use canonical::{CANONICAL_ENCODING_VERSION, canonical_json_bytes};
 pub use config::HistoryConfig;
-pub use diff::{ChangeKind, ChangeSink, GraphChange, RecordKind};
+pub use diff::{
+    ChangeKind, ChangeSink, GraphChange, RecordChangeCounts, RecordKind, StructuralChangeCounts,
+    structural_graph_projection,
+};
 pub use error::HistoryError;
 pub use fingerprint::{BuildProfile, ExtractionFingerprint, ExtractionFingerprintInput};
 pub use gc::{GcPlan, GcSweep};

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -325,6 +325,9 @@ fn structural_counts_collapse_graph_wide_source_coordinate_churn()
         old_reader.structural_change_counts(&new_reader)?,
         compass_history::StructuralChangeCounts::default()
     );
+    let mut structural = VecSink::default();
+    old_reader.structural_diff(&new_reader, &mut structural)?;
+    assert!(structural.0.is_empty());
     Ok(())
 }
 
@@ -374,6 +377,142 @@ fn structural_counts_preserve_meaningful_node_edge_and_multiplicity_changes()
     assert_eq!(counts.edges.changed, 1);
     assert_eq!(counts.edges.added, 1);
     assert_eq!(counts.edges.removed, 0);
+    Ok(())
+}
+
+#[test]
+fn structural_diff_pairs_every_parallel_anchor_identity_change()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let edges = |confidence: &str, offset: u64| {
+        ["first", "second"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, context)| {
+                json!({
+                    "source": "a",
+                    "target": "b",
+                    "relation": "calls",
+                    "confidence": confidence,
+                    "context": context,
+                    "relationshipSite": {
+                        "file": "src/lib.rs",
+                        "startByte": offset + index as u64,
+                        "endByte": offset + index as u64 + 1
+                    }
+                })
+            })
+            .collect::<Vec<_>>()
+    };
+    let nodes = vec![json!({"id":"a"}), json!({"id":"b"})];
+    let old = history.publish(request(
+        'a',
+        nodes.clone(),
+        edges("INFERRED", 10),
+        Vec::new(),
+        1,
+    )?)?;
+    let new = history.publish(request('b', nodes, edges("EXTRACTED", 20), Vec::new(), 1)?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    let mut structural = VecSink::default();
+    old_reader.structural_diff(&new_reader, &mut structural)?;
+    assert_eq!(structural.0.len(), 2);
+    assert!(structural.0.iter().all(|change| {
+        change.record == RecordKind::Edge && change.change == ChangeKind::Changed
+    }));
+    assert!(structural.0.iter().all(|change| {
+        change.old.as_ref().and_then(|value| value.get("context"))
+            == change.new.as_ref().and_then(|value| value.get("context"))
+    }));
+    let counts = old_reader.structural_change_counts(&new_reader)?;
+    assert_eq!(counts.edges.added, 0);
+    assert_eq!(counts.edges.removed, 0);
+    assert_eq!(counts.edges.changed, 2);
+    Ok(())
+}
+
+#[test]
+fn structural_diff_preserves_explicit_edge_identity_replacement()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let nodes = vec![json!({"id":"a"}), json!({"id":"b"})];
+    let old = history.publish(request(
+        'a',
+        nodes.clone(),
+        vec![json!({
+            "source":"a", "target":"b", "relation":"calls", "key":"stable-old"
+        })],
+        Vec::new(),
+        1,
+    )?)?;
+    let new = history.publish(request(
+        'b',
+        nodes,
+        vec![json!({
+            "source":"a", "target":"b", "relation":"calls", "key":"stable-new"
+        })],
+        Vec::new(),
+        1,
+    )?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    let mut structural = VecSink::default();
+    old_reader.structural_diff(&new_reader, &mut structural)?;
+    assert_eq!(structural.0.len(), 2);
+    assert_eq!(
+        structural
+            .0
+            .iter()
+            .filter(|change| change.change == ChangeKind::Added)
+            .count(),
+        1
+    );
+    assert_eq!(
+        structural
+            .0
+            .iter()
+            .filter(|change| change.change == ChangeKind::Removed)
+            .count(),
+        1
+    );
+    let counts = old_reader.structural_change_counts(&new_reader)?;
+    assert_eq!(counts.edges.added, 1);
+    assert_eq!(counts.edges.removed, 1);
+    assert_eq!(counts.edges.changed, 0);
+    Ok(())
+}
+
+#[test]
+fn structural_diff_treats_relation_as_topology() -> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let nodes = vec![json!({"id":"a"}), json!({"id":"b"})];
+    let old = history.publish(request(
+        'a',
+        nodes.clone(),
+        vec![json!({"source":"a", "target":"b", "relation":"calls"})],
+        Vec::new(),
+        1,
+    )?)?;
+    let new = history.publish(request(
+        'b',
+        nodes,
+        vec![json!({"source":"a", "target":"b", "relation":"uses"})],
+        Vec::new(),
+        1,
+    )?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    let counts = old_reader.structural_change_counts(&new_reader)?;
+    assert_eq!(counts.edges.added, 1);
+    assert_eq!(counts.edges.removed, 1);
+    assert_eq!(counts.edges.changed, 0);
     Ok(())
 }
 

--- a/crates/compass-history/tests/diff.rs
+++ b/crates/compass-history/tests/diff.rs
@@ -257,6 +257,144 @@ fn diff_reports_topology_attribute_and_analysis_changes() -> Result<(), Box<dyn 
 }
 
 #[test]
+fn structural_counts_collapse_graph_wide_source_coordinate_churn()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let nodes = |offset: usize| {
+        (0..256)
+            .map(|index| {
+                json!({
+                    "id": format!("node-{index:03}"),
+                    "label": format!("Node {index}"),
+                    "source_file": "src/service.rs",
+                    "source_location": format!("L{}", index + offset),
+                    "line_start": index + offset,
+                    "line_end": index + offset,
+                    "start_byte": index * 10 + offset,
+                    "end_byte": index * 10 + offset + 5,
+                })
+            })
+            .collect::<Vec<_>>()
+    };
+    let edges = |offset: usize| {
+        (0..255)
+            .map(|index| {
+                json!({
+                    "source": format!("node-{index:03}"),
+                    "target": format!("node-{:03}", index + 1),
+                    "relation": "calls",
+                    "confidence": "EXTRACTED",
+                    "source_file": "src/service.rs",
+                    "source_location": format!("L{}", index + offset),
+                    "start_byte": index * 10 + offset,
+                    "end_byte": index * 10 + offset + 5,
+                })
+            })
+            .collect::<Vec<_>>()
+    };
+    let old = history.publish(request('a', nodes(1), edges(1), Vec::new(), 1)?)?;
+    let new = history.publish(request('b', nodes(2), edges(2), Vec::new(), 1)?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    let mut exact = VecSink::default();
+    old_reader.diff_records(
+        &new_reader,
+        &[RecordKind::Node, RecordKind::Edge],
+        &mut exact,
+    )?;
+    assert_eq!(
+        exact
+            .0
+            .iter()
+            .filter(|change| change.record == RecordKind::Node)
+            .count(),
+        256
+    );
+    assert_eq!(
+        exact
+            .0
+            .iter()
+            .filter(|change| change.record == RecordKind::Edge)
+            .count(),
+        510
+    );
+
+    assert_eq!(
+        old_reader.structural_change_counts(&new_reader)?,
+        compass_history::StructuralChangeCounts::default()
+    );
+    Ok(())
+}
+
+#[test]
+fn structural_counts_preserve_meaningful_node_edge_and_multiplicity_changes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let old = history.publish(request(
+        'a',
+        vec![json!({"id":"a","label":"Old"}), json!({"id":"b"})],
+        vec![json!({
+            "source":"a",
+            "target":"b",
+            "relation":"calls",
+            "confidence":"INFERRED"
+        })],
+        Vec::new(),
+        1,
+    )?)?;
+    let new = history.publish(request(
+        'b',
+        vec![json!({"id":"a","label":"New"}), json!({"id":"b"})],
+        vec![
+            json!({
+                "source":"a",
+                "target":"b",
+                "relation":"calls",
+                "confidence":"EXTRACTED"
+            }),
+            json!({
+                "source":"a",
+                "target":"b",
+                "relation":"calls",
+                "confidence":"EXTRACTED",
+                "context":"second occurrence"
+            }),
+        ],
+        Vec::new(),
+        1,
+    )?)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    let counts = old_reader.structural_change_counts(&new_reader)?;
+    assert_eq!(counts.nodes.changed, 1);
+    assert_eq!(counts.edges.changed, 1);
+    assert_eq!(counts.edges.added, 1);
+    assert_eq!(counts.edges.removed, 0);
+    Ok(())
+}
+
+#[test]
+fn structural_counts_reject_different_build_profiles() -> Result<(), Box<dyn std::error::Error>> {
+    let (_directory, repository) = repository()?;
+    let history = HistoryStore::create(&repository)?;
+    let old = history.publish(request('a', vec![json!({"id":"a"})], vec![], vec![], 1)?)?;
+    let mut changed_profile = request('b', vec![json!({"id":"a"})], vec![], vec![], 1)?;
+    changed_profile
+        .profile
+        .insert("extractor_version", "different")?;
+    let new = history.publish(changed_profile)?;
+    let old_reader = history.reader(&old.id)?;
+    let new_reader = history.reader(&new.id)?;
+
+    assert!(old_reader.structural_change_counts(&new_reader).is_err());
+    Ok(())
+}
+
+#[test]
 fn identity_changes_are_remove_add_equal_roots_are_empty_and_sink_errors_stop()
 -> Result<(), Box<dyn std::error::Error>> {
     let (_directory, repository) = repository()?;

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -221,6 +221,39 @@ fn small_change_reuses_content_addressed_nodes() -> Result<(), Box<dyn std::erro
 }
 
 #[test]
+#[ignore = "performance evidence; run explicitly"]
+fn structural_diff_small_change_is_prolly_bounded() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("fixture.rs"), "pub struct Fixture;\n")?;
+    commit(directory.path(), "fixture")?;
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::create(&repository)?;
+    let first = history.publish(request(&repository, false)?)?;
+    let second = history.publish(request(&repository, true)?)?;
+    let first_reader = history.reader(&first.id)?;
+    let second_reader = history.reader(&second.id)?;
+    let mut sink = CountingSink::default();
+    let started = Instant::now();
+    first_reader.structural_diff(&second_reader, &mut sink)?;
+    let elapsed = started.elapsed();
+
+    assert_eq!(sink.changes, 1);
+    assert_eq!(sink.peak_buffered_records, 1);
+    println!(
+        "structural_diff_latency={elapsed:?} changes={} peak_callback_buffer={}",
+        sink.changes, sink.peak_buffered_records
+    );
+    Ok(())
+}
+
+#[test]
 #[ignore = "performance evidence; requires COMPASS_HISTORY_PERF_ARTIFACTS"]
 fn real_artifact_publication_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
     let artifacts_path = PathBuf::from(

--- a/crates/compass-output/src/history_viewer.rs
+++ b/crates/compass-output/src/history_viewer.rs
@@ -55,6 +55,10 @@ enum ProjectionMode {
 
 struct HistoricalViewBuilder {
     mode: ProjectionMode,
+    directed: bool,
+    multigraph: bool,
+    graph: Map<String, Value>,
+    extras: BTreeMap<String, Value>,
     attributes: BTreeMap<String, Map<String, Value>>,
     labels: Option<Value>,
     nodes: Vec<NodeRecord>,
@@ -68,6 +72,10 @@ impl HistoricalViewBuilder {
     fn new(mode: ProjectionMode) -> Self {
         Self {
             mode,
+            directed: true,
+            multigraph: false,
+            graph: Map::new(),
+            extras: BTreeMap::new(),
             attributes: BTreeMap::new(),
             labels: None,
             nodes: Vec::new(),
@@ -80,6 +88,20 @@ impl HistoricalViewBuilder {
 }
 
 impl GraphRecordSink for HistoricalViewBuilder {
+    fn document_metadata(
+        &mut self,
+        directed: bool,
+        multigraph: bool,
+        graph: Map<String, Value>,
+        extras: BTreeMap<String, Value>,
+    ) -> Result<(), HistoryError> {
+        self.directed = directed;
+        self.multigraph = multigraph;
+        self.graph = graph;
+        self.extras = extras;
+        Ok(())
+    }
+
     fn node_attribute(
         &mut self,
         node_id: String,
@@ -158,12 +180,12 @@ fn historical_graph_document_with_labels(
     });
     Ok((
         GraphDocument {
-            directed: true,
-            multigraph: false,
-            graph: Map::new(),
+            directed: builder.directed,
+            multigraph: builder.multigraph,
+            graph: builder.graph,
             nodes: builder.nodes,
             links: builder.edges,
-            extras: BTreeMap::new(),
+            extras: builder.extras,
         },
         builder.labels,
     ))
@@ -191,12 +213,12 @@ impl HistoricalViewBuilder {
             _ => None,
         };
         let document = GraphDocument {
-            directed: true,
-            multigraph: false,
-            graph: Map::new(),
+            directed: self.directed,
+            multigraph: self.multigraph,
+            graph: self.graph,
             nodes: self.nodes,
             links: self.edges,
-            extras: BTreeMap::new(),
+            extras: self.extras,
         };
         project_exact(document, self.labels, title, node_limit, selected)
     }

--- a/crates/compass-semantic-diff/src/lib.rs
+++ b/crates/compass-semantic-diff/src/lib.rs
@@ -19,4 +19,4 @@ pub use model::{
 pub use verification::StaticTestEvidence;
 
 /// Included in derived-cache keys. Increment whenever comparison semantics change.
-pub const ENGINE_VERSION: u32 = 2;
+pub const ENGINE_VERSION: u32 = 1;

--- a/crates/compass-semantic-diff/src/lib.rs
+++ b/crates/compass-semantic-diff/src/lib.rs
@@ -19,4 +19,4 @@ pub use model::{
 pub use verification::StaticTestEvidence;
 
 /// Included in derived-cache keys. Increment whenever comparison semantics change.
-pub const ENGINE_VERSION: u32 = 1;
+pub const ENGINE_VERSION: u32 = 2;

--- a/docs/design/storage-and-history.md
+++ b/docs/design/storage-and-history.md
@@ -223,7 +223,7 @@ execute arbitrary repository-controlled checkout behavior.
 
 ## Diff model
 
-Diff compares typed records:
+Exact diff compares typed records:
 
 - nodes;
 - edges;
@@ -235,8 +235,15 @@ Diff compares typed records:
 Topology-only diff avoids reconstructing irrelevant payloads and is qualified
 against the full diff.
 
-Normal comparison checks fingerprint compatibility first. An explicit mismatch
-flag permits inspection, not semantic equivalence.
+Structural change counts and graph-version views use a separate deterministic
+meaning projection. They preserve node and relationship identity, direction,
+multiplicity, and semantic attributes, while excluding source coordinates,
+clustering/layout fields, and anchor-derived edge-key churn. Exact source
+anchors remain available through `history diff`; they are never discarded from
+the immutable realization.
+
+Normal comparison checks complete build-profile and graph-engine compatibility
+first. Unlike profiles do not produce structural, semantic, or exact results.
 
 ## Export and reconstruction
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -253,6 +253,17 @@ Machine-readable output:
 compass diff v1.2.0 HEAD --format json
 ```
 
+For bounded graph-version counts used by timeline and IDE views, both
+realizations must already exist:
+
+```bash
+compass history change-counts HEAD --parent HEAD~1 --format json
+```
+
+These are structural counts: source-coordinate shifts, clustering/layout
+metadata, and anchor-derived edge IDs are collapsed, while node and edge
+meaning, direction, and multiplicity remain visible.
+
 For an exhaustive record-level diff rather than a ranked semantic review, use
 the history subcommand:
 
@@ -471,7 +482,7 @@ Failure handling:
 | Provider credentials missing | Configure the selected semantic profile or build a code-only realization explicitly |
 | Provider fails mid-build | Fix provider/network and rebuild; incomplete candidate cannot publish |
 | Preferred realization fails validation | Inspect with `show`; use explicit rebuild/recovery path |
-| Profiles differ during diff | Build with `--profile-from` or inspect explicitly with mismatch allowed |
+| Profiles differ during diff | Build the missing side with `--profile-from`; unlike profiles are not compared |
 | Live lease exists | Join/wait according to command behavior; do not delete lock files |
 | Historical checkout limitation | Read the reported Gitlink/LFS/filter limitation and adjust source policy |
 | Store copy is inconsistent | Restore a coherent SQLite/WAL backup; do not guess at Prolly records |

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -262,7 +262,19 @@ compass history change-counts HEAD --parent HEAD~1 --format json
 
 These are structural counts: source-coordinate shifts, clustering/layout
 metadata, and anchor-derived edge IDs are collapsed, while node and edge
-meaning, direction, and multiplicity remain visible.
+meaning, direction, relation, and multiplicity remain visible. Explicit
+NetworkX multigraph keys remain authoritative: replacing one is reported as a
+removal plus an addition, even when its endpoints and attributes are otherwise
+equal.
+
+The Rust history engine produces one canonical structural change stream
+directly from the typed Prolly roots. Timeline counts, semantic diff records,
+and the versioned graph view all consume that classification; the viewer does
+not independently reinterpret storage identities. Edge reconciliation retains
+at most one endpoint/relation group while streaming, cancels equal projected
+occurrences as multisets, and deterministically pairs every remaining parallel
+occurrence. This keeps work proportional to changed Prolly ranges plus the
+largest changed parallel-edge group rather than reconstructing both graphs.
 
 For an exhaustive record-level diff rather than a ranked semantic review, use
 the history subcommand:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -701,8 +701,11 @@ from local refs. `--limit` returns the newest bounded page, and `--after` uses
 the preceding page's opaque `nextCursor`. A cursor rejects local-ref changes
 instead of silently mixing snapshots. Responses include `hasMore`,
 `nextCursor`, and `totalEntries` once the final page establishes the exact
-count. `history change-counts` requires existing preferred realizations for
-both revisions and never builds them. `history diff` streams an exhaustive,
+count. `history change-counts` requires existing preferred realizations with
+the same complete build profile and never builds them. Its bounded structural
+counts exclude source-coordinate, clustering/layout, and anchor-derived edge
+identity churn while preserving topology and relationship multiplicity.
+`history diff` streams an exhaustive,
 deterministic record-level diff for selected immutable roots. It may lazily
 materialize a missing revision, requires identical complete build profiles and
 compatible graph engines, refuses to overwrite `--output`, and bounds stdout

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -416,21 +416,13 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       activeCommunityRequest = "";
       activeCommunityContext = undefined;
       const visibleComparison = compareGraphs(parent.data, current.data);
-      const structuralComparison = parent.data.stats.aggregated || current.data.stats.aggregated
-        ? comparisonFromSemanticDiff(message.semanticDiff, current.data) ?? visibleComparison
-        : visibleComparison;
+      const structuralComparison = comparisonFromSemanticDiff(
+        message.semanticDiff,
+        current.data,
+        parent.data
+      ) ?? visibleComparison;
       comparison = {
         ...structuralComparison,
-        ...(structuralCounts
-          ? {
-              addedNodes: structuralCounts.counts.nodes.added,
-              removedNodes: structuralCounts.counts.nodes.removed,
-              changedNodes: structuralCounts.counts.nodes.changed,
-              addedEdges: structuralCounts.counts.edges.added,
-              removedEdges: structuralCounts.counts.edges.removed,
-              changedEdges: structuralCounts.counts.edges.changed
-            }
-          : {}),
         parent: message.parent
       };
       semanticDiff = message.semanticDiff;

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -6,6 +6,7 @@ import {
   WorkspaceState,
   GraphViewModelSchema,
   compareGraphs,
+  comparisonFromSemanticDiff,
   type GraphViewModel,
   type GraphComparison,
   type CommunityGraphDetail,
@@ -392,7 +393,7 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       const parsedCounts = message.counts
         ? HistoryChangeCountsSchema.safeParse(message.counts)
         : undefined;
-      const exactCounts = parsedCounts?.success ? parsedCounts.data : undefined;
+      const structuralCounts = parsedCounts?.success ? parsedCounts.data : undefined;
       graph = current.data;
       graphCommit = message.commit;
       graphIdentity = {
@@ -414,22 +415,26 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       communityError = undefined;
       activeCommunityRequest = "";
       activeCommunityContext = undefined;
+      const visibleComparison = compareGraphs(parent.data, current.data);
+      const structuralComparison = parent.data.stats.aggregated || current.data.stats.aggregated
+        ? comparisonFromSemanticDiff(message.semanticDiff, current.data) ?? visibleComparison
+        : visibleComparison;
       comparison = {
-        ...compareGraphs(parent.data, current.data),
-        ...(exactCounts
+        ...structuralComparison,
+        ...(structuralCounts
           ? {
-              addedNodes: exactCounts.counts.nodes.added,
-              removedNodes: exactCounts.counts.nodes.removed,
-              changedNodes: exactCounts.counts.nodes.changed,
-              addedEdges: exactCounts.counts.edges.added,
-              removedEdges: exactCounts.counts.edges.removed,
-              changedEdges: exactCounts.counts.edges.changed
+              addedNodes: structuralCounts.counts.nodes.added,
+              removedNodes: structuralCounts.counts.nodes.removed,
+              changedNodes: structuralCounts.counts.nodes.changed,
+              addedEdges: structuralCounts.counts.edges.added,
+              removedEdges: structuralCounts.counts.edges.removed,
+              changedEdges: structuralCounts.counts.edges.changed
             }
           : {}),
         parent: message.parent
       };
       semanticDiff = message.semanticDiff;
-      if (exactCounts) changeCounts = exactCounts;
+      if (structuralCounts) changeCounts = structuralCounts;
       operationErrors.delete(message.commit);
       revisionLoadState = "ready";
     }

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -148,6 +148,27 @@ describe("compareGraphs", () => {
     expect(comparison.graph.edges).toEqual([]);
   });
 
+  it("does not turn degree-derived node sizes into structural node changes", () => {
+    const parent = graph(
+      [
+        { id: "a", label: "A", community: 0, degree: 0, size: 10 },
+        { id: "b", label: "B", community: 0, degree: 0, size: 10 }
+      ],
+      []
+    );
+    const current = graph(
+      [
+        { id: "a", label: "A", community: 0, degree: 1, size: 40 },
+        { id: "b", label: "B", community: 0, degree: 1, size: 40 }
+      ],
+      [{ id: "edge-0-a-b", source: "a", target: "b", relation: "calls" }]
+    );
+
+    const comparison = compareGraphs(parent, current);
+
+    expect(comparison).toMatchObject({ changedNodes: 0, addedEdges: 1 });
+  });
+
   it("retains exact before and after fields without presentation metadata", () => {
     const parent = graph(
       [{
@@ -254,7 +275,7 @@ describe("compareGraphs", () => {
     ]);
   });
 
-  it("retains field evidence when a shifted generated edge changes", () => {
+  it("treats a generated edge relation change as topology replacement", () => {
     const nodes = [
       { id: "a", label: "A", community: 0 },
       { id: "b", label: "B", community: 0 },
@@ -283,15 +304,11 @@ describe("compareGraphs", () => {
     const comparison = compareGraphs(parent, current);
 
     expect(comparison).toMatchObject({
-      addedEdges: 1,
-      removedEdges: 0,
-      changedEdges: 1
+      addedEdges: 2,
+      removedEdges: 1,
+      changedEdges: 0
     });
-    expect(comparison.graph.edges.find((edge) => edge.change === "changed")?.evidence?.fields)
-      .toEqual([
-        { field: "confidence", before: "inferred", after: "extracted" },
-        { field: "relation", before: "calls", after: "uses" }
-      ]);
+    expect(comparison.graph.edges.some((edge) => edge.change === "changed")).toBe(false);
   });
 
   it("keeps stable custom edge IDs authoritative when parallel records swap", () => {
@@ -399,5 +416,56 @@ describe("aggregated revision comparison", () => {
       target: "api::serve",
       change: "added"
     }]);
+  });
+
+  it("uses Rust graph deltas for exact views and retains rendered source evidence", () => {
+    const parent = graph(
+      [{
+        id: "api::serve",
+        label: "serve",
+        community: 0,
+        signature: "serve()",
+        source: { file: "src/api.rs", startLine: 10 }
+      }],
+      []
+    );
+    const current = graph(
+      [{
+        id: "api::serve",
+        label: "serve",
+        community: 0,
+        signature: "serve()",
+        source: { file: "src/api.rs", startLine: 11 }
+      }],
+      []
+    );
+    const comparison = comparisonFromSemanticDiff({
+      graph_delta: {
+        added_nodes: [],
+        removed_nodes: [],
+        changed_nodes: [{
+          id: "api::serve",
+          label: "serve",
+          kind: "function",
+          source_file: "src/api.rs",
+          changed_fields: ["implementation_hash"]
+        }],
+        added_edges: [],
+        removed_edges: [],
+        changed_edges: []
+      }
+    }, current, parent);
+
+    expect(comparison).toMatchObject({ changedNodes: 1 });
+    expect(comparison?.graph.nodes[0]).toMatchObject({
+      id: "api::serve",
+      change: "changed",
+      source: { file: "src/api.rs", startLine: 11 },
+      evidence: {
+        before: { source: { file: "src/api.rs", startLine: 10 } },
+        after: { source: { file: "src/api.rs", startLine: 11 } },
+        fields: [{ field: "implementation_hash" }]
+      }
+    });
   });
 });

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraphViewModel } from "../contracts/graph";
-import { compareGraphs } from "./ComparisonOverlay";
+import { compareGraphs, comparisonFromSemanticDiff } from "./ComparisonOverlay";
 import { compareRecord, displayFieldValue } from "./recordDiff";
 
 function graph(
@@ -86,6 +86,68 @@ describe("compareGraphs", () => {
     expect(comparison.graph.stats).toMatchObject({ nodes: 0, edges: 0 });
   });
 
+  it("does not turn shifted source coordinates into graph-wide structural changes", () => {
+    const nodes = Array.from({ length: 256 }, (_, index) => ({
+      id: `node-${index}`,
+      label: `Node ${index}`,
+      community: index % 4,
+      source: {
+        file: "src/service.ts",
+        startLine: index + 1,
+        endLine: index + 1,
+        startByte: index * 10,
+        endByte: index * 10 + 5
+      }
+    }));
+    const edges = nodes.slice(1).map((node, index) => ({
+      id: `edge-${index}-node-${index}-${node.id}`,
+      source: `node-${index}`,
+      target: node.id,
+      relation: "calls",
+      relationshipSite: {
+        file: "src/service.ts",
+        startLine: index + 1,
+        endLine: index + 1,
+        startByte: index * 10,
+        endByte: index * 10 + 5
+      }
+    }));
+    const shiftedNodes = nodes.map((node) => ({
+      ...node,
+      source: {
+        ...node.source,
+        startLine: node.source.startLine + 1,
+        endLine: node.source.endLine + 1,
+        startByte: node.source.startByte + 1,
+        endByte: node.source.endByte + 1
+      }
+    }));
+    const shiftedEdges = edges.map((edge, index) => ({
+      ...edge,
+      id: `edge-${index}-shifted-${edge.source}-${edge.target}`,
+      relationshipSite: {
+        ...edge.relationshipSite,
+        startLine: edge.relationshipSite.startLine + 1,
+        endLine: edge.relationshipSite.endLine + 1,
+        startByte: edge.relationshipSite.startByte + 1,
+        endByte: edge.relationshipSite.endByte + 1
+      }
+    }));
+
+    const comparison = compareGraphs(graph(nodes, edges), graph(shiftedNodes, shiftedEdges));
+
+    expect(comparison).toMatchObject({
+      addedNodes: 0,
+      removedNodes: 0,
+      changedNodes: 0,
+      addedEdges: 0,
+      removedEdges: 0,
+      changedEdges: 0
+    });
+    expect(comparison.graph.nodes).toEqual([]);
+    expect(comparison.graph.edges).toEqual([]);
+  });
+
   it("retains exact before and after fields without presentation metadata", () => {
     const parent = graph(
       [{
@@ -127,9 +189,12 @@ describe("compareGraphs", () => {
     const changedEdge = comparison.graph.edges[0];
 
     expect(changedNode?.evidence?.fields).toEqual([
-      { field: "signature", before: "old()", after: "new()" },
-      { field: "source.startLine", before: 2, after: 4 }
+      { field: "signature", before: "old()", after: "new()" }
     ]);
+    expect(changedNode?.evidence).toMatchObject({
+      before: { source: { file: "src/core.ts", startLine: 2 } },
+      after: { source: { file: "src/core.ts", startLine: 4 } }
+    });
     expect(changedNode?.evidence?.fields.map((field) => field.field))
       .not.toContain("color.background");
     expect(changedEdge?.evidence?.fields).toEqual([
@@ -284,5 +349,55 @@ describe("record diff presentation", () => {
       text: expect.stringMatching(/…$/),
       truncated: true
     });
+  });
+});
+
+describe("aggregated revision comparison", () => {
+  it("uses the semantic changed-subgraph instead of comparing unstable communities", () => {
+    const aggregate = graph(
+      [{ id: "community-7", label: "Renumbered cluster", community: 7, memberCount: 4000 }],
+      []
+    );
+    aggregate.stats.aggregated = true;
+    const comparison = comparisonFromSemanticDiff({
+      graph_delta: {
+        added_nodes: [],
+        removed_nodes: [],
+        changed_nodes: [{
+          id: "api::serve",
+          label: "serve",
+          kind: "function",
+          source_file: "src/api.rs",
+          changed_fields: ["signature"]
+        }],
+        added_edges: [{
+          source: "api::route",
+          target: "api::serve",
+          relation: "calls",
+          key: "route-to-serve",
+          source_file: "src/routes.rs",
+          changed_fields: []
+        }],
+        removed_edges: [],
+        changed_edges: []
+      },
+      entity_display_names: { "api::route": "route" }
+    }, aggregate);
+
+    expect(comparison).toMatchObject({
+      changedNodes: 1,
+      addedEdges: 1,
+      graph: { stats: { aggregated: false, nodes: 2, edges: 1 } }
+    });
+    expect(comparison?.graph.nodes.map((node) => [node.id, node.label, node.change])).toEqual([
+      ["api::route", "route", "unchanged"],
+      ["api::serve", "serve", "changed"]
+    ]);
+    expect(comparison?.graph.edges).toMatchObject([{
+      id: "route-to-serve",
+      source: "api::route",
+      target: "api::serve",
+      change: "added"
+    }]);
   });
 });

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -5,7 +5,11 @@ import type {
   GraphRecordEvidence,
   GraphViewModel
 } from "../contracts/graph";
-import { compareRecord } from "./recordDiff";
+import {
+  compareRecord,
+  compareStructuralRecord,
+  structuralRecordProjection
+} from "./recordDiff";
 
 export type GraphComparison = {
   addedNodes: number;
@@ -96,7 +100,7 @@ export function compareGraphs(
   const removedNodeIds = difference(parentNodes, currentNodes);
   const nodeEvidence = new Map(intersection(currentNodes, parentNodes).map((id) => [
     id,
-    compareRecord(parentNodes.get(id), currentNodes.get(id))
+    compareStructuralRecord(parentNodes.get(id), currentNodes.get(id), "node")
   ]));
   const changedNodeIds = [...nodeEvidence.entries()]
     .filter(([, evidence]) => evidence.fields.length > 0)
@@ -183,6 +187,166 @@ export function compareGraphs(
   };
 }
 
+/** Build an exact changed-subgraph when revision exports are community aggregates. */
+export function comparisonFromSemanticDiff(
+  report: unknown,
+  reference: GraphViewModel
+): GraphComparison | undefined {
+  if (!isObject(report) || !isObject(report.graph_delta)) return undefined;
+  const delta = report.graph_delta;
+  const addedNodes = graphNodeDeltas(delta.added_nodes);
+  const removedNodes = graphNodeDeltas(delta.removed_nodes);
+  const changedNodes = graphNodeDeltas(delta.changed_nodes);
+  const addedEdges = graphEdgeDeltas(delta.added_edges);
+  const removedEdges = graphEdgeDeltas(delta.removed_edges);
+  const changedEdges = graphEdgeDeltas(delta.changed_edges);
+  if ([addedNodes, removedNodes, changedNodes, addedEdges, removedEdges, changedEdges]
+    .some((records) => records === undefined)) return undefined;
+
+  const displayNames = isObject(report.entity_display_names)
+    ? report.entity_display_names
+    : {};
+  const nodes = new Map<string, GraphNode>();
+  const addDeltaNode = (
+    record: SemanticNodeDelta,
+    change: "added" | "removed" | "changed"
+  ): void => {
+    nodes.set(record.id, {
+      id: record.id,
+      label: record.label || stringField(displayNames, record.id) || record.id,
+      community: 0,
+      ...(record.kind ? { kind: record.kind } : {}),
+      ...(record.sourceFile ? { source: { file: record.sourceFile } } : {}),
+      change,
+      evidence: { fields: record.changedFields.map((field) => ({ field })) }
+    });
+  };
+  addedNodes!.forEach((node) => addDeltaNode(node, "added"));
+  removedNodes!.forEach((node) => addDeltaNode(node, "removed"));
+  changedNodes!.forEach((node) => addDeltaNode(node, "changed"));
+
+  const edges: GraphEdge[] = [];
+  const addDeltaEdges = (
+    records: SemanticEdgeDelta[],
+    change: "added" | "removed" | "changed"
+  ): void => records.forEach((record, index) => {
+    for (const id of [record.source, record.target]) {
+      if (!nodes.has(id)) nodes.set(id, {
+        id,
+        label: stringField(displayNames, id) || id,
+        community: 0,
+        change: "unchanged"
+      });
+    }
+    edges.push({
+      id: record.key || `semantic-${change}-${index}-${record.source}-${record.target}`,
+      source: record.source,
+      target: record.target,
+      relation: record.relation,
+      ...(record.sourceFile ? { relationshipSite: { file: record.sourceFile } } : {}),
+      change,
+      evidence: { fields: record.changedFields.map((field) => ({ field })) }
+    });
+  });
+  addDeltaEdges(addedEdges!, "added");
+  addDeltaEdges(removedEdges!, "removed");
+  addDeltaEdges(changedEdges!, "changed");
+  const orderedNodes = [...nodes.values()].sort((left, right) => left.id.localeCompare(right.id));
+  const orderedEdges = uniqueEdgeIds(edges.sort((left, right) => left.id.localeCompare(right.id)));
+  return {
+    addedNodes: addedNodes!.length,
+    removedNodes: removedNodes!.length,
+    changedNodes: changedNodes!.length,
+    addedEdges: addedEdges!.length,
+    removedEdges: removedEdges!.length,
+    changedEdges: changedEdges!.length,
+    graph: {
+      ...reference,
+      title: `Graph delta · ${reference.title}`,
+      stats: {
+        ...reference.stats,
+        nodes: orderedNodes.length,
+        edges: orderedEdges.length,
+        communities: orderedNodes.length > 0 ? 1 : 0,
+        aggregated: false
+      },
+      nodes: orderedNodes,
+      edges: orderedEdges,
+      communities: orderedNodes.length > 0
+        ? [{ id: 0, label: "Changed subgraph", color: "#6688aa", hidden: false }]
+        : [],
+      hyperedges: []
+    }
+  };
+}
+
+type SemanticNodeDelta = {
+  id: string;
+  label: string;
+  kind: string;
+  sourceFile: string;
+  changedFields: string[];
+};
+
+type SemanticEdgeDelta = {
+  source: string;
+  target: string;
+  relation: string;
+  key: string;
+  sourceFile: string;
+  changedFields: string[];
+};
+
+function graphNodeDeltas(value: unknown): SemanticNodeDelta[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const records = value.map((item) => {
+    if (!isObject(item) || typeof item.id !== "string") return undefined;
+    return {
+      id: item.id,
+      label: stringField(item, "label"),
+      kind: stringField(item, "kind"),
+      sourceFile: stringField(item, "source_file"),
+      changedFields: stringArray(item.changed_fields)
+    };
+  });
+  return records.every((record) => record !== undefined)
+    ? records as SemanticNodeDelta[]
+    : undefined;
+}
+
+function graphEdgeDeltas(value: unknown): SemanticEdgeDelta[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const records = value.map((item) => {
+    if (!isObject(item)
+      || typeof item.source !== "string"
+      || typeof item.target !== "string"
+      || typeof item.relation !== "string") return undefined;
+    return {
+      source: item.source,
+      target: item.target,
+      relation: item.relation,
+      key: stringField(item, "key"),
+      sourceFile: stringField(item, "source_file"),
+      changedFields: stringArray(item.changed_fields)
+    };
+  });
+  return records.every((record) => record !== undefined)
+    ? records as SemanticEdgeDelta[]
+    : undefined;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, key: string): string {
+  return typeof value[key] === "string" ? value[key] : "";
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
 function difference<T>(left: ReadonlyMap<string, T>, right: ReadonlyMap<string, T>): string[] {
   return [...left.keys()].filter((id) => !right.has(id));
 }
@@ -232,9 +396,10 @@ function compareMatchedEdges(
   before: GraphEdge,
   after: GraphEdge
 ): GraphRecordEvidence {
-  return compareRecord(
+  return compareStructuralRecord(
     { ...before, id: after.id },
-    after
+    after,
+    "edge"
   );
 }
 
@@ -332,9 +497,7 @@ function pairEdgesByKey(
 }
 
 function edgeSemanticKey(edge: GraphEdge): string {
-  const record: Record<string, unknown> = { ...edge };
-  delete record.id;
-  return JSON.stringify(compareRecord(undefined, record).after);
+  return JSON.stringify(structuralRecordProjection(edge, "edge"));
 }
 
 function edgeEndpointKey(edge: GraphEdge): string {

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -190,7 +190,8 @@ export function compareGraphs(
 /** Build an exact changed-subgraph when revision exports are community aggregates. */
 export function comparisonFromSemanticDiff(
   report: unknown,
-  reference: GraphViewModel
+  reference: GraphViewModel,
+  parent?: GraphViewModel
 ): GraphComparison | undefined {
   if (!isObject(report) || !isObject(report.graph_delta)) return undefined;
   const delta = report.graph_delta;
@@ -206,19 +207,29 @@ export function comparisonFromSemanticDiff(
   const displayNames = isObject(report.entity_display_names)
     ? report.entity_display_names
     : {};
+  const currentNodes = new Map(reference.nodes.map((node) => [node.id, node]));
+  const parentNodes = new Map((parent?.nodes ?? []).map((node) => [node.id, node]));
   const nodes = new Map<string, GraphNode>();
   const addDeltaNode = (
     record: SemanticNodeDelta,
     change: "added" | "removed" | "changed"
   ): void => {
+    const before = parentNodes.get(record.id);
+    const after = currentNodes.get(record.id);
+    const base = (change === "removed" ? before : after) ?? before;
     nodes.set(record.id, {
+      ...base,
       id: record.id,
-      label: record.label || stringField(displayNames, record.id) || record.id,
-      community: 0,
-      ...(record.kind ? { kind: record.kind } : {}),
-      ...(record.sourceFile ? { source: { file: record.sourceFile } } : {}),
+      label: base?.label || record.label || stringField(displayNames, record.id) || record.id,
+      community: base?.community ?? 0,
+      ...(base?.kind ? {} : record.kind ? { kind: record.kind } : {}),
+      ...(base?.source ? {} : record.sourceFile ? { source: { file: record.sourceFile } } : {}),
       change,
-      evidence: { fields: record.changedFields.map((field) => ({ field })) }
+      evidence: change === "added"
+        ? compareRecord(undefined, after)
+        : change === "removed"
+          ? compareRecord(before, undefined)
+          : semanticEvidence(before, after, record.changedFields)
     });
   };
   addedNodes!.forEach((node) => addDeltaNode(node, "added"));
@@ -226,33 +237,85 @@ export function comparisonFromSemanticDiff(
   changedNodes!.forEach((node) => addDeltaNode(node, "changed"));
 
   const edges: GraphEdge[] = [];
+  const currentEdgeIndexes = new Set<number>();
+  const parentEdgeIndexes = new Set<number>();
+  const takeEdge = (
+    candidates: GraphEdge[],
+    used: Set<number>,
+    record: SemanticEdgeDelta
+  ): GraphEdge | undefined => {
+    const matches = candidates
+      .map((edge, index) => ({ edge, index }))
+      .filter(({ edge, index }) => !used.has(index)
+        && edge.source === record.source
+        && edge.target === record.target
+        && edge.relation === record.relation)
+      .sort((left, right) => {
+        const leftFile = left.edge.relationshipSite?.file === record.sourceFile ? 0 : 1;
+        const rightFile = right.edge.relationshipSite?.file === record.sourceFile ? 0 : 1;
+        return leftFile - rightFile || left.edge.id.localeCompare(right.edge.id);
+      });
+    const match = matches[0];
+    if (match) used.add(match.index);
+    return match?.edge;
+  };
   const addDeltaEdges = (
     records: SemanticEdgeDelta[],
     change: "added" | "removed" | "changed"
   ): void => records.forEach((record, index) => {
+    const before = change === "added"
+      ? undefined
+      : takeEdge(parent?.edges ?? [], parentEdgeIndexes, record);
+    const after = change === "removed"
+      ? undefined
+      : takeEdge(reference.edges, currentEdgeIndexes, record);
+    const base = (change === "removed" ? before : after) ?? before;
     for (const id of [record.source, record.target]) {
-      if (!nodes.has(id)) nodes.set(id, {
-        id,
-        label: stringField(displayNames, id) || id,
-        community: 0,
-        change: "unchanged"
-      });
+      if (!nodes.has(id)) {
+        const context = currentNodes.get(id) ?? parentNodes.get(id);
+        nodes.set(id, {
+          ...context,
+          id,
+          label: context?.label || stringField(displayNames, id) || id,
+          community: context?.community ?? 0,
+          change: "unchanged"
+        });
+      }
     }
     edges.push({
-      id: record.key || `semantic-${change}-${index}-${record.source}-${record.target}`,
+      ...base,
+      id: base?.id || record.key || `semantic-${change}-${index}-${record.source}-${record.target}`,
       source: record.source,
       target: record.target,
       relation: record.relation,
-      ...(record.sourceFile ? { relationshipSite: { file: record.sourceFile } } : {}),
+      ...(base?.relationshipSite
+        ? {}
+        : record.sourceFile ? { relationshipSite: { file: record.sourceFile } } : {}),
       change,
-      evidence: { fields: record.changedFields.map((field) => ({ field })) }
+      evidence: change === "added"
+        ? compareRecord(undefined, after)
+        : change === "removed"
+          ? compareRecord(before, undefined)
+          : semanticEvidence(before, after, record.changedFields)
     });
   });
+  // Changed records consume their old/new occurrences first so exact evidence is retained for
+  // parallel edges before one-sided additions or removals claim a compatible rendered edge.
+  addDeltaEdges(changedEdges!, "changed");
   addDeltaEdges(addedEdges!, "added");
   addDeltaEdges(removedEdges!, "removed");
-  addDeltaEdges(changedEdges!, "changed");
   const orderedNodes = [...nodes.values()].sort((left, right) => left.id.localeCompare(right.id));
   const orderedEdges = uniqueEdgeIds(edges.sort((left, right) => left.id.localeCompare(right.id)));
+  const communityIds = new Set(orderedNodes.map((node) => node.community));
+  const communities = [
+    ...reference.communities,
+    ...(parent?.communities ?? []).filter((community) =>
+      !reference.communities.some((candidate) => candidate.id === community.id))
+  ].filter((community) => communityIds.has(community.id));
+  if (communityIds.has(0) && !communities.some((community) => community.id === 0)) {
+    communities.push({ id: 0, label: "Changed subgraph", color: "#6688aa", hidden: false });
+  }
+  communities.sort((left, right) => left.id - right.id);
   return {
     addedNodes: addedNodes!.length,
     removedNodes: removedNodes!.length,
@@ -267,14 +330,12 @@ export function comparisonFromSemanticDiff(
         ...reference.stats,
         nodes: orderedNodes.length,
         edges: orderedEdges.length,
-        communities: orderedNodes.length > 0 ? 1 : 0,
+        communities: communities.length,
         aggregated: false
       },
       nodes: orderedNodes,
       edges: orderedEdges,
-      communities: orderedNodes.length > 0
-        ? [{ id: 0, label: "Changed subgraph", color: "#6688aa", hidden: false }]
-        : [],
+      communities,
       hyperedges: []
     }
   };
@@ -345,6 +406,20 @@ function stringField(value: Record<string, unknown>, key: string): string {
 
 function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function semanticEvidence(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined,
+  changedFields: string[]
+): GraphRecordEvidence {
+  const exact = compareRecord(before, after);
+  const exactFields = new Map(exact.fields.map((field) => [field.field, field]));
+  return {
+    ...(exact.before ? { before: exact.before } : {}),
+    ...(exact.after ? { after: exact.after } : {}),
+    fields: changedFields.map((field) => exactFields.get(field) ?? { field })
+  };
 }
 
 function difference<T>(left: ReadonlyMap<string, T>, right: ReadonlyMap<string, T>): string[] {
@@ -501,7 +576,7 @@ function edgeSemanticKey(edge: GraphEdge): string {
 }
 
 function edgeEndpointKey(edge: GraphEdge): string {
-  return JSON.stringify([edge.source, edge.target]);
+  return JSON.stringify([edge.source, edge.target, edge.relation]);
 }
 
 function compareEdgeOrder(left: GraphEdge, right: GraphEdge): number {

--- a/packages/compass-viewer/src/history/recordDiff.ts
+++ b/packages/compass-viewer/src/history/recordDiff.ts
@@ -1,6 +1,41 @@
 import type { GraphRecordEvidence } from "../contracts/graph";
 
 const PRESENTATION_FIELDS = new Set(["color", "change", "evidence"]);
+const STRUCTURAL_DERIVED_FIELDS = new Set([
+  "anchor",
+  "anchors",
+  "columnEnd",
+  "columnStart",
+  "community",
+  "communityName",
+  "community_name",
+  "degree",
+  "endByte",
+  "endColumn",
+  "endLine",
+  "lineEnd",
+  "lineStart",
+  "line_end",
+  "line_start",
+  "location",
+  "normLabel",
+  "norm_label",
+  "relationshipSite",
+  "relationship_site",
+  "sourceDigest",
+  "sourceFile",
+  "sourceHash",
+  "source_digest",
+  "source_file",
+  "source_hash",
+  "startByte",
+  "startColumn",
+  "startLine",
+  "wiringSite",
+  "wiring_site"
+]);
+
+export type StructuralRecordKind = "node" | "edge";
 
 export function compareRecord(
   before: Record<string, unknown> | undefined,
@@ -13,6 +48,33 @@ export function compareRecord(
     ...(canonicalAfter ? { after: canonicalAfter } : {}),
     fields: collectChanges(canonicalBefore, canonicalAfter)
   };
+}
+
+/**
+ * Compare graph meaning rather than storage or layout metadata. Exact record
+ * diffs remain available through compareRecord and the history diff command.
+ */
+export function compareStructuralRecord(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined,
+  kind: StructuralRecordKind
+): GraphRecordEvidence {
+  const exactBefore = canonicalRecord(before);
+  const exactAfter = canonicalRecord(after);
+  const structuralBefore = canonicalStructuralRecord(before, kind);
+  const structuralAfter = canonicalStructuralRecord(after, kind);
+  return {
+    ...(exactBefore ? { before: exactBefore } : {}),
+    ...(exactAfter ? { after: exactAfter } : {}),
+    fields: collectChanges(structuralBefore, structuralAfter)
+  };
+}
+
+export function structuralRecordProjection(
+  record: Record<string, unknown>,
+  kind: StructuralRecordKind
+): Record<string, unknown> {
+  return canonicalStructuralRecord(record, kind) ?? {};
 }
 
 export function displayFieldValue(
@@ -36,6 +98,36 @@ function canonicalRecord(
 ): Record<string, unknown> | undefined {
   if (!record) return undefined;
   return canonicalObject(record);
+}
+
+function canonicalStructuralRecord(
+  record: Record<string, unknown> | undefined,
+  kind: StructuralRecordKind
+): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+  const rootIgnored = kind === "node" ? new Set(["source"]) : new Set(["id", "key"]);
+  return canonicalStructuralObject(record, rootIgnored);
+}
+
+function canonicalStructuralValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalStructuralValue);
+  if (isStructured(value)) return canonicalStructuralObject(value);
+  return value;
+}
+
+function canonicalStructuralObject(
+  value: Record<string, unknown>,
+  rootIgnored: ReadonlySet<string> = new Set()
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.keys(value)
+      .filter((key) =>
+        !PRESENTATION_FIELDS.has(key)
+        && !STRUCTURAL_DERIVED_FIELDS.has(key)
+        && !rootIgnored.has(key))
+      .sort((left, right) => left.localeCompare(right))
+      .map((key) => [key, canonicalStructuralValue(value[key])])
+  );
 }
 
 function canonicalValue(value: unknown): unknown {

--- a/packages/compass-viewer/src/history/recordDiff.ts
+++ b/packages/compass-viewer/src/history/recordDiff.ts
@@ -22,6 +22,7 @@ const STRUCTURAL_DERIVED_FIELDS = new Set([
   "norm_label",
   "relationshipSite",
   "relationship_site",
+  "size",
   "sourceDigest",
   "sourceFile",
   "sourceHash",

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -958,7 +958,21 @@ window.acquireVsCodeApi=()=>({postMessage(message){
           status:"modified",
           patch:"@@ -3,3 +3,3 @@ [package]\\n name = \\"compass\\"\\n-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\"\\n edition = \\"2021\\"\\n"
         }],
-        findings:[{summary:"Fixture comparison"}]
+        findings:[{summary:"Fixture comparison"}],
+        graph_delta:{
+          added_nodes:[],
+          removed_nodes:[],
+          changed_nodes:[{
+            id:"run",
+            label:"run",
+            kind:"function",
+            source_file:"src/lib.rs",
+            changed_fields:["signature"]
+          }],
+          added_edges:[],
+          removed_edges:[],
+          changed_edges:[]
+        }
       }
     },"*"),0);
   } else if(message.type==="compareCommunity") {

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -170,33 +170,15 @@ test("comparison replaces the full graph with a readable focused delta", async (
 
   await page.getByRole("tab", { name: /Changed graph/ }).click();
   await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
-  await expect(page.getByLabel("Graph change filters")).toContainText("Changed2");
+  await expect(page.getByLabel("Graph change filters")).toContainText("Changed1");
 
   const graphSearch = page.getByRole("combobox", { name: "Search graph nodes" });
-  await graphSearch.fill("Core B");
-  await page.getByRole("option", { name: /Core B/i }).click();
-  await page.getByRole("button", { name: /Inspect changes/i }).click();
-
-  await expect(page.getByText(/Viewing exact changes in community 0/)).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Changed symbols" })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Changed run/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Added added_symbol/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Removed removed_symbol/i })).toBeVisible();
-
-  await page.getByRole("button", { name: /Changed run/i }).click();
+  await graphSearch.fill("run");
+  await page.getByRole("option", { name: /run/i }).click();
   await expect(page.getByRole("heading", { name: "What changed" })).toBeVisible();
-  const fieldEvidence = page.locator(".compass-record-evidence");
-  await expect(fieldEvidence.getByText("pub fn run(old_value: usize)")).toBeVisible();
-  await expect(fieldEvidence.getByText("pub fn run(new_value: usize)")).toBeVisible();
-  const relationshipEvidence = page.locator(".compass-relationship-evidence");
-  await relationshipEvidence.locator("summary").click();
-  await expect(relationshipEvidence.getByText("inferred")).toBeVisible();
-  await expect(relationshipEvidence.locator("summary i")).toHaveText("extracted");
-  await expect(page.getByRole("button", { name: "Open before" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Open after" })).toBeVisible();
-
-  await page.getByRole("button", { name: "Back to community overview" }).click();
-  await expect(page.getByText(/Viewing changed subgraph for bbbbbbbbb/)).toBeVisible();
+  await expect(page.locator(".compass-record-evidence").getByText("signature")).toBeVisible();
+  await expect(page.getByRole("region", { name: "Inspector" }).getByText("src/lib.rs"))
+    .toBeVisible();
 
   await page.getByRole("tab", { name: /Semantic findings/ }).click();
   await expect(page.getByText("Fixture comparison", { exact: true })).toBeVisible();


### PR DESCRIPTION
## What changed

- Added a single canonical Rust structural-diff stream over typed Prolly roots for nodes, edges, and hyperedges; CLI counts and graph deltas now consume that stream instead of maintaining separate reconciliation logic.
- Kept exact record diffs lossless while making structural comparisons ignore source-coordinate, layout/clustering, derived-size, and anchor-derived identity churn.
- Modeled edge identity explicitly: NetworkX compatibility identities stay remove/add, anchor-derived identities reconcile by directed `(source, target, relation)` topology, parallel-edge multiplicity is preserved, and relation changes stay topological remove/add changes.
- Made the shared viewer and VS Code treat the Rust `graph_delta` as authoritative for exact and aggregate comparisons, enriching it with rendered records only for display and navigation.
- Kept the projection and semantic engine versions at `1` and removed the superseded CLI legacy normalization paths.
- Documented the exact-versus-structural contract, identity rules, and bounded Prolly traversal behavior.

## Root cause

The UI and CLI independently reconstructed semantic changes from exact storage events. Small source edits shift anchors and presentation fields, which changes generated relationship keys and creates many exact Prolly records even when graph meaning is unchanged. The duplicate implementations also disagreed on parallel edges, relationship changes, and aggregate counts.

## Versioned graph model

- **Exact diff:** immutable, lossless storage events for audit and compatibility.
- **Structural diff:** the product-facing versioned graph change stream, projected from typed records while preserving direction, relation, semantic attributes, provenance, and multiplicity.
- **Prolly execution:** equal roots are skipped; changed ranges are traversed in key order; only the current endpoint/relation parallel-edge group is buffered. Memory therefore scales with the largest parallel group rather than the full graph.
- **Compatibility:** complete build profiles must match before structural results are emitted, and explicit compatibility edge identities are never silently rewritten.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo clippy -p compass-history -p compass-cli --all-targets --all-features --locked -- -D warnings`
- `cargo test -p compass-history --locked`
- `cargo test -p compass-cli --test history_cli --locked` (24/24)
- `cargo test -p compass-history --test performance structural_diff_small_change_is_prolly_bounded --locked -- --ignored --nocapture` (2,000 nodes, one structural change, 1.26 ms locally)
- `npm run typecheck:js`
- `npm run test:js` (viewer 127, VS Code 113, browser 72)
- `node scripts/check_viewer_assets.mjs` from a clean worktree
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`

Regression coverage includes coordinate-only churn, semantic fields hidden from the rendered model, relationship changes, explicit identity replacement, deterministic pairing of parallel edges, and Rust-authoritative aggregate rendering.
