### PR TITLE
Polish Compass docs and hover affordances

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -344,7 +344,7 @@
 
   .hero-code-graph .compass-hover-hint {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 0.45rem;
     margin: 0.15rem 0 0;
     padding-top: 0.6rem;
@@ -358,7 +358,6 @@
     flex: 0 0 auto;
     width: 1rem;
     height: 1rem;
-    margin-top: 0.08rem;
   }
 
   .hero-code-graph .compass-hover-hint span {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -529,3 +529,16 @@
   --fd-border: var(--border);
   --fd-primary: var(--primary);
 }
+
+#nd-sidebar .docs-sidebar-icon,
+#nd-sidebar-mobile .docs-sidebar-icon {
+  color: var(--fd-primary);
+  stroke-width: 1.8;
+}
+
+#nd-sidebar [data-state='open'] > button .docs-sidebar-icon,
+#nd-sidebar [data-state='open'] > a .docs-sidebar-icon,
+#nd-sidebar-mobile [data-state='open'] > button .docs-sidebar-icon,
+#nd-sidebar-mobile [data-state='open'] > a .docs-sidebar-icon {
+  color: var(--fd-primary);
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -342,6 +342,34 @@
     margin: 0;
   }
 
+  .hero-code-graph .compass-hover-hint {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.45rem;
+    margin: 0.15rem 0 0;
+    padding-top: 0.6rem;
+    border-top: 1px solid var(--border);
+    color: var(--primary);
+    line-height: 1.4;
+  }
+
+  .hero-code-graph .compass-hover-hint svg {
+    display: block;
+    flex: 0 0 auto;
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0.08rem;
+  }
+
+  .hero-code-graph .compass-hover-hint span {
+    min-width: 0;
+  }
+
+  .hero-code-graph .compass-hover-hint strong {
+    color: var(--foreground);
+    font-weight: 650;
+  }
+
   .hero-code-graph .compass-hover-source,
   .hero-code-graph .compass-node-hover-card code,
   .hero-code-graph .compass-edge-metadata code {

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -21,7 +21,7 @@ const sidebarIcon = (Icon: LucideIcon): ReactNode =>
   });
 
 const START_PAGES = ['README.md', 'getting-started.md', 'roadmap.md'] as const;
-const COMPASSQL_PAGES = ['COMPASSQL.md', 'COMPASSQL_SUPPORT.md', 'concepts/compassql.md'] as const;
+const COMPASSQL_PAGES = ['concepts/compassql.md', 'COMPASSQL.md', 'COMPASSQL_SUPPORT.md'] as const;
 
 const FOLDER_SECTIONS = [
   { path: 'concepts', name: 'Core concepts', icon: BookOpenIcon },
@@ -78,9 +78,10 @@ function removePages(
   return output;
 }
 
-function withPageIcon(page: Item, Icon: LucideIcon): Item {
+function withPageIcon(page: Item, Icon: LucideIcon, name?: string): Item {
   return {
     ...page,
+    name: name ?? page.name,
     icon: page.icon ?? sidebarIcon(Icon),
   };
 }
@@ -136,7 +137,9 @@ function organizeDocsTree(tree: Root): Root {
   });
   const compassqlPages = COMPASSQL_PAGES.flatMap((ref) => {
     const page = getPage(ref);
-    return page ? [withPageIcon(page, BracesIcon)] : [];
+    return page
+      ? [withPageIcon(page, BracesIcon, ref === 'COMPASSQL.md' ? 'Use CompassQL' : undefined)]
+      : [];
   });
 
   const children: Node[] = [

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -1,7 +1,172 @@
+import { createElement, type ReactNode } from 'react';
+import {
+  BookOpenIcon,
+  BracesIcon,
+  CompassIcon,
+  FileTextIcon,
+  FlaskConicalIcon,
+  Layers3Icon,
+  MapIcon,
+  WrenchIcon,
+  type LucideIcon,
+} from 'lucide-react';
+import type { Folder, Item, Node, Root } from 'fumadocs-core/page-tree';
 import { docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
+
+const sidebarIcon = (Icon: LucideIcon): ReactNode =>
+  createElement(Icon, {
+    'aria-hidden': true,
+    className: 'docs-sidebar-icon',
+  });
+
+const START_PAGES = ['README.md', 'getting-started.md', 'roadmap.md'] as const;
+const COMPASSQL_PAGES = ['COMPASSQL.md', 'COMPASSQL_SUPPORT.md', 'concepts/compassql.md'] as const;
+
+const FOLDER_SECTIONS = [
+  { path: 'concepts', name: 'Core concepts', icon: BookOpenIcon },
+  { path: 'guides', name: 'Task guides', icon: MapIcon },
+  { path: 'cookbook', name: 'Cookbook', icon: FlaskConicalIcon },
+  { path: 'reference', name: 'Reference', icon: FileTextIcon },
+  { path: 'design', name: 'Design & architecture', icon: Layers3Icon },
+  { path: 'implementation', name: 'Implementation', icon: WrenchIcon },
+] as const;
+
+function collectPages(nodes: Node[], pages = new Map<string, Item>()): Map<string, Item> {
+  for (const node of nodes) {
+    if (node.type === 'page' && node.$ref) pages.set(node.$ref, node);
+    if (node.type === 'folder') {
+      if (node.index?.$ref) pages.set(node.index.$ref, node.index);
+      collectPages(node.children, pages);
+    }
+  }
+  return pages;
+}
+
+function removePages(
+  nodes: Node[],
+  refs: Set<string>,
+  extracted: Map<string, Item>,
+): Node[] {
+  const output: Node[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'page') {
+      if (node.$ref && refs.has(node.$ref)) extracted.set(node.$ref, node);
+      else output.push(node);
+      continue;
+    }
+
+    if (node.type !== 'folder') {
+      output.push(node);
+      continue;
+    }
+
+    let index = node.index;
+    if (index?.$ref && refs.has(index.$ref)) {
+      extracted.set(index.$ref, index);
+      index = undefined;
+    }
+
+    output.push({
+      ...node,
+      index,
+      children: removePages(node.children, refs, extracted),
+    });
+  }
+
+  return output;
+}
+
+function withPageIcon(page: Item, Icon: LucideIcon): Item {
+  return {
+    ...page,
+    icon: page.icon ?? sidebarIcon(Icon),
+  };
+}
+
+function withFolderPresentation(
+  folder: Folder,
+  name: string,
+  Icon: LucideIcon,
+): Folder {
+  return {
+    ...folder,
+    name,
+    icon: folder.icon ?? sidebarIcon(Icon),
+    collapsible: folder.collapsible ?? true,
+  };
+}
+
+function virtualFolder(
+  id: string,
+  name: string,
+  Icon: LucideIcon,
+  children: Item[],
+): Folder {
+  return {
+    $id: `compass-docs-${id}`,
+    type: 'folder',
+    name,
+    icon: sidebarIcon(Icon),
+    defaultOpen: true,
+    collapsible: true,
+    children,
+  };
+}
+
+function organizeDocsTree(tree: Root): Root {
+  const pages = collectPages(tree.children);
+  const compassqlRefs = new Set<string>([...START_PAGES, ...COMPASSQL_PAGES]);
+  const extracted = new Map<string, Item>();
+  const withoutGroupedPages = removePages(tree.children, compassqlRefs, extracted);
+  const folders = new Map<string, Folder>();
+  const remaining = withoutGroupedPages.filter((node) => {
+    if (node.type !== 'folder' || !node.$ref?.folder) return true;
+    const section = FOLDER_SECTIONS.find((item) => item.path === node.$ref?.folder);
+    if (!section) return true;
+    folders.set(section.path, node);
+    return false;
+  });
+
+  const getPage = (ref: string): Item | undefined => extracted.get(ref) ?? pages.get(ref);
+  const startPages = START_PAGES.flatMap((ref) => {
+    const page = getPage(ref);
+    return page ? [withPageIcon(page, BookOpenIcon)] : [];
+  });
+  const compassqlPages = COMPASSQL_PAGES.flatMap((ref) => {
+    const page = getPage(ref);
+    return page ? [withPageIcon(page, BracesIcon)] : [];
+  });
+
+  const children: Node[] = [
+    virtualFolder('start', 'Start here', CompassIcon, startPages),
+    virtualFolder('compassql', 'CompassQL', BracesIcon, compassqlPages),
+  ];
+
+  for (const section of FOLDER_SECTIONS) {
+    const folder = folders.get(section.path);
+    if (folder) children.push(withFolderPresentation(folder, section.name, section.icon));
+  }
+
+  if (remaining.length > 0) {
+    children.push({
+      $id: 'compass-docs-more',
+      type: 'folder',
+      name: 'More documentation',
+      icon: sidebarIcon(FileTextIcon),
+      collapsible: true,
+      children: remaining,
+    });
+  }
+
+  return { ...tree, children };
+}
 
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
+  pageTree: {
+    transformers: [{ root: organizeDocsTree }],
+  },
 });

--- a/docs/COMPASSQL.md
+++ b/docs/COMPASSQL.md
@@ -1,4 +1,4 @@
-# CompassQL 1
+# CompassQL
 
 CompassQL is Compass's deterministic, read-only structural query language. It is a documented subset of openCypher that executes directly over an immutable Compass graph snapshot. It does not invoke a model, access a network, mutate the graph, or copy data into another database.
 
@@ -36,7 +36,7 @@ Use `n.id` for the portable stable Compass string ID. `id(n)` and `id(r)` return
 
 ## Supported language
 
-CompassQL 1 supports `MATCH`, multiple patterns and repeated-variable joins, `OPTIONAL MATCH`, `WHERE`, correlated one-level `EXISTS { MATCH ... }` and openCypher's `EXISTS { (...)-->() }` shorthand, `UNWIND`, `WITH`, `RETURN`, projection wildcards, `DISTINCT`, `UNION`, `UNION ALL`, `ORDER BY`, `SKIP`, and `LIMIT`.
+CompassQL supports `MATCH`, multiple patterns and repeated-variable joins, `OPTIONAL MATCH`, `WHERE`, correlated one-level `EXISTS { MATCH ... }` and openCypher's `EXISTS { (...)-->() }` shorthand, `UNWIND`, `WITH`, `RETURN`, projection wildcards, `DISTINCT`, `UNION`, `UNION ALL`, `ORDER BY`, `SKIP`, and `LIMIT`.
 
 Expressions include scalar/list/map literals, parameters, property and label access, boolean and comparison operators, three-valued null logic, `IN`, safe regex/string predicates, arithmetic, simple/searched `CASE`, and list indexing/slicing.
 

--- a/docs/COMPASSQL_SUPPORT.md
+++ b/docs/COMPASSQL_SUPPORT.md
@@ -1,4 +1,4 @@
-# CompassQL 1 support matrix
+# CompassQL support matrix
 
 This matrix is the public compatibility boundary. “Supported” means native parsing, semantic validation, deterministic execution, and checked evidence. CompassQL does not claim support for syntax absent from this table.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ The [cookbook index](cookbook/README.md) routes to:
 | [Outputs](reference/outputs.md) | `compass-out/`, graph JSON, query results, and history exports |
 | [Document formats](reference/document-formats.md) | Markdown fields, limits, and discovery versus extraction |
 | [Compatibility](reference/compatibility.md) | Compass contracts, hard cutovers, and portability |
-| [CompassQL 1](COMPASSQL.md) | Canonical language and runtime contract |
+| [CompassQL](COMPASSQL.md) | Canonical language and runtime contract |
 | [CompassQL support](COMPASSQL_SUPPORT.md) | Checked syntax and feature matrix |
 
 ## How these documents are written

--- a/docs/concepts/compassql.md
+++ b/docs/concepts/compassql.md
@@ -12,7 +12,7 @@ copying the graph into another database.
 > automation.
 >
 > **Prerequisites:** familiarity with [the graph model](graph-model.md). This is
-> a concept guide; use [CompassQL 1](../COMPASSQL.md) as the canonical syntax
+> a concept guide; use [CompassQL](../COMPASSQL.md) as the canonical syntax
 > and runtime reference.
 >
 > **Reading time:** 8–10 minutes.
@@ -254,7 +254,7 @@ Use a smaller limit when a caller has a tighter budget. Do not treat a limit
 error as an empty result.
 
 Query files and stdin are also size-limited, and parameter files have a
-separate cap. Consult [CompassQL 1](../COMPASSQL.md) for current numeric values.
+separate cap. Consult [CompassQL](../COMPASSQL.md) for current numeric values.
 
 ## Explain and profile
 
@@ -350,7 +350,7 @@ Do I know the exact nodes, relations, and columns?
 
 ## Related pages
 
-- [CompassQL 1 reference](../COMPASSQL.md)
+- [CompassQL reference](../COMPASSQL.md)
 - [CompassQL support matrix](../COMPASSQL_SUPPORT.md)
 - [Graph model](graph-model.md)
 - [Integrating Compass](../guides/integrating-compass.md)

--- a/docs/cookbook/architecture-discovery.md
+++ b/docs/cookbook/architecture-discovery.md
@@ -128,7 +128,7 @@ RETURN module.id, p, length(p)
 LIMIT 100
 ```
 
-Verify supported path semantics in [CompassQL 1](../COMPASSQL.md).
+Verify supported path semantics in [CompassQL](../COMPASSQL.md).
 
 ## Recipe 6: create a shareable subsystem brief
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -337,7 +337,7 @@ CompassQL; `--cql` is explicit.
 Before building automation, read:
 
 - [CompassQL concepts](concepts/compassql.md)
-- [CompassQL 1 reference](COMPASSQL.md)
+- [CompassQL reference](COMPASSQL.md)
 - [CompassQL support matrix](COMPASSQL_SUPPORT.md)
 
 ## 8. Install the coding-assistant integration

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -224,7 +224,7 @@ Limits:
 --max-memory-bytes N
 ```
 
-Canonical language contract: [CompassQL 1](../COMPASSQL.md).
+Canonical language contract: [CompassQL](../COMPASSQL.md).
 
 ### `path`
 
@@ -742,7 +742,7 @@ the exact command boundary your automation uses.
 
 - [Configuration reference](configuration.md)
 - [Output reference](outputs.md)
-- [CompassQL 1](../COMPASSQL.md)
+- [CompassQL](../COMPASSQL.md)
 - [Versioned history guide](../guides/versioned-history.md)
 
 **Next step:** run `compass <command> --help` for the command you will automate,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ Evidence:
 - [compatibility ledger](../COMPATIBILITY.md);
 - [performance qualification](../PERFORMANCE.md).
 
-### CompassQL 1
+### CompassQL
 
 Compass includes a native, deterministic, read-only subset of openCypher with:
 
@@ -68,7 +68,7 @@ Compass includes a native, deterministic, read-only subset of openCypher with:
 
 Evidence:
 
-- [CompassQL 1](COMPASSQL.md);
+- [CompassQL](COMPASSQL.md);
 - [CompassQL support matrix](COMPASSQL_SUPPORT.md);
 - `compass-cypher` and `compass-query`;
 - CLI/TCK/differential tests.

--- a/packages/compass-viewer/src/graph/EdgeHoverCard.test.tsx
+++ b/packages/compass-viewer/src/graph/EdgeHoverCard.test.tsx
@@ -60,6 +60,7 @@ describe("EdgeHoverCard", () => {
     expect(markup).toContain("crates/globset/src/glob.rs:143");
     expect(markup).toContain("Double-click");
     expect(markup).toContain("to open relationship source");
+    expect(markup).toContain("lucide-git-branch");
   });
 
   it("omits source affordances when an edge has no relationship anchor", () => {

--- a/packages/compass-viewer/src/graph/EdgeHoverCard.tsx
+++ b/packages/compass-viewer/src/graph/EdgeHoverCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, FileCode2Icon, GitBranchIcon } from "lucide-react";
+import { ArrowRightIcon, GitBranchIcon } from "lucide-react";
 import type { CSSProperties } from "react";
 import type { GraphEdge, GraphNode } from "../contracts/graph";
 import { formatGraphRelation, formatRelationshipSite } from "./edgeLabels";
@@ -90,7 +90,7 @@ export function EdgeHoverCard({
 
       {navigable && (
         <p className="compass-hover-hint">
-          <FileCode2Icon aria-hidden="true" />
+          <GitBranchIcon aria-hidden="true" />
           <span><strong>Double-click</strong> to open relationship source</span>
         </p>
       )}

--- a/packages/compass-viewer/src/graph/NodeHoverCard.test.tsx
+++ b/packages/compass-viewer/src/graph/NodeHoverCard.test.tsx
@@ -29,6 +29,7 @@ describe("NodeHoverCard", () => {
 
     expect(markup).toContain("Double-click");
     expect(markup).toContain("to open community subgraph");
+    expect(markup).toContain("lucide-network");
   });
 
   it("hints that a concrete node opens its source code", () => {
@@ -42,6 +43,7 @@ describe("NodeHoverCard", () => {
 
     expect(markup).toContain("Double-click");
     expect(markup).toContain("to open source code");
+    expect(markup).toContain("lucide-file-code-2");
   });
 
   it("does not show an action hint for non-navigable nodes", () => {


### PR DESCRIPTION
## Summary
- align hover-card action icons with their double-click instructions
- use contextual source, community, and relationship icons
- group CompassQL documentation into its own expandable sidebar section
- organize the remaining documentation sections with descriptive labels and Lucide icons
- remove the version suffix from user-facing CompassQL documentation titles and links while preserving existing URLs

## Verification
- npm run build:web (74 routes)
- npm run typecheck:web
- npm run test -w @compass/viewer -- --run
- desktop and mobile docs sidebar smoke checks