### PR TITLE
Optimize warm incremental graph updates

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -225,9 +225,14 @@ uses a default cap of 8 local workers once that measured crossover is reached,
 while `--max-workers` remains the explicit override. Portable AST publication
 also streams one compressed value at a time instead of retaining the entire
 compressed batch in memory. Incremental cache hits now remain in that portable
-representation when loaded by the extraction pipeline, so only freshly
-extracted files pay the source-path normalization walk; the public cache reader
-continues to return its established absolute-path representation.
+representation and decode directly into typed extraction records when loaded
+by the pipeline, so only freshly extracted files pay the source-path
+normalization walk; the public cache reader continues to return its established
+absolute-path representation. The bounded graph-delta candidate check walks
+the already canonical node/link order without allocating full ID maps, and the
+framework resolver skips target-index construction when no framework facts
+exist. These are internal optimizations: the immutable snapshot validator and
+the full graph publication contract remain authoritative.
 
 The same Cobra checkout was cold-built into a fresh SQLite output and then
 received a comment-only edit. The edit extracted 1 file and reused 36 cached

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1819,13 +1819,15 @@ fn build_graph_inner(
                 );
                 continue;
             }
-            let cached = cache.load_portable_ast(path, false)?;
-            if let Some(value) = cached {
-                let extraction =
-                    serde_json::from_value(value).map_err(|source| CoreError::InvalidCache {
-                        path: path.clone(),
-                        source,
-                    })?;
+            let cached =
+                cache.load_portable_ast_typed(path, false, |extraction: &Extraction| {
+                    extraction
+                        .extensions
+                        .get(EXTRACTION_QUALITY_PARTIAL)
+                        .and_then(Value::as_bool)
+                        == Some(true)
+                })?;
+            if let Some(extraction) = cached {
                 if cached_framework_evidence_matches(&extraction, path, &project_evidence)
                     && cached_universal_evidence_matches(&extraction, path)
                 {
@@ -3515,58 +3517,15 @@ fn graph_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocument) 
     if previous.directed != current.directed || previous.multigraph != current.multigraph {
         return false;
     }
-    let previous_nodes = previous
-        .nodes
-        .iter()
-        .map(|node| (node.id.as_str(), node))
-        .collect::<BTreeMap<_, _>>();
-    let current_nodes = current
-        .nodes
-        .iter()
-        .map(|node| (node.id.as_str(), node))
-        .collect::<BTreeMap<_, _>>();
-    let changed_nodes = previous_nodes
-        .iter()
-        .filter(|(id, previous_node)| {
-            current_nodes
-                .get(*id)
-                .is_none_or(|current| *current != **previous_node)
-        })
-        .count()
-        + current_nodes
-            .iter()
-            .filter(|(id, current_node)| {
-                previous_nodes
-                    .get(*id)
-                    .is_none_or(|previous| *previous != **current_node)
-            })
-            .count();
-    let previous_edges = previous
-        .links
-        .iter()
-        .map(|edge| (edge.id.as_str(), edge))
-        .collect::<BTreeMap<_, _>>();
-    let current_edges = current
-        .links
-        .iter()
-        .map(|edge| (edge.id.as_str(), edge))
-        .collect::<BTreeMap<_, _>>();
-    let changed_edges = previous_edges
-        .iter()
-        .filter(|(id, previous_edge)| {
-            current_edges
-                .get(*id)
-                .is_none_or(|current| *current != **previous_edge)
-        })
-        .count()
-        + current_edges
-            .iter()
-            .filter(|(id, current_edge)| {
-                previous_edges
-                    .get(*id)
-                    .is_none_or(|previous| *previous != **current_edge)
-            })
-            .count();
+    // V1 publication sorts both records by stable ID. A merge walk avoids
+    // four BTreeMap allocations on every incremental build while preserving
+    // the same changed-record count. The snapshot layer repeats its complete
+    // validation before applying a delta, so this remains only a cheap
+    // candidate check and never decides graph meaning.
+    let changed_nodes =
+        changed_record_count(&previous.nodes, &current.nodes, |node| node.id.as_str());
+    let changed_edges =
+        changed_record_count(&previous.links, &current.links, |edge| edge.id.as_str());
     let changed_records = changed_nodes.saturating_add(changed_edges);
     let total_records = previous
         .nodes
@@ -3580,6 +3539,60 @@ fn graph_delta_candidate(previous: &V1GraphDocument, current: &V1GraphDocument) 
         return false;
     }
     true
+}
+
+fn changed_record_count<T, F>(previous: &[T], current: &[T], key: F) -> usize
+where
+    T: PartialEq,
+    F: Fn(&T) -> &str,
+{
+    debug_assert!(
+        previous
+            .windows(2)
+            .all(|records| key(&records[0]) <= key(&records[1]))
+    );
+    debug_assert!(
+        current
+            .windows(2)
+            .all(|records| key(&records[0]) <= key(&records[1]))
+    );
+
+    let mut previous_index = 0;
+    let mut current_index = 0;
+    let mut changed = 0;
+    while previous_index < previous.len() || current_index < current.len() {
+        match (previous.get(previous_index), current.get(current_index)) {
+            (Some(previous_record), Some(current_record)) => {
+                match key(previous_record).cmp(key(current_record)) {
+                    std::cmp::Ordering::Less => {
+                        changed += 1;
+                        previous_index += 1;
+                    }
+                    std::cmp::Ordering::Greater => {
+                        changed += 1;
+                        current_index += 1;
+                    }
+                    std::cmp::Ordering::Equal => {
+                        if previous_record != current_record {
+                            changed += 1;
+                        }
+                        previous_index += 1;
+                        current_index += 1;
+                    }
+                }
+            }
+            (Some(_), None) => {
+                changed += previous.len().saturating_sub(previous_index);
+                break;
+            }
+            (None, Some(_)) => {
+                changed += current.len().saturating_sub(current_index);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+    changed
 }
 
 fn publish_graph_and_store_from_canonical(
@@ -6111,6 +6124,20 @@ mod tests {
 
         assert_eq!(before, serde_json::to_value(extraction)?);
         Ok(())
+    }
+
+    #[test]
+    fn graph_delta_change_count_walks_canonical_records() {
+        let previous = [("a", 1_u8), ("c", 1_u8)];
+        let current = [("a", 1_u8), ("b", 1_u8), ("c", 2_u8)];
+        assert_eq!(
+            changed_record_count(&previous, &current, |record| record.0),
+            2
+        );
+        assert_eq!(
+            changed_record_count(&current, &previous, |record| record.0),
+            2
+        );
     }
 
     #[test]

--- a/crates/compass-files/src/cache.rs
+++ b/crates/compass-files/src/cache.rs
@@ -217,6 +217,41 @@ impl Cache {
         self.load_with_source_paths(path, &CacheKind::Ast, None, allow_partial, false)
     }
 
+    /// Load a portable AST cache entry directly into its typed representation.
+    ///
+    /// The compatibility [`Self::load_portable_ast`] API intentionally returns
+    /// a JSON value, but the extraction pipeline immediately deserializes that
+    /// value into its typed extraction. Keeping this typed path beside the
+    /// compatibility API avoids materializing a second full tree of JSON
+    /// values on every warm build. `is_partial` is supplied by the caller so
+    /// this filesystem crate does not need to depend on a language crate.
+    pub fn load_portable_ast_typed<T, F>(
+        &mut self,
+        path: &Path,
+        allow_partial: bool,
+        is_partial: F,
+    ) -> Result<Option<T>, FileError>
+    where
+        T: DeserializeOwned,
+        F: Fn(&T) -> bool,
+    {
+        let hash = self.content_hash(path)?;
+        let key = self.source_cache_key(path, &hash);
+        let entry = self
+            .directory(&CacheKind::Ast, None)
+            .join(format!("{key}.{MESSAGEPACK_EXTENSION}"));
+        let Ok(bytes) = fs::read(entry) else {
+            return Ok(None);
+        };
+        let Some(value) = decode_messagepack::<T>(&bytes) else {
+            return Ok(None);
+        };
+        if !allow_partial && is_partial(&value) {
+            return Ok(None);
+        }
+        Ok(Some(value))
+    }
+
     fn load_with_source_paths(
         &mut self,
         path: &Path,

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -11,8 +11,17 @@ use compass_files::{
     write_text_atomic,
 };
 use compass_files::{FileType, IgnorePolicy};
+use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct PortableAstFixture {
+    nodes: Vec<serde_json::Value>,
+    edges: Vec<serde_json::Value>,
+    #[serde(default)]
+    framework_facts: Vec<serde_json::Value>,
+}
 
 #[test]
 fn database_only_detection_does_not_read_local_files() -> Result<(), Box<dyn Error>> {
@@ -477,6 +486,14 @@ fn streaming_portable_ast_batch_round_trips() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         cache.load_portable_ast(&source, false)?,
         Some(portable.clone())
+    );
+    assert_eq!(
+        cache.load_portable_ast_typed::<PortableAstFixture, _>(&source, false, |_| false)?,
+        Some(PortableAstFixture {
+            nodes: vec![json!({"id":"streamed","source_file":"streamed.rs"})],
+            edges: Vec::new(),
+            framework_facts: Vec::new(),
+        })
     );
     let mut expected = portable;
     expected["nodes"][0]["source_file"] = json!(fs::canonicalize(&source)?.to_string_lossy());

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -65,6 +65,9 @@ pub(crate) fn resolve_framework_facts(
     Result<Vec<ResolvedRoute>, FrameworkResolutionError>,
     Result<Vec<ResolvedDomainFact>, FrameworkResolutionError>,
 ) {
+    if extraction.framework_facts.is_empty() {
+        return (Ok(Vec::new()), Ok(Vec::new()));
+    }
     let targets = target_index::FrameworkTargetIndex::new_with_root(extraction, Some(root));
     join(
         || routes::resolve_routes_with_targets(extraction, limits, &targets, Some(root)),
@@ -74,9 +77,23 @@ pub(crate) fn resolve_framework_facts(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use compass_languages::FrameworkPackRegistry;
+    use compass_languages::{Extraction, FrameworkLimits};
 
     use super::UNIVERSAL_FRAMEWORK_PACKS;
+
+    #[test]
+    fn empty_framework_facts_skip_target_indexing() {
+        let (routes, domains) = super::resolve_framework_facts(
+            &Extraction::default(),
+            FrameworkLimits::default(),
+            Path::new("."),
+        );
+        assert!(routes.is_ok_and(|routes| routes.is_empty()));
+        assert!(domains.is_ok_and(|domains| domains.is_empty()));
+    }
 
     #[test]
     fn every_universal_language_pack_has_one_expansion_adapter() {


### PR DESCRIPTION
## Summary

- Decode portable AST cache entries directly into typed extractions, avoiding the intermediate serde_json::Value tree on warm builds.
- Replace incremental graph-delta candidate BTreeMap construction with a linear walk over canonical node/link order.
- Skip framework target-index construction when the resolved extraction has no framework facts.
- Add contract/unit coverage and document the retained validation/publication boundaries.

## Evidence

- `cargo test -p compass-files --test contracts --locked` (28 passed)
- `cargo test -p compass-core --lib --locked` (48 passed)
- `cargo test -p compass-resolve --lib --test framework_routes --locked` (35 unit + 13 integration passed)
- `cargo clippy -p compass-files --lib --locked -- -D warnings` passed
- `cargo clippy -p compass-core --all-targets --locked -- -D warnings` passed
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` passed: 1,535 invariants and clean/warm/rebuild/alternate-checkout byte comparisons
- Python Click warm-cache A/B produced identical graph SHA-256 (`50f2e69b...`) and identical 3,878-node/9,473-edge output on both binaries.

Resolver all-target clippy remains blocked by pre-existing warnings in unrelated resolver tests and `routes.rs` (`expect_used`, `panic`, `items_after_test_module`); focused resolver tests pass. This PR does not claim the overall 4x cold-build target is met; the richer typed graph and publication contract remain authoritative.