### PR TITLE
Harden Go and Rust graph attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   across fully cached edit/restore builds, and improve canonical graph JSON
   publication parallelism for medium and large structural graphs without
   changing serialized bytes.
+- Bound default parallel AST extraction to eight workers to reduce parser
+  working-set multiplication on large repositories. Go multi-result call
+  attribution now preserves indexed return types through ranges and closures;
+  Rust generic trait-bound receivers resolve to their source trait methods,
+  while ambiguous bounds remain unresolved. Universal resolver publication
+  also avoids a duplicate declaration-slot index.
 
 ## 0.3.2 - 2026-08-03
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -220,8 +220,9 @@ Click (Python, 91 files). The run used `extract --code-only --no-cluster
 
 These are diagnostic observations, not promoted baselines or a claim of a
 4×–5× cold-build advantage. Small-project extraction now stays sequential by
-default to avoid multiplying parser/AST working sets; `--max-workers` remains
-the explicit opt-in for parallel extraction. Portable AST cache publication
+default to avoid multiplying parser/AST working sets; large-project extraction
+uses a default cap of 8 local workers so those working sets remain bounded,
+while `--max-workers` remains the explicit override. Portable AST publication
 also streams one compressed value at a time instead of retaining the entire
 compressed batch in memory.
 
@@ -249,6 +250,13 @@ the same graph SHA-256 for all four pinned repositories (`78ef5b7b` Cobra,
 `c25d3b97` Click, `06014539` Rayon, and `f620afe4` Zod). The observed peak RSS
 was 103, 168, 270, and 309 MiB respectively. These are single-run diagnostic
 measurements, not a promoted memory baseline.
+
+On the same 444-file Zod checkout, a release-binary smoke measurement recorded
+about 332 MiB peak RSS with the previous host-sized worker pool, 289 MiB with
+the new default cap of 8 workers, and 257 MiB with an explicit cap of 4. The
+8-worker run retained essentially the previous wall time; the 4-worker run
+was about 0.26 s slower. These are diagnostic measurements on one macOS
+runner, not a cross-platform performance guarantee.
 
 ## Django cold-build regression qualification
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -333,8 +333,9 @@ impl BuildOptions {
             program_analysis: false,
             program_artifacts: Vec::new(),
             program_artifact_limits: compass_program::ArtifactLimits::default(),
-            // Large builds use a local host-sized pool. Keeping this unset also
-            // lets CLI callers provide an explicit memory/throughput bound.
+            // Large builds use a bounded local pool. Keeping this unset uses
+            // the measured memory/throughput default; CLI callers can provide
+            // an explicit bound when their environment needs another tradeoff.
             max_workers: None,
             max_source_bytes: DEFAULT_MAX_SOURCE_BYTES,
             built_at_commit: None,
@@ -1883,8 +1884,9 @@ fn build_graph_inner(
     // A Rayon worker pool costs more resident memory than it saves time on
     // small multilingual projects, where parser-table page residency dominates.
     // Stay sequential below the measured crossover. Larger corpora use an
-    // explicit local pool so an embedding application's global Rayon settings
-    // cannot silently serialize cold extraction.
+    // bounded local pool so an embedding application's global Rayon settings
+    // cannot silently serialize cold extraction or multiply parser working
+    // sets without an explicit opt-in.
     let completed_files = Mutex::new(0_usize);
     let total_files = missing.len();
     let extract_source =
@@ -3681,13 +3683,17 @@ fn write_store_ref(output_dir: &Path, reference: &StoreRef) -> Result<(), CoreEr
 
 #[cfg(target_os = "macos")]
 fn default_ast_workers() -> usize {
-    num_cpus::get().max(num_cpus::get_physical())
+    num_cpus::get()
+        .max(num_cpus::get_physical())
+        .min(DEFAULT_AST_WORKER_CAP)
 }
 
 #[cfg(not(target_os = "macos"))]
 fn default_ast_workers() -> usize {
-    num_cpus::get()
+    num_cpus::get().min(DEFAULT_AST_WORKER_CAP)
 }
+
+const DEFAULT_AST_WORKER_CAP: usize = 8;
 
 fn should_parallel_extract(options: &BuildOptions, missing: usize, sources: usize) -> bool {
     missing >= 256 || sources >= 256 || options.max_workers.is_some_and(|workers| workers > 1)
@@ -6060,6 +6066,12 @@ mod tests {
         options.max_workers = Some(1);
         assert!(!should_parallel_extract(&options, 64, 64));
         assert!(should_parallel_extract(&options, 256, 256));
+    }
+
+    #[test]
+    fn default_ast_workers_stay_within_the_memory_bound() {
+        assert!(default_ast_workers() > 0);
+        assert!(default_ast_workers() <= DEFAULT_AST_WORKER_CAP);
     }
 
     #[test]

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -592,6 +592,8 @@ struct DirectAdapterState<'source> {
     rust_impls: HashMap<usize, RustImplContext>,
     rust_types_by_qualified_name: HashMap<String, DeclarationContext>,
     rust_types_by_name: HashMap<String, Vec<DeclarationContext>>,
+    rust_trait_methods: HashMap<(String, String), Vec<String>>,
+    rust_generic_bounds: HashMap<String, HashMap<String, Vec<String>>>,
     rust_receiver_methods: HashMap<(String, String), Vec<String>>,
     rust_typed_receivers: HashSet<(String, String)>,
     rust_imported_typed_receivers: HashSet<(String, String)>,
@@ -601,11 +603,11 @@ struct DirectAdapterState<'source> {
     rust_test_declarations: HashSet<String>,
     go_lexical_bindings: HashMap<usize, Vec<GoLexicalBinding>>,
     go_call_result_bindings: HashMap<(String, String, usize), String>,
-    go_return_types: HashMap<String, String>,
+    go_return_types: HashMap<String, Vec<Option<String>>>,
     go_member_types: HashMap<(String, String), String>,
     go_collection_element_types: HashMap<String, String>,
     go_collection_binding_element_types: HashMap<String, HashMap<String, String>>,
-    go_range_return_types: HashMap<String, String>,
+    go_range_return_types: HashMap<String, Vec<Option<String>>>,
     go_range_member_types: HashMap<(String, String), String>,
     java_containers: HashMap<usize, DeclarationContext>,
     java_value_types: HashMap<String, HashMap<String, String>>,
@@ -664,6 +666,8 @@ impl<'source> DirectAdapterState<'source> {
             rust_impls: HashMap::new(),
             rust_types_by_qualified_name: HashMap::new(),
             rust_types_by_name: HashMap::new(),
+            rust_trait_methods: HashMap::new(),
+            rust_generic_bounds: HashMap::new(),
             rust_receiver_methods: HashMap::new(),
             rust_typed_receivers: HashSet::new(),
             rust_imported_typed_receivers: HashSet::new(),
@@ -2793,6 +2797,13 @@ impl<'source> DirectAdapterState<'source> {
                 .or_else(|| owner.enclosing_type_qualified_name.clone()),
         };
         self.collect_rust_value_types(node, &context);
+        self.collect_rust_generic_bounds(node, &context);
+        if owner.kind == "trait" {
+            self.rust_trait_methods
+                .entry((owner.qualified_name.clone(), name.clone()))
+                .or_default()
+                .push(qualified_name.clone());
+        }
         if let Some(implementation) = active_impl {
             if let Some(type_owner) = implementation
                 .owner_declaration_id
@@ -2830,6 +2841,48 @@ impl<'source> DirectAdapterState<'source> {
         }
         self.declarations.insert(node.id(), context);
         Ok(())
+    }
+
+    fn collect_rust_generic_bounds(&mut self, callable: Node<'_>, owner: &DeclarationContext) {
+        let Some(parameters) = callable.child_by_field_name("type_parameters") else {
+            return;
+        };
+        let mut parameter_cursor = parameters.walk();
+        for parameter in parameters
+            .children(&mut parameter_cursor)
+            .filter(|child| child.kind() == "type_parameter")
+        {
+            let Some(name_node) = parameter.child_by_field_name("name") else {
+                continue;
+            };
+            let name = self.text(name_node);
+            if name.is_empty() {
+                continue;
+            }
+            let mut bounds = Vec::new();
+            let mut pending = vec![parameter];
+            while let Some(descendant) = pending.pop() {
+                if descendant.kind() == "trait_bound"
+                    && let Some(bound) = rust_trait_bound_path(&self.text(descendant))
+                {
+                    bounds.push(bound);
+                }
+                let mut cursor = descendant.walk();
+                pending.extend(
+                    descendant
+                        .children(&mut cursor)
+                        .filter(|child| child.is_named()),
+                );
+            }
+            bounds.sort_unstable();
+            bounds.dedup();
+            if !bounds.is_empty() {
+                self.rust_generic_bounds
+                    .entry(owner.scope_id.clone())
+                    .or_default()
+                    .insert(name, bounds);
+            }
+        }
     }
 
     fn collect_rust_parameter_bindings(
@@ -3760,10 +3813,17 @@ impl<'source> DirectAdapterState<'source> {
             use_start,
             Some(use_node),
         ) && let Some(nominal_type) = rust_nominal_type_path(raw_type)
-            && let Some(receiver_type) =
-                rust_qualify_evidence_path(self, owner, &nominal_type, use_start)
         {
-            return Some(rust_join_qualified(&receiver_type, spelling));
+            if let Some(method) =
+                self.rust_generic_receiver_method_target(owner, &nominal_type, spelling, use_start)
+            {
+                return Some(method);
+            }
+            if let Some(receiver_type) =
+                rust_qualify_evidence_path(self, owner, &nominal_type, use_start)
+            {
+                return Some(rust_join_qualified(&receiver_type, spelling));
+            }
         }
         if let Some(target) = self.local_target_for(owner, qualifier) {
             if let Some(method) = self.rust_receiver_method_target(target, spelling) {
@@ -3788,6 +3848,63 @@ impl<'source> DirectAdapterState<'source> {
             ));
         }
         Some(rust_join_qualified(qualifier, spelling))
+    }
+
+    fn rust_generic_receiver_method_target(
+        &self,
+        owner: &DeclarationContext,
+        receiver_type: &str,
+        method: &str,
+        use_start: usize,
+    ) -> Option<String> {
+        let mut bounds = Vec::new();
+        let mut scope_id = Some(owner.scope_id.as_str());
+        for _ in 0..64 {
+            let Some(current) = scope_id else {
+                break;
+            };
+            if let Some(values) = self
+                .rust_generic_bounds
+                .get(current)
+                .and_then(|values| values.get(receiver_type))
+            {
+                bounds.extend(
+                    values.iter().filter_map(|bound| {
+                        rust_qualify_evidence_path(self, owner, bound, use_start)
+                    }),
+                );
+                break;
+            }
+            scope_id = self.scope_parents.get(current).map(String::as_str);
+        }
+        bounds.sort_unstable();
+        bounds.dedup();
+        if bounds.is_empty() {
+            return None;
+        }
+
+        let mut targets = bounds
+            .iter()
+            .filter_map(|bound| {
+                self.rust_trait_methods
+                    .get(&(bound.clone(), method.to_owned()))
+                    .and_then(|methods| {
+                        let [target] = methods.as_slice() else {
+                            return None;
+                        };
+                        Some(target.clone())
+                    })
+            })
+            .collect::<Vec<_>>();
+        targets.sort_unstable();
+        targets.dedup();
+        if targets.len() == 1 {
+            return targets.pop();
+        }
+        if bounds.len() == 1 {
+            return Some(rust_join_qualified(&bounds[0], method));
+        }
+        None
     }
 
     fn rust_receiver_method_target(&self, receiver: &str, method: &str) -> Option<String> {
@@ -4149,19 +4266,7 @@ impl<'source> DirectAdapterState<'source> {
                 enclosing_type_qualified_name: None,
             };
             self.add_ownership(file, &context)?;
-            if let Some(result) = node.child_by_field_name("result")
-                && let Some(target) = go_direct_type_target(result)
-                && let Some(qualified_target) = self.go_qualified_type_target(file, target)
-            {
-                self.go_return_types
-                    .insert(context.qualified_name.clone(), qualified_target);
-            }
-            if let Some(result) = node.child_by_field_name("result")
-                && let Some(qualified_target) = self.go_collection_element_type(file, result)
-            {
-                self.go_range_return_types
-                    .insert(context.qualified_name.clone(), qualified_target);
-            }
+            self.record_go_return_types(&context, file, node);
             self.declarations.insert(node.id(), context);
             return Ok(());
         }
@@ -4170,6 +4275,43 @@ impl<'source> DirectAdapterState<'source> {
             self.collect_go_declarations(child, file)?;
         }
         Ok(())
+    }
+
+    fn record_go_return_types(
+        &mut self,
+        declaration: &DeclarationContext,
+        owner: &DeclarationContext,
+        node: Node<'_>,
+    ) {
+        let Some(result) = node.child_by_field_name("result") else {
+            return;
+        };
+        let result_types = go_result_type_nodes(result);
+        if result_types.is_empty() {
+            return;
+        }
+        let direct_types = result_types
+            .iter()
+            .map(|type_node| {
+                type_node
+                    .and_then(go_direct_type_target)
+                    .and_then(|target| self.go_qualified_type_target(owner, target))
+            })
+            .collect::<Vec<_>>();
+        if direct_types.iter().any(Option::is_some) {
+            self.go_return_types
+                .insert(declaration.qualified_name.clone(), direct_types);
+        }
+        let range_types = result_types
+            .iter()
+            .map(|type_node| {
+                type_node.and_then(|type_node| self.go_collection_element_type(owner, type_node))
+            })
+            .collect::<Vec<_>>();
+        if range_types.iter().any(Option::is_some) {
+            self.go_range_return_types
+                .insert(declaration.qualified_name.clone(), range_types);
+        }
     }
 
     fn collect_go_interface_methods(
@@ -4222,19 +4364,7 @@ impl<'source> DirectAdapterState<'source> {
                 enclosing_type_qualified_name: Some(owner.qualified_name.clone()),
             };
             self.add_ownership(owner, &context)?;
-            if let Some(result) = method.child_by_field_name("result")
-                && let Some(target) = go_direct_type_target(result)
-                && let Some(qualified_target) = self.go_qualified_type_target(owner, target)
-            {
-                self.go_return_types
-                    .insert(context.qualified_name.clone(), qualified_target);
-            }
-            if let Some(result) = method.child_by_field_name("result")
-                && let Some(qualified_target) = self.go_collection_element_type(owner, result)
-            {
-                self.go_range_return_types
-                    .insert(context.qualified_name.clone(), qualified_target);
-            }
+            self.record_go_return_types(&context, owner, method);
             self.declarations.insert(method.id(), context);
         }
         Ok(())
@@ -5057,8 +5187,15 @@ impl<'source> DirectAdapterState<'source> {
             .and_then(|range| self.go_range_expression_type(owner, range, depth + 1, visited))
             .or_else(|| self.local_target_for(owner, name).cloned())
             .or_else(|| {
-                let initializer = go_local_initializer_before(use_node, name, self.source)?;
-                self.go_expression_type(owner, initializer, depth + 1, visited)
+                let (initializer, output_index) =
+                    go_local_initializer_with_index_before(use_node, name, self.source)?;
+                self.go_expression_type_at_output(
+                    owner,
+                    initializer,
+                    depth + 1,
+                    visited,
+                    output_index,
+                )
             });
         visited.remove(name);
         result
@@ -5070,6 +5207,17 @@ impl<'source> DirectAdapterState<'source> {
         expression: Node<'_>,
         depth: usize,
         visited: &mut HashSet<String>,
+    ) -> Option<String> {
+        self.go_expression_type_at_output(owner, expression, depth, visited, None)
+    }
+
+    fn go_expression_type_at_output(
+        &self,
+        owner: &DeclarationContext,
+        expression: Node<'_>,
+        depth: usize,
+        visited: &mut HashSet<String>,
+        output_index: Option<u32>,
     ) -> Option<String> {
         if depth >= 8 {
             return None;
@@ -5123,7 +5271,9 @@ impl<'source> DirectAdapterState<'source> {
                     }
                     _ => return None,
                 };
-                self.go_return_types.get(&qualified_callable).cloned()
+                self.go_return_types
+                    .get(&qualified_callable)
+                    .and_then(|types| go_output_type(types, output_index))
             }
             "type_assertion_expression" | "type_assertion" => expression
                 .child_by_field_name("type")
@@ -5139,6 +5289,17 @@ impl<'source> DirectAdapterState<'source> {
         expression: Node<'_>,
         depth: usize,
         visited: &mut HashSet<String>,
+    ) -> Option<String> {
+        self.go_range_expression_type_at_output(owner, expression, depth, visited, None)
+    }
+
+    fn go_range_expression_type_at_output(
+        &self,
+        owner: &DeclarationContext,
+        expression: Node<'_>,
+        depth: usize,
+        visited: &mut HashSet<String>,
+        output_index: Option<u32>,
     ) -> Option<String> {
         if depth >= 8 {
             return None;
@@ -5162,16 +5323,16 @@ impl<'source> DirectAdapterState<'source> {
                         .cloned()
                     })
                     .or_else(|| {
-                        go_local_initializer_before(expression, &name, self.source).and_then(
-                            |initializer| {
-                                self.go_range_expression_type(
+                        go_local_initializer_with_index_before(expression, &name, self.source)
+                            .and_then(|(initializer, output_index)| {
+                                self.go_range_expression_type_at_output(
                                     owner,
                                     initializer,
                                     depth + 1,
                                     visited,
+                                    output_index,
                                 )
-                            },
-                        )
+                            })
                     });
                 visited.remove(&name);
                 result
@@ -5196,7 +5357,9 @@ impl<'source> DirectAdapterState<'source> {
                     }
                     _ => return None,
                 };
-                self.go_range_return_types.get(&qualified_callable).cloned()
+                self.go_range_return_types
+                    .get(&qualified_callable)
+                    .and_then(|types| go_output_type(types, output_index))
             }
             "selector_expression" => {
                 let operand = expression.child_by_field_name("operand")?;
@@ -6073,6 +6236,15 @@ fn rust_nominal_type_path(raw: &str) -> Option<String> {
             .chars()
             .all(|character| character.is_alphanumeric() || matches!(character, '_' | ':')))
     .then_some(nominal)
+}
+
+fn rust_trait_bound_path(raw: &str) -> Option<String> {
+    let raw = raw.trim().trim_start_matches('?').trim();
+    let raw = raw
+        .strip_prefix("for<")
+        .and_then(|value| value.split_once('>').map(|(_, remainder)| remainder))
+        .map_or(raw, str::trim);
+    rust_nominal_type_path(raw)
 }
 
 fn rust_qualified_parent(path: &str) -> Option<&str> {
@@ -7113,6 +7285,43 @@ fn collect_named_targets<'tree>(node: Node<'tree>, kinds: &[&str], output: &mut 
     }
 }
 
+fn go_result_type_nodes<'tree>(result: Node<'tree>) -> Vec<Option<Node<'tree>>> {
+    if result.kind() != "parameter_list" {
+        return vec![Some(result)];
+    }
+    let mut cursor = result.walk();
+    let mut output = Vec::new();
+    for parameter in result
+        .children(&mut cursor)
+        .filter(|child| child.is_named())
+    {
+        if !matches!(
+            parameter.kind(),
+            "parameter_declaration" | "variadic_parameter_declaration"
+        ) {
+            continue;
+        }
+        let mut parameter_cursor = parameter.walk();
+        let name_count = parameter
+            .children_by_field_name("name", &mut parameter_cursor)
+            .count()
+            .max(1);
+        let type_node = parameter.child_by_field_name("type");
+        output.extend(std::iter::repeat_n(type_node, name_count));
+    }
+    output
+}
+
+fn go_output_type(types: &[Option<String>], output_index: Option<u32>) -> Option<String> {
+    if output_index.is_none() && types.len() != 1 {
+        return None;
+    }
+    let index = output_index
+        .and_then(|index| usize::try_from(index).ok())
+        .unwrap_or_default();
+    types.get(index).and_then(Clone::clone)
+}
+
 fn go_direct_type_target(node: Node<'_>) -> Option<Node<'_>> {
     match node.kind() {
         "type_identifier" | "qualified_type" => Some(node),
@@ -7369,14 +7578,6 @@ fn go_local_initializer_with_index_before<'tree>(
         ancestor = scope.parent();
     }
     None
-}
-
-fn go_local_initializer_before<'tree>(
-    use_node: Node<'tree>,
-    name: &str,
-    source: &[u8],
-) -> Option<Node<'tree>> {
-    go_local_initializer_with_index_before(use_node, name, source).map(|(node, _)| node)
 }
 
 fn go_local_type_declaration_before(use_node: Node<'_>, name: &str, source: &[u8]) -> bool {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -261,15 +261,9 @@ impl UniversalResolutionIndex {
         profile_internal("universal fact collection", &mut profile_started);
         let mut declaration_ids = declarations.keys().cloned().collect::<Vec<_>>();
         declaration_ids.sort_unstable();
-        let declaration_slots = declaration_ids
-            .iter()
-            .enumerate()
-            .map(|(index, id)| {
-                u32::try_from(index)
-                    .map(|slot| (id.clone(), slot))
-                    .map_err(|_| "universal declaration slot count exceeds u32".to_owned())
-            })
-            .collect::<Result<AHashMap<_, _>, _>>()?;
+        if u32::try_from(declaration_ids.len()).is_err() {
+            return Err("universal declaration slot count exceeds u32".to_owned());
+        }
         let definition_ranges = unique_definition_ranges(&declarations, &scopes);
         for (name, count, limit) in [
             ("declarations", declarations.len(), limits.declarations),
@@ -288,7 +282,7 @@ impl UniversalResolutionIndex {
                 || {
                     let mut index = AHashMap::<(String, String), Vec<DeclarationSlot>>::new();
                     for declaration in declarations.values() {
-                        let Some(&slot) = declaration_slots.get(&declaration.id) else {
+                        let Some(slot) = declaration_slot(&declaration_ids, &declaration.id) else {
                             continue;
                         };
                         index
@@ -312,7 +306,9 @@ impl UniversalResolutionIndex {
                             let mut index =
                                 AHashMap::<(String, String, String), Vec<DeclarationSlot>>::new();
                             for declaration in declarations.values() {
-                                let Some(&slot) = declaration_slots.get(&declaration.id) else {
+                                let Some(slot) =
+                                    declaration_slot(&declaration_ids, &declaration.id)
+                                else {
                                     continue;
                                 };
                                 let Some(module) = declaration.module_or_package.as_ref() else {
@@ -342,7 +338,8 @@ impl UniversalResolutionIndex {
                                         Vec<DeclarationSlot>,
                                     >::new();
                                     for declaration in declarations.values() {
-                                        let Some(&slot) = declaration_slots.get(&declaration.id)
+                                        let Some(slot) =
+                                            declaration_slot(&declaration_ids, &declaration.id)
                                         else {
                                             continue;
                                         };
@@ -371,7 +368,8 @@ impl UniversalResolutionIndex {
                                         Vec<DeclarationSlot>,
                                     >::new();
                                     for declaration in declarations.values() {
-                                        let Some(&slot) = declaration_slots.get(&declaration.id)
+                                        let Some(slot) =
+                                            declaration_slot(&declaration_ids, &declaration.id)
                                         else {
                                             continue;
                                         };
@@ -530,7 +528,7 @@ impl UniversalResolutionIndex {
         let mut members_by_owner =
             AHashMap::<(String, String, String), Vec<DeclarationSlot>>::new();
         for declaration in declarations.values() {
-            let Some(&slot) = declaration_slots.get(&declaration.id) else {
+            let Some(slot) = declaration_slot(&declaration_ids, &declaration.id) else {
                 continue;
             };
             let Some(owner) = declaration
@@ -2479,6 +2477,13 @@ fn materialized_declaration_ids<'a>(
         }
     }
     ids
+}
+
+fn declaration_slot(declaration_ids: &[String], id: &str) -> Option<DeclarationSlot> {
+    let index = declaration_ids
+        .binary_search_by(|candidate| candidate.as_str().cmp(id))
+        .ok()?;
+    u32::try_from(index).ok()
 }
 
 fn c3_merge(mut sequences: Vec<Vec<String>>, limit: usize) -> Result<Vec<String>, ()> {

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -496,6 +496,101 @@ fn invoke(container: Container<u32>) {
 }
 
 #[test]
+fn rust_generic_trait_bound_receiver_resolves_to_trait_method() {
+    let source = br#"trait Render { fn render(&self); }
+fn invoke<T: Render>(container: T) {
+    container.render();
+}
+"#;
+    let extracted = extract("src/lib.rs", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let render_method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "crate::Render::render")
+        .expect("Render trait method");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == render_method.id
+            && edge.string("source_location") == "L3"
+    }));
+}
+
+#[test]
+fn rust_cross_file_generic_trait_bound_receiver_keeps_imported_trait_owner() {
+    let provider_source = b"pub trait Render { fn render(&self); }\n";
+    let caller_source = b"use crate::api::Render;\nfn invoke<T: Render>(container: T) {\n    container.render();\n}\n";
+    let provider = extract("src/api.rs", provider_source);
+    let caller = extract("src/lib.rs", caller_source);
+    let resolved = compass_resolve::resolve(
+        &[provider, caller],
+        &HashMap::from([
+            (
+                "src/api.rs".to_owned(),
+                String::from_utf8(provider_source.to_vec()).expect("provider source"),
+            ),
+            (
+                "src/lib.rs".to_owned(),
+                String::from_utf8(caller_source.to_vec()).expect("caller source"),
+            ),
+        ]),
+    );
+    let render_method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "crate::api::Render::render")
+        .expect("imported Render trait method");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == render_method.id
+            && edge.string("source_location") == "L3"
+    }));
+}
+
+#[test]
+fn rust_ambiguous_generic_trait_bounds_do_not_choose_an_arbitrary_method() {
+    let source = br#"trait First { fn run(&self); }
+trait Second { fn run(&self); }
+fn invoke<T: First + Second>(value: T) {
+    value.run();
+}
+"#;
+    let extracted = extract("src/lib.rs", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let trait_methods = resolved
+        .nodes
+        .iter()
+        .filter(|node| {
+            matches!(
+                node.string("qualified_name").as_str(),
+                "crate::First::run" | "crate::Second::run"
+            )
+        })
+        .map(|node| node.id.clone())
+        .collect::<HashSet<_>>();
+    assert_eq!(trait_methods.len(), 2);
+    assert!(resolved.edges.iter().all(|edge| {
+        edge.string("relation") != "calls"
+            || edge.string("source_location") != "L4"
+            || !trait_methods.contains(&edge.target)
+    }));
+}
+
+#[test]
 fn rust_turbofish_and_explicit_trait_impl_paths_resolve_exactly() {
     let source = br#"trait Render<T> {
     fn render(&self, value: T);
@@ -1194,6 +1289,57 @@ func caller(command *Command) {
                 && edge.target == target
                 && edge.string("source_location") == location
         }));
+    }
+}
+
+#[test]
+fn go_multi_return_range_inside_closure_preserves_element_method_attribution() {
+    let go_source = br#"package pkg
+type Command struct{}
+func (*Command) Find(args []string) (*Command, []string, error) { return nil, nil, nil }
+func (*Command) Commands() []*Command { return nil }
+func (*Command) IsAvailableCommand() bool { return true }
+func (*Command) Name() string { return "" }
+func caller(command *Command) {
+    visit := func() {
+        cmd, _, _ := command.Find(nil)
+        for _, subCommand := range cmd.Commands() {
+            if subCommand.IsAvailableCommand() {
+                _ = subCommand.Name()
+            }
+        }
+    }
+    _ = visit
+}
+"#;
+    let extracted = extract("pkg/caller.go", go_source);
+    let sources = HashMap::from([(
+        "pkg/caller.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let command_methods = ["Find", "Commands", "IsAvailableCommand", "Name"]
+        .into_iter()
+        .map(|method| {
+            resolved
+                .nodes
+                .iter()
+                .find(|node| node.string("qualified_name") == format!("pkg.Command::{method}"))
+                .unwrap_or_else(|| panic!("Command.{method} declaration"))
+                .id
+                .clone()
+        })
+        .collect::<Vec<_>>();
+
+    for (target, location) in command_methods.into_iter().zip(["L9", "L10", "L11", "L12"]) {
+        assert!(
+            resolved.edges.iter().any(|edge| {
+                edge.string("relation") == "calls"
+                    && edge.target == target
+                    && edge.string("source_location") == location
+            }),
+            "missing Go call at {location}"
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up to merged PR #170.

## Summary
- propagate indexed Go multi-return types through destructuring and range bindings
- attribute Go closure calls from inferred command values
- resolve Rust generic trait-bound receiver calls while preserving ambiguity
- remove the duplicate resolver declaration-slot map
- cap the default AST worker pool at 8 for a bounded memory working set

## Verification
- cargo fmt --all -- --check
- cargo test -p compass-resolve --test universal_resolution --locked (48 passed)
- cargo test -p compass-resolve --test universal_evidence --locked (14 passed)
- cargo test -p compass-core --lib default_ast_workers_stay_within_the_memory_bound --locked
- sh scripts/qualify_code_graph_v1.sh --fixtures-only (passed)
- clean four-repository qualification run completed; cold speed/RSS targets remain documented as follow-up work rather than claimed as met.