### PR TITLE
Improve docs navigation

### DIFF
--- a/apps/web/lib/layout.shared.tsx
+++ b/apps/web/lib/layout.shared.tsx
@@ -1,9 +1,11 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 
+import { CompassLockup } from '@/components/compass-mark';
+
 export function baseOptions(): BaseLayoutProps {
   return {
     nav: {
-      title: 'Compass',
+      title: <CompassLockup />,
     },
     links: [
       {

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,16 +5,6 @@ project artifacts. It discovers the entities in a project, records how they
 relate, and gives people and tools a smaller, structured way to explore a large
 codebase.
 
-> **Who this page is for:** evaluators, Compass users, integrators, and
-> contributors.
->
-> **You will learn:** where to start, which documents answer which questions,
-> and which material describes current behavior versus future direction.
->
-> **Prerequisites:** none.
->
-> **Reading time:** about 5 minutes.
-
 Compass was inspired by
 [Graphify](https://github.com/Graphify-Labs/graphify), but the products now
 evolve independently. Compass has no Graphify runtime or test dependency. It includes
@@ -158,9 +148,9 @@ This separation is deliberate. A guide should not force you through an
 exhaustive option table, and a reference should not hide a precise contract
 inside a long tutorial.
 
-Substantial pages begin with their audience, outcomes, prerequisites, and
-estimated reading time. They end with related pages and a recommended next
-step. Small diagrams are ASCII so they remain useful in any terminal. Larger
+Substantial pages open directly with an overview and end with related pages and
+a recommended next step. Small diagrams are ASCII so they remain useful in any
+terminal. Larger
 architecture diagrams are checked-in SVG files with accessible titles and
 descriptions.
 

--- a/docs/concepts/compassql.md
+++ b/docs/concepts/compassql.md
@@ -4,19 +4,6 @@ CompassQL is Compass's deterministic, read-only structural query language. It
 uses a documented subset of openCypher to match exact graph patterns without
 copying the graph into another database.
 
-> **Who this page is for:** users deciding between discovery commands and
-> CompassQL, plus integrators preparing stable automated queries.
->
-> **You will learn:** when CompassQL is appropriate, how Compass data maps into
-> the language, how queries flow through the engine, and how limits protect
-> automation.
->
-> **Prerequisites:** familiarity with [the graph model](graph-model.md). This is
-> a concept guide; use [CompassQL](../COMPASSQL.md) as the canonical syntax
-> and runtime reference.
->
-> **Reading time:** 8–10 minutes.
-
 ## Discovery and structural matching solve different problems
 
 Use natural-language discovery when you do not yet know the exact graph shape:

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -4,18 +4,6 @@ Compass stores project knowledge as entities connected by directed,
 attributed relationships. This page develops the model from a small example to
 the node-link JSON and multigraph details used by advanced queries.
 
-> **Who this page is for:** anyone interpreting Compass output or writing
-> CompassQL and graph integrations.
->
-> **You will learn:** nodes, stable IDs, labels, directed relationships,
-> attributes, parallel edges, hyperedges, communities, snapshots, and common
-> interpretation mistakes.
->
-> **Prerequisites:** [How Compass works](how-it-works.md) is helpful but not
-> required.
->
-> **Reading time:** 10–12 minutes.
-
 ## Start with two nouns and a verb
 
 The smallest useful graph statement is:

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -5,18 +5,6 @@ queryable knowledge graph. This page explains the complete flow first in plain
 language, then at the level needed to reason about correctness, performance,
 and extension points.
 
-> **Who this page is for:** evaluators, users who want to interpret results,
-> and contributors building a mental model of the system.
->
-> **You will learn:** what happens during discovery, extraction, resolution,
-> graph analysis, publication, and querying; which stages are deterministic;
-> and where optional semantic providers enter.
->
-> **Prerequisites:** none. Familiarity with functions, files, and imports is
-> helpful; graph-database experience is not required.
->
-> **Reading time:** 12–15 minutes.
-
 ![The Compass graph construction and query pipeline](../assets/diagrams/graph-pipeline.svg)
 
 ## The short version

--- a/docs/concepts/provenance.md
+++ b/docs/concepts/provenance.md
@@ -4,17 +4,6 @@ Compass keeps evidence quality visible. A graph is more useful when you can
 distinguish a relation copied from direct syntax from one resolved across files
 or left ambiguous.
 
-> **Who this page is for:** users reviewing graph results, integrators ranking
-> evidence, and contributors adding relations or resolvers.
->
-> **You will learn:** what `EXTRACTED`, `INFERRED`, and `AMBIGUOUS` mean; how
-> they are created; and how to use them without turning provenance into a false
-> probability.
->
-> **Prerequisites:** basic familiarity with [the graph model](graph-model.md).
->
-> **Reading time:** 7–9 minutes.
-
 ![How Compass classifies relationship provenance](../assets/diagrams/provenance.svg)
 
 ## Provenance answers “how do we know?”

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -4,15 +4,6 @@ The cookbook contains short, outcome-focused recipes. Use it when you already
 know the problem and want commands, interpretation guidance, and caveats in one
 place.
 
-> **Who this page is for:** everyday Compass users and integrators.
->
-> **You will learn:** which recipe fits your task and how cookbook pages differ
-> from full guides and references.
->
-> **Prerequisites:** [Getting started](../getting-started.md).
->
-> **Reading time:** 3 minutes.
-
 ## Pick a problem
 
 | I need to… | Recipe |

--- a/docs/cookbook/architecture-discovery.md
+++ b/docs/cookbook/architecture-discovery.md
@@ -3,16 +3,6 @@
 These recipes help map a subsystem, request flow, data flow, or boundary in an
 unfamiliar repository.
 
-> **Who this page is for:** developers onboarding, debugging across modules, or
-> preparing architecture reviews.
->
-> **You will learn:** community-first, entry-to-side-effect, hub, boundary, and
-> exact-pattern recipes.
->
-> **Prerequisites:** a fresh `compass-out/`.
->
-> **Completion time:** 10–30 minutes.
-
 ## Recipe 1: map one subsystem
 
 ### Problem

--- a/docs/cookbook/ci-and-automation.md
+++ b/docs/cookbook/ci-and-automation.md
@@ -3,16 +3,6 @@
 Use these patterns to generate, query, and publish Compass artifacts in CI
 without depending on human text or hiding failures.
 
-> **Who this page is for:** CI/platform engineers and maintainers adding graph
-> checks to pull requests or scheduled jobs.
->
-> **You will learn:** deterministic build jobs, exact query policies, artifact
-> retention, cache keys, and historical comparison.
->
-> **Prerequisites:** Compass installed in the runner and repository checkout.
->
-> **Completion time:** 15–30 minutes.
-
 ## Recipe 1: build and upload a structural graph
 
 ```bash

--- a/docs/cookbook/impact-analysis.md
+++ b/docs/cookbook/impact-analysis.md
@@ -2,15 +2,6 @@
 
 Use these recipes to estimate what may depend on a symbol, file, or change.
 
-> **Who this page is for:** implementers and reviewers preparing a change.
->
-> **You will learn:** reverse-impact traversal, direct-caller queries,
-> historical topology diffs, and how to turn results into a review checklist.
->
-> **Prerequisites:** a current graph or versioned history.
->
-> **Completion time:** 5–15 minutes.
-
 ## Recipe 1: impact from one symbol
 
 ### Problem

--- a/docs/cookbook/troubleshooting.md
+++ b/docs/cookbook/troubleshooting.md
@@ -3,16 +3,6 @@
 This page is a symptom-to-diagnosis map. Start with the narrowest category and
 preserve the original diagnostic before deleting or rebuilding anything.
 
-> **Who this page is for:** all Compass users and operators.
->
-> **You will learn:** how to diagnose installation, build, graph, query,
-> semantic, service, assistant, and history problems safely.
->
-> **Prerequisites:** access to the failing command, stderr, and working
-> directory.
->
-> **Completion time:** 5–20 minutes for common failures.
-
 ## First five checks
 
 ```bash

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -3,16 +3,6 @@
 Compass is a Rust workspace organized around a deterministic graph pipeline,
 bounded query engines, optional integrations, and immutable history.
 
-> **Who this page is for:** contributors and technical evaluators.
->
-> **You will learn:** architectural layers, dependency direction, primary data
-> flows, public boundaries, and where to look when behavior changes.
->
-> **Prerequisites:** [Design principles](principles.md) and
-> [How Compass works](../concepts/how-it-works.md).
->
-> **Reading time:** 15 minutes.
-
 ![Compass workspace architecture](../assets/diagrams/workspace-architecture.svg)
 
 ## Layered view

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -25,21 +25,6 @@ by patch releases, while physical adapter files and disposable indexes remain
 rebuildable. The exact operator procedures and file-level backup bundle are in
 the [Compass Store operations guide](../guides/compass-store-operations.md).
 
-> **Who this page is for:** maintainers of graph publication and queries,
-> storage-adapter authors, cloud-service implementers, and reviewers of the
-> `compass-store` contract.
->
-> **You will learn:** the portable namespace/partition/key contract, the
-> store-independent graph layout, how `graph.json` remains supported, the
-> atomic publication and recovery rules, and how SQLite, redb, PostgreSQL, and
-> DynamoDB map onto the same semantics.
->
-> **Prerequisites:** [Design principles](principles.md),
-> [Storage and history](storage-and-history.md), and
-> [Query engine](../implementation/query-engine.md).
->
-> **Reading time:** 25–35 minutes.
-
 ## Decision summary
 
 Compass will introduce a backend-neutral crate named `compass-store`. Its

--- a/docs/design/document-processing.md
+++ b/docs/design/document-processing.md
@@ -24,15 +24,6 @@ extracted strings. The current structural implementation is Markdown-first:
 the same bounded bytes read by the build pipeline are parsed into a document
 root, structural blocks, and provenance-preserving relationships.
 
-> **Who this page is for:** contributors and integrators who need to understand
-> document graph facts.
->
-> **You will learn:** what Markdown emits, how links resolve, and which limits
-> keep extraction local and bounded.
->
-> **Prerequisites:** [Language architecture](language-architecture.md) and
-> [Graph model](../concepts/graph-model.md).
-
 ## Ownership and data flow
 
 ```text

--- a/docs/design/java-jdt-integration.md
+++ b/docs/design/java-jdt-integration.md
@@ -4,24 +4,6 @@ This document defines how Compass can add compiler-grade Java evidence through
 Eclipse JDT while preserving the native Tree-sitter code graph as the default
 and fallback.
 
-> **Status:** Planned. Compass does not currently download, install, or invoke
-> JDT Core or JDT LS. The current pipeline can consume verified offline SCIP
-> artifacts and project exact Java call identities onto AST-proven call sites.
->
-> **Who this page is for:** contributors implementing Java semantic analysis,
-> managed tools, Program providers, graph resolution, history, or CLI support.
->
-> **You will learn:** the selected integration architecture, user experience,
-> trust boundaries, machine contracts, crate ownership, implementation phases,
-> and acceptance criteria.
->
-> **Prerequisites:** [Managed language analyzers](managed-language-analyzers.md),
-> [Language architecture](language-architecture.md),
-> [Security and privacy](security-and-privacy.md), and
-> [Universal semantic evidence](../reference/universal-semantic-evidence.md).
->
-> **Reading time:** 20–25 minutes.
-
 ## Decision summary
 
 Compass will not embed a JVM or the full JDT language server into the Rust

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -22,14 +22,6 @@ meta:
 
 Compass separates parsing from semantic interpretation and graph publication. The vendored language pack supplies pinned parsers, language adapters interpret syntax, and the universal evidence framework gives independently qualified languages one resolution and publication path.
 
-> **Who this page is for:** contributors and technical evaluators working on language extraction.
->
-> **You will learn:** which layer owns grammars, semantic facts, cross-file resolution, graph publication, and framework targeting.
->
-> **Prerequisites:** [System architecture](architecture.md) and [Graph model](../concepts/graph-model.md).
->
-> **Reading time:** 10 minutes.
-
 ## Current and planned status
 
 This architecture is transitioning one language at a time. The status labels below prevent planned contracts from being mistaken for shipped behavior.

--- a/docs/design/managed-language-analyzers.md
+++ b/docs/design/managed-language-analyzers.md
@@ -4,27 +4,6 @@ This document defines a shared architecture for improving Compass code-graph
 quality with optional compiler, indexer, and language-server evidence across
 Python, Rust, Go, TypeScript, JavaScript, and Java.
 
-> **Status:** Planned. Compass does not currently install or invoke managed
-> language analyzers. It can consume verified offline SCIP artifacts, and Java
-> can project fresh exact SCIP identities onto AST-proven call sites. All
-> languages continue to work through their native structural paths without the
-> integrations described here.
->
-> **Who this page is for:** contributors implementing managed tools, Program
-> providers, language adapters, project discovery, semantic resolution,
-> history, qualification, or CLI support.
->
-> **You will learn:** the shared analyzer architecture, language-specific
-> semantic policies, tool and runtime boundaries, phased implementation
-> direction, and acceptance criteria.
->
-> **Prerequisites:** [Language architecture](language-architecture.md),
-> [Managed JDT integration](java-jdt-integration.md),
-> [Security and privacy](security-and-privacy.md), and
-> [Universal semantic evidence](../reference/universal-semantic-evidence.md).
->
-> **Reading time:** 25–30 minutes.
-
 ## Decision summary
 
 Compass will add one managed-analyzer framework with language-owned semantic

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -4,16 +4,6 @@ Compass is designed as a native, inspectable knowledge graph engine rather than
 a hidden retrieval service. These principles explain the trade-offs behind its
 public behavior and provide a test for future changes.
 
-> **Who this page is for:** contributors, maintainers, evaluators comparing
-> architectural approaches, and integrators relying on Compass contracts.
->
-> **You will learn:** the principles governing local execution, determinism,
-> evidence, bounds, publication, compatibility, and independent evolution.
->
-> **Prerequisites:** [How Compass works](../concepts/how-it-works.md).
->
-> **Reading time:** 10–12 minutes.
-
 ## 1. Local-first structural knowledge
 
 Source-code extraction and graph querying should work without:

--- a/docs/design/security-and-privacy.md
+++ b/docs/design/security-and-privacy.md
@@ -5,17 +5,6 @@ systems. Its security model begins by separating fully local structural work
 from explicit network, credential, subprocess, and historical-checkout
 boundaries.
 
-> **Who this page is for:** security reviewers, operators, integrators, and
-> contributors changing an input or network boundary.
->
-> **You will learn:** what stays local, when data can leave the machine, how
-> untrusted input is bounded, and which operational practices remain the
-> deployer's responsibility.
->
-> **Prerequisites:** [Design principles](principles.md).
->
-> **Reading time:** 12–15 minutes.
-
 > This page explains architecture. The authoritative vulnerability-reporting
 > and supported-version policy is [SECURITY.md](../../SECURITY.md).
 

--- a/docs/design/storage-and-history.md
+++ b/docs/design/storage-and-history.md
@@ -4,17 +4,6 @@ Compass has two storage models: a mutable current-tree artifact directory and
 an immutable exact-revision history store. They solve different problems and
 have different recovery rules.
 
-> **Who this page is for:** history contributors, maintainers operating large
-> repositories, and integrators requiring reproducible graphs.
->
-> **You will learn:** current artifact publication, incremental caches,
-> historical fingerprints, Prolly trees, SQLite durability, jobs/leases,
-> validation, export, and garbage collection.
->
-> **Prerequisites:** [Versioned graph history](../guides/versioned-history.md).
->
-> **Reading time:** 12–15 minutes.
-
 ## Two storage planes
 
 ```text

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,16 +4,6 @@ This guide takes you from a new installation to a useful answer about a
 codebase. It starts with structural code analysis, which runs locally and does
 not require model credentials.
 
-> **Who this guide is for:** new users and evaluators.
->
-> **You will learn:** how to install Compass, build a graph, understand its
-> output, ask four kinds of questions, and recognize a successful run.
->
-> **Prerequisites:** a macOS release target or a Rust 1.97.1+ toolchain for a
-> source build; a source-code repository to inspect.
->
-> **Completion time:** 10–15 minutes, plus compilation time for a source build.
-
 ![From a project directory to the first Compass answer](assets/diagrams/first-graph.svg)
 
 ## What you will produce

--- a/docs/guides/assistant-setup.md
+++ b/docs/guides/assistant-setup.md
@@ -4,16 +4,6 @@ Compass embeds assistant integration assets in its native executable. This
 guide explains automatic detection, explicit multi-agent selection, scope,
 verification, and safe removal.
 
-> **Who this guide is for:** developers using Compass with coding assistants
-> and maintainers deciding what agent instructions belong in a repository.
->
-> **You will learn:** user versus project scope, automatic and explicit platform
-> selection, strict mode, verification, upgrades, and safe uninstall.
->
-> **Prerequisites:** the `compass` executable installed.
->
-> **Completion time:** about 2 minutes, plus the first graph build.
-
 ## What the integration does
 
 When a graph exists, the installed skill teaches an assistant to use it before

--- a/docs/guides/exploring-a-codebase.md
+++ b/docs/guides/exploring-a-codebase.md
@@ -3,16 +3,6 @@
 This guide gives you a repeatable way to turn a large repository into a small
 set of architectural hypotheses, implementation paths, and review targets.
 
-> **Who this guide is for:** developers onboarding to a repository, reviewers,
-> maintainers, and coding-assistant users.
->
-> **You will learn:** how to move from a repository-wide report to communities,
-> symbols, paths, impact, source verification, and a concise architecture note.
->
-> **Prerequisites:** Compass installed and a successful `compass update .`.
->
-> **Completion time:** 20–45 minutes for an initial survey.
-
 ## The investigation loop
 
 Do not try to understand the whole graph at once. Use a narrowing loop:

--- a/docs/guides/integrating-compass.md
+++ b/docs/guides/integrating-compass.md
@@ -4,19 +4,6 @@ Compass can be used interactively, as a producer of versioned JSON, through an
 MCP service, or as an exporter to graph systems. This guide focuses on stable
 boundaries and failure-safe consumption.
 
-> **Who this guide is for:** developers building scripts, CI jobs, editor
-> features, internal portals, and graph-analysis integrations.
->
-> **You will learn:** how to choose an integration surface, consume outputs
-> safely, use CompassQL parameters and versioned results, and avoid coupling to
-> unstable human text.
->
-> **Prerequisites:** a working graph and familiarity with
-> [CompassQL concepts](../concepts/compassql.md).
->
-> **Completion time:** 20 minutes for the pattern; implementation time depends
-> on the consumer.
-
 ![Compass integration surfaces](../assets/diagrams/integration-surfaces.svg)
 
 ## Choose the narrowest stable surface

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -4,17 +4,6 @@ This guide covers the long-running and optional operational surfaces around the
 core build/query loop: watch mode, MCP serving, hooks, providers, global
 registries, ingestion, PR workflows, and exports.
 
-> **Who this guide is for:** maintainers, platform engineers, editor/assistant
-> integrators, and developers running Compass beyond one-shot local commands.
->
-> **You will learn:** lifecycle, safety boundaries, observability, and recovery
-> patterns for operational commands.
->
-> **Prerequisites:** [Getting started](../getting-started.md) and a working
-> `compass update .`.
->
-> **Reading time:** 15–20 minutes.
-
 ## Operational principle: start one-shot, then automate
 
 Before enabling a watcher, hook, service, or provider-backed workflow:

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -3,18 +3,6 @@
 Compass history stores complete, immutable graph realizations for exact Git
 commits in a SQLite-backed Prolly store outside normal Git history.
 
-> **Who this guide is for:** maintainers comparing revisions, auditors,
-> integrators needing reproducible snapshots, and contributors operating the
-> history subsystem.
->
-> **You will learn:** profiles, builds, lazy materialization, queries, diffs,
-> exports, preferred realizations, maintenance, failure recovery, and safety
-> boundaries.
->
-> **Prerequisites:** a Git repository and a working `compass` binary.
->
-> **Completion time:** 15–30 minutes plus extraction time.
-
 ![How Compass materializes and stores an exact Git revision](../assets/diagrams/history-materialization.svg)
 
 ## Mental model

--- a/docs/implementation/code-graph-parity-qualification.md
+++ b/docs/implementation/code-graph-parity-qualification.md
@@ -4,12 +4,6 @@ This report records the 2026-08-01 Compass-versus-Graphify qualification for
 Python, Rust, Go, Java, TypeScript, and JavaScript. It is an implementation
 checkpoint, not a claim that Graphify defines the upper bound for Compass.
 
-> **Who this page is for:** contributors improving structural extraction and
-> cross-file resolution.
->
-> **You will learn:** which repositories were pinned, how parity was measured,
-> which improvements are now protected, and which gaps remain open.
-
 ## Pinned repository matrix
 
 | Language | Repository | Revision | Source size |

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -6,22 +6,6 @@ publishes optional SQLite plus permanent `graph.json`; redb is a library-only
 adapter. PostgreSQL, DynamoDB, hosted operation, distributed leases/GC, and
 service quotas remain explicitly deferred until their phases are complete.
 
-> **Who this page is for:** implementers and reviewers delivering
-> `compass-store`, store-backed graph snapshots, backend adapters, and the
-> future cloud storage boundary.
->
-> **You will learn:** the mergeable phases, exact ownership boundaries,
-> deliverables, verification, failure tests, compatibility decisions, and
-> acceptance criteria for each phase.
->
-> **Prerequisites:** read the complete
-> [Compass store and graph-engine design](../design/compass-store.md),
-> [Workspace tour](workspace-tour.md),
-> [Extending Compass](extending-compass.md), and
-> [Compatibility policy](../../COMPATIBILITY.md).
->
-> **Reading time:** 30–40 minutes.
-
 ## Outcome
 
 At completion, Compass has:

--- a/docs/implementation/extending-compass.md
+++ b/docs/implementation/extending-compass.md
@@ -3,17 +3,6 @@
 This guide turns common extension goals into concrete crate, contract, and
 verification checklists.
 
-> **Who this guide is for:** contributors adding a language, relation,
-> integration, query capability, output, command, or provider.
->
-> **You will learn:** where an extension belongs, which public contracts it can
-> affect, and what evidence is required before it is complete.
->
-> **Prerequisites:** [Workspace tour](workspace-tour.md) and
-> [Contributing](../../CONTRIBUTING.md).
->
-> **Reading time:** 15 minutes.
-
 ## Before editing
 
 1. Read the relevant crate `src/lib.rs`.

--- a/docs/implementation/extraction-pipeline.md
+++ b/docs/implementation/extraction-pipeline.md
@@ -4,16 +4,6 @@ The extraction pipeline turns a filesystem snapshot into a coherent graph
 artifact set. This page follows the cold path, incremental path, and failure
 boundaries through the owning crates.
 
-> **Who this page is for:** contributors changing discovery, languages,
-> resolution, graph construction, or output publication.
->
-> **You will learn:** pipeline stages, core types, incremental invalidation,
-> concurrency, semantic merge, and the tests required for safe changes.
->
-> **Prerequisites:** [Workspace tour](workspace-tour.md).
->
-> **Reading time:** 15–20 minutes.
-
 ![Cold and incremental Compass update paths](../assets/diagrams/incremental-update.svg)
 
 ## Entry points

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -3,17 +3,6 @@
 Compass has two complementary query paths: focused discovery/traversal and the
 CompassQL compiler/executor. Both operate over the same indexed graph model.
 
-> **Who this page is for:** contributors changing query ranking, traversal,
-> CompassQL syntax/plans/execution, or machine output.
->
-> **You will learn:** loading, indexes, discovery scoring, traversal, affected,
-> CompassQL compilation and execution, caching, limits, profiling, and tests.
->
-> **Prerequisites:** [Graph model](../concepts/graph-model.md) and
-> [Workspace tour](workspace-tour.md).
->
-> **Reading time:** 15 minutes.
-
 ## Graph-engine boundary and query model
 
 `compass-query` exposes an immutable `GraphEngine` boundary with two supported

--- a/docs/implementation/semantic-pipeline.md
+++ b/docs/implementation/semantic-pipeline.md
@@ -4,18 +4,6 @@ The semantic pipeline turns untrusted non-code content and provider responses
 into validated graph facts. It is optional and explicitly separate from the
 fully local structural code path.
 
-> **Who this page is for:** contributors adding providers, media formats,
-> semantic relations, validation, or completeness behavior.
->
-> **You will learn:** source classification, extraction/chunking, backend
-> selection, request safety, response validation, evidence binding, partial
-> results, caching, and test requirements.
->
-> **Prerequisites:** [Extraction pipeline](extraction-pipeline.md) and
-> [Security and privacy](../design/security-and-privacy.md).
->
-> **Reading time:** 12–15 minutes.
-
 ## Boundary
 
 ```text

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -22,14 +22,6 @@ meta:
 
 Universal evidence is the semantic boundary between source-specific extraction and language-neutral graph construction. This reference defines the owning crates, required data, lifecycle, failure behavior, and transition gates.
 
-> **Who this page is for:** contributors implementing language adapters, resolution, projection, and framework integration.
->
-> **You will learn:** what each crate owns, which facts cross boundaries, and which invariants a language transition must preserve.
->
-> **Prerequisites:** [Language architecture](../design/language-architecture.md) and [Extraction pipeline](extraction-pipeline.md).
->
-> **Reading time:** 12 minutes.
-
 ## Implementation status
 
 The contracts on this page distinguish implemented hard cuts from approved

--- a/docs/implementation/workspace-tour.md
+++ b/docs/implementation/workspace-tour.md
@@ -4,15 +4,6 @@ This tour maps each crate to its responsibility, main public interfaces, and
 verification evidence. Use it to decide where a change belongs before opening
 large source files.
 
-> **Who this page is for:** new and returning Compass contributors.
->
-> **You will learn:** crate ownership, dependency direction, key modules, and
-> the tests that protect each boundary.
->
-> **Prerequisites:** [System architecture](../design/architecture.md).
->
-> **Reading time:** 15–20 minutes.
-
 ## Start at the workspace manifest
 
 `Cargo.toml` defines one Edition 2024 workspace, Rust 1.97, shared dependency

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5,16 +5,6 @@ Run `compass <command> --help` for the exact options in the installed version;
 this page explains how the families fit together and which outputs are stable
 for automation.
 
-> **Who this reference is for:** users and integrators looking up a command
-> without reading a tutorial.
->
-> **You will learn:** public command families, primary inputs/outputs, shared
-> conventions, and where exact subcommand contracts live.
->
-> **Prerequisites:** Compass installed.
->
-> **Reading time:** 12–15 minutes as a survey; use the tables for lookup.
-
 ## Global entry points
 
 ```bash

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -4,9 +4,6 @@ Compass is an independent native product. Its public behavior is defined by
 Compass documentation, native tests, and versioned Compass formats. It has no
 Graphify runtime or test dependency.
 
-> **Who this reference is for:** users, integrators, and contributors planning
-> upgrades or relying on a Compass interface.
-
 ## Product contract
 
 The supported identity is:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,16 +4,6 @@ Compass configuration comes from explicit command options, environment
 variables, provider registries, repository history configuration, and generated
 integration files. This page explains ownership and safe use.
 
-> **Who this reference is for:** users, operators, and integrators configuring
-> outputs, providers, history, databases, or assistant integrations.
->
-> **You will learn:** configuration sources, practical precedence, key
-> environment families, secret handling, and reproducibility rules.
->
-> **Prerequisites:** none.
->
-> **Reading time:** 10–12 minutes.
-
 ## Precedence rule
 
 For a specific command, use:

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -4,16 +4,6 @@ Compass outputs range from the current `compass-out/` directory to versioned
 CompassQL results and immutable history exports. This reference describes
 consumer responsibilities and authority.
 
-> **Who this reference is for:** integrators, operators, and contributors
-> changing an output or renderer.
->
-> **You will learn:** core artifacts, graph JSON, query schemas, derived views,
-> history export, caches, atomicity, and deterministic equivalence.
->
-> **Prerequisites:** [Graph model](../concepts/graph-model.md).
->
-> **Reading time:** 10–12 minutes.
-
 ## Current output directory
 
 Default:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,17 +4,6 @@ Compass is inspired by Graphify, implemented natively in Rust, and expected to
 evolve independently. This roadmap separates shipped/current behavior from
 committed design work and longer-term ideas.
 
-> **Who this page is for:** users evaluating project direction, integrators
-> planning adoption, and contributors choosing work.
->
-> **You will learn:** what exists in the current repository, what has a
-> committed design or implementation plan, and which ideas are explicitly
-> aspirational.
->
-> **Prerequisites:** none.
->
-> **Reading time:** 8–10 minutes.
-
 ## How to read status
 
 - **Available now** means the behavior exists in the current repository and is


### PR DESCRIPTION
## Summary

- add the Compass logo lockup to the documentation navigation
- remove audience, learning-goal, prerequisite, and reading-time callouts from all 38 public documentation pages
- update the documentation style guidance so substantial pages open directly with their overview

## Why

The introductory metadata blocks add visual weight before the useful content on every documentation page. Removing them makes pages faster to scan, while the logo gives the docs navigation a clearer connection to the Compass product.

## Impact

Documentation content now begins immediately after each page overview. This is a presentation and documentation-only change; it does not change CLI, schema, storage, or integration contracts.

## Validation

- `npm run typecheck:web`
- `npm run build:web`
- verified all 74 production pages generated successfully
- verified removed metadata labels are absent from rendered docs HTML
- `git diff --check`
