### PR TITLE
Focus public docs on user workflows

### DIFF
--- a/apps/web/app/(marketing)/docs/page.tsx
+++ b/apps/web/app/(marketing)/docs/page.tsx
@@ -1,20 +1,20 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import { ArrowRightIcon, BookOpenIcon, BoxesIcon, Code2Icon, ShieldCheckIcon } from 'lucide-react';
+import { ArrowRightIcon, BookOpenIcon, BoxesIcon, Code2Icon, FileTextIcon } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const paths = [
-  { icon: BookOpenIcon, eyebrow: 'Evaluate', title: 'Understand the product', description: 'Start with the getting started guide, the pipeline, graph model, and security boundary.', href: '/docs/README' },
-  { icon: BoxesIcon, eyebrow: 'Use', title: 'Get useful answers', description: 'Explore a codebase, trace impact, integrate Compass, or set up the editor workflow.', href: '/docs/getting-started' },
-  { icon: Code2Icon, eyebrow: 'Query', title: 'Learn CompassQL', description: 'Read the language contract and support matrix before you automate structural checks.', href: '/docs/COMPASSQL' },
-  { icon: ShieldCheckIcon, eyebrow: 'Contribute', title: 'Work on Compass', description: 'Follow the architecture, language, implementation, and extension boundaries.', href: '/docs/implementation/workspace-tour' },
+  { icon: BookOpenIcon, eyebrow: 'Start', title: 'Build your first graph', description: 'Install Compass, scan a repository, and answer your first structural question.', href: '/docs/getting-started', action: 'Start the guide' },
+  { icon: BoxesIcon, eyebrow: 'Learn', title: 'Understand how Compass works', description: 'Learn how source files become an evidence-backed graph and what the results mean.', href: '/docs/concepts/how-it-works', action: 'Explore the concepts' },
+  { icon: Code2Icon, eyebrow: 'Use', title: 'Complete a common task', description: 'Explore a codebase, trace change impact, connect an assistant, or automate a workflow.', href: '/docs/guides/exploring-a-codebase', action: 'Browse task guides' },
+  { icon: FileTextIcon, eyebrow: 'Look up', title: 'Find commands and formats', description: 'Check exact commands, configuration options, output formats, and CompassQL syntax.', href: '/docs/reference/commands', action: 'Open the reference' },
 ];
 
 export const metadata: Metadata = {
   title: 'Documentation',
-  description: 'Learn, use, query, and contribute to Compass through the canonical project documentation.',
+  description: 'Install Compass, learn the core concepts, follow task guides, and look up commands and formats.',
 };
 
 export default function DocsLandingPage() {
@@ -24,16 +24,16 @@ export default function DocsLandingPage() {
         <div className="site-grid pointer-events-none absolute inset-0 opacity-50" aria-hidden="true" />
         <div className="relative mx-auto max-w-7xl px-5 pb-16 pt-20 lg:px-8 lg:pb-24 lg:pt-28">
           <Badge className="rounded-full px-3 py-1 font-mono text-[0.68rem] uppercase tracking-[0.14em]" variant="outline">Compass documentation</Badge>
-          <h1 className="mt-6 max-w-4xl font-heading text-[clamp(3rem,7vw,6.4rem)] font-semibold leading-[0.94] tracking-[-0.075em]">A clear route into a complex workspace.</h1>
-          <p className="mt-7 max-w-2xl text-lg leading-8 text-muted-foreground">Choose the path that matches the question in front of you. The pages below are backed by the repository&apos;s canonical documentation.</p>
+          <h1 className="mt-6 max-w-4xl font-heading text-[clamp(3rem,7vw,6.4rem)] font-semibold leading-[0.94] tracking-[-0.075em]">Find an answer, then get back to your code.</h1>
+          <p className="mt-7 max-w-2xl text-lg leading-8 text-muted-foreground">Start with a working graph, learn the ideas as you need them, or jump straight to a task or reference.</p>
         </div>
       </section>
       <section className="mx-auto max-w-7xl px-5 py-16 lg:px-8 lg:py-24">
         <div className="grid gap-5 md:grid-cols-2">
-          {paths.map(({ icon: Icon, ...path }) => (
+          {paths.map(({ icon: Icon, action, ...path }) => (
             <Card className="group border-border/80 bg-card/70 shadow-none transition-transform duration-300 hover:-translate-y-1" key={path.href}>
               <CardHeader className="gap-4"><Icon className="text-primary" /><div className="flex flex-col gap-2"><span className="eyebrow">{path.eyebrow}</span><CardTitle className="font-heading text-2xl tracking-[-0.045em]">{path.title}</CardTitle></div></CardHeader>
-              <CardContent className="flex flex-col gap-6"><p className="max-w-lg text-sm leading-7 text-muted-foreground">{path.description}</p><Link className="inline-flex items-center gap-2 text-sm font-medium text-primary transition-[gap] group-hover:gap-3" href={path.href}>Open path <ArrowRightIcon data-icon="inline-end" /></Link></CardContent>
+              <CardContent className="flex flex-col gap-6"><p className="max-w-lg text-sm leading-7 text-muted-foreground">{path.description}</p><Link className="inline-flex items-center gap-2 text-sm font-medium text-primary transition-[gap] group-hover:gap-3" href={path.href}>{action} <ArrowRightIcon data-icon="inline-end" /></Link></CardContent>
             </Card>
           ))}
         </div>

--- a/apps/web/app/(marketing)/roadmap/page.tsx
+++ b/apps/web/app/(marketing)/roadmap/page.tsx
@@ -18,6 +18,6 @@ export default function RoadmapPage() {
     <PageSection eyebrow="Current status" title="Read the label before you read the promise.">
       <div className="grid gap-5 md:grid-cols-3">{items.map(([Icon, title, text]) => <Card className="border-border/80 bg-card/70 shadow-none" key={title}><CardHeader className="gap-4"><Icon className="text-primary" /><CardTitle className="font-heading text-xl tracking-[-0.04em]">{title}</CardTitle></CardHeader><CardContent><p className="text-sm leading-7 text-muted-foreground">{text}</p></CardContent></Card>)}</div>
     </PageSection>
-    <div className="mx-auto max-w-7xl px-5 pb-20 lg:px-8 lg:pb-28"><Link className="inline-flex items-center gap-2 text-sm font-medium text-primary" href="/docs/roadmap">Open the detailed roadmap <ArrowUpRightIcon data-icon="inline-end" /></Link></div>
+    <div className="mx-auto max-w-7xl px-5 pb-20 lg:px-8 lg:pb-28"><Link className="inline-flex items-center gap-2 text-sm font-medium text-primary" href="https://github.com/crabbuild/compass/blob/main/docs/roadmap.md" target="_blank" rel="noreferrer">Open the detailed roadmap <ArrowUpRightIcon data-icon="inline-end" /></Link></div>
   </MarketingPage>;
 }

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -5,9 +5,7 @@ import {
   CompassIcon,
   FileTextIcon,
   FlaskConicalIcon,
-  Layers3Icon,
   MapIcon,
-  WrenchIcon,
   type LucideIcon,
 } from 'lucide-react';
 import type { Folder, Item, Node, Root } from 'fumadocs-core/page-tree';
@@ -20,7 +18,7 @@ const sidebarIcon = (Icon: LucideIcon): ReactNode =>
     className: 'docs-sidebar-icon',
   });
 
-const START_PAGES = ['README.md', 'getting-started.md', 'roadmap.md'] as const;
+const START_PAGES = ['README.md', 'getting-started.md'] as const;
 const COMPASSQL_PAGES = ['concepts/compassql.md', 'COMPASSQL.md', 'COMPASSQL_SUPPORT.md'] as const;
 
 const FOLDER_SECTIONS = [
@@ -28,8 +26,6 @@ const FOLDER_SECTIONS = [
   { path: 'guides', name: 'Task guides', icon: MapIcon },
   { path: 'cookbook', name: 'Cookbook', icon: FlaskConicalIcon },
   { path: 'reference', name: 'Reference', icon: FileTextIcon },
-  { path: 'design', name: 'Design & architecture', icon: Layers3Icon },
-  { path: 'implementation', name: 'Implementation', icon: WrenchIcon },
 ] as const;
 
 function collectPages(nodes: Node[], pages = new Map<string, Item>()): Map<string, Item> {

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -14,18 +14,20 @@ export const blog = defineCollections({
   }),
 });
 
-// The repository's existing docs remain the canonical source for the public
-// documentation. Fumadocs compiles them in place for the web surface.
+// The repository's user documentation remains the canonical source for the
+// public website. Contributor-focused design and implementation documents stay
+// in the repository, but are intentionally excluded from this collection.
 export const docs = defineDocs({
   dir: '../../docs',
   docs: {
     files: [
-      '*.md',
+      'README.md',
+      'getting-started.md',
+      'COMPASSQL.md',
+      'COMPASSQL_SUPPORT.md',
       'concepts/*.md',
       'cookbook/*.md',
-      'design/*.md',
       'guides/*.md',
-      'implementation/*.md',
       'reference/*.md',
     ],
     schema: (ctx) =>

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,8 @@ Start here if you want to understand the product before adopting it:
    without needing graph-database experience.
 3. [Graph model](concepts/graph-model.md) — learn what nodes, relationships,
    communities, and provenance mean.
-4. [Security and privacy](design/security-and-privacy.md) — see what stays
-   local and when a configured provider may be contacted.
+4. [Operations](guides/operations.md) — understand local execution,
+   credentials, long-running processes, and recovery.
 5. [Compatibility](../COMPATIBILITY.md) and
    [performance](../PERFORMANCE.md) — inspect the published evidence.
 
@@ -43,24 +43,6 @@ to yours:
 - [Operate the Compass Store](guides/compass-store-operations.md)
 - [Solve a concrete problem](cookbook/README.md)
 - [Look up commands and contracts](reference/commands.md)
-
-### I contribute to Compass
-
-Read these in order when you need a durable mental model of the Rust
-workspace:
-
-1. [Design principles](design/principles.md)
-2. [System architecture](design/architecture.md)
-3. [Language architecture](design/language-architecture.md)
-4. [Workspace and crate tour](implementation/workspace-tour.md)
-5. [Extraction pipeline](implementation/extraction-pipeline.md)
-6. [Universal evidence implementation](implementation/universal-evidence.md)
-7. [Query engine](implementation/query-engine.md)
-8. [Compass store design](design/compass-store.md)
-9. [Compass store implementation plan](implementation/compass-store-plan.md)
-10. [Semantic pipeline](implementation/semantic-pipeline.md)
-11. [Extending Compass](implementation/extending-compass.md)
-12. [Contributing](../CONTRIBUTING.md)
 
 ## Documentation map
 
@@ -84,33 +66,6 @@ workspace:
 | [Versioned history](guides/versioned-history.md) | Immutable graphs and diffs for exact Git commits |
 | [Operations](guides/operations.md) | Safe operation of long-running and optional surfaces |
 | [Compass Store operations](guides/compass-store-operations.md) | Store health, backup, restore, rebuild, and release qualification |
-
-### Understand the design
-
-| Document | Focus |
-| --- | --- |
-| [Design principles](design/principles.md) | Local-first, deterministic, bounded, inspectable behavior |
-| [Architecture](design/architecture.md) | Major layers and the data that crosses them |
-| [Language architecture](design/language-architecture.md) | Grammar, adapter, evidence, resolution, and transition boundaries |
-| [Managed language analyzers](design/managed-language-analyzers.md) | Planned compiler, indexer, and language-server enrichment across languages |
-| [Managed JDT integration](design/java-jdt-integration.md) | Planned Java semantic tooling, trust boundaries, phases, and acceptance criteria |
-| [Storage and history](design/storage-and-history.md) | Incremental artifacts and immutable historical realizations |
-| [Compass store](design/compass-store.md) | Namespace/partition/key contract, current SQLite slice, graph engines, snapshot schema, and database mappings |
-| [Security and privacy](design/security-and-privacy.md) | Trust boundaries, credentials, and offline behavior |
-| [Document processing](design/document-processing.md) | Source-driven Markdown structure, metadata, links, and bounds |
-
-### Work on the implementation
-
-| Document | Focus |
-| --- | --- |
-| [Workspace tour](implementation/workspace-tour.md) | Which crate owns which responsibility |
-| [Extraction pipeline](implementation/extraction-pipeline.md) | Discovery through atomic output publication |
-| [Universal evidence](implementation/universal-evidence.md) | Language contracts, crate boundaries, resolution, and qualification |
-| [Code-graph parity qualification](implementation/code-graph-parity-qualification.md) | Pinned real-repository Graphify comparison and open quality gaps |
-| [Query engine](implementation/query-engine.md) | Discovery queries, traversal, and CompassQL |
-| [Compass store plan](implementation/compass-store-plan.md) | Executable phases and acceptance criteria for local and cloud database engines |
-| [Semantic pipeline](implementation/semantic-pipeline.md) | Optional provider-backed extraction |
-| [Extending Compass](implementation/extending-compass.md) | Adding languages, relations, integrations, and commands |
 
 ### Copy a recipe
 
@@ -154,20 +109,6 @@ terminal. Larger
 architecture diagrams are checked-in SVG files with accessible titles and
 descriptions.
 
-## Current, planned, and aspirational
-
-Compass evolves quickly, so future-facing documentation uses explicit labels:
-
-- **Available now** means the behavior is implemented and supported by current
-  source, help text, tests, or release evidence.
-- **Planned** means a committed design or implementation plan describes the
-  work. A plan is evidence of intent, not evidence that the feature has
-  shipped.
-- **Aspirational** means the idea expresses a direction or problem worth
-  exploring. It has no promised release, compatibility, or delivery date.
-
-See the [roadmap](roadmap.md) for the combined view.
-
 ## Canonical policy and evidence
 
 Some topics already have a single authoritative document. The learning guides
@@ -200,8 +141,8 @@ compile on one developer machine.
 
 - [Getting started](getting-started.md)
 - [How Compass works](concepts/how-it-works.md)
-- [Roadmap](roadmap.md)
-- [Support](../SUPPORT.md)
+- [Explore a codebase](guides/exploring-a-codebase.md)
+- [Command reference](reference/commands.md)
 
 **Next step:** follow [Getting started](getting-started.md) to build and query
 your first graph.

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -378,8 +378,8 @@ documents for automation.
 
 - [Graph model](graph-model.md)
 - [Provenance and confidence](provenance.md)
-- [System architecture](../design/architecture.md)
-- [Extraction pipeline](../implementation/extraction-pipeline.md)
+- [Getting started](../getting-started.md)
+- [Command reference](../reference/commands.md)
 
 **Next step:** read [Graph model](graph-model.md) to interpret the entities,
 relationships, and attributes returned by Compass.

--- a/docs/concepts/provenance.md
+++ b/docs/concepts/provenance.md
@@ -260,7 +260,7 @@ public graph contract.
 - [Graph model](graph-model.md)
 - [How Compass works](how-it-works.md)
 - [Impact-analysis cookbook](../cookbook/impact-analysis.md)
-- [Extending Compass](../implementation/extending-compass.md)
+- [Output reference](../reference/outputs.md)
 
 **Next step:** read [CompassQL concepts](compassql.md) to select and filter
 evidence precisely.

--- a/docs/cookbook/ci-and-automation.md
+++ b/docs/cookbook/ci-and-automation.md
@@ -156,7 +156,7 @@ HTML is optional and can be omitted for size or security.
 
 - [Integrating Compass](../guides/integrating-compass.md)
 - [Output reference](../reference/outputs.md)
-- [Security and privacy](../design/security-and-privacy.md)
+- [Configuration reference](../reference/configuration.md)
 
 **Next step:** implement the build-only recipe first, inspect its artifacts,
 then add one exact policy query with explicit schema validation.

--- a/docs/guides/assistant-setup.md
+++ b/docs/guides/assistant-setup.md
@@ -317,7 +317,7 @@ Avoid:
 
 - [Getting started](../getting-started.md)
 - [Explore a codebase](exploring-a-codebase.md)
-- [Security and privacy](../design/security-and-privacy.md)
+- [Configuration reference](../reference/configuration.md)
 - [Troubleshooting cookbook](../cookbook/troubleshooting.md)
 
 **Next step:** ask the configured assistant one architecture question and

--- a/docs/guides/integrating-compass.md
+++ b/docs/guides/integrating-compass.md
@@ -315,7 +315,7 @@ nonzero.
 - [CompassQL concepts](../concepts/compassql.md)
 - [Output reference](../reference/outputs.md)
 - [CI and automation cookbook](../cookbook/ci-and-automation.md)
-- [Security and privacy](../design/security-and-privacy.md)
+- [Operations guide](operations.md)
 
 **Next step:** build one parameterized CompassQL query and validate its schema
 tag before connecting it to a larger application.

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -373,7 +373,7 @@ Avoid deleting a live SQLite/WAL store, lock, or lease as a first response.
 
 - [Integrating Compass](integrating-compass.md)
 - [Versioned graph history](versioned-history.md)
-- [Security and privacy](../design/security-and-privacy.md)
+- [Configuration reference](../reference/configuration.md)
 - [Troubleshooting cookbook](../cookbook/troubleshooting.md)
 
 **Next step:** choose one operational surface, run its one-shot equivalent, and

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -508,9 +508,8 @@ This is release evidence, not a substitute for application-specific validation.
 
 ## Related pages
 
-- [Storage and history design](../design/storage-and-history.md)
-- [History implementation](../implementation/workspace-tour.md)
 - [Output reference](../reference/outputs.md)
+- [Command reference](../reference/commands.md)
 - [Compatibility ledger](../../COMPATIBILITY.md)
 
 **Next step:** enable a code-only profile in a disposable repository, build

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -367,8 +367,8 @@ job metadata even if Compass's own history fingerprint already includes it.
 ## Related pages
 
 - [Command reference](commands.md)
-- [Security and privacy](../design/security-and-privacy.md)
-- [Semantic implementation](../implementation/semantic-pipeline.md)
+- [Operations guide](../guides/operations.md)
+- [Assistant setup](../guides/assistant-setup.md)
 - [Versioned history](../guides/versioned-history.md)
 
 **Next step:** replace implicit defaults in one automation workflow with

--- a/docs/reference/document-formats.md
+++ b/docs/reference/document-formats.md
@@ -97,6 +97,6 @@ tests, and cache/version contracts before it becomes graph evidence.
 
 ## Related contracts
 
-- [Structural document processing](../design/document-processing.md)
+- [Configuration](configuration.md)
 - [Output reference](outputs.md)
 - [Compatibility](../../COMPATIBILITY.md)

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -463,7 +463,7 @@ First-party editor and offline-viewer contracts are versioned independently:
 
 - [Graph model](../concepts/graph-model.md)
 - [Integrating Compass](../guides/integrating-compass.md)
-- [Storage and history](../design/storage-and-history.md)
+- [Versioned history](../guides/versioned-history.md)
 - [Command reference](commands.md)
 
 **Next step:** identify the most structured available output for your consumer


### PR DESCRIPTION
## Summary
- publish only user-facing getting-started, concepts, guides, cookbook, reference, and CompassQL documentation
- remove internal design, implementation, and detailed roadmap pages from public routes, navigation, search, and sitemap generation
- reshape the docs landing page around four clear user goals and remove cross-links into excluded contributor material
- keep the detailed roadmap available from the roadmap page through its canonical GitHub source

## Verification
- `npm run typecheck:web`
- `npm run build:web`
- Playwright desktop and mobile smoke checks
- confirmed `/docs/design/architecture`, `/docs/implementation/workspace-tour`, and `/docs/roadmap` return 404
- confirmed user guide routes remain available and the sidebar contains only user-facing sections