### PR TITLE
Fix Compass web deployment on Vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,13 @@
+# Qualification and vendored repositories are not part of the web deployment.
+3rd/
+
+# Local/build-only files.
+.git/
+.vercel/
+node_modules/
+target/
+dist/
+**/node_modules/
+**/.next/
+**/.source/
+**/dist/

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build:web",
+  "outputDirectory": "apps/web/.next"
+}


### PR DESCRIPTION
## Summary

- Configure Vercel to install from the npm workspace root and build only `@compass/web`.
- Set the Next.js output directory to `apps/web/.next`.
- Add a Vercel ignore file so vendored qualification repositories and local build artifacts are not uploaded.

## Root cause

Deploying from `apps/web` uploaded only the app subtree. npm therefore treated the private workspace package `@compass/viewer@0.1.0` as a public registry dependency and failed with `E404`.

## Validation

- `npm run build:web`
- Production Vercel deployment completed successfully.
- Smoke-tested `/`, `/docs`, `/product`, `/blog`, and `/use-cases` with HTTP 200 responses.

The unrelated untracked `3rd/` directory and `apps/web/.gitignore` were intentionally excluded from this change.
