### PR TITLE
Harden versioned graph diff consumers

### DIFF
--- a/crates/compass-cli/assets/semantic-diff-graph.js
+++ b/crates/compass-cli/assets/semantic-diff-graph.js
@@ -4,6 +4,8 @@
   const NS = "http://www.w3.org/2000/svg";
   const MAX_VISUAL_NODES = 42;
   const MAX_VISUAL_EDGES = 100;
+  const MAX_MODEL_NODES = 10000;
+  const MAX_MODEL_EDGES = 200000;
   const STATUS_PRIORITY = Object.freeze({
     context: 0,
     added: 1,
@@ -32,6 +34,65 @@
 
   function richer(current, candidate) {
     return current || candidate || "";
+  }
+
+  function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+
+  function validateGraphReport(report) {
+    if (!isRecord(report) || report.schema !== "compass.semantic_diff.report/1") {
+      throw new Error("Unsupported semantic diff report schema");
+    }
+    if (!Array.isArray(report.findings) || !Array.isArray(report.source_changes)) {
+      throw new Error("Malformed semantic diff evidence");
+    }
+    const delta = report.graph_delta;
+    if (!isRecord(delta)) throw new Error("Missing graph delta");
+    const nodeGroups = ["changed_nodes", "removed_nodes", "added_nodes"];
+    const edgeGroups = ["changed_edges", "removed_edges", "added_edges"];
+    let nodeCount = 0;
+    let edgeCount = 0;
+    for (const key of nodeGroups) {
+      const records = delta[key];
+      if (!Array.isArray(records)) throw new Error(`Malformed ${key}`);
+      nodeCount += records.length;
+      for (const node of records) {
+        if (!isRecord(node)
+          || typeof node.id !== "string"
+          || node.id.length === 0
+          || typeof node.label !== "string"
+          || typeof node.kind !== "string"
+          || typeof node.source_file !== "string"
+          || !Array.isArray(node.changed_fields)
+          || !node.changed_fields.every((field) => typeof field === "string")) {
+          throw new Error(`Malformed ${key} record`);
+        }
+      }
+    }
+    for (const key of edgeGroups) {
+      const records = delta[key];
+      if (!Array.isArray(records)) throw new Error(`Malformed ${key}`);
+      edgeCount += records.length;
+      for (const edge of records) {
+        if (!isRecord(edge)
+          || typeof edge.source !== "string"
+          || edge.source.length === 0
+          || typeof edge.target !== "string"
+          || edge.target.length === 0
+          || typeof edge.relation !== "string"
+          || typeof edge.key !== "string"
+          || typeof edge.source_file !== "string"
+          || !Array.isArray(edge.changed_fields)
+          || !edge.changed_fields.every((field) => typeof field === "string")) {
+          throw new Error(`Malformed ${key} record`);
+        }
+      }
+    }
+    if (nodeCount > MAX_MODEL_NODES || edgeCount > MAX_MODEL_EDGES) {
+      throw new Error("Graph delta exceeds the interactive safety limit");
+    }
+    return delta;
   }
 
   function rememberNode(nodes, raw, status) {
@@ -68,8 +129,8 @@
     }
   }
 
-  function buildGraphModel(delta) {
-    if (!delta) throw new Error("Missing graph delta");
+  function buildGraphModel(report) {
+    const delta = validateGraphReport(report);
     const nodes = new Map();
     for (const node of delta.changed_nodes || []) rememberNode(nodes, node, "changed");
     for (const node of delta.removed_nodes || []) rememberNode(nodes, node, "removed");
@@ -82,6 +143,9 @@
     for (const edge of edges) {
       rememberNode(nodes, edge.source, "context");
       rememberNode(nodes, edge.target, "context");
+      if (nodes.size > MAX_MODEL_NODES) {
+        throw new Error("Graph delta exceeds the interactive node safety limit");
+      }
       nodes.get(edge.source).degree += 1;
       nodes.get(edge.target).degree += 1;
     }
@@ -395,7 +459,7 @@
     }
     const listeners = [];
     try {
-      const model = buildGraphModel(report.graph_delta);
+      const model = buildGraphModel(report);
       const ranked = rankVisualNodes(model);
       const visualNodes = ranked.slice(0, MAX_VISUAL_NODES);
       const selectedIds = new Set(visualNodes.map((node) => node.id));

--- a/crates/compass-cli/src/capability_commands.rs
+++ b/crates/compass-cli/src/capability_commands.rs
@@ -32,6 +32,7 @@ pub fn command(frontend: Frontend, args: &[String]) -> Outcome {
             ("history_timeline", compass_history::HISTORY_TIMELINE_SCHEMA),
             ("history_change_counts", "compass.history.change_counts/1"),
             ("history_viewer_graph", "compass.history.viewer_graph/1"),
+            ("semantic_diff_report", compass_semantic_diff::REPORT_SCHEMA),
         ]),
         features: BTreeMap::from([
             ("init", true),

--- a/crates/compass-cli/tests/capabilities_cli.rs
+++ b/crates/compass-cli/tests/capabilities_cli.rs
@@ -15,6 +15,10 @@ fn capabilities_reports_versioned_ide_contracts() -> Result<(), Box<dyn Error>> 
     assert_eq!(value["contracts"]["graph_viewer"], "compass.viewer.graph/1");
     assert_eq!(value["contracts"]["call_graph"], "compass.call_graph/1");
     assert_eq!(
+        value["contracts"]["semantic_diff_report"],
+        "compass.semantic_diff.report/1"
+    );
+    assert_eq!(
         value["contracts"]["program_call_graph"],
         "compass.program.call_graph/1"
     );

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -451,6 +451,9 @@ First-party editor and offline-viewer contracts are versioned independently:
 - `compass.history.change_counts/1` — lazy structural counts between existing
   realizations;
 - `compass.history.viewer_graph/1` — exact historical graph envelope;
+- `compass.semantic_diff.report/1` — exhaustive semantic findings, source
+  changes, and exact added, removed, and changed node/edge records consumed by
+  the CLI HTML report and editor comparison views;
 - `compass.ide.progress/1` — newline-delimited guided-operation events.
 
 ## Filesystem and concurrency

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -149,6 +149,12 @@ changes**. Compass lazily compares that community at both revisions and shows
 the exact added, removed, and changed symbols and relationships. Selecting a
 changed symbol reveals a Before/After table containing only modified fields,
 including signatures and source ranges, with source actions for both commits.
+The semantic tab renders the report's current finding headlines, verification
+state, reviewer action, and evidence. The changed-graph tab uses the exact Rust
+semantic-diff node and edge records instead of comparing unstable aggregate
+community projections. Large finding details are bounded in the editor; use
+`compass diff OLD NEW --format html --output semantic-diff.html` for the
+exhaustive standalone review report.
 If either community exceeds `compass.graphNodeLimit`, the detail view labels
 its counts as partial and explains how to increase the limit.
 

--- a/editors/vscode/src/cli/runtime.test.ts
+++ b/editors/vscode/src/cli/runtime.test.ts
@@ -15,7 +15,8 @@ const capabilities: CapabilityReport = {
     callflow_viewer: "compass.viewer.callflow/1",
     history_timeline: "compass.history.timeline/1",
     history_change_counts: "compass.history.change_counts/1",
-    history_viewer_graph: "compass.history.viewer_graph/1"
+    history_viewer_graph: "compass.history.viewer_graph/1",
+    semantic_diff_report: "compass.semantic_diff.report/1"
   },
   features: {
     init: true,

--- a/editors/vscode/src/history/diffClient.test.ts
+++ b/editors/vscode/src/history/diffClient.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ZodType } from "zod";
+import { loadSemanticDiff } from "./diffClient";
+
+function report(schema = "compass.semantic_diff.report/1") {
+  return {
+    schema,
+    comparison: { old_commit: "parent", new_commit: "current", fingerprint: "fingerprint" },
+    findings: [],
+    feature_groups: [],
+    collapsed_groups: [],
+    source_changes: [],
+    graph_delta: {
+      added_nodes: [],
+      removed_nodes: [],
+      changed_nodes: [],
+      added_edges: [],
+      removed_edges: [],
+      changed_edges: [],
+      collapsed_attribute_changes: {}
+    },
+    entity_display_names: {},
+    completeness: {},
+    limitations: []
+  };
+}
+
+describe("semantic-diff client", () => {
+  it("requests and validates the current versioned semantic report", async () => {
+    const payload = report();
+    const runJson = vi.fn(async (
+      _root: string,
+      _args: readonly string[],
+      schema: ZodType
+    ) => schema.parse(payload));
+    const session = { root: "/repo", processes: { runJson } };
+
+    await expect(loadSemanticDiff(session as never, "parent", "current"))
+      .resolves.toMatchObject({ schema: "compass.semantic_diff.report/1" });
+    expect(runJson.mock.calls[0]?.[1]).toEqual([
+      "diff",
+      "parent",
+      "current",
+      "--format",
+      "json"
+    ]);
+  });
+
+  it("rejects unknown report versions before they reach the webview", async () => {
+    const payload = report("compass.semantic_diff.report/2");
+    const runJson = vi.fn(async (
+      _root: string,
+      _args: readonly string[],
+      schema: ZodType
+    ) => schema.parse(payload));
+    const session = { root: "/repo", processes: { runJson } };
+
+    await expect(loadSemanticDiff(session as never, "parent", "current"))
+      .rejects.toThrow();
+  });
+});

--- a/editors/vscode/src/history/diffClient.ts
+++ b/editors/vscode/src/history/diffClient.ts
@@ -1,3 +1,7 @@
+import {
+  SemanticDiffReportSchema,
+  type SemanticDiffReport
+} from "@compass/viewer/contracts/history";
 import type { RepositorySession } from "../workspace/repositorySession";
 
 export async function loadSemanticDiff(
@@ -5,12 +9,11 @@ export async function loadSemanticDiff(
   parent: string,
   commit: string,
   signal?: AbortSignal
-): Promise<unknown> {
-  const result = await session.processes.run(
+): Promise<SemanticDiffReport> {
+  return session.processes.runJson(
     session.root,
     ["diff", parent, commit, "--format", "json"],
+    SemanticDiffReportSchema,
     signal
   );
-  if (result.code !== 0) throw new Error(result.stderr || `Compass exited with ${result.code}`);
-  return JSON.parse(result.stdout);
 }

--- a/editors/vscode/src/history/panelMessages.ts
+++ b/editors/vscode/src/history/panelMessages.ts
@@ -2,6 +2,7 @@ import type {
   GraphViewModel,
   HistoryChangeCounts,
   HistoryTimeline,
+  SemanticDiffReport,
   SourceLocation
 } from "@compass/viewer";
 
@@ -96,7 +97,7 @@ export type HistoryHostMessage =
     parentFingerprint: string;
     currentGraph: GraphViewModel;
     parentGraph: GraphViewModel;
-    semanticDiff: unknown;
+    semanticDiff: SemanticDiffReport;
     counts?: HistoryChangeCounts;
   }
   | {

--- a/editors/vscode/src/test/fake-bin/compass
+++ b/editors/vscode/src/test/fake-bin/compass
@@ -11,7 +11,8 @@ if (command === "capabilities") {
       progress: "compass.ide.progress/1",
       history_timeline: "compass.history.timeline/1",
       history_change_counts: "compass.history.change_counts/1",
-      history_viewer_graph: "compass.history.viewer_graph/1"
+      history_viewer_graph: "compass.history.viewer_graph/1",
+      semantic_diff_report: "compass.semantic_diff.report/1"
     },
     features: {
       init: true,

--- a/editors/vscode/src/webviews/history.tsx
+++ b/editors/vscode/src/webviews/history.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import {
   HistoryTimelineSchema,
   HistoryChangeCountsSchema,
+  SemanticDiffReportSchema,
   HistoryWorkspace,
   WorkspaceState,
   GraphViewModelSchema,
@@ -13,6 +14,7 @@ import {
   type HistoryBuildState,
   type HistoryChangeCounts,
   type HistoryOperationError,
+  type SemanticDiffReport,
   type HistoryTimeline
 } from "@compass/viewer";
 import type {
@@ -46,7 +48,7 @@ let activeCommunityContext: {
   parentMembers: number;
   currentMembers: number;
 } | undefined;
-let semanticDiff: unknown;
+let semanticDiff: SemanticDiffReport | undefined;
 let comparison: (GraphComparison & { parent: string }) | undefined;
 let repositoryId = "";
 let changeCounts: HistoryChangeCounts | undefined;
@@ -389,7 +391,8 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
     if (!acceptsCommit(message.commit)) return;
     const current = GraphViewModelSchema.safeParse(message.currentGraph);
     const parent = GraphViewModelSchema.safeParse(message.parentGraph);
-    if (current.success && parent.success) {
+    const report = SemanticDiffReportSchema.safeParse(message.semanticDiff);
+    if (current.success && parent.success && report.success) {
       const parsedCounts = message.counts
         ? HistoryChangeCountsSchema.safeParse(message.counts)
         : undefined;
@@ -417,7 +420,7 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
       activeCommunityContext = undefined;
       const visibleComparison = compareGraphs(parent.data, current.data);
       const structuralComparison = comparisonFromSemanticDiff(
-        message.semanticDiff,
+        report.data,
         current.data,
         parent.data
       ) ?? visibleComparison;
@@ -425,10 +428,33 @@ window.addEventListener("message", (event: MessageEvent<HistoryHostMessage>) => 
         ...structuralComparison,
         parent: message.parent
       };
-      semanticDiff = message.semanticDiff;
+      semanticDiff = report.data;
       if (structuralCounts) changeCounts = structuralCounts;
       operationErrors.delete(message.commit);
       revisionLoadState = "ready";
+    } else {
+      comparison = undefined;
+      comparisonIdentities = undefined;
+      semanticDiff = undefined;
+      changeCounts = undefined;
+      communityDetail = undefined;
+      communityLoading = null;
+      communityError = undefined;
+      activeCommunityRequest = "";
+      activeCommunityContext = undefined;
+      if (current.success) {
+        graph = current.data;
+        graphCommit = message.commit;
+        graphIdentity = {
+          realization: message.realization,
+          fingerprint: message.fingerprint
+        };
+        revisionLoadState = "ready";
+      }
+      operationErrors.set(message.commit, {
+        operation: "Compare revisions",
+        message: "Compass returned an unsupported or malformed versioned graph comparison."
+      });
     }
   } else if (message?.type === "communityComparison") {
     const context = activeCommunityContext;

--- a/packages/compass-viewer/src/contracts/history.test.ts
+++ b/packages/compass-viewer/src/contracts/history.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { SemanticDiffReportSchema } from "./history";
+
+function currentReport() {
+  return {
+    schema: "compass.semantic_diff.report/1",
+    comparison: {
+      old_commit: "23e35d792b9154f922b8b575b12596a4d8664c65",
+      new_commit: "578eeb702ec0fbb6b9780f3d4147b1076630d633",
+      fingerprint: "fixture-fingerprint"
+    },
+    findings: [{
+      id: "sd1-hash",
+      finding_type: "behavior_change",
+      subject: "sha256:hash",
+      origin: "direct",
+      headline: "Hash() implementation changed",
+      explanation: "An implementation digest changed without supported semantic evidence.",
+      compatibility: "indeterminate",
+      confidence: "unknown",
+      review_priority: 3,
+      public_surface: false,
+      routine: false,
+      before: {
+        body_digest: "0e8905",
+        signature_digest: "unchanged",
+        source_file: "util/hash.cc"
+      },
+      after: {
+        body_digest: "3286cd",
+        signature_digest: "unchanged",
+        source_file: "util/hash.cc"
+      },
+      affected_consumers: [],
+      witness_paths: [],
+      verification: {
+        state: "partial",
+        exact_tests: [],
+        recommended_tests: [],
+        reason: "Test mapping is partial."
+      },
+      reviewer_action: "Inspect the body-only change.",
+      evidence: [{
+        source_file: "util/hash.cc",
+        start_byte: 17,
+        end_byte: 64,
+        record_key: "sha256:hash",
+        capability: "implementation"
+      }],
+      completeness: {
+        call_resolution: "partial",
+        implementation: "partial",
+        signature: "complete",
+        test_mapping: "partial"
+      }
+    }],
+    feature_groups: [],
+    collapsed_groups: [],
+    source_changes: [{
+      old_path: "util/hash.cc",
+      new_path: "util/hash.cc",
+      status: "modified",
+      hunks: [{ old_start: 1, old_lines: 3, new_start: 1, new_lines: 3 }],
+      patch: "@@ -1,3 +1,3 @@\n-old\n+new"
+    }],
+    graph_delta: {
+      added_nodes: [],
+      removed_nodes: [],
+      changed_nodes: [{
+        id: "sha256:hash",
+        label: "Hash",
+        kind: "function",
+        source_file: "util/hash.cc",
+        changed_fields: ["details"]
+      }],
+      added_edges: [],
+      removed_edges: [],
+      changed_edges: [],
+      collapsed_attribute_changes: {}
+    },
+    entity_display_names: { "sha256:hash": "Hash" },
+    completeness: {
+      identity: "complete",
+      source_delta: "complete",
+      call_resolution: "partial",
+      test_mapping: "partial"
+    },
+    limitations: ["Call mapping is partial."]
+  };
+}
+
+describe("SemanticDiffReportSchema", () => {
+  it("accepts the current Rust report including exact graph delta evidence", () => {
+    const parsed = SemanticDiffReportSchema.parse(currentReport());
+
+    expect(parsed.findings[0]?.headline).toBe("Hash() implementation changed");
+    expect(parsed.graph_delta.changed_nodes).toEqual([expect.objectContaining({
+      id: "sha256:hash",
+      changed_fields: ["details"]
+    })]);
+    expect(parsed.graph_delta.changed_edges).toEqual([]);
+  });
+
+  it("rejects unknown versions and malformed edge records", () => {
+    const unknownVersion = currentReport();
+    unknownVersion.schema = "compass.semantic_diff.report/2";
+    expect(SemanticDiffReportSchema.safeParse(unknownVersion).success).toBe(false);
+
+    const malformed = currentReport();
+    malformed.graph_delta.added_edges = [{
+      source: "a",
+      target: "b",
+      relation: "calls",
+      key: "a-b",
+      source_file: "src/lib.rs",
+      changed_fields: "confidence"
+    }] as never;
+    expect(SemanticDiffReportSchema.safeParse(malformed).success).toBe(false);
+  });
+});

--- a/packages/compass-viewer/src/contracts/history.ts
+++ b/packages/compass-viewer/src/contracts/history.ts
@@ -1,6 +1,139 @@
 import { z } from "zod";
 import { GraphViewModelSchema } from "./graph";
 
+const MAX_SEMANTIC_FINDINGS = 5_000;
+const MAX_SEMANTIC_EVIDENCE = 20;
+const MAX_GRAPH_DELTA_NODES = 10_000;
+const MAX_GRAPH_DELTA_EDGES = 200_000;
+
+const CompletenessSchema = z.enum(["complete", "partial", "unavailable"]);
+const SemanticEvidenceRefSchema = z.object({
+  source_file: z.string(),
+  start_byte: z.number().int().nonnegative().optional(),
+  end_byte: z.number().int().nonnegative().optional(),
+  record_key: z.string().optional(),
+  capability: z.string()
+});
+const SemanticNodeDeltaSchema = z.object({
+  id: z.string().min(1),
+  label: z.string(),
+  kind: z.string(),
+  source_file: z.string(),
+  changed_fields: z.array(z.string())
+});
+const SemanticEdgeDeltaSchema = z.object({
+  source: z.string().min(1),
+  target: z.string().min(1),
+  relation: z.string(),
+  key: z.string(),
+  source_file: z.string(),
+  changed_fields: z.array(z.string())
+});
+const SourceFileDeltaSchema = z.object({
+  old_path: z.string().nullable(),
+  new_path: z.string().nullable(),
+  status: z.enum(["added", "modified", "deleted", "renamed"]),
+  hunks: z.array(z.object({
+    old_start: z.number().int().nonnegative(),
+    old_lines: z.number().int().nonnegative(),
+    new_start: z.number().int().nonnegative(),
+    new_lines: z.number().int().nonnegative()
+  })),
+  patch: z.string()
+});
+
+export const SemanticDiffReportSchema = z.object({
+  schema: z.literal("compass.semantic_diff.report/1"),
+  comparison: z.object({
+    old_commit: z.string().min(1),
+    new_commit: z.string().min(1),
+    fingerprint: z.string().min(1)
+  }),
+  findings: z.array(z.object({
+    id: z.string().min(1),
+    finding_type: z.enum([
+      "contract_change",
+      "behavior_change",
+      "dependency_change",
+      "impact_change",
+      "verification_gap",
+      "structural_change"
+    ]),
+    subject: z.string().min(1),
+    origin: z.enum(["direct", "derived"]),
+    headline: z.string(),
+    explanation: z.string(),
+    compatibility: z.enum([
+      "proven_break",
+      "possible_break",
+      "compatible",
+      "behavioral",
+      "not_applicable",
+      "indeterminate"
+    ]),
+    confidence: z.enum(["exact", "probable", "inferred", "unknown"]),
+    review_priority: z.number().int().nonnegative(),
+    public_surface: z.boolean(),
+    routine: z.boolean(),
+    before: z.unknown().optional(),
+    after: z.unknown().optional(),
+    affected_consumers: z.array(z.object({
+      symbol_id: z.string(),
+      display_name: z.string(),
+      source_file: z.string(),
+      distance: z.number().int().nonnegative()
+    })),
+    witness_paths: z.array(z.object({
+      consumer: z.string(),
+      confidence: z.enum(["exact", "probable", "inferred", "unknown"]),
+      hops: z.array(z.object({
+        source: z.string(),
+        relation: z.string(),
+        target: z.string(),
+        confidence: z.enum(["exact", "probable", "inferred", "unknown"])
+      }))
+    })),
+    verification: z.object({
+      state: z.enum(["unknown", "covered", "gap", "partial", "stale", "failing", "not_run"]),
+      exact_tests: z.array(z.string()),
+      recommended_tests: z.array(z.string()),
+      reason: z.string()
+    }),
+    reviewer_action: z.string(),
+    evidence: z.array(SemanticEvidenceRefSchema).max(MAX_SEMANTIC_EVIDENCE),
+    completeness: z.record(z.string(), CompletenessSchema)
+  })).max(MAX_SEMANTIC_FINDINGS),
+  feature_groups: z.array(z.object({
+    id: z.string(),
+    headline: z.string(),
+    summary: z.string(),
+    finding_ids: z.array(z.string()),
+    source_files: z.array(z.string()),
+    public_surface_changes: z.number().int().nonnegative(),
+    behavior_changes: z.number().int().nonnegative(),
+    dependency_changes: z.number().int().nonnegative(),
+    test_changes: z.number().int().nonnegative()
+  })),
+  collapsed_groups: z.array(z.object({
+    label: z.string(),
+    count: z.number().int().nonnegative(),
+    finding_ids: z.array(z.string())
+  })),
+  source_changes: z.array(SourceFileDeltaSchema),
+  graph_delta: z.object({
+    added_nodes: z.array(SemanticNodeDeltaSchema).max(MAX_GRAPH_DELTA_NODES),
+    removed_nodes: z.array(SemanticNodeDeltaSchema).max(MAX_GRAPH_DELTA_NODES),
+    changed_nodes: z.array(SemanticNodeDeltaSchema).max(MAX_GRAPH_DELTA_NODES),
+    added_edges: z.array(SemanticEdgeDeltaSchema).max(MAX_GRAPH_DELTA_EDGES),
+    removed_edges: z.array(SemanticEdgeDeltaSchema).max(MAX_GRAPH_DELTA_EDGES),
+    changed_edges: z.array(SemanticEdgeDeltaSchema).max(MAX_GRAPH_DELTA_EDGES),
+    collapsed_attribute_changes: z.record(z.string(), z.number().int().nonnegative())
+  }),
+  entity_display_names: z.record(z.string(), z.string()).optional(),
+  completeness: z.record(z.string(), CompletenessSchema),
+  limitations: z.array(z.string())
+});
+
 export const HistoryGraphStateSchema = z.enum([
   "graph_available",
   "not_materialized",
@@ -50,6 +183,7 @@ export type HistoryTimeline = z.infer<typeof HistoryTimelineSchema>;
 export type HistoryEntry = HistoryTimeline["entries"][number];
 export type HistoricalGraph = z.infer<typeof HistoricalGraphSchema>;
 export type HistoryChangeCounts = z.infer<typeof HistoryChangeCountsSchema>;
+export type SemanticDiffReport = z.infer<typeof SemanticDiffReportSchema>;
 export type HistoryBuildState =
   | { status: "requesting" }
   | { status: "running" }

--- a/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GraphViewModel } from "../contracts/graph";
+import type { SemanticDiffReport } from "../contracts/history";
 import { compareGraphs, comparisonFromSemanticDiff } from "./ComparisonOverlay";
 import { compareRecord, displayFieldValue } from "./recordDiff";
 
@@ -20,6 +21,25 @@ function graph(
     edges,
     communities: [{ id: 0, label: "Core", color: "#6688aa", hidden: false }],
     hyperedges: []
+  };
+}
+
+function semanticReport(
+  graphDelta: SemanticDiffReport["graph_delta"],
+  extra: Partial<SemanticDiffReport> = {}
+): SemanticDiffReport {
+  return {
+    schema: "compass.semantic_diff.report/1",
+    comparison: { old_commit: "parent", new_commit: "current", fingerprint: "fixture" },
+    findings: [],
+    feature_groups: [],
+    collapsed_groups: [],
+    source_changes: [],
+    graph_delta: graphDelta,
+    entity_display_names: {},
+    completeness: {},
+    limitations: [],
+    ...extra
   };
 }
 
@@ -376,8 +396,7 @@ describe("aggregated revision comparison", () => {
       []
     );
     aggregate.stats.aggregated = true;
-    const comparison = comparisonFromSemanticDiff({
-      graph_delta: {
+    const comparison = comparisonFromSemanticDiff(semanticReport({
         added_nodes: [],
         removed_nodes: [],
         changed_nodes: [{
@@ -396,10 +415,11 @@ describe("aggregated revision comparison", () => {
           changed_fields: []
         }],
         removed_edges: [],
-        changed_edges: []
-      },
-      entity_display_names: { "api::route": "route" }
-    }, aggregate);
+        changed_edges: [],
+        collapsed_attribute_changes: {}
+      }, {
+        entity_display_names: { "api::route": "route" }
+      }), aggregate);
 
     expect(comparison).toMatchObject({
       changedNodes: 1,
@@ -439,8 +459,7 @@ describe("aggregated revision comparison", () => {
       }],
       []
     );
-    const comparison = comparisonFromSemanticDiff({
-      graph_delta: {
+    const comparison = comparisonFromSemanticDiff(semanticReport({
         added_nodes: [],
         removed_nodes: [],
         changed_nodes: [{
@@ -452,9 +471,9 @@ describe("aggregated revision comparison", () => {
         }],
         added_edges: [],
         removed_edges: [],
-        changed_edges: []
-      }
-    }, current, parent);
+        changed_edges: [],
+        collapsed_attribute_changes: {}
+      }), current, parent);
 
     expect(comparison).toMatchObject({ changedNodes: 1 });
     expect(comparison?.graph.nodes[0]).toMatchObject({
@@ -468,4 +487,5 @@ describe("aggregated revision comparison", () => {
       }
     });
   });
+
 });

--- a/packages/compass-viewer/src/history/ComparisonOverlay.tsx
+++ b/packages/compass-viewer/src/history/ComparisonOverlay.tsx
@@ -5,6 +5,7 @@ import type {
   GraphRecordEvidence,
   GraphViewModel
 } from "../contracts/graph";
+import type { SemanticDiffReport } from "../contracts/history";
 import {
   compareRecord,
   compareStructuralRecord,
@@ -189,12 +190,11 @@ export function compareGraphs(
 
 /** Build an exact changed-subgraph when revision exports are community aggregates. */
 export function comparisonFromSemanticDiff(
-  report: unknown,
+  semanticReport: SemanticDiffReport,
   reference: GraphViewModel,
   parent?: GraphViewModel
 ): GraphComparison | undefined {
-  if (!isObject(report) || !isObject(report.graph_delta)) return undefined;
-  const delta = report.graph_delta;
+  const delta = semanticReport.graph_delta;
   const addedNodes = graphNodeDeltas(delta.added_nodes);
   const removedNodes = graphNodeDeltas(delta.removed_nodes);
   const changedNodes = graphNodeDeltas(delta.changed_nodes);
@@ -204,9 +204,7 @@ export function comparisonFromSemanticDiff(
   if ([addedNodes, removedNodes, changedNodes, addedEdges, removedEdges, changedEdges]
     .some((records) => records === undefined)) return undefined;
 
-  const displayNames = isObject(report.entity_display_names)
-    ? report.entity_display_names
-    : {};
+  const displayNames = semanticReport.entity_display_names ?? {};
   const currentNodes = new Map(reference.nodes.map((node) => [node.id, node]));
   const parentNodes = new Map((parent?.nodes ?? []).map((node) => [node.id, node]));
   const nodes = new Map<string, GraphNode>();

--- a/packages/compass-viewer/src/history/HistoryWorkspace.tsx
+++ b/packages/compass-viewer/src/history/HistoryWorkspace.tsx
@@ -21,7 +21,8 @@ import type {
   HistoryBuildState,
   HistoryChangeCounts,
   HistoryOperationError,
-  HistoryTimeline
+  HistoryTimeline,
+  SemanticDiffReport
 } from "../contracts/history";
 import { CommitDetails } from "./CommitDetails";
 import { CommitRail } from "./CommitRail";
@@ -71,7 +72,7 @@ export function HistoryWorkspace({
   timeline: HistoryTimeline;
   graph?: GraphViewModel | undefined;
   comparison?: (GraphComparison & { parent: string }) | undefined;
-  semanticDiff?: unknown;
+  semanticDiff?: SemanticDiffReport | undefined;
   changeCounts?: HistoryChangeCounts | undefined;
   graphCommit?: string | undefined;
   communityDetail?: CommunityGraphDetail | undefined;

--- a/packages/compass-viewer/src/history/SemanticFindings.test.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.test.tsx
@@ -1,6 +1,7 @@
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
+import type { SemanticDiffReport } from "../contracts/history";
 import { SemanticFindings, SourceChangeEvidence } from "./SemanticFindings";
 import { normalizeSourcePatch } from "./SourceChanges";
 
@@ -9,6 +10,62 @@ globalThis.ResizeObserver = class {
   unobserve() {}
   disconnect() {}
 };
+
+function report(overrides: Partial<SemanticDiffReport> = {}): SemanticDiffReport {
+  return {
+    schema: "compass.semantic_diff.report/1",
+    comparison: { old_commit: "parent", new_commit: "current", fingerprint: "fixture" },
+    findings: [],
+    feature_groups: [],
+    collapsed_groups: [],
+    source_changes: [],
+    graph_delta: {
+      added_nodes: [],
+      removed_nodes: [],
+      changed_nodes: [],
+      added_edges: [],
+      removed_edges: [],
+      changed_edges: [],
+      collapsed_attribute_changes: {}
+    },
+    entity_display_names: {},
+    completeness: {},
+    limitations: [],
+    ...overrides
+  };
+}
+
+function finding(
+  id: string,
+  headline: string,
+  overrides: Partial<SemanticDiffReport["findings"][number]> = {}
+): SemanticDiffReport["findings"][number] {
+  return {
+    id,
+    finding_type: "behavior_change",
+    subject: "resolver",
+    origin: "direct",
+    headline,
+    explanation: "The implementation changed.",
+    compatibility: "indeterminate",
+    confidence: "unknown",
+    review_priority: 3,
+    public_surface: false,
+    routine: false,
+    affected_consumers: [],
+    witness_paths: [],
+    verification: {
+      state: "partial",
+      exact_tests: [],
+      recommended_tests: ["resolver tests"],
+      reason: "Test mapping is partial."
+    },
+    reviewer_action: "Inspect the body-only change.",
+    evidence: [],
+    completeness: { implementation: "partial" },
+    ...overrides
+  };
+}
 
 describe("SemanticFindings", () => {
   it("normalizes GitHub hunk fragments into a complete one-file patch", () => {
@@ -30,24 +87,15 @@ describe("SemanticFindings", () => {
     const root = createRoot(container);
     flushSync(() => root.render(
         <SourceChangeEvidence
-          report={{
-            schema: "compass.semantic_diff.report/1",
-            comparison: { old_revision: "parent", new_revision: "current" },
+          report={report({
             source_changes: [{
               old_path: "Cargo.toml",
               new_path: "Cargo.toml",
               status: "modified",
               hunks: [{ old_start: 5, old_lines: 1, new_start: 5, new_lines: 1 }],
               patch: "-version = \"3.1.6\"\n+version = \"3.1.7\""
-            }],
-            findings: [],
-            completeness: {
-              identity: "complete",
-              source_delta: "complete",
-              call_resolution: "unavailable",
-              test_mapping: "unavailable"
-            }
-          }}
+            }]
+          })}
         />
     ));
 
@@ -63,16 +111,25 @@ describe("SemanticFindings", () => {
     const root = createRoot(container);
     flushSync(() => root.render(
       <SemanticFindings
-        report={{
-          findings: [{
-            summary: "Resolver now falls back to the parent organization",
-            affected_symbols: ["resolveOrgRef", "pickOrg"],
-            confidence: "high"
-          }, {
-            summary: "Tests cover the new fallback",
-            evidence: { file: "resolveref_test.go", line: 42 }
-          }]
-        }}
+        report={report({
+          findings: [
+            finding("sd1-resolver", "Resolver now falls back to the parent organization", {
+              affected_consumers: [{
+                symbol_id: "resolveOrgRef",
+                display_name: "resolveOrgRef",
+                source_file: "resolver.ts",
+                distance: 1
+              }]
+            }),
+            finding("sd1-tests", "Tests cover the new fallback", {
+              evidence: [{
+                source_file: "resolveref_test.go",
+                start_byte: 42,
+                capability: "test_mapping"
+              }]
+            })
+          ]
+        })}
       />
     ));
 
@@ -82,10 +139,13 @@ describe("SemanticFindings", () => {
     expect(cards).toHaveLength(2);
     expect(cards[0]?.open).toBe(true);
     expect(cards[1]?.open).toBe(false);
-    expect(container.textContent).toContain("2 evidence fields");
-    expect(container.textContent).toContain("Affected symbols");
+    expect(container.textContent).toContain("Resolver now falls back");
+    expect(container.textContent).not.toContain("Finding 1");
+    expect(container.textContent).toContain("Affected consumers");
     expect(container.textContent).toContain("resolveOrgRef");
-    expect(container.textContent).not.toContain("\"affected_symbols\"");
+    expect(container.textContent).toContain("Reviewer action");
+    expect(container.textContent).toContain("Inspect the body-only change");
     root.unmount();
   });
+
 });

--- a/packages/compass-viewer/src/history/SemanticFindings.tsx
+++ b/packages/compass-viewer/src/history/SemanticFindings.tsx
@@ -1,26 +1,32 @@
 import { ChevronRightIcon, FileDiffIcon, SparklesIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Badge } from "../components/ui/badge";
+import type { SemanticDiffReport } from "../contracts/history";
 import { SourceChanges, type SourceChange } from "./SourceChanges";
+
+const MAX_RENDERED_FINDINGS = 500;
+const MAX_RENDERED_VALUES = 100;
+const MAX_STRUCTURED_VALUE_CHARACTERS = 20_000;
 
 export type SemanticEvidence = {
   sourceChanges: SourceChange[];
-  findings: unknown[];
+  findings: SemanticDiffReport["findings"];
 };
 
-export function semanticEvidence(report: unknown): SemanticEvidence {
-  const value = report && typeof report === "object"
-    ? report as Record<string, unknown>
-    : {};
+export function semanticEvidence(report: SemanticDiffReport | undefined): SemanticEvidence {
+  if (report === undefined) return { findings: [], sourceChanges: [] };
   return {
-    findings: Array.isArray(value.findings) ? value.findings : [],
-    sourceChanges: Array.isArray(value.source_changes)
-      ? value.source_changes.filter(isSourceChange)
-      : []
+    findings: report.findings,
+    sourceChanges: report.source_changes.map((change) => ({
+      ...(change.old_path === null ? {} : { old_path: change.old_path }),
+      ...(change.new_path === null ? {} : { new_path: change.new_path }),
+      status: change.status,
+      patch: change.patch
+    }))
   };
 }
 
-export function SourceChangeEvidence({ report }: { report: unknown }) {
+export function SourceChangeEvidence({ report }: { report: SemanticDiffReport | undefined }) {
   const { sourceChanges } = semanticEvidence(report);
   return (
     <section className="history-evidence-panel" aria-labelledby="history-source-title">
@@ -41,19 +47,20 @@ export function SourceChangeEvidence({ report }: { report: unknown }) {
   );
 }
 
-export function SemanticFindings({ report }: { report: unknown }) {
+export function SemanticFindings({ report }: { report: SemanticDiffReport | undefined }) {
   const { findings } = semanticEvidence(report);
+  const visibleFindings = findings.slice(0, MAX_RENDERED_FINDINGS);
   const [openFindings, setOpenFindings] = useState<ReadonlySet<number>>(
-    () => new Set(findings.length ? [0] : [])
+    () => new Set(visibleFindings.length ? [0] : [])
   );
 
   useEffect(() => {
     setOpenFindings((current) => new Set(
-      [...current].filter((index) => index < findings.length)
+      [...current].filter((index) => index < visibleFindings.length)
     ));
-  }, [findings.length]);
+  }, [visibleFindings.length]);
 
-  const allOpen = findings.length > 0 && openFindings.size === findings.length;
+  const allOpen = visibleFindings.length > 0 && openFindings.size === visibleFindings.length;
 
   return (
     <section className="history-evidence-panel" aria-labelledby="history-findings-title">
@@ -71,16 +78,16 @@ export function SemanticFindings({ report }: { report: unknown }) {
             type="button"
             className="history-findings-expand"
             onClick={() => setOpenFindings(
-              allOpen ? new Set() : new Set(findings.map((_, index) => index))
+              allOpen ? new Set() : new Set(visibleFindings.map((_, index) => index))
             )}
           >
             {allOpen ? "Collapse all" : "Expand all"}
           </button>
         )}
       </header>
-      {findings.length > 0 ? (
+      {visibleFindings.length > 0 ? (
         <div className="history-finding-list">
-          {findings.map((finding, index) => {
+          {visibleFindings.map((finding, index) => {
             const details = findingDetails(finding);
             return (
               <details
@@ -127,6 +134,11 @@ export function SemanticFindings({ report }: { report: unknown }) {
               </details>
             );
           })}
+          {findings.length > visibleFindings.length && (
+            <p className="history-diff-empty" role="note">
+              Showing the first {visibleFindings.length.toLocaleString()} of {findings.length.toLocaleString()} findings. Export the HTML or JSON semantic diff for the exhaustive report.
+            </p>
+          )}
         </div>
       ) : (
         <div className="history-findings-empty">
@@ -141,18 +153,10 @@ export function SemanticFindings({ report }: { report: unknown }) {
   );
 }
 
-function isSourceChange(value: unknown): value is SourceChange {
-  if (value === null || typeof value !== "object") return false;
-  const change = value as Record<string, unknown>;
-  return ["old_path", "new_path", "status", "patch"].every(
-    (key) => change[key] === undefined || typeof change[key] === "string"
-  );
-}
-
 function findingSummary(finding: unknown, index: number): string {
   if (finding && typeof finding === "object") {
     const record = finding as Record<string, unknown>;
-    for (const key of ["summary", "title", "message"]) {
+    for (const key of ["headline", "summary", "title", "message"]) {
       if (typeof record[key] === "string") return record[key];
     }
   }
@@ -163,7 +167,7 @@ function findingDetails(finding: unknown): Record<string, unknown> | undefined {
   if (!finding || typeof finding !== "object" || Array.isArray(finding)) return undefined;
   const details = Object.fromEntries(
     Object.entries(finding as Record<string, unknown>)
-      .filter(([key]) => !["summary", "title", "message"].includes(key))
+      .filter(([key]) => !["headline", "summary", "title", "message"].includes(key))
   );
   return Object.keys(details).length > 0 ? details : undefined;
 }
@@ -182,16 +186,26 @@ function renderFindingValue(value: unknown) {
   }
   if (Array.isArray(value)) {
     if (value.length === 0) return <span className="history-finding-muted">None</span>;
+    const visible = value.slice(0, MAX_RENDERED_VALUES);
     return (
       <ul>
-        {value.map((item, index) => (
+        {visible.map((item, index) => (
           <li key={index}>{renderFindingValue(item)}</li>
         ))}
+        {value.length > visible.length && (
+          <li className="history-finding-muted">
+            {value.length - visible.length} additional values omitted from this bounded preview
+          </li>
+        )}
       </ul>
     );
   }
   if (typeof value === "object") {
-    return <pre>{JSON.stringify(value, null, 2)}</pre>;
+    const json = JSON.stringify(value, null, 2);
+    const bounded = json.length > MAX_STRUCTURED_VALUE_CHARACTERS
+      ? `${json.slice(0, MAX_STRUCTURED_VALUE_CHARACTERS)}\n… structured value shortened`
+      : json;
+    return <pre>{bounded}</pre>;
   }
   if (typeof value === "boolean") return <code>{value ? "Yes" : "No"}</code>;
   if (typeof value === "number") return <code>{value.toLocaleString()}</code>;

--- a/tests/viewer/fixtures/generate.ts
+++ b/tests/viewer/fixtures/generate.ts
@@ -952,13 +952,36 @@ window.acquireVsCodeApi=()=>({postMessage(message){
         }
       },
       semanticDiff:{
+        schema:"compass.semantic_diff.report/1",
+        comparison:{old_commit:message.parent,new_commit:message.commit,fingerprint:"fixture"},
         source_changes:[{
           old_path:"Cargo.toml",
           new_path:"Cargo.toml",
           status:"modified",
+          hunks:[{old_start:3,old_lines:3,new_start:3,new_lines:3}],
           patch:"@@ -3,3 +3,3 @@ [package]\\n name = \\"compass\\"\\n-version = \\"3.1.6\\"\\n+version = \\"3.1.7\\"\\n edition = \\"2021\\"\\n"
         }],
-        findings:[{summary:"Fixture comparison"}],
+        findings:[{
+          id:"sd1-fixture",
+          finding_type:"behavior_change",
+          subject:"run",
+          origin:"direct",
+          headline:"Fixture comparison",
+          explanation:"The run signature changed.",
+          compatibility:"indeterminate",
+          confidence:"exact",
+          review_priority:2,
+          public_surface:true,
+          routine:false,
+          affected_consumers:[],
+          witness_paths:[],
+          verification:{state:"partial",exact_tests:[],recommended_tests:["run tests"],reason:"Fixture mapping is partial."},
+          reviewer_action:"Review callers of run.",
+          evidence:[{source_file:"src/lib.rs",record_key:"run",capability:"signature"}],
+          completeness:{signature:"complete",test_mapping:"partial"}
+        }],
+        feature_groups:[],
+        collapsed_groups:[],
         graph_delta:{
           added_nodes:[],
           removed_nodes:[],
@@ -971,8 +994,12 @@ window.acquireVsCodeApi=()=>({postMessage(message){
           }],
           added_edges:[],
           removed_edges:[],
-          changed_edges:[]
-        }
+          changed_edges:[],
+          collapsed_attribute_changes:{}
+        },
+        entity_display_names:{run:"run"},
+        completeness:{identity:"complete",source_delta:"complete",call_resolution:"partial",test_mapping:"partial"},
+        limitations:["Fixture call mapping is partial."]
       }
     },"*"),0);
   } else if(message.type==="compareCommunity") {

--- a/tests/viewer/history.spec.ts
+++ b/tests/viewer/history.spec.ts
@@ -197,6 +197,47 @@ test("comparison replaces the full graph with a readable focused delta", async (
   });
 });
 
+test("rejects an unknown semantic report before drawing a versioned graph delta", async ({ page }) => {
+  await page.goto("/history.html");
+  await page.getByRole("listbox", { name: "Git commit timeline" })
+    .getByRole("option", { name: /Revision B graph/i }).click();
+  await expect(page.getByText(/Viewing graph for bbbbbbbbb/)).toBeVisible();
+  await page.getByRole("button", { name: /Compare revisions/i }).click();
+  await expect(page.getByText("Comparison mode")).toBeVisible();
+
+  await page.evaluate(() => {
+    const fixture = window as typeof window & {
+      emitHistoryMessage(message: unknown): void;
+      historyGraphs: Record<string, unknown>;
+    };
+    const commit = "b".repeat(40);
+    const parent = "a".repeat(40);
+    fixture.emitHistoryMessage({
+      type: "comparison",
+      commit,
+      parent,
+      realization: "r-b",
+      fingerprint: "f-b",
+      parentRealization: "r-a",
+      parentFingerprint: "f-a",
+      currentGraph: fixture.historyGraphs[commit],
+      parentGraph: fixture.historyGraphs[parent],
+      semanticDiff: {
+        schema: "compass.semantic_diff.report/2",
+        graph_delta: {
+          added_nodes: [{ id: "invented", label: "Invented" }]
+        }
+      }
+    });
+  });
+
+  await expect(page.getByRole("alert")).toContainText(
+    "unsupported or malformed versioned graph comparison"
+  );
+  await expect(page.getByText("Comparison mode")).toHaveCount(0);
+  await expect(page.getByText("Invented", { exact: true })).toHaveCount(0);
+});
+
 test("revision actions share a common control baseline", async ({ page }) => {
   await page.goto("/history.html");
 

--- a/tests/viewer/semantic-diff-graph.spec.ts
+++ b/tests/viewer/semantic-diff-graph.spec.ts
@@ -104,3 +104,29 @@ test("falls back safely when graph data is unavailable", async ({ page }) => {
   await expect(page.locator("#graph-note")).toContainText("exhaustive graph-change lists");
   await expect(page.locator("#exhaustive-list")).toContainText("changed-core");
 });
+
+test("rejects unknown semantic report versions without rendering guessed topology", async ({ page }) => {
+  await page.evaluate(() => {
+    const runtime = globalThis as typeof globalThis & {
+      graphFixture: { destroy(): void };
+      CompassSemanticDiffGraph: {
+        mount(options: Record<string, unknown>): unknown;
+      };
+    };
+    runtime.graphFixture.destroy();
+    const data = document.getElementById("semantic-diff-data")?.textContent || "{}";
+    const report = JSON.parse(data);
+    report.schema = "compass.semantic_diff.report/2";
+    runtime.CompassSemanticDiffGraph.mount({
+      report,
+      host: document.getElementById("graph-canvas"),
+      inspector: document.getElementById("graph-inspector"),
+      liveRegion: document.getElementById("graph-live"),
+      note: document.getElementById("graph-note")
+    });
+  });
+
+  await expect(page.locator("#graph-canvas")).toContainText("Interactive graph unavailable.");
+  await expect(page.locator("#graph-note")).toContainText("embedded report data");
+  await expect(page.locator("#graph-canvas [data-node-id]")).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed

- add a complete bounded TypeScript contract for `compass.semantic_diff.report/1`
- validate CLI JSON and webview messages before versioned graph comparisons render
- drive the changed subgraph from the Rust engine's exact node and edge deltas
- render current semantic finding headlines and bound expensive editor previews
- validate and bound the standalone semantic-diff HTML graph, with safe fallback for unknown or malformed reports
- advertise and document the semantic-diff report contract

## Why

The VS Code history client previously parsed semantic diff output as untyped JSON. The shared findings view also looked for legacy summary fields instead of the current Rust report's `headline`, and graph consumers could attempt to interpret malformed or unknown report versions. This could hide real semantic findings, render stale or guessed topology, or perform unnecessary work on oversized data.

## Impact

VS Code Codebase Evolution and `compass diff OLD NEW --format html` now consume the same current versioned report semantics. Unknown major versions fail explicitly, stale comparisons are cleared, exact Rust graph deltas remain authoritative, and the standalone HTML/JSON report remains exhaustive when the editor preview is bounded.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test capabilities_cli --locked`
- `cargo test -p compass-cli --lib semantic_diff_render --locked`
- `cargo test -p compass-cli --test history_cli diff_emits_semantic_text_json_html_and_rejects_removed_flags --locked`
- `npm run typecheck:js`
- `npm run test:js` (244 unit tests and 74 Chromium tests passed)
- focused history and semantic-diff browser tests, including unknown-version and stale-comparison rejection

`node scripts/check_viewer_assets.mjs` was also run. It reports that `viewer.css` differs because `packages/compass-viewer/src/theme.css` contains separate pre-existing working-tree changes; this PR does not modify or regenerate that CSS.
