### PR TITLE
Harden Rust generic resolution and canonical graph publication

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -243,8 +243,11 @@ Communities, and Diagnostics roots remain immutable for a file-only change.
 
 The language fixtures cover the remaining attribution gaps directly: Go
 variadic range elements, type assertions, and nested closure parameters now
-resolve to their receiver methods; Rust generic impl calls resolve to the
-exact impl owner both within one file and across an imported module. On the
+resolve to their receiver methods; Rust generic `impl` and struct bounds now
+carry through direct and field receivers, resolving calls to the exact trait
+method while preserving fail-closed ambiguity. Rust generic impl calls also
+resolve to the exact impl owner both within one file and across an imported
+module. On the
 same filtered Graphify Go comparison, exact comparable edges improved from
 1,469 to 1,492 and missing edges fell from 38 to 15. These quality numbers are
 diagnostic and do not imply that all Graphify gaps are closed.
@@ -258,6 +261,17 @@ the same graph SHA-256 for all four pinned repositories (`78ef5b7b` Cobra,
 `c25d3b97` Click, `06014539` Rayon, and `f620afe4` Zod). The observed peak RSS
 was 103, 168, 270, and 309 MiB respectively. These are single-run diagnostic
 measurements, not a promoted memory baseline.
+
+The default SQLite publication path now uses the same bounded canonical graph
+stream as JSON-only publication while the immutable snapshot indexes are built
+in parallel. This removes per-record hashing overhead from the generic serde
+writer without changing the atomic-write, digest, or snapshot contracts. On a
+release-binary A/B smoke run over the pinned Go Cobra, Rust Rayon, and
+TypeScript Zod repositories, the resulting `graph.json` bytes were byte-for-byte
+identical in every comparison; observed internal cold-build wall times were
+0.7 s, 1.1 s, and 1.4 s respectively for the changed path versus 0.6 s, 1.5 s,
+and 1.5 s for the control. Mounted-volume contention makes these diagnostic
+observations rather than a promoted baseline.
 
 On the same 444-file Zod checkout, a release-binary smoke measurement recorded
 about 332 MiB peak RSS with the previous host-sized worker pool, 289 MiB with

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -9,17 +9,16 @@ use std::time::{Duration, Instant};
 use ahash::{AHashMap, AHashSet};
 use compass_files::{
     BuildGuard, BuildScope, Cache, CacheOptions, DetectOptions, Detection, IgnorePolicy, Manifest,
-    ManifestKind, detect, write_atomic_with_digest, write_json_atomic,
-    write_json_atomic_with_digest, write_text_atomic,
+    ManifestKind, detect, write_atomic_with_digest, write_json_atomic, write_text_atomic,
 };
 use compass_graph::{
     BuildEvidence, ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION,
     GRAPH_SNAPSHOT_MAX_OBJECTS, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder,
     GraphSnapshotGcStats, InventoryEvidence, PublicationOmissions, SnapshotSelector, SourceDigest,
-    build_owned_with_tiebreaker as build_document, canonical_edge_kind,
-    canonical_graph_document_presorted, canonical_raw_edge_sites, cluster, deduped_node_count,
-    extraction_from_v1, garbage_collect_graph_snapshots, graph_insights, graph_snapshot_needs_gc,
-    label_communities_by_hub, normalize_document_v1_with_evidence_best_effort_owned,
+    build_owned_with_tiebreaker as build_document, canonical_edge_kind, canonical_raw_edge_sites,
+    cluster, deduped_node_count, extraction_from_v1, garbage_collect_graph_snapshots,
+    graph_insights, graph_snapshot_needs_gc, label_communities_by_hub,
+    normalize_document_v1_with_evidence_best_effort_owned,
     normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
     score_communities, write_canonical_graph_json,
@@ -3608,9 +3607,17 @@ fn publish_graph_and_store_from_canonical(
     let graph_path = output_dir.join("graph.json");
     let store = SqliteStore::open(local_sqlite_store_path(&graph_path))?;
     let builder = GraphSnapshotBuilder::new();
-    let canonical = canonical_graph_document_presorted(graph);
     let (graph_receipt, content) = rayon::join(
-        || write_json_atomic_with_digest(&graph_path, &canonical),
+        || {
+            write_atomic_with_digest(&graph_path, |writer| {
+                write_canonical_graph_json(graph, writer).map_err(|source| {
+                    compass_files::FileError::Io {
+                        path: graph_path.clone(),
+                        source,
+                    }
+                })
+            })
+        },
         || builder.prepare_content(&store, graph),
     );
     let graph_receipt = graph_receipt?;
@@ -3638,9 +3645,17 @@ fn publish_graph_and_store_delta(
     let graph_path = output_dir.join("graph.json");
     let store = SqliteStore::open(local_sqlite_store_path(&graph_path))?;
     let builder = GraphSnapshotBuilder::new();
-    let canonical = canonical_graph_document_presorted(graph);
     let (graph_receipt, content) = rayon::join(
-        || write_json_atomic_with_digest(&graph_path, &canonical),
+        || {
+            write_atomic_with_digest(&graph_path, |writer| {
+                write_canonical_graph_json(graph, writer).map_err(|source| {
+                    compass_files::FileError::Io {
+                        path: graph_path.clone(),
+                        source,
+                    }
+                })
+            })
+        },
         || builder.prepare_graph_delta(&store, previous, graph),
     );
     let graph_receipt = graph_receipt?;

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -2600,6 +2600,7 @@ impl<'source> DirectAdapterState<'source> {
                 enclosing_type_qualified_name: matches!(kind, "trait" | "struct" | "enum")
                     .then_some(qualified_name.clone()),
             };
+            self.collect_rust_generic_bounds_in_scope(node, &context.scope_id);
             self.add_ownership(owner, &context)?;
             self.local_targets
                 .entry(owner.scope_id.clone())
@@ -2850,7 +2851,11 @@ impl<'source> DirectAdapterState<'source> {
     }
 
     fn collect_rust_generic_bounds(&mut self, callable: Node<'_>, owner: &DeclarationContext) {
-        if let Some(parameters) = callable.child_by_field_name("type_parameters") {
+        self.collect_rust_generic_bounds_in_scope(callable, &owner.scope_id);
+    }
+
+    fn collect_rust_generic_bounds_in_scope(&mut self, declaration: Node<'_>, scope_id: &str) {
+        if let Some(parameters) = declaration.child_by_field_name("type_parameters") {
             let mut parameter_cursor = parameters.walk();
             for parameter in parameters
                 .children(&mut parameter_cursor)
@@ -2885,13 +2890,13 @@ impl<'source> DirectAdapterState<'source> {
                         );
                     }
                 }
-                self.record_rust_generic_bounds(&owner.scope_id, &name, bounds);
+                self.record_rust_generic_bounds(scope_id, &name, bounds);
             }
         }
 
-        let mut callable_cursor = callable.walk();
-        for where_clause in callable
-            .children(&mut callable_cursor)
+        let mut declaration_cursor = declaration.walk();
+        for where_clause in declaration
+            .children(&mut declaration_cursor)
             .filter(|child| child.kind() == "where_clause")
         {
             let mut predicate_cursor = where_clause.walk();
@@ -2911,7 +2916,7 @@ impl<'source> DirectAdapterState<'source> {
                 };
                 let mut bounds = Vec::new();
                 self.collect_rust_trait_bound_paths(bound_nodes, &mut bounds);
-                self.record_rust_generic_bounds(&owner.scope_id, &name, bounds);
+                self.record_rust_generic_bounds(scope_id, &name, bounds);
             }
         }
     }
@@ -3086,6 +3091,17 @@ impl<'source> DirectAdapterState<'source> {
             trait_qualified_name: trait_qualified_name.clone(),
             owner_declaration_id: type_context.as_ref().map(|context| context.fact_id.clone()),
         };
+        self.collect_rust_generic_bounds_in_scope(node, &implementation.scope_id);
+        if let Some(type_context) = type_context.as_ref()
+            && let Some(bounds) = self
+                .rust_generic_bounds
+                .get(&type_context.scope_id)
+                .cloned()
+        {
+            for (name, bounds) in bounds {
+                self.record_rust_generic_bounds(&implementation.scope_id, &name, bounds);
+            }
+        }
         if let (Some(type_context), Some(trait_node), Some(trait_qualified_name)) = (
             type_context.as_ref(),
             trait_node,
@@ -3223,6 +3239,29 @@ impl<'source> DirectAdapterState<'source> {
             current = rust_qualify_evidence_path(self, owner, &nominal, use_start)?;
         }
         Some(current)
+    }
+
+    fn rust_field_receiver_nominal_type(
+        &self,
+        owner: &DeclarationContext,
+        qualifier: &str,
+        use_start: usize,
+        use_node: Node<'_>,
+    ) -> Option<String> {
+        let mut fields = qualifier.split('.');
+        let first = fields.next()?.trim();
+        let mut current = if first == "self" {
+            rust_callable_owner(owner)?.to_owned()
+        } else {
+            self.rust_value_type_for(owner, first, use_start, Some(use_node))?
+                .to_owned()
+        };
+        for field in fields.map(str::trim).filter(|field| !field.is_empty()) {
+            let nominal = rust_nominal_type_path(&current)?;
+            let qualified = rust_qualify_evidence_path(self, owner, &nominal, use_start)?;
+            current = self.rust_field_types.get(&qualified)?.get(field)?.clone();
+        }
+        rust_nominal_type_path(&current)
     }
 
     fn collect_rust_parameter_value_types(&mut self, parameters: Node<'_>, scope_id: &str) {
@@ -3874,6 +3913,13 @@ impl<'source> DirectAdapterState<'source> {
         if let Some(receiver_type) = generic_receiver_type.as_deref()
             && let Some(method) =
                 self.rust_generic_receiver_method_target(owner, receiver_type, spelling, use_start)
+        {
+            return Some(method);
+        }
+        if let Some(receiver_type) =
+            self.rust_field_receiver_nominal_type(owner, qualifier, use_start, use_node)
+            && let Some(method) =
+                self.rust_generic_receiver_method_target(owner, &receiver_type, spelling, use_start)
         {
             return Some(method);
         }

--- a/crates/compass-languages/tests/rust_universal_phase2.rs
+++ b/crates/compass-languages/tests/rust_universal_phase2.rs
@@ -364,3 +364,77 @@ enum Event { Local(Local), Remote { value: Remote } }
     }
     Ok(())
 }
+
+#[test]
+fn rust_generic_impl_bounds_resolve_direct_and_field_receivers() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("src/lib.rs"),
+        br#"
+trait Render { fn render(&self); }
+struct Wrapper<T> { value: T }
+impl<T> Wrapper<T>
+where
+    T: Render,
+{
+    fn invoke(&self, value: T) { value.render(); self.value.render(); }
+}
+"#,
+    )?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing Rust semantic evidence")?;
+    validate_evidence(evidence, EvidenceLimits::default())?;
+
+    let calls = evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "render"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2, "calls={calls:#?}");
+    assert!(
+        calls.iter().all(|candidate| {
+            candidate.constraints.qualified_name.as_deref() == Some("crate::Render::render")
+                && !candidate.constraints.allow_external
+        }),
+        "calls={calls:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn rust_struct_generic_bounds_flow_into_inherent_impls() -> Result<(), Box<dyn Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("src/lib.rs"),
+        br#"
+trait Render { fn render(&self); }
+struct Wrapper<T: Render> { value: T }
+impl<T> Wrapper<T> {
+    fn invoke(&self, value: T) { value.render(); self.value.render(); }
+}
+"#,
+    )?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing Rust semantic evidence")?;
+    validate_evidence(evidence, EvidenceLimits::default())?;
+    let calls = evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "render"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2, "calls={calls:#?}");
+    assert!(
+        calls.iter().all(|candidate| {
+            candidate.constraints.qualified_name.as_deref() == Some("crate::Render::render")
+                && !candidate.constraints.allow_external
+        }),
+        "calls={calls:#?}"
+    );
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_evidence.rs
+++ b/crates/compass-resolve/tests/universal_evidence.rs
@@ -345,6 +345,47 @@ fn read(entry: &Entry) { entry.path(); }
 }
 
 #[test]
+fn rust_generic_impl_bound_calls_resolve_to_the_trait_method() -> Result<(), Box<dyn Error>> {
+    let source = br#"
+trait Render { fn render(&self); }
+struct Wrapper<T> { value: T }
+impl<T> Wrapper<T>
+where
+    T: Render,
+{
+    fn invoke(&self, value: T) { value.render(); self.value.render(); }
+}
+"#;
+    let source_file = "src/lib.rs";
+    let extracted = Engine::default().extract_source(Path::new(source_file), source)?;
+    let merged = resolve(
+        &[extracted],
+        &HashMap::from([(source_file.to_owned(), String::from_utf8(source.to_vec())?)]),
+    );
+    let invoke = merged
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "crate::Wrapper::invoke")
+        .ok_or("missing generic impl method")?;
+    let render = merged
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "crate::Render::render")
+        .ok_or("missing trait method")?;
+    let calls = merged
+        .edges
+        .iter()
+        .filter(|edge| edge.source == invoke.id && edge.string("relation") == "calls")
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2, "calls={calls:#?}");
+    assert!(
+        calls.iter().all(|edge| edge.target == render.id),
+        "calls={calls:#?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn rust_import_aliases_resolve_cross_file_types_functions_and_methods() -> Result<(), Box<dyn Error>>
 {
     let mut engine = Engine::default();


### PR DESCRIPTION
## Summary

- Stream default SQLite graph publication through the bounded canonical writer while immutable snapshot indexes build in parallel; A/B checks produced byte-identical graph.json output.
- Propagate Rust generic bounds from struct/type declarations into impl scopes and preserve nominal field receivers, resolving direct and field calls to the exact trait method while remaining fail-closed for ambiguity.
- Add language and resolver regressions and document the diagnostic qualification result.

## Verification

- `cargo test -p compass-languages --test rust_universal_phase2 --locked`
- `cargo test -p compass-resolve --test universal_evidence --locked`
- `cargo test -p compass-core --lib --locked`
- `cargo clippy -p compass-core --all-targets --locked -- -D warnings`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `cargo fmt --all -- --check`
- `sh scripts/check_product_boundary.sh`

PR #175 is already merged into main, so this follow-up is based on the merged tip and has no unresolved conflict.