### PR TITLE
Improve Compass web SEO metadata and discovery

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,8 +19,10 @@ npm run build:web
 ```
 
 Set `NEXT_PUBLIC_SITE_URL` when deploying to a domain other than the default
-`https://compass.crabbuild.dev`. The value is used for metadata, canonical URLs,
-robots, and the sitemap.
+`https://compass.crab.build`. The value is used for metadata, canonical URLs,
+robots, social cards, and the sitemap. If you use Google or Bing Search
+Console, set `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` or
+`NEXT_PUBLIC_BING_SITE_VERIFICATION` as the corresponding verification token.
 
 ## Content and routes
 

--- a/apps/web/app/(marketing)/about/page.tsx
+++ b/apps/web/app/(marketing)/about/page.tsx
@@ -1,7 +1,7 @@
 import { pageMetadata } from '@/lib/site';
 import { FeatureGrid, MarketingPage, PageSection } from '@/components/marketing-page';
 
-export const metadata = pageMetadata('About', 'Learn why Compass is built as a local-first, deterministic, inspectable tool for understanding complex codebases.');
+export const metadata = pageMetadata('About', 'Learn why Compass is built as a local-first, deterministic, inspectable tool for understanding complex codebases.', { path: '/about' });
 
 export default function AboutPage() {
   return <MarketingPage eyebrow="About Compass" title="A native tool for making complex systems legible." description="Compass is an independent local-first product inspired by the code-graph workflow: extract structure, preserve evidence, and make the next question smaller.">

--- a/apps/web/app/(marketing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/page.tsx
@@ -6,6 +6,9 @@ import { DocsBody } from 'fumadocs-ui/layouts/docs/page';
 
 import { getMDXComponents } from '@/components/mdx';
 import { blogSource } from '@/lib/blog';
+import { JsonLd } from '@/components/structured-data';
+import { blogPostingJsonLd, breadcrumbJsonLd } from '@/lib/seo';
+import { pageMetadata } from '@/lib/site';
 
 export function generateStaticParams() {
   return blogSource.getPages().map((page) => ({ slug: page.slugs[0] }));
@@ -15,7 +18,15 @@ export async function generateMetadata(props: { params: Promise<{ slug: string }
   const { slug } = await props.params;
   const post = blogSource.getPage([slug]);
   if (!post) return {};
-  return { title: post.data.title, description: post.data.description, alternates: { canonical: post.url } };
+  const description = post.data.description ?? `Read ${post.data.title} from the Compass team.`;
+  return pageMetadata(post.data.title, description, {
+    path: post.url,
+    type: 'article',
+    publishedTime: post.data.date.toISOString(),
+    authors: [post.data.author],
+    tags: post.data.tags,
+    keywords: [...post.data.tags, 'Compass', 'code graph'],
+  });
 }
 
 export default async function BlogPostPage(props: { params: Promise<{ slug: string }> }) {
@@ -23,6 +34,28 @@ export default async function BlogPostPage(props: { params: Promise<{ slug: stri
   const post = blogSource.getPage([slug]);
   if (!post || post.data.draft) notFound();
   const MDX = post.data.body;
+  const description = post.data.description ?? `Read ${post.data.title} from the Compass team.`;
 
-  return <article className="mx-auto max-w-4xl px-5 py-16 lg:px-8 lg:py-24"><Link className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground" href="/blog"><ArrowLeftIcon data-icon="inline-start" /> All stories</Link><header className="mt-12 border-b border-border/70 pb-10"><p className="eyebrow">{post.data.tags.join(' / ') || 'Compass'}</p><h1 className="mt-5 font-heading text-4xl font-semibold leading-tight tracking-[-0.06em] sm:text-5xl">{post.data.title}</h1><p className="mt-5 text-lg leading-8 text-muted-foreground">{post.data.description}</p><p className="mt-7 font-mono text-xs text-muted-foreground">{post.data.author} · {new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(post.data.date)}</p></header><DocsBody className="mt-12"><MDX components={getMDXComponents()} /></DocsBody></article>;
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: 'Compass', path: '/' },
+          { name: 'Blog', path: '/blog' },
+          { name: post.data.title, path: post.url },
+        ])}
+      />
+      <JsonLd
+        data={blogPostingJsonLd({
+          title: post.data.title,
+          description,
+          path: post.url,
+          author: post.data.author,
+          datePublished: post.data.date,
+          tags: post.data.tags,
+        })}
+      />
+      <article className="mx-auto max-w-4xl px-5 py-16 lg:px-8 lg:py-24"><Link className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground" href="/blog"><ArrowLeftIcon data-icon="inline-start" /> All stories</Link><header className="mt-12 border-b border-border/70 pb-10"><p className="eyebrow">{post.data.tags.join(' / ') || 'Compass'}</p><h1 className="mt-5 font-heading text-4xl font-semibold leading-tight tracking-[-0.06em] sm:text-5xl">{post.data.title}</h1><p className="mt-5 text-lg leading-8 text-muted-foreground">{description}</p><p className="mt-7 font-mono text-xs text-muted-foreground">{post.data.author} · {new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(post.data.date)}</p></header><DocsBody className="mt-12"><MDX components={getMDXComponents()} /></DocsBody></article>
+    </>
+  );
 }

--- a/apps/web/app/(marketing)/blog/page.tsx
+++ b/apps/web/app/(marketing)/blog/page.tsx
@@ -1,15 +1,18 @@
-import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ArrowRightIcon, CalendarDaysIcon } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { blogSource } from '@/lib/blog';
+import { JsonLd } from '@/components/structured-data';
+import { breadcrumbJsonLd } from '@/lib/seo';
+import { pageMetadata } from '@/lib/site';
 
-export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Stories about code graphs, provenance, local-first tooling, and building Compass.',
-};
+export const metadata = pageMetadata(
+  'Blog',
+  'Stories about code graphs, provenance, local-first tooling, and building Compass.',
+  { path: '/blog' },
+);
 
 export default function BlogPage() {
   const posts = blogSource.getPages().filter((page) => !page.data.draft).sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -17,6 +20,12 @@ export default function BlogPage() {
 
   return (
     <>
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: 'Compass', path: '/' },
+          { name: 'Blog', path: '/blog' },
+        ])}
+      />
       <section className="relative overflow-hidden border-b border-border/70">
         <div className="site-grid pointer-events-none absolute inset-0 opacity-50" aria-hidden="true" />
         <div className="relative mx-auto grid max-w-7xl gap-10 px-5 pb-16 pt-20 lg:grid-cols-[1fr_0.7fr] lg:items-end lg:px-8 lg:pb-24 lg:pt-28">

--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -5,7 +5,7 @@ import { MarketingPage, PageSection } from '@/components/marketing-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Changelog', 'Follow release-visible changes to the Compass CLI, graph formats, history, integrations, and documentation.');
+export const metadata = pageMetadata('Changelog', 'Follow release-visible changes to the Compass CLI, graph formats, history, integrations, and documentation.', { path: '/changelog' });
 
 export default function ChangelogPage() {
   return <MarketingPage eyebrow="Changelog" title="Small releases, visible contracts." description="Follow release-visible changes to the CLI, graph formats, history, integrations, and documentation.">

--- a/apps/web/app/(marketing)/docs/page.tsx
+++ b/apps/web/app/(marketing)/docs/page.tsx
@@ -4,6 +4,9 @@ import { ArrowRightIcon, BookOpenIcon, BoxesIcon, Code2Icon, FileTextIcon } from
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { JsonLd } from '@/components/structured-data';
+import { pageMetadata } from '@/lib/site';
+import { breadcrumbJsonLd } from '@/lib/seo';
 
 const paths = [
   { icon: BookOpenIcon, eyebrow: 'Start', title: 'Build your first graph', description: 'Install Compass, scan a repository, and answer your first structural question.', href: '/docs/getting-started', action: 'Start the guide' },
@@ -12,14 +15,21 @@ const paths = [
   { icon: FileTextIcon, eyebrow: 'Look up', title: 'Find commands and formats', description: 'Check exact commands, configuration options, output formats, and CompassQL syntax.', href: '/docs/reference/commands', action: 'Open the reference' },
 ];
 
-export const metadata: Metadata = {
-  title: 'Documentation',
-  description: 'Install Compass, learn the core concepts, follow task guides, and look up commands and formats.',
-};
+export const metadata: Metadata = pageMetadata(
+  'Documentation',
+  'Install Compass, learn the core concepts, follow task guides, and look up commands and formats.',
+  { path: '/docs' },
+);
 
 export default function DocsLandingPage() {
   return (
     <>
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: 'Compass', path: '/' },
+          { name: 'Documentation', path: '/docs' },
+        ])}
+      />
       <section className="relative overflow-hidden border-b border-border/70">
         <div className="site-grid pointer-events-none absolute inset-0 opacity-50" aria-hidden="true" />
         <div className="relative mx-auto max-w-7xl px-5 pb-16 pt-20 lg:px-8 lg:pb-24 lg:pt-28">

--- a/apps/web/app/(marketing)/install/page.tsx
+++ b/apps/web/app/(marketing)/install/page.tsx
@@ -16,7 +16,7 @@ import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Install', 'Install the Compass CLI on macOS, Linux, or Windows, then add the Compass Codegraph extension to VS Code.');
+export const metadata = pageMetadata('Install', 'Install the Compass CLI on macOS, Linux, or Windows, then add the Compass Codegraph extension to VS Code.', { path: '/install' });
 
 const vscodeMarketplaceUrl = 'https://marketplace.visualstudio.com/items?itemName=crabbuild.crabbuild-compass-vscode';
 const vscodeInstallCommand = 'code --install-extension crabbuild.crabbuild-compass-vscode';

--- a/apps/web/app/(marketing)/integrations/page.tsx
+++ b/apps/web/app/(marketing)/integrations/page.tsx
@@ -9,7 +9,7 @@ import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Integrations', 'Bring Compass into editors, assistants, automation, and portable graph workflows without leaving the local workspace.');
+export const metadata = pageMetadata('Integrations', 'Bring Compass into editors, assistants, automation, and portable graph workflows without leaving the local workspace.', { path: '/integrations' });
 
 const surfaces = [
   {

--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -21,6 +21,7 @@ import { ExportGallery } from '@/components/export-gallery';
 import { InstallCommand } from '@/components/install-command';
 import { PipelineDiagram } from '@/components/diagrams';
 import { ProductionGraphExplorer } from '@/components/production-graph-explorer';
+import { JsonLd } from '@/components/structured-data';
 import { SectionHeading } from '@/components/section-heading';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -32,6 +33,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { softwareApplicationJsonLd } from '@/lib/seo';
 
 const evidence = [
   { icon: CpuIcon, value: 'native Rust', label: 'one executable, linked parsers' },
@@ -70,6 +72,7 @@ const featureCards = [
 export default function HomePage() {
   return (
     <>
+      <JsonLd data={softwareApplicationJsonLd()} />
       <section className="relative isolate overflow-hidden border-b border-border/70">
         <div className="site-grid pointer-events-none absolute inset-0 -z-10 opacity-70" aria-hidden="true" />
         <div className="mx-auto grid max-w-7xl grid-cols-[minmax(0,1fr)] items-center gap-12 px-5 pb-20 pt-16 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:gap-16 lg:px-8 lg:pb-28 lg:pt-24">

--- a/apps/web/app/(marketing)/product/page.tsx
+++ b/apps/web/app/(marketing)/product/page.tsx
@@ -32,14 +32,17 @@ import {
 } from '@/components/diagrams';
 import { MarketingPage, PageSection } from '@/components/marketing-page';
 import { ProductionGraphExplorer } from '@/components/production-graph-explorer';
+import { JsonLd } from '@/components/structured-data';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { pageMetadata } from '@/lib/site';
+import { breadcrumbJsonLd, softwareApplicationJsonLd } from '@/lib/seo';
 
 export const metadata = pageMetadata(
   'Product',
   'Explore Compass in one place: source graphs, CompassQL, versioned history, integrations, and portable evidence.',
+  { path: '/product' },
 );
 
 const surfaces = [
@@ -75,7 +78,15 @@ const graphPrinciples = [
 
 export default function ProductPage() {
   return (
-    <MarketingPage
+    <>
+      <JsonLd data={softwareApplicationJsonLd()} />
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: 'Compass', path: '/' },
+          { name: 'Product', path: '/product' },
+        ])}
+      />
+      <MarketingPage
       eyebrow="Product"
       title="One local graph. Every useful question."
       description="Compass turns a repository into an inspectable, evidence-backed graph, then gives you the smallest surface for exploring, querying, comparing, and sharing what you found."
@@ -214,7 +225,8 @@ export default function ProductPage() {
           <div className="flex flex-col gap-3 sm:flex-row"><Link className={cn(buttonVariants({ variant: 'secondary', size: 'lg' }), 'gap-2')} href="/install">Install Compass <ArrowRightIcon data-icon="inline-end" /></Link><Link className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'border-primary-foreground/30 bg-transparent text-primary-foreground hover:bg-primary-foreground/10 hover:text-primary-foreground')} href="/docs">Read the docs</Link></div>
         </div>
       </section>
-    </MarketingPage>
+      </MarketingPage>
+    </>
   );
 }
 

--- a/apps/web/app/(marketing)/roadmap/page.tsx
+++ b/apps/web/app/(marketing)/roadmap/page.tsx
@@ -5,7 +5,7 @@ import { MarketingPage, PageSection } from '@/components/marketing-page';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Roadmap', 'See what Compass ships today, what is in progress, and which ideas remain explicitly aspirational.');
+export const metadata = pageMetadata('Roadmap', 'See what Compass ships today, what is in progress, and which ideas remain explicitly aspirational.', { path: '/roadmap' });
 
 const items = [
   [CircleDotIcon, 'Available now', 'Native structural extraction, graph queries, CompassQL, history, exports, and the VS Code workflow.'],

--- a/apps/web/app/(marketing)/security/page.tsx
+++ b/apps/web/app/(marketing)/security/page.tsx
@@ -3,7 +3,7 @@ import { CheckCircle2Icon, CloudOffIcon, KeyRoundIcon, ShieldCheckIcon } from 'l
 import { FeatureGrid, MarketingPage, PageSection } from '@/components/marketing-page';
 import { pageMetadata } from '@/lib/site';
 
-export const metadata = pageMetadata('Security and privacy', 'Understand Compass local-first defaults, optional provider boundaries, bounded inputs, and validated outputs.');
+export const metadata = pageMetadata('Security and privacy', 'Understand Compass local-first defaults, optional provider boundaries, bounded inputs, and validated outputs.', { path: '/security' });
 
 export default function SecurityPage() {
   return <MarketingPage eyebrow="Security and privacy" title="Local-first is a boundary, not a slogan." description="Compass keeps structural extraction and graph queries on the machine where the repository lives. Optional network and credential paths are explicit.">

--- a/apps/web/app/(marketing)/use-cases/page.tsx
+++ b/apps/web/app/(marketing)/use-cases/page.tsx
@@ -28,6 +28,7 @@ import { pageMetadata } from '@/lib/site';
 export const metadata = pageMetadata(
   'Use cases',
   'Use Compass to explore unfamiliar codebases, review change impact, focus assistant context, and understand system evolution.',
+  { path: '/use-cases' },
 );
 
 const workflows = [

--- a/apps/web/app/apple-icon.tsx
+++ b/apps/web/app/apple-icon.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: 'center',
+          background: '#5865f2',
+          borderRadius: 42,
+          color: '#ffffff',
+          display: 'flex',
+          fontSize: 106,
+          fontWeight: 700,
+          height: '100%',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        C
+      </div>
+    ),
+    size,
+  );
+}

--- a/apps/web/app/docs/[...slug]/page.tsx
+++ b/apps/web/app/docs/[...slug]/page.tsx
@@ -6,6 +6,9 @@ import { createRelativeLink } from 'fumadocs-ui/mdx';
 
 import { getMDXComponents } from '@/components/mdx';
 import { source } from '@/lib/source';
+import { JsonLd } from '@/components/structured-data';
+import { breadcrumbJsonLd, docsArticleJsonLd } from '@/lib/seo';
+import { pageMetadata } from '@/lib/site';
 
 export function generateStaticParams() {
   return source.generateParams();
@@ -18,13 +21,12 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug);
   if (!page) return {};
 
-  return {
-    title: page.data.title,
-    description: page.data.description,
-    alternates: {
-      canonical: page.url,
-    },
-  };
+  const description = page.data.description || `Learn ${page.data.title} in the Compass documentation.`;
+
+  return pageMetadata(page.data.title, description, {
+    path: page.url,
+    keywords: ['Compass documentation', 'code graph', page.data.title],
+  });
 }
 
 export default async function Page(props: { params: Promise<{ slug: string[] }> }) {
@@ -48,16 +50,32 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   };
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
-      <DocsBody>
-        <MDX
-          components={getMDXComponents({
-            a: docsLink,
-          })}
-        />
-      </DocsBody>
-    </DocsPage>
+    <>
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: 'Compass', path: '/' },
+          { name: 'Documentation', path: '/docs' },
+          { name: page.data.title, path: page.url },
+        ])}
+      />
+      <JsonLd
+        data={docsArticleJsonLd({
+          title: page.data.title,
+          description: page.data.description || `Learn ${page.data.title} in the Compass documentation.`,
+          path: page.url,
+        })}
+      />
+      <DocsPage toc={page.data.toc} full={page.data.full}>
+        <DocsTitle>{page.data.title}</DocsTitle>
+        <DocsDescription>{page.data.description || `Learn ${page.data.title} in the Compass documentation.`}</DocsDescription>
+        <DocsBody>
+          <MDX
+            components={getMDXComponents({
+              a: docsLink,
+            })}
+          />
+        </DocsBody>
+      </DocsPage>
+    </>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,10 +1,19 @@
 import type { ReactNode } from 'react';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { IBM_Plex_Mono, Inter, Space_Grotesk } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 
 import './globals.css';
-import { siteUrl } from '@/lib/site';
+import { JsonLd } from '@/components/structured-data';
+import {
+  siteDescription,
+  siteImagePath,
+  siteKeywords,
+  siteName,
+  siteUrl,
+  isProductionDeployment,
+} from '@/lib/site';
+import { siteJsonLd } from '@/lib/seo';
 
 const spaceGrotesk = Space_Grotesk({
   subsets: ['latin'],
@@ -31,27 +40,87 @@ export const metadata: Metadata = {
     default: 'Compass — understand the codebase before changing it',
     template: '%s · Compass',
   },
-  description:
-    'A fast, local-first knowledge graph for understanding codebases, tracing impact, and querying architecture with evidence.',
-  applicationName: 'Compass',
+  description: siteDescription,
+  keywords: siteKeywords,
+  applicationName: siteName,
   generator: 'Next.js',
-  icons: {
-    icon: '/brand/compass-mark.svg',
+  referrer: 'origin-when-cross-origin',
+  authors: [{ name: 'Compass contributors', url: 'https://github.com/crabbuild/compass' }],
+  creator: siteName,
+  publisher: siteName,
+  category: 'Developer tools',
+  alternates: {
+    canonical: '/',
   },
+  icons: {
+    icon: [
+      {
+        url: '/brand/compass-mark.svg',
+        type: 'image/svg+xml',
+      },
+    ],
+    shortcut: ['/brand/compass-mark.svg'],
+  },
+  manifest: '/manifest.webmanifest',
   openGraph: {
     type: 'website',
-    siteName: 'Compass',
+    siteName,
     title: 'Compass — understand the codebase before changing it',
-    description:
-      'Turn a repository into a local, inspectable map of entities, relationships, provenance, and change impact.',
+    description: siteDescription,
+    url: '/',
+    locale: 'en_US',
+    images: [
+      {
+        url: siteImagePath,
+        width: 1200,
+        height: 630,
+        alt: 'Compass local-first code graph for understanding a codebase.',
+      },
+    ],
   },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Compass — understand the codebase before changing it',
+    description: siteDescription,
+    images: [siteImagePath],
+  },
+  robots: {
+    index: isProductionDeployment,
+    follow: isProductionDeployment,
+    googleBot: {
+      index: isProductionDeployment,
+      follow: isProductionDeployment,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+  verification: {
+    ...(process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+      ? { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }
+      : {}),
+    ...(process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION
+      ? { other: { 'msvalidate.01': process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION } }
+      : {}),
+  },
+};
+
+export const viewport: Viewport = {
+  colorScheme: 'light dark',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#f5f7ff' },
+    { media: '(prefers-color-scheme: dark)', color: '#11131a' },
+  ],
 };
 
 export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${spaceGrotesk.variable} ${inter.variable} ${plexMono.variable}`}>
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          <JsonLd data={siteJsonLd()} />
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Compass — local-first code intelligence',
+    short_name: 'Compass',
+    description:
+      'Explore codebases as local, evidence-backed graphs with Compass.',
+    id: '/',
+    start_url: '/',
+    scope: '/',
+    display: 'browser',
+    background_color: '#f5f7ff',
+    theme_color: '#5865f2',
+    lang: 'en-US',
+    icons: [
+      {
+        src: '/brand/compass-mark.svg',
+        sizes: '128x128',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+    ],
+  };
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,8 +1,17 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
 import { ArrowLeftIcon, CompassIcon } from 'lucide-react';
 
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 export default function NotFound() {
   return <main className="grid min-h-[70vh] place-items-center px-5 py-24"><div className="flex max-w-md flex-col items-center text-center"><div className="grid size-14 place-items-center rounded-2xl border border-border bg-muted/60 text-primary"><CompassIcon /></div><p className="eyebrow mt-7">404 / off the map</p><h1 className="mt-4 font-heading text-4xl font-semibold tracking-[-0.06em]">That path does not exist.</h1><p className="mt-4 text-base leading-7 text-muted-foreground">The page may have moved, or the route was never part of this graph.</p><Link className={cn(buttonVariants({ variant: 'outline' }), 'mt-8 gap-2')} href="/"><ArrowLeftIcon data-icon="inline-start" /> Back to Compass</Link></div></main>;

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,65 @@
+import { ImageResponse } from 'next/og';
+
+import { siteUrl } from '@/lib/site';
+
+export const alt = 'Compass — understand the codebase before changing it';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  const displayUrl = siteUrl.replace(/^https?:\/\//, '');
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#f5f7ff',
+          color: '#111827',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          justifyContent: 'space-between',
+          padding: '64px 72px',
+          width: '100%',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
+          <div
+            style={{
+              alignItems: 'center',
+              background: '#5865f2',
+              borderRadius: 22,
+              color: '#ffffff',
+              display: 'flex',
+              fontSize: 44,
+              fontWeight: 700,
+              height: 76,
+              justifyContent: 'center',
+              width: 76,
+            }}
+          >
+            C
+          </div>
+          <div style={{ display: 'flex', fontSize: 34, fontWeight: 700 }}>Compass</div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 920 }}>
+          <div style={{ color: '#5865f2', display: 'flex', fontSize: 24, fontWeight: 600, letterSpacing: 4, textTransform: 'uppercase' }}>
+            Local-first code intelligence
+          </div>
+          <div style={{ display: 'flex', fontSize: 66, fontWeight: 700, letterSpacing: -3, lineHeight: 1.04 }}>
+            Understand the codebase before changing it.
+          </div>
+          <div style={{ color: '#526079', display: 'flex', fontSize: 28, lineHeight: 1.3 }}>
+            Explore source relationships, trace impact, and keep evidence attached.
+          </div>
+        </div>
+
+        <div style={{ color: '#526079', display: 'flex', fontFamily: 'monospace', fontSize: 20 }}>
+          {displayUrl} · native · inspectable
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,10 +1,24 @@
 import type { MetadataRoute } from 'next';
 
-import { siteUrl } from '@/lib/site';
+import { isProductionDeployment, siteUrl } from '@/lib/site';
 
 export default function robots(): MetadataRoute.Robots {
+  if (!isProductionDeployment) {
+    return {
+      rules: { userAgent: '*', disallow: '/' },
+      host: new URL(siteUrl).host,
+    };
+  }
+
   return {
-    rules: { userAgent: '*', allow: '/' },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/'],
+      },
+    ],
     sitemap: `${siteUrl}/sitemap.xml`,
+    host: new URL(siteUrl).host,
   };
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -30,11 +30,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
-  const blogEntries = blogSource.getPages().filter((page) => !page.data.draft).map((page) => ({
-    url: `${siteUrl}${page.url}`,
-    changeFrequency: 'monthly' as const,
-    priority: 0.6,
-  }));
+  const blogEntries = blogSource.getPages()
+    .filter((page) => !page.data.draft)
+    .map((page) => ({
+      url: `${siteUrl}${page.url}`,
+      lastModified: page.data.date,
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    }));
 
-  return [...staticEntries, ...docsEntries, ...blogEntries];
+  const seen = new Set<string>();
+  return [...staticEntries, ...docsEntries, ...blogEntries].filter((entry) => {
+    if (seen.has(entry.url)) return false;
+    seen.add(entry.url);
+    return true;
+  });
 }

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { alt, contentType, default, size } from './opengraph-image';

--- a/apps/web/components/structured-data.tsx
+++ b/apps/web/components/structured-data.tsx
@@ -1,0 +1,18 @@
+type JsonLdProps = {
+  data: unknown;
+};
+
+/**
+ * Render JSON-LD in the initial HTML so crawlers can understand the site
+ * without waiting for client-side JavaScript.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  const serialized = (JSON.stringify(data) ?? '').replace(/</g, '\\u003c');
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialized }}
+    />
+  );
+}

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -1,0 +1,136 @@
+import { githubRepositoryUrl } from '@/lib/github';
+import {
+  absoluteUrl,
+  siteDescription,
+  siteImagePath,
+  siteName,
+  siteUrl,
+} from '@/lib/site';
+
+type BreadcrumbItem = {
+  name: string;
+  path?: string;
+};
+
+export function siteJsonLd() {
+  const organizationId = `${siteUrl}/#organization`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': organizationId,
+        name: siteName,
+        url: siteUrl,
+        logo: absoluteUrl('/brand/compass-mark.svg'),
+        description: siteDescription,
+        sameAs: [githubRepositoryUrl],
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${siteUrl}/#website`,
+        name: siteName,
+        url: siteUrl,
+        description: siteDescription,
+        publisher: { '@id': organizationId },
+        inLanguage: 'en-US',
+      },
+    ],
+  };
+}
+
+export function softwareApplicationJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    '@id': `${siteUrl}/#software`,
+    name: siteName,
+    description: siteDescription,
+    url: siteUrl,
+    image: absoluteUrl(siteImagePath),
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'macOS, Linux, Windows',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    codeRepository: githubRepositoryUrl,
+    publisher: { '@id': `${siteUrl}/#organization` },
+  };
+}
+
+export function breadcrumbJsonLd(items: readonly BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      ...(item.path ? { item: absoluteUrl(item.path) } : {}),
+    })),
+  };
+}
+
+export function docsArticleJsonLd({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: title,
+    description,
+    url: absoluteUrl(path),
+    image: absoluteUrl(siteImagePath),
+    mainEntityOfPage: absoluteUrl(path),
+    author: { '@id': `${siteUrl}/#organization` },
+    publisher: { '@id': `${siteUrl}/#organization` },
+    isPartOf: { '@id': `${siteUrl}/#website` },
+    inLanguage: 'en-US',
+  };
+}
+
+export function blogPostingJsonLd({
+  title,
+  description,
+  path,
+  author,
+  datePublished,
+  tags,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  author: string;
+  datePublished: Date;
+  tags: readonly string[];
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    url: absoluteUrl(path),
+    image: absoluteUrl(siteImagePath),
+    mainEntityOfPage: absoluteUrl(path),
+    author: {
+      '@type': 'Organization',
+      name: author,
+      url: siteUrl,
+    },
+    publisher: { '@id': `${siteUrl}/#organization` },
+    datePublished: datePublished.toISOString(),
+    articleSection: tags[0],
+    keywords: tags,
+    inLanguage: 'en-US',
+  };
+}

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,22 +1,101 @@
 import type { Metadata } from 'next';
 
-export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'https://compass.crabbuild.dev').replace(/\/$/, '');
+export const siteName = 'Compass';
+export const siteDescription =
+  'A fast, local-first knowledge graph for understanding codebases, tracing impact, and querying architecture with evidence.';
+export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'https://compass.crab.build').replace(/\/$/, '');
+export const isProductionDeployment = process.env.VERCEL_ENV !== 'preview' && process.env.VERCEL_ENV !== 'development';
+export const siteImagePath = '/opengraph-image';
+export const siteKeywords = [
+  'code graph',
+  'codebase navigation',
+  'repository intelligence',
+  'software architecture',
+  'impact analysis',
+  'CompassQL',
+  'local-first developer tools',
+];
 
-export function pageMetadata(title: string, description: string): Metadata {
+export function absoluteUrl(path = '/'): string {
+  return new URL(path, siteUrl).toString();
+}
+
+export type PageMetadataOptions = {
+  path?: string;
+  keywords?: string[];
+  image?: string;
+  imageAlt?: string;
+  type?: 'website' | 'article';
+  publishedTime?: string;
+  modifiedTime?: string;
+  authors?: string[];
+  tags?: string[];
+  noIndex?: boolean;
+};
+
+export function pageMetadata(
+  title: string,
+  description: string,
+  options: PageMetadataOptions = {},
+): Metadata {
   const fullTitle = `${title} · Compass`;
+  const path = options.path ?? '/';
+  const image = options.image ?? siteImagePath;
+  const imageAlt = options.imageAlt ?? `${title} — Compass`;
+  const type = options.type ?? 'website';
 
   return {
     title,
     description,
+    keywords: options.keywords ?? siteKeywords,
+    alternates: {
+      canonical: path,
+    },
     openGraph: {
-      type: 'website',
+      type,
       title: fullTitle,
       description,
+      url: path,
+      siteName,
+      locale: 'en_US',
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: imageAlt,
+        },
+      ],
+      ...(type === 'article'
+        ? {
+            publishedTime: options.publishedTime,
+            modifiedTime: options.modifiedTime,
+            authors: options.authors,
+            tags: options.tags,
+          }
+        : {}),
     },
     twitter: {
-      card: 'summary',
+      card: 'summary_large_image',
       title: fullTitle,
       description,
+      images: [image],
     },
+    robots: options.noIndex || !isProductionDeployment
+      ? {
+          index: false,
+          follow: false,
+        }
+      : {
+          index: true,
+          follow: true,
+          googleBot: {
+            index: true,
+            follow: true,
+            'max-image-preview': 'large',
+            'max-snippet': -1,
+            'max-video-preview': -1,
+          },
+        },
   };
 }

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,6 +7,16 @@ const config = {
   async redirects() {
     return [
       {
+        source: '/docs/README',
+        destination: '/docs/docmap',
+        permanent: true,
+      },
+      {
+        source: '/docs/cookbook/README',
+        destination: '/docs/cookbook/overview',
+        permanent: true,
+      },
+      {
         source: '/docs/:path*.md',
         destination: '/docs/:path*',
         permanent: true,

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -40,6 +40,17 @@ export const docs = defineDocs({
           const heading = ctx.source.match(/^#\s+(.+)$/m)?.[1]?.trim();
           return heading ?? ctx.path.split('/').pop()?.replace(/\.(md|mdx)$/, '') ?? 'Compass';
         }),
+        description: z.string().default(() => {
+          const paragraph = ctx.source
+            .replace(/^---[\s\S]*?---\s*/m, '')
+            .split(/\n\s*\n/)
+            .map((block) => block.trim())
+            .find((block) => block && !block.startsWith('#') && !block.startsWith('```'));
+          const plain = paragraph?.replace(/[>*_`]/g, '').replace(/\s+/g, ' ').trim();
+          if (!plain) return 'Learn how Compass makes codebases easier to understand.';
+          if (plain.length <= 160) return plain;
+          return `${plain.slice(0, 157).replace(/\s+\S*$/, '')}…`;
+        }),
       }),
   },
 });


### PR DESCRIPTION
## What changed

- Add shared canonical, title, description, keyword, Open Graph, Twitter, viewport, favicon, Apple icon, and manifest metadata.
- Add Organization, WebSite, SoftwareApplication, BreadcrumbList, TechArticle, and BlogPosting JSON-LD.
- Add preview deployment `noindex` protection and keep production canonicals on `https://compass.crab.build`.
- Improve robots and sitemap output, generate useful documentation descriptions, and redirect renamed documentation URLs.

## Why

The site had good content and route coverage, but crawlers and link unfurlers were missing key identity, canonical, social preview, and structured-data signals. This makes the public Compass pages easier to discover, classify, and share without changing the product UI.

## Validation

- `npm run build:web`
- Local HTML checks for canonical tags, JSON-LD, robots.txt, sitemap.xml, manifest.webmanifest, and generated Open Graph image routes.
