### PR TITLE
Harden follow-up extraction and TypeScript graph publication

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -224,7 +224,10 @@ sequential to avoid multiplying parser/AST working sets; the automatic path
 uses a default cap of 8 local workers once that measured crossover is reached,
 while `--max-workers` remains the explicit override. Portable AST publication
 also streams one compressed value at a time instead of retaining the entire
-compressed batch in memory.
+compressed batch in memory. Incremental cache hits now remain in that portable
+representation when loaded by the extraction pipeline, so only freshly
+extracted files pay the source-path normalization walk; the public cache reader
+continues to return its established absolute-path representation.
 
 The same Cobra checkout was cold-built into a fresh SQLite output and then
 received a comment-only edit. The edit extracted 1 file and reused 36 cached

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -219,9 +219,9 @@ Click (Python, 91 files). The run used `extract --code-only --no-cluster
 | Click | 1.47 s | 3,876 | 9,471 |
 
 These are diagnostic observations, not promoted baselines or a claim of a
-4×–5× cold-build advantage. Small-project extraction now stays sequential by
-default to avoid multiplying parser/AST working sets; large-project extraction
-uses a default cap of 8 local workers so those working sets remain bounded,
+4×–5× cold-build advantage. Extraction with fewer than 32 missing files stays
+sequential to avoid multiplying parser/AST working sets; the automatic path
+uses a default cap of 8 local workers once that measured crossover is reached,
 while `--max-workers` remains the explicit override. Portable AST publication
 also streams one compressed value at a time instead of retaining the entire
 compressed batch in memory.
@@ -257,6 +257,25 @@ the new default cap of 8 workers, and 257 MiB with an explicit cap of 4. The
 8-worker run retained essentially the previous wall time; the 4-worker run
 was about 0.26 s slower. These are diagnostic measurements on one macOS
 runner, not a cross-platform performance guarantee.
+
+A follow-up release build from the merged `origin/main` tip was measured with
+three fresh cold processes per repository on the same four pinned corpora. The
+Graphify values are the authoritative three-sample baselines from the pinned
+comparison run; the Compass samples used the compact JSON graph path:
+
+| Repository | Compass p50 | Graphify p50 | Graphify / Compass | Compass RSS p50 | Graphify RSS | Compass graph (nodes / edges) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Cobra | 0.32 s | 0.718 s | 2.24× | 121.00 MiB | 64.53 MiB | 1,206 / 5,711 |
+| Click | 0.54 s | 1.764 s | 3.27× | 181.34 MiB | 99.45 MiB | 3,876 / 9,471 |
+| Rayon | 0.82 s | 2.025 s | 2.47× | 298.38 MiB | 80.95 MiB | 8,563 / 17,941 |
+| Zod | 1.14 s | 4.330 s | 3.80× | 295.44 MiB | 234.62 MiB | 11,058 / 9,644 |
+
+The run is deterministic across all three samples per corpus and no longer
+reports a partial graph for Zod: its recovered TypeScript `implements`
+relationship now targets the structural `ParseInput` type alias. These
+measurements still do not establish the requested 4× speed target for every
+repository or the Graphify RSS gate; the richer typed graph remains the
+correctness priority while publication and resolver costs are reduced.
 
 ## Django cold-build regression qualification
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 
 use ahash::{AHashMap, AHashSet};
 use compass_files::{
-    BuildGuard, BuildScope, Cache, CacheKind, CacheOptions, DetectOptions, Detection, IgnorePolicy,
-    Manifest, ManifestKind, detect, write_atomic_with_digest, write_json_atomic,
+    BuildGuard, BuildScope, Cache, CacheOptions, DetectOptions, Detection, IgnorePolicy, Manifest,
+    ManifestKind, detect, write_atomic_with_digest, write_json_atomic,
     write_json_atomic_with_digest, write_text_atomic,
 };
 use compass_graph::{
@@ -1819,14 +1819,13 @@ fn build_graph_inner(
                 );
                 continue;
             }
-            let cached = cache.load(path, &CacheKind::Ast, None, false)?;
+            let cached = cache.load_portable_ast(path, false)?;
             if let Some(value) = cached {
-                let mut extraction =
+                let extraction =
                     serde_json::from_value(value).map_err(|source| CoreError::InvalidCache {
                         path: path.clone(),
                         source,
                     })?;
-                absolutize_cached_framework_fact_sources(&mut extraction, &root);
                 if cached_framework_evidence_matches(&extraction, path, &project_evidence)
                     && cached_universal_evidence_matches(&extraction, path)
                 {
@@ -2216,11 +2215,12 @@ fn build_graph_inner(
     }
     profile_internal("portable AST ID remapping", &mut internal_started);
     // Continue the cold build from the same portable representation that a
-    // subsequent cache hit will decode. Otherwise absolute origin attributes
-    // can make project-wide declaration merging and edge de-duplication depend
-    // on whether a file was freshly extracted or loaded from the AST cache.
+    // subsequent cache hit will decode. Cache hits already have this
+    // representation; only fresh extractions need the normalization walk.
     for (path, extraction) in ordered_paths.iter().zip(&mut ordered) {
-        prepare_portable_ast_cache_entry(extraction, path, &root);
+        if fresh_paths.contains(path) {
+            prepare_portable_ast_cache_entry(extraction, path, &root);
+        }
     }
     let ast_cache_sources = ordered_paths
         .iter()
@@ -5508,19 +5508,6 @@ fn make_framework_fact_sources_portable(extraction: &mut Extraction, root: &Path
             |_| portable_out_of_root_source(&canonical, root),
             |relative| relative.to_string_lossy().replace('\\', "/"),
         );
-    }
-}
-
-fn absolutize_cached_framework_fact_sources(extraction: &mut Extraction, root: &Path) {
-    for fact in &mut extraction.framework_facts {
-        let source_file = match fact {
-            RawFrameworkFact::Route(route) => &mut route.anchor.source_file,
-            RawFrameworkFact::Domain(domain) => &mut domain.anchor.source_file,
-            RawFrameworkFact::Annotation(annotation) => &mut annotation.anchor.source_file,
-        };
-        if !source_file.is_empty() && !Path::new(source_file).is_absolute() {
-            *source_file = root.join(&*source_file).to_string_lossy().into_owned();
-        }
     }
 }
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -120,7 +120,8 @@ pub struct BuildOptions {
     /// Resource limits for offline program artifacts.
     pub program_artifact_limits: compass_program::ArtifactLimits,
     /// Maximum number of worker threads used by the deterministic AST stages.
-    /// `None` uses the host CPU count in a build-local Rayon pool.
+    /// `None` uses the bounded host CPU count in a build-local Rayon pool once
+    /// enough files are missing to amortize parser-table residency.
     pub max_workers: Option<usize>,
     /// Maximum size of one source file admitted to AST and Program analysis.
     ///
@@ -1864,10 +1865,11 @@ fn build_graph_inner(
     // An explicit worker count is an opt-in performance decision. Honor it
     // even for smaller repositories so callers can trade parser-table
     // residency for throughput instead of silently falling back to the
-    // sequential path below. On small repositories, a single requested worker
-    // remains sequential; it avoids paying for a pool that cannot add
-    // parallelism.
-    let parallel_extraction = should_parallel_extract(options, missing.len(), sources.len());
+    // sequential path below. The automatic path uses the same bounded local
+    // pool once enough missing files exist to amortize parser-table residency.
+    // On small repositories, a single requested worker remains sequential; it
+    // avoids paying for a pool that cannot add parallelism.
+    let parallel_extraction = should_parallel_extract(options, missing.len());
     let worker_pool = if parallel_extraction {
         Some(
             rayon::ThreadPoolBuilder::new()
@@ -1880,12 +1882,11 @@ fn build_graph_inner(
         None
     };
     profile_internal("extract setup and cache load", &mut internal_started);
-    // A Rayon worker pool costs more resident memory than it saves time on
-    // small multilingual projects, where parser-table page residency dominates.
-    // Stay sequential below the measured crossover. Larger corpora use an
-    // bounded local pool so an embedding application's global Rayon settings
-    // cannot silently serialize cold extraction or multiply parser working
-    // sets without an explicit opt-in.
+    // A Rayon worker pool costs more resident memory than it saves time when
+    // only a handful of files are missing. Below the measured crossover stay
+    // sequential; above it use a bounded local pool so an embedding
+    // application's global Rayon settings cannot silently serialize cold
+    // extraction or multiply parser working sets without an explicit opt-in.
     let completed_files = Mutex::new(0_usize);
     let total_files = missing.len();
     let extract_source =
@@ -3694,9 +3695,11 @@ fn default_ast_workers() -> usize {
 }
 
 const DEFAULT_AST_WORKER_CAP: usize = 8;
+const AUTOMATIC_PARALLEL_EXTRACT_MIN_FILES: usize = 32;
 
-fn should_parallel_extract(options: &BuildOptions, missing: usize, sources: usize) -> bool {
-    missing >= 256 || sources >= 256 || options.max_workers.is_some_and(|workers| workers > 1)
+fn should_parallel_extract(options: &BuildOptions, missing: usize) -> bool {
+    missing >= AUTOMATIC_PARALLEL_EXTRACT_MIN_FILES
+        || options.max_workers.is_some_and(|workers| workers > 1)
 }
 
 fn is_php_source_path(path: &Path) -> bool {
@@ -6063,14 +6066,15 @@ mod tests {
     #[test]
     fn explicit_multiple_ast_workers_enable_small_project_parallelism() {
         let mut options = BuildOptions::new(".");
-        assert!(!should_parallel_extract(&options, 64, 64));
+        assert!(!should_parallel_extract(&options, 31));
+        assert!(should_parallel_extract(&options, 32));
 
         options.max_workers = Some(2);
-        assert!(should_parallel_extract(&options, 64, 64));
+        assert!(should_parallel_extract(&options, 1));
 
         options.max_workers = Some(1);
-        assert!(!should_parallel_extract(&options, 64, 64));
-        assert!(should_parallel_extract(&options, 256, 256));
+        assert!(!should_parallel_extract(&options, 31));
+        assert!(should_parallel_extract(&options, 32));
     }
 
     #[test]

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -202,6 +202,29 @@ impl Cache {
         prompt_fingerprint: Option<&str>,
         allow_partial: bool,
     ) -> Result<Option<Value>, FileError> {
+        self.load_with_source_paths(path, kind, prompt_fingerprint, allow_partial, true)
+    }
+
+    /// Load a pipeline-owned AST cache entry without expanding its portable
+    /// source paths. The extraction pipeline keeps these values portable until
+    /// publication, so expanding and then re-normalizing every cached node and
+    /// edge would only add work to incremental builds.
+    pub fn load_portable_ast(
+        &mut self,
+        path: &Path,
+        allow_partial: bool,
+    ) -> Result<Option<Value>, FileError> {
+        self.load_with_source_paths(path, &CacheKind::Ast, None, allow_partial, false)
+    }
+
+    fn load_with_source_paths(
+        &mut self,
+        path: &Path,
+        kind: &CacheKind,
+        prompt_fingerprint: Option<&str>,
+        allow_partial: bool,
+        absolutize_paths: bool,
+    ) -> Result<Option<Value>, FileError> {
         let hash = self.content_hash(path)?;
         let key = self.source_cache_key(path, &hash);
         if deterministic_binary_kind(kind) {
@@ -214,7 +237,9 @@ impl Cache {
                 if !allow_partial && value.get("partial").and_then(Value::as_bool) == Some(true) {
                     return Ok(None);
                 }
-                absolutize_source_files(&mut value, &self.root);
+                if absolutize_paths {
+                    absolutize_source_files(&mut value, &self.root);
+                }
                 return Ok(Some(value));
             }
             return Ok(None);
@@ -225,7 +250,7 @@ impl Cache {
         if !entry.exists() {
             return Ok(None);
         }
-        load_json_value(&entry, allow_partial, &self.root)
+        load_json_value(&entry, allow_partial, &self.root, absolutize_paths)
     }
 
     pub fn save(
@@ -699,6 +724,7 @@ fn load_json_value(
     path: &Path,
     allow_partial: bool,
     root: &Path,
+    absolutize_paths: bool,
 ) -> Result<Option<Value>, FileError> {
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
@@ -711,7 +737,9 @@ fn load_json_value(
     if !allow_partial && value.get("partial").and_then(Value::as_bool) == Some(true) {
         return Ok(None);
     }
-    absolutize_source_files(&mut value, root);
+    if absolutize_paths {
+        absolutize_source_files(&mut value, root);
+    }
     Ok(Some(value))
 }
 

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -474,6 +474,10 @@ fn streaming_portable_ast_batch_round_trips() -> Result<(), Box<dyn Error>> {
     });
 
     cache.write_portable_ast_batch_ref(&[(&source, &portable)])?;
+    assert_eq!(
+        cache.load_portable_ast(&source, false)?,
+        Some(portable.clone())
+    );
     let mut expected = portable;
     expected["nodes"][0]["source_file"] = json!(fs::canonicalize(&source)?.to_string_lossy());
     assert_eq!(

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -834,6 +834,17 @@ where
     W: Write + ?Sized,
     T: Serialize + Sync,
 {
+    // Most small and medium repositories fit in one bounded chunk. Avoid
+    // dispatching a one-chunk array through Rayon: that path cannot overlap
+    // useful work and otherwise pays the global-pool scheduling cost during
+    // the latency-sensitive final publication step.
+    if records.len() <= CANONICAL_RECORD_CHUNK {
+        writer.write_all(b"[")?;
+        if !records.is_empty() {
+            writer.write_all(&encode_canonical_record_chunk(records)?)?;
+        }
+        return writer.write_all(b"]");
+    }
     writer.write_all(b"[")?;
     let mut chunks = records.chunks(CANONICAL_RECORD_CHUNK);
     let mut first = true;

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -939,7 +939,13 @@ fn finalize_prepared_edge(
                 EdgeKind::Embeds | EdgeKind::Extends => target_kind.is_type(),
                 EdgeKind::Implements => matches!(
                     target_kind,
-                    NodeKind::Interface | NodeKind::Trait | NodeKind::Protocol
+                    NodeKind::Interface
+                        | NodeKind::Trait
+                        | NodeKind::Protocol
+                        // TypeScript permits a class to implement a
+                        // structural object type declared through a type
+                        // alias.
+                        | NodeKind::TypeAlias
                 ),
                 _ => false,
             };

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -380,6 +380,62 @@ fn raw_go_embeddings_remain_first_class_v1_relationships() -> Result<(), Box<dyn
     Ok(())
 }
 
+#[test]
+fn raw_typescript_implements_type_alias_remains_a_published_relationship()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut implementation = raw_node(root, "implementation", "ParseInputLazyPath", 10);
+    implementation
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("class"));
+    implementation
+        .attributes
+        .insert("language".to_owned(), json!("typescript"));
+    implementation.attributes.insert(
+        "extractor".to_owned(),
+        json!("compass.languages.typescript"),
+    );
+    let mut contract = raw_node(root, "contract", "ParseInput", 30);
+    contract
+        .attributes
+        .insert("symbol_kind".to_owned(), json!("type_alias"));
+    contract
+        .attributes
+        .insert("language".to_owned(), json!("typescript"));
+    contract.attributes.insert(
+        "extractor".to_owned(),
+        json!("compass.languages.typescript"),
+    );
+    let graph = normalize_v1(
+        Extraction {
+            nodes: vec![implementation, contract],
+            edges: vec![RawEdgeRecord {
+                source: "implementation".to_owned(),
+                target: "contract".to_owned(),
+                attributes: Map::from_iter([
+                    ("relation".to_owned(), json!("implements")),
+                    ("confidence".to_owned(), json!("EXTRACTED")),
+                    (
+                        "extractor".to_owned(),
+                        json!("compass.languages.typescript"),
+                    ),
+                    ("source_anchor".to_owned(), anchor(root, 50)),
+                ]),
+            }],
+            ..Extraction::default()
+        },
+        build_evidence(root)?,
+    )?;
+
+    assert_eq!(graph.links.len(), 1);
+    assert_eq!(graph.links[0].kind, EdgeKind::Implements);
+    assert_eq!(graph.nodes[0].kind, NodeKind::Class);
+    assert_eq!(graph.nodes[1].kind, NodeKind::TypeAlias);
+    assert!(validate_code_graph(&graph).is_ok());
+    Ok(())
+}
+
 fn raw_class_node(
     root: &Path,
     id: &str,

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -609,7 +609,13 @@ fn endpoint_kinds_are_valid(
             source.kind.is_type()
                 && matches!(
                     target.kind,
-                    NodeKind::Interface | NodeKind::Trait | NodeKind::Protocol
+                    NodeKind::Interface
+                        | NodeKind::Trait
+                        | NodeKind::Protocol
+                        // TypeScript permits a class to implement a
+                        // structural object type declared through a type
+                        // alias.
+                        | NodeKind::TypeAlias
                 )
         }
         EdgeKind::TypeOf => is_typed_value(source.kind) && target.kind.is_type(),

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -647,6 +647,27 @@ fn endpoint_matrix_accepts_nested_dynamic_and_database_producer_shapes() {
 }
 
 #[test]
+fn typescript_implements_accepts_a_structural_type_alias() {
+    let mut graph = document();
+    graph.nodes[0].kind = NodeKind::Class;
+    graph.nodes[0].language = Some("typescript".to_owned());
+    graph.nodes[1].kind = NodeKind::TypeAlias;
+    graph.nodes[1].language = Some("typescript".to_owned());
+    graph.links[0].kind = EdgeKind::Implements;
+    let id = edge_id(
+        "route",
+        EdgeKind::Implements,
+        "handler",
+        Some(&anchor()),
+        None,
+    );
+    graph.links[0].id.clone_from(&id);
+    graph.links[0].key = id;
+
+    assert!(validate_code_graph(&graph).is_ok());
+}
+
+#[test]
 fn heuristic_and_ambiguous_provenance_require_auditable_evidence() {
     let invalid = Provenance {
         origin: EvidenceOrigin::Heuristic,


### PR DESCRIPTION
## Summary

- Start automatic AST parallel extraction at the measured 32-missing-file crossover while keeping the bounded default cap of 8 and explicit worker overrides.
- Avoid global Rayon scheduling for one-chunk canonical JSON arrays during latency-sensitive publication.
- Preserve TypeScript `class implements TypeAlias` relationships through both v1 best-effort publication and strict graph validation.
- Document the latest deterministic four-repository Compass/Graphify verification without overstating the 4x target.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- targeted `compass-model`, `compass-graph`, and `compass-core` tests
- targeted Clippy for `compass-core`, `compass-graph`, and `compass-model` with `-D warnings`
- three cold samples each on Cobra, Click, Rayon, and Zod
- deterministic graph digests and no partial-publication diagnostics

PR #173 is already merged into `origin/main`; this follow-up is based directly on that merge and has no unresolved merge conflicts.