### PR TITLE
Refine public docs navigation

### DIFF
--- a/apps/web/app/(marketing)/product/page.tsx
+++ b/apps/web/app/(marketing)/product/page.tsx
@@ -132,7 +132,7 @@ export default function ProductPage() {
               <div className="grid gap-3 sm:grid-cols-2">
                 {graphPrinciples.map(([label, text]) => <div className="rounded-lg border border-border/80 bg-card/75 p-3" key={label}><span className="font-mono text-[0.65rem] uppercase tracking-[0.12em] text-primary">{label}</span><p className="mt-1 text-sm leading-6 text-muted-foreground">{text}</p></div>)}
               </div>
-              <Link className="inline-flex items-center gap-2 text-sm font-medium text-primary" href="/docs/reference/universal-semantic-evidence">Read the evidence model <ArrowRightIcon data-icon="inline-end" /></Link>
+              <Link className="inline-flex items-center gap-2 text-sm font-medium text-primary" href="/docs/concepts/provenance">Read the provenance model <ArrowRightIcon data-icon="inline-end" /></Link>
             </div>
           </div>
         </div>

--- a/apps/web/app/docs/[...slug]/page.tsx
+++ b/apps/web/app/docs/[...slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
@@ -32,6 +33,19 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const RelativeLink = createRelativeLink(source, page);
+  const docsLink = async ({ href, ...linkProps }: ComponentProps<'a'>) => {
+    const normalizedHref =
+      typeof href === 'string' &&
+      !href.startsWith('.') &&
+      !href.startsWith('/') &&
+      !href.startsWith('#') &&
+      (href.split('#', 1)[0].endsWith('.md') || href.split('#', 1)[0].endsWith('.mdx'))
+        ? `./${href}`
+        : href;
+
+    return RelativeLink({ ...linkProps, href: normalizedHref });
+  };
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
@@ -40,7 +54,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
       <DocsBody>
         <MDX
           components={getMDXComponents({
-            a: createRelativeLink(source, page),
+            a: docsLink,
           })}
         />
       </DocsBody>

--- a/apps/web/components/site-footer.tsx
+++ b/apps/web/components/site-footer.tsx
@@ -1,9 +1,13 @@
 import Link from 'next/link';
-import { ArrowUpRightIcon } from 'lucide-react';
+import { GithubIcon, StarIcon } from 'lucide-react';
 
 import { CompassLockup } from '@/components/compass-mark';
+import { formatGitHubStarCount, getGitHubStarCount, githubRepositoryUrl } from '@/lib/github';
 
-export function SiteFooter() {
+export async function SiteFooter() {
+  const starCount = await getGitHubStarCount();
+  const formattedStarCount = starCount === null ? null : formatGitHubStarCount(starCount);
+
   return (
     <footer className="border-t border-border/70 bg-muted/25">
       <div className="mx-auto grid max-w-7xl gap-10 px-5 py-12 lg:grid-cols-[1.4fr_1fr_1fr_1fr] lg:px-8">
@@ -36,8 +40,21 @@ export function SiteFooter() {
         />
         <div className="flex flex-col gap-3">
           <span className="eyebrow">Project</span>
-          <Link className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground" href="https://github.com/crabbuild/compass" target="_blank" rel="noreferrer">
-            GitHub <ArrowUpRightIcon data-icon="inline-end" />
+          <Link
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+            href={githubRepositoryUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={formattedStarCount ? `Open Compass on GitHub, ${formattedStarCount} stars` : 'Open Compass on GitHub'}
+          >
+            <GithubIcon aria-hidden="true" className="size-4" />
+            <span>GitHub</span>
+            {formattedStarCount && (
+              <span className="inline-flex items-center gap-1 font-mono text-xs tabular-nums text-muted-foreground/80" title={`${formattedStarCount} GitHub stars`}>
+                <StarIcon aria-hidden="true" className="size-3.5 fill-current" />
+                {formattedStarCount}
+              </span>
+            )}
           </Link>
           <Link className="text-sm text-muted-foreground hover:text-foreground" href="/about">About Compass</Link>
           <Link className="text-sm text-muted-foreground hover:text-foreground" href="/changelog">Changelog</Link>

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link';
-import { ArrowUpRightIcon, MenuIcon } from 'lucide-react';
+import { GithubIcon, MenuIcon, StarIcon } from 'lucide-react';
 
 import { CompassLockup } from '@/components/compass-mark';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { buttonVariants } from '@/components/ui/button';
+import { formatGitHubStarCount, getGitHubStarCount, githubRepositoryUrl } from '@/lib/github';
 import {
   Sheet,
   SheetClose,
@@ -23,7 +24,10 @@ const links = [
   { href: '/blog', label: 'Blog' },
 ];
 
-export function SiteHeader() {
+export async function SiteHeader() {
+  const starCount = await getGitHubStarCount();
+  const formattedStarCount = starCount === null ? null : formatGitHubStarCount(starCount);
+
   return (
     <header className="sticky top-0 z-40 border-b border-border/70 bg-background/90 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-5 lg:px-8">
@@ -47,12 +51,19 @@ export function SiteHeader() {
           <ThemeToggle />
           <Link
             className="inline-flex items-center gap-1.5 px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            href="https://github.com/crabbuild/compass"
+            href={githubRepositoryUrl}
             target="_blank"
             rel="noreferrer"
+            aria-label={formattedStarCount ? `Open Compass on GitHub, ${formattedStarCount} stars` : 'Open Compass on GitHub'}
           >
+            <GithubIcon aria-hidden="true" className="size-4" />
             GitHub
-            <ArrowUpRightIcon data-icon="inline-end" />
+            {formattedStarCount && (
+              <span className="ml-1 inline-flex items-center gap-1 font-mono text-xs tabular-nums text-muted-foreground/80" title={`${formattedStarCount} GitHub stars`}>
+                <StarIcon aria-hidden="true" className="size-3.5 fill-current" />
+                {formattedStarCount}
+              </span>
+            )}
           </Link>
           <Link className={cn(buttonVariants({ size: 'sm' }))} href="/install">
             Install Compass

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,0 +1,29 @@
+export const githubRepository = 'crabbuild/compass';
+export const githubRepositoryUrl = `https://github.com/${githubRepository}`;
+
+type GitHubRepositoryResponse = {
+  stargazers_count?: unknown;
+};
+
+export async function getGitHubStarCount(): Promise<number | null> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${githubRepository}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) return null;
+
+    const repository = (await response.json()) as GitHubRepositoryResponse;
+    return typeof repository.stargazers_count === 'number' ? repository.stargazers_count : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatGitHubStarCount(count: number): string {
+  return new Intl.NumberFormat('en-US').format(count);
+}

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -20,6 +20,13 @@ const sidebarIcon = (Icon: LucideIcon): ReactNode =>
 
 const START_PAGES = ['getting-started.md', 'README.md'] as const;
 const COMPASSQL_PAGES = ['concepts/compassql.md', 'COMPASSQL.md', 'COMPASSQL_SUPPORT.md'] as const;
+const COOKBOOK_PAGES = [
+  'cookbook/README.md',
+  'cookbook/architecture-discovery.md',
+  'cookbook/ci-and-automation.md',
+  'cookbook/impact-analysis.md',
+  'cookbook/troubleshooting.md',
+] as const;
 
 const FOLDER_SECTIONS = [
   { path: 'concepts', name: 'Core concepts', icon: BookOpenIcon },
@@ -82,9 +89,12 @@ function withPageName(page: Item, name: string): Item {
 }
 
 function withCookbookPageName(page: Item): Item {
-  if (page.$ref === 'cookbook/README.md') return withPageName(page, 'Cookbook: overview');
-  if (typeof page.name !== 'string' || page.name.toLocaleLowerCase().startsWith('cookbook:')) return page;
-  return withPageName(page, `Cookbook: ${page.name}`);
+  if (page.$ref === 'cookbook/README.md') return withPageName(page, 'Overview');
+  if (typeof page.name !== 'string') return page;
+
+  const name = page.name.replace(/^Cookbook:\s*/i, '');
+  const capitalizedName = name ? `${name[0].toUpperCase()}${name.slice(1)}` : name;
+  return capitalizedName === page.name ? page : withPageName(page, capitalizedName);
 }
 
 function keepOnlyTopLevelIcons(nodes: Node[], depth = 0): Node[] {
@@ -116,11 +126,27 @@ function withFolderPresentation(
 
 function withCookbookPresentation(folder: Folder): Folder {
   const presented = withFolderPresentation(folder, 'Cookbook', FlaskConicalIcon);
+  const orderedRefs = new Set<string>(COOKBOOK_PAGES);
+  const pagesByRef = new Map<string, Item>();
+  const nonPageChildren: Node[] = [];
+
+  for (const node of presented.children) {
+    if (node.type === 'page' && node.$ref) pagesByRef.set(node.$ref, node);
+    else nonPageChildren.push(node);
+  }
+
+  const orderedPages = COOKBOOK_PAGES.flatMap((ref) => {
+    const page = pagesByRef.get(ref);
+    return page ? [withCookbookPageName(page)] : [];
+  });
+  const remainingPages = [...pagesByRef.entries()]
+    .filter(([ref]) => !orderedRefs.has(ref))
+    .map(([, page]) => withCookbookPageName(page));
 
   return {
     ...presented,
     index: presented.index ? withCookbookPageName(presented.index) : undefined,
-    children: presented.children.map((node) => node.type === 'page' ? withCookbookPageName(node) : node),
+    children: [...orderedPages, ...remainingPages, ...nonPageChildren],
   };
 }
 
@@ -198,7 +224,11 @@ function organizeDocsTree(tree: Root): Root {
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
-  slugs: (file) => file.path === 'README.md' ? ['docmap'] : undefined,
+  slugs: (file) => {
+    if (file.path === 'README.md') return ['docmap'];
+    if (file.path === 'cookbook/README.md') return ['cookbook', 'overview'];
+    return undefined;
+  },
   pageTree: {
     transformers: [{ root: organizeDocsTree }],
   },

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -30,6 +30,7 @@ export const docs = defineDocs({
       'guides/*.md',
       '!guides/compass-store-operations.md',
       'reference/*.md',
+      '!reference/universal-semantic-evidence.md',
     ],
     schema: (ctx) =>
       pageSchema.extend({

--- a/docs/reference/framework-routes.md
+++ b/docs/reference/framework-routes.md
@@ -1,101 +1,111 @@
-# Framework-aware routes
+# How Compass maps framework routes
 
-Compass detects supported framework registrations during local structural
-extraction and publishes them in `compass.graph/1`. No framework detector
-downloads a grammar, invokes a language server, or requires credentials.
+Compass detects supported framework registrations during local structural extraction and publishes them in `compass.graph/1`. Detection stays local: route packs do not download grammars, invoke language servers, or require credentials. This reference lists the route shapes Compass recognizes, the graph records it emits, and the cases it leaves unresolved.
 
-> **Who this page is for:** Compass users and integrators querying application
-> entry points.
+> **Who this page is for:** Compass users and integrators who need to trace application entry points.
 >
-> **You will learn:** which route forms are recognized, how they appear in the
-> graph, and which dynamic forms intentionally remain unresolved.
+> **You will learn:** how route nodes and `routes_to` edges work, which framework forms Compass recognizes, and why some dynamic routes remain unresolved.
 >
 > **Prerequisites:** [Graph model](../concepts/graph-model.md).
 >
 > **Reading time:** about 8 minutes.
 
-## Graph contract
+## Route records and edges
 
-Each HTTP, page, or hook registration becomes a `route` node with its
-framework, operation, normalized path, original path, declaring scope, source
-anchor, ordered stages, and resolution state. A `routes_to` edge points from
-the route to each exact middleware and handler target. Middleware positions
-preserve declaration order; the handler is the final stage.
+Compass records a route when it can connect a framework registration to source evidence. The record keeps the path, operation, declaration, and resolution state together so you can inspect the result without guessing.
 
-An ambiguous or unresolved handler remains recorded on the route node, with
-bounded candidates when available, but does not receive an invented exact
-edge. Config- and convention-derived routes retain the rule and source that
-produced them. Equivalent inputs have deterministic route identities and
-ordering.
+Each registration becomes a `route` node with these details:
 
-`callers` follows incoming `calls` and `routes_to` edges. After building a
-graph, this surfaces both code callers and URL registrations for a handler:
+- **Framework and operation**: the framework family and HTTP, page, hook, messaging, or subscription operation
+- **Path**: the normalized path plus the original path expression
+- **Declaration**: the source scope and anchor that declared the route
+- **Stages**: ordered middleware and handler stages, with the handler last
+- **Resolution**: the exact target, bounded candidates, or an explicit unresolved state
+
+A `routes_to` edge points from the route to each exact middleware and handler target. Compass preserves declaration order. It does not create an exact edge when several targets remain valid.
+
+Configuration and file-convention routes keep the rule and source that produced them. Equivalent inputs receive deterministic route identities and ordering.
+
+## Read a route through callers
+
+The `callers` command follows incoming `calls` and `routes_to` edges. Use it to see code callers and URL registrations for the same handler:
 
 ```bash
 compass callers UsersController.show --graph compass-out/graph.json
 ```
 
+The output stays tied to source anchors. Open the listed file and line when you need to verify a registration or investigate an unresolved target.
+
 ## Supported route shapes
 
-| Framework | Recognized shapes |
-| --- | --- |
-| Django | `path`, `re_path`, legacy `url`, and `include` in an activated URL module; positional or named `route`/`view` arguments; function views, dotted string handlers, and class-based `.as_view()` handlers |
-| Flask | `Flask` and `Blueprint` `@receiver.route` decorators, constructor and registration-time `url_prefix`, positional or named `rule`, and literal `methods` lists |
-| FastAPI | `FastAPI` and `APIRouter` decorators for `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `trace`; `api_route`/`route` literal method lists; positional or named `path`; constructor and `include_router(prefix=...)` prefixes and `Depends` stages |
-| Express | `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths, ordered middleware chains, and opaque inline callbacks that remain unresolved |
-| NestJS | `Controller` with HTTP method decorators and `RequestMapping`; GraphQL `Resolver` with `Query`/`Mutation` operations at the `/graphql` endpoint plus a typed field detail; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations |
-| Laravel | Exact `Illuminate\\Support\\Facades\\Route` receivers, including aliases; HTTP, `match`, `any`, `prefix(...)->group`, `resource`/`apiResource`, and `only`/`except` resource modifiers; `Controller@action` and controller/action tuple handlers |
-| Drupal | `*.routing.yml`/`*.routing.yaml` paths with controller, form, entity-form, entity-view, or entity-list handlers; pipe- or comma-separated `_method` values; documented `Implements hook_*().` functions and functions named `hook_*` in `.module`, `.theme`, `.install`, and `.inc` files |
-| Rails | HTTP and `match` declarations inside `Rails.application.routes.draw`, `to:` and hash-rocket handlers, literal `scope`/`namespace` prefixes with namespaced controller owners, and `via` method lists |
-| Spring | Java and Kotlin controller mappings, including class/method composition, HTTP mapping annotations, `RequestMapping` methods, composed and inherited Java mappings, constants, packages, and overloaded handler signatures |
-| Play | Literal `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, and `HEAD` entries in `conf/routes`, targeting Java, Scala, or injected controller actions |
-| Gin, chi, gorilla/mux | Imported router registrations, grouped/closure prefixes, Gin middleware chains, chi method calls, and gorilla `HandleFunc(...).Methods(...)` (including `PathPrefix(...).Subrouter()` chains) |
-| Axum, actix-web, Rocket | Axum nested `.nest(...).route(...)` chains, actix scoped resources and `.route(...).to(...)` handlers, plus Rocket and actix route attributes (including multiline attributes), guarded by framework imports or qualified macros |
-| ASP.NET Core | MVC controller/action templates, `[controller]` and `[action]` tokens, HTTP method attributes, and absolute `/` or `~/` action-template overrides |
-| Vapor | Grouped literal/path-component prefixes, closure groups, `app.on(...)`, and HTTP registrations with explicit `use:` handlers; opaque closures remain visible as unresolved handlers |
-| React Router | JSX `Route` elements using `element={<Component />}` or `Component={Component}`, and literal object route configs with `component`, `element`, or `Component` targets and loader/action stages |
-| SvelteKit | `src/routes` `+page.svelte` components and `+server` endpoints, including `[param]` and `[...rest]` segments and source-backed exported HTTP methods; `+page.ts` load modules are not pages |
-| Vue Router and Nuxt | Vue Router literal route objects; Nuxt `pages` components, `server/api` method-suffixed endpoints, dynamic segments, and route-middleware domain facts |
-| Astro | `src/pages` `.astro` pages and `.ts`/`.js` endpoints, including `[param]` and `[...rest]` segments, exported HTTP methods, `ALL`, and source-backed default handlers |
+Compass activates a framework pack only when the repository contains direct evidence, such as an import, exact receiver, framework configuration file, or dependency-backed file convention. The lists below describe the supported registration shapes.
 
-File-route packs require matching project dependency evidence during a normal
-repository build. Direct single-file extraction without project evidence is
-available for fixtures and tooling, but does not weaken repository activation.
+### Python web frameworks
 
-NestJS messaging, WebSocket subscriptions, and Nuxt middleware use their typed
-messaging/domain contracts rather than being assigned fictitious HTTP URLs.
-GraphQL fields retain their field name in route details while sharing the
-transport endpoint path. They still retain handler references and source
-anchors.
+- **Django**: `path`, `re_path`, legacy `url`, and `include` in an activated URL module; positional or named `route` and `view` arguments; function views, dotted string handlers, and class-based `.as_view()` handlers
+- **Flask**: `Flask` and `Blueprint` route decorators, constructor and registration-time `url_prefix`, positional or named `rule`, and literal `methods` lists
+- **FastAPI**: `FastAPI` and `APIRouter` decorators for `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `trace`; `api_route` and `route` method lists; literal `path`; constructor and `include_router(prefix=...)` prefixes; `Depends` stages
 
-## Conservative boundaries
+### JavaScript and TypeScript frameworks
 
-Compass publishes a route only when the framework is activated by direct
-evidence such as an import, exact receiver, framework config filename, or
-dependency-backed file convention. A filename or decorator name alone does not
-activate most source packs.
+- **Express**: `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths and ordered middleware chains; opaque inline callbacks remain unresolved
+- **NestJS**: `Controller` HTTP method decorators and `RequestMapping`; GraphQL `Resolver` `Query` and `Mutation` operations at `/graphql`; typed GraphQL field details; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations
+- **React Router**: JSX `Route` elements with `element={<Component />}` or `Component={Component}`, plus literal object route configs with `component`, `element`, or `Component` targets and loader or action stages
+- **SvelteKit**: `src/routes` `+page.svelte` components and `+server` endpoints, including `[param]` and `[...rest]` segments and source-backed exported HTTP methods; `+page.ts` load modules are not pages
+- **Vue Router and Nuxt**: Vue Router literal route objects; Nuxt `pages` components; `server/api` method-suffixed endpoints; dynamic segments; and route-middleware domain facts
+- **Astro**: `src/pages` `.astro` pages and `.ts` or `.js` endpoints, including `[param]` and `[...rest]` segments, exported HTTP methods, `ALL`, and source-backed default handlers
 
-The following forms intentionally do not become exact route bindings:
+### PHP, Ruby, and JVM frameworks
 
-- computed or concatenated paths;
-- dynamic method names and arbitrary metaprogramming;
-- opaque closures when no source-backed callable can be identified;
-- same-named handlers with more than one valid target;
-- route targets selected only by repository-wide terminal-name similarity; and
-- file-route conventions without matching project dependency evidence.
+- **Laravel**: exact `Illuminate\\Support\\Facades\\Route` receivers, including aliases; HTTP, `match`, `any`, `prefix(...)->group`, `resource`, `apiResource`, and `only` or `except` resource modifiers; `Controller@action` and controller or action tuple handlers
+- **Drupal**: `*.routing.yml` and `*.routing.yaml` paths with controller, form, entity-form, entity-view, or entity-list handlers; pipe or comma-separated `_method` values; documented `hook_*` implementations and matching functions in `.module`, `.theme`, `.install`, and `.inc` files
+- **Rails**: HTTP and `match` declarations inside `Rails.application.routes.draw`, `to:` and hash-rocket handlers, literal `scope` and `namespace` prefixes with namespaced controller owners, and `via` method lists
+- **Spring**: Java and Kotlin controller mappings, including class and method composition, HTTP mapping annotations, `RequestMapping` methods, composed and inherited Java mappings, constants, packages, and overloaded handler signatures
+- **Play**: literal `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, and `HEAD` entries in `conf/routes`, targeting Java, Scala, or injected controller actions
 
-Framework resolution is bounded by per-file fact, candidate, alias-expansion,
-and include-depth limits. Exceeding a limit is an explicit failure or
-diagnostic, never an empty successful result. Django include cycles stop without
-inventing a route, and ambiguous handlers preserve their candidate state
-without publishing a misleading `routes_to` edge.
+### Go, Rust, and native server frameworks
+
+- **Gin, chi, and gorilla/mux**: imported router registrations, grouped or closure prefixes, Gin middleware chains, chi method calls, and gorilla `HandleFunc(...).Methods(...)`, including `PathPrefix(...).Subrouter()` chains
+- **Axum, actix-web, and Rocket**: Axum nested `.nest(...).route(...)` chains, actix scoped resources and `.route(...).to(...)` handlers, plus Rocket and actix route attributes, including multiline attributes, guarded by framework imports or qualified macros
+- **Vapor**: grouped literal and path-component prefixes, closure groups, `app.on(...)`, and HTTP registrations with explicit `use:` handlers; opaque closures remain visible as unresolved handlers
+- **ASP.NET Core**: MVC controller and action templates, `[controller]` and `[action]` tokens, HTTP method attributes, and absolute `/` or `~/` action-template overrides
+
+## Special route contracts
+
+Some frameworks expose routes that are not HTTP URLs. Compass keeps their domain meaning instead of assigning a misleading path:
+
+- NestJS messaging and WebSocket subscriptions retain their typed messaging or subscription contracts
+- Nuxt middleware retains its middleware domain fact
+- GraphQL fields retain the field name in route details while sharing the `/graphql` transport endpoint
+
+These records still retain handler references and source anchors. File-route packs require matching project dependency evidence during a normal repository build. Direct single-file extraction remains available for fixtures and tooling, but it does not activate a repository pack by itself.
+
+## Why a route can remain unresolved
+
+Compass publishes a route only when its evidence identifies a framework and a target within bounded limits. The following forms do not become exact route bindings:
+
+- computed or concatenated paths
+- dynamic method names and arbitrary metaprogramming
+- opaque closures with no source-backed callable
+- same-named handlers with more than one valid target
+- targets selected only by repository-wide terminal-name similarity
+- file-route conventions without matching project dependency evidence
+
+An unresolved route remains visible on its `route` node. Compass keeps bounded candidates when available and omits a misleading `routes_to` edge. Limit errors remain explicit diagnostics, never empty successful results. Django include cycles stop without inventing a route.
+
+## A practical route investigation workflow
+
+Use this sequence when you need to explain how a request reaches a handler:
+
+1. Run `compass update . --no-viz` to publish a local graph snapshot
+2. Run `compass callers UsersController.show --graph compass-out/graph.json` to list code callers and route registrations
+3. Open each source anchor and compare the declaration with the route path, stages, and resolution state
+4. Treat a missing `routes_to` edge as unresolved evidence, not as proof that the route has no handler
 
 ## Related pages
 
 - [Graph model](../concepts/graph-model.md)
 - [Provenance](../concepts/provenance.md)
 - [Outputs](outputs.md)
-- [Universal semantic evidence](universal-semantic-evidence.md)
 
-**Next step:** build a graph and run `compass callers` for a known controller or
-view to inspect its code callers and framework registrations together.
+**Next step:** build a graph, then run `compass callers` for a known controller or view.


### PR DESCRIPTION
## What changed

- reorder the public docs sidebar with an explicit Cookbook sequence and place CompassQL after it
- rename the Cookbook README route to `/docs/cookbook/overview` and remove the repeated `Cookbook:` prefix from entries
- exclude the internal universal semantic evidence reference from the public collection
- rewrite the framework-routes reference with grouped framework coverage, route contracts, unresolved cases, and a practical investigation workflow
- resolve canonical `.md` and `.mdx` links through Fumadocs so public cross-links use their published slugs
- point the product page evidence link to the public provenance concept

## Validation

- `npm run typecheck` in `apps/web`
- `npm run build` in `apps/web`
- `git diff --check`
- HTTP smoke checks for the renamed, excluded, and framework-routes URLs

This PR keeps unrelated local files unstaged.
