### PR TITLE
Harden incremental graph publication and Go/Rust attribution

### DIFF
--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1077,8 +1077,7 @@ fn publish_fact_neutral_incremental(
                 "fact-neutral SQLite publication is missing its prior graph".to_owned(),
             )
         })?;
-        let (metrics, seal) =
-            publish_graph_and_store_file_node_delta(&output_dir, previous, current)?;
+        let (metrics, seal) = publish_graph_and_store_delta(&output_dir, previous, current)?;
         (Some(metrics), Some(seal))
     } else {
         let receipt = write_atomic_with_digest(&graph_path, |writer| {
@@ -1952,7 +1951,7 @@ fn build_graph_inner(
                 graph.error = Some(format!("{language} extraction failed: empty document"));
             }
             compact_extraction(&mut graph);
-            let source = if needs_resolver_source_text {
+            let source = if needs_resolver_source_text && is_php_source_path(&path) {
                 (
                     path.to_string_lossy().into_owned(),
                     String::from_utf8_lossy(&bytes).into_owned(),
@@ -2316,7 +2315,7 @@ fn build_graph_inner(
     let read_cached_source = |path: &PathBuf| {
         if fresh_paths.contains(path) {
             None
-        } else if needs_resolver_source_text {
+        } else if needs_resolver_source_text && is_php_source_path(path) {
             read_source(path)
         } else {
             // Cross-file resolution uses the keys as the complete language
@@ -2529,17 +2528,12 @@ fn build_graph_inner(
         let published_nodes = published.document.nodes.len();
         let published_edges = published.document.links.len();
         let (store_metrics, graph_seal) = if options.graph_storage.publishes_store() {
-            let (metrics, seal) = if let Some(previous) =
-                load_file_node_delta_base(&output_dir, &published.document)
-            {
-                publish_graph_and_store_file_node_delta(
-                    &output_dir,
-                    &previous,
-                    &published.document,
-                )?
-            } else {
-                publish_graph_and_store_from_canonical(&output_dir, &published.document)?
-            };
+            let (metrics, seal) =
+                if let Some(previous) = load_graph_delta_base(&output_dir, &published.document) {
+                    publish_graph_and_store_delta(&output_dir, &previous, &published.document)?
+                } else {
+                    publish_graph_and_store_from_canonical(&output_dir, &published.document)?
+                };
             (Some(metrics), Some(seal))
         } else {
             let graph_path = output_dir.join("graph.json");
@@ -3025,13 +3019,12 @@ fn build_graph_inner(
     let omissions = published.omissions;
     let serialization_started = Instant::now();
     let (store_metrics, graph_seal) = if options.graph_storage.publishes_store() {
-        let (metrics, seal) = if let Some(previous) =
-            load_file_node_delta_base(&output_dir, &published.document)
-        {
-            publish_graph_and_store_file_node_delta(&output_dir, &previous, &published.document)?
-        } else {
-            publish_graph_and_store_from_canonical(&output_dir, &published.document)?
-        };
+        let (metrics, seal) =
+            if let Some(previous) = load_graph_delta_base(&output_dir, &published.document) {
+                publish_graph_and_store_delta(&output_dir, &previous, &published.document)?
+            } else {
+                publish_graph_and_store_from_canonical(&output_dir, &published.document)?
+            };
         (Some(metrics), Some(seal))
     } else {
         let graph_path = output_dir.join("graph.json");
@@ -3509,18 +3502,15 @@ fn ensure_store_snapshot(output_dir: &Path) -> Result<StorePublishMetrics, CoreE
 }
 
 /// Return the previous graph only when the current publication can use the
-/// strict file-node delta path. The check is intentionally cheap and does not
-/// serialize records; the snapshot layer repeats its bounded validation before
-/// touching the active store.
-fn load_file_node_delta_base(
-    output_dir: &Path,
-    current: &V1GraphDocument,
-) -> Option<V1GraphDocument> {
+/// bounded graph-delta path. The check is intentionally cheap and does not
+/// serialize records; the snapshot layer repeats its validation before touching
+/// the active store.
+fn load_graph_delta_base(output_dir: &Path, current: &V1GraphDocument) -> Option<V1GraphDocument> {
     let previous = V1GraphDocument::load(&output_dir.join("graph.json")).ok()?;
-    file_node_delta_candidate(&previous, current).then_some(previous)
+    graph_delta_candidate(&previous, current).then_some(previous)
 }
 
-fn file_node_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocument) -> bool {
+fn graph_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocument) -> bool {
     if previous.directed != current.directed || previous.multigraph != current.multigraph {
         return false;
     }
@@ -3534,25 +3524,22 @@ fn file_node_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocume
         .iter()
         .map(|node| (node.id.as_str(), node))
         .collect::<BTreeMap<_, _>>();
-    if previous_nodes.len() != current_nodes.len() || previous_nodes.keys().ne(current_nodes.keys())
-    {
-        return false;
-    }
-    let mut changed_file = false;
-    for (id, current_node) in &current_nodes {
-        let Some(previous_node) = previous_nodes.get(id) else {
-            return false;
-        };
-        if *previous_node != *current_node {
-            if current_node.kind != NodeKind::File {
-                return false;
-            }
-            changed_file = true;
-        }
-    }
-    if !changed_file {
-        return false;
-    }
+    let changed_nodes = previous_nodes
+        .iter()
+        .filter(|(id, previous_node)| {
+            current_nodes
+                .get(*id)
+                .is_none_or(|current| *current != **previous_node)
+        })
+        .count()
+        + current_nodes
+            .iter()
+            .filter(|(id, current_node)| {
+                previous_nodes
+                    .get(*id)
+                    .is_none_or(|previous| *previous != **current_node)
+            })
+            .count();
     let previous_edges = previous
         .links
         .iter()
@@ -3563,22 +3550,35 @@ fn file_node_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocume
         .iter()
         .map(|edge| (edge.id.as_str(), edge))
         .collect::<BTreeMap<_, _>>();
-    if previous_edges.len() != current_edges.len() || previous_edges != current_edges {
+    let changed_edges = previous_edges
+        .iter()
+        .filter(|(id, previous_edge)| {
+            current_edges
+                .get(*id)
+                .is_none_or(|current| *current != **previous_edge)
+        })
+        .count()
+        + current_edges
+            .iter()
+            .filter(|(id, current_edge)| {
+                previous_edges
+                    .get(*id)
+                    .is_none_or(|previous| *previous != **current_edge)
+            })
+            .count();
+    let changed_records = changed_nodes.saturating_add(changed_edges);
+    let total_records = previous
+        .nodes
+        .len()
+        .saturating_add(previous.links.len())
+        .max(1);
+    if changed_records == 0 {
+        return previous.graph != current.graph;
+    }
+    if changed_records > total_records.saturating_div(4).max(64) {
         return false;
     }
-    let previous_files = previous
-        .graph
-        .files
-        .iter()
-        .map(|file| (file.path.as_str(), file.id.as_str()))
-        .collect::<BTreeMap<_, _>>();
-    let current_files = current
-        .graph
-        .files
-        .iter()
-        .map(|file| (file.path.as_str(), file.id.as_str()))
-        .collect::<BTreeMap<_, _>>();
-    previous_files == current_files
+    true
 }
 
 fn publish_graph_and_store_from_canonical(
@@ -3610,7 +3610,7 @@ fn publish_graph_and_store_from_canonical(
     Ok((metrics, graph_seal))
 }
 
-fn publish_graph_and_store_file_node_delta(
+fn publish_graph_and_store_delta(
     output_dir: &Path,
     previous: &V1GraphDocument,
     graph: &V1GraphDocument,
@@ -3627,7 +3627,7 @@ fn publish_graph_and_store_file_node_delta(
     let canonical = canonical_graph_document_presorted(graph);
     let (graph_receipt, content) = rayon::join(
         || write_json_atomic_with_digest(&graph_path, &canonical),
-        || builder.prepare_file_node_delta(&store, previous, graph),
+        || builder.prepare_graph_delta(&store, previous, graph),
     );
     let graph_receipt = graph_receipt?;
     let graph_seal = ArtifactSeal {
@@ -3697,6 +3697,11 @@ const DEFAULT_AST_WORKER_CAP: usize = 8;
 
 fn should_parallel_extract(options: &BuildOptions, missing: usize, sources: usize) -> bool {
     missing >= 256 || sources >= 256 || options.max_workers.is_some_and(|workers| workers > 1)
+}
+
+fn is_php_source_path(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("php"))
 }
 
 fn semantic_layer_is_empty(layer: &SemanticLayer) -> bool {
@@ -6072,6 +6077,13 @@ mod tests {
     fn default_ast_workers_stay_within_the_memory_bound() {
         assert!(default_ast_workers() > 0);
         assert!(default_ast_workers() <= DEFAULT_AST_WORKER_CAP);
+    }
+
+    #[test]
+    fn resolver_source_text_is_scoped_to_php_files() {
+        assert!(is_php_source_path(Path::new("src/controller.PHP")));
+        assert!(!is_php_source_path(Path::new("src/controller.py")));
+        assert!(!is_php_source_path(Path::new("src/controller")));
     }
 
     #[test]

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1951,7 +1951,7 @@ fn build_graph_inner(
                 graph.error = Some(format!("{language} extraction failed: empty document"));
             }
             compact_extraction(&mut graph);
-            let source = if needs_resolver_source_text && is_php_source_path(&path) {
+            let source = if needs_resolver_source_text && is_php_source_path(path) {
                 (
                     path.to_string_lossy().into_owned(),
                     String::from_utf8_lossy(&bytes).into_owned(),

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -627,6 +627,61 @@ impl GraphSnapshotBuilder {
         })
     }
 
+    /// Prepare a bounded graph delta when an incremental edit changes graph
+    /// records or relationships. Unchanged immutable index trees are reused;
+    /// only indexes whose logical projection depends on changed records are
+    /// rebuilt. This preserves the full graph contract while avoiding a full
+    /// snapshot rewrite for small topology edits.
+    pub fn prepare_graph_delta<S: Store + ?Sized>(
+        &self,
+        store: &S,
+        previous: &GraphDocument,
+        current: &GraphDocument,
+    ) -> Result<PreparedGraphSnapshotContent, SnapshotError> {
+        validate_code_graph(current)
+            .map_err(|error| SnapshotError::Corrupt(format!("graph validation failed: {error}")))?;
+        validate_graph_delta(previous, current)?;
+        let reader = GraphSnapshotReader::open_active(store)?.ok_or_else(|| {
+            SnapshotError::Unsupported("graph delta requires an active snapshot".to_owned())
+        })?;
+        let previous_snapshot_id = snapshot_identity(previous)?;
+        if reader.selector().snapshot_id != previous_snapshot_id
+            || reader.manifest().node_count != previous.nodes.len() as u64
+            || reader.manifest().edge_count != previous.links.len() as u64
+        {
+            return Err(SnapshotError::Corrupt(
+                "active snapshot does not match the previous graph".to_owned(),
+            ));
+        }
+
+        let changed_indexes = graph_delta_indexes(previous, current);
+        if changed_indexes.is_empty() {
+            return Err(SnapshotError::Corrupt(
+                "graph delta contains no changed index projections".to_owned(),
+            ));
+        }
+        let mut writer = ObjectWriter::new(store)?;
+        let mut roots = reader.manifest().roots.clone();
+        for root in &mut roots {
+            if !changed_indexes.contains(&root.index) {
+                continue;
+            }
+            let term_postings =
+                (root.index == IndexKind::Terms).then(|| build_term_postings(current));
+            let entries = build_index(current, root.index, term_postings.as_ref())?;
+            root.entry_count = entries.len() as u64;
+            root.digest = build_index_tree(&mut writer, root.index, entries)?;
+        }
+        let stats = writer.finish()?;
+        Ok(PreparedGraphSnapshotContent {
+            snapshot_id: snapshot_identity(current)?,
+            node_count: current.nodes.len() as u64,
+            edge_count: current.links.len() as u64,
+            roots,
+            stats,
+        })
+    }
+
     /// Bind prepared index content to the digest of the exact compact
     /// canonical JSON bytes and publish the immutable manifest.
     pub fn finish_content<S: Store + ?Sized>(
@@ -2012,6 +2067,47 @@ fn validate_file_node_delta(
         ));
     }
     Ok(())
+}
+
+fn validate_graph_delta(
+    previous: &GraphDocument,
+    current: &GraphDocument,
+) -> Result<(), SnapshotError> {
+    if previous.directed != current.directed || previous.multigraph != current.multigraph {
+        return Err(SnapshotError::Unsupported(
+            "graph delta changed graph directionality".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn graph_delta_indexes(previous: &GraphDocument, current: &GraphDocument) -> BTreeSet<IndexKind> {
+    let mut changed = BTreeSet::new();
+    if previous.graph != current.graph {
+        changed.insert(IndexKind::Metadata);
+    }
+    if previous.graph.files != current.graph.files {
+        changed.insert(IndexKind::Files);
+    }
+
+    let nodes_changed = previous.nodes != current.nodes;
+    if nodes_changed {
+        changed.insert(IndexKind::Nodes);
+        changed.insert(IndexKind::Names);
+        changed.insert(IndexKind::Communities);
+    }
+
+    let links_changed = previous.links != current.links;
+    if links_changed {
+        changed.insert(IndexKind::Edges);
+        changed.insert(IndexKind::Outgoing);
+        changed.insert(IndexKind::Incoming);
+    }
+    if nodes_changed || links_changed {
+        // Alias edges contribute searchable terms for their target nodes.
+        changed.insert(IndexKind::Terms);
+    }
+    changed
 }
 
 fn file_node_index_projection_equal(previous: &NodeRecord, current: &NodeRecord) -> bool {

--- a/crates/compass-graph/tests/store_snapshot.rs
+++ b/crates/compass-graph/tests/store_snapshot.rs
@@ -317,6 +317,84 @@ fn file_node_delta_reuses_unaffected_index_trees() -> Result<(), Box<dyn Error>>
 }
 
 #[test]
+fn graph_delta_rebuilds_relationship_indexes_without_rewriting_nodes() -> Result<(), Box<dyn Error>>
+{
+    let store = MemoryStore::default();
+    let builder = GraphSnapshotBuilder::new();
+    let previous = graph();
+    let first = builder.prepare(&store, &previous)?;
+    builder.activate(&store, &first)?;
+
+    let mut current = previous.clone();
+    current.graph.build.generation_id = "next-generation".to_owned();
+    let mut replacement = current.links.pop().ok_or("relationship missing")?;
+    replacement.source = "b".to_owned();
+    replacement.target = "a".to_owned();
+    replacement.occurrence_rule = OccurrenceRule::new("third");
+    replacement.id = edge_id(
+        &replacement.source,
+        replacement.kind,
+        &replacement.target,
+        replacement.relationship_site.as_ref(),
+        replacement
+            .occurrence_rule
+            .as_ref()
+            .map(OccurrenceRule::as_str),
+    );
+    replacement.key.clone_from(&replacement.id);
+    current.links.push(replacement.clone());
+
+    let content = builder.prepare_graph_delta(&store, &previous, &current)?;
+    let graph_bytes = canonical_graph_json(&current)?;
+    let graph_digest = format!("{:x}", sha2::Sha256::digest(&graph_bytes));
+    let delta = builder.finish_content(&store, content, graph_digest, graph_bytes.len() as u64)?;
+    let first_roots = first
+        .manifest
+        .roots
+        .iter()
+        .map(|root| (root.index, root.digest.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let delta_roots = delta
+        .manifest
+        .roots
+        .iter()
+        .map(|root| (root.index, root.digest.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    for index in [
+        IndexKind::Nodes,
+        IndexKind::Names,
+        IndexKind::Files,
+        IndexKind::Communities,
+        IndexKind::Diagnostics,
+    ] {
+        assert_eq!(
+            first_roots.get(&index),
+            delta_roots.get(&index),
+            "{index:?}"
+        );
+    }
+    for index in [
+        IndexKind::Metadata,
+        IndexKind::Edges,
+        IndexKind::Outgoing,
+        IndexKind::Incoming,
+    ] {
+        assert_ne!(
+            first_roots.get(&index),
+            delta_roots.get(&index),
+            "{index:?}"
+        );
+    }
+
+    builder.activate(&store, &delta)?;
+    let reader = GraphSnapshotReader::open_active(&store)?.ok_or("active snapshot missing")?;
+    assert_eq!(reader.get_edge(&replacement.id)?, Some(replacement));
+    assert_eq!(reader.outgoing("b", limits(4))?.len(), 1);
+    assert_eq!(reader.export_graph()?, graph_sorted_with(&current));
+    Ok(())
+}
+
+#[test]
 fn missing_or_tampered_objects_fail_closed() -> Result<(), Box<dyn Error>> {
     let store = MemoryStore::default();
     let builder = GraphSnapshotBuilder::new();

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -15,6 +15,12 @@ use super::model::{
 };
 use super::validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits, validate_evidence};
 
+// Go selector attribution can cross a closure, a multi-return call, and a
+// range expression before reaching the receiver type. Keep that traversal
+// bounded, but allow the real-world chain without falling back to an
+// unresolved method.
+const GO_TYPE_INFERENCE_DEPTH_LIMIT: usize = 16;
+
 /// Bounded direct-construction API shared by hard-cut language adapters.
 pub struct EvidenceBuilder {
     batch: SemanticEvidenceBatch,
@@ -2844,45 +2850,100 @@ impl<'source> DirectAdapterState<'source> {
     }
 
     fn collect_rust_generic_bounds(&mut self, callable: Node<'_>, owner: &DeclarationContext) {
-        let Some(parameters) = callable.child_by_field_name("type_parameters") else {
-            return;
-        };
-        let mut parameter_cursor = parameters.walk();
-        for parameter in parameters
-            .children(&mut parameter_cursor)
-            .filter(|child| child.kind() == "type_parameter")
-        {
-            let Some(name_node) = parameter.child_by_field_name("name") else {
-                continue;
-            };
-            let name = self.text(name_node);
-            if name.is_empty() {
-                continue;
-            }
-            let mut bounds = Vec::new();
-            let mut pending = vec![parameter];
-            while let Some(descendant) = pending.pop() {
-                if descendant.kind() == "trait_bound"
-                    && let Some(bound) = rust_trait_bound_path(&self.text(descendant))
-                {
-                    bounds.push(bound);
+        if let Some(parameters) = callable.child_by_field_name("type_parameters") {
+            let mut parameter_cursor = parameters.walk();
+            for parameter in parameters
+                .children(&mut parameter_cursor)
+                .filter(|child| child.kind() == "type_parameter")
+            {
+                let Some(name_node) = parameter.child_by_field_name("name") else {
+                    continue;
+                };
+                let name = self.text(name_node);
+                if name.is_empty() {
+                    continue;
                 }
-                let mut cursor = descendant.walk();
-                pending.extend(
-                    descendant
-                        .children(&mut cursor)
-                        .filter(|child| child.is_named()),
-                );
-            }
-            bounds.sort_unstable();
-            bounds.dedup();
-            if !bounds.is_empty() {
-                self.rust_generic_bounds
-                    .entry(owner.scope_id.clone())
-                    .or_default()
-                    .insert(name, bounds);
+                let mut bounds = Vec::new();
+                if let Some(bound_nodes) = parameter.child_by_field_name("bounds") {
+                    self.collect_rust_trait_bound_paths(bound_nodes, &mut bounds);
+                } else {
+                    // Keep compatibility with older Rust grammars that exposed
+                    // bounds as `trait_bound` descendants instead of a
+                    // `trait_bounds` field.
+                    let mut pending = vec![parameter];
+                    while let Some(descendant) = pending.pop() {
+                        if descendant.kind() == "trait_bound"
+                            && let Some(bound) = rust_trait_bound_path(&self.text(descendant))
+                        {
+                            bounds.push(bound);
+                        }
+                        let mut cursor = descendant.walk();
+                        pending.extend(
+                            descendant
+                                .children(&mut cursor)
+                                .filter(|child| child.is_named()),
+                        );
+                    }
+                }
+                self.record_rust_generic_bounds(&owner.scope_id, &name, bounds);
             }
         }
+
+        let mut callable_cursor = callable.walk();
+        for where_clause in callable
+            .children(&mut callable_cursor)
+            .filter(|child| child.kind() == "where_clause")
+        {
+            let mut predicate_cursor = where_clause.walk();
+            for predicate in where_clause
+                .children(&mut predicate_cursor)
+                .filter(|child| child.kind() == "where_predicate")
+            {
+                let Some(left) = predicate.child_by_field_name("left") else {
+                    continue;
+                };
+                let name = self.text(left);
+                if name.is_empty() {
+                    continue;
+                }
+                let Some(bound_nodes) = predicate.child_by_field_name("bounds") else {
+                    continue;
+                };
+                let mut bounds = Vec::new();
+                self.collect_rust_trait_bound_paths(bound_nodes, &mut bounds);
+                self.record_rust_generic_bounds(&owner.scope_id, &name, bounds);
+            }
+        }
+    }
+
+    fn collect_rust_trait_bound_paths(&self, node: Node<'_>, output: &mut Vec<String>) {
+        if matches!(node.kind(), "trait_bound" | "higher_ranked_trait_bound")
+            || rust_is_type_node(node.kind())
+        {
+            if let Some(bound) = rust_trait_bound_path(&self.text(node)) {
+                output.push(bound);
+            }
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+            self.collect_rust_trait_bound_paths(child, output);
+        }
+    }
+
+    fn record_rust_generic_bounds(&mut self, scope_id: &str, name: &str, bounds: Vec<String>) {
+        if name.is_empty() || bounds.is_empty() {
+            return;
+        }
+        let entry = self
+            .rust_generic_bounds
+            .entry(scope_id.to_owned())
+            .or_default()
+            .entry(name.to_owned())
+            .or_default();
+        entry.extend(bounds);
+        entry.sort_unstable();
+        entry.dedup();
     }
 
     fn collect_rust_parameter_bindings(
@@ -3802,28 +3863,30 @@ impl<'source> DirectAdapterState<'source> {
                 .rust_receiver_method_target(enclosing, spelling)
                 .or_else(|| Some(rust_join_qualified(enclosing, spelling)));
         }
+        let generic_receiver_type = self
+            .rust_value_type_for(
+                owner,
+                qualified_binding_head(qualifier),
+                use_start,
+                Some(use_node),
+            )
+            .and_then(rust_nominal_type_path);
+        if let Some(receiver_type) = generic_receiver_type.as_deref()
+            && let Some(method) =
+                self.rust_generic_receiver_method_target(owner, receiver_type, spelling, use_start)
+        {
+            return Some(method);
+        }
         if let Some(receiver_type) =
             self.rust_field_receiver_type(owner, qualifier, use_start, use_node)
         {
             return Some(rust_join_qualified(&receiver_type, spelling));
         }
-        if let Some(raw_type) = self.rust_value_type_for(
-            owner,
-            qualified_binding_head(qualifier),
-            use_start,
-            Some(use_node),
-        ) && let Some(nominal_type) = rust_nominal_type_path(raw_type)
-        {
-            if let Some(method) =
-                self.rust_generic_receiver_method_target(owner, &nominal_type, spelling, use_start)
-            {
-                return Some(method);
-            }
-            if let Some(receiver_type) =
+        if let Some(nominal_type) = generic_receiver_type
+            && let Some(receiver_type) =
                 rust_qualify_evidence_path(self, owner, &nominal_type, use_start)
-            {
-                return Some(rust_join_qualified(&receiver_type, spelling));
-            }
+        {
+            return Some(rust_join_qualified(&receiver_type, spelling));
         }
         if let Some(target) = self.local_target_for(owner, qualifier) {
             if let Some(method) = self.rust_receiver_method_target(target, spelling) {
@@ -5099,7 +5162,7 @@ impl<'source> DirectAdapterState<'source> {
         depth: usize,
         visited: &mut HashSet<String>,
     ) -> Option<String> {
-        if depth >= 8 {
+        if depth >= GO_TYPE_INFERENCE_DEPTH_LIMIT {
             return None;
         }
         match function.kind() {
@@ -5180,7 +5243,7 @@ impl<'source> DirectAdapterState<'source> {
         depth: usize,
         visited: &mut HashSet<String>,
     ) -> Option<String> {
-        if depth >= 8 || !visited.insert(name.to_owned()) {
+        if depth >= GO_TYPE_INFERENCE_DEPTH_LIMIT || !visited.insert(name.to_owned()) {
             return None;
         }
         let result = go_enclosing_range_value(use_node, name, self.source)
@@ -5219,7 +5282,7 @@ impl<'source> DirectAdapterState<'source> {
         visited: &mut HashSet<String>,
         output_index: Option<u32>,
     ) -> Option<String> {
-        if depth >= 8 {
+        if depth >= GO_TYPE_INFERENCE_DEPTH_LIMIT {
             return None;
         }
         match expression.kind() {
@@ -5301,7 +5364,7 @@ impl<'source> DirectAdapterState<'source> {
         visited: &mut HashSet<String>,
         output_index: Option<u32>,
     ) -> Option<String> {
-        if depth >= 8 {
+        if depth >= GO_TYPE_INFERENCE_DEPTH_LIMIT {
             return None;
         }
         match expression.kind() {

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -524,6 +524,75 @@ fn invoke<T: Render>(container: T) {
 }
 
 #[test]
+fn rust_where_clause_generic_receiver_resolves_to_trait_method() {
+    let source = br#"trait IndexedParallelIterator {
+    fn with_producer(&self);
+}
+fn bridge<I>(par_iter: I)
+where
+    I: IndexedParallelIterator,
+{
+    par_iter.with_producer();
+}
+"#;
+    let extracted = extract("src/lib.rs", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "src/lib.rs".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let with_producer = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name") == "crate::IndexedParallelIterator::with_producer"
+        })
+        .expect("IndexedParallelIterator::with_producer trait method");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == with_producer.id
+            && edge.string("source_location") == "L8"
+    }));
+}
+
+#[test]
+fn rust_cross_module_where_clause_generic_receiver_resolves_to_trait_method() {
+    let provider_source = b"pub trait IndexedParallelIterator {\n    fn with_producer(&self);\n}\n";
+    let caller_source = b"use super::IndexedParallelIterator;\nfn bridge<I>(par_iter: I)\nwhere\n    I: IndexedParallelIterator,\n{\n    par_iter.with_producer();\n}\n";
+    let provider = extract("src/iter/mod.rs", provider_source);
+    let caller = extract("src/iter/plumbing/mod.rs", caller_source);
+    let resolved = compass_resolve::resolve(
+        &[provider, caller],
+        &HashMap::from([
+            (
+                "src/iter/mod.rs".to_owned(),
+                String::from_utf8(provider_source.to_vec()).expect("provider source"),
+            ),
+            (
+                "src/iter/plumbing/mod.rs".to_owned(),
+                String::from_utf8(caller_source.to_vec()).expect("caller source"),
+            ),
+        ]),
+    );
+    let with_producer = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name") == "crate::iter::IndexedParallelIterator::with_producer"
+        })
+        .expect("IndexedParallelIterator::with_producer trait method");
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == with_producer.id
+            && edge.string("source_location") == "L6"
+    }));
+}
+
+#[test]
 fn rust_cross_file_generic_trait_bound_receiver_keeps_imported_trait_owner() {
     let provider_source = b"pub trait Render { fn render(&self); }\n";
     let caller_source = b"use crate::api::Render;\nfn invoke<T: Render>(container: T) {\n    container.render();\n}\n";
@@ -1339,6 +1408,127 @@ func caller(command *Command) {
                     && edge.string("source_location") == location
             }),
             "missing Go call at {location}"
+        );
+    }
+}
+
+#[test]
+fn go_cobra_shape_preserves_nested_closure_and_multi_return_method_attribution() {
+    let go_source = br#"package pkg
+type ShellCompDirective int
+type Command struct { helpCommand *Command }
+func (*Command) Root() *Command { return nil }
+func (*Command) Find(args []string) (*Command, []string, error) { return nil, nil, nil }
+func (*Command) Commands() []*Command { return nil }
+func (*Command) IsAvailableCommand() bool { return true }
+func (*Command) Name() string { return "" }
+func (c *Command) initDefaultHelpCmd() {
+    c.helpCommand = &Command{}
+    c.helpCommand.ValidArgsFunction = func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective) {
+        cmd, _, _ := c.Root().Find(args)
+        for _, subCmd := range cmd.Commands() {
+            if subCmd.IsAvailableCommand() || subCmd == cmd.helpCommand {
+                _ = subCmd.Name()
+            }
+        }
+        return nil, 0
+    }
+}
+"#;
+    let extracted = extract("pkg/command.go", go_source);
+    let sources = HashMap::from([(
+        "pkg/command.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let command_methods = ["Root", "Find", "Commands", "IsAvailableCommand", "Name"]
+        .into_iter()
+        .map(|method| {
+            resolved
+                .nodes
+                .iter()
+                .find(|node| node.string("qualified_name") == format!("pkg.Command::{method}"))
+                .unwrap_or_else(|| panic!("Command.{method} declaration"))
+                .id
+                .clone()
+        })
+        .collect::<Vec<_>>();
+
+    for (target, location) in command_methods
+        .into_iter()
+        .zip(["L12", "L12", "L13", "L14", "L15"])
+    {
+        assert!(
+            resolved.edges.iter().any(|edge| {
+                edge.string("relation") == "calls"
+                    && edge.target == target
+                    && edge.string("source_location") == location
+            }),
+            "missing Cobra-shaped Go call at {location}"
+        );
+    }
+}
+
+#[test]
+fn go_cobra_exact_find_guard_preserves_range_element_method_attribution() {
+    let go_source = br#"package pkg
+import "strings"
+type ShellCompDirective int
+type Completion struct{}
+type Command struct {
+    helpCommand *Command
+    ValidArgsFunction func(*Command, []string, string) ([]Completion, ShellCompDirective)
+    Short string
+}
+func (*Command) Root() *Command { return nil }
+func (*Command) Find(args []string) (*Command, []string, error) { return nil, nil, nil }
+func (*Command) Commands() []*Command { return nil }
+func (*Command) IsAvailableCommand() bool { return true }
+func (*Command) Name() string { return "" }
+func (*Command) HasSubCommands() bool { return true }
+func CompletionWithDesc(choice string, description string) Completion { return Completion{} }
+func (c *Command) initDefaultHelpCmd() {
+    if !c.HasSubCommands() { return }
+    if c.helpCommand == nil {
+        c.helpCommand = &Command{
+            ValidArgsFunction: func(c *Command, args []string, toComplete string) ([]Completion, ShellCompDirective) {
+                var completions []Completion
+                cmd, _, e := c.Root().Find(args)
+                if e != nil { return nil, 0 }
+                if cmd == nil { cmd = c.Root() }
+                for _, subCmd := range cmd.Commands() {
+                    if subCmd.IsAvailableCommand() || subCmd == cmd.helpCommand {
+                        if strings.HasPrefix(subCmd.Name(), toComplete) {
+                            completions = append(completions, CompletionWithDesc(subCmd.Name(), subCmd.Short))
+                        }
+                    }
+                }
+                return completions, 0
+            },
+        }
+    }
+}
+"#;
+    let extracted = extract("pkg/command.go", go_source);
+    let sources = HashMap::from([(
+        "pkg/command.go".to_owned(),
+        String::from_utf8(go_source.to_vec()).expect("source"),
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    for method in ["Root", "Find", "Commands", "IsAvailableCommand", "Name"] {
+        let target = resolved
+            .nodes
+            .iter()
+            .find(|node| node.string("qualified_name") == format!("pkg.Command::{method}"))
+            .unwrap_or_else(|| panic!("Command.{method} declaration"))
+            .id
+            .clone();
+        assert!(
+            resolved
+                .edges
+                .iter()
+                .any(|edge| { edge.string("relation") == "calls" && edge.target == target }),
+            "missing Cobra exact-shape Go call to {method}"
         );
     }
 }


### PR DESCRIPTION
Summary: generalized bounded SQLite graph deltas with immutable index-root reuse and safe fallback; scoped resolver source retention to PHP and compacted extraction buffers; hardened bounded Go closure, variadic, multi-return, and range attribution; resolved Rust where-clause generic receiver methods across modules. Verification: focused core, graph, resolver, and evidence tests pass; code-graph qualification passes with 1,535 invariants and deterministic clean/warm/rebuild/restored/checkout outputs; pinned Cobra and Rayon real-repository attribution checks resolve exact definitions. Performance: release cold p50 versus stored Graphify baselines is Go 0.89x, Python 1.71x, Rust 1.72x, TypeScript 4.33x; RSS remains higher. The overall 4-5x target is not met by this PR and is reported explicitly.