### PR TITLE
Preserve cached module resolution and speed graph publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Preserve JavaScript and TypeScript workspace import and re-export resolution
+  across fully cached edit/restore builds, and improve canonical graph JSON
+  publication parallelism for medium and large structural graphs without
+  changing serialized bytes.
+
 ## 0.3.2 - 2026-08-03
 
 - Harden graph correctness and make the default query path use canonical

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1213,13 +1213,19 @@ fn build_graph_inner(
     profile_internal("AST cache snapshot and dispatch", &mut internal_started);
     let read_source = |path: &PathBuf| read_source_text_with_limit(path, options.max_source_bytes);
     let read_cached_source = |path: &PathBuf| {
-        (!fresh_paths.contains(path))
-            .then(|| read_source(path))
-            .flatten()
+        if fresh_paths.contains(path) {
+            None
+        } else if needs_resolver_source_text {
+            read_source(path)
+        } else {
+            // Cross-file resolution uses the keys as the complete language
+            // inventory even when a language does not need decoded source
+            // text. Preserve that inventory across partial and fully cached
+            // rebuilds without retaining duplicate source contents.
+            Some((path.to_string_lossy().into_owned(), String::new()))
+        }
     };
-    let cached_source_text: HashMap<_, _> = if !needs_resolver_source_text {
-        HashMap::new()
-    } else if sources.len() < 256 {
+    let cached_source_text: HashMap<_, _> = if sources.len() < 256 {
         sources.iter().filter_map(read_cached_source).collect()
     } else if let Some(pool) = &worker_pool {
         pool.install(|| sources.par_iter().filter_map(read_cached_source).collect())

--- a/crates/compass-core/tests/code_graph_v1_determinism.rs
+++ b/crates/compass-core/tests/code_graph_v1_determinism.rs
@@ -298,6 +298,53 @@ export const router = createBrowserRouter([
     Ok(())
 }
 
+#[test]
+fn typescript_edit_restore_preserves_cached_workspace_module_edges() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    for (relative, source) in [
+        ("src/value.ts", "export const value = 1;\n"),
+        ("src/index.ts", "export { value } from \"./value\";\n"),
+        (
+            "src/use.ts",
+            "import { value } from \"./index\";\nexport function read() { return value; }\n",
+        ),
+        ("src/unrelated.ts", "export const unrelated = true;\n"),
+    ] {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, source)?;
+    }
+
+    let (clean, _) = build(root)?;
+    let clean_graph: GraphDocument = serde_json::from_slice(&clean)?;
+    assert!(
+        clean_graph
+            .links
+            .iter()
+            .any(|edge| edge.kind == EdgeKind::Imports),
+        "fixture must exercise TypeScript workspace import resolution"
+    );
+    assert!(
+        clean_graph
+            .links
+            .iter()
+            .any(|edge| edge.kind == EdgeKind::Exports),
+        "fixture must exercise TypeScript workspace re-export resolution"
+    );
+
+    let unrelated = root.join("src/unrelated.ts");
+    fs::write(&unrelated, "export const unrelated = false;\n")?;
+    let _ = build(root)?;
+    fs::write(&unrelated, "export const unrelated = true;\n")?;
+    let (restored, _) = build(root)?;
+
+    assert_eq!(restored, clean);
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn cached_file_symlink_keeps_its_logical_graph_identity() -> Result<(), Box<dyn Error>> {

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -649,7 +649,12 @@ pub fn canonical_graph_document_presorted(graph: &GraphDocument) -> CanonicalGra
     }
 }
 
-const CANONICAL_RECORD_CHUNK: usize = 16_384;
+// Keep enough independent work for modest real-repository graphs while
+// bounding each temporary JSON buffer. At 16K records, a 10K-node/27K-edge
+// graph exposed only three serialization tasks and retained multi-megabyte
+// chunks; 8K preserves amortized encoding while allowing the in-flight bound
+// to control both parallelism and peak memory.
+const CANONICAL_RECORD_CHUNK: usize = 8_192;
 const CANONICAL_RECORD_IN_FLIGHT: usize = 4;
 
 /// Stream the canonical graph JSON while serializing record chunks in


### PR DESCRIPTION
## Summary

- preserve the complete source-language inventory during fully cached rebuilds without retaining duplicate source contents
- keep JavaScript and TypeScript workspace import/re-export resolution byte-identical across unrelated edit/restore cycles
- reduce canonical graph serialization chunks from 16K to 8K records to expose more bounded parallel work on medium real-repository graphs
- add a deterministic TypeScript cache regression and an Unreleased changelog entry

## Root cause

The pipeline retained decoded cached source only for languages that require resolver source text. However, cross-file resolution also uses the source-map keys as the complete language inventory. On a fully cached JavaScript/TypeScript rebuild, the empty map disabled workspace module and re-export resolution, dropping valid edges after an unrelated edit/restore cycle.

Cached files now contribute an empty source value when decoded contents are unnecessary. This preserves the inventory without duplicating source memory.

## Real-repository evidence

Pinned experiments covered Go (Cobra, bbolt), Python (Click, HTTPX), Rust (Rayon, ripgrep), and TypeScript (Zod, Axios).

- Zod edit/restore previously dropped 343 import/export edges; restored output is now exactly equal to the clean graph.
- Axios edit/restore previously dropped one import edge; restored output is now exactly equal to the clean graph.
- Ripgrep canonical serialization improved from 1.005s to 0.639–0.697s.
- Ripgrep cold wall time improved from 3.33s to 2.40–2.54s.
- Ripgrep graph bytes remained identical (SHA-256 `7157e988b05050a9316c79f3effce60afda32857dbd7f80e83e5221870f19363`).
- On a pinned Django run, Compass produced 80,997 nodes and 187,295 edges in 14.92s; pinned Graphify produced 50,861 nodes and 158,765 edges in approximately 42s.

This does not claim the broader 4–5x cold-build target is complete. Publication remains the dominant opportunity on large graphs.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-core --test code_graph_v1_determinism --locked` (13 passed)
- canonical streamed JSON byte-equivalence test
- `sh scripts/check_product_boundary.sh`
- fixture-only code-graph qualification
- exact real-repository edit/restore checks for Zod and Axios

## Known unrelated failure

The full `cargo test -p compass-graph --locked` integration run consistently fails `repeated_markdown_headings_use_stable_hierarchical_identities`. The changed resolver and serialization paths do not participate in that Markdown identity test; the workspace lib/bin baseline and all targeted graph tests pass.