### PR TITLE
Harden AST memory, incremental publication, and Go/Rust resolution

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -240,6 +240,16 @@ same filtered Graphify Go comparison, exact comparable edges improved from
 1,469 to 1,492 and missing edges fell from 38 to 15. These quality numbers are
 diagnostic and do not imply that all Graphify gaps are closed.
 
+The extraction handoff now releases excess capacity from the AST fact working
+set before project-wide resolution. Large nested JSON fact maps are rebuilt
+only above a high cardinality threshold; this keeps the common per-node and
+per-edge path allocation-neutral while bounding the large-map case. The
+compaction is lossless: a threshold-tuned release-binary smoke run produced
+the same graph SHA-256 for all four pinned repositories (`78ef5b7b` Cobra,
+`c25d3b97` Click, `06014539` Rayon, and `f620afe4` Zod). The observed peak RSS
+was 103, 168, 270, and 309 MiB respectively. These are single-run diagnostic
+measurements, not a promoted memory baseline.
+
 ## Django cold-build regression qualification
 
 The 0.2.1 code-graph performance hardening was qualified against Django commit

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -210,6 +210,94 @@ struct FactNeutralExtractionBatch {
     empty_files: Vec<PathBuf>,
 }
 
+/// Release parser/extractor over-allocation before a result crosses the worker
+/// boundary. Extractors grow vectors and JSON maps incrementally, so a large
+/// source can otherwise retain roughly the next power-of-two capacity for
+/// every node, edge, and evidence container while the project-wide resolver
+/// keeps all file facts alive.
+///
+/// This only changes allocation capacity. It deliberately does not remove or
+/// normalize any fact, because the portable AST cache and the resolver must
+/// see the exact same evidence as the non-compacted path.
+fn compact_extraction(extraction: &mut Extraction) {
+    for node in &mut extraction.nodes {
+        compact_json_map(&mut node.attributes);
+    }
+    for edge in &mut extraction.edges {
+        compact_json_map(&mut edge.attributes);
+    }
+    for value in &mut extraction.hyperedges {
+        compact_json_value(value);
+    }
+    if let Some(calls) = extraction.raw_calls.as_mut() {
+        for call in &mut *calls {
+            compact_json_map(&mut call.extensions);
+        }
+        calls.shrink_to_fit();
+    }
+    for fact in &mut extraction.framework_facts {
+        match fact {
+            compass_languages::RawFrameworkFact::Route(route) => {
+                route.middleware_references.shrink_to_fit();
+                compact_json_map(&mut route.detail);
+            }
+            compass_languages::RawFrameworkFact::Domain(domain) => {
+                compact_json_map(&mut domain.detail);
+            }
+            compass_languages::RawFrameworkFact::Annotation(annotation) => {
+                compact_json_map(&mut annotation.arguments);
+                compact_json_map(&mut annotation.detail);
+            }
+        }
+    }
+    if let Some(evidence) = extraction.semantic_evidence.as_mut() {
+        evidence.adapter.capabilities.shrink_to_fit();
+        evidence.declarations.shrink_to_fit();
+        evidence.scopes.shrink_to_fit();
+        evidence.bindings.shrink_to_fit();
+        evidence.occurrences.shrink_to_fit();
+        evidence.candidates.shrink_to_fit();
+        evidence.diagnostics.shrink_to_fit();
+    }
+    compact_json_map(&mut extraction.extensions);
+    extraction.nodes.shrink_to_fit();
+    extraction.edges.shrink_to_fit();
+    extraction.hyperedges.shrink_to_fit();
+    extraction.framework_facts.shrink_to_fit();
+}
+
+fn compact_json_map(map: &mut serde_json::Map<String, Value>) {
+    for value in map.values_mut() {
+        compact_json_value(value);
+    }
+    // serde_json intentionally keeps its backing map implementation private,
+    // so rebuild genuinely large maps with an exact initial capacity. Medium
+    // maps are left alone because rebuilding them costs more than their bounded
+    // slack on the common per-node/per-edge path.
+    if map.len() < 32 {
+        return;
+    }
+    let values = std::mem::take(map);
+    let mut compacted = serde_json::Map::with_capacity(values.len());
+    for (key, value) in values {
+        compacted.insert(key, value);
+    }
+    *map = compacted;
+}
+
+fn compact_json_value(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values.iter_mut() {
+                compact_json_value(value);
+            }
+            values.shrink_to_fit();
+        }
+        Value::Object(map) => compact_json_map(map),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
 impl OutputStats {
     const fn omissions(&self) -> PublicationOmissions {
         PublicationOmissions {
@@ -742,6 +830,7 @@ fn extract_fact_neutral_sources(
     // changed-file set is sufficient for the neutral proof because every
     // unchanged extraction is covered by the prior sidecar's exact digest.
     merge_decl_def_classes_if_needed(&mut extractions, paths);
+    extractions.iter_mut().for_each(compact_extraction);
     if extractions.is_empty() {
         return Ok(None);
     }
@@ -1860,6 +1949,7 @@ fn build_graph_inner(
             if empty_structured_document && graph.error.is_none() {
                 graph.error = Some(format!("{language} extraction failed: empty document"));
             }
+            compact_extraction(&mut graph);
             let source = if needs_resolver_source_text {
                 (
                     path.to_string_lossy().into_owned(),
@@ -5970,6 +6060,42 @@ mod tests {
         options.max_workers = Some(1);
         assert!(!should_parallel_extract(&options, 64, 64));
         assert!(should_parallel_extract(&options, 256, 256));
+    }
+
+    #[test]
+    fn compact_extraction_preserves_nested_ast_facts() -> Result<(), Box<dyn Error>> {
+        let mut attributes = Map::with_capacity(64);
+        for index in 0..32 {
+            attributes.insert(format!("attribute_{index}"), json!(index));
+        }
+        attributes.insert(
+            "nested".to_owned(),
+            json!([{"deep": ["a", "b", {"value": true}]}]),
+        );
+        let mut extraction = Extraction {
+            nodes: vec![compass_languages::RawNodeRecord {
+                id: "node".to_owned(),
+                attributes,
+            }],
+            ..Extraction::default()
+        };
+        extraction.raw_calls = Some(vec![compass_languages::RawCall {
+            caller_nid: "node".to_owned(),
+            callee: "callee".to_owned(),
+            is_member_call: None,
+            source_file: "source.go".to_owned(),
+            source_location: "1:1".to_owned(),
+            receiver: None,
+            receiver_type: None,
+            lang: Some("go".to_owned()),
+            extensions: Map::new(),
+        }]);
+        let before = serde_json::to_value(&extraction)?;
+
+        compact_extraction(&mut extraction);
+
+        assert_eq!(before, serde_json::to_value(extraction)?);
+        Ok(())
     }
 
     #[test]

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -743,20 +743,35 @@ pub fn write_canonical_graph_json<W: Write + ?Sized>(
     graph: &GraphDocument,
     writer: &mut W,
 ) -> io::Result<()> {
-    let mut metadata = graph.graph.clone();
-    metadata.files.sort_by(|left, right| left.id.cmp(&right.id));
-
     writer.write_all(b"{\"directed\":")?;
     serde_json::to_writer(&mut *writer, &graph.directed).map_err(io::Error::other)?;
     writer.write_all(b",\"multigraph\":")?;
     serde_json::to_writer(&mut *writer, &graph.multigraph).map_err(io::Error::other)?;
     writer.write_all(b",\"graph\":")?;
-    serde_json::to_writer(&mut *writer, &metadata).map_err(io::Error::other)?;
+    if graph_metadata_files_are_canonical(graph) {
+        // V1 publication already sorts the inventory. Borrowing the metadata
+        // on that hot path avoids cloning every file record before the graph
+        // stream starts; arbitrary caller-provided documents still take the
+        // canonicalizing fallback below.
+        serde_json::to_writer(&mut *writer, &graph.graph).map_err(io::Error::other)?;
+    } else {
+        let mut metadata = graph.graph.clone();
+        metadata.files.sort_by(|left, right| left.id.cmp(&right.id));
+        serde_json::to_writer(&mut *writer, &metadata).map_err(io::Error::other)?;
+    }
     writer.write_all(b",\"nodes\":")?;
     write_canonical_record_array(writer, &graph.nodes)?;
     writer.write_all(b",\"links\":")?;
     write_canonical_record_array(writer, &graph.links)?;
     writer.write_all(b"}")
+}
+
+fn graph_metadata_files_are_canonical(graph: &GraphDocument) -> bool {
+    graph
+        .graph
+        .files
+        .windows(2)
+        .all(|pair| pair[0].id.as_str() <= pair[1].id.as_str())
 }
 
 fn write_canonical_record_array<W, T>(writer: &mut W, records: &[T]) -> io::Result<()>
@@ -2740,7 +2755,7 @@ fn digest_bytes(value: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use compass_model::code_graph::{BuildMetadata, NodeKind};
+    use compass_model::code_graph::{BuildMetadata, ExtractionStatus, FileRecord, NodeKind};
 
     #[test]
     fn streamed_canonical_graph_json_matches_serde_encoding() -> Result<(), SnapshotError> {
@@ -2794,6 +2809,40 @@ mod tests {
         let mut actual = Vec::new();
         write_canonical_graph_json(&graph, &mut actual)
             .map_err(|error| SnapshotError::Encode(error.to_string()))?;
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn streamed_canonical_graph_json_sorts_unsorted_file_inventory() -> Result<(), SnapshotError> {
+        let mut graph = GraphDocument::empty_v1(BuildMetadata {
+            builder_version: "test".to_owned(),
+            schema_fingerprint: "schema".to_owned(),
+            source_tree_digest: "tree".to_owned(),
+            configuration_digest: "config".to_owned(),
+            generation_id: "generation".to_owned(),
+            source_commit: None,
+        });
+        let file = |id: &str| FileRecord {
+            id: id.to_owned(),
+            path: format!("{id}.rs"),
+            language: Some("rust".to_owned()),
+            content_digest: "sha256:test".to_owned(),
+            byte_size: 1,
+            generated: false,
+            extraction_status: ExtractionStatus::Extracted,
+            extractor_versions: Vec::new(),
+            coverage: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        graph.graph.files = vec![file("z"), file("a")];
+
+        let expected = serde_json::to_vec(&canonical_graph_document_presorted(&graph))
+            .map_err(|error| SnapshotError::Encode(error.to_string()))?;
+        let mut actual = Vec::new();
+        write_canonical_graph_json(&graph, &mut actual)
+            .map_err(|error| SnapshotError::Encode(error.to_string()))?;
+
         assert_eq!(actual, expected);
         Ok(())
     }

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -3724,11 +3724,22 @@ impl<'source> DirectAdapterState<'source> {
         use_start: usize,
         use_node: Node<'_>,
     ) -> Option<String> {
-        let Some(qualifier) = qualifier else {
+        let Some(raw_qualifier) = qualifier else {
             return self
                 .imported_target_for_occurrence(owner, spelling, 0, true)
                 .cloned();
         };
+        let normalized_qualifier = rust_normalize_path(raw_qualifier);
+        if let Some(inner) = normalized_qualifier
+            .strip_prefix('<')
+            .and_then(|value| value.strip_suffix('>'))
+            && let Some((type_path, trait_path)) = inner.split_once(" as ")
+            && let Some(type_name) = rust_qualify_evidence_path(self, owner, type_path, use_start)
+            && let Some(trait_name) = rust_qualify_evidence_path(self, owner, trait_path, use_start)
+        {
+            return Some(format!("<{type_name} as {trait_name}>::{spelling}"));
+        }
+        let qualifier = normalized_qualifier.as_str();
         if (qualifier == "Self" || rust_receiver_is_self(qualifier))
             && let Some(enclosing) = rust_callable_owner(owner)
         {
@@ -4104,7 +4115,10 @@ impl<'source> DirectAdapterState<'source> {
             } else {
                 "function"
             };
-            let metadata = self.declaration_metadata(node);
+            let mut metadata = self.declaration_metadata(node);
+            let (parameter_count, variadic) = go_parameter_signature(node);
+            metadata.parameter_count = Some(parameter_count);
+            metadata.variadic = variadic;
             let fact_id = self.builder.declare_with_metadata(
                 kind,
                 &graph_node_id,
@@ -4174,7 +4188,10 @@ impl<'source> DirectAdapterState<'source> {
             let qualified_name = format!("{}::{name}", owner.qualified_name);
             let graph_node_id =
                 self.unique_graph_id(make_id(&[&owner.graph_node_id, &name]), method);
-            let metadata = self.declaration_metadata(method);
+            let mut metadata = self.declaration_metadata(method);
+            let (parameter_count, variadic) = go_parameter_signature(method);
+            metadata.parameter_count = Some(parameter_count);
+            metadata.variadic = variadic;
             let fact_id = self.builder.declare_with_metadata(
                 "method",
                 &graph_node_id,
@@ -4232,7 +4249,7 @@ impl<'source> DirectAdapterState<'source> {
             .get(&node.id())
             .cloned()
             .unwrap_or_else(|| owner.clone());
-        if node.kind() == "func_literal" && self.go_has_named_parameters(node) {
+        if node.kind() == "func_literal" {
             let parent_scope_id = active.scope_id.clone();
             let scope_id = self.builder.open_scope(
                 "closure",
@@ -4391,32 +4408,6 @@ impl<'source> DirectAdapterState<'source> {
             }
         }
         Ok(())
-    }
-
-    fn go_has_named_parameters(&self, declaration: Node<'_>) -> bool {
-        let Some(parameters) = declaration.child_by_field_name("parameters") else {
-            return false;
-        };
-        let mut parameter_declarations = Vec::new();
-        collect_nodes(
-            parameters,
-            "parameter_declaration",
-            &mut parameter_declarations,
-        );
-        collect_nodes(
-            parameters,
-            "variadic_parameter_declaration",
-            &mut parameter_declarations,
-        );
-        parameter_declarations.into_iter().any(|parameter| {
-            let mut cursor = parameter.walk();
-            parameter
-                .children_by_field_name("name", &mut cursor)
-                .any(|name_node| {
-                    let name = self.text(name_node);
-                    !name.is_empty() && name != "_"
-                })
-        })
     }
 
     fn add_go_imports(
@@ -4794,6 +4785,10 @@ impl<'source> DirectAdapterState<'source> {
         } else {
             (SemanticRole::Call, CandidateRelation::Calls)
         };
+        let argument_count = (self.language == "go")
+            .then(|| call.child_by_field_name("arguments"))
+            .flatten()
+            .and_then(|arguments| u32::try_from(arguments.named_child_count()).ok());
         let binding_name = qualifier.map(qualified_binding_head).unwrap_or(spelling);
         let call_result_binding = if self.language == "go" {
             qualifier
@@ -4875,7 +4870,7 @@ impl<'source> DirectAdapterState<'source> {
                     .or_else(|| Some(self.module_or_package.clone())),
                 scope_id: Some(owner.scope_id.clone()),
                 qualified_name: qualified_name.clone(),
-                argument_count: None,
+                argument_count,
                 argument_types: Vec::new(),
                 allowed_target_kinds: if construction {
                     vec![
@@ -5726,6 +5721,35 @@ fn java_qualified_parent(target: &str) -> Option<&str> {
         .map(|(parent, _)| parent)
 }
 
+fn go_parameter_signature(node: Node<'_>) -> (u32, bool) {
+    let Some(parameters) = node.child_by_field_name("parameters") else {
+        return (0, false);
+    };
+    let mut count = 0_u32;
+    let mut variadic = false;
+    let mut cursor = parameters.walk();
+    for parameter in parameters
+        .children(&mut cursor)
+        .filter(|child| child.is_named())
+    {
+        let is_variadic = parameter.kind() == "variadic_parameter_declaration";
+        if !matches!(
+            parameter.kind(),
+            "parameter_declaration" | "variadic_parameter_declaration"
+        ) {
+            continue;
+        }
+        let mut parameter_cursor = parameter.walk();
+        let names = parameter
+            .children_by_field_name("name", &mut parameter_cursor)
+            .count();
+        let slots = names.max(1);
+        count = count.saturating_add(u32::try_from(slots).unwrap_or(u32::MAX));
+        variadic |= is_variadic;
+    }
+    (count, variadic)
+}
+
 fn last_java_import_name(node: Node<'_>) -> Option<Node<'_>> {
     let mut cursor = node.walk();
     node.children(&mut cursor)
@@ -5981,6 +6005,42 @@ fn rust_path_leaf(path: &str) -> &str {
         .unwrap_or_default()
 }
 
+fn rust_strip_generic_arguments(raw: &str) -> String {
+    let raw = raw.trim();
+    let mut normalized = String::with_capacity(raw.len());
+    let mut angle_depth = 0_u32;
+    for character in raw.chars() {
+        match character {
+            '<' => {
+                if angle_depth == 0 && normalized.ends_with("::") {
+                    normalized.truncate(normalized.len().saturating_sub(2));
+                }
+                angle_depth = angle_depth.saturating_add(1);
+            }
+            '>' if angle_depth > 0 => angle_depth = angle_depth.saturating_sub(1),
+            _ if angle_depth > 0 => {}
+            character => normalized.push(character),
+        }
+    }
+    normalized.trim().trim_end_matches("::").to_owned()
+}
+
+fn rust_normalize_path(raw: &str) -> String {
+    let raw = raw.trim();
+    if let Some(inner) = raw
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        && let Some((type_path, trait_path)) = inner.split_once(" as ")
+    {
+        return format!(
+            "<{} as {}>",
+            rust_strip_generic_arguments(type_path),
+            rust_strip_generic_arguments(trait_path)
+        );
+    }
+    rust_strip_generic_arguments(raw)
+}
+
 fn rust_nominal_type_path(raw: &str) -> Option<String> {
     let mut raw = raw.trim();
     loop {
@@ -6005,12 +6065,12 @@ fn rust_nominal_type_path(raw: &str) -> Option<String> {
     if raw.is_empty() || raw.starts_with(['<', '[', '(']) {
         return None;
     }
-    let nominal = raw.split('<').next().unwrap_or_default().trim();
+    let nominal = rust_normalize_path(raw);
     (!nominal.is_empty()
         && nominal
             .chars()
             .all(|character| character.is_alphanumeric() || matches!(character, '_' | ':')))
-    .then(|| nominal.to_owned())
+    .then_some(nominal)
 }
 
 fn rust_qualified_parent(path: &str) -> Option<&str> {
@@ -6284,14 +6344,14 @@ fn rust_manifest_dependency_aliases(path: &Path) -> HashMap<String, String> {
 }
 
 fn rust_qualify_local_path(module: &str, raw: &str) -> String {
-    let raw = raw.trim().trim_start_matches(['&', '*']);
+    let raw = rust_normalize_path(raw.trim().trim_start_matches(['&', '*']));
     if raw.is_empty() {
         return module.to_owned();
     }
     if raw == "Self" {
         return module.to_owned();
     }
-    rust_canonical_import_target(module, raw)
+    rust_canonical_import_target(module, &raw)
 }
 
 fn rust_qualify_imported_path(
@@ -6300,7 +6360,8 @@ fn rust_qualify_imported_path(
     raw: &str,
     use_start: usize,
 ) -> String {
-    let (qualifier, spelling) = split_qualified(raw);
+    let raw = rust_normalize_path(raw);
+    let (qualifier, spelling) = split_qualified(&raw);
     if let Some(target) = state.imported_target_for_occurrence(
         owner,
         qualifier.map(qualified_binding_head).unwrap_or(spelling),
@@ -6312,7 +6373,7 @@ fn rust_qualify_imported_path(
         }
         return target.clone();
     }
-    state.rust_canonical_import_target(&state.rust_enclosing_module(owner), raw)
+    state.rust_canonical_import_target(&state.rust_enclosing_module(owner), &raw)
 }
 
 fn rust_qualify_evidence_path(
@@ -6321,11 +6382,11 @@ fn rust_qualify_evidence_path(
     raw: &str,
     use_start: usize,
 ) -> Option<String> {
-    let raw = raw.trim().trim_start_matches(['&', '*']);
-    if raw.is_empty() || rust_primitive_type(raw) {
+    let raw = rust_normalize_path(raw.trim().trim_start_matches(['&', '*']));
+    if raw.is_empty() || rust_primitive_type(&raw) {
         return None;
     }
-    let (qualifier, spelling) = split_qualified(raw);
+    let (qualifier, spelling) = split_qualified(&raw);
     let binding_name = qualifier.map(qualified_binding_head).unwrap_or(spelling);
     if let Some(target) = state.imported_target_for_occurrence(owner, binding_name, use_start, true)
     {
@@ -6343,17 +6404,17 @@ fn rust_qualify_evidence_path(
         });
     }
     if matches!(binding_name, "crate" | "self" | "super") {
-        return Some(state.rust_canonical_import_target(&state.rust_enclosing_module(owner), raw));
+        return Some(state.rust_canonical_import_target(&state.rust_enclosing_module(owner), &raw));
     }
     if qualifier.is_some_and(|value| {
         value.contains("::") || value.chars().next().is_some_and(char::is_lowercase)
     }) {
-        let target = state.rust_canonical_import_target(&state.rust_enclosing_module(owner), raw);
+        let target = state.rust_canonical_import_target(&state.rust_enclosing_module(owner), &raw);
         return Some(target);
     }
     Some(rust_join_qualified(
         &state.rust_enclosing_module(owner),
-        raw,
+        &raw,
     ))
 }
 
@@ -7272,6 +7333,23 @@ fn go_local_initializer_with_index_before<'tree>(
     let use_start = use_node.start_byte();
     let mut ancestor = use_node.parent();
     while let Some(scope) = ancestor {
+        let for_initializer = if scope.kind() == "for_clause" {
+            scope.child_by_field_name("initializer")
+        } else if scope.kind() == "for_statement" {
+            let mut cursor = scope.walk();
+            scope
+                .children(&mut cursor)
+                .filter(|child| child.is_named() && child.kind() == "for_clause")
+                .find_map(|clause| clause.child_by_field_name("initializer"))
+        } else {
+            None
+        };
+        if let Some(initializer) = for_initializer
+            && initializer.end_byte() <= use_start
+            && let Some(found) = in_statement(initializer, name, source)
+        {
+            return Some(found);
+        }
         if matches!(scope.kind(), "block" | "statement_list") {
             let mut statements = named_children(scope);
             statements.reverse();

--- a/crates/compass-languages/src/program/rust.rs
+++ b/crates/compass-languages/src/program/rust.rs
@@ -591,14 +591,50 @@ fn add_reason(
 
 fn impl_owner(source: &[u8], node: Node<'_>) -> Option<String> {
     let type_node = node.child_by_field_name("type")?;
-    let owner = text(source, type_node);
+    let owner = normalize_rust_path(text(source, type_node));
     let trait_name = node
         .child_by_field_name("trait")
-        .map(|node| text(source, node));
+        .map(|node| normalize_rust_path(text(source, node)));
     Some(trait_name.map_or_else(
-        || owner.to_owned(),
+        || owner.clone(),
         |trait_name| format!("<{owner} as {trait_name}>"),
     ))
+}
+
+fn normalize_rust_path(raw: &str) -> String {
+    let raw = raw.trim();
+    if let Some(inner) = raw
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        && let Some((type_path, trait_path)) = inner.split_once(" as ")
+    {
+        return format!(
+            "<{} as {}>",
+            strip_rust_generic_arguments(type_path),
+            strip_rust_generic_arguments(trait_path)
+        );
+    }
+    strip_rust_generic_arguments(raw)
+}
+
+fn strip_rust_generic_arguments(raw: &str) -> String {
+    let raw = raw.trim();
+    let mut normalized = String::with_capacity(raw.len());
+    let mut angle_depth = 0_u32;
+    for character in raw.chars() {
+        match character {
+            '<' => {
+                if angle_depth == 0 && normalized.ends_with("::") {
+                    normalized.truncate(normalized.len().saturating_sub(2));
+                }
+                angle_depth = angle_depth.saturating_add(1);
+            }
+            '>' if angle_depth > 0 => angle_depth = angle_depth.saturating_sub(1),
+            _ if angle_depth > 0 => {}
+            character => normalized.push(character),
+        }
+    }
+    normalized.trim().trim_end_matches("::").to_owned()
 }
 
 fn graph_node_id(path: &str, owner: Option<&str>, name: &str) -> String {

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -496,6 +496,46 @@ fn invoke(container: Container<u32>) {
 }
 
 #[test]
+fn rust_turbofish_and_explicit_trait_impl_paths_resolve_exactly() {
+    let source = br#"trait Render<T> {
+    fn render(&self, value: T);
+}
+struct Container<T>(T);
+impl<T> Render<T> for Container<T> {
+    fn render(&self, _value: T) {}
+}
+fn invoke(container: Container<u32>) {
+    Container::<u32>::render(&container, 1);
+    <Container<u32> as Render<u32>>::render(&container, 1);
+}
+"#;
+    let extracted = extract("src/lib.rs", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let render_method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "<crate::Container as crate::Render>::render")
+        .expect("generic Render implementation method");
+
+    for line in ["L9", "L10"] {
+        assert!(
+            resolved.edges.iter().any(|edge| {
+                edge.string("relation") == "calls"
+                    && edge.target == render_method.id
+                    && edge.string("source_location") == line
+            }),
+            "generic call at {line} was not resolved"
+        );
+    }
+}
+
+#[test]
 fn rust_cargo_manifest_resolution_uses_workspace_alias_and_custom_lib_roots()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
@@ -1110,6 +1150,118 @@ func caller(workers ...*Worker) {
         edge.string("relation") == "calls"
             && edge.target == command_name.id
             && edge.string("source_location") == "L15"
+    }));
+}
+
+#[test]
+fn go_for_clause_initializers_and_empty_closures_keep_exact_attribution() {
+    let go_source = br#"package pkg
+type Worker struct{}
+func (worker *Worker) Run() {}
+func (worker *Worker) Parent() *Worker { return nil }
+func caller(worker *Worker) {
+    for current := worker; current != nil; current = current.Parent() {
+        current.Run()
+    }
+    visit := func() {
+        worker.Run()
+    }
+    _ = visit
+}
+"#;
+    let extracted = extract("pkg/caller.go", go_source);
+    let evidence = extracted
+        .semantic_evidence
+        .clone()
+        .expect("Go universal evidence");
+    let sources = HashMap::from([(
+        "pkg/caller.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let worker_run = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.Worker::Run")
+        .expect("Worker.Run declaration");
+    let worker_parent = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.Worker::Parent")
+        .expect("Worker.Parent declaration");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == worker_parent.id
+            && edge.string("source_location") == "L6"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == worker_run.id
+            && edge.string("source_location") == "L7"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == worker_run.id
+            && edge.string("source_location") == "L10"
+    }));
+
+    let closure_scope_ids = evidence
+        .scopes
+        .iter()
+        .filter(|scope| scope.kind == "closure")
+        .map(|scope| scope.id.as_str())
+        .collect::<HashSet<_>>();
+    let empty_closure_call = evidence
+        .occurrences
+        .iter()
+        .find(|occurrence| occurrence.range.start_line == 10 && occurrence.spelling == "Run")
+        .expect("empty closure call occurrence");
+    assert!(
+        empty_closure_call
+            .scope_id
+            .as_deref()
+            .is_some_and(|scope_id| closure_scope_ids.contains(scope_id)),
+        "empty closures must own their call occurrences"
+    );
+}
+
+#[test]
+fn go_variadic_declarations_use_source_arity_for_calls() {
+    let go_source = br#"package pkg
+type Worker struct{}
+func fanout(workers ...*Worker) {}
+func caller(worker *Worker) {
+    fanout(worker, worker)
+}
+"#;
+    let extracted = extract("pkg/caller.go", go_source);
+    let evidence = extracted
+        .semantic_evidence
+        .clone()
+        .expect("Go universal evidence");
+    let fanout = evidence
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "fanout")
+        .expect("variadic declaration");
+    assert_eq!(fanout.parameter_count, Some(1));
+    assert!(fanout.variadic);
+
+    let sources = HashMap::from([(
+        "pkg/caller.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let fanout_node = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.fanout")
+        .expect("fanout node");
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == fanout_node.id
+            && edge.string("source_location") == "L5"
     }));
 }
 


### PR DESCRIPTION
## Summary

This branch now includes the current `origin/main` through merge commit
`20caeff0` and the final publication-path optimization in `16e4a964`.

- Bound extraction-owned AST fact working sets by compacting large nested
  vectors/maps before resolver ownership transfer. The compaction is
  allocation-only and preserves graph facts.
- Keep the incremental publication work from #166: file-only SQLite updates
  reuse unchanged index roots and publish atomically. The default JSON path
  still materializes a canonical full `graph.json`; true byte-range JSON delta
  publication remains the largest unshipped performance opportunity.
- Avoid cloning graph metadata during canonical JSON publication when the V1
  file inventory is already sorted; arbitrary input still takes the existing
  canonicalizing fallback, with a regression test for both paths.
- Harden Go evidence and resolution with source-level callable arity,
  variadic matching, `for`/`for_clause` initializer lookup, and lexical scope
  for every closure, including parameterless closures.
- Harden Rust generic resolution by normalizing generic/turbofish paths and
  explicit `<Type as Trait>::method` paths in universal evidence and Program IR
  ownership.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked` — passed
- Focused Go/Rust evidence, resolver, framework, graph, and core tests — passed
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` — passed at
  `16e4a964`; 967 coverage records, 28 edge kinds, 82 exact routes, and
  deterministic clean/warm/rebuild/restored byte equality. Graph digest:
  `sha256:68de3cac970e79da9ab48c9896b2cc230fd422d254f67551f477937a162072bf`.

## Real-repository qualification

Run `20260804T194006Z` used pinned Cobra, Click, Rayon, and Zod commits with
three repeats. The gate intentionally remains failed because the current
4–5× end-to-end target is not yet met:

| Repository | Cold | Incremental | Warm |
| --- | ---: | ---: | ---: |
| go-cobra | 1.214× | ineligible (Graphify digest changed) | 4.174× |
| python-click | 1.764× | 1.472× | 4.822× |
| rust-rayon | 1.404× | ineligible (Graphify digest changed) | 5.836× |
| ts-zod | 4.012× | 1.726× | 7.909× |

Compass peak RSS remains above Graphify on comparable cold/incremental rows,
especially Rust and Python. The current profile points to cold AST extraction,
typed graph retention, staging/serialization, and JSON publication as the next
performance work.

Graphify mismatch counts in this comparison are comparator hypotheses, not
authoritative Compass omissions: several are caused by different containment,
configuration, or source-anchor policies. The strict in-tree qualification and
source-grounded language tests remain the correctness evidence.

## Remaining opportunities

1. Add a bounded, atomic JSON delta/overlay publication path that preserves the
   `compass.graph/1` canonical artifact contract; the current JSON path still
   rewrites the full graph.
2. Profile and reduce typed graph/cache/staging peak memory without weakening
   validation or generation atomicity.
3. Build source-oracle audits for the remaining Go and Rust relationship classes
   before changing resolver behavior based on Graphify-only differences.

The PR resolves the upstream conflict and is intentionally honest that the
4–5× target remains open rather than claiming the comparator gate passed.
