### PR TITLE
Harden versioned graph materialization end to end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ candle-core = "=0.9.2"
 candle-nn = "=0.9.2"
 candle-transformers = "=0.9.2"
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["float_roundtrip", "preserve_order"] }
 rmp-serde = "1.3.1"
 zstd = "0.13"
 sha2 = "0.10"

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -325,6 +325,30 @@ const PAGES: &[Page] = &[
         "Examples:\n  compass history disable\n\nNotes:\n  Explicit builds, historical queries, and existing realizations remain available."
     ),
     page!(
+        "history timeline",
+        "List commit graph-history state for timeline views",
+        ["compass history timeline [OPTIONS] --format json"],
+        "Options:\n  --rev <REV>              Timeline tip [default: HEAD]\n  --limit <N>              Page size from 1 to 1000\n  --after <CURSOR>          Continue a stable paginated snapshot; requires --limit\n  --format json             Required machine-readable output\n\nExamples:\n  compass history timeline --format json\n  compass history timeline --rev main --limit 100 --format json"
+    ),
+    page!(
+        "history change-counts",
+        "Count structural graph changes between materialized revisions",
+        ["compass history change-counts <REV> [OPTIONS] --format json"],
+        "Arguments:\n  <REV>                    Materialized target revision\n\nOptions:\n  --parent <REV>           Materialized base revision [default: first parent]\n  --format json             Required machine-readable output\n\nExamples:\n  compass history change-counts HEAD --format json\n  compass history change-counts feature --parent main --format json\n\nNotes:\n  Counts use the canonical Rust structural diff over typed Prolly roots."
+    ),
+    page!(
+        "history diff",
+        "Stream an exact typed-record diff between realizations",
+        ["compass history diff <OLD> <NEW> [OPTIONS] --format jsonl"],
+        "Arguments:\n  <OLD>                    Materialized base revision\n  <NEW>                    Materialized target revision\n\nOptions:\n  --root <NAME>            Restrict to a typed root; repeatable\n  --output <PATH>          Atomically write large output\n  --format jsonl           Required streaming format\n\nExamples:\n  compass history diff HEAD~1 HEAD --format jsonl\n  compass history diff v1.2.0 HEAD --root nodes --root edges --output exact.jsonl --format jsonl\n\nNotes:\n  Roots are nodes, edges, hyperedges, analysis, metadata, program-facts, and program-summaries."
+    ),
+    page!(
+        "history verify",
+        "Validate an immutable realization and all typed roots",
+        ["compass history verify <REV_OR_REALIZATION> [OPTIONS]"],
+        "Arguments:\n  <REV_OR_REALIZATION>     Git revision or realization identifier\n\nOptions:\n  --format <text|json>     Output format [default: text]\n\nExamples:\n  compass history verify HEAD\n  compass history verify 0123456789abcdef --format json"
+    ),
+    page!(
         "history status",
         "Show history configuration and realization status",
         ["compass history status [REV] [OPTIONS]"],

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -1152,16 +1152,15 @@ impl NativeCompleteGraphBuilder {
             retained.analysis,
             Some(manifest),
         )?;
-        Ok(Some(CompletedGraphArtifacts {
-            artifacts,
-            completion: CompletionEvidence {
-                extraction_succeeded: true,
-                allow_partial: false,
-                semantic_files_expected: 0,
-                semantic_files_completed: 0,
-                failed_chunks: 0,
-            },
-        }))
+        let code_files = result
+            .detection
+            .files
+            .get("code")
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        Ok(Some(compass_core::normalize_current_code_only_snapshot(
+            artifacts, checkout, code_files,
+        )?))
     }
 }
 
@@ -1360,6 +1359,7 @@ mod tests {
 
         let completed = builder.build(directory.path(), output_root.path())?;
         assert!(completed.artifacts.program.is_some());
+        assert!(analysis_ids_match_graph(&completed));
         assert!(!completed.partition()?.nodes.is_empty());
         Ok(())
     }

--- a/crates/compass-cli/tests/help_cli.rs
+++ b/crates/compass-cli/tests/help_cli.rs
@@ -106,8 +106,20 @@ fn every_public_nested_command_has_a_dedicated_page() {
         (
             "history",
             &[
-                "enable", "disable", "status", "build", "rebuild", "list", "show", "prefer",
-                "export", "gc",
+                "enable",
+                "disable",
+                "timeline",
+                "change-counts",
+                "diff",
+                "verify",
+                "status",
+                "build",
+                "rebuild",
+                "list",
+                "show",
+                "prefer",
+                "export",
+                "gc",
             ][..],
         ),
         (

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -718,6 +718,26 @@ fn history_commands_inspect_prefer_and_export_published_realizations()
     let exported = GraphDocument::load_for_recluster(&graph_json)?;
     assert_eq!(exported.nodes[0].label(), "First");
 
+    let relative_export = run(
+        compass,
+        directory.path(),
+        &[
+            "history",
+            "export",
+            "HEAD",
+            "--format",
+            "graph-json",
+            "--output",
+            "historical-relative.json",
+        ],
+    )?;
+    assert!(
+        relative_export.status.success(),
+        "{}",
+        String::from_utf8_lossy(&relative_export.stderr)
+    );
+    assert!(directory.path().join("historical-relative.json").is_file());
+
     let viewer_json = directory.path().join("historical-viewer.json");
     let viewer_export = run(
         compass,

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -54,7 +54,14 @@ pub fn normalize_current_code_only_snapshot(
         let community = node
             .attributes
             .get("community")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| {
+                value.as_u64().or_else(|| {
+                    value
+                        .as_object()
+                        .and_then(|community| community.get("id"))
+                        .and_then(serde_json::Value::as_u64)
+                })
+            })
             .and_then(|value| usize::try_from(value).ok())
             .ok_or_else(|| {
                 MaterializeError::Incomplete(format!(

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1004,8 +1004,6 @@ fn build_graph_inner(
         .iter()
         .filter_map(|path| extractions.remove(path))
         .collect::<Vec<_>>();
-    merge_decl_def_classes(&mut ordered);
-    profile_internal("declaration merge", &mut internal_started);
     let ast_root_marker = format!("{}_", make_id(&[&root.to_string_lossy()]));
     let portable_check_started = Instant::now();
     let ast_is_portable = ast_extractions_are_portable(&ordered, &root);
@@ -1044,6 +1042,13 @@ fn build_graph_inner(
         );
     }
     profile_internal("portable AST ID remapping", &mut internal_started);
+    // Continue the cold build from the same portable representation that a
+    // subsequent cache hit will decode. Otherwise absolute origin attributes
+    // can make project-wide declaration merging and edge de-duplication depend
+    // on whether a file was freshly extracted or loaded from the AST cache.
+    for (path, extraction) in ordered_paths.iter().zip(&mut ordered) {
+        prepare_portable_ast_cache_entry(extraction, path, &root);
+    }
     let ast_cache_sources = ordered_paths
         .iter()
         .zip(&ordered)
@@ -1054,10 +1059,17 @@ fn build_graph_inner(
     let ast_cache_entries =
         cache.encode_portable_ast_batch(&ast_cache_sources, |path, extraction| {
             let mut cache_entry = extraction.clone();
+            // Keep this normalization at the cache boundary as a defensive
+            // invariant for callers that construct cache entries directly.
             prepare_portable_ast_cache_entry(&mut cache_entry, path, &root);
             cache_entry
         })?;
     drop(ast_cache_sources);
+    // Declaration/definition merging is project-wide and is not idempotent.
+    // Cache the portable per-file facts before applying it so a warm build
+    // executes the same single merge as a cold build.
+    merge_decl_def_classes(&mut ordered);
+    profile_internal("declaration merge", &mut internal_started);
     let ast_cache_handle = std::thread::Builder::new()
         .name("compass-ast-cache".to_owned())
         .spawn(move || {
@@ -4969,6 +4981,71 @@ mod tests {
                 .iter()
                 .all(|node| node.source_file() != Some("helper.py"))
         );
+        Ok(())
+    }
+
+    #[test]
+    fn cached_cpp_declarations_are_not_project_merged_twice() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path().join("checkout");
+        fs::create_dir(&root)?;
+        fs::write(
+            root.join("arena.h"),
+            r#"#include <cstddef>
+class Arena {
+ public:
+  Arena();
+  Arena(const Arena&) = delete;
+  Arena& operator=(const Arena&) = delete;
+  ~Arena();
+  char* Allocate(size_t bytes);
+  char* AllocateAligned(size_t bytes);
+ private:
+  char* AllocateFallback(size_t bytes);
+};
+inline char* Arena::Allocate(size_t bytes) {
+  return AllocateFallback(bytes);
+}
+"#,
+        )?;
+        fs::write(
+            root.join("arena.cc"),
+            r#"#include "arena.h"
+Arena::Arena() {}
+Arena::~Arena() {}
+char* Arena::AllocateFallback(size_t bytes) { return nullptr; }
+char* Arena::AllocateAligned(size_t bytes) { return Allocate(bytes); }
+"#,
+        )?;
+        let output = directory.path().join("output");
+        let cache = directory.path().join("history-cache");
+        let semantic = SemanticLayer {
+            fragment: json!({
+                "nodes": [],
+                "edges": [],
+                "hyperedges": [],
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "failed_chunks": 0,
+            }),
+            refreshed_files: Vec::new(),
+            partial_files: Vec::new(),
+            allow_partial: false,
+        };
+        let mut options = BuildOptions::new(&root);
+        options.output_root = Some(output);
+        options.cache_root = Some(cache);
+        options.no_viz = true;
+        options.program_analysis = true;
+        options.purpose = BuildPurpose::Extract;
+
+        let (cold_result, cold) = build_graph_with_layers_retained(&options, Some(&semantic), &[])?;
+        assert_eq!(cold_result.files_extracted, 2);
+        options.force = true;
+        options.reuse_cache_on_force = true;
+        let (warm_result, warm) = build_graph_with_layers_retained(&options, Some(&semantic), &[])?;
+        assert_eq!(warm_result.files_cached, 2);
+        assert_eq!(warm.document, cold.document);
         Ok(())
     }
 

--- a/crates/compass-files/src/atomic.rs
+++ b/crates/compass-files/src/atomic.rs
@@ -41,7 +41,10 @@ where
     F: FnOnce(&mut BufWriter<File>) -> Result<(), FileError>,
 {
     let destination = resolved_destination(path);
-    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let parent = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(parent).map_err(|source| io_error(parent, source))?;
     let temporary = temporary_path(&destination);
     let file = OpenOptions::new()

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -4,13 +4,14 @@ use std::fs::{self, FileTimes};
 use std::time::{Duration, UNIX_EPOCH};
 
 use compass_files::{
-    BuildGuard, Cache, CacheKind, CacheOptions, DetectOptions, FileSlice, Manifest, ManifestKind,
-    StatHashIndex, WatchPathFilter, bisect_slice, body_content, classify_file, file_hash, md5_file,
-    prompt_fingerprint, read_slice_text, read_source_lossy, slice_boundaries, split_file,
-    write_bytes_atomic, write_json_atomic, write_text_atomic,
+    BuildGuard, CACHE_ENCODING_VERSION, Cache, CacheKind, CacheOptions, DetectOptions, FileSlice,
+    Manifest, ManifestKind, StatHashIndex, WatchPathFilter, bisect_slice, body_content,
+    classify_file, file_hash, md5_file, prompt_fingerprint, read_slice_text, read_source_lossy,
+    slice_boundaries, split_file, write_bytes_atomic, write_json_atomic, write_text_atomic,
 };
 use compass_files::{FileType, IgnorePolicy};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 #[test]
 fn database_only_detection_does_not_read_local_files() -> Result<(), Box<dyn Error>> {
@@ -755,7 +756,7 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     assert!(
         default_cache
             .directory(&CacheKind::Ast, None)
-            .ends_with("ast/v5/e7")
+            .ends_with(format!("ast/v5/e{CACHE_ENCODING_VERSION}"))
     );
     assert!(!cache_root.join("compass-out/cache/ast/v0.9.21").exists());
 
@@ -1083,7 +1084,7 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
     )?;
     cache.save_program(&artifact, "index.scip:bbbbbbbb", &json!({"kind":"scip"}))?;
     let syntax_directory = cache.directory(&syntax, None);
-    assert!(syntax_directory.ends_with("e7"));
+    assert!(syntax_directory.ends_with(format!("e{CACHE_ENCODING_VERSION}")));
     assert!(
         fs::read_dir(&syntax_directory)?
             .filter_map(Result::ok)
@@ -1102,16 +1103,15 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
     assert_eq!(first["source_file"], "src/a.rs");
     assert_eq!(second["source_file"], "src/b.rs");
 
-    let first_entry = fs::read_dir(&syntax_directory)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .find(|path| {
-            fs::read(path)
-                .ok()
-                .and_then(|bytes| rmp_serde::from_slice::<serde_json::Value>(&bytes).ok())
-                .is_some_and(|value| value["source_file"] == "src/a.rs")
-        })
-        .ok_or("missing first MessagePack syntax entry")?;
+    let program_entry = |logical_key: &str| {
+        let digest = Sha256::digest(logical_key.as_bytes());
+        syntax_directory.join(format!("{digest:x}.msgpack"))
+    };
+    let first_entry = program_entry("src/a.rs:aaaaaaaa");
+    assert!(
+        first_entry.is_file(),
+        "missing first MessagePack syntax entry"
+    );
     let legacy_directory = syntax_directory.parent().ok_or("missing encoding parent")?;
     let legacy_entry = legacy_directory.join(
         first_entry
@@ -1128,11 +1128,11 @@ fn program_cache_is_path_sensitive_and_namespace_isolated() -> Result<(), Box<dy
         "hard cutover must not decode the legacy JSON cache"
     );
 
-    let second_entry = fs::read_dir(&syntax_directory)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .next()
-        .ok_or("missing second MessagePack syntax entry")?;
+    let second_entry = program_entry("src/b.rs:aaaaaaaa");
+    assert!(
+        second_entry.is_file(),
+        "missing second MessagePack syntax entry"
+    );
     fs::write(&second_entry, b"not-messagepack")?;
     assert!(
         cache

--- a/crates/compass-history/src/validate.rs
+++ b/crates/compass-history/src/validate.rs
@@ -126,7 +126,7 @@ pub(crate) fn validate_publication_partition(
                 entries.len()
             );
         }
-        validate_generated_partition_records(kind, entries, &mut total_bytes, &mut problems);
+        validate_generated_partition_records(kind, entries, &mut total_bytes, &mut problems)?;
     }
     if !problems.is_empty() {
         return Err(HistoryError::InvalidRealization(problems));
@@ -296,7 +296,7 @@ fn validate_generated_partition_records(
     entries: &[(Vec<u8>, Vec<u8>)],
     total_bytes: &mut u64,
     problems: &mut Vec<ValidationProblem>,
-) {
+) -> Result<(), HistoryError> {
     let count = record_count(entries);
     if exceeds_limit(count, MAX_RECORDS_PER_TREE) {
         problems.push(ValidationProblem::ResourceLimit {
@@ -314,8 +314,9 @@ fn validate_generated_partition_records(
         }
     }
     for (key, value) in entries {
-        validate_record_size_limits(key, value, total_bytes, problems);
+        validate_record_limits(kind, key, value, total_bytes, problems)?;
     }
+    Ok(())
 }
 
 fn validate_record_limits(

--- a/crates/compass-history/tests/canonical.rs
+++ b/crates/compass-history/tests/canonical.rs
@@ -41,6 +41,17 @@ fn canonical_number_boundaries_and_exponents_are_stable() -> Result<(), Box<dyn 
 }
 
 #[test]
+fn canonical_floats_are_idempotent_after_json_round_trip() -> Result<(), Box<dyn std::error::Error>>
+{
+    let value = json!({"cohesion": 0.10384068278805121_f64});
+    let first = canonical_json_bytes(&value)?;
+    let reparsed: Value = serde_json::from_slice(&first)?;
+    let second = canonical_json_bytes(&reparsed)?;
+    assert_eq!(first, second);
+    Ok(())
+}
+
+#[test]
 fn typed_keys_are_segment_safe_and_direction_aware() -> Result<(), Box<dyn std::error::Error>> {
     assert_ne!(node_key("a\0b"), node_key("a"));
     assert_ne!(

--- a/crates/compass-history/tests/performance.rs
+++ b/crates/compass-history/tests/performance.rs
@@ -185,6 +185,8 @@ fn small_change_reuses_content_addressed_nodes() -> Result<(), Box<dyn std::erro
     first_reader.diff(&second_reader, &mut sink)?;
     let diff_latency = started.elapsed();
     assert!(sink.changes > 0);
+    drop(first_reader);
+    drop(second_reader);
 
     let started = Instant::now();
     let reconstructed = history.artifacts(&second.id)?;

--- a/crates/compass-history/tests/publication.rs
+++ b/crates/compass-history/tests/publication.rs
@@ -149,6 +149,32 @@ fn publication_is_atomic_reopenable_and_content_idempotent()
 }
 
 #[test]
+fn publication_with_computed_floats_is_immediately_valid_and_reconstructable()
+-> Result<(), Box<dyn std::error::Error>> {
+    let fixture = Fixture::new()?;
+    let repository = Repository::discover(&fixture.path)?;
+    let history = HistoryStore::create(&repository)?;
+    let mut publish = request('a', false)?;
+    publish.artifacts.analysis = Some(json!({
+        "cohesion": {"14": 0.10384068278805121_f64}
+    }));
+
+    let published = history.publish(publish)?;
+    history.validate(&published.id)?;
+    let reconstructed = history.artifacts(&published.id)?;
+    assert_eq!(
+        reconstructed
+            .artifacts
+            .analysis
+            .as_ref()
+            .and_then(|value| value.pointer("/cohesion/14"))
+            .and_then(serde_json::Value::as_f64),
+        Some(0.10384068278805121_f64)
+    );
+    Ok(())
+}
+
+#[test]
 fn previous_graph_schema_profiles_are_rejected_at_publication()
 -> Result<(), Box<dyn std::error::Error>> {
     let fixture = Fixture::new()?;


### PR DESCRIPTION
## What changed

- make cold, warm, and mixed-cache historical builds continue from the same portable per-file representation before project-wide C/C++ declaration merging
- cache unmerged extraction facts and apply the non-idempotent project merge exactly once per build
- recompute code-only analysis from trusted published node IDs so realization identity is independent of protected-worktree or clone paths
- make canonical JSON float round-trips idempotent and validate every generated typed record before immutable publication
- fix atomic exports to relative single-component paths
- expose the existing timeline, change-counts, exact-diff, and verify history commands in rich help
- repair cache and performance qualification contracts discovered by the end-to-end experiments

## Root causes

A one-line LevelDB edit exposed several interacting defects: project-merged C++ facts could be cached and merged again; fresh and cached facts entered cross-file resolution with different path representations; retained analysis referenced pre-publication IDs and checkout-specific paths; and computed floating-point analysis could canonicalize to adjacent representations after reopen. The Prolly engine correctly reported these upstream inconsistencies, which made a tiny source edit appear to remove many nodes and edges.

## End-to-end evidence

LevelDB commits `23e35d7` → `578eeb7` differ by one expression in `util/hash.cc`. After the fixes both realizations contain 2,471 nodes and 3,312 edges. Exact and structural diff both report exactly one changed `Hash()` node and zero edge changes. A warm rebuild reproduced the same realization ID, and an independent clone produced the same realization ID and byte-identical graph.

A controlled two-commit Python repository verified topology semantics: the source change added `added()`, changed `helper()` and `caller()`, replaced `caller → helper` with `caller → added → helper`, and added containment. The structural diff reported 1 node added, 3 nodes changed, 3 edges added, and 1 edge removed. The exact Prolly diff retained coordinate-sensitive record history, while the structural projection correctly reconciled anchor-only containment-key churn. Historical CompassQL returned the expected call graph at both commits.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-history --locked`
- `cargo test -p compass-core --lib --locked`
- `cargo test -p compass-files --locked`
- `cargo test -p compass-cli --test help_cli --test history_cli --locked`
- ignored Prolly performance qualifications: 1 semantic change streamed in ~1.1 ms with a one-record peak callback buffer; 85/90 content-addressed storage nodes reused
- `sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_code_graph_v1.sh --fixtures-only`: clean/warm/rebuild/restored/alternate-checkout byte equality and 1,442 semantic invariants
