### PR TITLE
Harden resolver bounds and graph qualification

### DIFF
--- a/benchmarks/performance/compass/correctness.py
+++ b/benchmarks/performance/compass/correctness.py
@@ -73,6 +73,8 @@ class EdgeFact:
     target_fact_key: str
     occurrence_file: str
     occurrence_location: str
+    occurrence_start_byte: int | None
+    occurrence_end_byte: int | None
     payload_sha256: str
 
 
@@ -174,7 +176,7 @@ def _qualified_name(record: dict[str, object]) -> str:
     ).casefold()
 
 
-def _edge_occurrence(record: dict[str, object]) -> tuple[str, str]:
+def _edge_occurrence(record: dict[str, object]) -> tuple[str, str, int | None, int | None]:
     site = record.get("relationshipSite", record.get("relationship_site"))
     nested = site if isinstance(site, dict) else {}
     source_file = _text(record.get("source_file", nested.get("file"))).replace("\\", "/")
@@ -183,7 +185,11 @@ def _edge_occurrence(record: dict[str, object]) -> tuple[str, str]:
         start_line = nested.get("startLine", nested.get("start_line"))
         if isinstance(start_line, int) and start_line > 0:
             source_location = f"L{start_line}"
-    return source_file, source_location
+    start_byte = nested.get("startByte", nested.get("start_byte"))
+    end_byte = nested.get("endByte", nested.get("end_byte"))
+    start_byte = start_byte if type(start_byte) is int and start_byte >= 0 else None
+    end_byte = end_byte if type(end_byte) is int and end_byte >= 0 else None
+    return source_file, source_location, start_byte, end_byte
 
 
 def _shared_relation(tool: str, relation: str) -> str:
@@ -202,7 +208,7 @@ def _shared_relation(tool: str, relation: str) -> str:
 
 
 def _create_schema(database: sqlite3.Connection) -> None:
-    schema_version = 2
+    schema_version = 3
     current = int(database.execute("PRAGMA user_version").fetchone()[0])
     if current != schema_version:
         database.executescript(
@@ -247,6 +253,8 @@ def _create_schema(database: sqlite3.Connection) -> None:
             target_fact_key TEXT NOT NULL,
             occurrence_file TEXT NOT NULL,
             occurrence_location TEXT NOT NULL,
+            occurrence_start_byte INTEGER,
+            occurrence_end_byte INTEGER,
             payload_sha256 TEXT NOT NULL,
             UNIQUE (tool, source, target, relation, payload_sha256)
         );
@@ -418,7 +426,12 @@ def index_graph(
         context = _text(record.get("context"))
         source_fact_key = node_facts.get(source, "")
         target_fact_key = node_facts.get(target, "")
-        occurrence_file, occurrence_location = _edge_occurrence(record)
+        (
+            occurrence_file,
+            occurrence_location,
+            occurrence_start_byte,
+            occurrence_end_byte,
+        ) = _edge_occurrence(record)
         confidence = record.get("confidence")
         if isinstance(confidence, float) and not math.isfinite(confidence):
             raise ValueError(f"{tool} edge has non-finite confidence")
@@ -432,11 +445,13 @@ def index_graph(
                 _text(confidence),
                 occurrence_file,
                 occurrence_location,
+                occurrence_start_byte,
+                occurrence_end_byte,
             )
         )
         before = database.total_changes
         database.execute(
-            "INSERT OR IGNORE INTO edges VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT OR IGNORE INTO edges VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 tool,
                 source,
@@ -448,6 +463,8 @@ def index_graph(
                 target_fact_key,
                 occurrence_file,
                 occurrence_location,
+                occurrence_start_byte,
+                occurrence_end_byte,
                 payload,
             ),
         )
@@ -497,9 +514,11 @@ def canonical_graph_digest(database: sqlite3.Connection, tool: str) -> str:
         ),
         (
             "edge",
-            "SELECT source,target,relation,occurrence_file,occurrence_location,payload_sha256 "
+            "SELECT source,target,relation,occurrence_file,occurrence_location,"
+            "occurrence_start_byte,occurrence_end_byte,payload_sha256 "
             "FROM edges "
-            "WHERE tool = ? ORDER BY source,target,relation,payload_sha256",
+            "WHERE tool = ? ORDER BY source,target,relation,occurrence_file,"
+            "occurrence_location,occurrence_start_byte,occurrence_end_byte,payload_sha256",
         ),
     ):
         for row in database.execute(query, (tool,)):
@@ -554,15 +573,19 @@ def _edge_facts(database: sqlite3.Connection, tool: str) -> list[EdgeFact]:
             target_fact_key=str(row[6]),
             occurrence_file=str(row[7]),
             occurrence_location=str(row[8]),
-            payload_sha256=str(row[9]),
+            occurrence_start_byte=(int(row[9]) if row[9] is not None else None),
+            occurrence_end_byte=(int(row[10]) if row[10] is not None else None),
+            payload_sha256=str(row[11]),
         )
         for row in database.execute(
             """
             SELECT source,target,relation,original_relation,context,
                    source_fact_key,target_fact_key,occurrence_file,
-                   occurrence_location,payload_sha256
+                   occurrence_location,occurrence_start_byte,occurrence_end_byte,
+                   payload_sha256
             FROM edges WHERE tool = ?
-            ORDER BY source,target,relation,occurrence_file,occurrence_location,payload_sha256
+            ORDER BY source,target,relation,occurrence_file,occurrence_location,
+                     occurrence_start_byte,occurrence_end_byte,payload_sha256
             """,
             (tool,),
         )

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -295,6 +295,7 @@ def independent_source_inventory(
         try:
             resolved.relative_to(root)
         except ValueError:
+            rejected.append(path.relative_to(root).as_posix())
             continue
         if resolved.is_file():
             scanned += 1

--- a/benchmarks/performance/harness.py
+++ b/benchmarks/performance/harness.py
@@ -8,6 +8,8 @@ from dataclasses import replace
 from datetime import datetime, timezone
 import hashlib
 import json
+import math
+import multiprocessing
 import os
 from pathlib import Path
 import platform
@@ -304,22 +306,76 @@ def _merge_gates(*reports: GateReport) -> GateReport:
     return GateReport(not issues, issues, ratios)
 
 
+def _shared_graph_gate_child(
+    connection,
+    compass_graph: Path,
+    graphify_graph: Path,
+    source_root: Path,
+) -> None:
+    try:
+        database = sqlite3.connect(":memory:")
+        try:
+            index_graph("compass", compass_graph, database)
+            index_graph("graphify", graphify_graph, database)
+            comparison = compare_graphs(database, source_root)
+        finally:
+            database.close()
+        connection.send({"passed": comparison.passed, "failures": comparison.failures})
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as error:
+        connection.send({"error": str(error)})
+    finally:
+        connection.close()
+
+
 def _shared_graph_gate(
     compass_graph: Path,
     graphify_graph: Path,
     repository: str,
     source_root: Path,
+    timeout_seconds: float,
 ) -> GateReport:
-    database = sqlite3.connect(":memory:")
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise ValueError("graph comparison timeout must be finite and positive")
+    context = multiprocessing.get_context("spawn")
+    parent, child = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_shared_graph_gate_child,
+        args=(child, compass_graph, graphify_graph, source_root),
+    )
+    process.start()
+    child.close()
     try:
-        index_graph("compass", compass_graph, database)
-        index_graph("graphify", graphify_graph, database)
-        comparison = compare_graphs(database, source_root)
+        if not parent.poll(timeout_seconds):
+            process.terminate()
+            process.join()
+            issues = (
+                GateIssue(
+                    "graph-comparison-timeout",
+                    repository,
+                    "cold",
+                    f"graph comparator exceeded {timeout_seconds:g}s",
+                ),
+            )
+            return GateReport(False, issues)
+        payload = parent.recv()
     finally:
-        database.close()
+        parent.close()
+        if process.is_alive():
+            process.terminate()
+        process.join()
+    if "error" in payload:
+        issues = (
+            GateIssue(
+                "graph-comparison-failure",
+                repository,
+                "cold",
+                str(payload["error"]),
+            ),
+        )
+        return GateReport(False, issues)
     issues = tuple(
         GateIssue("graph-quality", repository, "cold", failure)
-        for failure in comparison.failures
+        for failure in payload.get("failures", ())
     )
     return GateReport(not issues, issues)
 
@@ -427,6 +483,7 @@ def qualify(args: argparse.Namespace, *, comparison: bool) -> int:
                         graphify_graph,
                         repository.name,
                         checkout,
+                        args.graph_comparison_timeout,
                     )
                 )
     tools = (compass.revision,) if graphify is None else (compass.revision, graphify.revision)
@@ -530,6 +587,7 @@ def _common(parser: argparse.ArgumentParser, *, execution: bool = False) -> None
         parser.add_argument("--build-repeats", type=int, default=3)
         parser.add_argument("--query-batches", type=int, default=10)
         parser.add_argument("--build-timeout", type=float, default=1800)
+        parser.add_argument("--graph-comparison-timeout", type=float, default=600)
         parser.add_argument("--query-timeout", type=float, default=120)
         parser.add_argument("--baseline", type=Path)
         parser.add_argument(

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -82,6 +82,53 @@ class CorrectnessTests(unittest.TestCase):
             second = index_graph("compass", reordered, database)
         self.assertEqual(first.digest, second.digest)
 
+    def test_anchor_distinct_same_line_edges_are_retained(self) -> None:
+        database = self.database()
+        with tempfile.TemporaryDirectory() as directory:
+            graph = Path(directory) / "graph.json"
+            graph.write_text(
+                '{"graph":{"diagnostics":[]},"nodes":['
+                '{"id":"source","label":"run()","kind":"function",'
+                '"source_file":"main.py","source_location":"L1"},'
+                '{"id":"target","label":"target()","kind":"function",'
+                '"source_file":"main.py","source_location":"L1"}],"links":['
+                '{"source":"source","target":"target","relation":"calls",'
+                '"relationshipSite":{"file":"main.py","startLine":1,'
+                '"startByte":0,"endByte":8}},'
+                '{"source":"source","target":"target","relation":"calls",'
+                '"relationshipSite":{"file":"main.py","startLine":1,'
+                '"startByte":10,"endByte":18}}]}',
+                encoding="utf-8",
+            )
+            summary = index_graph("compass", graph, database)
+
+        self.assertEqual(summary.edges, 2)
+        self.assertEqual(
+            database.execute(
+                "SELECT occurrence_start_byte,occurrence_end_byte FROM edges "
+                "WHERE tool = 'compass' ORDER BY occurrence_start_byte"
+            ).fetchall(),
+            [(0, 8), (10, 18)],
+        )
+
+    def test_source_oracle_rejects_escaped_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "corpus"
+            outside = Path(directory) / "outside.py"
+            root.mkdir()
+            outside.write_text("target()\n", encoding="utf-8")
+            escaped = root / "escaped.py"
+            try:
+                escaped.symlink_to(outside)
+            except (OSError, NotImplementedError) as error:
+                self.skipTest(f"symlinks unavailable: {error}")
+
+            inventory = independent_source_inventory(root, "python")
+
+        self.assertEqual(inventory.scanned_files, 0)
+        self.assertEqual(inventory.parsed_files, 0)
+        self.assertEqual(inventory.rejected_files, ("escaped.py",))
+
     def test_missing_shared_node_fails(self) -> None:
         database = self.database()
         with tempfile.TemporaryDirectory() as directory:

--- a/benchmarks/performance/tests/test_harness.py
+++ b/benchmarks/performance/tests/test_harness.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import unittest
 
 from benchmarks.performance.compass.model import RepositorySpec
 from benchmarks.performance.harness import (
     _existing_ancestor,
+    _shared_graph_gate,
     build_parser,
     requested_repository_commits,
 )
@@ -105,6 +107,19 @@ class HarnessTests(unittest.TestCase):
     def test_disk_check_accepts_a_not_yet_created_workspace(self) -> None:
         missing = Path("/tmp") / "compass-does-not-exist" / "workspace"
         self.assertEqual(Path("/tmp").resolve(), _existing_ancestor(missing))
+
+    def test_shared_graph_gate_reports_bounded_child_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            report = _shared_graph_gate(
+                root / "missing-compass.json",
+                root / "missing-graphify.json",
+                "fixture",
+                root,
+                5,
+            )
+        self.assertFalse(report.passed)
+        self.assertEqual("graph-comparison-failure", report.issues[0].code)
 
 
 if __name__ == "__main__":

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -502,7 +502,8 @@ pub(crate) fn extract_tree_evidence(
     let mut state = DirectAdapterState::new(path, source_file, source, root, profile);
     state.add_file(root)?;
     if root.end_byte() == root.start_byte() {
-        return state.builder.finish();
+        let DirectAdapterState { builder, .. } = state;
+        return builder.finish();
     }
     state.capture_parser_errors(root);
     match profile.language {
@@ -528,7 +529,8 @@ pub(crate) fn extract_tree_evidence(
             "parser recovered from malformed source; emitted evidence remains source-bounded",
         )?;
     }
-    state.builder.finish()
+    let DirectAdapterState { builder, .. } = state;
+    builder.finish()
 }
 
 #[derive(Clone)]

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -182,29 +182,64 @@ impl UniversalResolutionIndex {
         validate_batches: bool,
     ) -> Result<Self, String> {
         let mut profile_started = Instant::now();
-        let go_module_path = read_go_module_path(root);
-        // Reserve the aggregate fact counts before consuming the batches. A
-        // corpus-scale evidence index otherwise grows each primary map by
-        // repeated rehashes while the old and new tables overlap in memory.
-        let capacities = batches.iter().fold([0_usize; 5], |mut counts, batch| {
-            counts[0] = counts[0].saturating_add(batch.declarations.len());
-            counts[1] = counts[1].saturating_add(batch.occurrences.len());
-            counts[2] = counts[2].saturating_add(batch.bindings.len());
-            counts[3] = counts[3].saturating_add(batch.candidates.len());
-            counts[4] = counts[4].saturating_add(batch.scopes.len());
-            counts
-        });
-        let mut declarations = AHashMap::with_capacity(capacities[0]);
-        let mut occurrences = AHashMap::with_capacity(capacities[1]);
-        let mut bindings = AHashMap::with_capacity(capacities[2]);
-        let mut candidates = AHashMap::with_capacity(capacities[3]);
-        let mut scopes = AHashMap::with_capacity(capacities[4]);
         if validate_batches {
             batches.par_iter().try_for_each(|batch| {
                 validate_evidence(batch, EvidenceLimits::default())
                     .map_err(|error| format!("invalid universal evidence: {error}"))
             })?;
         }
+
+        // Check aggregate input sizes before reserving hash-map capacity. A
+        // valid batch is bounded on its own, but an unbounded number of valid
+        // batches could otherwise make the old aggregate reservation attempt
+        // a very large allocation before the resolver's configured limits are
+        // consulted. The scope table has no separate public limit; sharing the
+        // candidate ceiling keeps the public limit shape stable while still
+        // bounding every resolver-owned primary table.
+        let capacities = batches.iter().try_fold(
+            [0_usize; 5],
+            |mut counts, batch| -> Result<[usize; 5], String> {
+                for (index, (name, value)) in [
+                    ("declarations", batch.declarations.len()),
+                    ("occurrences", batch.occurrences.len()),
+                    ("bindings", batch.bindings.len()),
+                    ("candidates", batch.candidates.len()),
+                    ("scopes", batch.scopes.len()),
+                ]
+                .into_iter()
+                .enumerate()
+                {
+                    counts[index] = counts[index].checked_add(value).ok_or_else(|| {
+                        format!("universal aggregate {name} count overflows usize")
+                    })?;
+                }
+                Ok(counts)
+            },
+        )?;
+        for (name, count, limit) in [
+            ("declarations", capacities[0], limits.declarations),
+            ("occurrences", capacities[1], limits.occurrences),
+            ("bindings", capacities[2], limits.bindings),
+            ("candidates", capacities[3], limits.candidates),
+            ("scopes", capacities[4], limits.candidates),
+        ] {
+            if count > limit {
+                return Err(format!(
+                    "universal aggregate {name} count {count} exceeds limit {limit}"
+                ));
+            }
+        }
+
+        let go_module_path = read_go_module_path(root);
+        // Reserve the checked aggregate fact counts before consuming the
+        // batches. A corpus-scale evidence index otherwise grows each primary
+        // map by repeated rehashes while the old and new tables overlap in
+        // memory.
+        let mut declarations = AHashMap::with_capacity(capacities[0]);
+        let mut occurrences = AHashMap::with_capacity(capacities[1]);
+        let mut bindings = AHashMap::with_capacity(capacities[2]);
+        let mut candidates = AHashMap::with_capacity(capacities[3]);
+        let mut scopes = AHashMap::with_capacity(capacities[4]);
         profile_internal("universal evidence validation", &mut profile_started);
         for batch in batches {
             for fact in batch.declarations {
@@ -394,7 +429,7 @@ impl UniversalResolutionIndex {
             values.sort_unstable();
             values.dedup();
             if values.len() > limits.candidates_per_lookup {
-                values.truncate(limits.candidates_per_lookup);
+                values.truncate(candidate_storage_limit(limits.candidates_per_lookup));
             }
         }
         profile_internal("universal source inventory index", &mut profile_started);
@@ -522,7 +557,7 @@ impl UniversalResolutionIndex {
             });
             members.dedup();
             if members.len() > limits.candidates_per_lookup {
-                members.truncate(limits.candidates_per_lookup);
+                members.truncate(candidate_storage_limit(limits.candidates_per_lookup));
             }
         }
         profile_internal("universal hierarchy indices", &mut profile_started);
@@ -547,7 +582,7 @@ impl UniversalResolutionIndex {
             values.sort_unstable();
             values.dedup();
             if values.len() > limits.candidates_per_lookup {
-                values.truncate(limits.candidates_per_lookup);
+                values.truncate(candidate_storage_limit(limits.candidates_per_lookup));
             }
         }
         profile_internal("universal wildcard index", &mut profile_started);
@@ -603,7 +638,7 @@ impl UniversalResolutionIndex {
             .into_iter()
             .map(|(key, mut entries)| {
                 entries.sort_unstable();
-                entries.truncate(limits.candidates_per_lookup);
+                entries.truncate(candidate_storage_limit(limits.candidates_per_lookup));
                 (
                     key,
                     entries.into_iter().map(|(_, _, target)| target).collect(),
@@ -1831,7 +1866,7 @@ impl UniversalResolutionIndex {
         let mut declarations = BTreeSet::<DeclarationSlot>::new();
         for owner_id in owner_ids
             .into_iter()
-            .take(self.limits.candidates_per_lookup)
+            .take(candidate_storage_limit(self.limits.candidates_per_lookup))
         {
             let owner = &self.declaration(owner_id)?.qualified_name;
             if let Some(ids) = self
@@ -1960,7 +1995,7 @@ impl UniversalResolutionIndex {
         }
         declarations
             .into_iter()
-            .take(self.limits.candidates_per_lookup)
+            .take(candidate_storage_limit(self.limits.candidates_per_lookup))
             .collect()
     }
 
@@ -2555,8 +2590,23 @@ fn sort_declaration_index<K: Eq + Hash>(
         });
         values.dedup();
         if values.len() > candidate_limit {
-            values.truncate(candidate_limit);
+            values.truncate(candidate_storage_limit(candidate_limit));
         }
+    }
+}
+
+/// Keep one extra candidate as an overflow marker when an index is bounded.
+///
+/// A lookup is allowed to resolve only when exactly one eligible candidate is
+/// present. Truncating a vector of two candidates to a configured limit of one
+/// erased the evidence that the result was ambiguous and could manufacture a
+/// false unique resolution. The extra slot keeps the operation bounded while
+/// making incompleteness observable to the existing `take(limit + 1)` checks.
+fn candidate_storage_limit(candidate_limit: usize) -> usize {
+    if candidate_limit == 0 {
+        0
+    } else {
+        candidate_limit.saturating_add(1)
     }
 }
 

--- a/crates/compass-resolve/tests/universal_evidence.rs
+++ b/crates/compass-resolve/tests/universal_evidence.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 use compass_graph::{BuildEvidence, normalize_v1};
 use compass_languages::{CandidateRelation, Engine, EvidenceLimits, validate_evidence};
 use compass_model::code_graph::NodeKind;
+use compass_resolve::evidence::{
+    ResolutionDecision, UniversalResolutionIndex, UniversalResolutionLimits,
+};
 use compass_resolve::{resolve, resolve_with_root};
 
 #[test]
@@ -107,6 +110,67 @@ fn ambiguous_owned_scopes_fall_back_to_the_exact_declaration_anchor() -> Result<
             .get("line_end")
             .and_then(serde_json::Value::as_u64),
         Some(3)
+    );
+    Ok(())
+}
+
+#[test]
+fn bounded_universal_indexes_preserve_ambiguous_declarations() -> Result<(), Box<dyn Error>> {
+    let source =
+        b"def target():\n    pass\n\ndef target():\n    pass\n\ndef caller():\n    target()\n";
+    let extraction = Engine::default().extract_source(Path::new("module.py"), source)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing Python semantic evidence")?;
+    let candidate = evidence
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "target"
+        })
+        .ok_or("missing target call candidate")?;
+
+    let index = UniversalResolutionIndex::new(
+        std::slice::from_ref(evidence),
+        UniversalResolutionLimits {
+            candidates_per_lookup: 1,
+            ..UniversalResolutionLimits::default()
+        },
+    )?;
+    assert!(matches!(
+        index.resolve(&candidate.id),
+        ResolutionDecision::Ambiguous { candidate_count: 2 }
+    ));
+    Ok(())
+}
+
+#[test]
+fn aggregate_universal_limits_are_checked_before_reserving_indexes() -> Result<(), Box<dyn Error>> {
+    let mut engine = Engine::default();
+    let left = engine.extract_source(Path::new("left.py"), b"def left():\n    pass\n")?;
+    let right = engine.extract_source(Path::new("right.py"), b"def right():\n    pass\n")?;
+    let batches = [
+        left.semantic_evidence
+            .ok_or("missing left semantic evidence")?,
+        right
+            .semantic_evidence
+            .ok_or("missing right semantic evidence")?,
+    ];
+
+    let error = match UniversalResolutionIndex::new(
+        &batches,
+        UniversalResolutionLimits {
+            declarations: 1,
+            ..UniversalResolutionLimits::default()
+        },
+    ) {
+        Ok(_) => return Err("aggregate declaration limit was not enforced".into()),
+        Err(error) => error,
+    };
+    assert!(
+        error.contains("aggregate declarations count"),
+        "error={error}"
     );
     Ok(())
 }

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -1154,6 +1154,50 @@ func caller(workers ...*Worker) {
 }
 
 #[test]
+fn go_top_level_range_variable_preserves_method_attribution() {
+    let go_source = br#"package pkg
+type Command struct{}
+func (*Command) Commands() []*Command { return nil }
+func (*Command) IsAvailableCommand() bool { return true }
+func (*Command) Name() string { return "" }
+func caller(command *Command) {
+    for _, c := range command.Commands() {
+        if !c.IsAvailableCommand() {
+            continue
+        }
+        _ = c.Name()
+    }
+}
+"#;
+    let extracted = extract("pkg/caller.go", go_source);
+    let sources = HashMap::from([(
+        "pkg/caller.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let command_methods = ["Commands", "IsAvailableCommand", "Name"]
+        .into_iter()
+        .map(|method| {
+            resolved
+                .nodes
+                .iter()
+                .find(|node| node.string("qualified_name") == format!("pkg.Command::{method}"))
+                .unwrap_or_else(|| panic!("Command.{method} declaration"))
+                .id
+                .clone()
+        })
+        .collect::<Vec<_>>();
+
+    for (target, location) in command_methods.into_iter().zip(["L7", "L8", "L11"]) {
+        assert!(resolved.edges.iter().any(|edge| {
+            edge.string("relation") == "calls"
+                && edge.target == target
+                && edge.string("source_location") == location
+        }));
+    }
+}
+
+#[test]
 fn go_for_clause_initializers_and_empty_closures_keep_exact_attribution() {
     let go_source = br#"package pkg
 type Worker struct{}


### PR DESCRIPTION
## What changed

- Preserve one bounded overflow candidate in universal resolver indexes so truncation cannot turn an ambiguous declaration/member/import into a false unique resolution.
- Validate aggregate universal evidence counts, checked for overflow, before reserving resolver hash-map capacity; scope facts share the existing candidate ceiling without changing the public limits shape.
- Preserve relationship-site byte anchors in the qualification comparator so same-line, anchor-distinct edges remain separate in counts, digests, and facts.
- Mark repository-escaping source-oracle symlinks as rejected so completeness fails closed.
- Run graph comparison in a child process with a configurable 600-second deadline and typed timeout/failure gates.

## Why

The merged performance-hardening PR was tree-equivalent to `origin/main`, but fresh pinned qualification found resolver ambiguity risk and an unbounded correctness comparator. These changes make the evidence boundary conservative and make comparison failures bounded and diagnosable.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p compass-resolve --lib --locked -- -D warnings`
- `cargo test -p compass-resolve --tests --locked` (all resolver tests passed)
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` (passed, deterministic graph digest and byte comparisons)
- 81 focused Python qualification tests passed
- Pinned four-repository comparison completed from Compass commit `7696c664` and Graphify commit `00efd6e7`.

The comparison still fails the existing 5× gate and does not establish the user-level 4× goal: cold speedups were 1.18×–3.71×, incremental speedups 1.18×–2.31×, and Compass peak RSS remained above Graphify on comparable cases. Go/Rust Graphify incremental digests remain ineligible due to Graphify instability. This PR makes the measurement safer; it does not claim the performance target is complete.
