### PR TITLE
Release Compass 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.1 - 2026-08-03
+
 - Make versioned graph comparisons meaning-aware: source-coordinate shifts,
   clustering/layout metadata, and anchor-derived edge identities no longer
   appear as graph-wide structural changes. Historical queries now read only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "compass-core",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,29 +35,29 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-program = { path = "../compass-program", version = "0.3.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.0" }
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
-compass-global = { path = "../compass-global", version = "0.3.0" }
-compass-history = { path = "../compass-history", version = "0.3.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.0" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.0" }
-compass-output = { path = "../compass-output", version = "0.3.0" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.0" }
-compass-prs = { path = "../compass-prs", version = "0.3.0" }
-compass-query = { path = "../compass-query", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.0" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.0" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.0" }
+compass-core = { path = "../compass-core", version = "0.3.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-program = { path = "../compass-program", version = "0.3.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.1" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.1" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.1" }
+compass-global = { path = "../compass-global", version = "0.3.1" }
+compass-history = { path = "../compass-history", version = "0.3.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.1" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.1" }
+compass-output = { path = "../compass-output", version = "0.3.1" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.1" }
+compass-prs = { path = "../compass-prs", version = "0.3.1" }
+compass-query = { path = "../compass-query", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.1" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.1" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-program = { path = "../compass-program", version = "0.3.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-program = { path = "../compass-program", version = "0.3.1" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,16 +24,16 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.0" }
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-history = { path = "../compass-history", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0" }
-compass-output = { path = "../compass-output", version = "0.3.0" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.0" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-history = { path = "../compass-history", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
+compass-output = { path = "../compass-output", version = "0.3.1" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.1" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.0" }
+compass-media = { path = "../compass-media", version = "0.3.1" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-program = { path = "../compass-program", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-program = { path = "../compass-program", version = "0.3.1" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,12 +19,12 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.0" }
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-prs = { path = "../compass-prs", version = "0.3.0" }
-compass-query = { path = "../compass-query", version = "0.3.0" }
+compass-core = { path = "../compass-core", version = "0.3.1" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-prs = { path = "../compass-prs", version = "0.3.1" }
+compass-query = { path = "../compass-query", version = "0.3.1" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,12 +20,12 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-history = { path = "../compass-history", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-query = { path = "../compass-query", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-history = { path = "../compass-history", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-query = { path = "../compass-query", version = "0.3.1" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
 protobuf.workspace = true
 scip.workspace = true
 serde.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-files = { path = "../compass-files", version = "0.3.0" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -18,12 +18,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -31,9 +31,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.0" }
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.0" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.1" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-program = { path = "../compass-program", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-program = { path = "../compass-program", version = "0.3.1" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.0" }
-compass-history = { path = "../compass-history", version = "0.3.0" }
-compass-ir = { path = "../compass-ir", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.1" }
+compass-history = { path = "../compass-history", version = "0.3.1" }
+compass-ir = { path = "../compass-ir", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.0" }
-compass-program = { path = "../compass-program", version = "0.3.0" }
+compass-languages = { path = "../compass-languages", version = "0.3.1" }
+compass-program = { path = "../compass-program", version = "0.3.1" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.0" }
-compass-media = { path = "../compass-media", version = "0.3.0" }
+compass-files = { path = "../compass-files", version = "0.3.1" }
+compass-media = { path = "../compass-media", version = "0.3.1" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.0" }
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-query = { path = "../compass-query", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.0" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.1" }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-query = { path = "../compass-query", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.0" }
+compass-store = { path = "../compass-store", version = "0.3.1" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.0" }
-compass-model = { path = "../compass-model", version = "0.3.0" }
-compass-store = { path = "../compass-store", version = "0.3.0", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.1" }
+compass-model = { path = "../compass-model", version = "0.3.1" }
+compass-store = { path = "../compass-store", version = "0.3.1", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.0", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.0", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.1", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.1", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -852,6 +852,7 @@ dependencies = [
  "compass-reflect",
  "compass-semantic",
  "compass-semantic-diff",
+ "compass-store",
  "ctrlc",
  "flate2",
  "glob",
@@ -873,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -888,6 +889,7 @@ dependencies = [
  "compass-program",
  "compass-reflect",
  "compass-resolve",
+ "compass-store",
  "notify",
  "num_cpus",
  "rayon",
@@ -900,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "regex",
@@ -912,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -949,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -961,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -974,12 +976,14 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-languages",
  "compass-model",
+ "compass-store",
  "rayon",
+ "rmp-serde",
  "serde",
  "serde_json",
  "sha1",
@@ -988,11 +992,12 @@ dependencies = [
  "thiserror 2.0.19",
  "unicode-casefold",
  "unicode-normalization",
+ "zstd",
 ]
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1004,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1024,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1042,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1052,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1081,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "compass-core",
@@ -1100,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1110,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1122,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1143,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1157,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "compass-ir",
@@ -1171,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1184,12 +1189,14 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
+ "compass-graph",
  "compass-ir",
  "compass-model",
+ "compass-store",
  "libc",
  "regex",
  "rusqlite",
@@ -1203,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1217,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1234,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1255,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1268,8 +1275,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compass-store"
+version = "0.3.1"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "compass-transcribe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.0", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.0", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.0", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.0", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.0", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.0", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.0", path = "../crates/compass-output" }
-compass-query = { version = "0.3.0", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.0", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.0", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.1", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.1", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.1", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.1", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.1", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.1", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.1", path = "../crates/compass-output" }
+compass-query = { version = "0.3.1", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.1", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.1", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1599,7 +1599,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.0"
+    "producerVersion": "compass-languages/0.3.1"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary
- bump the Compass workspace, internal crate constraints, VS Code extension, lockfiles, and qualification producer metadata to 0.3.1
- promote the accumulated post-0.3.0 changes into the 0.3.1 changelog

## Validation
- cargo fmt --all -- --check
- product boundary, release script, and code-graph qualification gates
- cargo test -p compass-cli --test compass_product --locked
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked
- optimized aarch64 macOS package, checksum, version, help, and license verification

This commit is the source for the Compass 0.3.1 release tag and the macOS/Linux/Windows artifact workflow.