### PR TITLE
Expand framework-aware route extraction and resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- Document the supported framework-route matrix and harden common route forms:
+  named Django, Flask, and FastAPI path arguments; React Router `Component`
+  elements; ASP.NET absolute action templates; Drupal multi-method routing YAML;
+  and documented Drupal hook implementations. Route resolution now fails closed
+  on explicit owner mismatches, preserves opaque Express callbacks, composes
+  FastAPI/Flask registration prefixes, binds file-based endpoint exports,
+  recognizes NestJS gateways, applies Rails namespaces/Laravel resource
+  modifiers/ASP.NET action routes, and gates Spring mappings to controller
+  owners. Native route composition now covers Go chi/gorilla prefixes, Axum and
+  Actix nested builders, multiline Rust attributes, and Vapor grouped/`on`
+  registrations; the release qualification manifest exercises 27 route flows.
+  Extraction semantics and the AST cache namespace advance to version 6
+  so existing projects refresh these facts once instead of retaining stale
+  route graphs.
+
 ## 0.3.1 - 2026-08-03
 
 - Make versioned graph comparisons meaning-aware: source-coordinate shifts,

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 use crate::{FileError, StatHashIndex, file_hash, io_error, write_bytes_atomic, write_json_atomic};
 
 /// Changes whenever cached extraction semantics change, even if the wire encoding does not.
-pub const AST_CACHE_VERSION: &str = "5";
+pub const AST_CACHE_VERSION: &str = "6";
 /// Portable cache encoding version used in the on-disk namespace.
 pub const CACHE_ENCODING_VERSION: u32 = 8;
 const MESSAGEPACK_EXTENSION: &str = "msgpack";

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -4,10 +4,11 @@ use std::fs::{self, FileTimes};
 use std::time::{Duration, UNIX_EPOCH};
 
 use compass_files::{
-    BuildGuard, CACHE_ENCODING_VERSION, Cache, CacheKind, CacheOptions, DetectOptions, FileSlice,
-    Manifest, ManifestKind, StatHashIndex, WatchPathFilter, bisect_slice, body_content,
-    classify_file, file_hash, md5_file, prompt_fingerprint, read_slice_text, read_source_lossy,
-    slice_boundaries, split_file, write_bytes_atomic, write_json_atomic, write_text_atomic,
+    AST_CACHE_VERSION, BuildGuard, CACHE_ENCODING_VERSION, Cache, CacheKind, CacheOptions,
+    DetectOptions, FileSlice, Manifest, ManifestKind, StatHashIndex, WatchPathFilter, bisect_slice,
+    body_content, classify_file, file_hash, md5_file, prompt_fingerprint, read_slice_text,
+    read_source_lossy, slice_boundaries, split_file, write_bytes_atomic, write_json_atomic,
+    write_text_atomic,
 };
 use compass_files::{FileType, IgnorePolicy};
 use serde_json::json;
@@ -800,7 +801,9 @@ fn cache_versions_legacy_fingerprints_pruning_and_cleanup_are_total() -> Result<
     assert!(
         default_cache
             .directory(&CacheKind::Ast, None)
-            .ends_with(format!("ast/v5/e{CACHE_ENCODING_VERSION}"))
+            .ends_with(format!(
+                "ast/v{AST_CACHE_VERSION}/e{CACHE_ENCODING_VERSION}"
+            ))
     );
     assert!(!cache_root.join("compass-out/cache/ast/v0.9.21").exists());
 

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -2019,11 +2019,19 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
     fn declaration_name(&self, node: Node<'tree>) -> Option<String> {
         if self.language == "kotlin"
             && self.config.class_types.contains(&node.kind())
-            && let Some(name) = first_descendant(node, "type_identifier")
-                .and_then(|name| self.node_text(name))
-                .map(clean_name)
+            && let Some(text) = self.node_text(node)
         {
-            return Some(name);
+            for marker in ["class ", "interface ", "object "] {
+                if let Some(offset) = text.rfind(marker)
+                    && let Some(name) = text[offset + marker.len()..]
+                        .split_whitespace()
+                        .next()
+                        .map(|name| clean_name(name.to_owned()))
+                        .filter(|name| !name.is_empty())
+                {
+                    return Some(name);
+                }
+            }
         }
         node.child_by_field_name("name")
             .and_then(|name| self.node_text(name))

--- a/crates/compass-languages/src/frameworks/csharp.rs
+++ b/crates/compass-languages/src/frameworks/csharp.rs
@@ -45,6 +45,7 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     let mut class_name = None::<String>;
     let mut class_prefix = String::new();
     let mut pending_route = None::<String>;
+    let mut pending_action_route = None::<String>;
     let mut pending_http = Vec::<(String, String, usize, String)>::new();
     let mut facts = Vec::new();
     let mut offset = 0_usize;
@@ -52,7 +53,11 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
         if let Some(capture) = route_attribute.captures(line)
             && let Some(value) = capture.get(1)
         {
-            pending_route = Some(value.as_str().to_owned());
+            if class_name.is_some() {
+                pending_action_route = Some(value.as_str().to_owned());
+            } else {
+                pending_route = Some(value.as_str().to_owned());
+            }
         }
         for capture in http_attribute.captures_iter(line) {
             let Some(operation) = capture.get(1) else {
@@ -78,7 +83,7 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
             offset = offset.saturating_add(line.len());
             continue;
         }
-        if !pending_http.is_empty()
+        if (!pending_http.is_empty() || pending_action_route.is_some())
             && let (Some(class_name), Some(method_name)) = (
                 class_name.as_deref(),
                 method
@@ -87,23 +92,39 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
                     .map(|value| value.as_str()),
             )
         {
-            for (operation, action_path, anchor_offset, anchor_line) in pending_http.drain(..) {
-                let normalized_path = if class_prefix.is_empty() {
-                    normalize_route_path(&action_path)
+            let action_route = pending_action_route.take();
+            let pending_http = if pending_http.is_empty() {
+                vec![("ANY".to_owned(), String::new(), offset, line.to_owned())]
+            } else {
+                std::mem::take(&mut pending_http)
+            };
+            for (operation, action_path, anchor_offset, anchor_line) in pending_http {
+                let template = action_route.as_deref().unwrap_or(&action_path);
+                let expanded_action = template
+                    .replace("[controller]", class_name.trim_end_matches("Controller"))
+                    .replace("[action]", method_name);
+                let normalized_path = if let Some(absolute) = expanded_action.strip_prefix("~/") {
+                    normalize_route_path(absolute)
+                } else if expanded_action.starts_with('/') || class_prefix.is_empty() {
+                    normalize_route_path(&expanded_action)
                 } else {
-                    join_route_path(&class_prefix, &action_path)
+                    join_route_path(&class_prefix, &expanded_action)
                 };
                 facts.push(RawFrameworkFact::Route(RawRouteFact {
                     framework: "aspnet".to_owned(),
                     operation,
-                    raw_path: action_path,
+                    raw_path: template.to_owned(),
                     normalized_path,
                     declaring_scope: class_name.to_owned(),
                     anchor: line_anchor(path, source, anchor_offset, &anchor_line),
                     handler_reference: format!("{class_name}.{method_name}"),
                     middleware_references: Vec::new(),
                     origin: RawFrameworkOrigin::Ast,
-                    rule: Some("aspnet-http-attribute".to_owned()),
+                    rule: Some(if action_route.is_some() {
+                        "aspnet-action-route-attribute".to_owned()
+                    } else {
+                        "aspnet-http-attribute".to_owned()
+                    }),
                     detail: Map::new(),
                 }));
             }

--- a/crates/compass-languages/src/frameworks/file_routes.rs
+++ b/crates/compass-languages/src/frameworks/file_routes.rs
@@ -20,13 +20,14 @@ pub(super) fn detect(
     }
     let portable = path.to_string_lossy().replace('\\', "/");
     let lower = portable.to_ascii_lowercase();
+    let body = std::str::from_utf8(source).unwrap_or_default();
     let evidence = EvidenceSet::new()
         .direct_if(
             project.is_none_or(|project| project.has_dependency("@sveltejs/kit"))
                 && segment_after(&portable, "src/routes/").is_some()
                 && matches!(
                     path.file_name().and_then(|name| name.to_str()),
-                    Some("+page.svelte" | "+page.ts" | "+server.ts" | "+server.js")
+                    Some("+page.svelte" | "+server.ts" | "+server.js")
                 ),
             "sveltekit",
             EvidenceKind::ConfigurationContract,
@@ -38,7 +39,7 @@ pub(super) fn detect(
                     || segment_after(&portable, "server/api/").is_some()
                     || (segment_after(&portable, "middleware/").is_some()
                         && lower.ends_with(".ts")
-                        && lower.contains("nuxt"))),
+                        && (project.is_some() || body.contains("defineNuxtRouteMiddleware")))),
             "nuxt",
             EvidenceKind::ConfigurationContract,
             "Nuxt route artifact",
@@ -58,12 +59,10 @@ pub(super) fn detect(
     if evidence.activates("sveltekit")
         && let Some(relative) = segment_after(&portable, "src/routes/")
     {
-        if lower.ends_with("/+page.svelte") || lower.ends_with("/+page.ts") {
+        if lower.ends_with("/+page.svelte") {
             return page_routes(
                 "sveltekit",
-                relative
-                    .trim_end_matches("+page.svelte")
-                    .trim_end_matches("+page.ts"),
+                relative.trim_end_matches("+page.svelte"),
                 path,
                 source,
                 extraction,
@@ -96,20 +95,28 @@ pub(super) fn detect(
         )
     {
         let (route, method) = nuxt_api_route(relative);
+        let operation = method.as_deref().unwrap_or("ANY");
+        let handler =
+            exported_endpoint_handlers(std::str::from_utf8(source).unwrap_or_default(), "nuxt")
+                .into_iter()
+                .find(|handler| handler.operation == operation || handler.operation == "ANY");
+        let Some(handler) = handler else {
+            return Vec::new();
+        };
         return one_route(
             "nuxt",
-            method.as_deref().unwrap_or("ANY"),
+            operation,
             &route,
             path,
             source,
             extraction,
             "nuxt-server-api-convention",
+            Some(&handler),
         );
     }
     if evidence.activates("nuxt")
         && let Some(relative) = segment_after(&portable, "middleware/")
         && lower.ends_with(".ts")
-        && lower.contains("nuxt")
     {
         return vec![RawFrameworkFact::Domain(RawDomainFact {
             framework: "nuxt".to_owned(),
@@ -164,6 +171,7 @@ fn page_routes(
         source,
         extraction,
         &format!("{framework}-file-route-convention"),
+        None,
     )
 }
 
@@ -175,23 +183,19 @@ fn endpoint_routes(
     extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
     let text = std::str::from_utf8(source).unwrap_or_default();
-    let operations = exported_http_methods(text);
-    let operations = if operations.is_empty() {
-        vec!["ANY".to_owned()]
-    } else {
-        operations
-    };
-    operations
+    let handlers = exported_endpoint_handlers(text, framework);
+    handlers
         .into_iter()
-        .flat_map(|operation| {
+        .flat_map(|handler| {
             one_route(
                 framework,
-                &operation,
+                &handler.operation,
                 relative,
                 path,
                 source,
                 extraction,
                 &format!("{framework}-endpoint-convention"),
+                Some(&handler),
             )
         })
         .collect()
@@ -206,17 +210,25 @@ fn one_route(
     source: &[u8],
     extraction: &mut Extraction,
     rule: &str,
+    handler: Option<&EndpointHandler>,
 ) -> Vec<RawFrameworkFact> {
     let original_path = convention_path(relative);
     let normalized_path = normalize_dynamic_segments(&original_path);
-    let handler = ensure_route_component(
-        path,
-        framework,
-        operation,
-        &normalized_path,
-        source,
-        extraction,
-    );
+    let handler_reference = match handler {
+        Some(handler) if handler.reference == "default" => {
+            ensure_default_export_handler(path, framework, operation, source, extraction);
+            "default".to_owned()
+        }
+        Some(handler) => handler.reference.clone(),
+        None => ensure_route_component(
+            path,
+            framework,
+            operation,
+            &normalized_path,
+            source,
+            extraction,
+        ),
+    };
     vec![RawFrameworkFact::Route(RawRouteFact {
         framework: framework.to_owned(),
         operation: operation.to_owned(),
@@ -224,15 +236,36 @@ fn one_route(
         normalized_path,
         declaring_scope: path.to_string_lossy().replace('\\', "/"),
         anchor: file_anchor(path, source),
-        handler_reference: handler,
+        handler_reference,
         middleware_references: Vec::new(),
         origin: RawFrameworkOrigin::Convention,
         rule: Some(rule.to_owned()),
-        detail: Map::from_iter([(
+        detail: endpoint_detail(handler, path),
+    })]
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EndpointHandler {
+    operation: String,
+    reference: String,
+    module: Option<String>,
+}
+
+fn endpoint_detail(handler: Option<&EndpointHandler>, path: &Path) -> Map<String, Value> {
+    let mut detail = Map::from_iter([
+        (
             "route_file".into(),
             Value::String(path.to_string_lossy().replace('\\', "/")),
-        )]),
-    })]
+        ),
+        (
+            "handler_source".into(),
+            Value::String(path.to_string_lossy().replace('\\', "/")),
+        ),
+    ]);
+    if let Some(module) = handler.and_then(|handler| handler.module.as_ref()) {
+        detail.insert("handler_module".into(), Value::String(module.clone()));
+    }
+    detail
 }
 
 fn ensure_route_component(
@@ -319,20 +352,157 @@ fn ensure_route_component(
     qualified_name
 }
 
-fn exported_http_methods(source: &str) -> Vec<String> {
-    let Ok(regex) = Regex::new(
-        r"(?m)\bexport\s+(?:(?:async\s+)?function|const|let|var)\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\b",
+fn ensure_default_export_handler(
+    path: &Path,
+    framework: &str,
+    operation: &str,
+    source: &[u8],
+    extraction: &mut Extraction,
+) {
+    let source_file = path.to_string_lossy().into_owned();
+    let id = make_id(&["route-default-handler", framework, &source_file, operation]);
+    if extraction.nodes.iter().any(|node| node.id == id) {
+        return;
+    }
+    let line_end = source.iter().filter(|byte| **byte == b'\n').count() + 1;
+    extraction.nodes.push(RawNodeRecord {
+        id: id.clone(),
+        attributes: Map::from_iter([
+            ("label".into(), Value::String("default".into())),
+            ("name".into(), Value::String("default".into())),
+            ("qualified_name".into(), Value::String("default".into())),
+            ("symbol_kind".into(), Value::String("function".into())),
+            ("file_type".into(), Value::String("code".into())),
+            ("framework".into(), Value::String(framework.to_owned())),
+            ("source_file".into(), Value::String(source_file.clone())),
+            ("source_location".into(), Value::String("L1".into())),
+            ("line_start".into(), Value::from(1)),
+            ("line_end".into(), Value::from(line_end)),
+            ("_origin".into(), Value::String("convention".into())),
+            (
+                "rule".into(),
+                Value::String(format!("{framework}-default-export-handler")),
+            ),
+            (
+                "extractor".into(),
+                Value::String(format!("compass.frameworks.{framework}")),
+            ),
+        ]),
+    });
+    if let Some(file_id) = extraction
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("symbol_kind") == "file" || node.string("source_file") == source_file
+        })
+        .map(|node| node.id.clone())
+    {
+        extraction.edges.push(RawEdgeRecord {
+            source: file_id,
+            target: id,
+            attributes: Map::from_iter([
+                ("relation".into(), Value::String("contains".into())),
+                ("confidence".into(), Value::String("EXTRACTED".into())),
+                ("source_file".into(), Value::String(source_file)),
+                ("source_location".into(), Value::String("L1".into())),
+                ("_origin".into(), Value::String("convention".into())),
+                (
+                    "rule".into(),
+                    Value::String(format!("{framework}-default-export-handler")),
+                ),
+                (
+                    "extractor".into(),
+                    Value::String(format!("compass.frameworks.{framework}")),
+                ),
+            ]),
+        });
+    }
+}
+
+fn exported_endpoint_handlers(source: &str, framework: &str) -> Vec<EndpointHandler> {
+    let Ok(named) = Regex::new(
+        r"(?m)^\s*export\s+(?:(?:async\s+)?function|const|let|var)\s+(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|ALL|fallback)\b",
     ) else {
         return Vec::new();
     };
-    let mut methods = regex
+    let mut handlers = named
         .captures_iter(source)
-        .filter_map(|capture| capture.get(1))
-        .map(|method| method.as_str().to_owned())
+        .filter_map(|capture| capture.get(1).map(|name| name.as_str().to_owned()))
+        .map(|name| {
+            let operation = match name.as_str() {
+                "ALL" | "fallback" => "ANY".to_owned(),
+                method => method.to_owned(),
+            };
+            EndpointHandler {
+                operation,
+                reference: name,
+                module: None,
+            }
+        })
         .collect::<Vec<_>>();
-    methods.sort();
-    methods.dedup();
-    methods
+    let Ok(reexports) =
+        Regex::new(r#"(?m)^\s*export\s*\{([^}]*)\}(?:\s*from\s*[\"']([^\"']+)[\"'])?"#)
+    else {
+        return handlers;
+    };
+    for capture in reexports.captures_iter(source) {
+        let Some(names) = capture.get(1) else {
+            continue;
+        };
+        let module = capture.get(2).map(|value| value.as_str().to_owned());
+        for name in names.as_str().split(',').map(str::trim) {
+            let (local, exported) = name
+                .split_once(" as ")
+                .map(|(local, exported)| (local.trim(), exported.trim()))
+                .unwrap_or((name, name));
+            if matches!(
+                exported,
+                "GET"
+                    | "POST"
+                    | "PUT"
+                    | "PATCH"
+                    | "DELETE"
+                    | "OPTIONS"
+                    | "HEAD"
+                    | "ALL"
+                    | "fallback"
+            ) {
+                let operation = match exported {
+                    "ALL" | "fallback" => "ANY".to_owned(),
+                    method => method.to_owned(),
+                };
+                handlers.push(EndpointHandler {
+                    operation,
+                    reference: local.to_owned(),
+                    module: module.clone(),
+                });
+            }
+        }
+    }
+    handlers.sort_by(|left, right| {
+        (&left.operation, &left.reference, &left.module).cmp(&(
+            &right.operation,
+            &right.reference,
+            &right.module,
+        ))
+    });
+    handlers.dedup();
+
+    // Nuxt server handlers and Astro endpoints commonly use a default export.
+    // The route operation comes from the filename for Nuxt method files; for a
+    // generic endpoint it is an explicit ANY operation rather than an
+    // invented route component.
+    if handlers.is_empty()
+        && source.contains("export default")
+        && (framework == "nuxt" || framework == "astro")
+    {
+        handlers.push(EndpointHandler {
+            operation: "ANY".to_owned(),
+            reference: "default".to_owned(),
+            module: None,
+        });
+    }
+    handlers
 }
 
 fn nuxt_api_route(relative: &str) -> (String, Option<String>) {
@@ -357,14 +527,41 @@ fn convention_path(relative: &str) -> String {
 }
 
 fn normalize_dynamic_segments(path: &str) -> String {
-    let Ok(rest) = Regex::new(r"\[\.\.\.([^\]]+)\]") else {
-        return path.to_owned();
-    };
-    let path = rest.replace_all(path, "{*$1}");
-    let Ok(parameter) = Regex::new(r"\[([^\]]+)\]") else {
-        return path.into_owned();
-    };
-    parameter.replace_all(&path, "{$1}").into_owned()
+    let mut segments = Vec::new();
+    for segment in path.trim_matches('/').split('/') {
+        if segment.is_empty() || (segment.starts_with('(') && segment.ends_with(')')) {
+            continue;
+        }
+        let normalized = if let Some(rest) = segment
+            .strip_prefix("[[...")
+            .and_then(|value| value.strip_suffix("]]"))
+        {
+            format!("{{*{rest}}}")
+        } else if let Some(rest) = segment
+            .strip_prefix("[...")
+            .and_then(|value| value.strip_suffix(']'))
+        {
+            format!("{{*{rest}}}")
+        } else if let Some(rest) = segment
+            .strip_prefix("[[")
+            .and_then(|value| value.strip_suffix("]]"))
+        {
+            format!("{{{}}}", rest.split('=').next().unwrap_or(rest))
+        } else if let Some(rest) = segment
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+        {
+            format!("{{{}}}", rest.split('=').next().unwrap_or(rest))
+        } else {
+            segment.to_owned()
+        };
+        segments.push(normalized);
+    }
+    if segments.is_empty() {
+        "/".to_owned()
+    } else {
+        format!("/{}", segments.join("/"))
+    }
 }
 
 fn trim_known_extension(value: &str) -> &str {

--- a/crates/compass-languages/src/frameworks/go.rs
+++ b/crates/compass-languages/src/frameworks/go.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use regex::Regex;
@@ -6,10 +6,16 @@ use serde_json::{Map, Value};
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::text::{join_route_path, line_anchor, normalize_route_path, split_top_level, text};
+use super::text::{anchor, join_route_path, normalize_route_path, split_top_level, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
-pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFrameworkFact> {
+#[derive(Clone, Default)]
+struct GoContext {
+    prefixes: HashMap<String, String>,
+    frameworks: HashMap<String, &'static str>,
+}
+
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
     let body = text(source);
     let evidence = EvidenceSet::new()
         .direct_if(
@@ -39,104 +45,356 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     } else {
         return Vec::new();
     };
-    let Ok(group) = Regex::new(
-        r#"^\s*([A-Za-z_]\w*)\s*:?=\s*([A-Za-z_]\w*)\.(?:Group|Route)\(\s*["']([^"']*)["']"#,
+    let Ok(receiver_types) = Regex::new(
+        r#"\b([A-Za-z_]\w*)\s+(?:\*\s*)?(gin\.Engine|chi\.Router|mux\.Router)\b|\b([A-Za-z_]\w*)\s*:?=\s*(?:gin\.(?:New|Default)|chi\.NewRouter|mux\.NewRouter)\s*\("#,
     ) else {
         return Vec::new();
     };
-    let Ok(route) = Regex::new(
-        r#"^\s*([A-Za-z_]\w*)\.(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD|Get|Post|Put|Patch|Delete|Options|Head|HandleFunc)\(\s*["']([^"']*)["']\s*,\s*([^)]+)\)"#,
-    ) else {
-        return Vec::new();
-    };
-    let Ok(methods) = Regex::new(r#"\.Methods\(\s*([^)]+)\)"#) else {
-        return Vec::new();
-    };
-    let mut prefixes = HashMap::<String, String>::new();
-    let mut facts = Vec::new();
-    let mut offset = 0_usize;
-    for line in body.split_inclusive('\n') {
-        if let Some(capture) = group.captures(line)
-            && let (Some(child), Some(parent), Some(prefix)) =
-                (capture.get(1), capture.get(2), capture.get(3))
-        {
-            let parent_prefix = prefixes
-                .get(parent.as_str())
-                .map(String::as_str)
-                .unwrap_or_default();
-            prefixes.insert(
-                child.as_str().to_owned(),
-                join_route_path(parent_prefix, prefix.as_str()),
-            );
+    let prefixes = HashMap::<String, String>::new();
+    let mut receiver_frameworks = HashMap::<String, &'static str>::new();
+    for capture in receiver_types.captures_iter(body) {
+        let receiver = capture
+            .get(1)
+            .or_else(|| capture.get(3))
+            .map(|value| value.as_str());
+        let framework = capture
+            .get(2)
+            .and_then(|value| match value.as_str() {
+                "gin.Engine" => Some("gin"),
+                "chi.Router" => Some("chi"),
+                "mux.Router" => Some("gorilla"),
+                _ => None,
+            })
+            .or_else(|| {
+                capture
+                    .get(3)
+                    .and_then(|_| body.get(capture.get(0)?.start()..capture.get(0)?.end()))
+                    .and_then(|value| {
+                        if value.contains("gin.") {
+                            Some("gin")
+                        } else if value.contains("chi.") {
+                            Some("chi")
+                        } else if value.contains("mux.") {
+                            Some("gorilla")
+                        } else {
+                            None
+                        }
+                    })
+            });
+        if let (Some(receiver), Some(framework)) = (receiver, framework) {
+            receiver_frameworks.insert(receiver.to_owned(), framework);
         }
-        let Some(capture) = route.captures(line) else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        let (Some(receiver), Some(method), Some(raw_path), Some(stages)) = (
-            capture.get(1),
-            capture.get(2),
-            capture.get(3),
-            capture.get(4),
-        ) else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        let stages = split_top_level(stages.as_str())
-            .into_iter()
-            .map(clean_reference)
-            .filter(|stage| !stage.is_empty())
-            .collect::<Vec<_>>();
-        let Some((handler, middleware)) = stages.split_last() else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        let prefix = prefixes
-            .get(receiver.as_str())
-            .map(String::as_str)
-            .unwrap_or_default();
-        let normalized_path = if prefix.is_empty() {
-            normalize_route_path(raw_path.as_str())
-        } else {
-            join_route_path(prefix, raw_path.as_str())
-        };
-        let operations = if method.as_str() == "HandleFunc" {
-            methods
-                .captures(line)
-                .and_then(|capture| capture.get(1))
-                .map(|value| {
-                    split_top_level(value.as_str())
-                        .into_iter()
-                        .filter_map(super::text::literal)
-                        .map(|value| value.to_ascii_uppercase())
-                        .collect::<Vec<_>>()
-                })
-                .filter(|values| !values.is_empty())
-                .unwrap_or_else(|| vec!["ANY".to_owned()])
-        } else {
-            vec![method.as_str().to_ascii_uppercase()]
-        };
-        for operation in operations {
-            facts.push(RawFrameworkFact::Route(RawRouteFact {
-                framework: framework.to_owned(),
-                operation,
-                raw_path: raw_path.as_str().to_owned(),
-                normalized_path: normalized_path.clone(),
-                declaring_scope: receiver.as_str().to_owned(),
-                anchor: line_anchor(path, source, offset, line),
-                handler_reference: handler.clone(),
-                middleware_references: middleware.to_vec(),
-                origin: RawFrameworkOrigin::Ast,
-                rule: Some(format!("{framework}-router-call")),
-                detail: Map::from_iter([(
-                    "receiver".into(),
-                    Value::String(receiver.as_str().to_owned()),
-                )]),
-            }));
-        }
-        offset = offset.saturating_add(line.len());
     }
+    let mut context = GoContext {
+        prefixes,
+        frameworks: receiver_frameworks,
+    };
+    collect_go_group_prefixes(root, source, &mut context);
+    let mut facts = Vec::new();
+    collect_go_route_calls(root, source, path, framework, &context, &mut facts);
     facts
+}
+
+fn collect_go_route_calls(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    default_framework: &str,
+    context: &GoContext,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    let mut skip_children = HashSet::new();
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some((_, method)) = selector_parts(function, source)
+        && matches!(method.as_str(), "Route" | "Group")
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let mut cursor = arguments.walk();
+        let named = arguments.named_children(&mut cursor).collect::<Vec<_>>();
+        let prefix = named
+            .first()
+            .and_then(|value| super::text::literal(node_text(*value, source)))
+            .unwrap_or_default();
+        if !prefix.is_empty()
+            && method == "Route"
+            && let Some(base) = function
+                .child_by_field_name("operand")
+                .and_then(|operand| expression_receiver_info(operand, source, context))
+        {
+            for closure in named
+                .iter()
+                .skip(1)
+                .copied()
+                .filter(|child| child.kind() == "func_literal")
+            {
+                let Some(parameter) = closure_parameter_name(closure, source) else {
+                    continue;
+                };
+                let mut local = context.clone();
+                local
+                    .prefixes
+                    .insert(parameter.clone(), join_route_path(&base.1, &prefix));
+                local.frameworks.insert(parameter, "chi");
+                if let Some(body) = closure.child_by_field_name("body") {
+                    collect_go_route_calls(body, source, path, "chi", &local, facts);
+                }
+                skip_children.insert(closure.id());
+            }
+        }
+    }
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some((receiver, method, route_prefix)) =
+            route_receiver_info(function, source, context)
+        && matches_method(&method)
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let mut cursor = arguments.walk();
+        let arguments = arguments
+            .named_children(&mut cursor)
+            .map(|argument| node_text(argument, source).trim().to_owned())
+            .collect::<Vec<_>>();
+        let raw_path = arguments
+            .first()
+            .and_then(|value| super::text::literal(value));
+        if let Some(raw_path) = raw_path
+            && let Some((handler, middleware)) = arguments
+                .iter()
+                .skip(1)
+                .map(|value| clean_reference(value))
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .split_last()
+                .map(|(handler, middleware)| (handler.clone(), middleware.to_vec()))
+        {
+            let normalized_path = if route_prefix.is_empty() {
+                normalize_route_path(&raw_path)
+            } else {
+                join_route_path(&route_prefix, &raw_path)
+            };
+            let operations = if method.eq_ignore_ascii_case("handlefunc") {
+                method_operations(node, source).unwrap_or_else(|| {
+                    if has_methods_parent(node, source) {
+                        Vec::new()
+                    } else {
+                        vec!["ANY".to_owned()]
+                    }
+                })
+            } else {
+                vec![method.to_ascii_uppercase()]
+            };
+            let framework = context
+                .frameworks
+                .get(&receiver)
+                .copied()
+                .unwrap_or(default_framework);
+            for operation in operations {
+                facts.push(RawFrameworkFact::Route(RawRouteFact {
+                    framework: framework.to_owned(),
+                    operation,
+                    raw_path: raw_path.clone(),
+                    normalized_path: normalized_path.clone(),
+                    declaring_scope: receiver.clone(),
+                    anchor: anchor(path, source, node.start_byte(), node.end_byte()),
+                    handler_reference: handler.clone(),
+                    middleware_references: middleware.clone(),
+                    origin: RawFrameworkOrigin::Ast,
+                    rule: Some(format!("{framework}-router-call")),
+                    detail: Map::from_iter([("receiver".into(), Value::String(receiver.clone()))]),
+                }));
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node
+        .children(&mut cursor)
+        .filter(|child| child.is_named() && !skip_children.contains(&child.id()))
+    {
+        collect_go_route_calls(child, source, path, default_framework, context, facts);
+    }
+}
+
+fn collect_go_group_prefixes(node: Node<'_>, source: &[u8], context: &mut GoContext) {
+    if matches!(
+        node.kind(),
+        "short_var_declaration" | "var_spec" | "assignment"
+    ) && let Some(left) = node
+        .child_by_field_name("left")
+        .or_else(|| node.child_by_field_name("name"))
+        && let Some(right) = node.child_by_field_name("right")
+        && let Some(child) = first_named_child(left)
+        && let Some(expression) = first_named_child(right)
+        && let Some(call) = (expression.kind() == "call_expression").then_some(expression)
+        && let Some(function) = call.child_by_field_name("function")
+        && let Some((operand, method)) = selector_parts(function, source)
+        && matches!(
+            method.as_str(),
+            "Group" | "Route" | "PathPrefix" | "Subrouter"
+        )
+        && let Some((parent, parent_prefix)) = expression_receiver_info(operand, source, context)
+    {
+        let mut arguments = call.child_by_field_name("arguments").into_iter();
+        let prefix = arguments
+            .next()
+            .and_then(|arguments| {
+                let mut cursor = arguments.walk();
+                arguments
+                    .named_children(&mut cursor)
+                    .next()
+                    .and_then(|value| super::text::literal(node_text(value, source)))
+            })
+            .unwrap_or_default();
+        let child_name = node_text(child, source).trim();
+        if !child_name.is_empty() {
+            let child_prefix = if method == "Subrouter" || prefix.is_empty() {
+                parent_prefix
+            } else {
+                join_route_path(&parent_prefix, &prefix)
+            };
+            context.prefixes.insert(child_name.to_owned(), child_prefix);
+            if let Some(framework) = context.frameworks.get(&parent).copied() {
+                context.frameworks.insert(child_name.to_owned(), framework);
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_go_group_prefixes(child, source, context);
+    }
+}
+
+fn first_named_child(node: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).next()
+}
+
+fn selector_parts<'tree>(node: Node<'tree>, source: &[u8]) -> Option<(Node<'tree>, String)> {
+    (node.kind() == "selector_expression").then(|| {
+        let operand = node.child_by_field_name("operand")?;
+        let field = node.child_by_field_name("field")?;
+        Some((operand, node_text(field, source).to_owned()))
+    })?
+}
+
+fn route_receiver_info(
+    function: Node<'_>,
+    source: &[u8],
+    context: &GoContext,
+) -> Option<(String, String, String)> {
+    let (operand, method) = selector_parts(function, source)?;
+    if !matches_method(&method) {
+        return None;
+    }
+    let (receiver, prefix) = expression_receiver_info(operand, source, context)?;
+    Some((receiver, method, prefix))
+}
+
+fn expression_receiver_info(
+    expression: Node<'_>,
+    source: &[u8],
+    context: &GoContext,
+) -> Option<(String, String)> {
+    if expression.kind() == "identifier" {
+        let receiver = node_text(expression, source).to_owned();
+        return context.frameworks.contains_key(&receiver).then(|| {
+            (
+                receiver.clone(),
+                context.prefixes.get(&receiver).cloned().unwrap_or_default(),
+            )
+        });
+    }
+    if expression.kind() != "call_expression" {
+        return None;
+    }
+    let function = expression.child_by_field_name("function")?;
+    let (operand, method) = selector_parts(function, source)?;
+    let mut base = expression_receiver_info(operand, source, context)?;
+    let arguments = expression.child_by_field_name("arguments")?;
+    let mut cursor = arguments.walk();
+    let first = arguments
+        .named_children(&mut cursor)
+        .next()
+        .and_then(|value| super::text::literal(node_text(value, source)));
+    if matches!(method.as_str(), "PathPrefix" | "Group" | "Route")
+        && let Some(prefix) = first
+    {
+        base.1 = join_route_path(&base.1, &prefix);
+    }
+    Some(base)
+}
+
+fn closure_parameter_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let parameters = node.child_by_field_name("parameters")?;
+    let mut cursor = parameters.walk();
+    parameters.named_children(&mut cursor).find_map(|child| {
+        child
+            .child_by_field_name("name")
+            .or_else(|| (child.kind() == "identifier").then_some(child))
+            .map(|name| node_text(name, source).to_owned())
+    })
+}
+
+fn matches_method(method: &str) -> bool {
+    matches!(
+        method,
+        "GET"
+            | "POST"
+            | "PUT"
+            | "PATCH"
+            | "DELETE"
+            | "OPTIONS"
+            | "HEAD"
+            | "Get"
+            | "Post"
+            | "Put"
+            | "Patch"
+            | "Delete"
+            | "Options"
+            | "Head"
+            | "HandleFunc"
+    )
+}
+
+fn method_operations(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {
+    let mut parent = node.parent()?;
+    let parent = loop {
+        if parent.kind() == "call_expression"
+            && parent
+                .child_by_field_name("function")
+                .is_some_and(|function| node_text(function, source).trim().ends_with(".Methods"))
+        {
+            break parent;
+        }
+        parent = parent.parent()?;
+    };
+    let arguments = parent.child_by_field_name("arguments")?;
+    let mut cursor = arguments.walk();
+    let operations = arguments
+        .named_children(&mut cursor)
+        .flat_map(|argument| split_top_level(node_text(argument, source)))
+        .filter_map(|value| {
+            super::text::literal(value)
+                .or_else(|| value.trim().strip_prefix("http.Method").map(str::to_owned))
+        })
+        .map(|value| value.to_ascii_uppercase())
+        .collect::<Vec<_>>();
+    (!operations.is_empty()).then_some(operations)
+}
+
+fn has_methods_parent(node: Node<'_>, source: &[u8]) -> bool {
+    let mut parent = node.parent();
+    while let Some(candidate) = parent {
+        if candidate.kind() == "call_expression"
+            && candidate
+                .child_by_field_name("function")
+                .is_some_and(|function| node_text(function, source).trim().ends_with(".Methods"))
+        {
+            return true;
+        }
+        parent = candidate.parent();
+    }
+    false
 }
 
 fn clean_reference(value: &str) -> String {
@@ -146,4 +404,11 @@ fn clean_reference(value: &str) -> String {
         .trim_end_matches("...")
         .trim()
         .to_owned()
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a [u8]) -> &'a str {
+    std::str::from_utf8(
+        &source[node.start_byte().min(source.len())..node.end_byte().min(source.len())],
+    )
+    .unwrap_or_default()
 }

--- a/crates/compass-languages/src/frameworks/java.rs
+++ b/crates/compass-languages/src/frameworks/java.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use regex::Regex;
@@ -34,6 +35,13 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     if !evidence.activates("spring") {
         return Vec::new();
     }
+    // Method mappings are only HTTP endpoints when owned by a Spring MVC
+    // controller. Importing the annotation package alone is not sufficient;
+    // helpers, DTOs, and custom annotation declarations commonly reference
+    // the same types without registering routes.
+    if !body.contains("@RestController") && !body.contains("@Controller") {
+        return Vec::new();
+    }
     let Ok(annotation) = Regex::new(
         r"@(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)\s*(?:\((.*)\))?",
     ) else {
@@ -54,10 +62,46 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     let mut facts = Vec::new();
     let package = java_package_name(body);
     let mut pending = Vec::<Mapping>::new();
+    let mut multiline = BTreeMap::<usize, Vec<Mapping>>::new();
+    if let Ok(multiline_annotation) = Regex::new(
+        r"(?s)@(GetMapping|PostMapping|PutMapping|PatchMapping|DeleteMapping|RequestMapping)\s*\((.*?)\)",
+    ) {
+        for capture in multiline_annotation.captures_iter(body) {
+            let Some(whole) = capture.get(0) else {
+                continue;
+            };
+            if !whole.as_str().contains('\n') {
+                continue;
+            }
+            let line_start = body[..whole.start()]
+                .rfind('\n')
+                .map_or(0, |index| index.saturating_add(1));
+            let line = body[line_start..]
+                .split_inclusive('\n')
+                .next()
+                .unwrap_or_default()
+                .to_owned();
+            let Some(name) = capture.get(1) else {
+                continue;
+            };
+            multiline.entry(line_start).or_default().push(Mapping {
+                name: name.as_str().to_owned(),
+                arguments: capture
+                    .get(2)
+                    .map(|value| value.as_str().to_owned())
+                    .unwrap_or_default(),
+                offset: line_start,
+                line,
+            });
+        }
+    }
     let mut class_name = None::<String>;
     let mut class_prefix = String::new();
     let mut offset = 0_usize;
     for line in body.split_inclusive('\n') {
+        if let Some(values) = multiline.remove(&offset) {
+            pending.extend(values);
+        }
         for capture in annotation.captures_iter(line) {
             let Some(name) = capture.get(1) else {
                 continue;

--- a/crates/compass-languages/src/frameworks/php.rs
+++ b/crates/compass-languages/src/frameworks/php.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
 use regex::Regex;
@@ -6,9 +6,7 @@ use serde_json::{Map, Value};
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::text::{
-    anchor, join_route_path, line_anchor, literal, normalize_route_path, split_top_level, text,
-};
+use super::text::{anchor, join_route_path, literal, normalize_route_path, split_top_level, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
 const LARAVEL_ROUTE_FACADE: &str = "Illuminate\\Support\\Facades\\Route";
@@ -72,81 +70,82 @@ pub(super) fn detect_drupal_routing(path: &Path, source: &[u8]) -> Vec<RawFramew
         return Vec::new();
     }
     let body = text(source);
-    let mut facts = Vec::new();
-    let mut current_name = None::<String>;
-    let mut current_path = None::<String>;
-    let mut current_method = None::<String>;
-    let mut current_handler = None::<(String, usize, String)>;
-    let mut offset = 0_usize;
-
-    let flush = |facts: &mut Vec<RawFrameworkFact>,
-                 name: &mut Option<String>,
-                 route_path: &mut Option<String>,
-                 method: &mut Option<String>,
-                 handler: &mut Option<(String, usize, String)>| {
-        let Some(route_name) = name.take() else {
-            return;
-        };
-        let Some(raw_path) = route_path.take() else {
-            handler.take();
-            method.take();
-            return;
-        };
-        let Some((reference, line_start, line)) = handler.take() else {
-            method.take();
-            return;
-        };
-        let operation = method
-            .take()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "ANY".to_owned());
-        facts.push(RawFrameworkFact::Route(RawRouteFact {
-            framework: "drupal".to_owned(),
-            operation: operation.to_ascii_uppercase(),
-            raw_path: raw_path.clone(),
-            normalized_path: normalize_route_path(&raw_path),
-            declaring_scope: route_name,
-            anchor: line_anchor(path, source, line_start, &line),
-            handler_reference: normalize_drupal_handler(&reference),
-            middleware_references: Vec::new(),
-            origin: RawFrameworkOrigin::Config,
-            rule: Some("drupal-routing-yaml".to_owned()),
-            detail: Map::new(),
-        }));
+    let Ok(document) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(body) else {
+        return Vec::new();
     };
-
-    for line in body.split_inclusive('\n') {
-        let trimmed = line.trim();
-        let indentation = line.len().saturating_sub(line.trim_start().len());
-        if indentation == 0 && trimmed.ends_with(':') && !trimmed.starts_with(['#', '-', '{']) {
-            flush(
-                &mut facts,
-                &mut current_name,
-                &mut current_path,
-                &mut current_method,
-                &mut current_handler,
-            );
-            current_name = Some(trimmed.trim_end_matches(':').to_owned());
-        } else if let Some((key, value)) = trimmed.split_once(':') {
-            let value = unquote_yaml(value);
-            match key.trim() {
-                "path" => current_path = Some(value),
-                "_controller" | "_form" | "_entity_form" | "_entity_view" | "_entity_list" => {
-                    current_handler = Some((value, offset, line.to_owned()));
-                }
-                "_method" => current_method = Some(value.replace('|', ",")),
-                _ => {}
-            }
+    let serde_yaml_ng::Value::Mapping(routes) = document else {
+        return Vec::new();
+    };
+    let mut entries = routes
+        .into_iter()
+        .filter_map(|(name, value)| {
+            let route_name = yaml_string(&name)?;
+            let serde_yaml_ng::Value::Mapping(fields) = value else {
+                return None;
+            };
+            let raw_path = fields.get(yaml_key("path")).and_then(yaml_string)?;
+            let defaults = fields
+                .get(yaml_key("defaults"))
+                .and_then(|value| match value {
+                    serde_yaml_ng::Value::Mapping(fields) => Some(fields),
+                    _ => None,
+                })
+                .unwrap_or(&fields);
+            let (handler_key, reference) = [
+                "_controller",
+                "_form",
+                "_entity_form",
+                "_entity_view",
+                "_entity_list",
+            ]
+            .into_iter()
+            .find_map(|key| {
+                defaults
+                    .get(yaml_key(key))
+                    .and_then(yaml_string)
+                    .map(|value| (key, value))
+            })?;
+            let requirements = fields
+                .get(yaml_key("requirements"))
+                .and_then(|value| match value {
+                    serde_yaml_ng::Value::Mapping(fields) => Some(fields),
+                    _ => None,
+                })
+                .unwrap_or(&fields);
+            let methods = requirements
+                .get(yaml_key("_method"))
+                .map(yaml_methods)
+                .filter(|methods| !methods.is_empty())
+                .unwrap_or_else(|| vec!["ANY".to_owned()]);
+            Some((route_name, raw_path, handler_key, reference, methods))
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut facts = Vec::new();
+    for (route_name, raw_path, handler_key, reference, operations) in entries {
+        let needle = format!("{handler_key}: {reference}");
+        let start = body
+            .find(&needle)
+            .unwrap_or_else(|| body.find(&reference).unwrap_or(0));
+        let end = start.saturating_add(needle.len().min(source.len().saturating_sub(start)));
+        let anchor = anchor(path, source, start, end);
+        let handler_reference = normalize_drupal_handler(&reference);
+        for operation in operations {
+            facts.push(RawFrameworkFact::Route(RawRouteFact {
+                framework: "drupal".to_owned(),
+                operation,
+                raw_path: raw_path.clone(),
+                normalized_path: normalize_route_path(&raw_path),
+                declaring_scope: route_name.clone(),
+                anchor: anchor.clone(),
+                handler_reference: handler_reference.clone(),
+                middleware_references: Vec::new(),
+                origin: RawFrameworkOrigin::Config,
+                rule: Some("drupal-routing-yaml".to_owned()),
+                detail: Map::new(),
+            }));
         }
-        offset = offset.saturating_add(line.len());
     }
-    flush(
-        &mut facts,
-        &mut current_name,
-        &mut current_path,
-        &mut current_method,
-        &mut current_handler,
-    );
     facts
 }
 
@@ -165,7 +164,7 @@ fn detect_laravel(path: &Path, source: &[u8], calls: &[LaravelCall]) -> Vec<RawF
             .map(|(prefix, _, _)| prefix.as_str())
             .unwrap_or_default();
         let call_anchor = anchor(path, source, call.start, call.end);
-        if method == "resource" {
+        if matches!(method, "resource" | "apiresource") {
             let Some(resource) = call.arguments.first().and_then(|value| literal(value)) else {
                 continue;
             };
@@ -176,7 +175,14 @@ fn detect_laravel(path: &Path, source: &[u8], calls: &[LaravelCall]) -> Vec<RawF
             else {
                 continue;
             };
-            facts.extend(resource_routes(&resource, prefix, &controller, call_anchor));
+            let actions = resource_actions(source, call, method == "apiresource");
+            facts.extend(resource_routes(
+                &resource,
+                prefix,
+                &controller,
+                &actions,
+                call_anchor,
+            ));
             continue;
         }
         let (operations, path_index, handler_index) = if method == "match" {
@@ -413,6 +419,7 @@ fn resource_routes(
     resource: &str,
     prefix: &str,
     controller: &str,
+    actions: &BTreeSet<String>,
     call_anchor: super::RawFrameworkAnchor,
 ) -> Vec<RawFrameworkFact> {
     let base = join_route_path(prefix, resource);
@@ -421,7 +428,8 @@ fn resource_routes(
         .rsplit('/')
         .next()
         .unwrap_or("resource")
-        .trim_end_matches('s');
+        .to_owned();
+    let parameter = singular_resource_name(&parameter);
     [
         ("GET", base.clone(), "index"),
         ("GET", format!("{base}/create"), "create"),
@@ -433,6 +441,7 @@ fn resource_routes(
         ("DELETE", format!("{base}/{{{parameter}}}"), "destroy"),
     ]
     .into_iter()
+    .filter(|(_, _, action)| actions.contains(*action))
     .map(|(operation, route_path, action)| {
         RawFrameworkFact::Route(RawRouteFact {
             framework: "laravel".to_owned(),
@@ -454,26 +463,105 @@ fn resource_routes(
     .collect()
 }
 
+fn singular_resource_name(value: &str) -> String {
+    let lower = value.to_ascii_lowercase();
+    if lower.ends_with("ies") && value.len() > 3 {
+        return format!("{}y", &value[..value.len().saturating_sub(3)]);
+    }
+    if ["sses", "shes", "ches", "xes", "zes"]
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+        && value.len() > 2
+    {
+        return value[..value.len().saturating_sub(2)].to_owned();
+    }
+    if lower.ends_with('s') && !lower.ends_with("ss") && value.len() > 1 {
+        return value[..value.len().saturating_sub(1)].to_owned();
+    }
+    value.to_owned()
+}
+
+fn resource_actions(source: &[u8], call: &LaravelCall, api_resource: bool) -> BTreeSet<String> {
+    let mut actions = [
+        "index", "create", "store", "show", "edit", "update", "destroy",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<BTreeSet<_>>();
+    if api_resource {
+        actions.remove("create");
+        actions.remove("edit");
+    }
+    let suffix = source
+        .get(call.end..)
+        .and_then(|value| std::str::from_utf8(value).ok())
+        .unwrap_or_default();
+    let Ok(modifier) = Regex::new(r"(?s)^\s*->\s*(only|except)\s*\(([^)]*)\)") else {
+        return actions;
+    };
+    let Some(capture) = modifier.captures(suffix) else {
+        return actions;
+    };
+    let selected = capture
+        .get(2)
+        .map(|value| array_literals(value.as_str()))
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if capture.get(1).is_some_and(|value| value.as_str() == "only") {
+        actions.retain(|action| selected.contains(action));
+    } else {
+        actions.retain(|action| !selected.contains(action));
+    }
+    actions
+}
+
 fn detect_drupal_hooks(path: &Path, source: &[u8], body: &str) -> Vec<RawFrameworkFact> {
-    let Ok(function) = Regex::new(r"(?i)\bfunction\s+(hook_[A-Za-z0-9_]+)\s*\(") else {
+    let module = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default();
+    let Ok(documented) = Regex::new(
+        r"(?is)/\*\*.*?Implements\s+hook_([A-Za-z0-9_]+)\s*\(\s*\)\s*\..*?\*/\s*function\s+([A-Za-z0-9_]+)\s*\(",
+    ) else {
         return Vec::new();
     };
-    function
+    let Ok(placeholder) = Regex::new(r"(?i)\bfunction\s+(hook_[A-Za-z0-9_]+)\s*\(") else {
+        return Vec::new();
+    };
+    let mut hooks = documented
         .captures_iter(body)
         .filter_map(|capture| {
-            let name = capture.get(1)?;
+            let hook = capture.get(1)?.as_str();
+            let function = capture.get(2)?;
+            (function.as_str() == format!("{module}_{hook}"))
+                .then(|| (function.start(), function.end(), hook.to_owned()))
+        })
+        .collect::<Vec<_>>();
+    hooks.extend(placeholder.captures_iter(body).filter_map(|capture| {
+        let function = capture.get(1)?;
+        let hook = function.as_str().get("hook_".len()..)?.to_owned();
+        Some((function.start(), function.end(), hook))
+    }));
+    let mut seen = BTreeSet::new();
+    hooks.sort();
+    hooks
+        .into_iter()
+        .filter(|(start, end, _)| seen.insert((*start, *end)))
+        .filter_map(|(start, end, hook)| {
+            let name = body.get(start..end)?;
             Some(RawFrameworkFact::Route(RawRouteFact {
                 framework: "drupal".to_owned(),
                 operation: "HOOK".to_owned(),
-                raw_path: format!("hook://{}", name.as_str()),
-                normalized_path: format!("/__hook/{}", name.as_str()),
+                raw_path: format!("hook://hook_{hook}"),
+                normalized_path: format!("/__hook/hook_{hook}"),
                 declaring_scope: path.to_string_lossy().replace('\\', "/"),
-                anchor: anchor(path, source, name.start(), name.end()),
-                handler_reference: name.as_str().to_owned(),
+                anchor: anchor(path, source, start, end),
+                handler_reference: name.to_owned(),
                 middleware_references: Vec::new(),
                 origin: RawFrameworkOrigin::Ast,
                 rule: Some("drupal-hook-implementation".to_owned()),
-                detail: Map::new(),
+                detail: Map::from_iter([("hook".into(), Value::String(hook))]),
             }))
         })
         .collect()
@@ -555,6 +643,37 @@ fn normalize_drupal_handler(value: &str) -> String {
         .replace("::", ".")
 }
 
-fn unquote_yaml(value: &str) -> String {
-    value.trim().trim_matches(['\'', '"']).trim().to_owned()
+fn drupal_methods(value: &str) -> Vec<String> {
+    let mut methods = value
+        .split(['|', ','])
+        .map(str::trim)
+        .filter(|method| !method.is_empty())
+        .map(str::to_ascii_uppercase)
+        .collect::<Vec<_>>();
+    methods.sort();
+    methods.dedup();
+    methods
+}
+
+fn yaml_key(value: &str) -> serde_yaml_ng::Value {
+    serde_yaml_ng::Value::String(value.to_owned())
+}
+
+fn yaml_string(value: &serde_yaml_ng::Value) -> Option<String> {
+    match value {
+        serde_yaml_ng::Value::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn yaml_methods(value: &serde_yaml_ng::Value) -> Vec<String> {
+    match value {
+        serde_yaml_ng::Value::String(value) => drupal_methods(value),
+        serde_yaml_ng::Value::Sequence(values) => values
+            .iter()
+            .filter_map(yaml_string)
+            .flat_map(|value| drupal_methods(&value))
+            .collect(),
+        _ => Vec::new(),
+    }
 }

--- a/crates/compass-languages/src/frameworks/python.rs
+++ b/crates/compass-languages/src/frameworks/python.rs
@@ -6,7 +6,9 @@ use serde_json::{Map, Value};
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::{RawFrameworkAnchor, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
+use super::{
+    RawDomainFact, RawFrameworkAnchor, RawFrameworkFact, RawFrameworkOrigin, RawRouteFact,
+};
 
 #[derive(Clone, Debug)]
 struct Receiver {
@@ -18,6 +20,7 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
     let text = std::str::from_utf8(source).unwrap_or_default();
     let aliases = import_aliases(root, source);
     let receivers = receiver_declarations(root, source, &aliases);
+    let mounts = receiver_mounts(root, source, &receivers);
     let django_import = aliases.values().any(|target| {
         target.starts_with("django.urls.") || target.starts_with("django.conf.urls.")
     });
@@ -46,11 +49,16 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
             "fastapi application receiver",
         );
     let mut facts = Vec::new();
+    facts.extend(receiver_mount_facts(
+        root, source, path, &receivers, &aliases,
+    ));
     if evidence.activates("django") {
         collect_django_routes(root, source, path, &aliases, &mut facts);
     }
     if evidence.activates("flask") || evidence.activates("fastapi") {
-        collect_decorated_routes(root, source, path, &receivers, &aliases, &mut facts);
+        collect_decorated_routes(
+            root, source, path, &receivers, &mounts, &aliases, &mut facts,
+        );
     }
     facts
 }
@@ -70,8 +78,11 @@ fn collect_django_routes(
         let terminal = function.rsplit('.').next().unwrap_or(function);
         if matches!(terminal, "path" | "re_path" | "url")
             && let Some(arguments) = call_arguments(node, source)
-            && let Some(raw_path) = arguments.first().and_then(|value| string_literal(value))
-            && let Some(handler) = arguments.get(1)
+            && let Some(raw_path) = positional_argument(&arguments, 0)
+                .and_then(string_literal)
+                .or_else(|| keyword_string(&arguments, "route"))
+            && let Some(handler) =
+                positional_argument(&arguments, 1).or_else(|| keyword_value(&arguments, "view"))
         {
             let mut detail = Map::new();
             detail.insert("django_function".into(), Value::String(terminal.to_owned()));
@@ -121,6 +132,7 @@ fn collect_decorated_routes(
     source: &[u8],
     path: &Path,
     receivers: &HashMap<String, Receiver>,
+    mounts: &HashMap<String, Vec<String>>,
     aliases: &HashMap<String, String>,
     facts: &mut Vec<RawFrameworkFact>,
 ) {
@@ -145,14 +157,25 @@ fn collect_decorated_routes(
             let Some(receiver) = receivers.get(receiver_name) else {
                 continue;
             };
-            let Some(raw_path) = arguments.first().and_then(|value| string_literal(value)) else {
+            let path_keyword = if receiver.framework == "flask" {
+                "rule"
+            } else {
+                "path"
+            };
+            let Some(raw_path) = positional_argument(&arguments, 0)
+                .and_then(string_literal)
+                .or_else(|| keyword_string(&arguments, path_keyword))
+            else {
                 continue;
             };
             let operations = operations(receiver.framework, method, &arguments);
             if operations.is_empty() {
                 continue;
             }
-            let normalized_path = join_route_paths(&receiver.prefix, &raw_path);
+            let mount_prefixes = mounts
+                .get(receiver_name)
+                .cloned()
+                .unwrap_or_else(|| vec![String::new()]);
             let middleware_references = if receiver.framework == "fastapi" {
                 fastapi_dependencies(&arguments)
                     .into_iter()
@@ -161,29 +184,152 @@ fn collect_decorated_routes(
             } else {
                 Vec::new()
             };
-            for operation in operations {
-                facts.push(RawFrameworkFact::Route(RawRouteFact {
-                    framework: receiver.framework.to_owned(),
-                    operation,
-                    raw_path: raw_path.clone(),
-                    normalized_path: normalized_path.clone(),
-                    declaring_scope: module_scope(path),
-                    anchor: anchor(path, decorator),
-                    handler_reference: name.clone(),
-                    middleware_references: middleware_references.clone(),
-                    origin: RawFrameworkOrigin::Ast,
-                    rule: None,
-                    detail: Map::from_iter([(
-                        "receiver".into(),
-                        Value::String(receiver_name.to_owned()),
-                    )]),
-                }));
+            for mount_prefix in mount_prefixes {
+                let composed_prefix = join_route_paths(&mount_prefix, &receiver.prefix);
+                let normalized_path = join_route_paths(&composed_prefix, &raw_path);
+                for operation in &operations {
+                    facts.push(RawFrameworkFact::Route(RawRouteFact {
+                        framework: receiver.framework.to_owned(),
+                        operation: operation.clone(),
+                        raw_path: raw_path.clone(),
+                        normalized_path: normalized_path.clone(),
+                        declaring_scope: module_scope(path),
+                        anchor: anchor(path, decorator),
+                        handler_reference: name.clone(),
+                        middleware_references: middleware_references.clone(),
+                        origin: RawFrameworkOrigin::Ast,
+                        rule: (!mount_prefix.is_empty())
+                            .then(|| "python-mounted-router".to_owned()),
+                        detail: Map::from_iter([
+                            ("receiver".into(), Value::String(receiver_name.to_owned())),
+                            ("mount_prefix".into(), Value::String(mount_prefix.clone())),
+                        ]),
+                    }));
+                }
             }
         }
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
-        collect_decorated_routes(child, source, path, receivers, aliases, facts);
+        collect_decorated_routes(child, source, path, receivers, mounts, aliases, facts);
+    }
+}
+
+fn receiver_mounts(
+    root: Node<'_>,
+    source: &[u8],
+    receivers: &HashMap<String, Receiver>,
+) -> HashMap<String, Vec<String>> {
+    let mut mounts = HashMap::<String, Vec<String>>::new();
+    collect_receiver_mounts(root, source, receivers, &mut mounts);
+    for values in mounts.values_mut() {
+        values.sort();
+        values.dedup();
+    }
+    mounts
+}
+
+fn receiver_mount_facts(
+    root: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    receivers: &HashMap<String, Receiver>,
+    aliases: &HashMap<String, String>,
+) -> Vec<RawFrameworkFact> {
+    let mut facts = Vec::new();
+    collect_receiver_mount_facts(root, source, path, receivers, aliases, &mut facts);
+    facts
+}
+
+fn collect_receiver_mount_facts(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    receivers: &HashMap<String, Receiver>,
+    aliases: &HashMap<String, String>,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some(arguments) = call_arguments(node, source)
+    {
+        let function_text = node_text(function, source);
+        let method = function_text.rsplit('.').next().unwrap_or(function_text);
+        let prefix_key = match method {
+            "include_router" => Some("prefix"),
+            "register_blueprint" => Some("url_prefix"),
+            _ => None,
+        };
+        if let Some(prefix_key) = prefix_key
+            && let Some(parent) = function_text.rsplit_once('.').map(|(parent, _)| parent)
+            && let Some(parent_receiver) = receivers.get(parent)
+            && let Some(target) = positional_argument(&arguments, 0)
+            && is_identifier(target.trim())
+            && let Some(prefix) = keyword_string(&arguments, prefix_key)
+        {
+            let expanded = expand_alias(target.trim(), aliases);
+            let target_module = expanded
+                .rsplit_once('.')
+                .map(|(module, _)| module.to_owned())
+                .unwrap_or_default();
+            facts.push(RawFrameworkFact::Domain(RawDomainFact {
+                framework: parent_receiver.framework.to_owned(),
+                kind: "router_mount".to_owned(),
+                name: target.trim().to_owned(),
+                declaring_scope: module_scope(path),
+                anchor: anchor(path, node),
+                origin: RawFrameworkOrigin::Ast,
+                detail: Map::from_iter([
+                    (
+                        "target_receiver".into(),
+                        Value::String(target.trim().to_owned()),
+                    ),
+                    ("target_module".into(), Value::String(target_module)),
+                    ("mount_prefix".into(), Value::String(prefix)),
+                    ("parent_receiver".into(), Value::String(parent.to_owned())),
+                ]),
+            }));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_receiver_mount_facts(child, source, path, receivers, aliases, facts);
+    }
+}
+
+fn collect_receiver_mounts(
+    node: Node<'_>,
+    source: &[u8],
+    receivers: &HashMap<String, Receiver>,
+    mounts: &mut HashMap<String, Vec<String>>,
+) {
+    if node.kind() == "call"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some(arguments) = call_arguments(node, source)
+    {
+        let function = node_text(function, source);
+        let method = function.rsplit('.').next().unwrap_or(function);
+        let prefix_key = match method {
+            "include_router" => Some("prefix"),
+            "register_blueprint" => Some("url_prefix"),
+            _ => None,
+        };
+        if let Some(prefix_key) = prefix_key
+            && let Some(parent) = function.rsplit_once('.').map(|(parent, _)| parent)
+            && receivers.contains_key(parent)
+            && let Some(target) = positional_argument(&arguments, 0)
+            && is_identifier(target.trim())
+            && let Some(prefix) = keyword_string(&arguments, prefix_key)
+        {
+            mounts
+                .entry(target.trim().to_owned())
+                .or_default()
+                .push(prefix);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_receiver_mounts(child, source, receivers, mounts);
     }
 }
 
@@ -470,9 +616,43 @@ fn string_literal(value: &str) -> Option<String> {
 
 fn keyword_value<'a>(arguments: &'a [String], key: &str) -> Option<&'a str> {
     arguments.iter().find_map(|argument| {
-        let (name, value) = argument.split_once('=')?;
+        let (name, value) = split_keyword_argument(argument)?;
         (name.trim() == key).then(|| value.trim())
     })
+}
+
+fn positional_argument(arguments: &[String], index: usize) -> Option<&str> {
+    arguments
+        .iter()
+        .filter(|argument| split_keyword_argument(argument).is_none())
+        .nth(index)
+        .map(String::as_str)
+}
+
+fn split_keyword_argument(argument: &str) -> Option<(&str, &str)> {
+    let mut depth = 0_u32;
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in argument.char_indices() {
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' | '[' | '{' => depth = depth.saturating_add(1),
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            '=' if depth == 0 => return Some((&argument[..index], &argument[index + 1..])),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn keyword_string(arguments: &[String], key: &str) -> Option<String> {

--- a/crates/compass-languages/src/frameworks/ruby.rs
+++ b/crates/compass-languages/src/frameworks/ruby.rs
@@ -34,8 +34,40 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
 
     let mut facts = Vec::new();
     let mut prefixes = Vec::<String>::new();
+    let mut namespaces = Vec::<String>::new();
+    let mut scope_frames = Vec::<usize>::new();
+    let mut in_draw = false;
+    let mut block_depth = 0_usize;
     let mut offset = 0_usize;
     for line in body.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if !in_draw {
+            if line.contains(".routes.draw do") {
+                in_draw = true;
+                block_depth = 1;
+            }
+            offset = offset.saturating_add(line.len());
+            continue;
+        }
+        if trimmed == "end" {
+            if scope_frames
+                .last()
+                .is_some_and(|depth| *depth == block_depth)
+            {
+                scope_frames.pop();
+                prefixes.pop();
+                namespaces.pop();
+            }
+            if block_depth == 1 {
+                in_draw = false;
+                block_depth = 0;
+                offset = offset.saturating_add(line.len());
+                continue;
+            }
+            block_depth = block_depth.saturating_sub(1);
+            offset = offset.saturating_add(line.len());
+            continue;
+        }
         if let Some(capture) = scope.captures(line) {
             let prefix = capture
                 .get(1)
@@ -43,12 +75,15 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
                 .or_else(|| capture.get(2).map(|value| value.as_str().to_owned()));
             if let Some(prefix) = prefix {
                 prefixes.push(prefix);
+                namespaces.push(
+                    capture
+                        .get(2)
+                        .map(|value| camelize(value.as_str()))
+                        .unwrap_or_default(),
+                );
+                scope_frames.push(block_depth.saturating_add(1));
             }
-            offset = offset.saturating_add(line.len());
-            continue;
-        }
-        if line.trim() == "end" && !prefixes.is_empty() {
-            prefixes.pop();
+            block_depth = block_depth.saturating_add(1);
             offset = offset.saturating_add(line.len());
             continue;
         }
@@ -56,7 +91,7 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
             offset = offset.saturating_add(line.len());
             continue;
         };
-        let handler = rails_handler(&handler);
+        let handler = rails_handler(&handler, &namespaces);
         let prefix = prefixes.join("/");
         let normalized_path = if prefix.is_empty() {
             normalize_route_path(&raw_path)
@@ -85,6 +120,8 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
                 detail: Map::new(),
             }));
         }
+        let do_count = line.matches(" do").count();
+        block_depth = block_depth.saturating_add(do_count);
         offset = offset.saturating_add(line.len());
     }
     facts
@@ -143,13 +180,22 @@ fn rails_via(suffix: &str) -> Vec<String> {
         .collect()
 }
 
-fn rails_handler(value: &str) -> String {
+fn rails_handler(value: &str, namespaces: &[String]) -> String {
     let Some((controller, action)) = value.split_once('#') else {
         return value.to_owned();
     };
-    let mut namespaces = controller.split('/').collect::<Vec<_>>();
-    let controller = namespaces.pop().unwrap_or(controller);
-    namespaces
+    let mut controller_parts = controller.split('/').collect::<Vec<_>>();
+    let controller = controller_parts.pop().unwrap_or(controller);
+    let owners = if controller_parts.is_empty() {
+        namespaces
+            .iter()
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>()
+    } else {
+        controller_parts
+    };
+    owners
         .into_iter()
         .map(camelize)
         .chain(std::iter::once(format!(

--- a/crates/compass-languages/src/frameworks/rust.rs
+++ b/crates/compass-languages/src/frameworks/rust.rs
@@ -5,10 +5,10 @@ use serde_json::Map;
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::text::{line_anchor, normalize_route_path, text};
+use super::text::{anchor, join_route_path, literal, normalize_route_path, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
-pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFrameworkFact> {
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
     let body = text(source);
     let evidence = EvidenceSet::new()
         .direct_if(
@@ -41,13 +41,8 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     if !axum && !actix && !rocket {
         return Vec::new();
     }
-    let Ok(route) = Regex::new(
-        r#"\.route\(\s*["']([^"']+)["']\s*,\s*(?:(?:web::)?(get|post|put|patch|delete|head)\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\)|web::(get|post|put|patch|delete|head)\s*\(\s*\)\s*\.to\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\))"#,
-    ) else {
-        return Vec::new();
-    };
     let Ok(attribute) = Regex::new(
-        r#"^\s*#\[(?:(?:rocket|actix_web)::)?(get|post|put|patch|delete|head)\(\s*["']([^"']+)["'][^\]]*\)\]"#,
+        r#"(?s)#\[(?:(rocket|actix_web)::)?(get|post|put|patch|delete|head)\(\s*["']([^"']+)["'][^\]]*\)\]"#,
     ) else {
         return Vec::new();
     };
@@ -63,61 +58,334 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
         "rocket"
     };
     let mut facts = Vec::new();
-    for capture in route.captures_iter(body) {
+    collect_rust_calls(root, source, path, framework, "", &mut facts);
+    let masked_body = masked_rust_source(root, source);
+
+    let functions = function
+        .captures_iter(&masked_body)
+        .filter_map(|capture| {
+            let whole = capture.get(0)?;
+            let handler = capture.get(1)?;
+            Some((whole.start(), handler.as_str().to_owned()))
+        })
+        .collect::<Vec<_>>();
+    for capture in attribute.captures_iter(&masked_body) {
         let Some(whole) = capture.get(0) else {
             continue;
         };
-        let operation = capture.get(2).or_else(|| capture.get(4));
-        let handler = capture.get(3).or_else(|| capture.get(5));
-        let (Some(raw_path), Some(operation), Some(handler)) = (capture.get(1), operation, handler)
-        else {
+        let (Some(operation), Some(raw_path)) = (capture.get(2), capture.get(3)) else {
             continue;
         };
-        facts.push(route_fact(
-            path,
-            source,
-            framework,
-            operation.as_str(),
-            raw_path.as_str(),
-            handler.as_str(),
-            whole.start(),
-            whole.end(),
-            "rust-router-call",
-        ));
-    }
-
-    let mut pending = None;
-    let mut offset = 0_usize;
-    for line in body.split_inclusive('\n') {
-        if let Some(capture) = attribute.captures(line)
-            && let (Some(operation), Some(raw_path)) = (capture.get(1), capture.get(2))
-        {
-            pending = Some((
-                operation.as_str().to_owned(),
-                raw_path.as_str().to_owned(),
-                offset,
-                line.to_owned(),
-            ));
-        } else if let Some((operation, raw_path, anchor_offset, anchor_line)) = pending.take()
-            && let Some(handler) = function.captures(line).and_then(|capture| capture.get(1))
-        {
-            facts.push(RawFrameworkFact::Route(RawRouteFact {
-                framework: if actix { "actix" } else { "rocket" }.to_owned(),
-                operation: operation.to_ascii_uppercase(),
-                raw_path: raw_path.clone(),
-                normalized_path: normalize_route_path(&raw_path),
-                declaring_scope: path.to_string_lossy().into_owned(),
-                anchor: line_anchor(path, source, anchor_offset, &anchor_line),
-                handler_reference: handler.as_str().to_owned(),
-                middleware_references: Vec::new(),
-                origin: RawFrameworkOrigin::Ast,
-                rule: Some("rust-route-attribute".to_owned()),
-                detail: Map::new(),
-            }));
-        }
-        offset = offset.saturating_add(line.len());
+        let Some((_, handler)) = functions.iter().find(|(start, _)| *start >= whole.end()) else {
+            continue;
+        };
+        let framework = match capture.get(1).map(|value| value.as_str()) {
+            Some("rocket") => "rocket",
+            Some("actix_web") => "actix",
+            _ if actix => "actix",
+            _ => "rocket",
+        };
+        facts.push(RawFrameworkFact::Route(RawRouteFact {
+            framework: framework.to_owned(),
+            operation: operation.as_str().to_ascii_uppercase(),
+            raw_path: raw_path.as_str().to_owned(),
+            normalized_path: normalize_route_path(raw_path.as_str()),
+            declaring_scope: path.to_string_lossy().into_owned(),
+            anchor: anchor(path, source, whole.start(), whole.end()),
+            handler_reference: handler.clone(),
+            middleware_references: Vec::new(),
+            origin: RawFrameworkOrigin::Ast,
+            rule: Some("rust-route-attribute".to_owned()),
+            detail: Map::new(),
+        }));
     }
     facts
+}
+
+fn masked_rust_source(root: Node<'_>, source: &[u8]) -> String {
+    let mut masked = source.to_vec();
+    mask_rust_comments(root, &mut masked);
+    String::from_utf8(masked).unwrap_or_default()
+}
+
+fn mask_rust_comments(node: Node<'_>, source: &mut [u8]) {
+    if matches!(node.kind(), "line_comment" | "block_comment") {
+        let start = node.start_byte().min(source.len());
+        let end = node.end_byte().min(source.len());
+        for byte in &mut source[start..end] {
+            if !matches!(*byte, b'\n' | b'\r') {
+                *byte = b' ';
+            }
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        mask_rust_comments(child, source);
+    }
+}
+
+fn collect_rust_calls(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    default_framework: &str,
+    prefix: &str,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+    {
+        let method = rust_call_method(function, source);
+        let arguments = node.child_by_field_name("arguments");
+        let argument_values = arguments
+            .map(|arguments| named_children(arguments))
+            .unwrap_or_default();
+        let receiver_prefix = function
+            .child_by_field_name("value")
+            .map(|value| rust_chain_prefix(value, source))
+            .unwrap_or_default();
+        let mut child_prefix = append_prefix(prefix, &receiver_prefix);
+        if matches!(method.as_deref(), Some("nest" | "scope"))
+            && let Some(route_prefix) = argument_values
+                .first()
+                .and_then(|argument| literal(node_text(*argument, source)))
+        {
+            child_prefix = join_route_path(prefix, &route_prefix);
+        }
+        if method.as_deref() == Some("route") {
+            let (raw_path, method_expression) = if argument_values
+                .first()
+                .and_then(|argument| literal(node_text(*argument, source)))
+                .is_some()
+            {
+                (
+                    argument_values
+                        .first()
+                        .and_then(|argument| literal(node_text(*argument, source))),
+                    argument_values.get(1).copied(),
+                )
+            } else {
+                (
+                    function
+                        .child_by_field_name("value")
+                        .and_then(|value| rust_resource_path(value, source)),
+                    argument_values.first().copied(),
+                )
+            };
+            if let (Some(raw_path), Some(method_expression)) = (raw_path, method_expression) {
+                let framework =
+                    route_framework(method_expression, function, source, default_framework);
+                for (operation, handler) in rust_method_handlers(method_expression, source) {
+                    if handler.is_empty() {
+                        continue;
+                    }
+                    let mut fact = route_fact(
+                        path,
+                        source,
+                        framework,
+                        &operation,
+                        &raw_path,
+                        &handler,
+                        node.start_byte(),
+                        node.end_byte(),
+                        "rust-router-call",
+                    );
+                    if !child_prefix.is_empty()
+                        && let RawFrameworkFact::Route(route) = &mut fact
+                    {
+                        route.normalized_path =
+                            join_route_path(&child_prefix, &route.normalized_path);
+                    }
+                    facts.push(fact);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        let function_id = function.id();
+        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+            let next_prefix = if function_id == child.id() {
+                prefix
+            } else {
+                &child_prefix
+            };
+            collect_rust_calls(child, source, path, default_framework, next_prefix, facts);
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_rust_calls(child, source, path, default_framework, prefix, facts);
+    }
+}
+
+fn rust_call_method(function: Node<'_>, source: &[u8]) -> Option<String> {
+    if function.kind() == "field_expression" {
+        return function
+            .child_by_field_name("field")
+            .map(|field| node_text(field, source).to_owned());
+    }
+    if matches!(function.kind(), "scoped_identifier" | "identifier") {
+        return Some(
+            node_text(function, source)
+                .rsplit("::")
+                .next()
+                .unwrap_or_default()
+                .to_owned(),
+        );
+    }
+    None
+}
+
+fn append_prefix(base: &str, suffix: &str) -> String {
+    if suffix.is_empty() {
+        return base.to_owned();
+    }
+    if base.is_empty() || base == suffix {
+        return suffix.to_owned();
+    }
+    let suffix = suffix.trim_matches('/');
+    if base.ends_with(&format!("/{suffix}")) {
+        base.to_owned()
+    } else {
+        join_route_path(base, suffix)
+    }
+}
+
+fn rust_chain_prefix(node: Node<'_>, source: &[u8]) -> String {
+    if node.kind() != "call_expression" {
+        return node
+            .child_by_field_name("value")
+            .map(|value| rust_chain_prefix(value, source))
+            .unwrap_or_default();
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return String::new();
+    };
+    let base = function
+        .child_by_field_name("value")
+        .map(|value| rust_chain_prefix(value, source))
+        .unwrap_or_default();
+    let Some(method) = rust_call_method(function, source) else {
+        return base;
+    };
+    if matches!(method.as_str(), "nest" | "scope")
+        && let Some(prefix) = node
+            .child_by_field_name("arguments")
+            .and_then(|arguments| named_children(arguments).first().copied())
+            .and_then(|argument| literal(node_text(argument, source)))
+    {
+        return append_prefix(&base, &prefix);
+    }
+    base
+}
+
+fn rust_resource_path(node: Node<'_>, source: &[u8]) -> Option<String> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+    let function = node.child_by_field_name("function")?;
+    if rust_call_method(function, source).as_deref() != Some("resource") {
+        return function
+            .child_by_field_name("value")
+            .and_then(|value| rust_resource_path(value, source));
+    }
+    node.child_by_field_name("arguments")
+        .and_then(|arguments| named_children(arguments).first().copied())
+        .and_then(|argument| literal(node_text(argument, source)))
+}
+
+fn rust_method_handlers(node: Node<'_>, source: &[u8]) -> Vec<(String, String)> {
+    if node.kind() != "call_expression" {
+        return Vec::new();
+    }
+    let Some(function) = node.child_by_field_name("function") else {
+        return Vec::new();
+    };
+    let Some(method) = rust_call_method(function, source) else {
+        return Vec::new();
+    };
+    let arguments = node
+        .child_by_field_name("arguments")
+        .map(|arguments| named_children(arguments))
+        .unwrap_or_default();
+    let value = function.child_by_field_name("value");
+    if is_http_method(&method) {
+        let mut output = value
+            .map(|value| rust_method_handlers(value, source))
+            .unwrap_or_default();
+        let handler = arguments
+            .first()
+            .map(|argument| clean_rust_handler(node_text(*argument, source)))
+            .unwrap_or_default();
+        output.push((method.to_ascii_uppercase(), handler));
+        return output;
+    }
+    if method == "to" {
+        let handler = arguments
+            .first()
+            .map(|argument| clean_rust_handler(node_text(*argument, source)))
+            .unwrap_or_default();
+        return value
+            .map(|value| {
+                rust_method_handlers(value, source)
+                    .into_iter()
+                    .map(|(operation, _)| (operation, handler.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+    }
+    if matches!(function.kind(), "scoped_identifier" | "identifier") && is_http_method(&method) {
+        let handler = arguments
+            .first()
+            .map(|argument| clean_rust_handler(node_text(*argument, source)))
+            .unwrap_or_default();
+        return vec![(method.to_ascii_uppercase(), handler)];
+    }
+    Vec::new()
+}
+
+fn is_http_method(method: &str) -> bool {
+    matches!(
+        method.to_ascii_lowercase().as_str(),
+        "get" | "post" | "put" | "patch" | "delete" | "head" | "options" | "trace" | "connect"
+    )
+}
+
+fn clean_rust_handler(value: &str) -> String {
+    value.trim().trim_start_matches('&').replace("::", ".")
+}
+
+fn route_framework<'framework>(
+    method_expression: Node<'_>,
+    function: Node<'_>,
+    source: &[u8],
+    default_framework: &'framework str,
+) -> &'framework str {
+    let method_text = node_text(method_expression, source);
+    let function_text = node_text(function, source);
+    if method_text.contains("web::")
+        || function_text.contains("web::")
+        || function_text.contains("App")
+        || function_text.contains("scope")
+        || function_text.contains("resource")
+    {
+        "actix"
+    } else {
+        default_framework
+    }
+}
+
+fn named_children(node: Node<'_>) -> Vec<Node<'_>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).collect()
+}
+
+fn node_text<'source>(node: Node<'_>, source: &'source [u8]) -> &'source str {
+    std::str::from_utf8(
+        &source[node.start_byte().min(source.len())..node.end_byte().min(source.len())],
+    )
+    .unwrap_or_default()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/compass-languages/src/frameworks/swift.rs
+++ b/crates/compass-languages/src/frameworks/swift.rs
@@ -1,15 +1,16 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use regex::Regex;
-use serde_json::Map;
+use serde_json::{Map, Value};
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::text::{join_route_path, line_anchor, text};
+use super::text::{anchor, join_route_path, literal, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
-pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFrameworkFact> {
+const HTTP_METHODS: &[&str] = &["get", "post", "put", "patch", "delete", "options", "head"];
+
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
     let body = text(source);
     let evidence = EvidenceSet::new().direct_if(
         body.contains("import Vapor"),
@@ -20,115 +21,267 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     if !evidence.activates("vapor") {
         return Vec::new();
     }
-    let Ok(group) =
-        Regex::new(r#"^\s*let\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.grouped\(\s*([^)]+)\)"#)
-    else {
-        return Vec::new();
-    };
-    let Ok(route) =
-        Regex::new(r#"^\s*([A-Za-z_]\w*)\.(get|post|put|patch|delete|options|head)\(\s*(.+)\)"#)
-    else {
-        return Vec::new();
-    };
-    let mut prefixes = HashMap::<String, String>::new();
+    let mut prefixes = HashMap::new();
+    collect_vapor_bindings(root, source, &mut prefixes);
     let mut facts = Vec::new();
-    let mut offset = 0_usize;
-    for line in body.split_inclusive('\n') {
-        if let Some(capture) = group.captures(line)
-            && let (Some(child), Some(parent), Some(segments)) =
-                (capture.get(1), capture.get(2), capture.get(3))
-        {
-            let parent_prefix = prefixes
-                .get(parent.as_str())
-                .map(String::as_str)
-                .unwrap_or_default();
-            if let Some(prefix) = vapor_path(segments.as_str()) {
-                prefixes.insert(
-                    child.as_str().to_owned(),
-                    join_route_path(parent_prefix, &prefix),
-                );
-            }
-        }
-        let Some(capture) = route.captures(line) else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        let (Some(receiver), Some(operation), Some(arguments)) =
-            (capture.get(1), capture.get(2), capture.get(3))
-        else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        let (path_arguments, handler, opaque_handler) =
-            if let Some((path_arguments, handler)) = arguments.as_str().rsplit_once("use:") {
-                (
-                    path_arguments,
-                    handler.trim().trim_end_matches(',').trim(),
-                    false,
-                )
-            } else if line.contains(") {") {
-                (arguments.as_str(), "", true)
-            } else {
-                offset = offset.saturating_add(line.len());
-                continue;
-            };
-        let Some(raw_path) = vapor_path(path_arguments.trim().trim_end_matches(',')) else {
-            offset = offset.saturating_add(line.len());
-            continue;
-        };
-        if !opaque_handler && (handler.is_empty() || handler.starts_with('{')) {
-            offset = offset.saturating_add(line.len());
-            continue;
-        }
-        let prefix = prefixes
-            .get(receiver.as_str())
-            .map(String::as_str)
-            .unwrap_or_default();
-        let anchor = line_anchor(path, source, offset, line);
-        facts.push(RawFrameworkFact::Route(RawRouteFact {
-            framework: "vapor".to_owned(),
-            operation: operation.as_str().to_ascii_uppercase(),
-            raw_path: raw_path.clone(),
-            normalized_path: join_route_path(prefix, &raw_path),
-            declaring_scope: receiver.as_str().to_owned(),
-            handler_reference: if opaque_handler {
-                format!("opaque_closure_at_line_{}", anchor.start_line)
-            } else {
-                handler.to_owned()
-            },
-            anchor,
-            middleware_references: Vec::new(),
-            origin: RawFrameworkOrigin::Ast,
-            rule: Some("vapor-route-call".to_owned()),
-            detail: if opaque_handler {
-                Map::from_iter([("opaque_handler".into(), true.into())])
-            } else {
-                Map::new()
-            },
-        }));
-        offset = offset.saturating_add(line.len());
-    }
+    collect_vapor_calls(root, source, path, &prefixes, &mut facts);
     facts
 }
 
-fn vapor_path(arguments: &str) -> Option<String> {
-    let segments = arguments
-        .split(',')
-        .map(str::trim)
-        .map(|segment| {
-            if let Some(literal) = super::text::literal(segment) {
-                Some(literal)
-            } else {
-                segment
-                    .strip_prefix('.')
-                    .filter(|segment| {
-                        segment
-                            .chars()
-                            .all(|character| character.is_ascii_alphanumeric() || character == '_')
-                    })
-                    .map(|segment| format!(":{segment}"))
+fn collect_vapor_bindings(node: Node<'_>, source: &[u8], prefixes: &mut HashMap<String, String>) {
+    if node.kind() == "property_declaration"
+        && let Some(name) = node
+            .child_by_field_name("name")
+            .and_then(|name| name.child_by_field_name("bound_identifier"))
+        && let Some(value) = node.child_by_field_name("value")
+        && value.kind() == "call_expression"
+        && let Some((navigation, arguments, _)) = call_parts(value)
+        && navigation_method(navigation, source).is_some_and(|method| method == "grouped")
+        && let Some(target) = navigation.child_by_field_name("target")
+        && let Some((receiver, parent_prefix)) = vapor_target(target, source, prefixes)
+        && let Some(prefix) = first_argument_literal(arguments, source)
+    {
+        let name = node_text(name, source).to_owned();
+        let _ = receiver;
+        prefixes.insert(name, join_route_path(&parent_prefix, &prefix));
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_vapor_bindings(child, source, prefixes);
+    }
+}
+
+fn collect_vapor_calls(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    prefixes: &HashMap<String, String>,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    let mut skip_children = HashSet::new();
+    if node.kind() == "call_expression"
+        && let Some((navigation, arguments, lambda)) = call_parts(node)
+        && let Some(method) = navigation_method(navigation, source)
+    {
+        if method == "group"
+            && let Some(lambda) = lambda
+            && let Some(prefix) = first_argument_literal(arguments, source)
+            && let Some(target) = navigation.child_by_field_name("target")
+            && let Some((_, parent_prefix)) = vapor_target(target, source, prefixes)
+            && let Some(parameter) = lambda_parameter_name(lambda, source)
+        {
+            let mut local = prefixes.clone();
+            local.insert(parameter, join_route_path(&parent_prefix, &prefix));
+            if let Some(body) = lambda_statements(lambda) {
+                collect_vapor_calls(body, source, path, &local, facts);
             }
+            skip_children.insert(lambda.id());
+        }
+        if (HTTP_METHODS.contains(&method.as_str()) || method == "on")
+            && let Some(target) = navigation.child_by_field_name("target")
+            && let Some((receiver, prefix)) = vapor_target(target, source, prefixes)
+        {
+            collect_vapor_route(
+                node, &method, arguments, lambda, receiver, &prefix, source, path, facts,
+            );
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node
+        .children(&mut cursor)
+        .filter(|child| child.is_named() && !skip_children.contains(&child.id()))
+    {
+        collect_vapor_calls(child, source, path, prefixes, facts);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_vapor_route(
+    node: Node<'_>,
+    method: &str,
+    arguments: Node<'_>,
+    lambda: Option<Node<'_>>,
+    receiver: String,
+    prefix: &str,
+    source: &[u8],
+    path: &Path,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    let values = value_arguments(arguments);
+    let mut start = 0_usize;
+    let operation = if method == "on" {
+        let Some(first) = values
+            .first()
+            .and_then(|value| value.child_by_field_name("value"))
+        else {
+            return;
+        };
+        let operation = node_text(first, source)
+            .trim()
+            .strip_prefix('.')
+            .unwrap_or_else(|| node_text(first, source).trim())
+            .to_ascii_uppercase();
+        start = 1;
+        operation
+    } else {
+        method.to_ascii_uppercase()
+    };
+    let mut path_segments = Vec::new();
+    let mut handler = None;
+    for value in values.iter().skip(start) {
+        if value
+            .child_by_field_name("name")
+            .is_some_and(|name| node_text(name, source).trim() == "use")
+        {
+            handler = value.child_by_field_name("value");
+            continue;
+        }
+        if let Some(value_node) = value.child_by_field_name("value") {
+            if value_node.kind() == "lambda_literal" {
+                handler = Some(value_node);
+            } else if let Some(segment) = vapor_segment(value_node, source) {
+                path_segments.push(segment);
+            }
+        }
+    }
+    let raw_path = if path_segments.is_empty() {
+        "/".to_owned()
+    } else {
+        format!("/{}", path_segments.join("/"))
+    };
+    let opaque_handler = handler.is_none() && lambda.is_some()
+        || handler.is_some_and(|handler| handler.kind() == "lambda_literal");
+    let anchor = anchor(path, source, node.start_byte(), node.end_byte());
+    let handler_reference = if opaque_handler {
+        format!("opaque_closure_at_line_{}", anchor.start_line)
+    } else if let Some(handler) = handler {
+        node_text(handler, source).trim().to_owned()
+    } else {
+        return;
+    };
+    if handler_reference.is_empty() {
+        return;
+    }
+    facts.push(RawFrameworkFact::Route(RawRouteFact {
+        framework: "vapor".to_owned(),
+        operation,
+        raw_path: raw_path.clone(),
+        normalized_path: join_route_path(prefix, &raw_path),
+        declaring_scope: receiver,
+        anchor,
+        handler_reference,
+        middleware_references: Vec::new(),
+        origin: RawFrameworkOrigin::Ast,
+        rule: Some("vapor-route-call".to_owned()),
+        detail: if opaque_handler {
+            Map::from_iter([("opaque_handler".into(), Value::Bool(true))])
+        } else {
+            Map::new()
+        },
+    }));
+}
+
+fn call_parts(node: Node<'_>) -> Option<(Node<'_>, Node<'_>, Option<Node<'_>>)> {
+    let mut cursor = node.walk();
+    let mut named = node.named_children(&mut cursor);
+    let navigation = named.find(|child| child.kind() == "navigation_expression")?;
+    let suffix = named.find(|child| child.kind() == "call_suffix")?;
+    let mut suffix_cursor = suffix.walk();
+    let mut suffix_children = suffix.named_children(&mut suffix_cursor);
+    let arguments = suffix_children.find(|child| child.kind() == "value_arguments")?;
+    let lambda = suffix_children.find(|child| child.kind() == "lambda_literal");
+    Some((navigation, arguments, lambda))
+}
+
+fn navigation_method(navigation: Node<'_>, source: &[u8]) -> Option<String> {
+    navigation
+        .child_by_field_name("suffix")
+        .and_then(|suffix| suffix.child_by_field_name("suffix"))
+        .map(|suffix| node_text(suffix, source).to_owned())
+}
+
+fn vapor_target(
+    target: Node<'_>,
+    source: &[u8],
+    prefixes: &HashMap<String, String>,
+) -> Option<(String, String)> {
+    if target.kind() == "simple_identifier" {
+        let receiver = node_text(target, source).to_owned();
+        return Some((
+            receiver.clone(),
+            prefixes.get(&receiver).cloned().unwrap_or_default(),
+        ));
+    }
+    if target.kind() != "call_expression" {
+        return None;
+    }
+    let (navigation, arguments, _) = call_parts(target)?;
+    let method = navigation_method(navigation, source)?;
+    let base_target = navigation.child_by_field_name("target")?;
+    let (receiver, mut prefix) = vapor_target(base_target, source, prefixes)?;
+    if matches!(method.as_str(), "grouped" | "group")
+        && let Some(segment) = first_argument_literal(arguments, source)
+    {
+        prefix = join_route_path(&prefix, &segment);
+    }
+    Some((receiver, prefix))
+}
+
+fn first_argument_literal(arguments: Node<'_>, source: &[u8]) -> Option<String> {
+    value_arguments(arguments)
+        .first()
+        .and_then(|value| value.child_by_field_name("value"))
+        .and_then(|value| literal(node_text(value, source)))
+}
+
+fn value_arguments(arguments: Node<'_>) -> Vec<Node<'_>> {
+    let mut cursor = arguments.walk();
+    arguments
+        .named_children(&mut cursor)
+        .filter(|child| child.kind() == "value_argument")
+        .collect()
+}
+
+fn vapor_segment(value: Node<'_>, source: &[u8]) -> Option<String> {
+    let value = node_text(value, source).trim();
+    if let Some(value) = literal(value) {
+        return Some(value);
+    }
+    value
+        .strip_prefix('.')
+        .filter(|value| {
+            value
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || character == '_')
         })
-        .collect::<Option<Vec<_>>>()?;
-    (!segments.is_empty()).then(|| format!("/{}", segments.join("/")))
+        .map(|value| format!(":{value}"))
+}
+
+fn lambda_parameter_name(lambda: Node<'_>, source: &[u8]) -> Option<String> {
+    let parameters = lambda.child_by_field_name("type")?;
+    let parameter = find_descendant(parameters, "lambda_parameter")?;
+    parameter
+        .child_by_field_name("name")
+        .map(|name| node_text(name, source).to_owned())
+}
+
+fn lambda_statements(lambda: Node<'_>) -> Option<Node<'_>> {
+    find_descendant(lambda, "statements")
+}
+
+fn find_descendant<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    if node.kind() == kind {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.is_named())
+        .find_map(|child| find_descendant(child, kind))
+}
+
+fn node_text<'source>(node: Node<'_>, source: &'source [u8]) -> &'source str {
+    std::str::from_utf8(
+        &source[node.start_byte().min(source.len())..node.end_byte().min(source.len())],
+    )
+    .unwrap_or_default()
 }

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use regex::Regex;
@@ -24,6 +24,7 @@ pub(super) fn detect(
     if source.is_empty() {
         return Vec::new();
     }
+    let body = std::str::from_utf8(source).unwrap_or_default();
     let mut imports = Vec::new();
     collect_import_aliases(root, source, &mut imports);
     attach_import_aliases(path, source, root, extraction, &imports);
@@ -36,9 +37,14 @@ pub(super) fn detect(
     };
     let mut facts = Vec::new();
     let receivers = express_receivers(root, source);
+    let mounts = express_mounts(root, source, &receivers);
     let evidence = EvidenceSet::new()
         .direct_if(
-            !receivers.is_empty() && imports_module("express"),
+            !receivers.is_empty()
+                && (imports_module("express")
+                    || source_has_express_require(root, source)
+                    || body.contains("require(\"express\")")
+                    || body.contains("require('express')")),
             "express",
             EvidenceKind::Receiver,
             "express application/router",
@@ -62,13 +68,13 @@ pub(super) fn detect(
             "vue-router",
         );
     if evidence.activates("express") {
-        collect_express_routes(root, source, path, &receivers, &mut facts);
+        collect_express_routes(root, source, path, &receivers, &mounts, &mut facts);
     }
     if evidence.activates("nestjs") {
         collect_nest_routes(root, source, path, &mut facts);
     }
     if evidence.activates("react-router") {
-        collect_react_router_routes(root, source, path, &mut facts);
+        collect_react_router_routes(root, source, path, &mut facts, "");
     }
     if evidence.activates("vue-router") {
         collect_vue_router_routes(root, source, path, &mut facts);
@@ -251,12 +257,60 @@ fn parse_import_bindings(source: &str) -> Vec<(String, String)> {
 }
 
 fn express_receivers(root: Node<'_>, source: &[u8]) -> HashSet<String> {
+    let mut constructors = HashSet::new();
+    collect_express_require_aliases(root, source, &mut constructors);
     let mut receivers = HashSet::new();
-    collect_express_receivers(root, source, &mut receivers);
+    collect_express_receivers(root, source, &constructors, &mut receivers);
+    let body = std::str::from_utf8(source).unwrap_or_default();
+    if let Ok(require_alias) = Regex::new(
+        r#"(?m)^\s*(?:const|let|var)\s+([A-Za-z_]\w*)\s*=\s*require\(\s*["']express["']\s*\)\s*;"#,
+    ) {
+        for capture in require_alias.captures_iter(body) {
+            if let Some(alias) = capture.get(1)
+                && let Ok(constructed) = Regex::new(&format!(
+                    r"(?m)^\s*(?:const|let|var)\s+([A-Za-z_]\w*)\s*=\s*{}(?:\.Router)?\(\s*\)\s*;",
+                    regex::escape(alias.as_str())
+                ))
+            {
+                receivers.extend(
+                    constructed
+                        .captures_iter(body)
+                        .filter_map(|capture| capture.get(1).map(|name| name.as_str().to_owned())),
+                );
+            }
+        }
+    }
     receivers
 }
 
-fn collect_express_receivers(node: Node<'_>, source: &[u8], receivers: &mut HashSet<String>) {
+fn collect_express_require_aliases(
+    node: Node<'_>,
+    source: &[u8],
+    constructors: &mut HashSet<String>,
+) {
+    if node.kind() == "variable_declarator"
+        && let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        )
+        && is_identifier(node_text(name, source).trim())
+        && node_text(value, source).trim().starts_with("require(")
+        && node_text(value, source).contains("express")
+    {
+        constructors.insert(node_text(name, source).trim().to_owned());
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_express_require_aliases(child, source, constructors);
+    }
+}
+
+fn collect_express_receivers(
+    node: Node<'_>,
+    source: &[u8],
+    constructors: &HashSet<String>,
+    receivers: &mut HashSet<String>,
+) {
     if node.kind() == "variable_declarator"
         && let (Some(name), Some(value)) = (
             node.child_by_field_name("name"),
@@ -266,17 +320,22 @@ fn collect_express_receivers(node: Node<'_>, source: &[u8], receivers: &mut Hash
         let variable = node_text(name, source).trim();
         let expression = node_text(value, source).trim();
         if is_identifier(variable)
-            && matches!(
+            && (matches!(
                 expression,
                 "express()" | "Router()" | "express.Router()" | "router()"
-            )
+            ) || expression.starts_with("require(\"express\")")
+                || expression.starts_with("require('express')")
+                || constructors.iter().any(|constructor| {
+                    expression == format!("{constructor}()")
+                        || expression == format!("{constructor}.Router()")
+                }))
         {
             receivers.insert(variable.to_owned());
         }
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
-        collect_express_receivers(child, source, receivers);
+        collect_express_receivers(child, source, constructors, receivers);
     }
 }
 
@@ -285,28 +344,73 @@ fn collect_express_routes(
     source: &[u8],
     path: &Path,
     receivers: &HashSet<String>,
+    mounts: &HashMap<String, String>,
     facts: &mut Vec<RawFrameworkFact>,
 ) {
     if node.kind() == "call_expression"
         && let Some(function) = node.child_by_field_name("function")
     {
         let function = node_text(function, source).trim();
-        if let Some((receiver, method)) = function.rsplit_once('.')
-            && receivers.contains(receiver)
-            && HTTP_METHODS.contains(&method)
+        let parsed = function.rsplit_once('.').and_then(|(receiver, method)| {
+            if receivers.contains(receiver) && HTTP_METHODS.contains(&method) {
+                return Some((receiver, method, None));
+            }
+            let pattern = Regex::new(&format!(
+                r#"^([A-Za-z_]\w*)\.route\(\s*["']([^"']+)["']\s*\)\.({})$"#,
+                HTTP_METHODS.join("|")
+            ))
+            .ok()?;
+            let capture = pattern.captures(function)?;
+            let receiver = capture.get(1)?.as_str();
+            receivers.contains(receiver).then_some((
+                receiver,
+                capture.get(3)?.as_str(),
+                capture.get(2).map(|value| value.as_str().to_owned()),
+            ))
+        });
+        if let Some((receiver, method, chained_path)) = parsed
             && let Some(arguments) = node.child_by_field_name("arguments")
         {
             let arguments = split_arguments(node_text(arguments, source));
-            if let Some(raw_path) = arguments
-                .first()
-                .and_then(|argument| string_literal(argument))
-            {
-                let stages = arguments
+            let is_chained = chained_path.is_some();
+            let raw_path = chained_path.or_else(|| {
+                arguments
+                    .first()
+                    .and_then(|argument| string_literal(argument))
+            });
+            if let Some(raw_path) = raw_path {
+                let raw_stages = if is_chained {
+                    arguments.iter().collect::<Vec<_>>()
+                } else {
+                    arguments.iter().skip(1).collect::<Vec<_>>()
+                };
+                let last_stage = raw_stages.last().copied();
+                let inline_handler = last_stage.is_some_and(|argument| {
+                    handler_reference(argument).is_none() && is_inline_handler_expression(argument)
+                });
+                let stages = raw_stages
                     .iter()
-                    .skip(1)
                     .filter_map(|argument| handler_reference(argument))
                     .collect::<Vec<_>>();
-                if let Some((handler, middleware)) = stages.split_last() {
+                let (handler, middleware, mut detail) = if inline_handler {
+                    let handler = format!("opaque_inline_handler_at_{}", node.start_byte());
+                    let middleware = raw_stages
+                        .iter()
+                        .take(raw_stages.len().saturating_sub(1))
+                        .filter_map(|argument| handler_reference(argument))
+                        .collect::<Vec<_>>();
+                    (
+                        handler,
+                        middleware,
+                        Map::from_iter([("opaque_handler".into(), Value::Bool(true))]),
+                    )
+                } else if let Some((handler, middleware)) = stages.split_last() {
+                    (handler.clone(), middleware.to_vec(), Map::new())
+                } else {
+                    (String::new(), Vec::new(), Map::new())
+                };
+                if !handler.is_empty() {
+                    detail.insert("receiver".into(), Value::String(receiver.to_owned()));
                     facts.push(RawFrameworkFact::Route(RawRouteFact {
                         framework: "express".to_owned(),
                         operation: if method == "all" {
@@ -315,17 +419,17 @@ fn collect_express_routes(
                             method.to_ascii_uppercase()
                         },
                         raw_path: raw_path.clone(),
-                        normalized_path: normalize_path(&raw_path),
+                        normalized_path: normalize_path(&join_paths(
+                            mounts.get(receiver).map(String::as_str).unwrap_or_default(),
+                            &raw_path,
+                        )),
                         declaring_scope: module_scope(path),
                         anchor: anchor(path, node),
-                        handler_reference: handler.clone(),
-                        middleware_references: middleware.to_vec(),
+                        handler_reference: handler,
+                        middleware_references: middleware,
                         origin: RawFrameworkOrigin::Ast,
                         rule: None,
-                        detail: Map::from_iter([(
-                            "receiver".into(),
-                            Value::String(receiver.to_owned()),
-                        )]),
+                        detail,
                     }));
                 }
             }
@@ -333,7 +437,71 @@ fn collect_express_routes(
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
-        collect_express_routes(child, source, path, receivers, facts);
+        collect_express_routes(child, source, path, receivers, mounts, facts);
+    }
+}
+
+fn source_has_express_require(node: Node<'_>, source: &[u8]) -> bool {
+    if node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| node_text(function, source).trim() == "require")
+        && node
+            .child_by_field_name("arguments")
+            .is_some_and(|arguments| {
+                split_arguments(node_text(arguments, source))
+                    .first()
+                    .and_then(|argument| string_literal(argument))
+                    .is_some_and(|module| module == "express")
+            })
+    {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.is_named())
+        .any(|child| source_has_express_require(child, source))
+}
+
+fn express_mounts(
+    root: Node<'_>,
+    source: &[u8],
+    receivers: &HashSet<String>,
+) -> HashMap<String, String> {
+    let mut mounts = HashMap::new();
+    collect_express_mounts(root, source, receivers, &mut mounts);
+    mounts
+}
+
+fn collect_express_mounts(
+    node: Node<'_>,
+    source: &[u8],
+    receivers: &HashSet<String>,
+    mounts: &mut HashMap<String, String>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some((parent, "use")) = node_text(function, source).trim().rsplit_once('.')
+        && receivers.contains(parent)
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let arguments = split_arguments(node_text(arguments, source));
+        if let Some(prefix) = arguments
+            .first()
+            .and_then(|argument| string_literal(argument))
+            && let Some(child) = arguments.get(1).and_then(|argument| {
+                let candidate = argument.trim();
+                is_identifier(candidate).then_some(candidate)
+            })
+            && receivers.contains(child)
+        {
+            let parent_prefix = mounts.get(parent).map(String::as_str).unwrap_or_default();
+            mounts.insert(child.to_owned(), join_paths(parent_prefix, &prefix));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_express_mounts(child, source, receivers, mounts);
     }
 }
 
@@ -364,9 +532,15 @@ fn collect_nest_class(
     };
     let class_name = node_text(name_node, source);
     let class_text = decorator_context(class, source);
-    let controller_prefix = decorator_argument(&class_text, "Controller");
+    let controller_present = has_decorator(&class_text, "Controller");
+    let controller_prefix = controller_present
+        .then(|| decorator_argument(&class_text, "Controller"))
+        .flatten();
     let is_resolver = has_decorator(&class_text, "Resolver");
-    if controller_prefix.is_none() && !is_resolver {
+    let is_gateway = has_decorator(&class_text, "WebSocketGateway");
+    if (!controller_present && !is_resolver && !is_gateway)
+        || (controller_present && controller_prefix.is_none())
+    {
         return;
     }
     collect_nest_methods(
@@ -376,6 +550,7 @@ fn collect_nest_class(
         class_name,
         controller_prefix.as_deref().unwrap_or_default(),
         is_resolver,
+        is_gateway,
         facts,
     );
 }
@@ -388,6 +563,7 @@ fn collect_nest_methods(
     class_name: &str,
     controller_prefix: &str,
     is_resolver: bool,
+    is_gateway: bool,
     facts: &mut Vec<RawFrameworkFact>,
 ) {
     if node.kind() == "method_definition" {
@@ -408,7 +584,9 @@ fn collect_nest_methods(
             ("All", "ANY"),
         ] {
             if has_decorator(&method_text, decorator) {
-                let local = decorator_argument(&method_text, decorator).unwrap_or_default();
+                let Some(local) = decorator_argument(&method_text, decorator) else {
+                    continue;
+                };
                 let route = join_paths(controller_prefix, &local);
                 facts.push(route_fact(
                     "nestjs",
@@ -422,7 +600,9 @@ fn collect_nest_methods(
             }
         }
         if has_decorator(&method_text, "RequestMapping") {
-            let local = decorator_argument(&method_text, "RequestMapping").unwrap_or_default();
+            let Some(local) = decorator_argument(&method_text, "RequestMapping") else {
+                return;
+            };
             let operation =
                 request_mapping_method(&method_text).unwrap_or_else(|| "ANY".to_owned());
             let route = join_paths(controller_prefix, &local);
@@ -439,13 +619,18 @@ fn collect_nest_methods(
         if is_resolver {
             for (decorator, operation) in [("Query", "QUERY"), ("Mutation", "MUTATION")] {
                 if has_decorator(&method_text, decorator) {
-                    let field = decorator_argument(&method_text, decorator)
-                        .filter(|value| !value.is_empty())
-                        .unwrap_or_else(|| method_name.to_owned());
+                    let Some(argument) = decorator_argument(&method_text, decorator) else {
+                        continue;
+                    };
+                    let field = if argument.is_empty() {
+                        method_name.to_owned()
+                    } else {
+                        argument
+                    };
                     facts.push(route_fact(
                         "nestjs-graphql",
                         operation,
-                        &format!("/graphql/{field}"),
+                        "/graphql",
                         &handler,
                         path,
                         node,
@@ -459,10 +644,18 @@ fn collect_nest_methods(
             ("EventPattern", "event", "microservice", "handles"),
             ("SubscribeMessage", "message", "websocket", "subscribes"),
         ] {
+            if decorator == "SubscribeMessage" && !is_gateway {
+                continue;
+            }
             if has_decorator(&method_text, decorator) {
-                let subject = decorator_argument(&method_text, decorator)
-                    .filter(|value| !value.is_empty())
-                    .unwrap_or_else(|| method_name.to_owned());
+                let Some(argument) = decorator_argument(&method_text, decorator) else {
+                    continue;
+                };
+                let subject = if argument.is_empty() {
+                    method_name.to_owned()
+                } else {
+                    argument
+                };
                 facts.push(RawFrameworkFact::Domain(RawDomainFact {
                     framework: "nestjs".to_owned(),
                     kind: kind.to_owned(),
@@ -509,6 +702,7 @@ fn collect_nest_methods(
             class_name,
             controller_prefix,
             is_resolver,
+            is_gateway,
             facts,
         );
     }
@@ -519,28 +713,35 @@ fn collect_react_router_routes(
     source: &[u8],
     path: &Path,
     facts: &mut Vec<RawFrameworkFact>,
+    parent_path: &str,
 ) {
+    let mut next_parent = parent_path.to_owned();
     if matches!(node.kind(), "jsx_self_closing_element" | "jsx_element") {
         let text = node_text(node, source);
-        if text.trim_start().starts_with("<Route")
+        if is_route_jsx_element(text)
             && let Some(raw_path) = jsx_string_attribute(text, "path")
             && let Some(handler) = jsx_component_attribute(text, "element")
+                .or_else(|| jsx_reference_attribute(text, "Component"))
         {
+            let route_path = join_paths(parent_path, &raw_path);
             facts.push(route_fact(
                 "react-router",
                 "PAGE",
-                &raw_path,
+                &route_path,
                 &handler,
                 path,
                 node,
                 Map::new(),
             ));
+            next_parent = route_path;
         }
     }
-    collect_route_config(node, source, path, "react-router", facts);
+    if node.parent().is_none() {
+        collect_router_config_calls(node, source, path, "react-router", facts);
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
-        collect_react_router_routes(child, source, path, facts);
+        collect_react_router_routes(child, source, path, facts, &next_parent);
     }
 }
 
@@ -550,50 +751,95 @@ fn collect_vue_router_routes(
     path: &Path,
     facts: &mut Vec<RawFrameworkFact>,
 ) {
-    collect_route_config(node, source, path, "vue-router", facts);
+    if node.parent().is_none() {
+        collect_router_config_calls(node, source, path, "vue-router", facts);
+    }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
         collect_vue_router_routes(child, source, path, facts);
     }
 }
 
-fn collect_route_config(
+fn collect_router_config_calls(
     node: Node<'_>,
     source: &[u8],
     path: &Path,
     framework: &str,
     facts: &mut Vec<RawFrameworkFact>,
 ) {
-    if !matches!(node.kind(), "object" | "object_pattern") {
-        return;
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && matches!(
+            node_text(function, source).trim().rsplit('.').next(),
+            Some(
+                "createBrowserRouter" | "createHashRouter" | "createMemoryRouter" | "createRouter"
+            )
+        )
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let mut cursor = arguments.walk();
+        if let Some(argument) = arguments.named_children(&mut cursor).next() {
+            collect_route_config_with_parent(argument, source, path, framework, facts, "");
+        }
     }
-    let Some(raw_path) = direct_object_string_property(node, source, "path") else {
-        return;
-    };
-    let handler = direct_object_identifier_property(node, source, "component")
-        .or_else(|| direct_object_identifier_property(node, source, "element"))
-        .or_else(|| direct_object_identifier_property(node, source, "Component"));
-    let Some(handler) = handler else {
-        return;
-    };
-    let middleware = ["loader", "action"]
-        .into_iter()
-        .filter_map(|property| direct_object_identifier_property(node, source, property))
-        .collect();
-    let mut fact = match route_fact(
-        framework,
-        "PAGE",
-        &raw_path,
-        &handler,
-        path,
-        node,
-        Map::new(),
-    ) {
-        RawFrameworkFact::Route(route) => route,
-        RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => unreachable!(),
-    };
-    fact.middleware_references = middleware;
-    facts.push(RawFrameworkFact::Route(fact));
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_router_config_calls(child, source, path, framework, facts);
+    }
+}
+
+fn collect_route_config_with_parent(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    framework: &str,
+    facts: &mut Vec<RawFrameworkFact>,
+    parent_path: &str,
+) {
+    let mut current_parent = parent_path.to_owned();
+    if matches!(node.kind(), "object" | "object_pattern")
+        && let Some(raw_path) = direct_object_string_property(node, source, "path")
+    {
+        current_parent = join_paths(parent_path, &raw_path);
+        if let Some((handler, opaque_handler)) = direct_object_handler_property(node, source) {
+            let middleware = ["loader", "action"]
+                .into_iter()
+                .filter_map(|property| direct_object_identifier_property(node, source, property))
+                .collect();
+            let detail = if opaque_handler {
+                Map::from_iter([("opaque_handler".into(), Value::Bool(true))])
+            } else {
+                Map::new()
+            };
+            let mut fact = match route_fact(
+                framework,
+                "PAGE",
+                &current_parent,
+                &handler,
+                path,
+                node,
+                detail,
+            ) {
+                RawFrameworkFact::Route(route) => route,
+                RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => unreachable!(),
+            };
+            fact.middleware_references = middleware;
+            facts.push(RawFrameworkFact::Route(fact));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        let child_parent = if child.kind() == "pair"
+            && child
+                .child_by_field_name("key")
+                .is_some_and(|key| node_text(key, source).trim_matches(['"', '\'']) == "children")
+        {
+            current_parent.as_str()
+        } else {
+            parent_path
+        };
+        collect_route_config_with_parent(child, source, path, framework, facts, child_parent);
+    }
 }
 
 fn route_fact(
@@ -680,6 +926,15 @@ fn handler_reference(value: &str) -> Option<String> {
     is_reference(callee).then(|| callee.to_owned())
 }
 
+fn is_inline_handler_expression(value: &str) -> bool {
+    let value = value.trim();
+    value.contains("=>")
+        || value.starts_with("function")
+        || value.starts_with("async function")
+        || value.starts_with("async(")
+        || value.starts_with("async (")
+}
+
 fn string_literal(value: &str) -> Option<String> {
     let value = value.trim();
     if value.len() < 2 {
@@ -697,16 +952,63 @@ fn string_literal(value: &str) -> Option<String> {
 }
 
 fn decorator_argument(source: &str, name: &str) -> Option<String> {
-    let pattern = Regex::new(&format!(
-        r#"(?s)@\s*{}\s*\(\s*["'`]([^"'`]*?)["'`]"#,
-        regex::escape(name)
-    ))
-    .ok()?;
-    pattern
-        .captures(source)
+    let pattern = Regex::new(&format!(r"@\s*{}\b", regex::escape(name))).ok()?;
+    let marker = pattern.find(source)?;
+    let rest = source[marker.end()..].trim_start();
+    let Some(rest) = rest.strip_prefix('(') else {
+        return Some(String::new());
+    };
+    let mut depth = 1_u32;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut close = None;
+    for (offset, character) in rest.char_indices() {
+        if let Some(active) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active {
+                quote = None;
+            }
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            quote = Some(character);
+            continue;
+        }
+        match character {
+            '(' => depth = depth.saturating_add(1),
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    close = Some(offset);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let body = rest.get(..close?)?.trim();
+    if body.is_empty() {
+        return Some(String::new());
+    }
+    if let Some(value) = string_literal(body) {
+        return Some(value);
+    }
+    if body.starts_with('[')
+        && body.ends_with(']')
+        && let Some(value) = super::text::split_top_level(&body[1..body.len() - 1])
+            .into_iter()
+            .find_map(string_literal)
+    {
+        return Some(value);
+    }
+    Regex::new(r#"(?:^|\b)(?:path|value|name)\s*:\s*["'`]([^"'`]+)["'`]"#)
+        .ok()?
+        .captures(body)
         .and_then(|capture| capture.get(1))
         .map(|value| value.as_str().to_owned())
-        .or_else(|| has_decorator(source, name).then(String::new))
 }
 
 fn has_decorator(source: &str, name: &str) -> bool {
@@ -746,6 +1048,28 @@ fn jsx_component_attribute(source: &str, name: &str) -> Option<String> {
         .map(|value| value.as_str().to_owned())
 }
 
+fn is_route_jsx_element(source: &str) -> bool {
+    let trimmed = source.trim_start();
+    let Some(rest) = trimmed.strip_prefix("<Route") else {
+        return false;
+    };
+    rest.chars()
+        .next()
+        .is_some_and(|character| matches!(character, ' ' | '\t' | '\n' | '/' | '>'))
+}
+
+fn jsx_reference_attribute(source: &str, name: &str) -> Option<String> {
+    let pattern = Regex::new(&format!(
+        r"\b{}\s*=\s*\{{\s*([A-Z][A-Za-z0-9_$.]*)\s*\}}",
+        regex::escape(name)
+    ))
+    .ok()?;
+    pattern
+        .captures(source)
+        .and_then(|capture| capture.get(1))
+        .map(|value| value.as_str().to_owned())
+}
+
 fn direct_object_string_property(node: Node<'_>, source: &[u8], name: &str) -> Option<String> {
     direct_object_property(node, source, name).and_then(string_literal)
 }
@@ -753,6 +1077,35 @@ fn direct_object_string_property(node: Node<'_>, source: &[u8], name: &str) -> O
 fn direct_object_identifier_property(node: Node<'_>, source: &[u8], name: &str) -> Option<String> {
     let value = direct_object_property(node, source, name)?.trim();
     is_reference(value).then(|| value.to_owned())
+}
+
+fn direct_object_handler_property(node: Node<'_>, source: &[u8]) -> Option<(String, bool)> {
+    for name in ["component", "element", "Component"] {
+        let Some(value) = direct_object_property(node, source, name) else {
+            continue;
+        };
+        let value = value.trim();
+        if is_reference(value) {
+            return Some((value.to_owned(), false));
+        }
+        if let Some(tag) = value.strip_prefix('<').and_then(|value| {
+            value
+                .split(|character: char| {
+                    character.is_whitespace() || matches!(character, '/' | '>')
+                })
+                .next()
+        }) && is_reference(tag)
+        {
+            return Some((tag.to_owned(), false));
+        }
+        if value.contains("=>") || value.contains("import(") || value.starts_with("lazy(") {
+            return Some((
+                format!("opaque_route_handler_at_{}", node.start_byte()),
+                true,
+            ));
+        }
+    }
+    None
 }
 
 fn direct_object_property<'a>(node: Node<'_>, source: &'a [u8], name: &str) -> Option<&'a str> {

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -18,7 +18,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/5";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/6";
 mod go;
 mod groovy;
 mod html;

--- a/crates/compass-resolve/src/frameworks/python.rs
+++ b/crates/compass-resolve/src/frameworks/python.rs
@@ -63,6 +63,109 @@ pub(super) fn expand_django_includes(
     Ok(output)
 }
 
+pub(super) fn expand_router_mounts(
+    facts: &[RawFrameworkFact],
+    routes: Vec<RawRouteFact>,
+    limits: FrameworkLimits,
+) -> Result<Vec<RawRouteFact>, FrameworkResolutionError> {
+    let mounts = facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Domain(domain) if domain.kind == "router_mount" => Some(domain),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if mounts.is_empty() {
+        return Ok(routes);
+    }
+    let mut output = Vec::new();
+    for route in routes {
+        if !matches!(route.framework.as_str(), "fastapi" | "flask")
+            || route
+                .detail
+                .get("mount_prefix")
+                .and_then(Value::as_str)
+                .is_some_and(|prefix| !prefix.is_empty())
+        {
+            output.push(route);
+            continue;
+        }
+        let receiver = route
+            .detail
+            .get("receiver")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let route_scope = normalize_mount_scope(&route.declaring_scope);
+        let applicable = mounts
+            .iter()
+            .filter(|mount| mount.framework == route.framework)
+            .filter(|mount| {
+                mount.detail.get("target_receiver").and_then(Value::as_str) == Some(receiver)
+            })
+            .filter(|mount| {
+                let target_module = mount
+                    .detail
+                    .get("target_module")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if target_module.is_empty() {
+                    // An unqualified receiver is only safe within the mount
+                    // module itself. Applying it to every same-named router
+                    // in the repository would create a false cross-module
+                    // binding when two modules both use `router`.
+                    mount.declaring_scope == route_scope
+                } else {
+                    route_scope == normalize_mount_scope(target_module)
+                        || route_scope.ends_with(&format!(".{target_module}"))
+                        || mount.declaring_scope == route_scope
+                }
+            })
+            .collect::<Vec<_>>();
+        if applicable.is_empty() {
+            output.push(route);
+            continue;
+        }
+        for mount in applicable {
+            let Some(prefix) = mount.detail.get("mount_prefix").and_then(Value::as_str) else {
+                continue;
+            };
+            let mut expanded = route.clone();
+            expanded.normalized_path = compose_paths(prefix, &route.normalized_path);
+            expanded.raw_path = format!(
+                "{}{}",
+                prefix.trim_end_matches('/'),
+                route.raw_path.trim_start_matches('/')
+            );
+            expanded
+                .detail
+                .insert("mount_prefix".into(), Value::String(prefix.to_owned()));
+            expanded.detail.insert(
+                "mount_anchor".into(),
+                serde_json::to_value(&mount.anchor).unwrap_or(Value::Null),
+            );
+            output.push(expanded);
+        }
+    }
+    let mut per_file = HashMap::new();
+    for route in &output {
+        *per_file
+            .entry(route.anchor.source_file.as_str())
+            .or_insert(0_usize) += 1;
+    }
+    for count in per_file.into_values() {
+        limits.check_facts(count)?;
+    }
+    Ok(output)
+}
+
+fn normalize_mount_scope(value: &str) -> String {
+    value
+        .replace(['/', '\\'], ".")
+        .trim_matches('.')
+        .trim_end_matches(".py")
+        .to_owned()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn expand_one(
     index: usize,

--- a/crates/compass-resolve/src/frameworks/routes.rs
+++ b/crates/compass-resolve/src/frameworks/routes.rs
@@ -70,7 +70,11 @@ pub(super) fn resolve_routes_with_targets(
 ) -> Result<Vec<ResolvedRoute>, FrameworkResolutionError> {
     validate_fact_limits(extraction, limits)?;
     let aliases = alias_map(extraction, limits, root)?;
-    let expanded = super::python::expand_django_includes(&extraction.framework_facts, limits)?;
+    let expanded = super::python::expand_router_mounts(
+        &extraction.framework_facts,
+        super::python::expand_django_includes(&extraction.framework_facts, limits)?,
+        limits,
+    )?;
     let mut unique = BTreeMap::new();
     for route in expanded {
         route
@@ -219,6 +223,8 @@ fn resolve_one_route(
             targets,
             aliases,
             limits,
+            None,
+            None,
         )?;
         stages.push(resolved_stage(
             &route,
@@ -250,6 +256,8 @@ fn resolve_one_route(
             targets,
             aliases,
             limits,
+            route.detail.get("handler_source").and_then(Value::as_str),
+            route.detail.get("handler_module").and_then(Value::as_str),
         )?
     };
     if candidates.is_empty() {
@@ -261,6 +269,8 @@ fn resolve_one_route(
             targets,
             aliases,
             limits,
+            route.detail.get("handler_source").and_then(Value::as_str),
+            route.detail.get("handler_module").and_then(Value::as_str),
         )?;
     }
     let state = candidate_state(&candidates);
@@ -279,6 +289,7 @@ fn resolve_one_route(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_reference(
     reference: &str,
     framework: &str,
@@ -287,6 +298,8 @@ fn resolve_reference(
     targets: &FrameworkTargetIndex<'_>,
     aliases: &super::typescript::ImportAliases,
     limits: FrameworkLimits,
+    preferred_source: Option<&str>,
+    preferred_module: Option<&str>,
 ) -> Result<Vec<ResolutionCandidate>, FrameworkResolutionError> {
     let reference = canonical_framework_reference(framework, reference);
     let reference = normalize_reference(&reference);
@@ -311,6 +324,7 @@ fn resolve_reference(
     });
     let families = [TargetFamily::Route];
     let max = limits.max_candidates;
+    let mut explicit_owner_unmatched = false;
     let (mut positions, mut candidates_truncated) = targets.by_id(&expanded, &families, max);
     let mut score = 100_u8;
     let mut reason = "exact stable ID";
@@ -344,17 +358,43 @@ fn resolve_reference(
         reason = "source-module import/export alias";
     }
     if positions.is_empty()
+        && let Some(preferred_source) = preferred_source
+    {
+        (positions, candidates_truncated) =
+            targets.by_source_terminal(preferred_source, &last, &families, max);
+        score = 100;
+        reason = "exact same-source endpoint handler";
+    }
+    if positions.is_empty()
+        && let Some(preferred_module) = preferred_module
+    {
+        (positions, candidates_truncated) =
+            targets.by_module_terminal(source_file, preferred_module, &last, &families, max);
+        score = 100;
+        reason = "exact endpoint re-export module";
+    }
+    if positions.is_empty()
         && let Some(owner) = owner.as_deref()
     {
         (positions, candidates_truncated) = targets.by_owner_terminal(owner, &last, &families, max);
         score = 97;
         reason = "owner-qualified member";
+        explicit_owner_unmatched = positions.is_empty();
     }
     if positions.is_empty() {
         (positions, candidates_truncated) =
             targets.by_names(std::slice::from_ref(&expanded), &families, max);
         score = 95;
         reason = "exact qualified name";
+    }
+    // An explicitly qualified handler must not silently degrade to a
+    // same-source or terminal-name match. Doing so can bind
+    // `MissingController.show` to an unrelated `ExistingController.show` and
+    // publish a confidently wrong route edge. Exact stable IDs and exact
+    // qualified names were attempted above; once an owner is present, failure
+    // to find that owner is an unresolved reference.
+    if positions.is_empty() && explicit_owner_unmatched {
+        return Ok(Vec::new());
     }
     if positions.is_empty() {
         let scoped = scoped
@@ -832,6 +872,55 @@ mod tests {
             resolved[0].stages[0].target.as_deref(),
             Some(target_id.as_str())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_owner_mismatch_is_unresolved_instead_of_terminal_fallback()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = "src/routes.ts";
+        let mut extraction = Extraction::default();
+        extraction.nodes.push(RawNodeRecord {
+            id: "existing-show".to_owned(),
+            attributes: Map::from_iter([
+                ("name".into(), Value::String("show".into())),
+                (
+                    "qualified_name".into(),
+                    Value::String("ExistingController.show".into()),
+                ),
+                ("symbol_kind".into(), Value::String("method".into())),
+                ("source_file".into(), Value::String(source.into())),
+            ]),
+        });
+        extraction
+            .framework_facts
+            .push(RawFrameworkFact::Route(RawRouteFact {
+                framework: "express".to_owned(),
+                operation: "GET".to_owned(),
+                raw_path: "/missing".to_owned(),
+                normalized_path: "/missing".to_owned(),
+                declaring_scope: "src.routes".to_owned(),
+                anchor: RawFrameworkAnchor {
+                    source_file: source.to_owned(),
+                    start_byte: 1,
+                    end_byte: 2,
+                    start_line: 1,
+                    start_column: 0,
+                    end_line: 1,
+                    end_column: 1,
+                },
+                handler_reference: "MissingController.show".to_owned(),
+                middleware_references: Vec::new(),
+                origin: RawFrameworkOrigin::Ast,
+                rule: None,
+                detail: Map::new(),
+            }));
+
+        let resolved = resolve_routes(&extraction, FrameworkLimits::default())?;
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].state, ResolutionState::Unresolved);
+        assert!(resolved[0].stages[0].target.is_none());
+        assert!(resolved[0].candidates.is_empty());
         Ok(())
     }
 }

--- a/crates/compass-resolve/src/frameworks/spring.rs
+++ b/crates/compass-resolve/src/frameworks/spring.rs
@@ -59,6 +59,19 @@ pub(super) fn expand(extraction: &mut Extraction) -> Result<(), FrameworkResolut
     );
     let definitions = mapping_definitions(&annotations, &by_owner);
     let aliases = alias_definitions(&annotations);
+    let controller_owners = annotations
+        .iter()
+        .filter(|annotation| {
+            matches!(
+                annotation.owner_kind.as_str(),
+                "class" | "interface" | "record"
+            ) && matches!(
+                annotation_terminal(annotation),
+                "Controller" | "RestController"
+            )
+        })
+        .map(|annotation| annotation.owner_qualified_name.clone())
+        .collect::<BTreeSet<_>>();
     let mappings = annotations
         .iter()
         .filter_map(|annotation| {
@@ -91,6 +104,9 @@ pub(super) fn expand(extraction: &mut Extraction) -> Result<(), FrameworkResolut
             .rsplit_once("::")
             .map(|(owner, _)| owner)
             .unwrap_or(annotation.owner_qualified_name.as_str());
+        if !controller_owners.contains(owner) {
+            continue;
+        }
         let prefixes = class_mappings
             .get(owner)
             .map(|mappings| {
@@ -158,6 +174,7 @@ pub(super) fn expand(extraction: &mut Extraction) -> Result<(), FrameworkResolut
         extraction,
         &mappings,
         &class_mappings,
+        &controller_owners,
         &mut route_keys,
         &mut derived,
     );
@@ -498,6 +515,7 @@ fn derive_inherited_method_routes(
     extraction: &Extraction,
     mappings: &[(&RawFrameworkAnnotationFact, MappingSpec)],
     class_mappings: &BTreeMap<String, Vec<MappingSpec>>,
+    controller_owners: &BTreeSet<String>,
     route_keys: &mut BTreeSet<(String, u64, String, String, String)>,
     output: &mut Vec<RawFrameworkFact>,
 ) {
@@ -574,6 +592,9 @@ fn derive_inherited_method_routes(
         let Some(base_id) = types.get(base_owner) else {
             continue;
         };
+        if !controller_owners.contains(base_owner) {
+            continue;
+        }
         let expected_arity = signature_arity(annotation.owner_signature.as_deref());
         for child_id in descendants.get(base_id).into_iter().flatten() {
             for method_id in contained.get(child_id).into_iter().flatten() {
@@ -591,6 +612,9 @@ fn derive_inherited_method_routes(
                     .rsplit_once("::")
                     .map(|(owner, _)| owner)
                     .unwrap_or_default();
+                if !controller_owners.contains(child_owner) {
+                    continue;
+                }
                 let prefixes = class_mappings
                     .get(child_owner)
                     .map(|mappings| {

--- a/crates/compass-resolve/tests/native_routes.rs
+++ b/crates/compass-resolve/tests/native_routes.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use compass_languages::{Engine, Extraction, FrameworkLimits};
+use compass_languages::{Engine, Extraction, FrameworkLimits, RawFrameworkFact};
 use compass_model::provenance::ResolutionState;
 use compass_resolve::frameworks::resolve_and_publish_framework_routes;
 
@@ -77,6 +77,33 @@ fn rust_calls_and_attributes_resolve_with_framework_guards() -> Result<(), Box<d
             route.route.framework == expected_framework && route.state == ResolutionState::Exact
         }));
     }
+    let multiline = Engine::default().extract_source(
+        Path::new("routes.rs"),
+        br#"use rocket::get;
+#[get(
+    "/multiline"
+)]
+fn multiline() {}
+"#,
+    )?;
+    assert!(multiline.framework_facts.iter().any(|fact| {
+        matches!(
+            fact,
+            RawFrameworkFact::Route(route)
+                if route.framework == "rocket"
+                    && route.operation == "GET"
+                    && route.normalized_path == "/multiline"
+                    && route.handler_reference == "multiline"
+        )
+    }));
+    let commented = Engine::default().extract_source(
+        Path::new("routes.rs"),
+        br#"use rocket::get;
+// #[get("/commented")]
+// fn commented() {}
+"#,
+    )?;
+    assert!(commented.framework_facts.is_empty());
     assert!(extract("rust/near_matches.rs")?.framework_facts.is_empty());
     Ok(())
 }
@@ -93,6 +120,18 @@ fn aspnet_composes_controller_and_action_templates() -> Result<(), Box<dyn Error
     assert!(routes.iter().any(|route| {
         route.route.operation == "POST"
             && route.route.normalized_path == "/api/Users"
+            && route.state == ResolutionState::Exact
+    }));
+    assert!(routes.iter().any(|route| {
+        route.route.operation == "GET"
+            && route.route.normalized_path == "/status"
+            && route.route.handler_reference == "UsersController.Status"
+            && route.state == ResolutionState::Exact
+    }));
+    assert!(routes.iter().any(|route| {
+        route.route.operation == "GET"
+            && route.route.normalized_path == "/api/Users/health"
+            && route.route.handler_reference == "UsersController.Health"
             && route.state == ResolutionState::Exact
     }));
     assert!(extract("csharp/NearMatches.cs")?.framework_facts.is_empty());
@@ -124,5 +163,230 @@ fn vapor_segmented_routes_resolve_explicit_handlers() -> Result<(), Box<dyn Erro
             .framework_facts
             .is_empty()
     );
+    Ok(())
+}
+
+#[test]
+fn gorilla_http_method_constants_and_comments_remain_precise() -> Result<(), Box<dyn Error>> {
+    let mut engine = Engine::default();
+    let extraction = engine.extract_source(
+        Path::new("routes.go"),
+        br#"package routes
+import (
+  "net/http"
+  "github.com/gorilla/mux"
+)
+func show(w http.ResponseWriter, r *http.Request) {}
+func configure(r *mux.Router) {
+  // r.HandleFunc("/comment", show).Methods("GET")
+  r.HandleFunc("/users", show).Methods(http.MethodGet)
+}
+"#,
+    )?;
+    let routes = extraction
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].operation, "GET");
+    assert_eq!(routes[0].normalized_path, "/users");
+    Ok(())
+}
+
+#[test]
+fn native_composition_and_multiline_registrations_keep_each_method_and_prefix()
+-> Result<(), Box<dyn Error>> {
+    let axum = Engine::default().extract_source(
+        Path::new("routes.rs"),
+        br#"use axum::{Router, routing::{get, post}};
+async fn show() {}
+async fn create() {}
+fn router() -> Router {
+  Router::new()
+    .route("/users/:id", get(show))
+    .route("/users", post(create))
+    .nest("/api", Router::new().route("/users", get(show).post(create)))
+}
+"#,
+    )?;
+    let axum_routes = axum
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        axum_routes
+            .iter()
+            .any(|route| { route.operation == "GET" && route.normalized_path == "/api/users" })
+    );
+    assert!(
+        axum_routes
+            .iter()
+            .any(|route| { route.operation == "POST" && route.normalized_path == "/api/users" })
+    );
+    assert!(
+        axum_routes
+            .iter()
+            .any(|route| { route.operation == "GET" && route.normalized_path == "/users/:id" })
+    );
+    assert!(
+        axum_routes
+            .iter()
+            .any(|route| { route.operation == "POST" && route.normalized_path == "/users" })
+    );
+
+    let go = Engine::default().extract_source(
+        Path::new("routes.go"),
+        br#"package routes
+import "github.com/gin-gonic/gin"
+func auth() {}
+func show() {}
+func configure(r *gin.Engine) {
+  r.GET(
+    "/users",
+    auth(),
+    show,
+  )
+}
+"#,
+    )?;
+    let go_route = go
+        .framework_facts
+        .iter()
+        .find_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .ok_or("missing multiline Go route")?;
+    assert_eq!(go_route.normalized_path, "/users");
+    assert_eq!(go_route.handler_reference, "show");
+    assert_eq!(go_route.middleware_references, ["auth()"]);
+
+    let chi = Engine::default().extract_source(
+        Path::new("routes.go"),
+        br#"package routes
+import "github.com/go-chi/chi/v5"
+func list(w http.ResponseWriter, r *http.Request) {}
+func configure(r chi.Router) {
+  r.Route("/api", func(r chi.Router) {
+    r.Get("/items", list)
+  })
+}
+"#,
+    )?;
+    let chi_route = chi
+        .framework_facts
+        .iter()
+        .find_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .ok_or("missing chi closure route")?;
+    assert_eq!(chi_route.framework, "chi");
+    assert_eq!(chi_route.normalized_path, "/api/items");
+
+    let gorilla = Engine::default().extract_source(
+        Path::new("routes.go"),
+        br#"package routes
+import "github.com/gorilla/mux"
+func show(w http.ResponseWriter, r *http.Request) {}
+func configure(r *mux.Router) {
+  r.PathPrefix("/api").Subrouter().HandleFunc("/items", show).Methods("GET")
+}
+"#,
+    )?;
+    let gorilla_route = gorilla
+        .framework_facts
+        .iter()
+        .find_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .ok_or("missing gorilla subrouter route")?;
+    assert_eq!(gorilla_route.framework, "gorilla");
+    assert_eq!(gorilla_route.normalized_path, "/api/items");
+    assert_eq!(gorilla_route.operation, "GET");
+
+    let actix = Engine::default().extract_source(
+        Path::new("routes.rs"),
+        br#"use actix_web::{web, App};
+async fn show() {}
+async fn create() {}
+fn configure() -> App {
+  App::new().service(web::scope("/api").service(
+    web::resource("/items")
+      .route(web::get().to(show))
+      .route(web::post().to(create))
+  ))
+}
+"#,
+    )?;
+    let actix_routes = actix
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(actix_routes.iter().any(|route| {
+        route.framework == "actix"
+            && route.operation == "GET"
+            && route.normalized_path == "/api/items"
+    }));
+    assert!(actix_routes.iter().any(|route| {
+        route.framework == "actix"
+            && route.operation == "POST"
+            && route.normalized_path == "/api/items"
+    }));
+    Ok(())
+}
+
+#[test]
+fn vapor_root_and_direct_grouped_routes_are_visible() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("VaporRoutes.swift"),
+        br#"import Vapor
+func index(_ request: Request) async throws -> String { "index" }
+func users(_ request: Request) async throws -> String { "users" }
+func routes(_ app: Application) throws {
+  app.get(use: index)
+  app.grouped("api").get("users", use: users)
+  app.on(.OPTIONS, "health", use: users)
+  app.group("v1") { grouped in
+    grouped.get("items", use: users)
+  }
+}
+"#,
+    )?;
+    let routes = extraction
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(routes.iter().any(|route| route.normalized_path == "/"));
+    assert!(
+        routes
+            .iter()
+            .any(|route| route.normalized_path == "/api/users")
+    );
+    assert!(
+        routes
+            .iter()
+            .any(|route| { route.operation == "OPTIONS" && route.normalized_path == "/health" })
+    );
+    assert!(routes.iter().any(|route| {
+        route.normalized_path == "/v1/items" && route.handler_reference == "users"
+    }));
     Ok(())
 }

--- a/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
+++ b/crates/compass-resolve/tests/php_ruby_jvm_routes.rs
@@ -93,6 +93,35 @@ fn laravel_routes_expand_resources_prefixes_and_handler_syntaxes() -> Result<(),
             && route.route.operation == "GET"
             && route.state == ResolutionState::Exact
     }));
+
+    let constrained = Engine::default().extract_source(
+        Path::new("routes/constrained.php"),
+        br#"<?php
+use Illuminate\Support\Facades\Route;
+Route::resource('/categories', CategoryController::class)->only(['index', 'show']);
+"#,
+    )?;
+    let constrained_routes = constrained
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) => Some(route),
+            RawFrameworkFact::Domain(_) | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(constrained_routes.len(), 2);
+    assert!(constrained_routes.iter().any(|route| {
+        route.operation == "GET" && route.normalized_path == "/categories/{category}"
+    }));
+    assert!(constrained_routes.iter().all(|route| {
+        !matches!(
+            route
+                .detail
+                .get("resourceAction")
+                .and_then(|value| value.as_str()),
+            Some("create" | "edit")
+        )
+    }));
     assert!(extract("php/near_matches.php")?.framework_facts.is_empty());
     Ok(())
 }
@@ -174,17 +203,39 @@ fn drupal_yaml_and_hook_files_publish_auditable_routes() -> Result<(), Box<dyn E
     let resolved =
         resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
 
-    let view = resolved
+    let views = resolved
         .iter()
-        .find(|route| route.route.normalized_path == "/examples/{example}")
-        .ok_or("missing Drupal controller route")?;
-    assert_eq!(view.route.operation, "GET");
-    assert_eq!(view.route.origin.as_str(), "config");
-    assert_eq!(view.state, ResolutionState::Exact);
+        .filter(|route| route.route.normalized_path == "/examples/{example}")
+        .collect::<Vec<_>>();
+    assert_eq!(views.len(), 2, "routes={resolved:#?}");
+    assert_eq!(
+        views
+            .iter()
+            .map(|route| route.route.operation.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["GET", "POST"])
+    );
+    assert!(views.iter().all(|route| {
+        route.route.origin.as_str() == "config" && route.state == ResolutionState::Exact
+    }));
     assert!(resolved.iter().any(|route| {
         route.route.operation == "HOOK"
-            && route.route.handler_reference == "hook_entity_type_build"
+            && route.route.normalized_path == "/__hook/hook_entity_type_build"
+            && route.route.handler_reference == "drupal_entity_type_build"
             && route.state == ResolutionState::Exact
+    }));
+    assert_eq!(
+        resolved
+            .iter()
+            .filter(|route| route.route.operation == "HOOK")
+            .count(),
+        1,
+        "same-prefix helper functions must not become Drupal hooks"
+    );
+    assert!(resolved.iter().any(|route| {
+        route.route.normalized_path == "/examples/{example}/edit"
+            && route.route.handler_reference == "example.edit"
+            && route.state == ResolutionState::Unresolved
     }));
     assert!(extraction.edges.iter().any(|edge| {
         edge.string("relation") == "routes_to"
@@ -208,7 +259,7 @@ fn rails_routes_resolve_to_controller_actions_and_compose_namespaces() -> Result
     }));
     assert!(resolved.iter().any(|route| {
         route.route.normalized_path == "/admin/dashboard"
-            && route.route.handler_reference == "DashboardController.index"
+            && route.route.handler_reference == "Admin.DashboardController.index"
     }));
     assert!(extract("ruby/near_matches.rb")?.framework_facts.is_empty());
     Ok(())
@@ -247,6 +298,20 @@ fn spring_composes_class_and_method_mappings_without_custom_annotation_matches()
         2
     );
     assert!(extract("jvm/NearMatches.java")?.framework_facts.is_empty());
+
+    let mut helper = Engine::default().extract_source(
+        Path::new("src/Helper.java"),
+        br#"import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+class Helper {
+    @GetMapping("/not-an-endpoint")
+    public String helper() { return "ok"; }
+}
+"#,
+    )?;
+    let helper_routes =
+        resolve_and_publish_framework_routes(&mut helper, FrameworkLimits::default())?;
+    assert!(helper_routes.is_empty(), "routes={helper_routes:#?}");
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/python_routes.rs
+++ b/crates/compass-resolve/tests/python_routes.rs
@@ -66,7 +66,7 @@ fn django_flask_and_fastapi_shapes_emit_framework_specific_route_facts()
     }));
     let methods = flask_routes
         .iter()
-        .filter(|route| route.normalized_path == "/api/users/<user_id>")
+        .filter(|route| route.normalized_path == "/v2/api/users/<user_id>")
         .map(|route| route.operation.as_str())
         .collect::<HashSet<_>>();
     assert_eq!(methods, HashSet::from(["GET", "PATCH"]));
@@ -75,10 +75,71 @@ fn django_flask_and_fastapi_shapes_emit_framework_specific_route_facts()
     let fastapi_routes = routes(&fastapi);
     let create = fastapi_routes
         .iter()
-        .find(|route| route.normalized_path == "/v1/users")
+        .find(|route| route.normalized_path == "/api/v1/users")
         .ok_or("missing FastAPI router route")?;
     assert_eq!(create.operation, "POST");
     assert_eq!(create.middleware_references, vec!["authenticate"]);
+    Ok(())
+}
+
+#[test]
+fn python_route_decorators_and_django_calls_accept_named_path_arguments()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut engine = Engine::default();
+    let django = engine.extract_source(
+        Path::new("project/urls.py"),
+        br#"from django.conf.urls import url
+from django.urls import path
+from . import views
+urlpatterns = [
+    path(route="named/", view=views.named),
+    url(r"^legacy/$", "project.views.named"),
+]
+"#,
+    )?;
+    assert!(routes(&django).iter().any(|route| {
+        route.framework == "django"
+            && route.normalized_path == "/named"
+            && route.handler_reference == "views.named"
+    }));
+    assert!(routes(&django).iter().any(|route| {
+        route.framework == "django"
+            && route.raw_path == "^legacy/$"
+            && route.handler_reference == "project.views.named"
+    }));
+
+    let flask = engine.extract_source(
+        Path::new("app.py"),
+        br#"from flask import Flask
+app = Flask(__name__)
+@app.route(rule="/named", methods=["POST"])
+def named(): return None
+"#,
+    )?;
+    assert!(routes(&flask).iter().any(|route| {
+        route.framework == "flask" && route.operation == "POST" && route.normalized_path == "/named"
+    }));
+
+    let fastapi = engine.extract_source(
+        Path::new("api.py"),
+        br#"from fastapi import FastAPI
+app = FastAPI()
+@app.patch(path="/named")
+def named(): return None
+@app.get("/search/a=b")
+def search(): return None
+"#,
+    )?;
+    assert!(routes(&fastapi).iter().any(|route| {
+        route.framework == "fastapi"
+            && route.operation == "PATCH"
+            && route.normalized_path == "/named"
+    }));
+    assert!(routes(&fastapi).iter().any(|route| {
+        route.framework == "fastapi"
+            && route.operation == "GET"
+            && route.normalized_path == "/search/a=b"
+    }));
     Ok(())
 }
 
@@ -89,7 +150,7 @@ fn python_routes_resolve_handlers_and_dependencies_but_not_near_matches()
     let resolved = resolve_and_publish_framework_routes(&mut fastapi, FrameworkLimits::default())?;
     let create = resolved
         .iter()
-        .find(|route| route.route.normalized_path == "/v1/users")
+        .find(|route| route.route.normalized_path == "/api/v1/users")
         .ok_or("missing create route")?;
     assert_eq!(create.state, ResolutionState::Exact);
     assert_eq!(
@@ -303,6 +364,65 @@ fn django_include_cycles_stop_and_depth_overflow_fails_explicitly()
         Err(FrameworkResolutionError::Limit(error))
             if error.limit == "max_include_depth"
     ));
+    Ok(())
+}
+
+#[test]
+fn python_router_mounts_resolve_across_imported_modules() -> Result<(), Box<dyn std::error::Error>>
+{
+    let mut engine = Engine::default();
+    let router_path = Path::new("src/api.py");
+    let app_path = Path::new("src/app.py");
+    let router_source = br#"from fastapi import APIRouter
+router = APIRouter(prefix="/v1")
+@router.get("/users")
+def users(): return None
+"#;
+    let app_source = br#"from fastapi import FastAPI
+from .api import router
+app = FastAPI()
+app.include_router(router, prefix="/api")
+"#;
+    let other_path = Path::new("src/other.py");
+    let other_source = br#"from fastapi import APIRouter
+router = APIRouter()
+@router.get("/other")
+def other(): return None
+"#;
+    let router_extraction = engine.extract_source(router_path, router_source)?;
+    let app_extraction = engine.extract_source(app_path, app_source)?;
+    let other_extraction = engine.extract_source(other_path, other_source)?;
+    let sources = HashMap::from([
+        (
+            router_path.to_string_lossy().into_owned(),
+            String::from_utf8(router_source.to_vec())?,
+        ),
+        (
+            app_path.to_string_lossy().into_owned(),
+            String::from_utf8(app_source.to_vec())?,
+        ),
+        (
+            other_path.to_string_lossy().into_owned(),
+            String::from_utf8(other_source.to_vec())?,
+        ),
+    ]);
+    let mut extraction = resolve(
+        &[router_extraction, app_extraction, other_extraction],
+        &sources,
+    );
+    let resolved =
+        resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+    let route = resolved
+        .iter()
+        .find(|route| route.route.framework == "fastapi")
+        .ok_or("missing mounted cross-module FastAPI route")?;
+    assert_eq!(route.route.normalized_path, "/api/v1/users");
+    assert_eq!(route.state, ResolutionState::Exact);
+    assert!(
+        !resolved
+            .iter()
+            .any(|route| route.route.normalized_path == "/api/other")
+    );
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -45,7 +45,50 @@ fn express_routes_preserve_ordered_middleware_and_reject_computed_paths()
     assert_eq!(user.operation, "GET");
     assert_eq!(user.middleware_references, ["authenticate", "audit"]);
     assert_eq!(user.handler_reference, "showUser");
-    assert_eq!(routes(&extraction).count(), 2);
+    let inline = routes(&extraction)
+        .find(|route| route.normalized_path == "/inline")
+        .ok_or("missing Express inline route")?;
+    assert_eq!(inline.middleware_references, ["authenticate"]);
+    assert!(
+        inline
+            .handler_reference
+            .starts_with("opaque_inline_handler_at_")
+    );
+    assert_eq!(
+        inline.detail.get("opaque_handler"),
+        Some(&serde_json::Value::Bool(true))
+    );
+    assert_eq!(routes(&extraction).count(), 3);
+
+    let commonjs = Engine::default().extract_source(
+        Path::new("src/server.ts"),
+        br#"const express = require("express");
+const app = express();
+const api = express.Router();
+app.use("/api", api);
+function show() {}
+api.route("/users").get(show);
+"#,
+    )?;
+    let mounted = routes(&commonjs)
+        .find(|route| route.normalized_path == "/api/users")
+        .ok_or("missing mounted CommonJS Express route")?;
+    assert_eq!(mounted.handler_reference, "show");
+
+    let nested = Engine::default().extract_source(
+        Path::new("src/nest.ts"),
+        br#"const express = require("express");
+const app = express();
+const api = express.Router();
+app.use("/v1", api);
+function list() {}
+api.route("/items").get(list);
+"#,
+    )?;
+    let nested_route = routes(&nested)
+        .find(|route| route.normalized_path == "/v1/items")
+        .ok_or("missing nested Express route")?;
+    assert_eq!(nested_route.handler_reference, "list");
     Ok(())
 }
 
@@ -63,8 +106,8 @@ fn nest_http_graphql_and_messaging_shapes_are_distinct() -> Result<(), Box<dyn s
         .collect::<HashSet<_>>();
     assert!(route_shapes.contains(&("nestjs", "GET", "/users/{userId}")));
     assert!(route_shapes.contains(&("nestjs", "POST", "/users")));
-    assert!(route_shapes.contains(&("nestjs-graphql", "QUERY", "/graphql/user")));
-    assert!(route_shapes.contains(&("nestjs-graphql", "MUTATION", "/graphql/createUser")));
+    assert!(route_shapes.contains(&("nestjs-graphql", "QUERY", "/graphql")));
+    assert!(route_shapes.contains(&("nestjs-graphql", "MUTATION", "/graphql")));
 
     let domain_shapes = extraction
         .framework_facts
@@ -84,12 +127,43 @@ fn nest_http_graphql_and_messaging_shapes_are_distinct() -> Result<(), Box<dyn s
 }
 
 #[test]
+fn nest_dynamic_decorators_are_not_promoted_to_root_routes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("src/nest-dynamic.ts"),
+        br#"import { Controller, Get } from "@nestjs/common";
+const PATH = "/dynamic";
+@Controller({ path: "/users" })
+class UsersController {
+  @Get(PATH)
+  dynamic() {}
+  @Get()
+  root() {}
+}
+"#,
+    )?;
+    let routes = routes(&extraction).collect::<Vec<_>>();
+    assert!(routes.iter().any(|route| route.normalized_path == "/users"));
+    assert!(
+        !routes
+            .iter()
+            .any(|route| route.normalized_path == "/users/dynamic")
+    );
+    Ok(())
+}
+
+#[test]
 fn react_and_vue_router_configs_require_literal_paths_and_known_shapes()
 -> Result<(), Box<dyn std::error::Error>> {
     let react = source_extract(Path::new("src/routes.tsx"), "react-router.tsx")?;
     assert!(routes(&react).any(|route| {
         route.framework == "react-router"
             && route.normalized_path == "/accounts/{accountId}"
+            && route.handler_reference == "AccountAlias"
+    }));
+    assert!(routes(&react).any(|route| {
+        route.framework == "react-router"
+            && route.normalized_path == "/account-settings"
             && route.handler_reference == "AccountAlias"
     }));
     assert!(routes(&react).any(|route| {
@@ -111,6 +185,49 @@ fn react_and_vue_router_configs_require_literal_paths_and_known_shapes()
         1,
         "nested route configuration objects must not duplicate their child route"
     );
+
+    let nested = Engine::default().extract_source(
+        Path::new("src/nested-routes.tsx"),
+        br#"import { createBrowserRouter } from "react-router-dom";
+const router = createBrowserRouter([
+  { path: "/admin", children: [{ path: "users/:id", Component: UserPage }] },
+]);
+const guard = <RouteGuard path="/not-a-route" component={UserPage} />;
+"#,
+    )?;
+    assert!(routes(&nested).any(|route| {
+        route.framework == "react-router"
+            && route.normalized_path == "/admin/users/{id}"
+            && route.handler_reference == "UserPage"
+    }));
+    assert!(!routes(&nested).any(|route| route.normalized_path == "/not-a-route"));
+
+    let object_routes = Engine::default().extract_source(
+        Path::new("src/object-routes.tsx"),
+        br#"import { createBrowserRouter } from "react-router-dom";
+function UserPage() { return null; }
+export const router = createBrowserRouter([
+  { path: "/users", element: <UserPage /> },
+  { path: "/lazy", component: () => import("./LazyPage") },
+]);
+const unrelated = { path: "/not-a-router", component: UserPage };
+"#,
+    )?;
+    assert!(routes(&object_routes).any(|route| {
+        route.normalized_path == "/users" && route.handler_reference == "UserPage"
+    }));
+    let lazy = routes(&object_routes)
+        .find(|route| route.normalized_path == "/lazy")
+        .ok_or("missing lazy route")?;
+    assert!(
+        lazy.handler_reference
+            .starts_with("opaque_route_handler_at_")
+    );
+    assert_eq!(
+        lazy.detail.get("opaque_handler"),
+        Some(&serde_json::Value::Bool(true))
+    );
+    assert!(!routes(&object_routes).any(|route| route.normalized_path == "/not-a-router"));
     Ok(())
 }
 
@@ -281,6 +398,12 @@ fn file_routes_emit_convention_components_and_exact_bindings()
             vec!["PAGE"],
         ),
         (
+            "astro/src/pages/files/[...rest].astro",
+            "astro",
+            "/files/{*rest}",
+            vec!["PAGE"],
+        ),
+        (
             "astro/src/pages/api/items/[id].ts",
             "astro",
             "/api/items/{id}",
@@ -301,23 +424,60 @@ fn file_routes_emit_convention_components_and_exact_bindings()
         );
         let resolved =
             resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
-        assert!(resolved.iter().all(|route| {
-            route.state == ResolutionState::Exact
-                && route
-                    .stages
-                    .last()
-                    .is_some_and(|stage| stage.role == RouteStageRole::Handler)
-        }));
-        for operation in &operations {
-            assert!(extraction.nodes.iter().any(|node| {
-                node.string("symbol_kind") == "component"
-                    && node.string("_origin") == "convention"
-                    && !node.string("rule").is_empty()
-                    && node.string("qualified_name")
-                        == format!(
-                            "{expected_framework}::route-component::{operation}::{expected_path}"
-                        )
-            }));
+        assert!(
+            resolved.iter().all(|route| {
+                route.state == ResolutionState::Exact
+                    && route
+                        .stages
+                        .last()
+                        .is_some_and(|stage| stage.role == RouteStageRole::Handler)
+            }),
+            "{name}: {:?}",
+            resolved
+                .iter()
+                .map(|route| (
+                    &route.route.operation,
+                    &route.route.handler_reference,
+                    route.state,
+                    route.stages.last().map(|stage| (
+                        &stage.reference,
+                        &stage.state,
+                        &stage.target
+                    ))
+                ))
+                .collect::<Vec<_>>()
+        );
+        let endpoint =
+            name.contains("+server") || (name.contains("/api/") && name.ends_with(".ts"));
+        if endpoint {
+            assert!(
+                routes(&extraction)
+                    .filter(|route| {
+                        route.framework == expected_framework
+                            && route.normalized_path == expected_path
+                    })
+                    .all(|route| !route
+                        .handler_reference
+                        .starts_with("sveltekit::route-component::")
+                        && !route
+                            .handler_reference
+                            .starts_with("nuxt::route-component::")
+                        && !route
+                            .handler_reference
+                            .starts_with("astro::route-component::"))
+            );
+        } else {
+            for operation in &operations {
+                assert!(extraction.nodes.iter().any(|node| {
+                    node.string("symbol_kind") == "component"
+                        && node.string("_origin") == "convention"
+                        && !node.string("rule").is_empty()
+                        && node.string("qualified_name")
+                            == format!(
+                                "{expected_framework}::route-component::{operation}::{expected_path}"
+                            )
+                }));
+            }
         }
         assert!(extraction.edges.iter().any(|edge| {
             edge.string("relation") == "routes_to"
@@ -325,6 +485,76 @@ fn file_routes_emit_convention_components_and_exact_bindings()
                 && !edge.string("rule").is_empty()
         }));
     }
+    let page_load_only = Engine::default().extract_source(
+        Path::new("src/routes/users/+page.ts"),
+        b"export const load = async () => ({ data: true });\n",
+    )?;
+    assert!(routes(&page_load_only).next().is_none());
+
+    let directory = tempfile::tempdir()?;
+    let grouped_path = directory
+        .path()
+        .join("src/routes/(app)/[[lang]]/[id=integer]/+page.svelte");
+    fs::create_dir_all(grouped_path.parent().ok_or("missing route parent")?)?;
+    fs::write(&grouped_path, "<h1>User</h1>")?;
+    let grouped = Engine::default().extract(&grouped_path)?;
+    assert!(routes(&grouped).any(|route| route.normalized_path == "/{lang}/{id}"));
+    Ok(())
+}
+
+#[test]
+fn file_endpoint_reexports_bind_to_the_exported_handler_module()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut engine = Engine::default();
+    let mut extraction = Extraction::default();
+    for (path, source) in [
+        (
+            "src/pages/api/users.ts",
+            r#"export { GET } from "./handlers";
+"#,
+        ),
+        (
+            "src/pages/api/handlers.ts",
+            "export async function GET() { return new Response(); }\n",
+        ),
+    ] {
+        let mut source = engine.extract_source(Path::new(path), source.as_bytes())?;
+        extraction.nodes.append(&mut source.nodes);
+        extraction.edges.append(&mut source.edges);
+        extraction
+            .framework_facts
+            .append(&mut source.framework_facts);
+    }
+
+    let route = routes(&extraction)
+        .find(|route| route.framework == "astro" && route.normalized_path == "/api/users")
+        .ok_or("missing Astro endpoint route")?;
+    assert_eq!(route.handler_reference, "GET");
+    assert_eq!(
+        route.detail.get("handler_module"),
+        Some(&serde_json::Value::String("./handlers".into()))
+    );
+
+    let resolved =
+        resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+    let resolved = resolved
+        .iter()
+        .find(|route| route.route.normalized_path == "/api/users")
+        .ok_or("missing resolved Astro endpoint")?;
+    assert_eq!(resolved.state, ResolutionState::Exact);
+    let target = resolved
+        .stages
+        .last()
+        .and_then(|stage| stage.target.as_deref())
+        .ok_or("missing re-export target")?;
+    assert_eq!(
+        extraction
+            .nodes
+            .iter()
+            .find(|node| node.id == target)
+            .map(|node| node.string("source_file")),
+        Some("src/pages/api/handlers.ts".to_owned())
+    );
     Ok(())
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ to yours:
 - [Operate the Compass Store](guides/compass-store-operations.md)
 - [Solve a concrete problem](cookbook/README.md)
 - [Look up commands and contracts](reference/commands.md)
+- [Check framework-route support](reference/framework-routes.md)
 
 ### I contribute to Compass
 
@@ -139,6 +140,7 @@ The [cookbook index](cookbook/README.md) routes to:
 | [Configuration](reference/configuration.md) | Providers, environment, paths, and precedence |
 | [Outputs](reference/outputs.md) | `compass-out/`, graph JSON, query results, and history exports |
 | [Document formats](reference/document-formats.md) | Markdown fields, limits, and discovery versus extraction |
+| [Framework routes](reference/framework-routes.md) | Recognized routing shapes, graph projection, and conservative boundaries |
 | [Compatibility](reference/compatibility.md) | Compass contracts, hard cutovers, and portability |
 | [CompassQL](COMPASSQL.md) | Canonical language and runtime contract |
 | [CompassQL support](COMPASSQL_SUPPORT.md) | Checked syntax and feature matrix |

--- a/docs/reference/framework-routes.md
+++ b/docs/reference/framework-routes.md
@@ -1,0 +1,101 @@
+# Framework-aware routes
+
+Compass detects supported framework registrations during local structural
+extraction and publishes them in `compass.graph/1`. No framework detector
+downloads a grammar, invokes a language server, or requires credentials.
+
+> **Who this page is for:** Compass users and integrators querying application
+> entry points.
+>
+> **You will learn:** which route forms are recognized, how they appear in the
+> graph, and which dynamic forms intentionally remain unresolved.
+>
+> **Prerequisites:** [Graph model](../concepts/graph-model.md).
+>
+> **Reading time:** about 8 minutes.
+
+## Graph contract
+
+Each HTTP, page, or hook registration becomes a `route` node with its
+framework, operation, normalized path, original path, declaring scope, source
+anchor, ordered stages, and resolution state. A `routes_to` edge points from
+the route to each exact middleware and handler target. Middleware positions
+preserve declaration order; the handler is the final stage.
+
+An ambiguous or unresolved handler remains recorded on the route node, with
+bounded candidates when available, but does not receive an invented exact
+edge. Config- and convention-derived routes retain the rule and source that
+produced them. Equivalent inputs have deterministic route identities and
+ordering.
+
+`callers` follows incoming `calls` and `routes_to` edges. After building a
+graph, this surfaces both code callers and URL registrations for a handler:
+
+```bash
+compass callers UsersController.show --graph compass-out/graph.json
+```
+
+## Supported route shapes
+
+| Framework | Recognized shapes |
+| --- | --- |
+| Django | `path`, `re_path`, legacy `url`, and `include` in an activated URL module; positional or named `route`/`view` arguments; function views, dotted string handlers, and class-based `.as_view()` handlers |
+| Flask | `Flask` and `Blueprint` `@receiver.route` decorators, constructor and registration-time `url_prefix`, positional or named `rule`, and literal `methods` lists |
+| FastAPI | `FastAPI` and `APIRouter` decorators for `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `trace`; `api_route`/`route` literal method lists; positional or named `path`; constructor and `include_router(prefix=...)` prefixes and `Depends` stages |
+| Express | `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths, ordered middleware chains, and opaque inline callbacks that remain unresolved |
+| NestJS | `Controller` with HTTP method decorators and `RequestMapping`; GraphQL `Resolver` with `Query`/`Mutation` operations at the `/graphql` endpoint plus a typed field detail; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations |
+| Laravel | Exact `Illuminate\\Support\\Facades\\Route` receivers, including aliases; HTTP, `match`, `any`, `prefix(...)->group`, `resource`/`apiResource`, and `only`/`except` resource modifiers; `Controller@action` and controller/action tuple handlers |
+| Drupal | `*.routing.yml`/`*.routing.yaml` paths with controller, form, entity-form, entity-view, or entity-list handlers; pipe- or comma-separated `_method` values; documented `Implements hook_*().` functions and functions named `hook_*` in `.module`, `.theme`, `.install`, and `.inc` files |
+| Rails | HTTP and `match` declarations inside `Rails.application.routes.draw`, `to:` and hash-rocket handlers, literal `scope`/`namespace` prefixes with namespaced controller owners, and `via` method lists |
+| Spring | Java and Kotlin controller mappings, including class/method composition, HTTP mapping annotations, `RequestMapping` methods, composed and inherited Java mappings, constants, packages, and overloaded handler signatures |
+| Play | Literal `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, and `HEAD` entries in `conf/routes`, targeting Java, Scala, or injected controller actions |
+| Gin, chi, gorilla/mux | Imported router registrations, grouped/closure prefixes, Gin middleware chains, chi method calls, and gorilla `HandleFunc(...).Methods(...)` (including `PathPrefix(...).Subrouter()` chains) |
+| Axum, actix-web, Rocket | Axum nested `.nest(...).route(...)` chains, actix scoped resources and `.route(...).to(...)` handlers, plus Rocket and actix route attributes (including multiline attributes), guarded by framework imports or qualified macros |
+| ASP.NET Core | MVC controller/action templates, `[controller]` and `[action]` tokens, HTTP method attributes, and absolute `/` or `~/` action-template overrides |
+| Vapor | Grouped literal/path-component prefixes, closure groups, `app.on(...)`, and HTTP registrations with explicit `use:` handlers; opaque closures remain visible as unresolved handlers |
+| React Router | JSX `Route` elements using `element={<Component />}` or `Component={Component}`, and literal object route configs with `component`, `element`, or `Component` targets and loader/action stages |
+| SvelteKit | `src/routes` `+page.svelte` components and `+server` endpoints, including `[param]` and `[...rest]` segments and source-backed exported HTTP methods; `+page.ts` load modules are not pages |
+| Vue Router and Nuxt | Vue Router literal route objects; Nuxt `pages` components, `server/api` method-suffixed endpoints, dynamic segments, and route-middleware domain facts |
+| Astro | `src/pages` `.astro` pages and `.ts`/`.js` endpoints, including `[param]` and `[...rest]` segments, exported HTTP methods, `ALL`, and source-backed default handlers |
+
+File-route packs require matching project dependency evidence during a normal
+repository build. Direct single-file extraction without project evidence is
+available for fixtures and tooling, but does not weaken repository activation.
+
+NestJS messaging, WebSocket subscriptions, and Nuxt middleware use their typed
+messaging/domain contracts rather than being assigned fictitious HTTP URLs.
+GraphQL fields retain their field name in route details while sharing the
+transport endpoint path. They still retain handler references and source
+anchors.
+
+## Conservative boundaries
+
+Compass publishes a route only when the framework is activated by direct
+evidence such as an import, exact receiver, framework config filename, or
+dependency-backed file convention. A filename or decorator name alone does not
+activate most source packs.
+
+The following forms intentionally do not become exact route bindings:
+
+- computed or concatenated paths;
+- dynamic method names and arbitrary metaprogramming;
+- opaque closures when no source-backed callable can be identified;
+- same-named handlers with more than one valid target;
+- route targets selected only by repository-wide terminal-name similarity; and
+- file-route conventions without matching project dependency evidence.
+
+Framework resolution is bounded by per-file fact, candidate, alias-expansion,
+and include-depth limits. Exceeding a limit is an explicit failure or
+diagnostic, never an empty successful result. Django include cycles stop without
+inventing a route, and ambiguous handlers preserve their candidate state
+without publishing a misleading `routes_to` edge.
+
+## Related pages
+
+- [Graph model](../concepts/graph-model.md)
+- [Provenance](../concepts/provenance.md)
+- [Outputs](outputs.md)
+- [Universal semantic evidence](universal-semantic-evidence.md)
+
+**Next step:** build a graph and run `compass callers` for a known controller or
+view to inspect its code callers and framework registrations together.

--- a/fixtures/code-graph/domain/messaging/nest.ts
+++ b/fixtures/code-graph/domain/messaging/nest.ts
@@ -1,8 +1,10 @@
 import { Controller } from '@nestjs/common';
 import { EventPattern, MessagePattern } from '@nestjs/microservices';
 import { SubscribeMessage } from '@nestjs/websockets';
+import { WebSocketGateway } from '@nestjs/websockets';
 
 @Controller()
+@WebSocketGateway()
 export class OrdersConsumer {
   @MessagePattern('orders.created')
   handleCreated() {}

--- a/fixtures/code-graph/routes/csharp/AspNetController.cs
+++ b/fixtures/code-graph/routes/csharp/AspNetController.cs
@@ -9,6 +9,13 @@ public class UsersController : ControllerBase
 
     [HttpPost]
     public object Create() => new();
+
+    [HttpGet("/status")]
+    public object Status() => new();
+
+    [HttpGet]
+    [Route("health")]
+    public object Health() => new();
 }
 
 public class QualificationPayload {}

--- a/fixtures/code-graph/routes/go/chi.go
+++ b/fixtures/code-graph/routes/go/chi.go
@@ -6,4 +6,7 @@ func showUser(w any, r any) {}
 
 func Routes(r chi.Router) {
 	r.Get("/users/{id}", showUser)
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/items", showUser)
+	})
 }

--- a/fixtures/code-graph/routes/php/drupal.module
+++ b/fixtures/code-graph/routes/php/drupal.module
@@ -6,4 +6,9 @@ class ExampleController {
 
 class ExampleForm {}
 
-function hook_entity_type_build() {}
+/**
+ * Implements hook_entity_type_build().
+ */
+function drupal_entity_type_build() {}
+
+function drupal_helper() {}

--- a/fixtures/code-graph/routes/php/drupal.routing.yml
+++ b/fixtures/code-graph/routes/php/drupal.routing.yml
@@ -3,9 +3,14 @@ example.view:
   defaults:
     _controller: '\Drupal\example\Controller\ExampleController::view'
   requirements:
-    _method: 'GET'
+    _method: 'GET|POST'
 
 example.form:
   path: '/examples/create'
   defaults:
     _form: '\Drupal\example\Form\ExampleForm'
+
+example.entity_edit:
+  path: '/examples/{example}/edit'
+  defaults:
+    _entity_form: 'example.edit'

--- a/fixtures/code-graph/routes/python/fastapi_app.py
+++ b/fixtures/code-graph/routes/python/fastapi_app.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, FastAPI
 
 app = FastAPI()
 router = APIRouter(prefix="/v1")
+app.include_router(router, prefix="/api")
 
 
 def authenticate():

--- a/fixtures/code-graph/routes/python/flask_app.py
+++ b/fixtures/code-graph/routes/python/flask_app.py
@@ -2,6 +2,7 @@ from flask import Blueprint, Flask
 
 app = Flask(__name__)
 api = Blueprint("api", __name__, url_prefix="/api")
+app.register_blueprint(api, url_prefix="/v2")
 
 
 @app.route("/health")

--- a/fixtures/code-graph/routes/ruby/rails.rb
+++ b/fixtures/code-graph/routes/ruby/rails.rb
@@ -6,8 +6,10 @@ class UsersController
   end
 end
 
-class DashboardController
-  def index
+module Admin
+  class DashboardController
+    def index
+    end
   end
 end
 

--- a/fixtures/code-graph/routes/rust/axum.rs
+++ b/fixtures/code-graph/routes/rust/axum.rs
@@ -7,4 +7,5 @@ fn router() -> Router {
     Router::new()
         .route("/users/:id", get(show_user))
         .route("/users", post(create_user))
+        .nest("/api", Router::new().route("/nested", get(show_user).post(create_user)))
 }

--- a/fixtures/code-graph/routes/typescript/astro/src/pages/files/[...rest].astro
+++ b/fixtures/code-graph/routes/typescript/astro/src/pages/files/[...rest].astro
@@ -1,0 +1,5 @@
+---
+const { rest } = Astro.params;
+---
+
+<h1>{rest}</h1>

--- a/fixtures/code-graph/routes/typescript/express.ts
+++ b/fixtures/code-graph/routes/typescript/express.ts
@@ -6,6 +6,7 @@ const router = express.Router();
 
 app.get("/health", health);
 router.get("/users/:userId", authenticate, audit(), showUser);
+app.get("/inline", authenticate, (request, response) => response.send("ok"));
 app.get(dynamicPath, ignoredHandler);
 unknown.get("/not-a-route", ignoredHandler);
 

--- a/fixtures/code-graph/routes/typescript/nest.ts
+++ b/fixtures/code-graph/routes/typescript/nest.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post } from "@nestjs/common";
 import { EventPattern, MessagePattern } from "@nestjs/microservices";
 import { Mutation, Query, Resolver } from "@nestjs/graphql";
-import { SubscribeMessage } from "@nestjs/websockets";
+import { SubscribeMessage, WebSocketGateway } from "@nestjs/websockets";
 
 @Controller("/users")
 export class UsersController {
@@ -17,6 +17,10 @@ export class UsersController {
   @EventPattern("users.created")
   userCreated() {}
 
+}
+
+@WebSocketGateway()
+export class UsersGateway {
   @SubscribeMessage("users.watch")
   watchUsers() {}
 }

--- a/fixtures/code-graph/routes/typescript/owner-mismatch.ts
+++ b/fixtures/code-graph/routes/typescript/owner-mismatch.ts
@@ -1,0 +1,11 @@
+import express from "express";
+
+const app = express();
+
+app.get("/owner-mismatch", MissingController.show);
+
+class ExistingController {
+  show() {
+    return "existing";
+  }
+}

--- a/fixtures/code-graph/routes/typescript/react-router.tsx
+++ b/fixtures/code-graph/routes/typescript/react-router.tsx
@@ -3,7 +3,10 @@ import { AccountPage as AccountAlias } from "./AccountPage";
 import { UserPage } from "./UserPage";
 
 export const routes = (
-  <Route path="/accounts/:accountId" element={<AccountAlias />} />
+  <>
+    <Route path="/accounts/:accountId" element={<AccountAlias />} />
+    <Route path="/account-settings" Component={AccountAlias} />
+  </>
 );
 
 export const router = createBrowserRouter([

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -60,7 +60,7 @@
       "framework": "fastapi",
       "routeFramework": "fastapi",
       "operation": "POST",
-      "path": "/v1/users",
+      "path": "/api/v1/users",
       "routeSource": "fixtures/code-graph/routes/python/fastapi_app.py",
       "handler": {
         "qualifiedName": "fixtures.code-graph.routes.python.fastapi_app.create_user"
@@ -77,7 +77,7 @@
       ],
       "producer": "compass.frameworks.fastapi",
       "rules": [
-        "framework-route-stage:handler:1"
+        "python-mounted-router|stage:handler:1"
       ],
       "allowHeuristic": false,
       "candidates": []
@@ -90,7 +90,7 @@
       "path": "/health",
       "routeSource": "fixtures/code-graph/routes/typescript/express.ts",
       "handler": {
-        "qualifiedName": "health()@324"
+        "qualifiedName": "health()@402"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/express.ts",
       "relationship": "routes_to",
@@ -117,7 +117,7 @@
       "path": "/users/{userId}",
       "routeSource": "fixtures/code-graph/routes/typescript/nest.ts",
       "handler": {
-        "qualifiedName": "UsersController::showUser()@316"
+        "qualifiedName": "UsersController::showUser()@334"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/nest.ts",
       "relationship": "routes_to",
@@ -141,10 +141,10 @@
       "framework": "nestjs-graphql",
       "routeFramework": "nestjs-graphql",
       "operation": "QUERY",
-      "path": "/graphql/user",
+      "path": "/graphql",
       "routeSource": "fixtures/code-graph/routes/typescript/nest.ts",
       "handler": {
-        "qualifiedName": "UsersResolver::user()@582"
+        "qualifiedName": "UsersResolver::user()@651"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/nest.ts",
       "relationship": "routes_to",
@@ -380,6 +380,33 @@
       "candidates": []
     },
     {
+      "id": "flow-chi-closure",
+      "framework": "chi",
+      "routeFramework": "chi",
+      "operation": "GET",
+      "path": "/api/items",
+      "routeSource": "fixtures/code-graph/routes/go/chi.go",
+      "handler": {
+        "qualifiedName": "fixtures/code-graph/routes/routes.showUser"
+      },
+      "handlerSource": "fixtures/code-graph/routes/go/chi.go",
+      "relationship": "routes_to",
+      "stage": "handler",
+      "position": 0,
+      "handlerKind": "function",
+      "handlerLanguage": "go",
+      "resolution": "exact",
+      "origins": [
+        "ast"
+      ],
+      "producer": "compass.frameworks.chi",
+      "rules": [
+        "chi-router-call|stage:handler:0"
+      ],
+      "allowHeuristic": false,
+      "candidates": []
+    },
+    {
       "id": "flow-axum",
       "framework": "axum",
       "routeFramework": "axum",
@@ -427,6 +454,60 @@
         "ast"
       ],
       "producer": "compass.frameworks.actix",
+      "rules": [
+        "rust-router-call|stage:handler:0"
+      ],
+      "allowHeuristic": false,
+      "candidates": []
+    },
+    {
+      "id": "flow-axum-nested-get",
+      "framework": "axum",
+      "routeFramework": "axum",
+      "operation": "GET",
+      "path": "/api/nested",
+      "routeSource": "fixtures/code-graph/routes/rust/axum.rs",
+      "handler": {
+        "qualifiedName": "crate::axum::show_user"
+      },
+      "handlerSource": "fixtures/code-graph/routes/rust/axum.rs",
+      "relationship": "routes_to",
+      "stage": "handler",
+      "position": 0,
+      "handlerKind": "function",
+      "handlerLanguage": "rust",
+      "resolution": "exact",
+      "origins": [
+        "ast"
+      ],
+      "producer": "compass.frameworks.axum",
+      "rules": [
+        "rust-router-call|stage:handler:0"
+      ],
+      "allowHeuristic": false,
+      "candidates": []
+    },
+    {
+      "id": "flow-axum-nested-post",
+      "framework": "axum",
+      "routeFramework": "axum",
+      "operation": "POST",
+      "path": "/api/nested",
+      "routeSource": "fixtures/code-graph/routes/rust/axum.rs",
+      "handler": {
+        "qualifiedName": "crate::axum::create_user"
+      },
+      "handlerSource": "fixtures/code-graph/routes/rust/axum.rs",
+      "relationship": "routes_to",
+      "stage": "handler",
+      "position": 0,
+      "handlerKind": "function",
+      "handlerLanguage": "rust",
+      "resolution": "exact",
+      "origins": [
+        "ast"
+      ],
+      "producer": "compass.frameworks.axum",
       "rules": [
         "rust-router-call|stage:handler:0"
       ],
@@ -549,13 +630,13 @@
       "path": "/api/users/{id}",
       "routeSource": "fixtures/code-graph/routes/typescript/sveltekit/src/routes/api/users/[id]/+server.ts",
       "handler": {
-        "qualifiedName": "sveltekit::route-component::GET::/api/users/{id}"
+        "qualifiedName": "GET()@7"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/sveltekit/src/routes/api/users/[id]/+server.ts",
       "relationship": "routes_to",
       "stage": "handler",
       "position": 0,
-      "handlerKind": "component",
+      "handlerKind": "function",
       "handlerLanguage": "typescript",
       "resolution": "exact",
       "origins": [
@@ -603,13 +684,13 @@
       "path": "/users",
       "routeSource": "fixtures/code-graph/routes/typescript/nuxt/server/api/users.get.ts",
       "handler": {
-        "qualifiedName": "nuxt::route-component::GET::/users"
+        "qualifiedName": "default"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/nuxt/server/api/users.get.ts",
       "relationship": "routes_to",
       "stage": "handler",
       "position": 0,
-      "handlerKind": "component",
+      "handlerKind": "function",
       "handlerLanguage": "typescript",
       "resolution": "exact",
       "origins": [
@@ -630,13 +711,13 @@
       "path": "/api/items/{id}",
       "routeSource": "fixtures/code-graph/routes/typescript/astro/src/pages/api/items/[id].ts",
       "handler": {
-        "qualifiedName": "astro::route-component::GET::/api/items/{id}"
+        "qualifiedName": "GET()@7"
       },
       "handlerSource": "fixtures/code-graph/routes/typescript/astro/src/pages/api/items/[id].ts",
       "relationship": "routes_to",
       "stage": "handler",
       "position": 0,
-      "handlerKind": "component",
+      "handlerKind": "function",
       "handlerLanguage": "typescript",
       "resolution": "exact",
       "origins": [
@@ -673,6 +754,12 @@
       "id": "negative-express",
       "framework": "express",
       "source": "fixtures/code-graph/routes/typescript/near-matches.ts",
+      "routeFramework": "express"
+    },
+    {
+      "id": "negative-express-owner-mismatch",
+      "framework": "express",
+      "source": "fixtures/code-graph/routes/typescript/owner-mismatch.ts",
       "routeFramework": "express"
     },
     {


### PR DESCRIPTION
## Summary

- Expand framework-aware route extraction and resolution across the requested framework matrix, including Python, JavaScript/TypeScript, PHP/Ruby/JVM, Go/Rust/Swift, and file-based routing.
- Compose mounts, prefixes, namespaces, scopes, middleware chains, nested route trees, controller metadata, and source-backed endpoint handlers while preserving deterministic identities and provenance.
- Fail closed on owner mismatches and ambiguous same-name targets instead of inventing bindings.
- Add native regressions, qualification fixtures/manifests, route reference documentation, and bump extraction/cache semantics to v6.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-ec06 cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-ec06 cargo test --workspace --lib --bins --locked`
- Focused route suites for `compass-languages`, `compass-resolve`, and `compass-files`
- `sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-ec06 ./scripts/qualify_code_graph_v1.sh --fixtures-only`
  - 27 flows / 24 frameworks / 24 negatives
  - deterministic clean, warm, rebuild, and checkout comparisons all pass
  - 80 exact route resolutions and 11 intentionally unresolved cases
