### PR TITLE
Improve Compass install and VS Code extension UX

### DIFF
--- a/apps/web/app/(marketing)/install/page.tsx
+++ b/apps/web/app/(marketing)/install/page.tsx
@@ -1,23 +1,128 @@
-import { AppleIcon, DownloadIcon, GithubIcon, LaptopIcon, TerminalIcon } from 'lucide-react';
+import {
+  ArrowRightIcon,
+  CheckCircle2Icon,
+  DownloadIcon,
+  GithubIcon,
+  MonitorDownIcon,
+  TerminalIcon,
+} from 'lucide-react';
 import Link from 'next/link';
 
-import { InstallCommand } from '@/components/install-command';
+import { InstallCommand, PlatformInstaller } from '@/components/install-command';
 import { MarketingPage, PageSection } from '@/components/marketing-page';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Install', 'Install Compass locally on macOS, Linux, or Windows, or build it from source with the pinned Rust toolchain.');
+export const metadata = pageMetadata('Install', 'Install the Compass CLI on macOS, Linux, or Windows, then add the Compass Codegraph extension to VS Code.');
+
+const vscodeInstallCommand = 'code --install-extension /path/to/crabbuild-compass-vscode-0.3.0.vsix';
 
 export default function InstallPage() {
-  return <MarketingPage eyebrow="Install Compass" title="Start with a local graph in minutes." description="Use the verified release installer on macOS, Linux, or Windows—or build Compass from source with the pinned Rust toolchain.">
-    <PageSection eyebrow="Choose your path" title="The first command should feel low-risk.">
-      <div className="grid gap-5 md:grid-cols-3"><InstallCard icon={AppleIcon} title="macOS" text="Apple Silicon or Intel" /><InstallCard icon={TerminalIcon} title="Linux" text="ARM64 or AMD64" /><InstallCard icon={LaptopIcon} title="Windows" text="x64 or ARM64" /></div>
-      <Card className="mt-6 max-w-3xl border-border/80 bg-card/70 shadow-none"><CardHeader><CardTitle className="font-heading text-xl tracking-[-0.04em]">macOS and Linux installer</CardTitle></CardHeader><CardContent><InstallCommand /></CardContent></Card>
-    </PageSection>
-    <section className="border-y border-border/70 bg-muted/25"><div className="mx-auto grid max-w-7xl gap-6 px-5 py-20 lg:grid-cols-2 lg:px-8 lg:py-28"><Card className="border-border/80 bg-card/70 shadow-none"><CardHeader className="gap-3"><DownloadIcon className="text-primary" /><CardTitle className="font-heading text-xl tracking-[-0.04em]">Offline release install</CardTitle></CardHeader><CardContent className="flex flex-col gap-4 text-sm leading-7 text-muted-foreground"><p>Download the matching archive and checksum from the latest release, verify it, and add Compass to your PATH.</p><Link className="inline-flex items-center gap-2 font-medium text-primary" href="https://github.com/crabbuild/compass/releases/latest" target="_blank" rel="noreferrer">View releases <GithubIcon data-icon="inline-end" /></Link></CardContent></Card><Card className="border-border/80 bg-card/70 shadow-none"><CardHeader className="gap-3"><TerminalIcon className="text-primary" /><CardTitle className="font-heading text-xl tracking-[-0.04em]">Build from source</CardTitle></CardHeader><CardContent className="flex flex-col gap-4 text-sm leading-7 text-muted-foreground"><code className="rounded-lg border border-border bg-background px-4 py-3 font-mono text-xs">cargo install --locked --path crates/compass-cli --bin compass</code><span>Use the pinned Rust 1.97.1+ toolchain documented by the repository.</span><Link className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'w-fit')} href="/docs/getting-started">Read getting started</Link></CardContent></Card></div></section>
-  </MarketingPage>;
+  return (
+    <MarketingPage
+      ctaHref="#cli-install"
+      ctaLabel="Choose your platform"
+      description="Install the local CLI first, then add Compass Codegraph to VS Code. Your source and graph stay on your machine."
+      eyebrow="Install Compass"
+      title="From terminal to code graph in two steps."
+    >
+      <div className="scroll-mt-20" id="cli-install">
+        <PageSection
+          description="Pick your operating system to get the right official command. The installer detects your CPU architecture and verifies the downloaded release."
+          eyebrow="Step 1 · Compass CLI"
+          title="Install the local engine."
+        >
+          <PlatformInstaller />
+        </PageSection>
+      </div>
+
+      <section className="scroll-mt-20 border-y border-border/70 bg-muted/25" id="vscode-extension">
+        <div className="mx-auto grid max-w-7xl gap-10 px-5 py-20 lg:grid-cols-[0.82fr_1.18fr] lg:items-center lg:gap-16 lg:px-8 lg:py-28">
+          <div>
+            <p className="eyebrow">Step 2 · VS Code</p>
+            <h2 className="mt-4 max-w-xl font-heading text-4xl font-semibold leading-[1.02] tracking-[-0.06em] sm:text-5xl">Bring the graph into your editor.</h2>
+            <p className="mt-6 max-w-xl text-base leading-8 text-muted-foreground">
+              Compass Codegraph connects to the CLI you just installed. Explore relationships, trace callers and callees, inspect change impact, and open exact source locations without leaving VS Code.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                className={cn(buttonVariants({ variant: 'default', size: 'lg' }), 'gap-2 px-4')}
+                href="https://github.com/crabbuild/compass/actions/workflows/compass-vscode-release.yml"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Get the VSIX on GitHub <GithubIcon data-icon="inline-end" />
+              </Link>
+              <Link className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'gap-2 px-4')} href="/docs/guides/vscode">
+                Read the setup guide <ArrowRightIcon data-icon="inline-end" />
+              </Link>
+            </div>
+          </div>
+
+          <Card className="border-border/80 bg-card/85 shadow-[0_28px_70px_-50px_color-mix(in_oklch,var(--foreground)_45%,transparent)]">
+            <CardHeader className="gap-3 border-b border-border/70 pb-5">
+              <span className="grid size-10 place-items-center rounded-lg bg-primary text-primary-foreground"><MonitorDownIcon className="size-5" /></span>
+              <CardTitle className="font-heading text-2xl tracking-[-0.045em]">Install the VS Code extension</CardTitle>
+              <CardDescription>Compass is currently distributed as a VSIX package and requires Compass CLI 0.3.0 or newer.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6 pt-2">
+              <ol className="space-y-5">
+                <VscodeStep number="1" title="Get the Compass VSIX" text="Download the latest crabbuild-compass-vscode package from a Compass VS Code release." />
+                <VscodeStep number="2" title="Install it in VS Code" text="Open Extensions, choose the … menu, select Install from VSIX…, then choose the downloaded file." />
+                <VscodeStep number="3" title="Open your first graph" text="Open a trusted repository, select Compass in the activity bar, and choose Initialize repository." />
+              </ol>
+              <div className="rounded-xl border border-border/70 bg-muted/45 p-4">
+                <p className="mb-3 text-sm font-medium">Already have the VSIX? Install it from a terminal:</p>
+                <InstallCommand ariaLabel="Copy VS Code extension install command" command={vscodeInstallCommand} prompt=">" />
+              </div>
+              <div className="flex items-start gap-2 text-sm leading-6 text-muted-foreground">
+                <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-primary" />
+                <p>The extension auto-detects Compass on PATH and in common user-local install locations.</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <PageSection eyebrow="Other install paths" title="Need a manual route?">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card className="border-border/80 bg-card/70 shadow-none">
+            <CardHeader className="gap-3">
+              <DownloadIcon className="text-primary" />
+              <CardTitle className="font-heading text-xl tracking-[-0.04em]">Offline release install</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4 text-sm leading-7 text-muted-foreground">
+              <p>Download the matching archive and checksum from the latest release, verify it, and add Compass to your PATH.</p>
+              <Link className="inline-flex items-center gap-2 font-medium text-primary" href="https://github.com/crabbuild/compass/releases/latest" target="_blank" rel="noreferrer">View releases <GithubIcon data-icon="inline-end" /></Link>
+            </CardContent>
+          </Card>
+          <Card className="border-border/80 bg-card/70 shadow-none">
+            <CardHeader className="gap-3">
+              <TerminalIcon className="text-primary" />
+              <CardTitle className="font-heading text-xl tracking-[-0.04em]">Build from source</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4 text-sm leading-7 text-muted-foreground">
+              <code className="overflow-x-auto rounded-lg border border-border bg-background px-4 py-3 font-mono text-xs whitespace-nowrap text-foreground">cargo install --locked --path crates/compass-cli --bin compass</code>
+              <span>Use the pinned Rust 1.97.1+ toolchain documented by the repository.</span>
+              <Link className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'w-fit')} href="/docs/getting-started">Read getting started</Link>
+            </CardContent>
+          </Card>
+        </div>
+      </PageSection>
+    </MarketingPage>
+  );
 }
 
-function InstallCard({ icon: Icon, title, text }: { icon: typeof AppleIcon; title: string; text: string }) { return <Card className="border-border/80 bg-card/70 shadow-none"><CardContent className="flex items-center gap-4 p-6"><Icon className="text-primary" /><div className="flex flex-col gap-1"><span className="font-heading text-lg font-semibold tracking-[-0.03em]">{title}</span><span className="text-sm text-muted-foreground">{text}</span></div></CardContent></Card>; }
+function VscodeStep({ number, title, text }: { number: string; title: string; text: string }) {
+  return (
+    <li className="grid grid-cols-[2rem_1fr] gap-3">
+      <span className="grid size-8 place-items-center rounded-full border border-primary/25 bg-primary/[0.07] font-mono text-xs font-semibold text-primary">{number}</span>
+      <div>
+        <p className="font-heading font-semibold tracking-[-0.025em]">{title}</p>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">{text}</p>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/(marketing)/integrations/vscode/page.tsx
+++ b/apps/web/app/(marketing)/integrations/vscode/page.tsx
@@ -28,7 +28,7 @@ export default function VscodePage() {
         <EditorStep icon={CheckCircle2Icon} title="Navigate" text="Double-click to open the source range." />
       </div>
     </PageSection>
-    <section className="border-t border-border/70 bg-primary text-primary-foreground"><div className="mx-auto flex max-w-7xl flex-col gap-6 px-5 py-16 lg:flex-row lg:items-center lg:justify-between lg:px-8"><div><p className="font-heading text-2xl font-semibold tracking-[-0.04em]">Start with the editor you already use.</p><p className="mt-2 text-sm text-primary-foreground/75">Install Compass locally, then open the extension from the workspace.</p></div><Link className={cn(buttonVariants({ variant: 'secondary' }), 'gap-2')} href="/install">Install Compass <ArrowRightIcon data-icon="inline-end" /></Link></div></section>
+    <section className="border-t border-border/70 bg-primary text-primary-foreground"><div className="mx-auto flex max-w-7xl flex-col gap-6 px-5 py-16 lg:flex-row lg:items-center lg:justify-between lg:px-8"><div><p className="font-heading text-2xl font-semibold tracking-[-0.04em]">Start with the editor you already use.</p><p className="mt-2 text-sm text-primary-foreground/75">Install Compass locally, then open the extension from the workspace.</p></div><Link className={cn(buttonVariants({ variant: 'secondary' }), 'gap-2')} href="/install#vscode-extension">Install Compass for VS Code <ArrowRightIcon data-icon="inline-end" /></Link></div></section>
   </MarketingPage>;
 }
 

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -66,8 +66,8 @@ export default function HomePage() {
     <>
       <section className="relative isolate overflow-hidden border-b border-border/70">
         <div className="site-grid pointer-events-none absolute inset-0 -z-10 opacity-70" aria-hidden="true" />
-        <div className="mx-auto grid max-w-7xl grid-cols-[minmax(0,1fr)] items-center gap-12 px-5 pb-20 pt-16 lg:grid-cols-[0.9fr_1.1fr] lg:gap-16 lg:px-8 lg:pb-28 lg:pt-24">
-          <div className="flex flex-col items-start">
+        <div className="mx-auto grid max-w-7xl grid-cols-[minmax(0,1fr)] items-center gap-12 px-5 pb-20 pt-16 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-16 lg:px-8 lg:pb-28 lg:pt-24">
+          <div className="flex min-w-0 w-full flex-col items-start">
             <Badge className="gap-2 rounded-full px-3 py-1 font-mono text-[0.68rem] uppercase tracking-[0.14em]" variant="outline">
               <span className="size-1.5 rounded-full bg-compass-amber" />
               Native code intelligence

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -4,10 +4,14 @@ import {
   BoxesIcon,
   BracesIcon,
   CheckCircle2Icon,
+  CpuIcon,
   FileDiffIcon,
+  GaugeIcon,
   GithubIcon,
+  HardDriveIcon,
   LockKeyholeIcon,
   NetworkIcon,
+  RouteIcon,
   SearchIcon,
   TerminalSquareIcon,
 } from 'lucide-react';
@@ -28,10 +32,10 @@ import {
 import { cn } from '@/lib/utils';
 
 const evidence = [
-  ['native Rust', 'one executable, linked parsers'],
-  ['local first', 'no model or database required'],
-  ['traceable', 'source ranges and provenance'],
-  ['bounded', 'explicit limits on graph work'],
+  { icon: CpuIcon, value: 'native Rust', label: 'one executable, linked parsers' },
+  { icon: HardDriveIcon, value: 'local first', label: 'no model or database required' },
+  { icon: RouteIcon, value: 'traceable', label: 'source ranges and provenance' },
+  { icon: GaugeIcon, value: 'bounded', label: 'explicit limits on graph work' },
 ];
 
 const featureCards = [
@@ -101,11 +105,26 @@ export default function HomePage() {
       </section>
 
       <section className="border-b border-border/70 bg-card/45">
-        <div className="mx-auto grid max-w-7xl divide-y divide-border/70 px-5 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4 lg:px-8">
-          {evidence.map(([value, label]) => (
-            <div className="flex flex-col gap-1 px-0 py-5 first:pt-6 sm:px-6 sm:py-6 lg:px-8 lg:first:pl-0" key={value}>
-              <span className="font-heading text-lg font-semibold tracking-[-0.03em]">{value}</span>
-              <span className="text-sm text-muted-foreground">{label}</span>
+        <div className="mx-auto grid max-w-7xl sm:grid-cols-2 lg:grid-cols-4">
+          {evidence.map(({ icon: Icon, value, label }, index) => (
+            <div
+              className={cn(
+                'flex min-h-28 items-center gap-4 px-5 py-5',
+                index > 0 && 'border-t border-border/70',
+                index === 1 && 'sm:border-t-0 sm:border-l',
+                index === 3 && 'sm:border-l',
+                'lg:border-t-0 lg:px-8',
+                index > 0 && 'lg:border-l',
+              )}
+              key={value}
+            >
+              <span className="grid size-10 shrink-0 place-items-center rounded-xl border border-primary/15 bg-primary/[0.07] text-primary">
+                <Icon aria-hidden="true" className="size-5" strokeWidth={1.8} />
+              </span>
+              <span className="flex min-w-0 flex-col gap-1">
+                <span className="font-heading text-lg font-semibold tracking-[-0.03em]">{value}</span>
+                <span className="text-sm leading-5 text-muted-foreground">{label}</span>
+              </span>
             </div>
           ))}
         </div>

--- a/apps/web/components/install-command.tsx
+++ b/apps/web/components/install-command.tsx
@@ -1,13 +1,142 @@
 'use client';
 
-import { CheckIcon, CopyIcon } from 'lucide-react';
+import {
+  AppleIcon,
+  CheckCircle2Icon,
+  CheckIcon,
+  CopyIcon,
+  LaptopIcon,
+  TerminalIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
-const command = 'curl -LsSf https://github.com/crabbuild/compass/releases/latest/download/install.sh | sh';
+const shellCommand = "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/crabbuild/compass/releases/latest/download/install.sh | sh";
+const windowsCommand = 'irm https://github.com/crabbuild/compass/releases/latest/download/install.ps1 | iex';
 
-export function InstallCommand() {
+const installers = [
+  {
+    id: 'macos',
+    name: 'macOS',
+    detail: 'Apple Silicon or Intel',
+    terminal: 'Terminal',
+    prompt: '$',
+    command: shellCommand,
+    icon: AppleIcon,
+  },
+  {
+    id: 'linux',
+    name: 'Linux',
+    detail: 'ARM64 or AMD64',
+    terminal: 'Terminal',
+    prompt: '$',
+    command: shellCommand,
+    icon: TerminalIcon,
+  },
+  {
+    id: 'windows',
+    name: 'Windows',
+    detail: 'x64 or ARM64',
+    terminal: 'PowerShell',
+    prompt: 'PS>',
+    command: windowsCommand,
+    icon: LaptopIcon,
+  },
+] as const;
+
+type PlatformId = (typeof installers)[number]['id'];
+
+export function PlatformInstaller() {
+  const [platform, setPlatform] = useState<PlatformId>('macos');
+  const selected = installers.find((installer) => installer.id === platform) ?? installers[0];
+
+  return (
+    <div>
+      <div aria-label="Choose your operating system" className="grid gap-3 md:grid-cols-3" role="group">
+        {installers.map((installer) => {
+          const Icon = installer.icon;
+          const isSelected = installer.id === platform;
+
+          return (
+            <button
+              aria-pressed={isSelected}
+              className={cn(
+                'group flex min-h-28 items-center gap-4 rounded-xl border bg-card/70 px-5 py-5 text-left shadow-none transition-[border-color,background-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40',
+                isSelected
+                  ? 'border-primary/55 bg-primary/[0.06] shadow-[0_12px_32px_-24px_color-mix(in_oklch,var(--primary)_70%,transparent)] ring-1 ring-primary/20'
+                  : 'border-border/80',
+              )}
+              key={installer.id}
+              onClick={() => setPlatform(installer.id)}
+              type="button"
+            >
+              <span className={cn('grid size-10 shrink-0 place-items-center rounded-lg bg-muted text-muted-foreground transition-colors', isSelected && 'bg-primary text-primary-foreground')}>
+                <Icon className="size-5" />
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-1">
+                <span className="font-heading text-lg font-semibold tracking-[-0.03em]">{installer.name}</span>
+                <span className="text-sm text-muted-foreground">{installer.detail}</span>
+              </span>
+              <span aria-hidden="true" className={cn('size-2 rounded-full border border-border bg-background', isSelected && 'border-primary bg-primary')} />
+            </button>
+          );
+        })}
+      </div>
+
+      <div aria-live="polite" className="mt-4 overflow-hidden rounded-xl border border-border/80 bg-card/70 shadow-sm">
+        <div className="flex flex-col gap-2 border-b border-border/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-heading text-lg font-semibold tracking-[-0.035em]">Install on {selected.name}</p>
+            <p className="mt-1 text-sm text-muted-foreground">Open {selected.terminal}, then paste and run this command.</p>
+          </div>
+          <span className="w-fit rounded-full border border-border bg-background px-2.5 py-1 font-mono text-[0.65rem] uppercase tracking-[0.12em] text-muted-foreground">
+            Official release installer
+          </span>
+        </div>
+        <div className="space-y-5 p-5">
+          <CopyableCommand
+            ariaLabel={`Copy ${selected.name} install command`}
+            command={selected.command}
+            key={selected.id}
+            prompt={selected.prompt}
+          />
+          <div className="grid gap-3 border-t border-border/70 pt-5 sm:grid-cols-2">
+            <InstallStep number="1" title="Run the installer" text="Compass verifies the release checksum and installs the matching binary." />
+            <InstallStep number="2" title="Confirm it works" text="Open a new terminal and run compass --version." />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function InstallCommand({
+  command = shellCommand,
+  prompt = '$',
+  ariaLabel = 'Copy install command',
+  className,
+}: {
+  command?: string;
+  prompt?: string;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  return <CopyableCommand ariaLabel={ariaLabel} className={className} command={command} prompt={prompt} />;
+}
+
+function CopyableCommand({
+  command,
+  prompt,
+  ariaLabel,
+  className,
+}: {
+  command: string;
+  prompt: string;
+  ariaLabel: string;
+  className?: string;
+}) {
   const [copied, setCopied] = useState(false);
 
   async function copyCommand() {
@@ -21,14 +150,29 @@ export function InstallCommand() {
   }
 
   return (
-    <div className="flex w-full max-w-xl items-center gap-2 rounded-xl border border-border/80 bg-card px-3 py-2 shadow-sm">
-      <code className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground sm:text-sm">
-        <span className="mr-2 text-compass-amber">$</span>
+    <div className={cn('flex w-full max-w-full items-center gap-2 rounded-xl border border-border/80 bg-background px-3 py-2 shadow-sm', className)}>
+      <code className="min-w-0 flex-1 overflow-x-auto py-1 font-mono text-xs whitespace-nowrap text-foreground sm:text-sm">
+        <span className="mr-2 select-none text-compass-amber">{prompt}</span>
         {command}
       </code>
-      <Button aria-label={copied ? 'Install command copied' : 'Copy install command'} size="icon-sm" variant="ghost" onClick={copyCommand}>
+      <Button aria-label={copied ? 'Command copied' : ariaLabel} className="shrink-0" size="icon-sm" variant="ghost" onClick={copyCommand}>
         {copied ? <CheckIcon className="text-primary" /> : <CopyIcon />}
       </Button>
+    </div>
+  );
+}
+
+function InstallStep({ number, title, text }: { number: string; title: string; text: string }) {
+  return (
+    <div className="flex gap-3">
+      <span className="grid size-7 shrink-0 place-items-center rounded-full bg-secondary font-mono text-xs font-semibold text-primary">{number}</span>
+      <div>
+        <p className="flex items-center gap-2 font-heading font-semibold tracking-[-0.02em]">
+          {title}
+          {number === '2' && <CheckCircle2Icon className="size-4 text-primary" />}
+        </p>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">{text}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- replace the static platform cards with an interactive macOS, Linux, and Windows installer chooser
- show the official Shell or PowerShell command with copy feedback, verification guidance, responsive overflow, and accessible selection states
- organize the page as a two-step CLI then VS Code flow
- add VSIX installation instructions, a terminal fallback, and compatibility guidance for Compass CLI 0.3.0+
- link the VS Code integration page directly to the new extension-install section
- constrain the home hero grid tracks so the terminal command cannot squeeze the interactive graph
- add semantic icons and responsive separators to the native/local/traceable/bounded evidence strip
- use story/stories consistently across the blog listing, counts, cards, metadata, and article navigation

## User impact

Visitors can select their operating system, copy the correct installer command, verify the CLI, and continue directly into VS Code setup without having to infer the next step. The extension CTA uses the current GitHub VSIX packaging workflow rather than implying a Marketplace listing. The home hero now preserves its intended copy/graph balance at desktop widths while keeping both surfaces full-width on mobile, and its core product properties are easier to scan. Blog readers now see consistent story-based terminology instead of field-note language.

## Validation

- `npm run typecheck:web`
- `npm run build:web`
- Playwright desktop and mobile rendering of `/install`
- Playwright interaction check for Windows command switching, `aria-pressed`, visible keyboard focus, and install-guide links
- Playwright home-page rendering at 1743px, 1280px, 768px, and 390px viewports
- computed hero layout verification: 518px copy / 634px graph at the reported wide viewport, with no page-level horizontal overflow
- computed evidence-strip separator verification for 1x4, 2x2, and stacked layouts
- Playwright verification of blog story labels, the singular `1 more story` count, and article navigation
- `git diff --check`