### PR TITLE
Split framework adapters and improve code-graph qualification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Split framework extraction into focused Spring, Express, Axum, Next.js, and
+  Vite adapters. Project evidence now indexes framework configuration files,
+  aliases, plugins, and file-route roots; Vite configuration nodes and a
+  reusable exact-route qualification API are available to graph consumers.
+  Extraction semantics advance to version 7 so cached source facts refresh.
 - Preserve JavaScript and TypeScript workspace import and re-export resolution
   across fully cached edit/restore builds, and improve canonical graph JSON
   publication parallelism for medium and large structural graphs without

--- a/crates/compass-languages/src/frameworks/axum.rs
+++ b/crates/compass-languages/src/frameworks/axum.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::RawFrameworkFact;
+
+/// Axum route calls and nested router scopes are intentionally isolated from
+/// the Actix/Rocket attribute adapter. This keeps mixed Rust workspaces
+/// deterministic and gives each framework a qualification seam of its own.
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+    super::rust::detect_axum(path, source, root)
+}

--- a/crates/compass-languages/src/frameworks/express.rs
+++ b/crates/compass-languages/src/frameworks/express.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::RawFrameworkFact;
+use crate::Extraction;
+
+/// Express owns the receiver/mount/handler interpretation for JavaScript and
+/// TypeScript. The shared TypeScript module only supplies the language-level
+/// traversal helpers; keeping this adapter separate prevents unrelated router
+/// conventions from activating in the Express pack.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    super::typescript::detect_express(path, source, root, extraction)
+}

--- a/crates/compass-languages/src/frameworks/file_routes.rs
+++ b/crates/compass-languages/src/frameworks/file_routes.rs
@@ -156,6 +156,125 @@ pub(super) fn detect(
     Vec::new()
 }
 
+/// Detect Next.js App Router and Pages Router conventions. The generic
+/// filesystem adapter deliberately excludes Next so a project cannot receive
+/// duplicate route facts from two convention packs.
+pub(super) fn detect_next(
+    path: &Path,
+    source: &[u8],
+    project: Option<&ProjectEvidence>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    let enabled = project.is_none_or(|project| {
+        project.has_dependency("next")
+            || project.has_configuration("next.config.js")
+            || project.has_configuration("next.config.mjs")
+            || project.has_configuration("next.config.ts")
+    });
+    if !enabled || source.is_empty() {
+        return Vec::new();
+    }
+    let portable = path.to_string_lossy().replace('\\', "/");
+    let project_relative = project
+        .and_then(|project| path.strip_prefix(project.project_root()).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or(portable);
+    let Some((router, relative)) = next_route_file(&project_relative) else {
+        return Vec::new();
+    };
+    let lower = relative.to_ascii_lowercase();
+    if router == "app" {
+        if ["page.tsx", "page.ts", "page.jsx", "page.js"]
+            .iter()
+            .any(|name| next_file_is(&lower, name))
+        {
+            let route = relative
+                .rsplit_once('/')
+                .map_or("", |(parent, _)| parent)
+                .trim_matches('/');
+            return page_routes("next", route, path, source, extraction);
+        }
+        if ["route.tsx", "route.ts", "route.jsx", "route.js"]
+            .iter()
+            .any(|name| next_file_is(&lower, name))
+        {
+            let route = relative
+                .rsplit_once('/')
+                .map_or("", |(parent, _)| parent)
+                .trim_matches('/');
+            return endpoint_routes("next", route, path, source, extraction);
+        }
+    } else if router == "pages" {
+        let page_route = trim_known_extension(relative);
+        if page_route == "api" || page_route.starts_with("api/") {
+            return next_pages_api_route(relative, path, source, extraction);
+        }
+        if matches!(page_route, "_app" | "_document" | "_error") {
+            return Vec::new();
+        }
+        if lower.ends_with(".tsx")
+            || lower.ends_with(".ts")
+            || lower.ends_with(".jsx")
+            || lower.ends_with(".js")
+        {
+            return page_routes(
+                "next",
+                trim_known_extension(relative),
+                path,
+                source,
+                extraction,
+            );
+        }
+    }
+    Vec::new()
+}
+
+fn next_pages_api_route(
+    relative: &str,
+    path: &Path,
+    source: &[u8],
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    let handler = EndpointHandler {
+        operation: "ANY".to_owned(),
+        reference: "default".to_owned(),
+        module: None,
+    };
+    one_route(
+        "next",
+        "ANY",
+        trim_known_extension(relative),
+        path,
+        source,
+        extraction,
+        "next-pages-api-convention",
+        Some(&handler),
+    )
+}
+
+fn next_route_file(relative: &str) -> Option<(&'static str, &str)> {
+    for (marker, router) in [
+        ("src/app/", "app"),
+        ("app/", "app"),
+        ("src/pages/", "pages"),
+        ("pages/", "pages"),
+    ] {
+        if let Some(relative) = relative.strip_prefix(marker) {
+            return Some((router, relative));
+        }
+        if let Some(index) = relative.find(marker)
+            && (index == 0 || relative.as_bytes().get(index - 1) == Some(&b'/'))
+        {
+            return Some((router, &relative[index + marker.len()..]));
+        }
+    }
+    None
+}
+
+fn next_file_is(relative: &str, file_name: &str) -> bool {
+    relative == file_name || relative.ends_with(&format!("/{file_name}"))
+}
+
 fn page_routes(
     framework: &str,
     relative: &str,

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -1,10 +1,13 @@
+mod axum;
 mod csharp;
 mod enterprise;
 mod evidence;
+mod express;
 mod file_routes;
 mod go;
 mod java;
 mod model;
+mod next;
 mod pack;
 mod php;
 mod play;
@@ -12,9 +15,11 @@ mod python;
 mod ruby;
 mod rust;
 mod spring;
+mod spring_kotlin;
 mod swift;
 mod text;
 mod typescript;
+mod vite;
 
 pub use model::{
     FrameworkLimitError, FrameworkLimits, RawDomainFact, RawFrameworkAnchor,
@@ -88,6 +93,7 @@ struct FrameworkPack {
     kind: FrameworkPackKind,
     languages: &'static [&'static str],
     dependency_markers: &'static [&'static str],
+    configuration_markers: &'static [&'static str],
     manifest_policy: FrameworkManifestPolicy,
     limits: FrameworkLimits,
     adapter: FrameworkPackAdapter,
@@ -105,7 +111,27 @@ impl FrameworkPack {
             kind: FrameworkPackKind::Source,
             languages,
             dependency_markers,
+            configuration_markers: &[],
             manifest_policy: FrameworkManifestPolicy::Advisory,
+            limits: FrameworkLimits::DEFAULT,
+            adapter: FrameworkPackAdapter::Source(detector),
+        }
+    }
+
+    const fn source_required(
+        id: &'static str,
+        languages: &'static [&'static str],
+        dependency_markers: &'static [&'static str],
+        configuration_markers: &'static [&'static str],
+        detector: SourceDetector,
+    ) -> Self {
+        Self {
+            id,
+            kind: FrameworkPackKind::Source,
+            languages,
+            dependency_markers,
+            configuration_markers,
+            manifest_policy: FrameworkManifestPolicy::Required,
             limits: FrameworkLimits::DEFAULT,
             adapter: FrameworkPackAdapter::Source(detector),
         }
@@ -120,6 +146,7 @@ impl FrameworkPack {
             kind: descriptor.kind,
             languages: descriptor.languages,
             dependency_markers: descriptor.dependency_markers,
+            configuration_markers: &[],
             manifest_policy: descriptor.manifest_policy,
             limits: descriptor.limits,
             adapter: FrameworkPackAdapter::Universal {
@@ -135,6 +162,7 @@ impl FrameworkPack {
             kind: FrameworkPackKind::Config,
             languages: &[],
             dependency_markers: &[],
+            configuration_markers: &[],
             manifest_policy: FrameworkManifestPolicy::Advisory,
             limits: FrameworkLimits::DEFAULT,
             adapter: FrameworkPackAdapter::Config { matcher, detector },
@@ -151,6 +179,7 @@ impl FrameworkPack {
             kind: FrameworkPackKind::Template,
             languages: &[],
             dependency_markers,
+            configuration_markers: &[],
             manifest_policy: FrameworkManifestPolicy::Required,
             limits: FrameworkLimits::DEFAULT,
             adapter: FrameworkPackAdapter::Template(detector),
@@ -160,9 +189,10 @@ impl FrameworkPack {
     fn enabled(self, project: Option<&ProjectEvidence>) -> bool {
         match self.manifest_policy {
             FrameworkManifestPolicy::Advisory => true,
-            FrameworkManifestPolicy::Required => {
-                project.is_none_or(|project| project.has_any_dependency(self.dependency_markers))
-            }
+            FrameworkManifestPolicy::Required => project.is_none_or(|project| {
+                project.has_any_dependency(self.dependency_markers)
+                    || project.has_any_configuration(self.configuration_markers)
+            }),
         }
     }
 
@@ -263,6 +293,7 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         detect_kotlin,
     ),
     FrameworkPack::source("go-web", &["go"], &[], detect_go),
+    FrameworkPack::source("axum-web", &["rust"], &["axum"], detect_axum),
     FrameworkPack::source("rust-web", &["rust"], &[], detect_rust),
     FrameworkPack::source(
         "aspnet-web",
@@ -272,10 +303,15 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
     ),
     FrameworkPack::source("vapor-routes", &["swift"], &["vapor"], detect_swift),
     FrameworkPack::source(
+        "express-web",
+        &["javascript", "typescript", "tsx"],
+        &["express"],
+        detect_express,
+    ),
+    FrameworkPack::source(
         "typescript-web",
         &["javascript", "typescript", "tsx"],
         &[
-            "express",
             "@nestjs/common",
             "react-router",
             "react-router-dom",
@@ -283,11 +319,31 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         ],
         detect_typescript,
     ),
+    FrameworkPack::source_required(
+        "nextjs-routes",
+        &["javascript", "typescript", "tsx"],
+        &["next"],
+        &["next.config.js", "next.config.mjs", "next.config.ts"],
+        detect_next,
+    ),
+    FrameworkPack::source_required(
+        "vite-config",
+        &["javascript", "typescript", "tsx"],
+        &["vite"],
+        &[
+            "vite.config.cjs",
+            "vite.config.js",
+            "vite.config.mjs",
+            "vite.config.ts",
+        ],
+        detect_vite,
+    ),
     FrameworkPack {
         id: "filesystem-routes",
         kind: FrameworkPackKind::Source,
         languages: &["javascript", "typescript", "tsx"],
         dependency_markers: &["@sveltejs/kit", "nuxt", "astro"],
+        configuration_markers: &[],
         manifest_policy: FrameworkManifestPolicy::Required,
         limits: FrameworkLimits::DEFAULT,
         adapter: FrameworkPackAdapter::Source(detect_file_routes),
@@ -307,6 +363,7 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
             "rust",
         ],
         dependency_markers: &[],
+        configuration_markers: &[],
         manifest_policy: FrameworkManifestPolicy::Advisory,
         limits: FrameworkLimits::DEFAULT,
         adapter: FrameworkPackAdapter::Source(detect_enterprise),
@@ -464,7 +521,7 @@ fn detect_kotlin(
     context: &DetectionContext<'_, '_>,
     _extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
-    java::detect(context.path, context.source, context.root)
+    spring_kotlin::detect(context.path, context.source, context.root)
 }
 
 fn detect_go(
@@ -478,7 +535,14 @@ fn detect_rust(
     context: &DetectionContext<'_, '_>,
     _extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
-    rust::detect(context.path, context.source, context.root)
+    rust::detect_non_axum(context.path, context.source, context.root)
+}
+
+fn detect_axum(
+    context: &DetectionContext<'_, '_>,
+    _extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    axum::detect(context.path, context.source, context.root)
 }
 
 fn detect_csharp(
@@ -499,7 +563,28 @@ fn detect_typescript(
     context: &DetectionContext<'_, '_>,
     extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
-    typescript::detect(context.path, context.source, context.root, extraction)
+    typescript::detect_non_express(context.path, context.source, context.root, extraction)
+}
+
+fn detect_express(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    express::detect(context.path, context.source, context.root, extraction)
+}
+
+fn detect_next(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    next::detect(context.path, context.source, context.project, extraction)
+}
+
+fn detect_vite(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    vite::detect(context.path, context.source, context.project, extraction)
 }
 
 fn detect_file_routes(
@@ -562,10 +647,14 @@ mod tests {
             "rails-routes",
             "spring-web-kotlin",
             "go-web",
+            "axum-web",
             "rust-web",
             "aspnet-web",
             "vapor-routes",
+            "express-web",
             "typescript-web",
+            "nextjs-routes",
+            "vite-config",
             "filesystem-routes",
             "enterprise-domain-facts",
             "drupal-routing-config",

--- a/crates/compass-languages/src/frameworks/next.rs
+++ b/crates/compass-languages/src/frameworks/next.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use super::RawFrameworkFact;
+use crate::{Extraction, ProjectEvidence};
+
+/// Next.js owns file-system route conventions; the shared file-route module
+/// supplies bounded path normalization and handler identity construction.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    project: Option<&ProjectEvidence>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    super::file_routes::detect_next(path, source, project, extraction)
+}

--- a/crates/compass-languages/src/frameworks/rust.rs
+++ b/crates/compass-languages/src/frameworks/rust.rs
@@ -8,7 +8,20 @@ use super::evidence::{EvidenceKind, EvidenceSet};
 use super::text::{anchor, join_route_path, literal, normalize_route_path, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
-pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+pub(super) fn detect_axum(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+    detect_selected(path, source, root, Some("axum"))
+}
+
+pub(super) fn detect_non_axum(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+    detect_selected(path, source, root, Some("non-axum"))
+}
+
+fn detect_selected(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    selected: Option<&str>,
+) -> Vec<RawFrameworkFact> {
     let body = text(source);
     let evidence = EvidenceSet::new()
         .direct_if(
@@ -35,9 +48,11 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
             EvidenceKind::Macro,
             "rocket route attribute",
         );
-    let axum = evidence.activates("axum");
-    let actix = evidence.activates("actix");
-    let rocket = evidence.activates("rocket");
+    let axum = selected.is_none_or(|framework| framework == "axum") && evidence.activates("axum");
+    let actix = selected.is_none_or(|framework| framework == "actix" || framework == "non-axum")
+        && evidence.activates("actix");
+    let rocket = selected.is_none_or(|framework| framework == "rocket" || framework == "non-axum")
+        && evidence.activates("rocket");
     if !axum && !actix && !rocket {
         return Vec::new();
     }
@@ -98,6 +113,20 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
             rule: Some("rust-route-attribute".to_owned()),
             detail: Map::new(),
         }));
+    }
+    if let Some(selected) = selected {
+        facts.retain(|fact| {
+            let framework = match fact {
+                RawFrameworkFact::Route(route) => route.framework.as_str(),
+                RawFrameworkFact::Domain(domain) => domain.framework.as_str(),
+                RawFrameworkFact::Annotation(annotation) => annotation.framework.as_str(),
+            };
+            if selected == "non-axum" {
+                framework != "axum"
+            } else {
+                framework == selected
+            }
+        });
     }
     facts
 }

--- a/crates/compass-languages/src/frameworks/spring_kotlin.rs
+++ b/crates/compass-languages/src/frameworks/spring_kotlin.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::RawFrameworkFact;
+
+/// Kotlin keeps the established JVM syntax extractor, but owns a dedicated
+/// adapter entry point so Spring can evolve without coupling its pack to other
+/// Kotlin framework conventions.
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+    super::java::detect(path, source, root)
+}

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -15,7 +15,7 @@ const HTTP_METHODS: &[&str] = &[
     "get", "post", "put", "patch", "delete", "options", "head", "all",
 ];
 
-pub(super) fn detect(
+pub(super) fn detect_express(
     path: &Path,
     source: &[u8],
     root: Node<'_>,
@@ -38,17 +38,43 @@ pub(super) fn detect(
     let mut facts = Vec::new();
     let receivers = express_receivers(root, source);
     let mounts = express_mounts(root, source, &receivers);
+    let evidence = EvidenceSet::new().direct_if(
+        !receivers.is_empty()
+            && (imports_module("express")
+                || source_has_express_require(root, source)
+                || body.contains("require(\"express\")")
+                || body.contains("require('express')")),
+        "express",
+        EvidenceKind::Receiver,
+        "express application/router",
+    );
+    if evidence.activates("express") {
+        collect_express_routes(root, source, path, &receivers, &mounts, &mut facts);
+    }
+    facts
+}
+
+pub(super) fn detect_non_express(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+    let mut imports = Vec::new();
+    collect_import_aliases(root, source, &mut imports);
+    attach_import_aliases(path, source, root, extraction, &imports);
+    let imports_module = |expected: &str| {
+        imports.iter().any(|(_, _, module, _)| {
+            module == expected
+                || (expected.ends_with('/') && module.starts_with(expected))
+                || (expected == "react-router" && module.starts_with("react-router-"))
+        })
+    };
+    let mut facts = Vec::new();
     let evidence = EvidenceSet::new()
-        .direct_if(
-            !receivers.is_empty()
-                && (imports_module("express")
-                    || source_has_express_require(root, source)
-                    || body.contains("require(\"express\")")
-                    || body.contains("require('express')")),
-            "express",
-            EvidenceKind::Receiver,
-            "express application/router",
-        )
         .direct_if(
             imports_module("@nestjs/"),
             "nestjs",
@@ -67,9 +93,6 @@ pub(super) fn detect(
             EvidenceKind::Import,
             "vue-router",
         );
-    if evidence.activates("express") {
-        collect_express_routes(root, source, path, &receivers, &mounts, &mut facts);
-    }
     if evidence.activates("nestjs") {
         collect_nest_routes(root, source, path, &mut facts);
     }

--- a/crates/compass-languages/src/frameworks/vite.rs
+++ b/crates/compass-languages/src/frameworks/vite.rs
@@ -1,0 +1,139 @@
+use std::path::Path;
+
+use regex::Regex;
+use serde_json::{Map, Value};
+
+use super::{RawDomainFact, RawFrameworkAnchor, RawFrameworkFact, RawFrameworkOrigin};
+use crate::{Extraction, ProjectEvidence};
+
+const MAX_CONFIG_ITEMS: usize = 256;
+
+/// Vite is a build/configuration framework rather than an HTTP router. This
+/// adapter publishes a bounded configuration node so aliases and plugins are
+/// visible to graph consumers without pretending that a build plugin is a
+/// route or callable target.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    project: Option<&ProjectEvidence>,
+    _extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    if !is_config(path) || source.is_empty() {
+        return Vec::new();
+    }
+    let body = std::str::from_utf8(source).unwrap_or_default();
+    let project_activates = project.is_none_or(|project| {
+        project.has_dependency("vite")
+            || project.has_configuration("vite.config.js")
+            || project.has_configuration("vite.config.mjs")
+            || project.has_configuration("vite.config.ts")
+            || project.has_configuration("vite.config.cjs")
+    });
+    let source_activates = body.contains("defineConfig")
+        || body.contains("from 'vite'")
+        || body.contains("from \"vite\"");
+    if !project_activates || !source_activates {
+        return Vec::new();
+    }
+
+    let mut detail = Map::new();
+    let mut keys = Vec::new();
+    if body.contains("resolve") && body.contains("alias") {
+        keys.push(Value::String("resolve.alias".to_owned()));
+    }
+    if body.contains("plugins") {
+        keys.push(Value::String("plugins".to_owned()));
+    }
+    if !keys.is_empty() {
+        detail.insert("configuration_keys".to_owned(), Value::Array(keys));
+    }
+    let aliases = quoted_pairs(body);
+    if !aliases.is_empty() {
+        detail.insert("aliases".to_owned(), Value::Object(aliases));
+    }
+    let plugins = imported_plugins(body);
+    if !plugins.is_empty() {
+        detail.insert("plugins".to_owned(), Value::Array(plugins));
+    }
+    let portable = path.to_string_lossy().replace('\\', "/");
+    vec![RawFrameworkFact::Domain(RawDomainFact {
+        framework: "vite".to_owned(),
+        kind: "framework_configuration".to_owned(),
+        name: portable.clone(),
+        declaring_scope: portable.clone(),
+        anchor: anchor(path, source),
+        origin: RawFrameworkOrigin::Config,
+        detail,
+    })]
+}
+
+pub(super) fn is_config(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            let lower = name.to_ascii_lowercase();
+            lower.starts_with("vite.config.")
+                && matches!(
+                    lower.rsplit_once('.').map(|(_, extension)| extension),
+                    Some("js" | "mjs" | "cjs" | "ts" | "mts" | "cts")
+                )
+        })
+}
+
+fn quoted_pairs(source: &str) -> Map<String, Value> {
+    let Ok(pattern) =
+        Regex::new(r#"[\"']([^\"']+)[\"']\s*:\s*(?:path\.resolve\([^,]+,\s*)?[\"']([^\"']+)[\"']"#)
+    else {
+        return Map::new();
+    };
+    let mut aliases = Map::new();
+    for capture in pattern.captures_iter(source).take(MAX_CONFIG_ITEMS) {
+        let (Some(alias), Some(target)) = (capture.get(1), capture.get(2)) else {
+            continue;
+        };
+        aliases.insert(
+            alias.as_str().trim().to_owned(),
+            Value::String(
+                target
+                    .as_str()
+                    .trim()
+                    .trim_start_matches("./")
+                    .replace('\\', "/"),
+            ),
+        );
+    }
+    aliases
+}
+
+fn imported_plugins(source: &str) -> Vec<Value> {
+    let Ok(pattern) = Regex::new(r#"(?:from|require\s*\()\s*[\"']([^\"']+)[\"']"#) else {
+        return Vec::new();
+    };
+    let mut plugins = pattern
+        .captures_iter(source)
+        .filter_map(|capture| capture.get(1).map(|value| value.as_str()))
+        .filter(|value| {
+            value.contains("plugin")
+                || value.starts_with("@vitejs/")
+                || value.starts_with("vite-plugin-")
+        })
+        .map(|value| Value::String(value.to_owned()))
+        .take(MAX_CONFIG_ITEMS)
+        .collect::<Vec<_>>();
+    plugins.sort_by(|left, right| left.as_str().cmp(&right.as_str()));
+    plugins.dedup();
+    plugins
+}
+
+fn anchor(path: &Path, source: &[u8]) -> RawFrameworkAnchor {
+    let end_line = source.iter().filter(|byte| **byte == b'\n').count() + 1;
+    RawFrameworkAnchor {
+        source_file: path.to_string_lossy().replace('\\', "/"),
+        start_byte: 0,
+        end_byte: source.len() as u64,
+        start_line: 1,
+        start_column: 0,
+        end_line: u32::try_from(end_line).unwrap_or(u32::MAX),
+        end_column: 0,
+    }
+}

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -18,7 +18,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/6";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/7";
 mod go;
 mod groovy;
 mod html;

--- a/crates/compass-languages/src/project_evidence.rs
+++ b/crates/compass-languages/src/project_evidence.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use regex::Regex;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -10,6 +11,13 @@ pub const FRAMEWORK_PROJECT_EVIDENCE_EXTENSION: &str = "_compass_framework_proje
 const EVIDENCE_SCHEMA: &str = "compass.framework-project-evidence/1";
 const MAX_MANIFEST_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_DEPENDENCIES_PER_PROJECT: usize = 10_000;
+const MAX_PROJECT_CONFIGURATIONS: usize = 256;
+const MAX_PROJECT_CONFIGURATION_KEYS: usize = 2_000;
+const MAX_PROJECT_ALIASES: usize = 2_000;
+const MAX_PROJECT_PLUGINS: usize = 2_000;
+const MAX_PROJECT_ROUTE_ROOTS: usize = 256;
+const MAX_PROJECT_SCAN_DIRECTORIES: usize = 4_096;
+const MAX_PROJECT_DIRECTORY_ENTRIES: usize = 4_096;
 const FIXED_MANIFEST_NAMES: &[&str] = &[
     "package.json",
     "composer.json",
@@ -24,6 +32,31 @@ const FIXED_MANIFEST_NAMES: &[&str] = &[
     "go.mod",
     "Package.swift",
 ];
+const FIXED_CONFIGURATION_NAMES: &[&str] = &[
+    "application.properties",
+    "application.yml",
+    "application.yaml",
+    "astro.config.js",
+    "astro.config.mjs",
+    "astro.config.ts",
+    "bootstrap.yml",
+    "bootstrap.yaml",
+    "jsconfig.json",
+    "next.config.js",
+    "next.config.mjs",
+    "next.config.ts",
+    "nuxt.config.js",
+    "nuxt.config.ts",
+    "svelte.config.js",
+    "svelte.config.ts",
+    "tsconfig.json",
+    "vite.config.cjs",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.ts",
+    "webpack.config.js",
+    "webpack.config.ts",
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProjectEvidence {
@@ -31,6 +64,11 @@ pub struct ProjectEvidence {
     manifests: Vec<String>,
     ecosystems: Vec<String>,
     dependencies: BTreeSet<String>,
+    configuration_files: Vec<String>,
+    configuration_keys: BTreeSet<String>,
+    aliases: BTreeMap<String, String>,
+    plugins: BTreeSet<String>,
+    route_roots: BTreeMap<String, BTreeSet<String>>,
     fingerprint: String,
 }
 
@@ -56,6 +94,31 @@ impl ProjectEvidence {
     }
 
     #[must_use]
+    pub fn configuration_files(&self) -> &[String] {
+        &self.configuration_files
+    }
+
+    #[must_use]
+    pub fn configuration_keys(&self) -> &BTreeSet<String> {
+        &self.configuration_keys
+    }
+
+    #[must_use]
+    pub fn aliases(&self) -> &BTreeMap<String, String> {
+        &self.aliases
+    }
+
+    #[must_use]
+    pub fn plugins(&self) -> &BTreeSet<String> {
+        &self.plugins
+    }
+
+    #[must_use]
+    pub fn route_roots(&self) -> &BTreeMap<String, BTreeSet<String>> {
+        &self.route_roots
+    }
+
+    #[must_use]
     pub fn fingerprint(&self) -> &str {
         &self.fingerprint
     }
@@ -72,6 +135,40 @@ impl ProjectEvidence {
             .iter()
             .any(|dependency| self.has_dependency(dependency))
     }
+
+    #[must_use]
+    pub fn has_configuration(&self, name: &str) -> bool {
+        let expected = normalize_project_name(name);
+        self.configuration_files.iter().any(|file| {
+            normalize_project_name(file) == expected
+                || Path::new(file)
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|file_name| normalize_project_name(file_name) == expected)
+        })
+    }
+
+    #[must_use]
+    pub fn has_any_configuration(&self, names: &[&str]) -> bool {
+        names.iter().any(|name| self.has_configuration(name))
+    }
+
+    #[must_use]
+    pub fn has_plugin(&self, plugin: &str) -> bool {
+        self.plugins.contains(&normalize_dependency(plugin))
+    }
+
+    #[must_use]
+    pub fn has_any_plugin(&self, plugins: &[&str]) -> bool {
+        plugins.iter().any(|plugin| self.has_plugin(plugin))
+    }
+
+    #[must_use]
+    pub fn has_route_root(&self, framework: &str, root: &str) -> bool {
+        self.route_roots
+            .get(&normalize_dependency(framework))
+            .is_some_and(|roots| roots.contains(&normalize_project_path(root)))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -86,54 +183,142 @@ impl ProjectEvidenceIndex {
     pub fn build(repository_root: &Path, sources: &[PathBuf]) -> Self {
         let repository_root = absolute_path(repository_root, repository_root);
         let mut directories = BTreeSet::new();
-        let mut manifests = BTreeSet::new();
+        let mut project_files = BTreeSet::new();
         directories.insert(repository_root.clone());
 
         for source in sources {
             let source = absolute_path(&repository_root, source);
-            if is_recognized_manifest(&source) {
-                manifests.insert(source.clone());
+            if is_project_file(&source) {
+                project_files.insert(source.clone());
             }
             let directory = source.parent().unwrap_or(&repository_root);
             for ancestor in directory.ancestors() {
                 if !ancestor.starts_with(&repository_root) {
                     break;
                 }
-                directories.insert(ancestor.to_path_buf());
+                if directories.len() < MAX_PROJECT_SCAN_DIRECTORIES
+                    || directories.contains(ancestor)
+                {
+                    directories.insert(ancestor.to_path_buf());
+                }
                 if ancestor == repository_root {
                     break;
                 }
             }
         }
 
+        let seed_directories = directories.iter().cloned().collect::<Vec<_>>();
+        for directory in seed_directories {
+            for suffix in ["resources", "config", "conf"] {
+                if directories.len() >= MAX_PROJECT_SCAN_DIRECTORIES {
+                    break;
+                }
+                let candidate = directory.join(suffix);
+                if candidate.starts_with(&repository_root) {
+                    directories.insert(candidate);
+                }
+            }
+        }
+
         for directory in &directories {
-            for name in FIXED_MANIFEST_NAMES {
+            for name in FIXED_MANIFEST_NAMES.iter().chain(FIXED_CONFIGURATION_NAMES) {
                 let candidate = directory.join(name);
-                if regular_manifest(&candidate) {
-                    manifests.insert(candidate);
+                if regular_project_file(&candidate) {
+                    project_files.insert(candidate);
+                }
+            }
+            if let Ok(entries) = fs::read_dir(directory) {
+                for entry in entries.flatten().take(MAX_PROJECT_DIRECTORY_ENTRIES) {
+                    let candidate = entry.path();
+                    if regular_project_file(&candidate) {
+                        project_files.insert(candidate);
+                    }
                 }
             }
         }
 
         let mut builders = BTreeMap::<PathBuf, ProjectBuilder>::new();
-        for manifest in manifests {
-            let project_root = manifest.parent().unwrap_or(&repository_root).to_path_buf();
-            let builder = builders.entry(project_root).or_default();
-            builder.manifests.insert(
-                manifest
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or_default()
-                    .to_owned(),
-            );
-            let Some(parsed) = parse_manifest(&manifest) else {
+        let manifest_roots = project_files
+            .iter()
+            .filter(|path| is_recognized_manifest(path))
+            .filter_map(|path| path.parent().map(Path::to_path_buf))
+            .collect::<Vec<_>>();
+        for project_file in project_files {
+            let project_root =
+                project_root_for_file(&repository_root, &manifest_roots, &project_file);
+            let builder = builders.entry(project_root.clone()).or_default();
+            if is_recognized_manifest(&project_file) {
+                builder.manifests.insert(file_name(&project_file));
+                if let Some(parsed) = parse_manifest(&project_file) {
+                    builder.ecosystems.insert(parsed.ecosystem.to_owned());
+                    let remaining =
+                        MAX_DEPENDENCIES_PER_PROJECT.saturating_sub(builder.dependencies.len());
+                    builder
+                        .dependencies
+                        .extend(parsed.dependencies.into_iter().take(remaining));
+                }
+                if let Some(parsed) = parse_configuration(&project_file) {
+                    builder.configuration_keys.extend(
+                        parsed.configuration_keys.into_iter().take(
+                            MAX_PROJECT_CONFIGURATION_KEYS
+                                .saturating_sub(builder.configuration_keys.len()),
+                        ),
+                    );
+                    builder.aliases.extend(
+                        parsed
+                            .aliases
+                            .into_iter()
+                            .take(MAX_PROJECT_ALIASES.saturating_sub(builder.aliases.len())),
+                    );
+                    builder.plugins.extend(
+                        parsed
+                            .plugins
+                            .into_iter()
+                            .take(MAX_PROJECT_PLUGINS.saturating_sub(builder.plugins.len())),
+                    );
+                }
+            } else {
+                if builder.configuration_files.len() < MAX_PROJECT_CONFIGURATIONS {
+                    builder
+                        .configuration_files
+                        .insert(relative_project_file(&project_root, &project_file));
+                }
+                if let Some(parsed) = parse_configuration(&project_file) {
+                    builder.configuration_keys.extend(
+                        parsed.configuration_keys.into_iter().take(
+                            MAX_PROJECT_CONFIGURATION_KEYS
+                                .saturating_sub(builder.configuration_keys.len()),
+                        ),
+                    );
+                    builder.aliases.extend(
+                        parsed
+                            .aliases
+                            .into_iter()
+                            .take(MAX_PROJECT_ALIASES.saturating_sub(builder.aliases.len())),
+                    );
+                    builder.plugins.extend(
+                        parsed
+                            .plugins
+                            .into_iter()
+                            .take(MAX_PROJECT_PLUGINS.saturating_sub(builder.plugins.len())),
+                    );
+                }
+            }
+        }
+
+        for source in sources {
+            let source = absolute_path(&repository_root, source);
+            let project_root = project_root_for_source(&repository_root, &builders, &source);
+            let Some((framework, route_root)) =
+                route_root_for_source(&project_root, &source, &builders)
+            else {
                 continue;
             };
-            builder.ecosystems.insert(parsed.ecosystem.to_owned());
-            let remaining = MAX_DEPENDENCIES_PER_PROJECT.saturating_sub(builder.dependencies.len());
-            builder
-                .dependencies
-                .extend(parsed.dependencies.into_iter().take(remaining));
+            let builder = builders.entry(project_root).or_default();
+            let roots = builder.route_roots.entry(framework).or_default();
+            if roots.len() < MAX_PROJECT_ROUTE_ROOTS {
+                roots.insert(route_root);
+            }
         }
 
         let projects = builders
@@ -186,11 +371,23 @@ struct ProjectBuilder {
     manifests: BTreeSet<String>,
     ecosystems: BTreeSet<String>,
     dependencies: BTreeSet<String>,
+    configuration_files: BTreeSet<String>,
+    configuration_keys: BTreeSet<String>,
+    aliases: BTreeMap<String, String>,
+    plugins: BTreeSet<String>,
+    route_roots: BTreeMap<String, BTreeSet<String>>,
 }
 
 struct ParsedManifest {
     ecosystem: &'static str,
     dependencies: BTreeSet<String>,
+}
+
+#[derive(Default)]
+struct ParsedConfiguration {
+    configuration_keys: BTreeSet<String>,
+    aliases: BTreeMap<String, String>,
+    plugins: BTreeSet<String>,
 }
 
 fn finish_project(
@@ -201,6 +398,11 @@ fn finish_project(
     let manifests = builder.manifests.into_iter().collect::<Vec<_>>();
     let ecosystems = builder.ecosystems.into_iter().collect::<Vec<_>>();
     let dependencies = builder.dependencies;
+    let configuration_files = builder.configuration_files.into_iter().collect::<Vec<_>>();
+    let configuration_keys = builder.configuration_keys;
+    let aliases = builder.aliases;
+    let plugins = builder.plugins;
+    let route_roots = builder.route_roots;
     let relative_root = project_root
         .strip_prefix(repository_root)
         .unwrap_or(&project_root)
@@ -223,11 +425,42 @@ fn finish_project(
         digest.update(dependency.as_bytes());
         digest.update([0]);
     }
+    for configuration_file in &configuration_files {
+        digest.update(configuration_file.as_bytes());
+        digest.update([0]);
+    }
+    for configuration_key in &configuration_keys {
+        digest.update(configuration_key.as_bytes());
+        digest.update([0]);
+    }
+    for (alias, target) in &aliases {
+        digest.update(alias.as_bytes());
+        digest.update([0]);
+        digest.update(target.as_bytes());
+        digest.update([0]);
+    }
+    for plugin in &plugins {
+        digest.update(plugin.as_bytes());
+        digest.update([0]);
+    }
+    for (framework, roots) in &route_roots {
+        digest.update(framework.as_bytes());
+        digest.update([0]);
+        for root in roots {
+            digest.update(root.as_bytes());
+            digest.update([0]);
+        }
+    }
     ProjectEvidence {
         project_root,
         manifests,
         ecosystems,
         dependencies,
+        configuration_files,
+        configuration_keys,
+        aliases,
+        plugins,
+        route_roots,
         fingerprint: format!("sha256:{:x}", digest.finalize()),
     }
 }
@@ -474,6 +707,315 @@ fn quoted_values(value: &str) -> impl Iterator<Item = String> + '_ {
     })
 }
 
+fn parse_configuration(path: &Path) -> Option<ParsedConfiguration> {
+    let metadata = fs::symlink_metadata(path).ok()?;
+    if !metadata.file_type().is_file()
+        || metadata.file_type().is_symlink()
+        || metadata.len() > MAX_MANIFEST_BYTES
+    {
+        return None;
+    }
+    let source = fs::read_to_string(path).ok()?;
+    let name = path.file_name()?.to_str()?.to_ascii_lowercase();
+    let mut parsed = ParsedConfiguration::default();
+    match name.as_str() {
+        "package.json" => parse_package_configuration(&source, &mut parsed),
+        name if name.starts_with("tsconfig.") || name.starts_with("jsconfig.") => {
+            parse_typescript_configuration(&source, &mut parsed)
+        }
+        name if name.starts_with("vite.config.") => parse_vite_configuration(&source, &mut parsed),
+        name if name.starts_with("next.config.") => parse_next_configuration(&source, &mut parsed),
+        name if (name.starts_with("application.") || name.starts_with("application-"))
+            || (name.starts_with("bootstrap.") || name.starts_with("bootstrap-")) =>
+        {
+            parse_spring_configuration(&source, &mut parsed)
+        }
+        _ => parse_generic_configuration(&source, &mut parsed),
+    }
+    Some(parsed)
+}
+
+fn parse_package_configuration(source: &str, output: &mut ParsedConfiguration) {
+    let Ok(root) = serde_json::from_str::<Value>(source) else {
+        return;
+    };
+    let Some(object) = root.as_object() else {
+        return;
+    };
+    for key in ["imports", "_moduleAliases", "_module_aliases"] {
+        if let Some(values) = object.get(key).and_then(Value::as_object) {
+            output.configuration_keys.insert(key.to_owned());
+            collect_json_aliases(values, &mut output.aliases);
+        }
+    }
+    for dependency_key in ["dependencies", "devDependencies", "peerDependencies"] {
+        let Some(dependencies) = object.get(dependency_key).and_then(Value::as_object) else {
+            continue;
+        };
+        for dependency in dependencies.keys() {
+            if is_plugin_name(dependency) {
+                output.plugins.insert(normalize_dependency(dependency));
+            }
+        }
+    }
+}
+
+fn parse_typescript_configuration(source: &str, output: &mut ParsedConfiguration) {
+    let Ok(root) = serde_json::from_str::<Value>(source) else {
+        return;
+    };
+    let Some(options) = root.get("compilerOptions").and_then(Value::as_object) else {
+        return;
+    };
+    if options.contains_key("baseUrl") {
+        output
+            .configuration_keys
+            .insert("compilerOptions.baseUrl".to_owned());
+    }
+    if let Some(paths) = options.get("paths").and_then(Value::as_object) {
+        output
+            .configuration_keys
+            .insert("compilerOptions.paths".to_owned());
+        collect_json_aliases(paths, &mut output.aliases);
+    }
+}
+
+fn parse_vite_configuration(source: &str, output: &mut ParsedConfiguration) {
+    if source.contains("resolve") && source.contains("alias") {
+        output.configuration_keys.insert("resolve.alias".to_owned());
+    }
+    if source.contains("plugins") {
+        output.configuration_keys.insert("plugins".to_owned());
+    }
+    collect_quoted_aliases(source, &mut output.aliases);
+    collect_config_plugins(source, output);
+}
+
+fn parse_next_configuration(source: &str, output: &mut ParsedConfiguration) {
+    for key in [
+        "rewrites",
+        "redirects",
+        "headers",
+        "experimental",
+        "pageExtensions",
+    ] {
+        if source.contains(key) {
+            output.configuration_keys.insert(key.to_owned());
+        }
+    }
+    collect_config_plugins(source, output);
+}
+
+fn parse_spring_configuration(source: &str, output: &mut ParsedConfiguration) {
+    for line in source.lines().map(str::trim) {
+        let key = line
+            .split_once(':')
+            .map(|(key, _)| key)
+            .or_else(|| line.split_once('=').map(|(key, _)| key))
+            .map(str::trim)
+            .unwrap_or_default();
+        if key.starts_with("spring.") || key.starts_with("server.") {
+            output.configuration_keys.insert(key.to_owned());
+        }
+    }
+}
+
+fn parse_generic_configuration(source: &str, output: &mut ParsedConfiguration) {
+    if source.contains("resolve") && source.contains("alias") {
+        output.configuration_keys.insert("resolve.alias".to_owned());
+        collect_quoted_aliases(source, &mut output.aliases);
+    }
+    collect_config_plugins(source, output);
+}
+
+fn collect_json_aliases(
+    values: &serde_json::Map<String, Value>,
+    output: &mut BTreeMap<String, String>,
+) {
+    for (alias, target) in values {
+        let Some(target) = target.as_str().or_else(|| {
+            target
+                .as_array()
+                .and_then(|values| values.first())
+                .and_then(Value::as_str)
+        }) else {
+            continue;
+        };
+        if output.len() >= MAX_PROJECT_ALIASES && !output.contains_key(alias) {
+            break;
+        }
+        output.insert(normalize_alias(alias), normalize_project_path(target));
+    }
+}
+
+fn collect_quoted_aliases(source: &str, output: &mut BTreeMap<String, String>) {
+    let Ok(pattern) =
+        Regex::new(r#"[\"']([^\"']+)[\"']\s*:\s*(?:path\.resolve\([^,]+,\s*)?[\"']([^\"']+)[\"']"#)
+    else {
+        return;
+    };
+    for capture in pattern.captures_iter(source) {
+        let (Some(alias), Some(target)) = (capture.get(1), capture.get(2)) else {
+            continue;
+        };
+        if output.len() >= MAX_PROJECT_ALIASES && !output.contains_key(alias.as_str()) {
+            break;
+        }
+        output.insert(
+            normalize_alias(alias.as_str()),
+            normalize_project_path(target.as_str()),
+        );
+    }
+}
+
+fn collect_config_plugins(source: &str, output: &mut ParsedConfiguration) {
+    let Ok(imports) = Regex::new(r#"(?:from|require\s*\()\s*[\"']([^\"']+)[\"']"#) else {
+        return;
+    };
+    for capture in imports.captures_iter(source) {
+        let Some(value) = capture.get(1).map(|value| value.as_str()) else {
+            continue;
+        };
+        if is_plugin_name(value) {
+            output.plugins.insert(normalize_dependency(value));
+        }
+    }
+    let Ok(calls) = Regex::new(r"\b([A-Za-z_$][A-Za-z0-9_$-]*)\s*\(") else {
+        return;
+    };
+    for capture in calls.captures_iter(source) {
+        let Some(value) = capture.get(1).map(|value| value.as_str()) else {
+            continue;
+        };
+        if is_plugin_name(value) {
+            output.plugins.insert(normalize_dependency(value));
+        }
+    }
+}
+
+fn is_plugin_name(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("plugin")
+        || lower.starts_with("@vitejs/")
+        || lower.starts_with("vite-plugin-")
+        || lower.starts_with("next-plugin-")
+        || matches!(
+            lower.as_str(),
+            "react" | "vue" | "svelte" | "solid" | "legacy"
+        )
+}
+
+fn normalize_alias(value: &str) -> String {
+    value.trim().replace('\\', "/")
+}
+
+fn normalize_project_path(value: &str) -> String {
+    value.trim().trim_start_matches("./").replace('\\', "/")
+}
+
+fn normalize_project_name(value: &str) -> String {
+    value.trim().replace('\\', "/").to_ascii_lowercase()
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+fn relative_project_file(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn project_root_for_file(
+    repository_root: &Path,
+    manifest_roots: &[PathBuf],
+    path: &Path,
+) -> PathBuf {
+    manifest_roots
+        .iter()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+        .or_else(|| {
+            path.parent().map(|parent| {
+                if matches!(
+                    parent.file_name().and_then(|name| name.to_str()),
+                    Some("resources" | "config" | "conf")
+                ) {
+                    parent.parent().unwrap_or(parent).to_path_buf()
+                } else {
+                    parent.to_path_buf()
+                }
+            })
+        })
+        .unwrap_or_else(|| repository_root.to_path_buf())
+}
+
+fn project_root_for_source(
+    repository_root: &Path,
+    builders: &BTreeMap<PathBuf, ProjectBuilder>,
+    path: &Path,
+) -> PathBuf {
+    builders
+        .keys()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+        .unwrap_or_else(|| repository_root.to_path_buf())
+}
+
+fn route_root_for_source(
+    project_root: &Path,
+    source: &Path,
+    builders: &BTreeMap<PathBuf, ProjectBuilder>,
+) -> Option<(String, String)> {
+    let relative = source.strip_prefix(project_root).ok()?;
+    let components = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    let builder = builders.get(project_root)?;
+    let has = |dependency: &str| builder.dependencies.contains(dependency);
+    let configured = |name: &str| {
+        builder
+            .configuration_files
+            .iter()
+            .any(|file| normalize_project_name(file).ends_with(&normalize_project_name(name)))
+    };
+    let next_configured = ["next.config.js", "next.config.mjs", "next.config.ts"]
+        .iter()
+        .any(|name| configured(name));
+    if (has("next") || next_configured)
+        && (components.first() == Some(&"app") || components.first() == Some(&"pages"))
+    {
+        return Some(("next".to_owned(), components[0].to_owned()));
+    }
+    if (has("next") || next_configured)
+        && components.first() == Some(&"src")
+        && matches!(components.get(1), Some(&"app" | &"pages"))
+    {
+        return Some(("next".to_owned(), format!("src/{}", components[1])));
+    }
+    if has("nuxt") && components.first() == Some(&"pages") {
+        return Some(("nuxt".to_owned(), "pages".to_owned()));
+    }
+    if has("nuxt") && components.starts_with(&["server", "api"]) {
+        return Some(("nuxt".to_owned(), "server/api".to_owned()));
+    }
+    if has("astro") && components.starts_with(&["src", "pages"]) {
+        return Some(("astro".to_owned(), "src/pages".to_owned()));
+    }
+    if has("@sveltejs/kit") && components.starts_with(&["src", "routes"]) {
+        return Some(("sveltekit".to_owned(), "src/routes".to_owned()));
+    }
+    None
+}
+
 fn normalize_dependency(value: &str) -> String {
     value.trim().to_ascii_lowercase().replace('_', "-")
 }
@@ -488,8 +1030,41 @@ fn is_recognized_manifest(path: &Path) -> bool {
         || name.to_ascii_lowercase().ends_with(".csproj")
 }
 
-fn regular_manifest(path: &Path) -> bool {
-    is_recognized_manifest(path)
+fn is_recognized_configuration(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    FIXED_CONFIGURATION_NAMES
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+        || (name.to_ascii_lowercase().starts_with("application.")
+            || name.to_ascii_lowercase().starts_with("application-"))
+            && matches!(
+                name.to_ascii_lowercase()
+                    .rsplit_once('.')
+                    .map(|(_, extension)| extension),
+                Some("properties" | "yml" | "yaml")
+            )
+        || (name.to_ascii_lowercase().starts_with("bootstrap.")
+            || name.to_ascii_lowercase().starts_with("bootstrap-"))
+            && matches!(
+                name.to_ascii_lowercase()
+                    .rsplit_once('.')
+                    .map(|(_, extension)| extension),
+                Some("properties" | "yml" | "yaml")
+            )
+        || (name.to_ascii_lowercase().starts_with("tsconfig.")
+            && name.to_ascii_lowercase().ends_with(".json"))
+        || (name.to_ascii_lowercase().starts_with("jsconfig.")
+            && name.to_ascii_lowercase().ends_with(".json"))
+}
+
+fn is_project_file(path: &Path) -> bool {
+    is_recognized_manifest(path) || is_recognized_configuration(path)
+}
+
+fn regular_project_file(path: &Path) -> bool {
+    is_project_file(path)
         && fs::symlink_metadata(path).is_ok_and(|metadata| {
             metadata.file_type().is_file() && !metadata.file_type().is_symlink()
         })
@@ -590,6 +1165,78 @@ mod tests {
         let index = ProjectEvidenceIndex::build(root, std::slice::from_ref(&source));
 
         assert!(!index.evidence_for(&source).has_dependency("nuxt"));
+        Ok(())
+    }
+
+    #[test]
+    fn framework_configuration_aliases_plugins_and_route_roots_are_indexed()
+    -> Result<(), Box<dyn Error>> {
+        let directory = tempdir()?;
+        let root = directory.path();
+        fs::create_dir_all(root.join("src/app"))?;
+        let source = root.join("src/app/page.tsx");
+        fs::write(&source, "export default function Page() { return null }")?;
+        fs::write(
+            root.join("package.json"),
+            r##"{"dependencies":{"next":"15","vite":"7"},"devDependencies":{"@vitejs/plugin-react":"4"},"imports":{"#shared/*":"./src/shared/*"}}"##,
+        )?;
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["./src/*"]}}}"#,
+        )?;
+        fs::write(
+            root.join("vite.config.ts"),
+            r#"import react from '@vitejs/plugin-react'; export default { plugins: [react()], resolve: { alias: { '~': './src' } } }"#,
+        )?;
+        fs::write(
+            root.join("next.config.mjs"),
+            "import withIntl from 'next-plugin-intl'; export default withIntl({ rewrites() { return [] } });",
+        )?;
+
+        let index = ProjectEvidenceIndex::build(root, std::slice::from_ref(&source));
+        let evidence = index.evidence_for(&source);
+
+        assert!(evidence.has_configuration("tsconfig.json"));
+        assert!(evidence.has_configuration("vite.config.ts"));
+        assert!(evidence.has_configuration("next.config.mjs"));
+        assert!(
+            evidence
+                .configuration_keys()
+                .contains("compilerOptions.paths")
+        );
+        assert!(evidence.configuration_keys().contains("resolve.alias"));
+        assert!(evidence.configuration_keys().contains("rewrites"));
+        assert_eq!(evidence.aliases().get("@/*"), Some(&"src/*".to_owned()));
+        assert_eq!(evidence.aliases().get("~"), Some(&"src".to_owned()));
+        assert!(evidence.has_plugin("@vitejs/plugin-react"));
+        assert!(evidence.has_plugin("next-plugin-intl"));
+        assert!(evidence.has_route_root("next", "src/app"));
+        Ok(())
+    }
+
+    #[test]
+    fn spring_resource_profiles_are_discovered_from_a_sibling_source_directory()
+    -> Result<(), Box<dyn Error>> {
+        let directory = tempdir()?;
+        let root = directory.path();
+        let source = root.join("src/main/java/example/App.java");
+        fs::create_dir_all(source.parent().ok_or("source has no parent")?)?;
+        fs::create_dir_all(root.join("src/main/resources"))?;
+        fs::write(&source, "class App {}")?;
+        fs::write(
+            root.join("src/main/resources/application-dev.yml"),
+            "spring.application.name: compass\nserver.port: 8080\n",
+        )?;
+
+        let index = ProjectEvidenceIndex::build(root, std::slice::from_ref(&source));
+        let evidence = index.evidence_for(&source);
+        assert!(evidence.has_configuration("application-dev.yml"));
+        assert!(
+            evidence
+                .configuration_keys()
+                .contains("spring.application.name")
+        );
+        assert!(evidence.configuration_keys().contains("server.port"));
         Ok(())
     }
 }

--- a/crates/compass-resolve/src/frameworks/domain.rs
+++ b/crates/compass-resolve/src/frameworks/domain.rs
@@ -181,6 +181,28 @@ pub fn publish_resolved_domains(extraction: &mut Extraction, resolved: &[Resolve
             continue;
         }
 
+        if matches!(
+            fact.kind.as_str(),
+            "framework_configuration" | "framework_plugin"
+        ) {
+            let domain_id = domain_id(fact);
+            if nodes.insert(domain_id.clone()) {
+                extraction.nodes.push(RawNodeRecord {
+                    id: domain_id,
+                    attributes: domain_attributes(
+                        fact,
+                        if fact.kind == "framework_plugin" {
+                            "component"
+                        } else {
+                            "config_key"
+                        },
+                        resolved.state,
+                    ),
+                });
+            }
+            continue;
+        }
+
         let Some(symbol_kind) = domain_node_kind(&fact.kind) else {
             diagnostics.push(json!({
                 "kind": "unsupported_domain_fact",
@@ -266,6 +288,17 @@ fn resolve_one(
     targets: &FrameworkTargetIndex<'_>,
     limits: FrameworkLimits,
 ) -> Result<ResolvedDomainFact, FrameworkResolutionError> {
+    if matches!(
+        fact.kind.as_str(),
+        "framework_configuration" | "framework_plugin"
+    ) {
+        return Ok(ResolvedDomainFact {
+            fact: fact.clone(),
+            state: ResolutionState::Exact,
+            source_candidates: Vec::new(),
+            target_candidates: Vec::new(),
+        });
+    }
     if fact.kind == "route_middleware" {
         return Ok(ResolvedDomainFact {
             fact: fact.clone(),
@@ -488,6 +521,8 @@ fn domain_node_kind(kind: &str) -> Option<&'static str> {
         "queue" => Some("queue"),
         "job" => Some("job"),
         "bean_definition" => Some("component"),
+        "framework_configuration" => Some("config_key"),
+        "framework_plugin" => Some("component"),
         _ => None,
     }
 }
@@ -610,6 +645,19 @@ fn domain_attributes(
             Value::String(resolution_name(state).to_owned()),
         ),
     ]);
+    if matches!(
+        fact.kind.as_str(),
+        "framework_configuration" | "framework_plugin"
+    ) {
+        attributes.insert("file_type".into(), Value::String("config".to_owned()));
+        attributes.insert("component_type".into(), Value::String(fact.kind.clone()));
+        for key in ["configuration_keys", "aliases", "plugins", "route_roots"] {
+            if let Some(value) = fact.detail.get(key).cloned() {
+                attributes.insert(key.to_owned(), value);
+            }
+        }
+        return attributes;
+    }
     if symbol_kind == "job" {
         for key in ["schedule", "queue"] {
             if let Some(value) = fact.detail.get(key).cloned() {

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -3,6 +3,7 @@ mod jvm;
 mod native;
 mod php;
 mod python;
+mod qualification;
 mod routes;
 mod ruby;
 mod spring;
@@ -30,6 +31,10 @@ const UNIVERSAL_FRAMEWORK_PACKS: &[UniversalFrameworkPack] = &[UniversalFramewor
 pub use domain::{
     ResolvedDomainFact, publish_resolved_domains, resolve_and_publish_framework_domains,
     resolve_domains,
+};
+pub use qualification::{
+    FrameworkQualificationCase, FrameworkQualificationError, FrameworkQualificationReport,
+    FrameworkRouteExpectation, qualify_framework_case,
 };
 pub use routes::{
     FrameworkResolutionError, ResolvedRoute, RouteStage, RouteStageRole, publish_resolved_routes,

--- a/crates/compass-resolve/src/frameworks/qualification.rs
+++ b/crates/compass-resolve/src/frameworks/qualification.rs
@@ -1,0 +1,175 @@
+use compass_languages::{Extraction, FrameworkLimits};
+use compass_model::provenance::ResolutionState;
+
+use super::{FrameworkResolutionError, ResolvedRoute, resolve_routes};
+
+/// A route assertion reusable by framework fixtures and external qualification
+/// harnesses. The handler is optional when a convention only promises the
+/// endpoint shape (for example a Next.js page component).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrameworkRouteExpectation {
+    pub framework: String,
+    pub operation: String,
+    pub normalized_path: String,
+    pub handler_reference: Option<String>,
+}
+
+impl FrameworkRouteExpectation {
+    #[must_use]
+    pub fn new(
+        framework: impl Into<String>,
+        operation: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Self {
+        Self {
+            framework: framework.into(),
+            operation: operation.into(),
+            normalized_path: path.into(),
+            handler_reference: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_handler(mut self, handler: impl Into<String>) -> Self {
+        self.handler_reference = Some(handler.into());
+        self
+    }
+}
+
+/// A named, deterministic qualification case. Cases are intentionally data
+/// only so the same runner can consume Rust fixtures, Java fixtures, or
+/// generated framework repositories.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrameworkQualificationCase {
+    pub id: String,
+    pub expectations: Vec<FrameworkRouteExpectation>,
+}
+
+impl FrameworkQualificationCase {
+    #[must_use]
+    pub fn new(id: impl Into<String>, expectations: Vec<FrameworkRouteExpectation>) -> Self {
+        Self {
+            id: id.into(),
+            expectations,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrameworkQualificationReport {
+    pub case_id: String,
+    pub expected_routes: usize,
+    pub matched_routes: usize,
+    pub resolved_routes: Vec<ResolvedRoute>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum FrameworkQualificationError {
+    #[error(transparent)]
+    Resolution(#[from] FrameworkResolutionError),
+    #[error("qualification case {case_id:?} is missing {framework} {operation} {normalized_path}")]
+    MissingRoute {
+        case_id: String,
+        framework: String,
+        operation: String,
+        normalized_path: String,
+    },
+    #[error(
+        "qualification case {case_id:?} found a non-exact {state:?} {framework} {operation} {normalized_path}"
+    )]
+    NonExactRoute {
+        case_id: String,
+        framework: String,
+        operation: String,
+        normalized_path: String,
+        state: ResolutionState,
+    },
+    #[error(
+        "qualification case {case_id:?} found multiple exact {framework} {operation} {normalized_path} routes"
+    )]
+    DuplicateRoute {
+        case_id: String,
+        framework: String,
+        operation: String,
+        normalized_path: String,
+    },
+    #[error(
+        "qualification case {case_id:?} expected handler {expected_handler:?} for {framework} {operation} {normalized_path}, found {actual_handler:?}"
+    )]
+    HandlerMismatch {
+        case_id: String,
+        framework: String,
+        operation: String,
+        normalized_path: String,
+        expected_handler: String,
+        actual_handler: String,
+    },
+}
+
+/// Resolve and validate a framework case without publishing graph nodes or
+/// edges. A case succeeds only when every expectation has exactly one exact
+/// route, making the helper safe for CI qualification and fixture snapshots.
+#[allow(clippy::result_large_err)]
+pub fn qualify_framework_case(
+    extraction: &Extraction,
+    limits: FrameworkLimits,
+    case: &FrameworkQualificationCase,
+) -> Result<FrameworkQualificationReport, FrameworkQualificationError> {
+    let resolved_routes = resolve_routes(extraction, limits)?;
+    let mut matched_routes = 0_usize;
+    for expected in &case.expectations {
+        let candidates = resolved_routes
+            .iter()
+            .filter(|route| {
+                route.route.framework == expected.framework
+                    && route.route.operation == expected.operation
+                    && route.route.normalized_path == expected.normalized_path
+            })
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Err(FrameworkQualificationError::MissingRoute {
+                case_id: case.id.clone(),
+                framework: expected.framework.clone(),
+                operation: expected.operation.clone(),
+                normalized_path: expected.normalized_path.clone(),
+            });
+        }
+        if candidates.len() > 1 {
+            return Err(FrameworkQualificationError::DuplicateRoute {
+                case_id: case.id.clone(),
+                framework: expected.framework.clone(),
+                operation: expected.operation.clone(),
+                normalized_path: expected.normalized_path.clone(),
+            });
+        }
+        let route = candidates[0];
+        if route.state != ResolutionState::Exact {
+            return Err(FrameworkQualificationError::NonExactRoute {
+                case_id: case.id.clone(),
+                framework: expected.framework.clone(),
+                operation: expected.operation.clone(),
+                normalized_path: expected.normalized_path.clone(),
+                state: route.state,
+            });
+        }
+        if let Some(expected_handler) = expected.handler_reference.as_deref()
+            && route.route.handler_reference != expected_handler
+        {
+            return Err(FrameworkQualificationError::HandlerMismatch {
+                case_id: case.id.clone(),
+                framework: expected.framework.clone(),
+                operation: expected.operation.clone(),
+                normalized_path: expected.normalized_path.clone(),
+                expected_handler: expected_handler.to_owned(),
+                actual_handler: route.route.handler_reference.clone(),
+            });
+        }
+        matched_routes += 1;
+    }
+    Ok(FrameworkQualificationReport {
+        case_id: case.id.clone(),
+        expected_routes: case.expectations.len(),
+        matched_routes,
+        resolved_routes,
+    })
+}

--- a/crates/compass-resolve/tests/framework_qualification.rs
+++ b/crates/compass-resolve/tests/framework_qualification.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::Path;
+
+use compass_languages::Engine;
+use compass_resolve::frameworks::{
+    FrameworkQualificationCase, FrameworkQualificationError, FrameworkRouteExpectation,
+    qualify_framework_case,
+};
+
+fn fixture() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/code-graph/routes/typescript/express.ts")
+}
+
+#[test]
+fn qualification_cases_share_exact_route_and_handler_contracts()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = fixture();
+    let extraction = Engine::default().extract(&path)?;
+    let case = FrameworkQualificationCase::new(
+        "express-basic",
+        vec![FrameworkRouteExpectation::new("express", "GET", "/health").with_handler("health")],
+    );
+    let report = qualify_framework_case(
+        &extraction,
+        compass_languages::FrameworkLimits::default(),
+        &case,
+    )?;
+    assert_eq!(report.case_id, "express-basic");
+    assert_eq!(report.expected_routes, 1);
+    assert_eq!(report.matched_routes, 1);
+    Ok(())
+}
+
+#[test]
+fn qualification_rejects_unresolved_or_missing_framework_routes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let path = fixture();
+    let source = fs::read(&path)?;
+    let extraction = Engine::default().extract_source(Path::new("routes.ts"), &source)?;
+    let case = FrameworkQualificationCase::new(
+        "missing-route",
+        vec![FrameworkRouteExpectation::new("express", "GET", "/missing")],
+    );
+    let error = qualify_framework_case(
+        &extraction,
+        compass_languages::FrameworkLimits::default(),
+        &case,
+    )
+    .expect_err("a missing framework route must fail qualification");
+    assert!(matches!(
+        error,
+        FrameworkQualificationError::MissingRoute { .. }
+    ));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -9,6 +9,7 @@ use compass_languages::{
 };
 use compass_model::provenance::ResolutionState;
 use compass_resolve::frameworks::{RouteStageRole, resolve_and_publish_framework_routes};
+use tempfile::tempdir;
 
 fn fixture(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -630,5 +631,114 @@ fn repository_file_routes_require_matching_project_dependencies()
         0,
         "an unrelated framework dependency must not activate a SvelteKit file route"
     );
+    Ok(())
+}
+
+#[test]
+fn next_app_and_pages_routes_use_project_evidence_and_vite_publishes_config_fact()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempdir()?;
+    let root = directory.path();
+    let app_page = root.join("src/app/users/[id]/page.tsx");
+    let app_route = root.join("src/app/api/health/route.ts");
+    let pages_api = root.join("pages/api/users.ts");
+    let vite_config = root.join("vite.config.ts");
+    for path in [&app_page, &app_route, &pages_api, &vite_config] {
+        fs::create_dir_all(path.parent().ok_or("route has no parent")?)?;
+    }
+    fs::write(&app_page, "export default function User() { return null }")?;
+    fs::write(
+        &app_route,
+        "export async function GET() { return Response.json({}) }",
+    )?;
+    fs::write(
+        &pages_api,
+        "export default function handler(req, res) { res.end() }",
+    )?;
+    fs::write(
+        &vite_config,
+        "import react from '@vitejs/plugin-react'; import { defineConfig } from 'vite'; export default defineConfig({ plugins: [react()], resolve: { alias: { '~': './src' } } });",
+    )?;
+    fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"next":"15.0.0","vite":"7.0.0"},"devDependencies":{"@vitejs/plugin-react":"4.0.0"}}"#,
+    )?;
+
+    let sources = vec![
+        app_page.clone(),
+        app_route.clone(),
+        pages_api.clone(),
+        vite_config.clone(),
+    ];
+    let evidence = ProjectEvidenceIndex::build(root, &sources);
+    assert!(
+        evidence
+            .evidence_for(&app_page)
+            .has_route_root("next", "src/app")
+    );
+    let mut engine = Engine::with_project_evidence(Arc::new(evidence));
+    let page = engine.extract(&app_page)?;
+    let route = engine.extract(&app_route)?;
+    let api = engine.extract(&pages_api)?;
+    let vite = engine.extract(&vite_config)?;
+    assert!(routes(&page).any(|route| {
+        route.framework == "next"
+            && route.operation == "PAGE"
+            && route.normalized_path == "/users/{id}"
+    }));
+    assert!(routes(&route).any(|route| {
+        route.framework == "next"
+            && route.operation == "GET"
+            && route.normalized_path == "/api/health"
+    }));
+    assert!(routes(&api).any(|route| {
+        route.framework == "next"
+            && route.operation == "ANY"
+            && route.normalized_path == "/api/users"
+    }));
+    assert!(vite.framework_facts.iter().any(|fact| {
+        matches!(
+            fact,
+            RawFrameworkFact::Domain(domain)
+                if domain.framework == "vite" && domain.kind == "framework_configuration"
+        )
+    }));
+    let vite_source = fs::read_to_string(&vite_config)?;
+    let mut sources = HashMap::new();
+    sources.insert(vite_config.to_string_lossy().into_owned(), vite_source);
+    let graph = compass_resolve::resolve(&[vite], &sources);
+    assert!(
+        graph.error.is_none(),
+        "Vite configuration resolution failed: {:?}",
+        graph.error
+    );
+    assert!(graph.nodes.iter().any(|node| {
+        node.string("symbol_kind") == "config_key"
+            && node.string("framework") == "vite"
+            && node.string("component_type") == "framework_configuration"
+    }));
+
+    let config_only = tempdir()?;
+    let config_page = config_only.path().join("src/app/page.tsx");
+    fs::create_dir_all(
+        config_page
+            .parent()
+            .ok_or("config-only page has no parent")?,
+    )?;
+    fs::write(
+        &config_page,
+        "export default function Home() { return null }",
+    )?;
+    fs::write(
+        config_only.path().join("next.config.mjs"),
+        "export default { rewrites() { return [] } }",
+    )?;
+    let config_evidence =
+        ProjectEvidenceIndex::build(config_only.path(), std::slice::from_ref(&config_page));
+    let config_extraction =
+        Engine::with_project_evidence(Arc::new(config_evidence)).extract(&config_page)?;
+    assert!(routes(&config_extraction).any(|route| {
+        route.framework == "next" && route.operation == "PAGE" && route.normalized_path == "/"
+    }));
     Ok(())
 }

--- a/docs/implementation/extending-compass.md
+++ b/docs/implementation/extending-compass.md
@@ -84,6 +84,14 @@ Evidence requirements:
 - cold, warm, and repeated extraction equivalence; and
 - route/domain publication coverage at the resolver seam.
 
+For repeatable framework qualification, use
+`compass_resolve::frameworks::qualify_framework_case`. A case names its
+expectations as `(framework, operation, normalized_path)` values and may pin a
+handler reference. Qualification requires one exact route per expectation;
+missing, ambiguous, duplicate, or mismatched handlers fail explicitly. This
+keeps fixture checks reusable across Express, Next.js, Axum, Spring, and new
+adapters without coupling the harness to one detector implementation.
+
 ## Add a relation
 
 Define:

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -401,9 +401,12 @@ expansion uses the same stable pack ID seam in `compass-resolve`; adding a
 universal expander without a matching descriptor is rejected by resolver
 tests.
 
-The Java hard cut is limited to Spring's Java-facing behavior. Kotlin Spring,
-Rails, Rust web, ASP.NET, Vapor, TypeScript web, filesystem-route, config, and
-template semantics are unchanged.
+The runtime keeps Spring's Java and Kotlin mappings, Express middleware,
+Axum builders, Next.js file routing, and Vite configuration in separate
+focused adapters. Shared project evidence supplies bounded configuration,
+alias, plugin, and route-root metadata, while the qualification module checks
+that each framework's expected routes resolve exactly before a fixture can
+claim support.
 
 ## Verification gates
 

--- a/docs/reference/framework-routes.md
+++ b/docs/reference/framework-routes.md
@@ -49,11 +49,17 @@ Compass activates a framework pack only when the repository contains direct evid
 ### JavaScript and TypeScript frameworks
 
 - **Express**: `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths and ordered middleware chains; opaque inline callbacks remain unresolved
+- **Next.js**: App Router `page.*` and `route.*` files under `app` or `src/app`, Pages Router pages and `pages/api` handlers, dynamic segments, route groups, named HTTP exports, and project activation from the `next` dependency or `next.config.*`
 - **NestJS**: `Controller` HTTP method decorators and `RequestMapping`; GraphQL `Resolver` `Query` and `Mutation` operations at `/graphql`; typed GraphQL field details; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations
 - **React Router**: JSX `Route` elements with `element={<Component />}` or `Component={Component}`, plus literal object route configs with `component`, `element`, or `Component` targets and loader or action stages
 - **SvelteKit**: `src/routes` `+page.svelte` components and `+server` endpoints, including `[param]` and `[...rest]` segments and source-backed exported HTTP methods; `+page.ts` load modules are not pages
 - **Vue Router and Nuxt**: Vue Router literal route objects; Nuxt `pages` components; `server/api` method-suffixed endpoints; dynamic segments; and route-middleware domain facts
 - **Astro**: `src/pages` `.astro` pages and `.ts` or `.js` endpoints, including `[param]` and `[...rest]` segments, exported HTTP methods, `ALL`, and source-backed default handlers
+
+Vite configuration is represented as a `configuration` node rather than a
+route. The node retains bounded `resolve.alias`, plugin imports, and
+configuration keys so build-time wiring remains inspectable without inventing
+HTTP endpoints.
 
 ### PHP, Ruby, and JVM frameworks
 
@@ -78,7 +84,7 @@ Some frameworks expose routes that are not HTTP URLs. Compass keeps their domain
 - Nuxt middleware retains its middleware domain fact
 - GraphQL fields retain the field name in route details while sharing the `/graphql` transport endpoint
 
-These records still retain handler references and source anchors. File-route packs require matching project dependency evidence during a normal repository build. Direct single-file extraction remains available for fixtures and tooling, but it does not activate a repository pack by itself.
+These records still retain handler references and source anchors. File-route packs require matching project dependency or framework-configuration evidence during a normal repository build. Direct single-file extraction remains available for fixtures and tooling, but it does not activate a repository pack by itself.
 
 ## Why a route can remain unresolved
 


### PR DESCRIPTION
## Summary

- split the framework runtime into focused Express, Axum, Next.js, Vite, and Spring Kotlin adapters while preserving the shared pack lifecycle
- expand bounded project evidence for configuration files, aliases, plugins, Spring resource profiles, and file-route roots
- publish Vite configuration as a typed `config_key` graph fact and add a reusable exact-route qualification API
- add Next App/Pages Router coverage and advance extraction semantics to v7 for cache refreshes

## Verification

- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main cargo test --workspace --lib --bins --locked --quiet`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-main ./scripts/qualify_code_graph_v1.sh --fixtures-only`
- focused framework and qualification tests
