### PR TITLE
Harden incremental graph publication and language resolution

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -203,6 +203,43 @@ These cross-tool observations are diagnostic evidence rather than a promoted
 Compass baseline. The remaining build gap is primarily the richer graph size
 and durable publication contract, not an unresolved duplicate atomic flush.
 
+## Incremental and language-hardening observations
+
+A follow-up release-binary smoke run on 2026-08-04 used four small,
+read-only real repositories under the mounted qualification volume: Cobra
+(Go, 37 files), Zod (TypeScript, 444 files), Rayon (Rust, 191 files), and
+Click (Python, 91 files). The run used `extract --code-only --no-cluster
+--no-viz --force --store sqlite` and measured one cold process per repository:
+
+| Repository | Wall time | Nodes | Edges |
+| --- | ---: | ---: | ---: |
+| Cobra | 0.82 s | 1,204 | 5,701 |
+| Zod | 1.59 s | 11,047 | 9,632 |
+| Rayon | 2.39 s | 8,807 | 17,942 |
+| Click | 1.47 s | 3,876 | 9,471 |
+
+These are diagnostic observations, not promoted baselines or a claim of a
+4×–5× cold-build advantage. Small-project extraction now stays sequential by
+default to avoid multiplying parser/AST working sets; `--max-workers` remains
+the explicit opt-in for parallel extraction. Portable AST cache publication
+also streams one compressed value at a time instead of retaining the entire
+compressed batch in memory.
+
+The same Cobra checkout was cold-built into a fresh SQLite output and then
+received a comment-only edit. The edit extracted 1 file and reused 36 cached
+files; store publication created 5 objects and wrote 32,325 bytes, compared
+with 192 objects and 2,072,182 bytes for the cold publication. Snapshot tests
+also verify that the Edges, Incoming, Outgoing, Files, Names, Terms,
+Communities, and Diagnostics roots remain immutable for a file-only change.
+
+The language fixtures cover the remaining attribution gaps directly: Go
+variadic range elements, type assertions, and nested closure parameters now
+resolve to their receiver methods; Rust generic impl calls resolve to the
+exact impl owner both within one file and across an imported module. On the
+same filtered Graphify Go comparison, exact comparable edges improved from
+1,469 to 1,492 and missing edges fell from 38 to 15. These quality numbers are
+diagnostic and do not imply that all Graphify gaps are closed.
+
 ## Django cold-build regression qualification
 
 The 0.2.1 code-graph performance hardening was qualified against Django commit

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -836,7 +836,14 @@ fn build_graph_inner(
             .extension()
             .is_some_and(|extension| extension.eq_ignore_ascii_case("php"))
     });
-    let worker_pool = if missing.len() >= 256 || sources.len() >= 256 {
+    // An explicit worker count is an opt-in performance decision. Honor it
+    // even for smaller repositories so callers can trade parser-table
+    // residency for throughput instead of silently falling back to the
+    // sequential path below. On small repositories, a single requested worker
+    // remains sequential; it avoids paying for a pool that cannot add
+    // parallelism.
+    let parallel_extraction = should_parallel_extract(options, missing.len(), sources.len());
+    let worker_pool = if parallel_extraction {
         Some(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(worker_count)
@@ -955,7 +962,7 @@ fn build_graph_inner(
                 )),
             ))
         };
-    let fresh_outcomes = if missing.len() < 256 {
+    let fresh_outcomes = if !parallel_extraction {
         let mut engine = Engine::with_project_evidence(Arc::clone(&project_evidence));
         missing
             .iter()
@@ -1194,23 +1201,19 @@ fn build_graph_inner(
             fresh_paths.contains(*path) && extraction_has_cacheable_ast_facts(extraction)
         })
         .collect::<Vec<_>>();
-    let ast_cache_entries = cache.encode_portable_ast_batch_ref(&ast_cache_sources)?;
+    let ast_cache_started = Instant::now();
+    cache.write_portable_ast_batch_ref(&ast_cache_sources)?;
+    cache.flush()?;
     drop(ast_cache_sources);
+    profile_internal_duration(
+        "AST cache streaming publication",
+        ast_cache_started.elapsed(),
+    );
     // Declaration/definition merging is project-wide and is not idempotent.
     // Cache the portable per-file facts before applying it so a warm build
     // executes the same single merge as a cold build.
     merge_decl_def_classes_if_needed(&mut ordered, &ordered_paths);
     profile_internal("declaration merge", &mut internal_started);
-    let ast_cache_handle = std::thread::Builder::new()
-        .name("compass-ast-cache".to_owned())
-        .spawn(move || {
-            let started = Instant::now();
-            Cache::write_encoded_batch(&ast_cache_entries)?;
-            cache.flush()?;
-            Ok::<_, CoreError>(started.elapsed())
-        })
-        .map_err(|error| CoreError::WorkerPool(error.to_string()))?;
-    profile_internal("AST cache snapshot and dispatch", &mut internal_started);
     let read_source = |path: &PathBuf| read_source_text_with_limit(path, options.max_source_bytes);
     let read_cached_source = |path: &PathBuf| {
         (!fresh_paths.contains(path))
@@ -1238,10 +1241,6 @@ fn build_graph_inner(
     let mut resolved = resolve_prevalidated_owned_with_root(ordered, &source_text, &root);
     profile_internal("cross-file resolution total", &mut internal_started);
     drop(source_text);
-    let ast_cache_elapsed = ast_cache_handle
-        .join()
-        .map_err(|_| CoreError::WorkerPanic("AST cache publication".to_owned()))??;
-    profile_internal_duration("AST cache publication worker", ast_cache_elapsed);
     internal_started = Instant::now();
     let defer_program_join = options.force && !options.no_cluster && !has_program_artifacts;
     let mut program = if defer_program_join {
@@ -1426,8 +1425,17 @@ fn build_graph_inner(
         let published_nodes = published.document.nodes.len();
         let published_edges = published.document.links.len();
         let (store_metrics, graph_seal) = if options.graph_storage.publishes_store() {
-            let (metrics, seal) =
-                publish_graph_and_store_from_canonical(&output_dir, &published.document)?;
+            let (metrics, seal) = if let Some(previous) =
+                load_file_node_delta_base(&output_dir, &published.document)
+            {
+                publish_graph_and_store_file_node_delta(
+                    &output_dir,
+                    &previous,
+                    &published.document,
+                )?
+            } else {
+                publish_graph_and_store_from_canonical(&output_dir, &published.document)?
+            };
             (Some(metrics), Some(seal))
         } else {
             let graph_path = output_dir.join("graph.json");
@@ -1912,8 +1920,13 @@ fn build_graph_inner(
     let omissions = published.omissions;
     let serialization_started = Instant::now();
     let (store_metrics, graph_seal) = if options.graph_storage.publishes_store() {
-        let (metrics, seal) =
-            publish_graph_and_store_from_canonical(&output_dir, &published.document)?;
+        let (metrics, seal) = if let Some(previous) =
+            load_file_node_delta_base(&output_dir, &published.document)
+        {
+            publish_graph_and_store_file_node_delta(&output_dir, &previous, &published.document)?
+        } else {
+            publish_graph_and_store_from_canonical(&output_dir, &published.document)?
+        };
         (Some(metrics), Some(seal))
     } else {
         let graph_path = output_dir.join("graph.json");
@@ -2389,6 +2402,79 @@ fn ensure_store_snapshot(output_dir: &Path) -> Result<StorePublishMetrics, CoreE
     finish_store_snapshot(output_dir, &store, &builder, prepared)
 }
 
+/// Return the previous graph only when the current publication can use the
+/// strict file-node delta path. The check is intentionally cheap and does not
+/// serialize records; the snapshot layer repeats its bounded validation before
+/// touching the active store.
+fn load_file_node_delta_base(
+    output_dir: &Path,
+    current: &V1GraphDocument,
+) -> Option<V1GraphDocument> {
+    let previous = V1GraphDocument::load(&output_dir.join("graph.json")).ok()?;
+    file_node_delta_candidate(&previous, current).then_some(previous)
+}
+
+fn file_node_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocument) -> bool {
+    if previous.directed != current.directed || previous.multigraph != current.multigraph {
+        return false;
+    }
+    let previous_nodes = previous
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let current_nodes = current
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    if previous_nodes.len() != current_nodes.len() || previous_nodes.keys().ne(current_nodes.keys())
+    {
+        return false;
+    }
+    let mut changed_file = false;
+    for (id, current_node) in &current_nodes {
+        let Some(previous_node) = previous_nodes.get(id) else {
+            return false;
+        };
+        if *previous_node != *current_node {
+            if current_node.kind != NodeKind::File {
+                return false;
+            }
+            changed_file = true;
+        }
+    }
+    if !changed_file {
+        return false;
+    }
+    let previous_edges = previous
+        .links
+        .iter()
+        .map(|edge| (edge.id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let current_edges = current
+        .links
+        .iter()
+        .map(|edge| (edge.id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    if previous_edges.len() != current_edges.len() || previous_edges != current_edges {
+        return false;
+    }
+    let previous_files = previous
+        .graph
+        .files
+        .iter()
+        .map(|file| (file.path.as_str(), file.id.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    let current_files = current
+        .graph
+        .files
+        .iter()
+        .map(|file| (file.path.as_str(), file.id.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    previous_files == current_files
+}
+
 fn publish_graph_and_store_from_canonical(
     output_dir: &Path,
     graph: &V1GraphDocument,
@@ -2414,6 +2500,37 @@ fn publish_graph_and_store_from_canonical(
     };
     let prepared =
         builder.finish_content(&store, content?, graph_receipt.sha256, graph_receipt.bytes)?;
+    let metrics = finish_store_snapshot(output_dir, &store, &builder, prepared)?;
+    Ok((metrics, graph_seal))
+}
+
+fn publish_graph_and_store_file_node_delta(
+    output_dir: &Path,
+    previous: &V1GraphDocument,
+    graph: &V1GraphDocument,
+) -> Result<(StorePublishMetrics, ArtifactSeal), CoreError> {
+    if graph.graph.schema != GRAPH_SCHEMA_V1 {
+        return Err(CoreError::InvalidBuildState(format!(
+            "graph has unsupported schema {}; expected {GRAPH_SCHEMA_V1}",
+            graph.graph.schema
+        )));
+    }
+    let graph_path = output_dir.join("graph.json");
+    let store = SqliteStore::open(local_sqlite_store_path(&graph_path))?;
+    let builder = GraphSnapshotBuilder::new();
+    let canonical = canonical_graph_document_presorted(graph);
+    let (graph_receipt, content) = rayon::join(
+        || write_json_atomic_with_digest(&graph_path, &canonical),
+        || builder.prepare_file_node_delta(&store, previous, graph),
+    );
+    let graph_receipt = graph_receipt?;
+    let graph_seal = ArtifactSeal {
+        bytes: graph_receipt.bytes,
+        sha256: graph_receipt.sha256.clone(),
+    };
+    let content = content.or_else(|_| builder.prepare_content(&store, graph))?;
+    let prepared =
+        builder.finish_content(&store, content, graph_receipt.sha256, graph_receipt.bytes)?;
     let metrics = finish_store_snapshot(output_dir, &store, &builder, prepared)?;
     Ok((metrics, graph_seal))
 }
@@ -2466,6 +2583,10 @@ fn default_ast_workers() -> usize {
 #[cfg(not(target_os = "macos"))]
 fn default_ast_workers() -> usize {
     num_cpus::get()
+}
+
+fn should_parallel_extract(options: &BuildOptions, missing: usize, sources: usize) -> bool {
+    missing >= 256 || sources >= 256 || options.max_workers.is_some_and(|workers| workers > 1)
 }
 
 fn semantic_layer_is_empty(layer: &SemanticLayer) -> bool {
@@ -4808,6 +4929,7 @@ fn extraction_has_cacheable_ast_facts(extraction: &Extraction) -> bool {
 mod tests {
     use std::error::Error;
 
+    use compass_graph::{GraphSnapshotReader, IndexKind};
     use compass_model::code_graph::GraphDocument as V1GraphDocument;
     use serde_json::{Map, Value};
 
@@ -4821,6 +4943,19 @@ mod tests {
         assert!(cache_reuse_enabled(true, true));
         assert!(prior_published_graph_input_enabled(false));
         assert!(!prior_published_graph_input_enabled(true));
+    }
+
+    #[test]
+    fn explicit_multiple_ast_workers_enable_small_project_parallelism() {
+        let mut options = BuildOptions::new(".");
+        assert!(!should_parallel_extract(&options, 64, 64));
+
+        options.max_workers = Some(2);
+        assert!(should_parallel_extract(&options, 64, 64));
+
+        options.max_workers = Some(1);
+        assert!(!should_parallel_extract(&options, 64, 64));
+        assert!(should_parallel_extract(&options, 256, 256));
     }
 
     #[test]
@@ -5440,6 +5575,83 @@ mod tests {
                 .nodes
                 .iter()
                 .all(|node| node.source_file() != Some("helper.py"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn file_only_incremental_edit_reuses_store_index_roots() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let root = directory.path();
+        let source = root.join("main.py");
+        fs::write(&source, "def main():\n    return 1\n")?;
+        let mut options = BuildOptions::new(root);
+        options.no_viz = true;
+
+        let cold = build_local_graph(&options)?;
+        let store_path = local_sqlite_store_path(&cold.output_dir.join("graph.json"));
+        let before_store = SqliteStore::open(&store_path)?;
+        let before_reader = GraphSnapshotReader::open_active(&before_store)?
+            .ok_or("cold snapshot is not active")?;
+        let before_roots = before_reader
+            .manifest()
+            .roots
+            .iter()
+            .map(|root| (root.index, root.digest.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let before_graph = V1GraphDocument::load(&cold.output_dir.join("graph.json"))?;
+        drop(before_reader);
+        drop(before_store);
+
+        fs::write(
+            &source,
+            "def main():\n    return 1\n\n# metadata-only edit\n",
+        )?;
+        let changed = build_local_graph(&options)?;
+        let after_store = SqliteStore::open(&store_path)?;
+        let after_reader = GraphSnapshotReader::open_active(&after_store)?
+            .ok_or("changed snapshot is not active")?;
+        let after_roots = after_reader
+            .manifest()
+            .roots
+            .iter()
+            .map(|root| (root.index, root.digest.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let changed_graph = V1GraphDocument::load(&changed.output_dir.join("graph.json"))?;
+        let file_changed = changed_graph
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::File)
+            .ok_or("changed file node missing")?;
+        assert!(
+            before_graph
+                .nodes
+                .iter()
+                .any(|node| { node.id == file_changed.id && node != file_changed })
+        );
+        for index in [
+            IndexKind::Edges,
+            IndexKind::Outgoing,
+            IndexKind::Incoming,
+            IndexKind::Files,
+            IndexKind::Names,
+            IndexKind::Terms,
+            IndexKind::Communities,
+            IndexKind::Diagnostics,
+        ] {
+            assert_eq!(
+                before_roots.get(&index),
+                after_roots.get(&index),
+                "{index:?} root should be reused"
+            );
+        }
+        assert_ne!(
+            before_roots.get(&IndexKind::Nodes),
+            after_roots.get(&IndexKind::Nodes)
+        );
+        assert_ne!(
+            before_roots.get(&IndexKind::Metadata),
+            after_roots.get(&IndexKind::Metadata)
         );
         Ok(())
     }

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -439,6 +439,36 @@ impl Cache {
             .collect()
     }
 
+    /// Encode and publish already-normalized portable AST values one entry at
+    /// a time. Unlike [`Self::encode_portable_ast_batch_ref`], this does not
+    /// retain every compressed payload until the whole batch is ready, which
+    /// keeps peak memory proportional to the largest in-flight file.
+    pub fn write_portable_ast_batch_ref<T: Serialize + Sync>(
+        &mut self,
+        entries: &[(&PathBuf, &T)],
+    ) -> Result<(), FileError> {
+        let directory = self.directory(&CacheKind::Ast, None);
+        fs::create_dir_all(&directory).map_err(|source| io_error(&directory, source))?;
+        let mut jobs = Vec::with_capacity(entries.len());
+        for &(path, value) in entries {
+            let hash = self.content_hash(path)?;
+            let key = self.source_cache_key(path, &hash);
+            jobs.push((
+                directory.join(format!("{key}.{MESSAGEPACK_EXTENSION}")),
+                value,
+            ));
+        }
+        let write_job = |(destination, value): &(PathBuf, &T)| {
+            let bytes = encode_messagepack(*value, destination)?;
+            write_cache_bytes(destination, &bytes)
+        };
+        if jobs.len() < 256 {
+            jobs.iter().try_for_each(write_job)
+        } else {
+            jobs.par_iter().try_for_each(write_job)
+        }
+    }
+
     /// Atomically publish cache payloads prepared by
     /// encode_portable_ast_batch or encode_portable_ast_batch_ref.
     pub fn write_encoded_batch(entries: &[EncodedCacheWrite]) -> Result<(), FileError> {

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -462,6 +462,28 @@ fn batched_cache_writes_are_portable_and_refresh_changed_sources() -> Result<(),
 }
 
 #[test]
+fn streaming_portable_ast_batch_round_trips() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let source = directory.path().join("streamed.rs");
+    fs::write(&source, "fn streamed() {}\n")?;
+    let mut cache = Cache::open(directory.path(), CacheOptions::output_directory(None))?;
+    let portable = json!({
+        "nodes":[{"id":"streamed","source_file":"streamed.rs"}],
+        "edges":[],
+        "framework_facts":[]
+    });
+
+    cache.write_portable_ast_batch_ref(&[(&source, &portable)])?;
+    let mut expected = portable;
+    expected["nodes"][0]["source_file"] = json!(fs::canonicalize(&source)?.to_string_lossy());
+    assert_eq!(
+        cache.load(&source, &CacheKind::Ast, None, false)?,
+        Some(expected)
+    );
+    Ok(())
+}
+
+#[test]
 fn cache_keeps_distinct_extractions_for_identical_source_bytes() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let first = directory.path().join("AGENTS.md");

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -11,7 +11,7 @@ use std::io::{self, Read, Write};
 
 use compass_model::code_graph::{
     CODE_GRAPH_SCHEMA_V1, EdgeRecord, FileRecord, GraphDiagnostic, GraphDocument, GraphMetadata,
-    NodeRecord,
+    NodeDetails, NodeKind, NodeRecord,
 };
 use compass_model::validate_code_graph;
 use compass_store::{
@@ -543,6 +543,85 @@ impl GraphSnapshotBuilder {
             snapshot_id,
             node_count: canonical.nodes.len() as u64,
             edge_count: canonical.links.len() as u64,
+            roots,
+            stats,
+        })
+    }
+
+    /// Prepare a snapshot for a source-only delta. This path reuses every
+    /// immutable index tree except metadata and the changed file records. It
+    /// is intentionally strict: callers may use it only when node and edge
+    /// topology is unchanged and the changed nodes are file records whose
+    /// content metadata moved with the edit.
+    pub fn prepare_file_node_delta<S: Store + ?Sized>(
+        &self,
+        store: &S,
+        previous: &GraphDocument,
+        current: &GraphDocument,
+    ) -> Result<PreparedGraphSnapshotContent, SnapshotError> {
+        validate_code_graph(current)
+            .map_err(|error| SnapshotError::Corrupt(format!("graph validation failed: {error}")))?;
+        validate_file_node_delta(previous, current)?;
+        let reader = GraphSnapshotReader::open_active(store)?.ok_or_else(|| {
+            SnapshotError::Unsupported("file-node delta requires an active snapshot".to_owned())
+        })?;
+        let (previous_snapshot_id, _) = digest_canonical_graph(previous, true)?;
+        if reader.selector().snapshot_id != previous_snapshot_id
+            || reader.manifest().node_count != previous.nodes.len() as u64
+            || reader.manifest().edge_count != previous.links.len() as u64
+        {
+            return Err(SnapshotError::Corrupt(
+                "active snapshot does not match the previous graph".to_owned(),
+            ));
+        }
+
+        let mut node_updates = BTreeMap::new();
+        let previous_nodes = previous
+            .nodes
+            .iter()
+            .map(|node| (node.id.as_str(), node))
+            .collect::<BTreeMap<_, _>>();
+        for node in &current.nodes {
+            if previous_nodes
+                .get(node.id.as_str())
+                .is_some_and(|previous| *previous != node)
+            {
+                node_updates.insert(
+                    encode_graph_index_key(IndexKind::Nodes, &[node.id.as_bytes()])?,
+                    Some(encode_json(node)?),
+                );
+            }
+        }
+        if node_updates.is_empty() {
+            return Err(SnapshotError::Corrupt(
+                "file-node delta contains no changed node records".to_owned(),
+            ));
+        }
+
+        let mut writer = ObjectWriter::new(store)?;
+        let metadata_entries = build_metadata_index(current)?;
+        let mut roots = reader.manifest().roots.clone();
+        for root in &mut roots {
+            if root.index == IndexKind::Metadata {
+                root.entry_count = metadata_entries.len() as u64;
+                root.digest = build_index_tree(&mut writer, root.index, &metadata_entries)?;
+            } else if root.index == IndexKind::Nodes {
+                root.digest = update_index_tree(
+                    store,
+                    &mut writer,
+                    root.index,
+                    &root.digest,
+                    &node_updates,
+                    0,
+                )?;
+            }
+        }
+        let stats = writer.finish()?;
+        let (snapshot_id, _) = digest_canonical_graph(current, true)?;
+        Ok(PreparedGraphSnapshotContent {
+            snapshot_id,
+            node_count: current.nodes.len() as u64,
+            edge_count: current.links.len() as u64,
             roots,
             stats,
         })
@@ -1518,66 +1597,7 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
         .into_iter()
         .map(|index| (index, BTreeMap::new()))
         .collect::<BTreeMap<_, _>>();
-    let mut metadata_graph = graph.graph.clone();
-    metadata_graph.files.clear();
-    metadata_graph.coverage.clear();
-    metadata_graph.diagnostics.clear();
-    let metadata = MetadataRecord {
-        directed: graph.directed,
-        multigraph: graph.multigraph,
-        graph: metadata_graph,
-    };
-    insert_json(
-        &mut indexes,
-        IndexKind::Metadata,
-        encode_graph_index_key(IndexKind::Metadata, &[])?,
-        &metadata,
-    )?;
-    for file in &graph.graph.files {
-        insert_json(
-            &mut indexes,
-            IndexKind::Metadata,
-            encode_graph_index_key(IndexKind::Metadata, &[b"file", file.id.as_bytes()])?,
-            file,
-        )?;
-    }
-    for (ordinal, coverage) in graph.graph.coverage.iter().enumerate() {
-        let ordinal = format!("{ordinal:08}");
-        insert_json(
-            &mut indexes,
-            IndexKind::Metadata,
-            encode_graph_index_key(IndexKind::Metadata, &[b"coverage", ordinal.as_bytes()])?,
-            coverage,
-        )?;
-    }
-    for (ordinal, diagnostic) in graph.graph.diagnostics.iter().enumerate() {
-        let ordinal = format!("{ordinal:08}");
-        insert_json(
-            &mut indexes,
-            IndexKind::Metadata,
-            encode_graph_index_key(
-                IndexKind::Metadata,
-                &[
-                    b"diagnostic",
-                    ordinal.as_bytes(),
-                    diagnostic.code.as_bytes(),
-                ],
-            )?,
-            diagnostic,
-        )?;
-        if diagnostic.code == "publication_omission_summary" {
-            let key = encode_graph_index_key(
-                IndexKind::Metadata,
-                &[b"diagnostic-code", diagnostic.code.as_bytes()],
-            )?;
-            let value = encode_json(diagnostic)?;
-            indexes
-                .get_mut(&IndexKind::Metadata)
-                .ok_or_else(|| SnapshotError::Corrupt("metadata index is missing".to_owned()))?
-                .entry(key)
-                .or_insert(value);
-        }
-    }
+    indexes.insert(IndexKind::Metadata, build_metadata_index(graph)?);
 
     let node_by_id = graph
         .nodes
@@ -1741,6 +1761,257 @@ fn build_indexes(graph: &GraphDocument) -> Result<SnapshotIndexes, SnapshotError
         )?;
     }
     Ok(indexes)
+}
+
+fn build_metadata_index(
+    graph: &GraphDocument,
+) -> Result<BTreeMap<Vec<u8>, Vec<u8>>, SnapshotError> {
+    let mut metadata = BTreeMap::new();
+    let mut metadata_graph = graph.graph.clone();
+    metadata_graph.files.clear();
+    metadata_graph.coverage.clear();
+    metadata_graph.diagnostics.clear();
+    metadata.insert(
+        encode_graph_index_key(IndexKind::Metadata, &[])?,
+        encode_json(&MetadataRecord {
+            directed: graph.directed,
+            multigraph: graph.multigraph,
+            graph: metadata_graph,
+        })?,
+    );
+    for file in &graph.graph.files {
+        metadata.insert(
+            encode_graph_index_key(IndexKind::Metadata, &[b"file", file.id.as_bytes()])?,
+            encode_json(file)?,
+        );
+    }
+    for (ordinal, coverage) in graph.graph.coverage.iter().enumerate() {
+        let ordinal = format!("{ordinal:08}");
+        metadata.insert(
+            encode_graph_index_key(IndexKind::Metadata, &[b"coverage", ordinal.as_bytes()])?,
+            encode_json(coverage)?,
+        );
+    }
+    for (ordinal, diagnostic) in graph.graph.diagnostics.iter().enumerate() {
+        let ordinal = format!("{ordinal:08}");
+        metadata.insert(
+            encode_graph_index_key(
+                IndexKind::Metadata,
+                &[
+                    b"diagnostic",
+                    ordinal.as_bytes(),
+                    diagnostic.code.as_bytes(),
+                ],
+            )?,
+            encode_json(diagnostic)?,
+        );
+        if diagnostic.code == "publication_omission_summary" {
+            metadata
+                .entry(encode_graph_index_key(
+                    IndexKind::Metadata,
+                    &[b"diagnostic-code", diagnostic.code.as_bytes()],
+                )?)
+                .or_insert(encode_json(diagnostic)?);
+        }
+    }
+    Ok(metadata)
+}
+
+fn validate_file_node_delta(
+    previous: &GraphDocument,
+    current: &GraphDocument,
+) -> Result<(), SnapshotError> {
+    if previous.directed != current.directed || previous.multigraph != current.multigraph {
+        return Err(SnapshotError::Unsupported(
+            "file-node delta changed graph directionality".to_owned(),
+        ));
+    }
+    let previous_nodes = previous
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let current_nodes = current
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    if previous_nodes.len() != previous.nodes.len()
+        || current_nodes.len() != current.nodes.len()
+        || previous_nodes.keys().ne(current_nodes.keys())
+    {
+        return Err(SnapshotError::Unsupported(
+            "file-node delta changed the node set".to_owned(),
+        ));
+    }
+    let mut changed_node = false;
+    for (id, node) in &current_nodes {
+        let Some(previous_node) = previous_nodes.get(id) else {
+            return Err(SnapshotError::Unsupported(
+                "file-node delta changed the node set".to_owned(),
+            ));
+        };
+        let changed = *previous_node != *node;
+        if changed
+            && (node.kind != NodeKind::File
+                || !file_node_index_projection_equal(previous_node, node))
+        {
+            return Err(SnapshotError::Unsupported(
+                "file-node delta changed a non-file node".to_owned(),
+            ));
+        }
+        changed_node |= changed;
+    }
+    let previous_edges = previous
+        .links
+        .iter()
+        .map(|edge| (edge.id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let current_edges = current
+        .links
+        .iter()
+        .map(|edge| (edge.id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    if previous_edges.len() != previous.links.len()
+        || current_edges.len() != current.links.len()
+        || previous_edges.len() != current_edges.len()
+        || current_edges.iter().any(|(id, edge)| {
+            previous_edges
+                .get(id)
+                .is_none_or(|previous_edge| *previous_edge != *edge)
+        })
+    {
+        return Err(SnapshotError::Unsupported(
+            "file-node delta changed graph relationships".to_owned(),
+        ));
+    }
+    let previous_files = previous
+        .graph
+        .files
+        .iter()
+        .map(|file| (file.path.clone(), file.id.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let current_files = current
+        .graph
+        .files
+        .iter()
+        .map(|file| (file.path.clone(), file.id.clone()))
+        .collect::<BTreeMap<_, _>>();
+    if previous_files != current_files {
+        return Err(SnapshotError::Unsupported(
+            "file-node delta changed the file path index".to_owned(),
+        ));
+    }
+    if !changed_node {
+        return Err(SnapshotError::Corrupt(
+            "file-node delta contains no changed node records".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn file_node_index_projection_equal(previous: &NodeRecord, current: &NodeRecord) -> bool {
+    if previous.kind != current.kind
+        || previous.roles != current.roles
+        || previous.name != current.name
+        || previous.qualified_name != current.qualified_name
+        || previous.language != current.language
+        || previous.framework != current.framework
+        || previous.community != current.community
+    {
+        return false;
+    }
+    match (&previous.details, &current.details) {
+        (Some(NodeDetails::File(previous)), Some(NodeDetails::File(current))) => {
+            previous.generated == current.generated
+        }
+        _ => previous.details == current.details,
+    }
+}
+
+fn update_index_tree<S: Store + ?Sized>(
+    store: &S,
+    writer: &mut ObjectWriter<'_, S>,
+    index: IndexKind,
+    digest: &str,
+    updates: &BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+    depth: usize,
+) -> Result<String, SnapshotError> {
+    if updates.is_empty() {
+        return Ok(digest.to_owned());
+    }
+    if depth >= GRAPH_SNAPSHOT_MAX_DEPTH {
+        return Err(SnapshotError::Limit(
+            "delta tree depth limit exceeded".to_owned(),
+        ));
+    }
+    match load_tree_object(store, index, digest)? {
+        TreeObject::Leaf { entries, .. } => {
+            let mut values = entries
+                .into_iter()
+                .map(|entry| (entry.key, entry.value))
+                .collect::<BTreeMap<_, _>>();
+            for (key, value) in updates {
+                match value {
+                    Some(value) => {
+                        values.insert(key.clone(), value.clone());
+                    }
+                    None => {
+                        values.remove(key);
+                    }
+                }
+            }
+            build_index_tree(writer, index, &values)
+        }
+        TreeObject::Branch { children, .. } => {
+            let mut changed = false;
+            let mut updated_children = children.clone();
+            for child_index in 0..children.len() {
+                let Some(child) = children.get(child_index) else {
+                    continue;
+                };
+                let next_first_key = children
+                    .get(child_index.saturating_add(1))
+                    .map(|next| next.first_key.as_slice());
+                let child_updates = updates
+                    .iter()
+                    .filter(|(key, _)| {
+                        child.first_key.as_slice() <= key.as_slice()
+                            && next_first_key.is_none_or(|next| key.as_slice() < next)
+                    })
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect::<BTreeMap<_, _>>();
+                if child_updates.is_empty() {
+                    continue;
+                }
+                let child_digest = update_index_tree(
+                    store,
+                    writer,
+                    index,
+                    &child.digest,
+                    &child_updates,
+                    depth.saturating_add(1),
+                )?;
+                if child_digest != child.digest {
+                    changed = true;
+                    if let Some(updated) = updated_children.get_mut(child_index) {
+                        updated.digest = child_digest;
+                    }
+                }
+            }
+            if !changed {
+                return Ok(digest.to_owned());
+            }
+            put_tree_object(
+                writer,
+                &TreeObject::Branch {
+                    schema: GRAPH_SNAPSHOT_LAYOUT_V2.to_owned(),
+                    index,
+                    children: updated_children,
+                },
+            )
+        }
+    }
 }
 
 /// Keep normal names ordered and readable while giving graph-valid, deeply

--- a/crates/compass-graph/tests/store_snapshot.rs
+++ b/crates/compass-graph/tests/store_snapshot.rs
@@ -6,8 +6,8 @@ use compass_graph::{
     garbage_collect_graph_snapshots, graph_snapshot_needs_gc,
 };
 use compass_model::code_graph::{
-    BuildMetadata, EdgeKind, EdgeRecord, ExtractionStatus, FileRecord, GraphDocument, NodeKind,
-    NodeRecord,
+    BuildMetadata, EdgeKind, EdgeRecord, ExtractionStatus, FileNodeDetails, FileRecord,
+    GraphDocument, NodeDetails, NodeKind, NodeRecord,
 };
 use compass_model::identity::{edge_id, file_id};
 use compass_model::provenance::{
@@ -15,6 +15,7 @@ use compass_model::provenance::{
 };
 use compass_store::SqliteStore;
 use compass_store::{Key, MemoryStore, NamespaceId, PartitionKey, Store, WriteCondition};
+use sha2::Digest;
 use tempfile::tempdir;
 
 fn graph() -> GraphDocument {
@@ -38,7 +39,16 @@ fn graph() -> GraphDocument {
         coverage: Vec::new(),
         diagnostics: Vec::new(),
     });
-    document.nodes = vec![node("b"), node("a")];
+    let mut file_node = node("file");
+    file_node.kind = NodeKind::File;
+    file_node.name = "lib.rs".to_owned();
+    file_node.qualified_name = "src/lib.rs".to_owned();
+    file_node.details = Some(NodeDetails::File(FileNodeDetails {
+        content_digest: "sha256:test".to_owned(),
+        byte_size: 1,
+        generated: false,
+    }));
+    document.nodes = vec![node("b"), node("a"), file_node];
     let first_id = edge_id("a", EdgeKind::Calls, "b", None, None);
     let second_id = edge_id("a", EdgeKind::Calls, "b", None, Some("second"));
     document.links = vec![
@@ -227,6 +237,86 @@ fn selector_is_not_active_until_commit_and_reads_are_bounded() -> Result<(), Box
 }
 
 #[test]
+fn file_node_delta_reuses_unaffected_index_trees() -> Result<(), Box<dyn Error>> {
+    let store = MemoryStore::default();
+    let builder = GraphSnapshotBuilder::new();
+    let previous = graph();
+    let first = builder.prepare(&store, &previous)?;
+    builder.activate(&store, &first)?;
+
+    let mut current = previous.clone();
+    current.graph.build.generation_id = "next-generation".to_owned();
+    current.graph.files[0].content_digest = "sha256:changed".to_owned();
+    current.graph.files[0].byte_size = 2;
+    let file_node = current
+        .nodes
+        .iter_mut()
+        .find(|node| node.kind == NodeKind::File)
+        .ok_or("file node missing")?;
+    file_node.details = Some(NodeDetails::File(FileNodeDetails {
+        content_digest: "sha256:changed".to_owned(),
+        byte_size: 2,
+        generated: false,
+    }));
+
+    let content = builder.prepare_file_node_delta(&store, &previous, &current)?;
+    let graph_bytes = canonical_graph_json(&current)?;
+    let graph_digest = format!("{:x}", sha2::Sha256::digest(&graph_bytes));
+    let delta = builder.finish_content(&store, content, graph_digest, graph_bytes.len() as u64)?;
+    let first_roots = first
+        .manifest
+        .roots
+        .iter()
+        .map(|root| (root.index, root.digest.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let delta_roots = delta
+        .manifest
+        .roots
+        .iter()
+        .map(|root| (root.index, root.digest.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for index in [
+        IndexKind::Edges,
+        IndexKind::Outgoing,
+        IndexKind::Incoming,
+        IndexKind::Files,
+        IndexKind::Names,
+        IndexKind::Terms,
+        IndexKind::Communities,
+        IndexKind::Diagnostics,
+    ] {
+        assert_eq!(
+            first_roots.get(&index),
+            delta_roots.get(&index),
+            "{index:?}"
+        );
+    }
+    assert_ne!(
+        first_roots.get(&IndexKind::Nodes),
+        delta_roots.get(&IndexKind::Nodes)
+    );
+    assert_ne!(
+        first_roots.get(&IndexKind::Metadata),
+        delta_roots.get(&IndexKind::Metadata)
+    );
+
+    builder.activate(&store, &delta)?;
+    let reader = GraphSnapshotReader::open_active(&store)?.ok_or("active snapshot missing")?;
+    assert_eq!(
+        reader.get_node("file")?.and_then(|node| {
+            node.details.and_then(|details| match details {
+                NodeDetails::File(file) => Some(file.content_digest),
+                _ => None,
+            })
+        }),
+        Some("sha256:changed".to_owned())
+    );
+    assert_eq!(reader.metadata()?.graph.files[0].byte_size, 2);
+    assert_eq!(reader.export_graph()?, graph_sorted_with(&current));
+    Ok(())
+}
+
+#[test]
 fn missing_or_tampered_objects_fail_closed() -> Result<(), Box<dyn Error>> {
     let store = MemoryStore::default();
     let builder = GraphSnapshotBuilder::new();
@@ -405,7 +495,11 @@ fn graph_valid_punctuation_names_use_an_explicit_empty_name_bucket() -> Result<(
 }
 
 fn graph_sorted() -> GraphDocument {
-    let mut document = graph();
+    graph_sorted_with(&graph())
+}
+
+fn graph_sorted_with(source: &GraphDocument) -> GraphDocument {
+    let mut document = source.clone();
     document.nodes.sort_by(|left, right| left.id.cmp(&right.id));
     document.links.sort_by(|left, right| left.id.cmp(&right.id));
     document

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -584,6 +584,9 @@ struct DirectAdapterState<'source> {
     rust_impls: HashMap<usize, RustImplContext>,
     rust_types_by_qualified_name: HashMap<String, DeclarationContext>,
     rust_types_by_name: HashMap<String, Vec<DeclarationContext>>,
+    rust_receiver_methods: HashMap<(String, String), Vec<String>>,
+    rust_typed_receivers: HashSet<(String, String)>,
+    rust_imported_typed_receivers: HashSet<(String, String)>,
     rust_import_nodes: HashSet<usize>,
     rust_test_declarations: HashSet<String>,
     go_lexical_bindings: HashMap<usize, Vec<GoLexicalBinding>>,
@@ -591,6 +594,7 @@ struct DirectAdapterState<'source> {
     go_return_types: HashMap<String, String>,
     go_member_types: HashMap<(String, String), String>,
     go_collection_element_types: HashMap<String, String>,
+    go_collection_binding_element_types: HashMap<String, HashMap<String, String>>,
     go_range_return_types: HashMap<String, String>,
     go_range_member_types: HashMap<(String, String), String>,
     java_containers: HashMap<usize, DeclarationContext>,
@@ -650,6 +654,9 @@ impl<'source> DirectAdapterState<'source> {
             rust_impls: HashMap::new(),
             rust_types_by_qualified_name: HashMap::new(),
             rust_types_by_name: HashMap::new(),
+            rust_receiver_methods: HashMap::new(),
+            rust_typed_receivers: HashSet::new(),
+            rust_imported_typed_receivers: HashSet::new(),
             rust_import_nodes: HashSet::new(),
             rust_test_declarations: HashSet::new(),
             go_lexical_bindings: HashMap::new(),
@@ -657,6 +664,7 @@ impl<'source> DirectAdapterState<'source> {
             go_return_types: HashMap::new(),
             go_member_types: HashMap::new(),
             go_collection_element_types: HashMap::new(),
+            go_collection_binding_element_types: HashMap::new(),
             go_range_return_types: HashMap::new(),
             go_range_member_types: HashMap::new(),
             java_containers: HashMap::new(),
@@ -2488,6 +2496,7 @@ impl<'source> DirectAdapterState<'source> {
         self.collect_rust_module_imports(root, &file)?;
         self.collect_rust_declarations(root, &file, None)?;
         self.collect_rust_imports(root, &file)?;
+        self.collect_rust_parameter_bindings(root, &file)?;
         self.walk_rust_evidence(root, &file, true)
     }
 
@@ -2796,11 +2805,113 @@ impl<'source> DirectAdapterState<'source> {
         self.local_targets
             .entry(parent_scope.to_owned())
             .or_default()
-            .insert(name, qualified_name);
+            .insert(name.clone(), qualified_name.clone());
+        if let Some(implementation) = active_impl {
+            self.rust_receiver_methods
+                .entry((implementation.type_qualified_name.clone(), name))
+                .or_default()
+                .push(qualified_name);
+        }
         if rust_has_test_attribute(node, self.source) {
             self.rust_test_declarations.insert(context.fact_id.clone());
         }
         self.declarations.insert(node.id(), context);
+        Ok(())
+    }
+
+    fn collect_rust_parameter_bindings(
+        &mut self,
+        node: Node<'_>,
+        owner: &DeclarationContext,
+    ) -> Result<(), EvidenceError> {
+        let active = self
+            .declarations
+            .get(&node.id())
+            .cloned()
+            .unwrap_or_else(|| owner.clone());
+        if matches!(node.kind(), "function_item" | "function_signature_item")
+            && self.declarations.contains_key(&node.id())
+        {
+            self.add_rust_parameter_bindings(node, &active)?;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+            self.collect_rust_parameter_bindings(child, &active)?;
+        }
+        Ok(())
+    }
+
+    fn add_rust_parameter_bindings(
+        &mut self,
+        callable: Node<'_>,
+        owner: &DeclarationContext,
+    ) -> Result<(), EvidenceError> {
+        let Some(parameters) = callable.child_by_field_name("parameters") else {
+            return Ok(());
+        };
+        let mut cursor = parameters.walk();
+        for parameter in parameters
+            .children(&mut cursor)
+            .filter(|node| node.is_named())
+        {
+            if parameter.kind() != "parameter" {
+                continue;
+            }
+            let Some(name_node) = parameter
+                .child_by_field_name("pattern")
+                .or_else(|| parameter.child_by_field_name("name"))
+                .filter(|node| node.kind() == "identifier")
+            else {
+                continue;
+            };
+            let Some(type_node) = parameter.child_by_field_name("type") else {
+                continue;
+            };
+            let raw_type_text = self.text(type_node);
+            let Some(raw_type) = rust_nominal_type_path(&raw_type_text) else {
+                continue;
+            };
+            let local_type = self.rust_type_context(owner, &raw_type).map(|context| {
+                (
+                    context.qualified_name.clone(),
+                    Some(context.fact_id.clone()),
+                )
+            });
+            let imported_type_target = self
+                .imported_target_for_occurrence(owner, &raw_type, type_node.start_byte(), true)
+                .cloned()
+                .map(|target| (target, None));
+            let imported_type = local_type.is_none();
+            let Some((target, type_fact_id)) = local_type.or(imported_type_target) else {
+                continue;
+            };
+            let name = self.text(name_node);
+            if name.is_empty() || name == "_" {
+                continue;
+            }
+            let binding_id = self.builder.bind(
+                BindingKind::LocalAlias,
+                &name,
+                &target,
+                type_fact_id.as_deref(),
+                Some(&owner.scope_id),
+                range_for_node(self.source_file, name_node),
+            )?;
+            self.local_bindings
+                .entry(owner.scope_id.clone())
+                .or_default()
+                .insert(name.clone(), binding_id);
+            self.local_targets
+                .entry(owner.scope_id.clone())
+                .or_default()
+                .insert(name.clone(), target);
+            self.rust_typed_receivers
+                .insert((owner.scope_id.clone(), name.clone()));
+            if imported_type {
+                self.rust_imported_typed_receivers
+                    .insert((owner.scope_id.clone(), name));
+            }
+        }
         Ok(())
     }
 
@@ -3372,9 +3483,20 @@ impl<'source> DirectAdapterState<'source> {
         if (qualifier == "Self" || rust_receiver_is_self(qualifier))
             && let Some(enclosing) = rust_callable_owner(owner)
         {
-            return Some(rust_join_qualified(enclosing, spelling));
+            return self
+                .rust_receiver_method_target(enclosing, spelling)
+                .or_else(|| Some(rust_join_qualified(enclosing, spelling)));
         }
         if let Some(target) = self.local_target_for(owner, qualifier) {
+            if let Some(method) = self.rust_receiver_method_target(target, spelling) {
+                return Some(method);
+            }
+            if self.rust_typed_receiver_for(owner, qualifier) {
+                if self.rust_imported_typed_receiver_for(owner, qualifier) {
+                    return Some(rust_join_qualified(target, spelling));
+                }
+                return Some(rust_join_qualified(qualifier, spelling));
+            }
             return Some(rust_join_qualified(target, spelling));
         }
         if let Some(target) = self.imported_qualified_target_for(owner, qualifier, 0, true) {
@@ -3388,6 +3510,50 @@ impl<'source> DirectAdapterState<'source> {
             ));
         }
         Some(rust_join_qualified(qualifier, spelling))
+    }
+
+    fn rust_receiver_method_target(&self, receiver: &str, method: &str) -> Option<String> {
+        let targets = self
+            .rust_receiver_methods
+            .get(&(receiver.to_owned(), method.to_owned()))?;
+        let [target] = targets.as_slice() else {
+            return None;
+        };
+        Some(target.clone())
+    }
+
+    fn rust_typed_receiver_for(&self, owner: &DeclarationContext, name: &str) -> bool {
+        let mut scope_id = Some(owner.scope_id.as_str());
+        for _ in 0..64 {
+            let Some(current) = scope_id else {
+                break;
+            };
+            if self
+                .rust_typed_receivers
+                .contains(&(current.to_owned(), name.to_owned()))
+            {
+                return true;
+            }
+            scope_id = self.scope_parents.get(current).map(String::as_str);
+        }
+        false
+    }
+
+    fn rust_imported_typed_receiver_for(&self, owner: &DeclarationContext, name: &str) -> bool {
+        let mut scope_id = Some(owner.scope_id.as_str());
+        for _ in 0..64 {
+            let Some(current) = scope_id else {
+                break;
+            };
+            if self
+                .rust_imported_typed_receivers
+                .contains(&(current.to_owned(), name.to_owned()))
+            {
+                return true;
+            }
+            scope_id = self.scope_parents.get(current).map(String::as_str);
+        }
+        false
     }
 
     fn add_rust_macro_invocation(
@@ -3891,12 +4057,27 @@ impl<'source> DirectAdapterState<'source> {
                     .entry(owner.scope_id.clone())
                     .or_default()
                     .extend(names.iter().map(|(name, _)| name.clone()));
-                if parameter.kind() == "variadic_parameter_declaration" {
-                    continue;
-                }
                 let Some(type_node) = parameter.child_by_field_name("type") else {
                     continue;
                 };
+                if parameter.kind() == "variadic_parameter_declaration" {
+                    let Some(element_target) = go_direct_type_target(type_node) else {
+                        continue;
+                    };
+                    let Some(element_type) = self.go_qualified_type_target(owner, element_target)
+                    else {
+                        continue;
+                    };
+                    self.go_collection_binding_element_types
+                        .entry(owner.scope_id.clone())
+                        .or_default()
+                        .extend(
+                            names
+                                .into_iter()
+                                .map(|(name, _)| (name, element_type.clone())),
+                        );
+                    continue;
+                }
                 let mut targets = Vec::new();
                 collect_named_targets(
                     type_node,
@@ -4682,6 +4863,10 @@ impl<'source> DirectAdapterState<'source> {
                 };
                 self.go_return_types.get(&qualified_callable).cloned()
             }
+            "type_assertion_expression" | "type_assertion" => expression
+                .child_by_field_name("type")
+                .and_then(go_direct_type_target)
+                .and_then(|target| self.go_qualified_type_target(owner, target)),
             _ => None,
         }
     }
@@ -4706,6 +4891,14 @@ impl<'source> DirectAdapterState<'source> {
                     .local_target_for(owner, &name)
                     .and_then(|collection| self.go_collection_element_types.get(collection))
                     .cloned()
+                    .or_else(|| {
+                        self.local_value_for(
+                            &self.go_collection_binding_element_types,
+                            owner,
+                            &name,
+                        )
+                        .cloned()
+                    })
                     .or_else(|| {
                         go_local_initializer_before(expression, &name, self.source).and_then(
                             |initializer| {
@@ -5615,6 +5808,9 @@ fn rust_module_identity(path: &Path, source_file: &str) -> String {
 /// manifests keeps the extractor offline and deterministic while fixing the
 /// common workspace case where `foo-bar` is imported as `foo_bar`.
 fn rust_manifest_crate_name(path: &Path) -> Option<String> {
+    if !path.is_absolute() {
+        return None;
+    }
     let mut directory = path.parent();
     while let Some(current) = directory {
         let manifest = current.join("Cargo.toml");

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -1018,6 +1018,39 @@ func create(b *Bucket) {
 }
 
 #[test]
+fn go_calls_follow_type_assertion_receiver_types() {
+    let source = br#"package sample
+
+type Command struct{}
+
+func (c *Command) Execute() {}
+
+func invoke(value interface{}) {
+    command := value.(*Command)
+    command.Execute()
+}
+"#;
+    let mut engine = Engine::default();
+    let evidence = engine
+        .extract_source_combined(
+            std::path::Path::new("/repo/sample/example.go"),
+            "sample/example.go",
+            source,
+        )
+        .expect("extract go")
+        .graph
+        .semantic_evidence
+        .expect("go universal evidence");
+    validate_evidence(&evidence, EvidenceLimits::default()).expect("valid go evidence");
+
+    assert!(evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "Execute"
+            && candidate.constraints.qualified_name.as_deref() == Some("sample.Command::Execute")
+    }));
+}
+
+#[test]
 fn direct_adapter_ids_and_partial_diagnostics_are_deterministic() {
     let path = std::path::Path::new("/repo/src/example.py");
     let source_file = "src/example.py";

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -409,6 +409,43 @@ impl<T> Render for Container<T> {
 }
 
 #[test]
+fn rust_generic_trait_impl_calls_resolve_to_exact_impl_owner() {
+    let source = br#"trait Render<T> {
+    fn render(&self, value: T);
+}
+struct Container<T>(T);
+impl<T> Render<T> for Container<T> {
+    fn render(&self, _value: T) {}
+}
+fn invoke(container: Container<u32>) {
+    container.render(1);
+}
+"#;
+    let extracted = extract("src/lib.rs", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let render_method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "<crate::Container as crate::Render>::render")
+        .expect("generic Render implementation method");
+
+    assert!(
+        resolved.edges.iter().any(|edge| {
+            edge.string("relation") == "calls"
+                && edge.target == render_method.id
+                && edge.string("source_location") == "L9"
+        }),
+        "generic method call was not resolved"
+    );
+}
+
+#[test]
 fn python_super_call_resolves_only_the_exact_direct_base_method() {
     let provider = extract(
         "pkg/base.py",
@@ -875,6 +912,68 @@ func caller(worker *Worker) {
 }
 
 #[test]
+fn go_variadic_ranges_and_nested_closures_resolve_element_receivers() {
+    let go_source = br#"package pkg
+type Worker struct{}
+func (worker *Worker) Run() {}
+type Command struct{}
+func (*Command) Commands() []*Command { return nil }
+func (*Command) IsAvailableCommand() bool { return true }
+func (*Command) Name() string { return "" }
+func caller(workers ...*Worker) {
+    for _, worker := range workers {
+        worker.Run()
+    }
+    visit := func(command *Command) {
+        for _, subCommand := range command.Commands() {
+            if subCommand.IsAvailableCommand() {
+                _ = subCommand.Name()
+            }
+        }
+    }
+    _ = visit
+}
+"#;
+    let extracted = extract("pkg/caller.go", go_source);
+    let sources = HashMap::from([(
+        "pkg/caller.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let worker_run = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.Worker::Run")
+        .expect("Worker.Run declaration");
+    let command_available = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.Command::IsAvailableCommand")
+        .expect("Command.IsAvailableCommand declaration");
+    let command_name = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.Command::Name")
+        .expect("Command.Name declaration");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == worker_run.id
+            && edge.string("source_location") == "L10"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == command_available.id
+            && edge.string("source_location") == "L14"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == command_name.id
+            && edge.string("source_location") == "L15"
+    }));
+}
+
+#[test]
 fn qualified_external_types_are_not_rebound_to_local_terminal_names() {
     let go_source = br#"package auth
 import deviceflow "example.com/deviceflow"
@@ -1165,6 +1264,36 @@ fn rust_import_binding_resolves_the_qualified_associated_function() {
             && edge.string("relation") == "calls"
             && edge.string("resolution_rule") == "member-binding"
             && edge.string("source_location") == "L2"
+    }));
+}
+
+#[test]
+fn rust_cross_file_generic_receiver_parameters_resolve_through_imported_impls() {
+    let provider = extract(
+        "src/api.rs",
+        b"pub trait Render<T> { fn render(&self, value: T); }\npub struct Container<T>(T);\nimpl<T> Render<T> for Container<T> { fn render(&self, _value: T) {} }\n",
+    );
+    let caller_source =
+        b"use crate::api::Container;\nfn invoke(container: Container<u32>) {\n    container.render(1);\n}\n";
+    let caller = extract("src/lib.rs", caller_source);
+    let resolved = compass_resolve::resolve(
+        &[provider, caller],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(caller_source.to_vec()).expect("source"),
+        )]),
+    );
+    let render_method = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name") == "<crate::api::Container as crate::api::Render>::render"
+        })
+        .expect("cross-file generic Render implementation method");
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == render_method.id
+            && edge.string("source_location") == "L3"
     }));
 }
 


### PR DESCRIPTION
## What changed

- Add a strict file-node delta publication path for SQLite snapshots that path-copies only changed Nodes/Metadata trees and reuses unaffected topology indexes.
- Stream portable AST cache encoding/publication and keep small-project extraction sequential by default, while preserving explicit `--max-workers` parallelism.
- Improve Go attribution for variadic range elements, type assertions, and nested closure receivers.
- Resolve Rust generic/impl method calls to exact implementation owners, including imported cross-file receivers.
- Add regression, store-contract, universal-evidence, resolver, and real-repository performance documentation.

## Why

Incremental edits were rebuilding immutable graph indexes even when topology was unchanged, and parser/AST working sets retained more compressed cache data than necessary. Go and Rust receiver attribution also left common real-world calls unresolved or ambiguously owned.

## Evidence

- Go Cobra comment-only edit: 1 extracted / 36 cached files; 5 new store objects and 32,325 bytes versus 192 objects and 2,072,182 bytes for the cold publication.
- Same filtered Graphify Go comparison: exact comparable edges improved from 1,469 to 1,492; missing edges decreased from 38 to 15.
- Four real repositories exercised: Go Cobra, TypeScript Zod, Rust Rayon, and Python Click.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- CLI product and product-boundary checks
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- Targeted file, graph snapshot, universal evidence, resolver, and core tests

The cold-build smoke measurements are diagnostic; this PR does not claim a universal 4–5x cold-build advantage.
