### PR TITLE
Add Fastify, Hono, and Remix framework adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   aliases, plugins, and file-route roots; Vite configuration nodes and a
   reusable exact-route qualification API are available to graph consumers.
   Extraction semantics advance to version 7 so cached source facts refresh.
+- Add focused Fastify, Hono, and Remix adapters. Fastify and Hono reuse the
+  bounded TypeScript route primitives for hooks, method arrays, mounts, and
+  literal route objects; Remix publishes nested file routes with `PAGE`,
+  `LOADER`, and `ACTION` operations and dependency/configuration activation.
 - Preserve JavaScript and TypeScript workspace import and re-export resolution
   across fully cached edit/restore builds, and improve canonical graph JSON
   publication parallelism for medium and large structural graphs without

--- a/crates/compass-languages/src/frameworks/fastify.rs
+++ b/crates/compass-languages/src/frameworks/fastify.rs
@@ -1,0 +1,18 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::RawFrameworkFact;
+use crate::Extraction;
+
+/// Fastify keeps route registration in a fluent application object. The
+/// TypeScript adapter supplies the shared literal route and middleware parser;
+/// this module is the focused runtime ownership boundary for the framework.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    super::typescript::detect_fastify(path, source, root, extraction)
+}

--- a/crates/compass-languages/src/frameworks/file_routes.rs
+++ b/crates/compass-languages/src/frameworks/file_routes.rs
@@ -302,25 +302,30 @@ fn remix_route_file(relative: &str) -> Option<&str> {
 
 fn remix_route_path(relative: &str) -> String {
     let mut stem = trim_known_extension(relative).trim_matches('/').to_owned();
-    if stem.ends_with("/index") {
-        stem.truncate(stem.len().saturating_sub("/index".len()));
+    if stem.ends_with("/index") || stem.ends_with("/route") {
+        let suffix = if stem.ends_with("/index") {
+            "/index"
+        } else {
+            "/route"
+        };
+        stem.truncate(stem.len().saturating_sub(suffix.len()));
     }
     let mut segments = Vec::new();
-    let mut pieces = stem.split('/').filter(|piece| !piece.is_empty()).peekable();
-    while let Some(piece) = pieces.next() {
-        if pieces.peek().is_none() {
-            for segment in piece.split('.').filter(|segment| !segment.is_empty()) {
-                if segment == "_index" || segment == "index" {
-                    continue;
-                }
-                let segment = segment.strip_suffix('_').unwrap_or(segment);
-                if segment.starts_with('_') {
-                    continue;
-                }
-                segments.push(remix_route_segment(segment));
+    let pieces = stem
+        .split('/')
+        .filter(|piece| !piece.is_empty())
+        .collect::<Vec<_>>();
+    for (piece_index, piece) in pieces.iter().enumerate() {
+        let final_piece = piece_index + 1 == pieces.len();
+        for segment in piece.split('.').filter(|segment| !segment.is_empty()) {
+            if final_piece && matches!(segment, "_index" | "index" | "route") {
+                continue;
             }
-        } else if piece != "index" && piece != "_index" && !piece.starts_with('_') {
-            segments.push(remix_route_segment(piece));
+            let segment = segment.strip_suffix('_').unwrap_or(segment);
+            if segment.starts_with('_') {
+                continue;
+            }
+            segments.push(remix_route_segment(segment));
         }
     }
     segments.join("/")
@@ -351,11 +356,14 @@ fn remix_endpoint_handlers(source: &str) -> Vec<EndpointHandler> {
             module: None,
         })
         .collect::<Vec<_>>();
-    if let Ok(reexports) = Regex::new(r"(?m)^\s*export\s*\{([^}]*)\}") {
+    if let Ok(reexports) =
+        Regex::new(r#"(?m)^\s*export\s*\{([^}]*)\}(?:\s*from\s*["']([^"']+)["'])?"#)
+    {
         for capture in reexports.captures_iter(source) {
             let Some(names) = capture.get(1) else {
                 continue;
             };
+            let module = capture.get(2).map(|value| value.as_str().to_owned());
             for name in names.as_str().split(',').map(str::trim) {
                 let (local, exported) = name
                     .split_once(" as ")
@@ -365,7 +373,13 @@ fn remix_endpoint_handlers(source: &str) -> Vec<EndpointHandler> {
                     handlers.push(EndpointHandler {
                         operation: exported.to_ascii_uppercase(),
                         reference: local.to_owned(),
-                        module: None,
+                        module: module.clone(),
+                    });
+                } else if exported == "default" {
+                    handlers.push(EndpointHandler {
+                        operation: "PAGE".to_owned(),
+                        reference: local.to_owned(),
+                        module: module.clone(),
                     });
                 }
             }

--- a/crates/compass-languages/src/frameworks/file_routes.rs
+++ b/crates/compass-languages/src/frameworks/file_routes.rs
@@ -229,6 +229,172 @@ pub(super) fn detect_next(
     Vec::new()
 }
 
+/// Detect Remix flat-route and nested route modules. Remix keeps page
+/// components and resource/data handlers in the same `app/routes` tree, so a
+/// route file can publish more than one operation (`PAGE`, `LOADER`, and
+/// `ACTION`) while retaining one convention anchor.
+pub(super) fn detect_remix(
+    path: &Path,
+    source: &[u8],
+    project: Option<&ProjectEvidence>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    let enabled = project.is_none_or(|project| {
+        project.has_any_dependency(&[
+            "@remix-run/dev",
+            "@remix-run/node",
+            "@remix-run/react",
+            "@remix-run/router",
+            "@remix-run/serve",
+        ]) || project.has_any_configuration(&[
+            "remix.config.cjs",
+            "remix.config.js",
+            "remix.config.mjs",
+            "remix.config.ts",
+        ])
+    });
+    if !enabled || source.is_empty() {
+        return Vec::new();
+    }
+    let portable = path.to_string_lossy().replace('\\', "/");
+    let project_relative = project
+        .and_then(|project| path.strip_prefix(project.project_root()).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or(portable);
+    let Some(relative) = remix_route_file(&project_relative) else {
+        return Vec::new();
+    };
+    let handlers = remix_endpoint_handlers(std::str::from_utf8(source).unwrap_or_default());
+    handlers
+        .into_iter()
+        .flat_map(|handler| {
+            one_route(
+                "remix",
+                &handler.operation,
+                &remix_route_path(relative),
+                path,
+                source,
+                extraction,
+                "remix-route-convention",
+                Some(&handler),
+            )
+        })
+        .collect()
+}
+
+fn remix_route_file(relative: &str) -> Option<&str> {
+    for marker in ["app/routes/", "src/routes/"] {
+        if let Some(route) = relative.strip_prefix(marker) {
+            return (!route.is_empty()).then_some(route);
+        }
+        if let Some(index) = relative.find(marker)
+            && (index == 0 || relative.as_bytes().get(index - 1) == Some(&b'/'))
+        {
+            let route = &relative[index + marker.len()..];
+            return (!route.is_empty()).then_some(route);
+        }
+    }
+    if let Some(route) = relative.strip_prefix("routes/") {
+        return (!route.is_empty()).then_some(route);
+    }
+    None
+}
+
+fn remix_route_path(relative: &str) -> String {
+    let mut stem = trim_known_extension(relative).trim_matches('/').to_owned();
+    if stem.ends_with("/index") {
+        stem.truncate(stem.len().saturating_sub("/index".len()));
+    }
+    let mut segments = Vec::new();
+    let mut pieces = stem.split('/').filter(|piece| !piece.is_empty()).peekable();
+    while let Some(piece) = pieces.next() {
+        if pieces.peek().is_none() {
+            for segment in piece.split('.').filter(|segment| !segment.is_empty()) {
+                if segment == "_index" || segment == "index" {
+                    continue;
+                }
+                let segment = segment.strip_suffix('_').unwrap_or(segment);
+                if segment.starts_with('_') {
+                    continue;
+                }
+                segments.push(remix_route_segment(segment));
+            }
+        } else if piece != "index" && piece != "_index" && !piece.starts_with('_') {
+            segments.push(remix_route_segment(piece));
+        }
+    }
+    segments.join("/")
+}
+
+fn remix_route_segment(segment: &str) -> String {
+    if segment == "$" {
+        "[...splat]".to_owned()
+    } else if let Some(name) = segment.strip_prefix('$') {
+        format!("[{name}]")
+    } else {
+        segment.to_owned()
+    }
+}
+
+fn remix_endpoint_handlers(source: &str) -> Vec<EndpointHandler> {
+    let Ok(named) =
+        Regex::new(r"(?m)^\s*export\s+(?:(?:async\s+)?function|const|let|var)\s+(loader|action)\b")
+    else {
+        return Vec::new();
+    };
+    let mut handlers = named
+        .captures_iter(source)
+        .filter_map(|capture| capture.get(1).map(|name| name.as_str().to_owned()))
+        .map(|name| EndpointHandler {
+            operation: name.to_ascii_uppercase(),
+            reference: name,
+            module: None,
+        })
+        .collect::<Vec<_>>();
+    if let Ok(reexports) = Regex::new(r"(?m)^\s*export\s*\{([^}]*)\}") {
+        for capture in reexports.captures_iter(source) {
+            let Some(names) = capture.get(1) else {
+                continue;
+            };
+            for name in names.as_str().split(',').map(str::trim) {
+                let (local, exported) = name
+                    .split_once(" as ")
+                    .map(|(local, exported)| (local.trim(), exported.trim()))
+                    .unwrap_or((name, name));
+                if matches!(exported, "loader" | "action") {
+                    handlers.push(EndpointHandler {
+                        operation: exported.to_ascii_uppercase(),
+                        reference: local.to_owned(),
+                        module: None,
+                    });
+                }
+            }
+        }
+    }
+    if Regex::new(r"(?m)^\s*export\s+default\b").is_ok_and(|pattern| pattern.is_match(source)) {
+        let reference = Regex::new(
+            r"(?m)^\s*export\s+default\s+(?:(?:async\s+)?function|class)\s+([A-Za-z_$][\w$]*)",
+        )
+        .ok()
+        .and_then(|pattern| {
+            pattern
+                .captures(source)
+                .and_then(|capture| capture.get(1).map(|name| name.as_str().to_owned()))
+        })
+        .unwrap_or_else(|| "default".to_owned());
+        handlers.push(EndpointHandler {
+            operation: "PAGE".to_owned(),
+            reference,
+            module: None,
+        });
+    }
+    handlers.sort_by(|left, right| {
+        (&left.operation, &left.reference).cmp(&(&right.operation, &right.reference))
+    });
+    handlers.dedup();
+    handlers
+}
+
 fn next_pages_api_route(
     relative: &str,
     path: &Path,

--- a/crates/compass-languages/src/frameworks/hono.rs
+++ b/crates/compass-languages/src/frameworks/hono.rs
@@ -1,0 +1,18 @@
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::RawFrameworkFact;
+use crate::Extraction;
+
+/// Hono route methods, `on` method arrays, base paths, and child mounts are
+/// selected by a dedicated pack while reusing the bounded TypeScript router
+/// primitives shared with Fastify and Express.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    super::typescript::detect_hono(path, source, root, extraction)
+}

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -3,8 +3,10 @@ mod csharp;
 mod enterprise;
 mod evidence;
 mod express;
+mod fastify;
 mod file_routes;
 mod go;
+mod hono;
 mod java;
 mod model;
 mod next;
@@ -12,6 +14,7 @@ mod pack;
 mod php;
 mod play;
 mod python;
+mod remix;
 mod ruby;
 mod rust;
 mod spring;
@@ -309,6 +312,18 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         detect_express,
     ),
     FrameworkPack::source(
+        "fastify-web",
+        &["javascript", "typescript", "tsx"],
+        &["fastify"],
+        detect_fastify,
+    ),
+    FrameworkPack::source(
+        "hono-web",
+        &["javascript", "typescript", "tsx"],
+        &["hono"],
+        detect_hono,
+    ),
+    FrameworkPack::source(
         "typescript-web",
         &["javascript", "typescript", "tsx"],
         &[
@@ -325,6 +340,24 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         &["next"],
         &["next.config.js", "next.config.mjs", "next.config.ts"],
         detect_next,
+    ),
+    FrameworkPack::source_required(
+        "remix-routes",
+        &["javascript", "typescript", "tsx"],
+        &[
+            "@remix-run/dev",
+            "@remix-run/node",
+            "@remix-run/react",
+            "@remix-run/router",
+            "@remix-run/serve",
+        ],
+        &[
+            "remix.config.cjs",
+            "remix.config.js",
+            "remix.config.mjs",
+            "remix.config.ts",
+        ],
+        detect_remix,
     ),
     FrameworkPack::source_required(
         "vite-config",
@@ -573,11 +606,32 @@ fn detect_express(
     express::detect(context.path, context.source, context.root, extraction)
 }
 
+fn detect_fastify(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    fastify::detect(context.path, context.source, context.root, extraction)
+}
+
+fn detect_hono(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    hono::detect(context.path, context.source, context.root, extraction)
+}
+
 fn detect_next(
     context: &DetectionContext<'_, '_>,
     extraction: &mut Extraction,
 ) -> Vec<RawFrameworkFact> {
     next::detect(context.path, context.source, context.project, extraction)
+}
+
+fn detect_remix(
+    context: &DetectionContext<'_, '_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    remix::detect(context.path, context.source, context.project, extraction)
 }
 
 fn detect_vite(
@@ -652,8 +706,11 @@ mod tests {
             "aspnet-web",
             "vapor-routes",
             "express-web",
+            "fastify-web",
+            "hono-web",
             "typescript-web",
             "nextjs-routes",
+            "remix-routes",
             "vite-config",
             "filesystem-routes",
             "enterprise-domain-facts",

--- a/crates/compass-languages/src/frameworks/remix.rs
+++ b/crates/compass-languages/src/frameworks/remix.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+use super::RawFrameworkFact;
+use crate::{Extraction, ProjectEvidence};
+
+/// Remix route modules are file conventions with named data handlers. The
+/// shared file-route implementation owns path normalization, convention
+/// anchors, and synthetic default identities; this adapter only selects the
+/// Remix project boundary.
+pub(super) fn detect(
+    path: &Path,
+    source: &[u8],
+    project: Option<&ProjectEvidence>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    super::file_routes::detect_remix(path, source, project, extraction)
+}

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -115,6 +115,15 @@ impl NodeRouterKind {
             ],
         }
     }
+
+    fn route_method_pattern(self) -> String {
+        let methods = self.route_methods().join("|");
+        if matches!(self, Self::Hono) {
+            format!("{methods}|on")
+        } else {
+            methods
+        }
+    }
 }
 
 fn detect_node_router(
@@ -342,7 +351,7 @@ fn collect_node_router_routes(
         } else if matches!(kind, NodeRouterKind::Hono)
             && let Ok(pattern) = Regex::new(&format!(
                 r#"^([A-Za-z_$][\w$]*)\.basePath\(\s*["']([^"']+)["']\s*\)\.({})$"#,
-                kind.route_methods().join("|")
+                kind.route_method_pattern()
             ))
             && let Some(capture) = pattern.captures(function)
             && let (Some(candidate), Some(prefix), Some(candidate_method)) =
@@ -539,7 +548,8 @@ fn object_hook_references(value: &str) -> Vec<String> {
     super::text::split_top_level(value)
         .into_iter()
         .filter_map(|entry| {
-            let (key, value) = entry.split_once(':')?;
+            let entry = entry.trim();
+            let (key, value) = entry.split_once(':').unwrap_or((entry, entry));
             let key = key
                 .trim()
                 .trim_matches(|character| matches!(character, '\'' | '"' | '`'));
@@ -575,6 +585,10 @@ fn object_property_text(value: &str, name: &str) -> Option<String> {
     super::text::split_top_level(value)
         .into_iter()
         .find_map(|entry| {
+            let entry = entry.trim();
+            if entry == name {
+                return Some(name.to_owned());
+            }
             let (key, value) = entry.split_once(':')?;
             let key = key
                 .trim()
@@ -584,6 +598,10 @@ fn object_property_text(value: &str, name: &str) -> Option<String> {
 }
 
 fn string_array_literals(value: &str) -> Vec<String> {
+    let value = value
+        .trim()
+        .strip_suffix("as const")
+        .map_or(value, str::trim);
     let value = value
         .trim()
         .strip_prefix('[')

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -54,6 +54,569 @@ pub(super) fn detect_express(
     facts
 }
 
+/// Fastify and Hono use the same JavaScript/TypeScript call shapes as
+/// Express, but their receiver construction and mount conventions differ.
+/// Keep those framework decisions behind one small router seam so the packs
+/// can share literal parsing, import identity, middleware ordering, and path
+/// normalization without making the Express adapter a catch-all detector.
+pub(super) fn detect_fastify(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    detect_node_router(path, source, root, extraction, NodeRouterKind::Fastify)
+}
+
+pub(super) fn detect_hono(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+) -> Vec<RawFrameworkFact> {
+    detect_node_router(path, source, root, extraction, NodeRouterKind::Hono)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NodeRouterKind {
+    Fastify,
+    Hono,
+}
+
+impl NodeRouterKind {
+    fn framework(self) -> &'static str {
+        match self {
+            Self::Fastify => "fastify",
+            Self::Hono => "hono",
+        }
+    }
+
+    fn module(self) -> &'static str {
+        match self {
+            Self::Fastify => "fastify",
+            Self::Hono => "hono",
+        }
+    }
+
+    fn constructor_import(self, imported: &str) -> bool {
+        match self {
+            Self::Fastify => imported == "default" || imported == "*",
+            Self::Hono => imported == "Hono" || imported == "default" || imported == "*",
+        }
+    }
+
+    fn route_methods(self) -> &'static [&'static str] {
+        match self {
+            Self::Fastify => &[
+                "get", "post", "put", "patch", "delete", "options", "head", "trace", "all",
+            ],
+            Self::Hono => &[
+                "get", "post", "put", "patch", "delete", "options", "head", "trace", "all",
+            ],
+        }
+    }
+}
+
+fn detect_node_router(
+    path: &Path,
+    source: &[u8],
+    root: Node<'_>,
+    extraction: &mut Extraction,
+    kind: NodeRouterKind,
+) -> Vec<RawFrameworkFact> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+    let mut imports = Vec::new();
+    collect_import_aliases(root, source, &mut imports);
+    attach_import_aliases(path, source, root, extraction, &imports);
+    let module = kind.module();
+    let imported = imports.iter().any(|(_, _, imported_module, _)| {
+        imported_module == module || imported_module.starts_with(&format!("{module}/"))
+    });
+    let direct = imported || source_has_module_require(root, source, module);
+    if !direct {
+        return Vec::new();
+    }
+    let receivers = node_router_receivers(root, source, &imports, kind);
+    if receivers.is_empty() {
+        return Vec::new();
+    }
+    let mounts = node_router_mounts(root, source, &receivers, kind);
+    let mut facts = Vec::new();
+    collect_node_router_routes(root, source, path, &receivers, &mounts, kind, &mut facts);
+    facts
+}
+
+fn node_router_receivers(
+    root: Node<'_>,
+    source: &[u8],
+    imports: &[(String, String, String, u64)],
+    kind: NodeRouterKind,
+) -> HashSet<String> {
+    let constructors = imports
+        .iter()
+        .filter(|(_, imported, module, _)| {
+            (module == kind.module() || module.starts_with(&format!("{}/", kind.module())))
+                && kind.constructor_import(imported)
+        })
+        .map(|(local, _, _, _)| local.clone())
+        .collect::<HashSet<_>>();
+    let body = std::str::from_utf8(source).unwrap_or_default();
+    let mut receivers = HashSet::new();
+    collect_node_router_receivers(root, source, &constructors, kind, &mut receivers);
+
+    // CommonJS bindings do not appear in import aliases. Keep the binding
+    // evidence exact and let the normal AST receiver walk handle construction.
+    if let Ok(pattern) = Regex::new(&format!(
+        r#"(?m)^\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["']{}["']\s*\)\s*;?"#,
+        regex::escape(kind.module())
+    )) {
+        let mut require_constructors = constructors;
+        require_constructors.extend(
+            pattern
+                .captures_iter(body)
+                .filter_map(|capture| capture.get(1).map(|value| value.as_str().to_owned())),
+        );
+        collect_node_router_receivers(root, source, &require_constructors, kind, &mut receivers);
+    }
+    receivers
+}
+
+fn collect_node_router_receivers(
+    node: Node<'_>,
+    source: &[u8],
+    constructors: &HashSet<String>,
+    kind: NodeRouterKind,
+    receivers: &mut HashSet<String>,
+) {
+    if node.kind() == "variable_declarator"
+        && let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        )
+    {
+        let variable = node_text(name, source).trim();
+        let expression = node_text(value, source).trim();
+        if is_identifier(variable) && node_router_constructor_call(expression, constructors, kind) {
+            receivers.insert(variable.to_owned());
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_node_router_receivers(child, source, constructors, kind, receivers);
+    }
+}
+
+fn node_router_constructor_call(
+    expression: &str,
+    constructors: &HashSet<String>,
+    kind: NodeRouterKind,
+) -> bool {
+    let expression = expression.trim();
+    match kind {
+        NodeRouterKind::Fastify => {
+            let callee = expression
+                .split_once('(')
+                .map_or(expression, |(callee, _)| callee.trim());
+            is_identifier(callee)
+                && (constructors.contains(callee)
+                    || callee.eq_ignore_ascii_case("fastify")
+                    || callee.eq_ignore_ascii_case("Fastify"))
+                || expression.starts_with("require(\"fastify\")")
+                || expression.starts_with("require('fastify')")
+        }
+        NodeRouterKind::Hono => {
+            let Some(constructed) = expression.strip_prefix("new ") else {
+                return false;
+            };
+            let callee = constructed
+                .split_once('(')
+                .map_or(constructed, |(callee, _)| callee.trim());
+            is_identifier(callee) && (constructors.contains(callee) || callee == "Hono")
+                || constructed.starts_with("(require(\"hono\").Hono)")
+                || constructed.starts_with("(require('hono').Hono)")
+        }
+    }
+}
+
+fn node_router_mounts(
+    root: Node<'_>,
+    source: &[u8],
+    receivers: &HashSet<String>,
+    kind: NodeRouterKind,
+) -> HashMap<String, String> {
+    let mut mounts = HashMap::new();
+    collect_node_router_mounts(root, source, receivers, kind, &mut mounts);
+    mounts
+}
+
+fn collect_node_router_mounts(
+    node: Node<'_>,
+    source: &[u8],
+    receivers: &HashSet<String>,
+    kind: NodeRouterKind,
+    mounts: &mut HashMap<String, String>,
+) {
+    let is_mount = node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| {
+                let Some((parent, method)) = node_text(function, source).trim().rsplit_once('.')
+                else {
+                    return false;
+                };
+                receivers.contains(parent)
+                    && ((matches!(kind, NodeRouterKind::Hono) && method == "route")
+                        || (matches!(kind, NodeRouterKind::Fastify) && method == "register"))
+            });
+    if is_mount {
+        let function = node
+            .child_by_field_name("function")
+            .map(|function| node_text(function, source).trim().to_owned())
+            .unwrap_or_default();
+        let Some((parent, method)) = function.rsplit_once('.') else {
+            return;
+        };
+        let Some(arguments) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let argument_text = split_arguments(node_text(arguments, source));
+        let prefix = if method == "route" {
+            argument_text
+                .first()
+                .and_then(|value| string_literal(value))
+        } else {
+            argument_text.get(1).and_then(|value| {
+                object_property_text(value, "prefix").and_then(|value| string_literal(&value))
+            })
+        };
+        let child = argument_text
+            .first()
+            .and_then(|value| {
+                if method == "route" {
+                    argument_text.get(1)
+                } else {
+                    Some(value)
+                }
+            })
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|value| is_identifier(value));
+        if let (Some(prefix), Some(child)) = (prefix, child)
+            && receivers.contains(child)
+        {
+            let parent_prefix = mounts.get(parent).map(String::as_str).unwrap_or_default();
+            mounts.insert(child.to_owned(), join_paths(parent_prefix, &prefix));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_node_router_mounts(child, source, receivers, kind, mounts);
+    }
+}
+
+fn collect_node_router_routes(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    receivers: &HashSet<String>,
+    mounts: &HashMap<String, String>,
+    kind: NodeRouterKind,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+    {
+        let function = node_text(function, source).trim();
+        let mut receiver = None;
+        let mut method = None;
+        let mut chained_path = None;
+        if let Some((candidate, candidate_method)) = function.rsplit_once('.')
+            && receivers.contains(candidate)
+            && (kind.route_methods().contains(&candidate_method)
+                || (matches!(kind, NodeRouterKind::Hono) && candidate_method == "on"))
+        {
+            receiver = Some(candidate.to_owned());
+            method = Some(candidate_method.to_owned());
+        } else if matches!(kind, NodeRouterKind::Hono)
+            && let Ok(pattern) = Regex::new(&format!(
+                r#"^([A-Za-z_$][\w$]*)\.basePath\(\s*["']([^"']+)["']\s*\)\.({})$"#,
+                kind.route_methods().join("|")
+            ))
+            && let Some(capture) = pattern.captures(function)
+            && let (Some(candidate), Some(prefix), Some(candidate_method)) =
+                (capture.get(1), capture.get(2), capture.get(3))
+            && receivers.contains(candidate.as_str())
+        {
+            receiver = Some(candidate.as_str().to_owned());
+            method = Some(candidate_method.as_str().to_owned());
+            chained_path = Some(prefix.as_str().to_owned());
+        }
+
+        if let (Some(receiver), Some(method), Some(arguments)) = (
+            receiver.as_deref(),
+            method.as_deref(),
+            node.child_by_field_name("arguments"),
+        ) {
+            let arguments = split_arguments(node_text(arguments, source));
+            let (methods, path_index) = if method == "on" {
+                let methods = arguments
+                    .first()
+                    .map(|value| string_array_literals(value))
+                    .unwrap_or_default();
+                (methods, 1_usize)
+            } else {
+                (vec![method.to_owned()], 0_usize)
+            };
+            let raw_path = arguments
+                .get(path_index)
+                .and_then(|argument| string_literal(argument))
+                .map(|route_path| {
+                    chained_path
+                        .as_deref()
+                        .map_or(route_path.clone(), |prefix| join_paths(prefix, &route_path))
+                });
+            if let Some(raw_path) = raw_path {
+                let raw_stages = arguments.iter().skip(path_index + 1).collect::<Vec<_>>();
+                let (handler, middleware, mut detail) = router_stages(&raw_stages, kind, node);
+                if let Some(handler) = handler {
+                    detail.insert("receiver".into(), Value::String(receiver.to_owned()));
+                    for operation in methods {
+                        facts.push(RawFrameworkFact::Route(RawRouteFact {
+                            framework: kind.framework().to_owned(),
+                            operation: if operation.eq_ignore_ascii_case("all") {
+                                "ANY".to_owned()
+                            } else {
+                                operation.to_ascii_uppercase()
+                            },
+                            raw_path: raw_path.clone(),
+                            normalized_path: normalize_path(&join_paths(
+                                mounts.get(receiver).map(String::as_str).unwrap_or_default(),
+                                &raw_path,
+                            )),
+                            declaring_scope: module_scope(path),
+                            anchor: anchor(path, node),
+                            handler_reference: handler.clone(),
+                            middleware_references: middleware.clone(),
+                            origin: RawFrameworkOrigin::Ast,
+                            rule: None,
+                            detail: detail.clone(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        if matches!(kind, NodeRouterKind::Fastify)
+            && function
+                .rsplit_once('.')
+                .is_some_and(|(receiver, method)| receivers.contains(receiver) && method == "route")
+            && let Some(arguments) = node.child_by_field_name("arguments")
+            && let Some(route_object) = arguments.named_child(0)
+        {
+            let object = node_text(route_object, source);
+            let Some(raw_path) = object_property_text(object, "url")
+                .and_then(|value| string_literal(&value))
+                .or_else(|| {
+                    object_property_text(object, "path").and_then(|value| string_literal(&value))
+                })
+            else {
+                return;
+            };
+            let methods = object_property_text(object, "method")
+                .map(|value| string_array_literals(&value))
+                .filter(|values| !values.is_empty())
+                .unwrap_or_else(|| {
+                    object_property_text(object, "method")
+                        .and_then(|value| string_literal(&value))
+                        .into_iter()
+                        .collect()
+                });
+            if methods.is_empty() {
+                return;
+            }
+            let Some(handler_value) = object_property_text(object, "handler") else {
+                return;
+            };
+            let (handler, opaque) = handler_from_value(&handler_value, node);
+            let mut detail = Map::from_iter([(
+                "receiver".into(),
+                Value::String(
+                    function
+                        .rsplit_once('.')
+                        .map(|(receiver, _)| receiver)
+                        .unwrap_or_default()
+                        .to_owned(),
+                ),
+            )]);
+            if opaque {
+                detail.insert("opaque_handler".into(), Value::Bool(true));
+            }
+            let middleware = object_hook_references(object);
+            let receiver = function
+                .rsplit_once('.')
+                .map(|(receiver, _)| receiver)
+                .unwrap_or_default();
+            for operation in methods {
+                facts.push(RawFrameworkFact::Route(RawRouteFact {
+                    framework: "fastify".to_owned(),
+                    operation: if operation.eq_ignore_ascii_case("all") {
+                        "ANY".to_owned()
+                    } else {
+                        operation.to_ascii_uppercase()
+                    },
+                    raw_path: raw_path.clone(),
+                    normalized_path: normalize_path(&join_paths(
+                        mounts.get(receiver).map(String::as_str).unwrap_or_default(),
+                        &raw_path,
+                    )),
+                    declaring_scope: module_scope(path),
+                    anchor: anchor(path, node),
+                    handler_reference: handler.clone(),
+                    middleware_references: middleware.clone(),
+                    origin: RawFrameworkOrigin::Ast,
+                    rule: None,
+                    detail: detail.clone(),
+                }));
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_node_router_routes(child, source, path, receivers, mounts, kind, facts);
+    }
+}
+
+fn router_stages(
+    stages: &[&String],
+    kind: NodeRouterKind,
+    node: Node<'_>,
+) -> (Option<String>, Vec<String>, Map<String, Value>) {
+    let mut detail = Map::new();
+    let mut candidates = Vec::new();
+    let mut middleware = Vec::new();
+    for stage in stages {
+        if matches!(kind, NodeRouterKind::Fastify) && stage.trim_start().starts_with('{') {
+            if let Some(value) = object_property_text(stage, "handler") {
+                let (handler, opaque) = handler_from_value(&value, node);
+                if opaque {
+                    detail.insert("opaque_handler".into(), Value::Bool(true));
+                }
+                candidates.push(handler);
+            }
+            middleware.extend(object_hook_references(stage));
+        } else if let Some(reference) = handler_reference(stage) {
+            candidates.push(reference);
+        } else if is_inline_handler_expression(stage) {
+            candidates.push(format!("opaque_inline_handler_at_{}", node.start_byte()));
+            detail.insert("opaque_handler".into(), Value::Bool(true));
+        }
+    }
+    let handler = candidates.pop();
+    middleware.extend(candidates);
+    (handler, middleware, detail)
+}
+
+fn handler_from_value(value: &str, node: Node<'_>) -> (String, bool) {
+    if let Some(reference) = handler_reference(value) {
+        return (reference, false);
+    }
+    (
+        format!("opaque_inline_handler_at_{}", node.start_byte()),
+        true,
+    )
+}
+
+fn object_hook_references(value: &str) -> Vec<String> {
+    let Some(value) = value
+        .trim()
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+    else {
+        return Vec::new();
+    };
+    super::text::split_top_level(value)
+        .into_iter()
+        .filter_map(|entry| {
+            let (key, value) = entry.split_once(':')?;
+            let key = key
+                .trim()
+                .trim_matches(|character| matches!(character, '\'' | '"' | '`'));
+            matches!(
+                key,
+                "onRequest"
+                    | "preParsing"
+                    | "preValidation"
+                    | "preHandler"
+                    | "onSend"
+                    | "onResponse"
+            )
+            .then(|| list_or_reference(value))
+        })
+        .flatten()
+        .collect()
+}
+
+fn list_or_reference(value: &str) -> Vec<String> {
+    let value = value.trim();
+    let value = value
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(value);
+    split_arguments(value)
+        .into_iter()
+        .filter_map(|value| handler_reference(&value))
+        .collect()
+}
+
+fn object_property_text(value: &str, name: &str) -> Option<String> {
+    let value = value.trim().strip_prefix('{')?.strip_suffix('}')?;
+    super::text::split_top_level(value)
+        .into_iter()
+        .find_map(|entry| {
+            let (key, value) = entry.split_once(':')?;
+            let key = key
+                .trim()
+                .trim_matches(|character| matches!(character, '\'' | '"' | '`'));
+            (key == name).then(|| value.trim().to_owned())
+        })
+}
+
+fn string_array_literals(value: &str) -> Vec<String> {
+    let value = value
+        .trim()
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(value);
+    split_arguments(value)
+        .into_iter()
+        .filter_map(|value| string_literal(&value))
+        .collect()
+}
+
+fn source_has_module_require(node: Node<'_>, source: &[u8], module: &str) -> bool {
+    if node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| node_text(function, source).trim() == "require")
+        && node
+            .child_by_field_name("arguments")
+            .is_some_and(|arguments| {
+                split_arguments(node_text(arguments, source))
+                    .first()
+                    .and_then(|argument| string_literal(argument))
+                    .is_some_and(|value| value == module)
+            })
+    {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.is_named())
+        .any(|child| source_has_module_require(child, source, module))
+}
+
 pub(super) fn detect_non_express(
     path: &Path,
     source: &[u8],

--- a/crates/compass-languages/src/project_evidence.rs
+++ b/crates/compass-languages/src/project_evidence.rs
@@ -47,6 +47,10 @@ const FIXED_CONFIGURATION_NAMES: &[&str] = &[
     "next.config.ts",
     "nuxt.config.js",
     "nuxt.config.ts",
+    "remix.config.js",
+    "remix.config.cjs",
+    "remix.config.mjs",
+    "remix.config.ts",
     "svelte.config.js",
     "svelte.config.ts",
     "tsconfig.json",
@@ -990,6 +994,14 @@ fn route_root_for_source(
     let next_configured = ["next.config.js", "next.config.mjs", "next.config.ts"]
         .iter()
         .any(|name| configured(name));
+    let remix_configured = [
+        "remix.config.cjs",
+        "remix.config.js",
+        "remix.config.mjs",
+        "remix.config.ts",
+    ]
+    .iter()
+    .any(|name| configured(name));
     if (has("next") || next_configured)
         && (components.first() == Some(&"app") || components.first() == Some(&"pages"))
     {
@@ -1000,6 +1012,51 @@ fn route_root_for_source(
         && matches!(components.get(1), Some(&"app" | &"pages"))
     {
         return Some(("next".to_owned(), format!("src/{}", components[1])));
+    }
+    if (remix_configured
+        || has_any_dependency(
+            builder,
+            &[
+                "@remix-run/dev",
+                "@remix-run/node",
+                "@remix-run/react",
+                "@remix-run/router",
+                "@remix-run/serve",
+            ],
+        ))
+        && components.starts_with(&["app", "routes"])
+    {
+        return Some(("remix".to_owned(), "app/routes".to_owned()));
+    }
+    if (remix_configured
+        || has_any_dependency(
+            builder,
+            &[
+                "@remix-run/dev",
+                "@remix-run/node",
+                "@remix-run/react",
+                "@remix-run/router",
+                "@remix-run/serve",
+            ],
+        ))
+        && components.starts_with(&["routes"])
+    {
+        return Some(("remix".to_owned(), "routes".to_owned()));
+    }
+    if (remix_configured
+        || has_any_dependency(
+            builder,
+            &[
+                "@remix-run/dev",
+                "@remix-run/node",
+                "@remix-run/react",
+                "@remix-run/router",
+                "@remix-run/serve",
+            ],
+        ))
+        && components.starts_with(&["src", "routes"])
+    {
+        return Some(("remix".to_owned(), "src/routes".to_owned()));
     }
     if has("nuxt") && components.first() == Some(&"pages") {
         return Some(("nuxt".to_owned(), "pages".to_owned()));
@@ -1014,6 +1071,14 @@ fn route_root_for_source(
         return Some(("sveltekit".to_owned(), "src/routes".to_owned()));
     }
     None
+}
+
+fn has_any_dependency(builder: &ProjectBuilder, dependencies: &[&str]) -> bool {
+    dependencies.iter().any(|dependency| {
+        builder
+            .dependencies
+            .contains(&normalize_dependency(dependency))
+    })
 }
 
 fn normalize_dependency(value: &str) -> String {
@@ -1211,6 +1276,45 @@ mod tests {
         assert!(evidence.has_plugin("@vitejs/plugin-react"));
         assert!(evidence.has_plugin("next-plugin-intl"));
         assert!(evidence.has_route_root("next", "src/app"));
+        Ok(())
+    }
+
+    #[test]
+    fn remix_route_roots_accept_dependency_or_config_evidence() -> Result<(), Box<dyn Error>> {
+        let directory = tempdir()?;
+        let root = directory.path();
+        let route = root.join("app/routes/users.$id.tsx");
+        fs::create_dir_all(route.parent().ok_or("route has no parent")?)?;
+        fs::write(&route, "export default function User() { return null }")?;
+        fs::write(
+            root.join("package.json"),
+            r#"{"dependencies":{"@remix-run/dev":"2.10.0"}}"#,
+        )?;
+        let dependency_index = ProjectEvidenceIndex::build(root, std::slice::from_ref(&route));
+        assert!(
+            dependency_index
+                .evidence_for(&route)
+                .has_route_root("remix", "app/routes")
+        );
+
+        let config_only = tempdir()?;
+        let config_route = config_only.path().join("routes/_index.tsx");
+        fs::create_dir_all(config_route.parent().ok_or("config route has no parent")?)?;
+        fs::write(
+            &config_route,
+            "export default function Home() { return null }",
+        )?;
+        fs::write(
+            config_only.path().join("remix.config.ts"),
+            "export default { appDirectory: 'app' }",
+        )?;
+        let config_index =
+            ProjectEvidenceIndex::build(config_only.path(), std::slice::from_ref(&config_route));
+        assert!(
+            config_index
+                .evidence_for(&config_route)
+                .has_route_root("remix", "routes")
+        );
         Ok(())
     }
 

--- a/crates/compass-resolve/tests/framework_qualification.rs
+++ b/crates/compass-resolve/tests/framework_qualification.rs
@@ -12,6 +12,12 @@ fn fixture() -> std::path::PathBuf {
         .join("../../fixtures/code-graph/routes/typescript/express.ts")
 }
 
+fn typescript_fixture(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/code-graph/routes/typescript")
+        .join(name)
+}
+
 #[test]
 fn qualification_cases_share_exact_route_and_handler_contracts()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -52,5 +58,52 @@ fn qualification_rejects_unresolved_or_missing_framework_routes()
         error,
         FrameworkQualificationError::MissingRoute { .. }
     ));
+    Ok(())
+}
+
+#[test]
+fn qualification_cases_cover_fastify_hono_and_remix_adapters()
+-> Result<(), Box<dyn std::error::Error>> {
+    for (name, case) in [
+        (
+            "fastify.ts",
+            FrameworkQualificationCase::new(
+                "fastify-health",
+                vec![
+                    FrameworkRouteExpectation::new("fastify", "GET", "/health")
+                        .with_handler("health"),
+                ],
+            ),
+        ),
+        (
+            "hono.ts",
+            FrameworkQualificationCase::new(
+                "hono-health",
+                vec![
+                    FrameworkRouteExpectation::new("hono", "GET", "/health").with_handler("health"),
+                ],
+            ),
+        ),
+        (
+            "remix/app/routes/users.$id.tsx",
+            FrameworkQualificationCase::new(
+                "remix-user",
+                vec![
+                    FrameworkRouteExpectation::new("remix", "LOADER", "/users/{id}")
+                        .with_handler("loader"),
+                    FrameworkRouteExpectation::new("remix", "PAGE", "/users/{id}")
+                        .with_handler("User"),
+                ],
+            ),
+        ),
+    ] {
+        let extraction = Engine::default().extract(&typescript_fixture(name))?;
+        let report = qualify_framework_case(
+            &extraction,
+            compass_languages::FrameworkLimits::default(),
+            &case,
+        )?;
+        assert_eq!(report.expected_routes, report.matched_routes, "{name}");
+    }
     Ok(())
 }

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -121,6 +121,20 @@ app.get(dynamicPath, ignored);
         .collect::<HashSet<_>>();
     assert_eq!(object_routes, HashSet::from(["POST", "PUT"]));
     assert_eq!(routes(&extraction).count(), 3);
+
+    let commonjs = Engine::default().extract_source(
+        Path::new("src/commonjs.ts"),
+        br#"const createFastify = require("fastify");
+const app = createFastify();
+function list() {}
+app.route({ method: ["GET", "POST"] as const, url: "/items", handler: list });
+"#,
+    )?;
+    let commonjs_operations = routes(&commonjs)
+        .filter(|route| route.normalized_path == "/items")
+        .map(|route| route.operation.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(commonjs_operations, HashSet::from(["GET", "POST"]));
     Ok(())
 }
 
@@ -138,6 +152,7 @@ app.route("/api", api);
 app.get("/health", listUsers);
 api.on(["GET", "POST"], "/users/:id", authenticate, listUsers);
 app.basePath("/v1").get("/status", listUsers);
+app.basePath("/v2").on(["GET", "POST"], "/batch", listUsers);
 unknown.get("/not-a-route", listUsers);
 "#,
     )?;
@@ -159,6 +174,11 @@ unknown.get("/not-a-route", listUsers);
         route.framework == "hono"
             && route.operation == "GET"
             && route.normalized_path == "/v1/status"
+    }));
+    assert!(routes(&extraction).any(|route| {
+        route.framework == "hono"
+            && route.operation == "POST"
+            && route.normalized_path == "/v2/batch"
     }));
     assert!(!routes(&extraction).any(|route| route.normalized_path == "/not-a-route"));
     Ok(())
@@ -822,7 +842,9 @@ fn remix_flat_routes_publish_nested_page_loader_and_action_operations()
     let index = root.join("app/routes/_index.tsx");
     let user = root.join("app/routes/users.$id.tsx");
     let resource = root.join("app/routes/api.users.ts");
-    for path in [&index, &user, &resource] {
+    let nested = root.join("app/routes/admin/users/route.tsx");
+    let reexport = root.join("app/routes/settings.tsx");
+    for path in [&index, &user, &resource, &nested, &reexport] {
         fs::create_dir_all(path.parent().ok_or("route has no parent")?)?;
     }
     fs::write(&index, "export default function Home() { return null }")?;
@@ -835,10 +857,24 @@ fn remix_flat_routes_publish_nested_page_loader_and_action_operations()
         "export async function loader() { return null }\nexport async function action() { return null }",
     )?;
     fs::write(
+        &nested,
+        "export default function AdminUser() { return null }",
+    )?;
+    fs::write(
+        &reexport,
+        "export { loader, action } from './settings.server';",
+    )?;
+    fs::write(
         root.join("package.json"),
         r#"{"dependencies":{"@remix-run/dev":"2.10.0","@remix-run/react":"2.10.0"}}"#,
     )?;
-    let sources = vec![index.clone(), user.clone(), resource.clone()];
+    let sources = vec![
+        index.clone(),
+        user.clone(),
+        resource.clone(),
+        nested.clone(),
+        reexport.clone(),
+    ];
     let evidence = ProjectEvidenceIndex::build(root, &sources);
     assert!(
         evidence
@@ -849,6 +885,8 @@ fn remix_flat_routes_publish_nested_page_loader_and_action_operations()
     let index_extraction = engine.extract(&index)?;
     let user_extraction = engine.extract(&user)?;
     let resource_extraction = engine.extract(&resource)?;
+    let nested_extraction = engine.extract(&nested)?;
+    let reexport_extraction = engine.extract(&reexport)?;
     assert!(routes(&index_extraction).any(|route| {
         route.framework == "remix"
             && route.operation == "PAGE"
@@ -870,5 +908,38 @@ fn remix_flat_routes_publish_nested_page_loader_and_action_operations()
         .map(|route| route.operation.as_str())
         .collect::<HashSet<_>>();
     assert_eq!(resource_operations, HashSet::from(["ACTION", "LOADER"]));
+    assert!(routes(&nested_extraction).any(|route| {
+        route.framework == "remix"
+            && route.operation == "PAGE"
+            && route.normalized_path == "/admin/users"
+            && route.handler_reference == "AdminUser"
+    }));
+    assert!(routes(&reexport_extraction).any(|route| {
+        route.framework == "remix"
+            && route.operation == "LOADER"
+            && route.detail.get("handler_module")
+                == Some(&serde_json::Value::String("./settings.server".to_owned()))
+    }));
+
+    let unrelated = tempdir()?;
+    let unrelated_route = unrelated.path().join("app/routes/home.tsx");
+    fs::create_dir_all(
+        unrelated_route
+            .parent()
+            .ok_or("unrelated route has no parent")?,
+    )?;
+    fs::write(
+        &unrelated_route,
+        "export default function Home() { return null }",
+    )?;
+    fs::write(
+        unrelated.path().join("package.json"),
+        r#"{"dependencies":{"react-router-dom":"7.0.0"}}"#,
+    )?;
+    let unrelated_evidence =
+        ProjectEvidenceIndex::build(unrelated.path(), std::slice::from_ref(&unrelated_route));
+    let unrelated_extraction =
+        Engine::with_project_evidence(Arc::new(unrelated_evidence)).extract(&unrelated_route)?;
+    assert!(routes(&unrelated_extraction).all(|route| route.framework != "remix"));
     Ok(())
 }

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -94,6 +94,77 @@ api.route("/items").get(list);
 }
 
 #[test]
+fn fastify_routes_reuse_literal_stages_and_route_objects() -> Result<(), Box<dyn std::error::Error>>
+{
+    let extraction = Engine::default().extract_source(
+        Path::new("src/server.ts"),
+        br#"import fastify from "fastify";
+const app = fastify();
+function authenticate() {}
+function listUsers() {}
+function createUser() {}
+app.get("/users/:id", { preHandler: [authenticate] }, listUsers);
+app.route({ method: ["POST", "PUT"], url: "/users", preHandler: authenticate, handler: createUser });
+app.get(dynamicPath, ignored);
+        "#,
+    )?;
+    let users = routes(&extraction)
+        .find(|route| route.normalized_path == "/users/{id}")
+        .ok_or("missing Fastify route")?;
+    assert_eq!(users.framework, "fastify");
+    assert_eq!(users.operation, "GET");
+    assert_eq!(users.handler_reference, "listUsers");
+    assert_eq!(users.middleware_references, ["authenticate"]);
+    let object_routes = routes(&extraction)
+        .filter(|route| route.normalized_path == "/users")
+        .map(|route| route.operation.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(object_routes, HashSet::from(["POST", "PUT"]));
+    assert_eq!(routes(&extraction).count(), 3);
+    Ok(())
+}
+
+#[test]
+fn hono_routes_preserve_mounts_method_arrays_and_base_paths()
+-> Result<(), Box<dyn std::error::Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("src/routes.ts"),
+        br#"import { Hono } from "hono";
+const app = new Hono();
+const api = new Hono();
+function authenticate() {}
+function listUsers() {}
+app.route("/api", api);
+app.get("/health", listUsers);
+api.on(["GET", "POST"], "/users/:id", authenticate, listUsers);
+app.basePath("/v1").get("/status", listUsers);
+unknown.get("/not-a-route", listUsers);
+"#,
+    )?;
+    assert!(routes(&extraction).any(|route| {
+        route.framework == "hono" && route.operation == "GET" && route.normalized_path == "/health"
+    }));
+    assert!(routes(&extraction).any(|route| {
+        route.framework == "hono"
+            && route.operation == "GET"
+            && route.normalized_path == "/api/users/{id}"
+            && route.middleware_references == ["authenticate"]
+    }));
+    assert!(routes(&extraction).any(|route| {
+        route.framework == "hono"
+            && route.operation == "POST"
+            && route.normalized_path == "/api/users/{id}"
+    }));
+    assert!(routes(&extraction).any(|route| {
+        route.framework == "hono"
+            && route.operation == "GET"
+            && route.normalized_path == "/v1/status"
+    }));
+    assert!(!routes(&extraction).any(|route| route.normalized_path == "/not-a-route"));
+    Ok(())
+}
+
+#[test]
 fn nest_http_graphql_and_messaging_shapes_are_distinct() -> Result<(), Box<dyn std::error::Error>> {
     let extraction = source_extract(Path::new("src/users.ts"), "nest.ts")?;
     let route_shapes = routes(&extraction)
@@ -740,5 +811,64 @@ fn next_app_and_pages_routes_use_project_evidence_and_vite_publishes_config_fact
     assert!(routes(&config_extraction).any(|route| {
         route.framework == "next" && route.operation == "PAGE" && route.normalized_path == "/"
     }));
+    Ok(())
+}
+
+#[test]
+fn remix_flat_routes_publish_nested_page_loader_and_action_operations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempdir()?;
+    let root = directory.path();
+    let index = root.join("app/routes/_index.tsx");
+    let user = root.join("app/routes/users.$id.tsx");
+    let resource = root.join("app/routes/api.users.ts");
+    for path in [&index, &user, &resource] {
+        fs::create_dir_all(path.parent().ok_or("route has no parent")?)?;
+    }
+    fs::write(&index, "export default function Home() { return null }")?;
+    fs::write(
+        &user,
+        "export async function loader() { return null }\nexport default function User() { return null }",
+    )?;
+    fs::write(
+        &resource,
+        "export async function loader() { return null }\nexport async function action() { return null }",
+    )?;
+    fs::write(
+        root.join("package.json"),
+        r#"{"dependencies":{"@remix-run/dev":"2.10.0","@remix-run/react":"2.10.0"}}"#,
+    )?;
+    let sources = vec![index.clone(), user.clone(), resource.clone()];
+    let evidence = ProjectEvidenceIndex::build(root, &sources);
+    assert!(
+        evidence
+            .evidence_for(&user)
+            .has_route_root("remix", "app/routes")
+    );
+    let mut engine = Engine::with_project_evidence(Arc::new(evidence));
+    let index_extraction = engine.extract(&index)?;
+    let user_extraction = engine.extract(&user)?;
+    let resource_extraction = engine.extract(&resource)?;
+    assert!(routes(&index_extraction).any(|route| {
+        route.framework == "remix"
+            && route.operation == "PAGE"
+            && route.normalized_path == "/"
+            && route.handler_reference == "Home"
+    }));
+    assert!(routes(&user_extraction).any(|route| {
+        route.framework == "remix"
+            && route.operation == "LOADER"
+            && route.normalized_path == "/users/{id}"
+            && route.handler_reference == "loader"
+    }));
+    assert!(routes(&user_extraction).any(|route| {
+        route.framework == "remix"
+            && route.operation == "PAGE"
+            && route.normalized_path == "/users/{id}"
+    }));
+    let resource_operations = routes(&resource_extraction)
+        .map(|route| route.operation.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(resource_operations, HashSet::from(["ACTION", "LOADER"]));
     Ok(())
 }

--- a/docs/implementation/extending-compass.md
+++ b/docs/implementation/extending-compass.md
@@ -89,8 +89,9 @@ For repeatable framework qualification, use
 expectations as `(framework, operation, normalized_path)` values and may pin a
 handler reference. Qualification requires one exact route per expectation;
 missing, ambiguous, duplicate, or mismatched handlers fail explicitly. This
-keeps fixture checks reusable across Express, Next.js, Axum, Spring, and new
-adapters without coupling the harness to one detector implementation.
+keeps fixture checks reusable across Express, Fastify, Hono, Remix, Next.js,
+Axum, Spring, and new adapters without coupling the harness to one detector
+implementation.
 
 ## Add a relation
 

--- a/docs/reference/framework-routes.md
+++ b/docs/reference/framework-routes.md
@@ -49,7 +49,10 @@ Compass activates a framework pack only when the repository contains direct evid
 ### JavaScript and TypeScript frameworks
 
 - **Express**: `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths and ordered middleware chains; opaque inline callbacks remain unresolved
+- **Fastify**: `fastify()` receivers; HTTP method calls and `route({ method, url, handler })` objects; literal `prefix` registrations, ordered hook stages such as `preHandler`, and opaque inline callbacks remain unresolved
+- **Hono**: `new Hono()` receivers; HTTP method calls, `on([methods], path, handler)` arrays, `basePath` chains, and literal `route(prefix, child)` mounts with ordered middleware stages
 - **Next.js**: App Router `page.*` and `route.*` files under `app` or `src/app`, Pages Router pages and `pages/api` handlers, dynamic segments, route groups, named HTTP exports, and project activation from the `next` dependency or `next.config.*`
+- **Remix**: flat and nested route modules under `app/routes`, `routes`, or `src/routes`; `_index`, dotted nested segments, `$param` and splat names; and `PAGE`, `LOADER`, and `ACTION` operations from default, loader, and action exports. Project activation uses `@remix-run/*` dependencies or `remix.config.*`.
 - **NestJS**: `Controller` HTTP method decorators and `RequestMapping`; GraphQL `Resolver` `Query` and `Mutation` operations at `/graphql`; typed GraphQL field details; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations
 - **React Router**: JSX `Route` elements with `element={<Component />}` or `Component={Component}`, plus literal object route configs with `component`, `element`, or `Component` targets and loader or action stages
 - **SvelteKit**: `src/routes` `+page.svelte` components and `+server` endpoints, including `[param]` and `[...rest]` segments and source-backed exported HTTP methods; `+page.ts` load modules are not pages

--- a/fixtures/code-graph/routes/typescript/fastify.ts
+++ b/fixtures/code-graph/routes/typescript/fastify.ts
@@ -1,0 +1,9 @@
+import fastify from "fastify";
+
+const app = fastify();
+
+function health() {
+  return "ok";
+}
+
+app.get("/health", health);

--- a/fixtures/code-graph/routes/typescript/hono.ts
+++ b/fixtures/code-graph/routes/typescript/hono.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+const app = new Hono();
+
+function health() {
+  return app.text("ok");
+}
+
+app.get("/health", health);

--- a/fixtures/code-graph/routes/typescript/remix/app/routes/users.$id.tsx
+++ b/fixtures/code-graph/routes/typescript/remix/app/routes/users.$id.tsx
@@ -1,0 +1,7 @@
+export async function loader() {
+  return null;
+}
+
+export default function User() {
+  return null;
+}


### PR DESCRIPTION
## What changed

- Add focused Fastify and Hono source adapters over the shared TypeScript router seam.
- Add Remix file-route extraction for flat/nested routes, dynamic and splat segments, and PAGE/LOADER/ACTION handlers.
- Extend project evidence with Remix dependency/config activation and route roots.
- Add exact-route qualification fixtures/tests and update framework-route documentation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked --quiet`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- Focused TypeScript route and framework qualification tests

The existing unrelated local web/environment files remain unstaged.