### PR TITLE
Harden Go/Python attribution and graph assembly performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
   attribution now preserves indexed return types through ranges and closures;
   Rust generic trait-bound receivers resolve to their source trait methods,
   while ambiguous bounds remain unresolved. Universal resolver publication
-  also avoids a duplicate declaration-slot index.
+  also avoids a duplicate declaration-slot index. Python bound-method calls
+  now carry source-proven `self`/`cls` receiver dispatch, while static,
+  rebound, and shadowed receivers fail closed.
 
 ## 0.3.2 - 2026-08-03
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -24,7 +24,8 @@ use compass_graph::{
     normalize_document_v1_with_evidence_best_effort_owned,
     normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
-    score_communities, write_canonical_graph_json, write_fact_neutral_graph_json_delta,
+    score_communities, write_canonical_graph_json,
+    write_fact_neutral_graph_json_delta_prevalidated,
 };
 use compass_languages::{
     BindingFact, DeclarationFact, EXTRACTION_QUALITY_EXTENSION, EXTRACTION_QUALITY_PARTIAL,
@@ -1820,8 +1821,13 @@ fn publish_fact_neutral_incremental(
         let receipt = write_atomic_with_digest(&graph_path, |writer| {
             let delta_started = Instant::now();
             let used_delta = if let Some(bytes) = previous_bytes.as_deref() {
-                write_fact_neutral_graph_json_delta(bytes, current, changed_file_node_ids, writer)
-                    .map_err(|source| compass_files::FileError::Io {
+                write_fact_neutral_graph_json_delta_prevalidated(
+                    bytes,
+                    current,
+                    changed_file_node_ids,
+                    writer,
+                )
+                .map_err(|source| compass_files::FileError::Io {
                     path: graph_path.clone(),
                     source,
                 })?

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::{BufReader, Write};
@@ -28,13 +29,13 @@ use compass_graph::{
 use compass_languages::{
     BindingFact, DeclarationFact, EXTRACTION_QUALITY_EXTENSION, EXTRACTION_QUALITY_PARTIAL,
     EXTRACTION_QUALITY_REASON_EXTENSION, Engine, Extraction, ExtractorKind,
-    FRAMEWORK_PROJECT_EVIDENCE_EXTENSION, OccurrenceFact, ProjectEvidenceIndex, RawEdgeRecord,
-    RawFrameworkFact, RawNodeRecord, Registry, RelationshipCandidate, ResolutionConstraint,
-    ScopeFact, SemanticEvidenceBatch, file_stem, make_id,
+    FRAMEWORK_PROJECT_EVIDENCE_EXTENSION, OccurrenceFact, ProjectEvidenceIndex, RawCall,
+    RawEdgeRecord, RawFrameworkFact, RawNodeRecord, Registry, RelationshipCandidate,
+    ResolutionConstraint, ScopeFact, SemanticEvidenceBatch, file_stem, make_id,
 };
 use compass_model::code_graph::{
-    CommunityMetadata, DiagnosticSeverity, ExtractionStatus, FileNodeDetails, GraphDiagnostic,
-    GraphDocument as V1GraphDocument, NodeDetails, NodeKind,
+    CommunityMetadata, CoverageRecord, DiagnosticSeverity, ExtractionStatus, FileNodeDetails,
+    GraphDiagnostic, GraphDocument as V1GraphDocument, NodeDetails, NodeKind,
 };
 use compass_model::provenance::{
     COALESCED_NODE_EVIDENCE_ATTRIBUTE, CONSUME_INCREMENTAL_ENDPOINT_REMAP_ATTRIBUTE,
@@ -56,9 +57,9 @@ use compass_store::{
     local_sqlite_store_path,
 };
 use rayon::prelude::*;
-use serde::ser::{SerializeMap, SerializeSeq, Serializer};
+use serde::ser::{Error as SerdeError, SerializeMap, SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::build_state::{
@@ -162,7 +163,7 @@ pub enum BuildPurpose {
 
 const OUTPUT_STATS_FILE: &str = ".compass_output_stats.json";
 const AST_FACT_DIGESTS_FILE: &str = ".compass_ast_fact_digests.json";
-const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/2";
+const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/3";
 const MAX_AST_FACT_DIGEST_ENTRIES: usize = 100_000;
 const MAX_AST_FACT_DIGEST_FILE_BYTES: usize = 16 * 1024 * 1024;
 const GRAPH_OVERVIEW_FILE: &str = "graph-overview.json";
@@ -402,7 +403,7 @@ fn build_profile_digest(profile: &BuildProfile, output_dir: &Path) -> Result<Str
         source,
     })?;
     let mut digest = Sha256::new();
-    digest.update(b"compass.ast-fact-digests/profile/2");
+    digest.update(b"compass.ast-fact-digests/profile/3");
     digest.update([0]);
     for component in [
         compass_model::code_graph::CODE_GRAPH_SCHEMA_V1,
@@ -470,6 +471,98 @@ impl Write for ExtractionDigestWriter {
     }
 }
 
+/// Serialize JSON object keys in lexical order for digesting.
+///
+/// `serde_json` is configured with `preserve_order` in this workspace. That
+/// is useful when round-tripping user-facing JSON, but it means an equivalent
+/// map can acquire a different byte representation after a cache load. Fact
+/// digests describe semantic extraction, so map insertion order must not be
+/// part of their identity.
+fn compare_fact_values(left: &Value, right: &Value) -> Ordering {
+    fn kind(value: &Value) -> u8 {
+        match value {
+            Value::Null => 0,
+            Value::Bool(_) => 1,
+            Value::Number(_) => 2,
+            Value::String(_) => 3,
+            Value::Array(_) => 4,
+            Value::Object(_) => 5,
+        }
+    }
+
+    let kind_order = kind(left).cmp(&kind(right));
+    if kind_order != Ordering::Equal {
+        return kind_order;
+    }
+    match (left, right) {
+        (Value::Null, Value::Null) => Ordering::Equal,
+        (Value::Bool(left), Value::Bool(right)) => left.cmp(right),
+        (Value::Number(left), Value::Number(right)) => left.to_string().cmp(&right.to_string()),
+        (Value::String(left), Value::String(right)) => left.cmp(right),
+        (Value::Array(left), Value::Array(right)) => left
+            .iter()
+            .zip(right)
+            .map(|(left, right)| compare_fact_values(left, right))
+            .find(|order| *order != Ordering::Equal)
+            .unwrap_or_else(|| left.len().cmp(&right.len())),
+        (Value::Object(left), Value::Object(right)) => compare_fact_maps(left, right),
+        _ => Ordering::Equal,
+    }
+}
+
+fn compare_fact_maps(left: &Map<String, Value>, right: &Map<String, Value>) -> Ordering {
+    let mut left_entries = left.iter().collect::<Vec<_>>();
+    let mut right_entries = right.iter().collect::<Vec<_>>();
+    left_entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+    right_entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+    left_entries
+        .iter()
+        .zip(&right_entries)
+        .map(|((left_key, left_value), (right_key, right_value))| {
+            left_key
+                .cmp(right_key)
+                .then_with(|| compare_fact_values(left_value, right_value))
+        })
+        .find(|order| *order != Ordering::Equal)
+        .unwrap_or_else(|| left_entries.len().cmp(&right_entries.len()))
+}
+
+fn normalized_call_text(value: &Option<Option<String>>) -> Option<&str> {
+    value.as_ref().and_then(|value| value.as_deref())
+}
+
+struct FactDigestValue<'a>(&'a Value);
+
+impl Serialize for FactDigestValue<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0 {
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(value) => serializer.serialize_bool(*value),
+            Value::Number(value) => value.serialize(serializer),
+            Value::String(value) => serializer.serialize_str(value),
+            Value::Array(values) => {
+                let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+                for value in values {
+                    sequence.serialize_element(&Self(value))?;
+                }
+                sequence.end()
+            }
+            Value::Object(values) => {
+                let mut entries = values.iter().collect::<Vec<_>>();
+                entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+                let mut map = serializer.serialize_map(Some(entries.len()))?;
+                for (key, value) in entries {
+                    map.serialize_entry(key, &Self(value))?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
 struct FactDigestNode<'a> {
     node: &'a RawNodeRecord,
 }
@@ -480,13 +573,17 @@ impl Serialize for FactDigestNode<'_> {
         S: Serializer,
     {
         let is_file = self.node.string("symbol_kind") == "file";
-        let mut map = serializer.serialize_map(Some(self.node.attributes.len() + 1))?;
+        let mut attributes = self
+            .node
+            .attributes
+            .iter()
+            .filter(|(key, _)| !(is_file && FILE_ENVELOPE_ATTRIBUTES.contains(&key.as_str())))
+            .collect::<Vec<_>>();
+        attributes.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        let mut map = serializer.serialize_map(Some(attributes.len() + 1))?;
         map.serialize_entry("id", &self.node.id)?;
-        for (key, value) in &self.node.attributes {
-            if is_file && FILE_ENVELOPE_ATTRIBUTES.contains(&key.as_str()) {
-                continue;
-            }
-            map.serialize_entry(key, value)?;
+        for (key, value) in attributes {
+            map.serialize_entry(key, &FactDigestValue(value))?;
         }
         map.end()
     }
@@ -501,9 +598,154 @@ impl Serialize for FactDigestNodes<'_> {
     where
         S: Serializer,
     {
+        let mut nodes = self.nodes.iter().collect::<Vec<_>>();
+        nodes.sort_unstable_by(|left, right| left.id.cmp(&right.id));
         let mut sequence = serializer.serialize_seq(Some(self.nodes.len()))?;
-        for node in self.nodes {
+        for node in nodes {
             sequence.serialize_element(&FactDigestNode { node })?;
+        }
+        sequence.end()
+    }
+}
+
+struct FactDigestEdge<'a> {
+    edge: &'a RawEdgeRecord,
+}
+
+impl Serialize for FactDigestEdge<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut attributes = self.edge.attributes.iter().collect::<Vec<_>>();
+        attributes.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        let mut map = serializer.serialize_map(Some(attributes.len() + 2))?;
+        map.serialize_entry("source", &self.edge.source)?;
+        map.serialize_entry("target", &self.edge.target)?;
+        for (key, value) in attributes {
+            map.serialize_entry(key, &FactDigestValue(value))?;
+        }
+        map.end()
+    }
+}
+
+struct FactDigestEdges<'a> {
+    edges: &'a [RawEdgeRecord],
+}
+
+impl Serialize for FactDigestEdges<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut edges = self.edges.iter().collect::<Vec<_>>();
+        edges.sort_unstable_by(|left, right| {
+            left.source
+                .cmp(&right.source)
+                .then_with(|| left.target.cmp(&right.target))
+                .then_with(|| compare_fact_maps(&left.attributes, &right.attributes))
+        });
+        let mut sequence = serializer.serialize_seq(Some(self.edges.len()))?;
+        for edge in edges {
+            sequence.serialize_element(&FactDigestEdge { edge })?;
+        }
+        sequence.end()
+    }
+}
+
+struct FactDigestCall<'a> {
+    call: &'a RawCall,
+}
+
+impl Serialize for FactDigestCall<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let call = self.call;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("caller_nid", &call.caller_nid)?;
+        map.serialize_entry("callee", &call.callee)?;
+        if let Some(value) = call.is_member_call {
+            map.serialize_entry("is_member_call", &value)?;
+        }
+        map.serialize_entry("source_file", &call.source_file)?;
+        map.serialize_entry("source_location", &call.source_location)?;
+        if let Some(Some(value)) = call.receiver.as_ref() {
+            map.serialize_entry("receiver", value)?;
+        }
+        if let Some(Some(value)) = call.receiver_type.as_ref() {
+            map.serialize_entry("receiver_type", value)?;
+        }
+        if let Some(value) = &call.lang {
+            map.serialize_entry("lang", value)?;
+        }
+        let mut extensions = call.extensions.iter().collect::<Vec<_>>();
+        extensions.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        for (key, value) in extensions {
+            map.serialize_entry(key, &FactDigestValue(value))?;
+        }
+        map.end()
+    }
+}
+
+struct FactDigestCalls<'a> {
+    calls: &'a [RawCall],
+}
+
+impl Serialize for FactDigestCalls<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut calls = self.calls.iter().collect::<Vec<_>>();
+        calls.sort_unstable_by(|left, right| {
+            left.caller_nid
+                .cmp(&right.caller_nid)
+                .then_with(|| left.callee.cmp(&right.callee))
+                .then_with(|| left.is_member_call.cmp(&right.is_member_call))
+                .then_with(|| left.source_file.cmp(&right.source_file))
+                .then_with(|| left.source_location.cmp(&right.source_location))
+                .then_with(|| {
+                    normalized_call_text(&left.receiver).cmp(&normalized_call_text(&right.receiver))
+                })
+                .then_with(|| {
+                    normalized_call_text(&left.receiver_type)
+                        .cmp(&normalized_call_text(&right.receiver_type))
+                })
+                .then_with(|| left.lang.cmp(&right.lang))
+                .then_with(|| compare_fact_maps(&left.extensions, &right.extensions))
+        });
+        let mut sequence = serializer.serialize_seq(Some(self.calls.len()))?;
+        for call in calls {
+            sequence.serialize_element(&FactDigestCall { call })?;
+        }
+        sequence.end()
+    }
+}
+
+struct FactDigestFrameworkFacts<'a> {
+    facts: &'a [RawFrameworkFact],
+}
+
+impl Serialize for FactDigestFrameworkFacts<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut facts = self
+            .facts
+            .iter()
+            .map(|fact| {
+                serde_json::to_value(fact)
+                    .map(|value| (value, fact))
+                    .map_err(S::Error::custom)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        facts.sort_unstable_by(|left, right| compare_fact_values(&left.0, &right.0));
+        let mut sequence = serializer.serialize_seq(Some(self.facts.len()))?;
+        for (value, _) in facts {
+            sequence.serialize_element(&FactDigestValue(&value))?;
         }
         sequence.end()
     }
@@ -1037,15 +1279,31 @@ impl Serialize for FactDigestExtraction<'_> {
                 nodes: &self.extraction.nodes,
             },
         )?;
-        map.serialize_entry("edges", &self.extraction.edges)?;
+        map.serialize_entry(
+            "edges",
+            &FactDigestEdges {
+                edges: &self.extraction.edges,
+            },
+        )?;
         if !self.extraction.hyperedges.is_empty() {
-            map.serialize_entry("hyperedges", &self.extraction.hyperedges)?;
+            let hyperedges = self
+                .extraction
+                .hyperedges
+                .iter()
+                .map(FactDigestValue)
+                .collect::<Vec<_>>();
+            map.serialize_entry("hyperedges", &hyperedges)?;
         }
         if let Some(raw_calls) = &self.extraction.raw_calls {
-            map.serialize_entry("raw_calls", raw_calls)?;
+            map.serialize_entry("raw_calls", &FactDigestCalls { calls: raw_calls })?;
         }
         if !self.extraction.framework_facts.is_empty() {
-            map.serialize_entry("framework_facts", &self.extraction.framework_facts)?;
+            map.serialize_entry(
+                "framework_facts",
+                &FactDigestFrameworkFacts {
+                    facts: &self.extraction.framework_facts,
+                },
+            )?;
         }
         if let Some(batch) = &self.extraction.semantic_evidence {
             map.serialize_entry(
@@ -1059,8 +1317,10 @@ impl Serialize for FactDigestExtraction<'_> {
         if let Some(error) = &self.extraction.error {
             map.serialize_entry("error", error)?;
         }
-        for (key, value) in &self.extraction.extensions {
-            map.serialize_entry(key, value)?;
+        let mut extensions = self.extraction.extensions.iter().collect::<Vec<_>>();
+        extensions.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        for (key, value) in extensions {
+            map.serialize_entry(key, &FactDigestValue(value))?;
         }
         map.end()
     }
@@ -1107,6 +1367,7 @@ fn detected_file_sets_match(manifest: &Manifest, files: &BTreeMap<String, Vec<St
         .entries()
         .keys()
         .map(PathBuf::from)
+        .map(|path| canonical_identity(&path))
         .collect::<BTreeSet<_>>();
     current == previous
 }
@@ -1339,6 +1600,53 @@ fn full_file_source_anchor(
 
 type FactNeutralDocument = (Option<V1GraphDocument>, V1GraphDocument, BTreeSet<String>);
 
+fn sort_dedup_serialized<T: Serialize>(values: &mut Vec<T>) {
+    if values.len() < 2 {
+        return;
+    }
+    let mut keyed = values
+        .drain(..)
+        .map(|value| (serde_json::to_vec(&value).unwrap_or_default(), value))
+        .collect::<Vec<_>>();
+    keyed.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    let mut previous = None;
+    for (key, value) in keyed {
+        if previous.as_ref() == Some(&key) {
+            continue;
+        }
+        previous = Some(key);
+        values.push(value);
+    }
+}
+
+fn canonicalize_fact_neutral_metadata(
+    coverage: &mut Vec<CoverageRecord>,
+    diagnostics: &mut Vec<GraphDiagnostic>,
+) {
+    // Fact-neutral publication bypasses the normal v1 normalization pass, so
+    // preserve the same metadata ordering and duplicate policy here. Without
+    // this, appending the refreshed file inventory to the prior graph changes
+    // coverage order even when the semantic graph is unchanged.
+    sort_dedup_serialized(coverage);
+    coverage.sort_by(|left, right| {
+        (
+            left.capability.as_str(),
+            left.producer.as_str(),
+            left.file_id.as_deref(),
+        )
+            .cmp(&(
+                right.capability.as_str(),
+                right.producer.as_str(),
+                right.file_id.as_deref(),
+            ))
+    });
+    sort_dedup_serialized(diagnostics);
+    diagnostics.sort_by(|left, right| {
+        (left.code.as_str(), left.message.as_str())
+            .cmp(&(right.code.as_str(), right.message.as_str()))
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 fn prepare_fact_neutral_document(
     output_dir: &Path,
@@ -1399,6 +1707,7 @@ fn prepare_fact_neutral_document(
     }
     evidence.build.configuration_digest = configuration_digest;
     evidence.include_inventory(inventory)?;
+    canonicalize_fact_neutral_metadata(&mut evidence.coverage, &mut evidence.diagnostics);
 
     let anchors = extraction_file_anchors(extractions, root);
     current.graph.build = evidence.build;
@@ -1428,11 +1737,13 @@ fn prepare_fact_neutral_document(
             byte_size: file.byte_size,
             generated: file.generated,
         }));
-        if let Some(anchor) = anchors
-            .get(&source)
-            .cloned()
-            .or_else(|| full_file_source_anchor(&root.join(&source), &source, max_source_bytes))
-        {
+        let anchor = source_digests.contains_key(&source).then(|| {
+            anchors
+                .get(&source)
+                .cloned()
+                .or_else(|| full_file_source_anchor(&root.join(&source), &source, max_source_bytes))
+        });
+        if let Some(anchor) = anchor.flatten() {
             node.source = Some(anchor.clone());
             for provenance in &mut node.evidence {
                 for candidate in &mut provenance.anchors {
@@ -6578,6 +6889,37 @@ mod tests {
         assert!(default_ast_workers() <= DEFAULT_AST_WORKER_CAP);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn detected_file_sets_match_canonicalizes_manifest_symlink_aliases()
+    -> Result<(), Box<dyn Error>> {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir()?;
+        let source_directory = directory.path().join("src");
+        fs::create_dir_all(&source_directory)?;
+        let source = source_directory.join("main.py");
+        fs::write(&source, "def main():\n    return 1\n")?;
+        let alias = source_directory.join("main-alias.py");
+        symlink("main.py", &alias)?;
+        let manifest_path = directory.path().join("manifest.json");
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&json!({
+                "src/main.py": {"mtime": 1.0, "ast_hash": "hash"},
+                "src/main-alias.py": {"mtime": 1.0, "ast_hash": "hash"}
+            }))?,
+        )?;
+        let manifest = Manifest::load(&manifest_path, Some(directory.path()));
+        let files = BTreeMap::from([(
+            "code".to_owned(),
+            vec![source.to_string_lossy().into_owned()],
+        )]);
+
+        assert!(detected_file_sets_match(&manifest, &files));
+        Ok(())
+    }
+
     #[test]
     fn resolver_source_text_is_scoped_to_php_files() {
         assert!(is_php_source_path(Path::new("src/controller.PHP")));
@@ -6618,6 +6960,125 @@ mod tests {
         compact_extraction(&mut extraction);
 
         assert_eq!(before, serde_json::to_value(extraction)?);
+        Ok(())
+    }
+
+    #[test]
+    fn ast_fact_digest_is_independent_of_map_insertion_order() -> Result<(), Box<dyn Error>> {
+        let mut first_attributes = Map::new();
+        first_attributes.insert("zeta".to_owned(), json!({"b": 2, "a": 1}));
+        first_attributes.insert("alpha".to_owned(), json!(true));
+        let mut second_attributes = Map::new();
+        second_attributes.insert("alpha".to_owned(), json!(true));
+        second_attributes.insert("zeta".to_owned(), json!({"a": 1, "b": 2}));
+        let first = Extraction {
+            nodes: vec![RawNodeRecord {
+                id: "node".to_owned(),
+                attributes: first_attributes,
+            }],
+            edges: vec![RawEdgeRecord {
+                source: "node".to_owned(),
+                target: "target".to_owned(),
+                attributes: Map::from_iter([
+                    ("zeta".to_owned(), json!({"b": 2, "a": 1})),
+                    ("alpha".to_owned(), json!(true)),
+                ]),
+            }],
+            ..Extraction::default()
+        };
+        let second = Extraction {
+            nodes: vec![RawNodeRecord {
+                id: "node".to_owned(),
+                attributes: second_attributes,
+            }],
+            edges: vec![RawEdgeRecord {
+                source: "node".to_owned(),
+                target: "target".to_owned(),
+                attributes: Map::from_iter([
+                    ("alpha".to_owned(), json!(true)),
+                    ("zeta".to_owned(), json!({"a": 1, "b": 2})),
+                ]),
+            }],
+            ..Extraction::default()
+        };
+
+        assert_ne!(serde_json::to_vec(&first)?, serde_json::to_vec(&second)?);
+        assert_eq!(
+            extraction_fact_digest(&first)?,
+            extraction_fact_digest(&second)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ast_fact_digest_is_independent_of_fact_sequence_order() -> Result<(), Box<dyn Error>> {
+        let first = Extraction {
+            nodes: vec![
+                RawNodeRecord {
+                    id: "node-a".to_owned(),
+                    attributes: Map::from_iter([("symbol_kind".to_owned(), json!("function"))]),
+                },
+                RawNodeRecord {
+                    id: "node-b".to_owned(),
+                    attributes: Map::from_iter([("symbol_kind".to_owned(), json!("class"))]),
+                },
+            ],
+            edges: vec![
+                RawEdgeRecord {
+                    source: "node-a".to_owned(),
+                    target: "node-b".to_owned(),
+                    attributes: Map::from_iter([("kind".to_owned(), json!("calls"))]),
+                },
+                RawEdgeRecord {
+                    source: "node-b".to_owned(),
+                    target: "node-a".to_owned(),
+                    attributes: Map::from_iter([("kind".to_owned(), json!("references"))]),
+                },
+            ],
+            ..Extraction::default()
+        };
+        let mut second = first.clone();
+        second.nodes.reverse();
+        second.edges.reverse();
+
+        assert_ne!(serde_json::to_vec(&first)?, serde_json::to_vec(&second)?);
+        assert_eq!(
+            extraction_fact_digest(&first)?,
+            extraction_fact_digest(&second)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ast_fact_digest_normalizes_cache_null_call_fields() -> Result<(), Box<dyn Error>> {
+        let call = RawCall {
+            caller_nid: "caller".to_owned(),
+            callee: "callee".to_owned(),
+            is_member_call: Some(false),
+            source_file: "main.js".to_owned(),
+            source_location: "L1".to_owned(),
+            receiver: None,
+            receiver_type: None,
+            lang: Some("javascript".to_owned()),
+            extensions: Map::new(),
+        };
+        let mut explicit_null = call.clone();
+        explicit_null.receiver = Some(None);
+        explicit_null.receiver_type = Some(None);
+        let first = Extraction {
+            raw_calls: Some(vec![call]),
+            ..Extraction::default()
+        };
+        let second = Extraction {
+            raw_calls: Some(vec![explicit_null]),
+            ..Extraction::default()
+        };
+
+        assert_ne!(serde_json::to_vec(&first)?, serde_json::to_vec(&second)?);
+        assert_eq!(
+            extraction_fact_digest(&first)?,
+            extraction_fact_digest(&second)?
+        );
         Ok(())
     }
 
@@ -7340,6 +7801,12 @@ mod tests {
         let root = directory.path();
         let source = root.join("main.py");
         fs::write(&source, "def main():\n    return 1\n")?;
+        fs::create_dir_all(root.join("src"))?;
+        let javascript = root.join("src/static.js");
+        fs::write(
+            &javascript,
+            "function show(value) { return value; }\nmodule.exports = { show };\n",
+        )?;
         let mut options = BuildOptions::new(root);
         options.no_cluster = true;
         options.no_viz = true;
@@ -7358,7 +7825,7 @@ mod tests {
         let cold_fact_state: AstFactDigestState =
             serde_json::from_slice(&fs::read(cold.output_dir.join(AST_FACT_DIGESTS_FILE))?)?;
         assert_eq!(cold_fact_state.schema, AST_FACT_DIGESTS_SCHEMA);
-        assert_eq!(cold_fact_state.entries.len(), 1);
+        assert_eq!(cold_fact_state.entries.len(), 2);
 
         fs::write(
             &source,
@@ -7366,6 +7833,7 @@ mod tests {
         )?;
         let changed = build_graph_with_semantic(&options, &empty_semantic)?;
         assert_eq!(changed.files_extracted, 1);
+        assert_eq!(changed.files_cached, 1);
         assert_eq!(changed.nodes, cold.nodes);
         assert_eq!(changed.edges, cold.edges);
         assert_eq!(changed.timings.graph_assembly, Duration::ZERO);
@@ -7391,16 +7859,27 @@ mod tests {
         let cold_file = cold_graph
             .nodes
             .iter()
-            .find(|node| node.kind == NodeKind::File)
+            .find(|node| node.kind == NodeKind::File && node.source_file() == Some("main.py"))
             .ok_or("cold file node missing")?;
+        let cold_static_file = cold_graph
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::File && node.source_file() == Some("src/static.js"))
+            .ok_or("cold static file node missing")?;
         let changed_file = changed_graph
             .nodes
             .iter()
-            .find(|node| node.kind == NodeKind::File)
+            .find(|node| node.kind == NodeKind::File && node.source_file() == Some("main.py"))
             .ok_or("changed file node missing")?;
+        let changed_static_file = changed_graph
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::File && node.source_file() == Some("src/static.js"))
+            .ok_or("changed static file node missing")?;
         assert_eq!(changed_file.id, cold_file.id);
         assert_ne!(changed_file, cold_file);
         assert_ne!(changed_file.source, cold_file.source);
+        assert_eq!(changed_static_file, cold_static_file);
         assert_ne!(changed_graph.graph.files, cold_graph.graph.files);
 
         fs::write(&source, "def main():\n    return 2\n\n# semantic edit\n")?;

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::{BufReader, Write};
@@ -13,21 +14,23 @@ use compass_files::{
 };
 use compass_graph::{
     BuildEvidence, ClusterOptions, EntityTiebreaker, GRAPH_DIAGNOSTICS_EXTENSION,
-    GRAPH_SNAPSHOT_MAX_OBJECTS, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder,
-    GraphSnapshotGcStats, InventoryEvidence, PublicationOmissions, SnapshotSelector, SourceDigest,
+    GRAPH_JSON_DELTA_MAX_SOURCE_BYTES, GRAPH_SNAPSHOT_MAX_OBJECTS,
+    GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder, GraphSnapshotGcStats,
+    InventoryEvidence, PublicationOmissions, SnapshotSelector, SourceDigest,
     build_owned_with_tiebreaker as build_document, canonical_edge_kind, canonical_raw_edge_sites,
     cluster, deduped_node_count, extraction_from_v1, garbage_collect_graph_snapshots,
     graph_insights, graph_snapshot_needs_gc, label_communities_by_hub,
     normalize_document_v1_with_evidence_best_effort_owned,
     normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
-    score_communities, write_canonical_graph_json,
+    score_communities, write_canonical_graph_json, write_fact_neutral_graph_json_delta,
 };
 use compass_languages::{
-    DeclarationFact, EXTRACTION_QUALITY_EXTENSION, EXTRACTION_QUALITY_PARTIAL,
+    BindingFact, DeclarationFact, EXTRACTION_QUALITY_EXTENSION, EXTRACTION_QUALITY_PARTIAL,
     EXTRACTION_QUALITY_REASON_EXTENSION, Engine, Extraction, ExtractorKind,
-    FRAMEWORK_PROJECT_EVIDENCE_EXTENSION, ProjectEvidenceIndex, RawEdgeRecord, RawFrameworkFact,
-    RawNodeRecord, Registry, SemanticEvidenceBatch, file_stem, make_id,
+    FRAMEWORK_PROJECT_EVIDENCE_EXTENSION, OccurrenceFact, ProjectEvidenceIndex, RawEdgeRecord,
+    RawFrameworkFact, RawNodeRecord, Registry, RelationshipCandidate, ResolutionConstraint,
+    ScopeFact, SemanticEvidenceBatch, file_stem, make_id,
 };
 use compass_model::code_graph::{
     CommunityMetadata, DiagnosticSeverity, ExtractionStatus, FileNodeDetails, GraphDiagnostic,
@@ -159,7 +162,7 @@ pub enum BuildPurpose {
 
 const OUTPUT_STATS_FILE: &str = ".compass_output_stats.json";
 const AST_FACT_DIGESTS_FILE: &str = ".compass_ast_fact_digests.json";
-const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/1";
+const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/2";
 const MAX_AST_FACT_DIGEST_ENTRIES: usize = 100_000;
 const MAX_AST_FACT_DIGEST_FILE_BYTES: usize = 16 * 1024 * 1024;
 const GRAPH_OVERVIEW_FILE: &str = "graph-overview.json";
@@ -506,19 +509,119 @@ impl Serialize for FactDigestNodes<'_> {
     }
 }
 
-struct FactDigestDeclaration<'a> {
-    declaration: &'a DeclarationFact,
-    is_file: bool,
+struct FactDigestEvidenceContext<'a> {
+    declaration_keys: BTreeMap<&'a str, &'a str>,
+    file_declarations: BTreeSet<&'a str>,
+    scope_keys: BTreeMap<&'a str, String>,
 }
 
-impl Serialize for FactDigestDeclaration<'_> {
+impl<'a> FactDigestEvidenceContext<'a> {
+    fn new(batch: &'a SemanticEvidenceBatch, file_ids: &'a BTreeSet<&'a str>) -> Self {
+        let declaration_keys = batch
+            .declarations
+            .iter()
+            .map(|declaration| (declaration.id.as_str(), declaration.graph_node_id.as_str()))
+            .collect::<BTreeMap<_, _>>();
+        let file_declarations = batch
+            .declarations
+            .iter()
+            .filter(|declaration| {
+                declaration.kind == "file" || file_ids.contains(declaration.graph_node_id.as_str())
+            })
+            .map(|declaration| declaration.id.as_str())
+            .collect::<BTreeSet<_>>();
+        let scope_bases = batch
+            .scopes
+            .iter()
+            .map(|scope| {
+                let owner = scope
+                    .owner_declaration_id
+                    .as_deref()
+                    .map(|id| {
+                        declaration_keys
+                            .get(id)
+                            .map_or_else(|| format!("raw:{id}"), |key| (*key).to_owned())
+                    })
+                    .unwrap_or_else(|| "none".to_owned());
+                (
+                    scope.id.as_str(),
+                    format!("scope|{}|{}|owner={owner}", scope.language, scope.kind),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let mut scope_keys = scope_bases.clone();
+
+        // Scope IDs are derived from source ranges. Rebuild them from the
+        // stable owner/kind/parent shape so a file-level range change does not
+        // invalidate the semantic fact digest. The fixed point is bounded by
+        // the number of scopes and falls back to raw parent IDs when a
+        // malformed batch references an unknown scope.
+        for _ in 0..=batch.scopes.len().min(1_024) {
+            let previous = scope_keys.clone();
+            let mut changed = false;
+            for scope in &batch.scopes {
+                let parent = scope.parent_scope_id.as_deref().map_or_else(
+                    || "none".to_owned(),
+                    |id| {
+                        previous
+                            .get(id)
+                            .cloned()
+                            .unwrap_or_else(|| format!("raw:{id}"))
+                    },
+                );
+                let Some(base) = scope_bases.get(scope.id.as_str()) else {
+                    continue;
+                };
+                let next = format!("{base}|parent={parent}");
+                if base != &next {
+                    changed = true;
+                }
+                scope_keys.insert(scope.id.as_str(), next);
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        Self {
+            declaration_keys,
+            file_declarations,
+            scope_keys,
+        }
+    }
+
+    fn declaration_key(&self, id: &str) -> Cow<'_, str> {
+        self.declaration_keys.get(id).map_or_else(
+            || Cow::Owned(format!("raw:{id}")),
+            |key| Cow::Borrowed(*key),
+        )
+    }
+
+    fn declaration_is_file(&self, id: &str) -> bool {
+        self.file_declarations.contains(id)
+    }
+
+    fn scope_key(&self, id: &str) -> Cow<'_, str> {
+        self.scope_keys.get(id).map_or_else(
+            || Cow::Owned(format!("raw:{id}")),
+            |key| Cow::Borrowed(key.as_str()),
+        )
+    }
+}
+
+struct FactDigestDeclaration<'a, 'context> {
+    declaration: &'a DeclarationFact,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestDeclaration<'_, '_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let declaration = self.declaration;
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("id", &declaration.id)?;
+        map.serialize_entry("id", &self.context.declaration_key(&declaration.id))?;
         map.serialize_entry("language", &declaration.language)?;
         map.serialize_entry("graphNodeId", &declaration.graph_node_id)?;
         map.serialize_entry("kind", &declaration.kind)?;
@@ -528,7 +631,7 @@ impl Serialize for FactDigestDeclaration<'_> {
             map.serialize_entry("moduleOrPackage", value)?;
         }
         if let Some(value) = &declaration.scope_id {
-            map.serialize_entry("scopeId", value)?;
+            map.serialize_entry("scopeId", &self.context.scope_key(value))?;
         }
         if let Some(value) = &declaration.signature {
             map.serialize_entry("signature", value)?;
@@ -552,31 +655,217 @@ impl Serialize for FactDigestDeclaration<'_> {
         if let Some(value) = &declaration.source_hash {
             map.serialize_entry("sourceHash", value)?;
         }
-        if !self.is_file {
+        if !self.context.declaration_is_file(&declaration.id) {
             map.serialize_entry("range", &declaration.range)?;
         }
         map.end()
     }
 }
 
-struct FactDigestDeclarations<'a> {
+struct FactDigestDeclarations<'a, 'context> {
     declarations: &'a [DeclarationFact],
-    file_ids: &'a BTreeSet<&'a str>,
+    context: &'context FactDigestEvidenceContext<'a>,
 }
 
-impl Serialize for FactDigestDeclarations<'_> {
+impl Serialize for FactDigestDeclarations<'_, '_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut sequence = serializer.serialize_seq(Some(self.declarations.len()))?;
-        for declaration in self.declarations {
+        let mut declarations = self.declarations.iter().collect::<Vec<_>>();
+        declarations.sort_by(|left, right| {
+            self.context
+                .declaration_key(&left.id)
+                .cmp(&self.context.declaration_key(&right.id))
+                .then_with(|| left.kind.cmp(&right.kind))
+                .then_with(|| left.name.cmp(&right.name))
+                .then_with(|| left.range.start_byte.cmp(&right.range.start_byte))
+                .then_with(|| left.range.end_byte.cmp(&right.range.end_byte))
+        });
+        let mut sequence = serializer.serialize_seq(Some(declarations.len()))?;
+        for declaration in declarations {
             sequence.serialize_element(&FactDigestDeclaration {
                 declaration,
-                is_file: self.file_ids.contains(declaration.graph_node_id.as_str()),
+                context: self.context,
             })?;
         }
         sequence.end()
+    }
+}
+
+struct FactDigestScope<'a, 'context> {
+    scope: &'a ScopeFact,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestScope<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("id", &self.context.scope_key(&self.scope.id))?;
+        map.serialize_entry("language", &self.scope.language)?;
+        map.serialize_entry("kind", &self.scope.kind)?;
+        if let Some(owner) = &self.scope.owner_declaration_id {
+            map.serialize_entry("ownerDeclarationId", &self.context.declaration_key(owner))?;
+        }
+        if let Some(parent) = &self.scope.parent_scope_id {
+            map.serialize_entry("parentScopeId", &self.context.scope_key(parent))?;
+        }
+        let file_scope = self
+            .scope
+            .owner_declaration_id
+            .as_deref()
+            .is_some_and(|owner| self.context.declaration_is_file(owner));
+        if !file_scope {
+            map.serialize_entry("range", &self.scope.range)?;
+        }
+        map.end()
+    }
+}
+
+struct FactDigestBinding<'a, 'context> {
+    binding: &'a BindingFact,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestBinding<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let binding = self.binding;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("language", &binding.language)?;
+        map.serialize_entry("kind", &binding.kind)?;
+        map.serialize_entry("spelling", &binding.spelling)?;
+        map.serialize_entry("qualifiedTarget", &binding.qualified_target)?;
+        if let Some(target) = &binding.target_declaration_id {
+            map.serialize_entry("targetDeclarationId", &self.context.declaration_key(target))?;
+        }
+        if let Some(scope) = &binding.scope_id {
+            map.serialize_entry("scopeId", &self.context.scope_key(scope))?;
+        }
+        if let Some(output_index) = binding.output_index {
+            map.serialize_entry("outputIndex", &output_index)?;
+        }
+        map.serialize_entry("range", &binding.range)?;
+        map.end()
+    }
+}
+
+struct FactDigestOccurrence<'a, 'context> {
+    occurrence: &'a OccurrenceFact,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestOccurrence<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let occurrence = self.occurrence;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("language", &occurrence.language)?;
+        map.serialize_entry("role", &occurrence.role)?;
+        map.serialize_entry(
+            "ownerDeclarationId",
+            &self
+                .context
+                .declaration_key(&occurrence.owner_declaration_id),
+        )?;
+        map.serialize_entry("spelling", &occurrence.spelling)?;
+        if let Some(value) = &occurrence.qualifier {
+            map.serialize_entry("qualifier", value)?;
+        }
+        if let Some(value) = &occurrence.context {
+            map.serialize_entry("context", value)?;
+        }
+        if let Some(scope) = &occurrence.scope_id {
+            map.serialize_entry("scopeId", &self.context.scope_key(scope))?;
+        }
+        map.serialize_entry("range", &occurrence.range)?;
+        map.end()
+    }
+}
+
+struct FactDigestResolutionConstraint<'a, 'context> {
+    constraint: &'a ResolutionConstraint,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestResolutionConstraint<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let constraint = self.constraint;
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(value) = &constraint.exact_target_declaration_id {
+            map.serialize_entry(
+                "exactTargetDeclarationId",
+                &self.context.declaration_key(value),
+            )?;
+        }
+        if let Some(value) = &constraint.exact_language {
+            map.serialize_entry("exactLanguage", value)?;
+        }
+        if let Some(value) = &constraint.module_or_package {
+            map.serialize_entry("moduleOrPackage", value)?;
+        }
+        if let Some(value) = &constraint.scope_id {
+            map.serialize_entry("scopeId", &self.context.scope_key(value))?;
+        }
+        if let Some(value) = &constraint.qualified_name {
+            map.serialize_entry("qualifiedName", value)?;
+        }
+        if let Some(value) = constraint.argument_count {
+            map.serialize_entry("argumentCount", &value)?;
+        }
+        if !constraint.argument_types.is_empty() {
+            map.serialize_entry("argumentTypes", &constraint.argument_types)?;
+        }
+        if !constraint.allowed_target_kinds.is_empty() {
+            map.serialize_entry("allowedTargetKinds", &constraint.allowed_target_kinds)?;
+        }
+        if let Some(value) = &constraint.hierarchy {
+            map.serialize_entry("hierarchy", value)?;
+        }
+        map.serialize_entry("allowExternal", &constraint.allow_external)?;
+        map.end()
+    }
+}
+
+struct FactDigestCandidate<'a, 'context> {
+    candidate: &'a RelationshipCandidate,
+    context: &'context FactDigestEvidenceContext<'a>,
+}
+
+impl Serialize for FactDigestCandidate<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let candidate = self.candidate;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("language", &candidate.language)?;
+        map.serialize_entry("relation", &candidate.relation)?;
+        map.serialize_entry(
+            "sourceDeclarationId",
+            &self
+                .context
+                .declaration_key(&candidate.source_declaration_id),
+        )?;
+        map.serialize_entry("targetSpelling", &candidate.target_spelling)?;
+        map.serialize_entry(
+            "constraints",
+            &FactDigestResolutionConstraint {
+                constraint: &candidate.constraints,
+                context: self.context,
+            },
+        )?;
+        map.end()
     }
 }
 
@@ -590,19 +879,134 @@ impl Serialize for FactDigestSemanticEvidence<'_> {
     where
         S: Serializer,
     {
+        let context = FactDigestEvidenceContext::new(self.batch, self.file_ids);
+        let mut scopes = self.batch.scopes.iter().collect::<Vec<_>>();
+        scopes.sort_by(|left, right| {
+            context
+                .scope_key(&left.id)
+                .cmp(&context.scope_key(&right.id))
+                .then_with(|| left.range.start_byte.cmp(&right.range.start_byte))
+                .then_with(|| left.range.end_byte.cmp(&right.range.end_byte))
+        });
+        let mut bindings = self.batch.bindings.iter().collect::<Vec<_>>();
+        bindings.sort_by(|left, right| {
+            left.range
+                .source_file
+                .cmp(&right.range.source_file)
+                .then_with(|| left.range.start_byte.cmp(&right.range.start_byte))
+                .then_with(|| left.range.end_byte.cmp(&right.range.end_byte))
+                .then_with(|| left.spelling.cmp(&right.spelling))
+                .then_with(|| left.qualified_target.cmp(&right.qualified_target))
+                .then_with(|| left.kind.cmp(&right.kind))
+        });
+        let mut occurrences = self.batch.occurrences.iter().collect::<Vec<_>>();
+        occurrences.sort_by(|left, right| {
+            left.range
+                .source_file
+                .cmp(&right.range.source_file)
+                .then_with(|| left.range.start_byte.cmp(&right.range.start_byte))
+                .then_with(|| left.range.end_byte.cmp(&right.range.end_byte))
+                .then_with(|| left.spelling.cmp(&right.spelling))
+                .then_with(|| left.role.cmp(&right.role))
+        });
+        let mut candidates = self.batch.candidates.iter().collect::<Vec<_>>();
+        candidates.sort_by(|left, right| {
+            context
+                .declaration_key(&left.source_declaration_id)
+                .cmp(&context.declaration_key(&right.source_declaration_id))
+                .then_with(|| left.relation.cmp(&right.relation))
+                .then_with(|| left.target_spelling.cmp(&right.target_spelling))
+                .then_with(|| {
+                    left.constraints
+                        .qualified_name
+                        .cmp(&right.constraints.qualified_name)
+                })
+                .then_with(|| {
+                    let left_target = left
+                        .constraints
+                        .exact_target_declaration_id
+                        .as_deref()
+                        .map_or(Cow::Borrowed(""), |id| context.declaration_key(id));
+                    let right_target = right
+                        .constraints
+                        .exact_target_declaration_id
+                        .as_deref()
+                        .map_or(Cow::Borrowed(""), |id| context.declaration_key(id));
+                    left_target.cmp(&right_target)
+                })
+                .then_with(|| {
+                    let left_scope = left
+                        .constraints
+                        .scope_id
+                        .as_deref()
+                        .map_or(Cow::Borrowed(""), |id| context.scope_key(id));
+                    let right_scope = right
+                        .constraints
+                        .scope_id
+                        .as_deref()
+                        .map_or(Cow::Borrowed(""), |id| context.scope_key(id));
+                    left_scope.cmp(&right_scope)
+                })
+                .then_with(|| {
+                    left.constraints
+                        .argument_count
+                        .cmp(&right.constraints.argument_count)
+                })
+                .then_with(|| {
+                    left.constraints
+                        .allowed_target_kinds
+                        .cmp(&right.constraints.allowed_target_kinds)
+                })
+        });
         let mut map = serializer.serialize_map(Some(7))?;
         map.serialize_entry("adapter", &self.batch.adapter)?;
         map.serialize_entry(
             "declarations",
             &FactDigestDeclarations {
                 declarations: &self.batch.declarations,
-                file_ids: self.file_ids,
+                context: &context,
             },
         )?;
-        map.serialize_entry("scopes", &self.batch.scopes)?;
-        map.serialize_entry("bindings", &self.batch.bindings)?;
-        map.serialize_entry("occurrences", &self.batch.occurrences)?;
-        map.serialize_entry("candidates", &self.batch.candidates)?;
+        map.serialize_entry(
+            "scopes",
+            &scopes
+                .iter()
+                .map(|scope| FactDigestScope {
+                    scope,
+                    context: &context,
+                })
+                .collect::<Vec<_>>(),
+        )?;
+        map.serialize_entry(
+            "bindings",
+            &bindings
+                .iter()
+                .map(|binding| FactDigestBinding {
+                    binding,
+                    context: &context,
+                })
+                .collect::<Vec<_>>(),
+        )?;
+        map.serialize_entry(
+            "occurrences",
+            &occurrences
+                .iter()
+                .map(|occurrence| FactDigestOccurrence {
+                    occurrence,
+                    context: &context,
+                })
+                .collect::<Vec<_>>(),
+        )?;
+        map.serialize_entry(
+            "candidates",
+            &candidates
+                .iter()
+                .map(|candidate| FactDigestCandidate {
+                    candidate,
+                    context: &context,
+                })
+                .collect::<Vec<_>>(),
+        )?;
         if !self.batch.diagnostics.is_empty() {
             map.serialize_entry("diagnostics", &self.batch.diagnostics)?;
         }
@@ -738,11 +1142,12 @@ fn fact_neutral_pre_cache_sources(
     preserve_prior_semantic: bool,
     root: &Path,
 ) -> Option<Vec<PathBuf>> {
+    let has_nonempty_semantic = semantic.is_some_and(|layer| !semantic_layer_is_empty(layer));
     if options.force
         || options.purpose != BuildPurpose::Extract
         || !options.no_cluster
         || options.program_analysis
-        || semantic.is_some()
+        || has_nonempty_semantic
         || !supplemental.is_empty()
         || retain_artifacts
         || preserve_prior_semantic
@@ -856,11 +1261,12 @@ fn fact_neutral_incremental_candidate(
     source_removed: bool,
     root: &Path,
 ) -> bool {
+    let has_nonempty_semantic = semantic.is_some_and(|layer| !semantic_layer_is_empty(layer));
     if options.force
         || options.purpose != BuildPurpose::Extract
         || !options.no_cluster
         || options.program_analysis
-        || semantic.is_some()
+        || has_nonempty_semantic
         || !supplemental.is_empty()
         || retain_artifacts
         || missing.is_empty()
@@ -931,6 +1337,8 @@ fn full_file_source_anchor(
     })
 }
 
+type FactNeutralDocument = (Option<V1GraphDocument>, V1GraphDocument, BTreeSet<String>);
+
 #[allow(clippy::too_many_arguments)]
 fn prepare_fact_neutral_document(
     output_dir: &Path,
@@ -941,7 +1349,7 @@ fn prepare_fact_neutral_document(
     configuration_digest: String,
     max_source_bytes: u64,
     retain_previous: bool,
-) -> Result<Option<(Option<V1GraphDocument>, V1GraphDocument)>, CoreError> {
+) -> Result<Option<FactNeutralDocument>, CoreError> {
     let graph_path = output_dir.join("graph.json");
     let Ok(previous) = V1GraphDocument::load(&graph_path) else {
         return Ok(None);
@@ -955,6 +1363,7 @@ fn prepare_fact_neutral_document(
     } else {
         (None, previous)
     };
+    let mut changed_file_node_ids = BTreeSet::new();
     let mut evidence = BuildEvidence::new(root.to_path_buf(), current.graph.build.clone());
     evidence.files = current.graph.files.clone();
     evidence.coverage = current
@@ -1006,6 +1415,7 @@ fn prepare_fact_neutral_document(
         if node.kind != NodeKind::File {
             continue;
         }
+        let before = node.clone();
         let Some(source) = node.source_file() else {
             continue;
         };
@@ -1039,13 +1449,27 @@ fn prepare_fact_neutral_document(
                 }
             }
         }
+        if *node != before {
+            changed_file_node_ids.insert(node.id.clone());
+        }
     }
     compass_model::validate_code_graph(&current).map_err(|error| {
         CoreError::InvalidBuildState(format!(
             "fact-neutral incremental graph failed validation: {error}"
         ))
     })?;
-    Ok(Some((previous_for_delta, current)))
+    Ok(Some((previous_for_delta, current, changed_file_node_ids)))
+}
+
+/// Keep the byte-preserving JSON delta bounded independently from the graph
+/// reader cap. Large graphs fall back to the existing streaming serializer so
+/// an incremental edit never adds another large resident byte buffer.
+fn read_fact_neutral_delta_source(path: &Path) -> Option<Vec<u8>> {
+    let metadata = fs::metadata(path).ok()?;
+    if !metadata.is_file() || metadata.len() > GRAPH_JSON_DELTA_MAX_SOURCE_BYTES as u64 {
+        return None;
+    }
+    fs::read(path).ok()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1063,6 +1487,7 @@ fn publish_fact_neutral_incremental(
     empty_files: Vec<PathBuf>,
     previous: Option<&V1GraphDocument>,
     current: &V1GraphDocument,
+    changed_file_node_ids: &BTreeSet<String>,
     fact_state: &AstFactDigestState,
     timings: &mut BuildTimings,
 ) -> Result<BuildResult, CoreError> {
@@ -1080,13 +1505,36 @@ fn publish_fact_neutral_incremental(
         let (metrics, seal) = publish_graph_and_store_delta(&output_dir, previous, current)?;
         (Some(metrics), Some(seal))
     } else {
+        let previous_bytes = read_fact_neutral_delta_source(&graph_path);
         let receipt = write_atomic_with_digest(&graph_path, |writer| {
-            write_canonical_graph_json(current, writer).map_err(|source| {
-                compass_files::FileError::Io {
+            let delta_started = Instant::now();
+            let used_delta = if let Some(bytes) = previous_bytes.as_deref() {
+                write_fact_neutral_graph_json_delta(bytes, current, changed_file_node_ids, writer)
+                    .map_err(|source| compass_files::FileError::Io {
                     path: graph_path.clone(),
                     source,
-                }
-            })
+                })?
+            } else {
+                false
+            };
+            profile_internal_duration(
+                if used_delta {
+                    "fact-neutral graph JSON delta"
+                } else {
+                    "fact-neutral graph JSON delta fallback"
+                },
+                delta_started.elapsed(),
+            );
+            if used_delta {
+                Ok(())
+            } else {
+                write_canonical_graph_json(current, writer).map_err(|source| {
+                    compass_files::FileError::Io {
+                        path: graph_path.clone(),
+                        source,
+                    }
+                })
+            }
         })?;
         (
             None,
@@ -1765,7 +2213,7 @@ fn build_graph_inner(
                 &root,
             );
             let configuration_digest = graph_configuration_digest(options, &output_dir)?;
-            if let Some((previous, current)) = prepare_fact_neutral_document(
+            if let Some((previous, current, changed_file_node_ids)) = prepare_fact_neutral_document(
                 &output_dir,
                 &root,
                 &early_source_digests,
@@ -1797,6 +2245,7 @@ fn build_graph_inner(
                     early_empty_files,
                     previous.as_ref(),
                     &current,
+                    &changed_file_node_ids,
                     &current_fact_state,
                     &mut timings,
                 )?;
@@ -2282,7 +2731,7 @@ fn build_graph_inner(
             &root,
         );
         let configuration_digest = graph_configuration_digest(options, &output_dir)?;
-        if let Some((previous, current)) = prepare_fact_neutral_document(
+        if let Some((previous, current, changed_file_node_ids)) = prepare_fact_neutral_document(
             &output_dir,
             &root,
             &fresh_source_digests,
@@ -2307,6 +2756,7 @@ fn build_graph_inner(
                 empty_files,
                 previous.as_ref(),
                 &current,
+                &changed_file_node_ids,
                 &current_fact_state,
                 &mut timings,
             )?;
@@ -6894,8 +7344,15 @@ mod tests {
         options.no_cluster = true;
         options.no_viz = true;
         options.purpose = BuildPurpose::Extract;
+        options.graph_storage = GraphStorage::Json;
+        let empty_semantic = SemanticLayer {
+            fragment: json!({"nodes": [], "edges": [], "hyperedges": []}),
+            refreshed_files: Vec::new(),
+            partial_files: Vec::new(),
+            allow_partial: false,
+        };
 
-        let cold = build_local_graph(&options)?;
+        let cold = build_graph_with_semantic(&options, &empty_semantic)?;
         assert!(cold.output_dir.join(AST_FACT_DIGESTS_FILE).is_file());
         let cold_graph = V1GraphDocument::load(&cold.output_dir.join("graph.json"))?;
         let cold_fact_state: AstFactDigestState =
@@ -6907,13 +7364,20 @@ mod tests {
             &source,
             "def main():\n    return 1\n\n# metadata-only edit\n",
         )?;
-        let changed = build_local_graph(&options)?;
+        let changed = build_graph_with_semantic(&options, &empty_semantic)?;
         assert_eq!(changed.files_extracted, 1);
         assert_eq!(changed.nodes, cold.nodes);
         assert_eq!(changed.edges, cold.edges);
         assert_eq!(changed.timings.graph_assembly, Duration::ZERO);
 
         let changed_graph = V1GraphDocument::load(&changed.output_dir.join("graph.json"))?;
+        let mut canonical_changed = Vec::new();
+        write_canonical_graph_json(&changed_graph, &mut canonical_changed)?;
+        assert_eq!(
+            fs::read(changed.output_dir.join("graph.json"))?,
+            canonical_changed,
+            "fact-neutral publication must remain byte-identical to canonical JSON"
+        );
         let semantic_nodes = |graph: &V1GraphDocument| {
             graph
                 .nodes
@@ -6940,7 +7404,7 @@ mod tests {
         assert_ne!(changed_graph.graph.files, cold_graph.graph.files);
 
         fs::write(&source, "def main():\n    return 2\n\n# semantic edit\n")?;
-        let semantic_change = build_local_graph(&options)?;
+        let semantic_change = build_graph_with_semantic(&options, &empty_semantic)?;
         let semantic_graph = V1GraphDocument::load(&semantic_change.output_dir.join("graph.json"))?;
         let implementation_hash = |graph: &V1GraphDocument| {
             graph
@@ -6954,6 +7418,33 @@ mod tests {
             implementation_hash(&semantic_graph),
             implementation_hash(&changed_graph)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn fact_digest_ignores_python_file_envelope_edits() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("main.py");
+        let initial_source = "def main():\n    return 1\n";
+        let changed_source = "def main():\n    return 1\n\n# metadata-only edit\n";
+        fs::write(&source, initial_source)?;
+        let evidence = Arc::new(ProjectEvidenceIndex::build(
+            directory.path(),
+            std::slice::from_ref(&source),
+        ));
+        let mut engine = Engine::with_project_evidence(evidence);
+        let initial =
+            engine.extract_source_graph_only(&source, "main.py", initial_source.as_bytes())?;
+        fs::write(&source, changed_source)?;
+        let changed =
+            engine.extract_source_graph_only(&source, "main.py", changed_source.as_bytes())?;
+        let initial_digest = serde_json::to_value(FactDigestExtraction {
+            extraction: &initial,
+        })?;
+        let changed_digest = serde_json::to_value(FactDigestExtraction {
+            extraction: &changed,
+        })?;
+        assert_eq!(initial_digest, changed_digest);
         Ok(())
     }
 

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -2498,6 +2498,7 @@ fn build_graph_inner(
         ));
     }
     if options.no_cluster {
+        let no_cluster_graph_started = Instant::now();
         enforce_incomplete_raw_guard(
             semantic,
             &output_dir.join("graph.json"),
@@ -2505,11 +2506,16 @@ fn build_graph_inner(
             deduped_node_count(&resolved.nodes),
         )?;
         let document = build_document(resolved, true, true, Some(&root), tiebreaker)?;
+        profile_internal_duration(
+            "no-cluster graph document build",
+            no_cluster_graph_started.elapsed(),
+        );
         let configuration_digest = graph_configuration_digest(options, &output_dir)?;
         let source_commit = options
             .built_at_commit
             .clone()
             .or_else(|| git_commit(&root));
+        let no_cluster_normalization_started = Instant::now();
         let published = normalize_document_v1_with_inventory_best_effort_owned(
             document,
             &root,
@@ -2523,12 +2529,17 @@ fn build_graph_inner(
                 &root,
             ),
         )?;
+        profile_internal_duration(
+            "no-cluster v1 normalization",
+            no_cluster_normalization_started.elapsed(),
+        );
         if published.document.nodes.is_empty() {
             return Err(CoreError::EmptyGraph);
         }
         let omissions = published.omissions;
         let published_nodes = published.document.nodes.len();
         let published_edges = published.document.links.len();
+        let no_cluster_graph_write_started = Instant::now();
         let (store_metrics, graph_seal) = if options.graph_storage.publishes_store() {
             let (metrics, seal) =
                 if let Some(previous) = load_graph_delta_base(&output_dir, &published.document) {
@@ -2555,6 +2566,10 @@ fn build_graph_inner(
                 }),
             )
         };
+        profile_internal_duration(
+            "no-cluster graph and store publication",
+            no_cluster_graph_write_started.elapsed(),
+        );
         if let Some(metrics) = store_metrics {
             record_store_metrics(&mut timings, metrics);
         }
@@ -2576,6 +2591,7 @@ fn build_graph_inner(
             )?;
         }
         let mut manifest = prior_manifest;
+        let no_cluster_manifest_started = Instant::now();
         save_build_manifest(
             &mut manifest,
             &detection.files,
@@ -2583,10 +2599,15 @@ fn build_graph_inner(
             &root,
             semantic,
         )?;
+        profile_internal_duration(
+            "no-cluster manifest publication",
+            no_cluster_manifest_started.elapsed(),
+        );
         remove_if_exists(&output_dir.join("needs_update"))?;
         if let Some(program) = program.as_mut() {
             program.finish_pending_seal(&mut timings)?;
         }
+        let no_cluster_state_started = Instant::now();
         publish_build_state(
             options,
             &output_dir,
@@ -2601,6 +2622,11 @@ fn build_graph_inner(
             store_metrics.is_some(),
             &mut timings,
         )?;
+        profile_internal_duration(
+            "no-cluster build-state publication",
+            no_cluster_state_started.elapsed(),
+        );
+        let no_cluster_commit_started = Instant::now();
         let published_output_dir = commit_generation(
             guard,
             &output_container,
@@ -2609,6 +2635,10 @@ fn build_graph_inner(
             !options.graph_storage.publishes_store(),
             &mut timings,
         )?;
+        profile_internal_duration(
+            "no-cluster generation commit",
+            no_cluster_commit_started.elapsed(),
+        );
         timings.publish = stage_started.elapsed();
         return Ok((
             BuildResult {

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -41,6 +41,7 @@ pub use v1::{
     normalize_document_v1_with_inventory_best_effort_owned, normalize_v1, normalize_v1_best_effort,
 };
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::time::Instant;
@@ -71,8 +72,8 @@ struct NodeSourceFacts<'a> {
 const COALESCED_EDGE_EVIDENCE: &str = "_coalesced_edge_evidence";
 pub const GRAPH_DIAGNOSTICS_EXTENSION: &str = "_compass_v1_graph_diagnostics";
 
-enum EndpointResolution {
-    Exact(String),
+enum EndpointResolution<'a> {
+    Exact(&'a str),
     Rewritten {
         endpoint: String,
         evidence: EndpointRewriteEvidence,
@@ -297,14 +298,18 @@ fn build_from_owned_extraction(
     let mut source_edges = std::mem::take(&mut extraction.edges);
     for edge in &mut source_edges {
         preserve_occurrence_rule(&mut edge.attributes);
-        let original_source = edge.source.clone();
-        let original_target = edge.target.clone();
+        let original_source_was_doc_twin = doc_twin_rewrite_sources.contains(edge.source.as_str());
+        let original_target_was_doc_twin = doc_twin_rewrite_sources.contains(edge.target.as_str());
         let (source, mut rewrites) =
             remap_endpoint_with_evidence(&edge.source, &endpoint_remap, &endpoint_rewrite_evidence);
         let (target, target_rewrites) =
             remap_endpoint_with_evidence(&edge.target, &endpoint_remap, &endpoint_rewrite_evidence);
-        edge.source = source;
-        edge.target = target;
+        if let Cow::Owned(source) = source {
+            edge.source = source;
+        }
+        if let Cow::Owned(target) = target {
+            edge.target = target;
+        }
         rewrites.extend(target_rewrites);
         rewrites.sort_by_key(|rewrite| rewrite.rule);
         rewrites.dedup_by_key(|rewrite| rewrite.rule);
@@ -312,8 +317,7 @@ fn build_from_owned_extraction(
             stamp_graph_endpoint_rewrites(edge, &rewrites);
         }
         if edge.source == edge.target
-            && (doc_twin_rewrite_sources.contains(original_source.as_str())
-                || doc_twin_rewrite_sources.contains(original_target.as_str()))
+            && (original_source_was_doc_twin || original_target_was_doc_twin)
         {
             edge.attributes
                 .insert("_drop".to_owned(), Value::Bool(true));
@@ -330,30 +334,44 @@ fn build_from_owned_extraction(
         if edge.attributes.remove("_drop") == Some(Value::Bool(true)) {
             return (None, diagnostics);
         }
-        let source_value = edge.source.clone();
-        let target_value = edge.target.clone();
-        let Some(source) = resolve_edge_endpoint(
-            &source_value,
+        let source = match resolve_edge_endpoint(
+            &edge.source,
             "source",
-            &mut edge,
             &positions,
             &normalized,
             &mut diagnostics,
-        ) else {
-            return (None, diagnostics);
+        ) {
+            Some(EndpointResolution::Exact(_)) => None,
+            Some(EndpointResolution::Rewritten { endpoint, evidence }) => {
+                stamp_graph_endpoint_rewrites(&mut edge, &[evidence]);
+                Some(endpoint)
+            }
+            Some(EndpointResolution::Ambiguous { .. })
+            | Some(EndpointResolution::Missing)
+            | None => return (None, diagnostics),
         };
-        let Some(target) = resolve_edge_endpoint(
-            &target_value,
+        let target = match resolve_edge_endpoint(
+            &edge.target,
             "target",
-            &mut edge,
             &positions,
             &normalized,
             &mut diagnostics,
-        ) else {
-            return (None, diagnostics);
+        ) {
+            Some(EndpointResolution::Exact(_)) => None,
+            Some(EndpointResolution::Rewritten { endpoint, evidence }) => {
+                stamp_graph_endpoint_rewrites(&mut edge, &[evidence]);
+                Some(endpoint)
+            }
+            Some(EndpointResolution::Ambiguous { .. })
+            | Some(EndpointResolution::Missing)
+            | None => return (None, diagnostics),
         };
-        edge.source = source;
-        edge.target = target;
+        if let Some(source) = source {
+            edge.source = source;
+        }
+        if let Some(target) = target {
+            edge.target = target;
+        }
         edge.attributes.remove("target_file");
         sanitize_numeric(&mut edge.attributes, "weight");
         sanitize_numeric(&mut edge.attributes, "confidence_score");
@@ -742,11 +760,11 @@ fn remap_endpoint(value: &str, remap: &HashMap<String, String>) -> String {
     current.to_owned()
 }
 
-fn remap_endpoint_with_evidence(
-    value: &str,
+fn remap_endpoint_with_evidence<'a>(
+    value: &'a str,
     remap: &HashMap<String, String>,
     evidence: &HashMap<String, EndpointRewriteEvidence>,
-) -> (String, Vec<EndpointRewriteEvidence>) {
+) -> (Cow<'a, str>, Vec<EndpointRewriteEvidence>) {
     let mut current = value;
     let mut rewrites = Vec::new();
     let mut remaining = remap.len() + 1;
@@ -763,7 +781,12 @@ fn remap_endpoint_with_evidence(
         current = next;
         remaining -= 1;
     }
-    (current.to_owned(), rewrites)
+    let endpoint = if current == value {
+        Cow::Borrowed(value)
+    } else {
+        Cow::Owned(current.to_owned())
+    };
+    (endpoint, rewrites)
 }
 
 fn stamp_graph_endpoint_rewrites(edge: &mut EdgeRecord, rewrites: &[EndpointRewriteEvidence]) {
@@ -1057,13 +1080,13 @@ fn path_text(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-fn resolve_endpoint(
-    value: &str,
+fn resolve_endpoint<'a>(
+    value: &'a str,
     positions: &HashMap<String, usize>,
     normalized: &EndpointAliases,
-) -> EndpointResolution {
+) -> EndpointResolution<'a> {
     if positions.contains_key(value) {
-        return EndpointResolution::Exact(value.to_owned());
+        return EndpointResolution::Exact(value);
     }
     let alias = normalize_id(value);
     let Some(candidates) = normalized.get(&alias) else {
@@ -1084,20 +1107,16 @@ fn resolve_endpoint(
     }
 }
 
-fn resolve_edge_endpoint(
-    value: &str,
+fn resolve_edge_endpoint<'a>(
+    value: &'a str,
     role: &str,
-    edge: &mut EdgeRecord,
     positions: &HashMap<String, usize>,
     normalized: &EndpointAliases,
     diagnostics: &mut Vec<Value>,
-) -> Option<String> {
+) -> Option<EndpointResolution<'a>> {
     match resolve_endpoint(value, positions, normalized) {
-        EndpointResolution::Exact(endpoint) => Some(endpoint),
-        EndpointResolution::Rewritten { endpoint, evidence } => {
-            stamp_graph_endpoint_rewrites(edge, &[evidence]);
-            Some(endpoint)
-        }
+        exact @ EndpointResolution::Exact(_) => Some(exact),
+        rewritten @ EndpointResolution::Rewritten { .. } => Some(rewritten),
         EndpointResolution::Ambiguous { alias, candidates } => {
             diagnostics.push(ambiguous_endpoint_diagnostic(
                 value, &alias, role, candidates,
@@ -1371,8 +1390,10 @@ fn canonical_hyperedges(
                 let (remapped, mut member_rewrites) =
                     remap_endpoint_with_evidence(member, rekey, rewrite_evidence);
                 rewrites.append(&mut member_rewrites);
-                match resolve_endpoint(&remapped, positions, normalized) {
-                    EndpointResolution::Exact(endpoint) => valid.push(Value::String(endpoint)),
+                match resolve_endpoint(remapped.as_ref(), positions, normalized) {
+                    EndpointResolution::Exact(endpoint) => {
+                        valid.push(Value::String(endpoint.to_owned()));
+                    }
                     EndpointResolution::Rewritten { endpoint, evidence } => {
                         valid.push(Value::String(endpoint));
                         rewrites.push(evidence);
@@ -1402,7 +1423,10 @@ fn canonical_hyperedges(
 
 #[cfg(test)]
 mod tests {
-    use super::{dedupe_nodes, deduped_node_count};
+    use std::borrow::Cow;
+
+    use super::{dedupe_nodes, deduped_node_count, remap_endpoint_with_evidence};
+    use ahash::AHashMap;
     use compass_languages::RawNodeRecord;
     use serde_json::Map;
 
@@ -1424,5 +1448,23 @@ mod tests {
         ];
 
         assert_eq!(deduped_node_count(&nodes), dedupe_nodes(&nodes).len());
+    }
+
+    #[test]
+    fn endpoint_remap_borrows_unchanged_ids_and_owns_rewritten_ids() {
+        let remap = AHashMap::new();
+        let evidence = AHashMap::new();
+        let unchanged = String::from("stable");
+        let (unchanged_endpoint, unchanged_rewrites) =
+            remap_endpoint_with_evidence(&unchanged, &remap, &evidence);
+        assert!(matches!(unchanged_endpoint, Cow::Borrowed("stable")));
+        assert!(unchanged_rewrites.is_empty());
+
+        let remap = AHashMap::from([(String::from("legacy"), String::from("canonical"))]);
+        let rewritten = String::from("legacy");
+        let (rewritten_endpoint, rewritten_rewrites) =
+            remap_endpoint_with_evidence(&rewritten, &remap, &evidence);
+        assert!(matches!(rewritten_endpoint, Cow::Owned(endpoint) if endpoint == "canonical"));
+        assert!(rewritten_rewrites.is_empty());
     }
 }

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -24,14 +24,15 @@ pub use dedup::{
 };
 pub use quarantine::{MAX_QUARANTINE_EXAMPLES, PublicationOmissions, PublicationOutcome};
 pub use snapshot::{
-    CanonicalGraphDocument, GRAPH_SNAPSHOT_LAYOUT_V2, GRAPH_SNAPSHOT_MAX_ITEMS,
-    GRAPH_SNAPSHOT_MAX_OBJECTS, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1, GraphSnapshotBuilder,
-    GraphSnapshotGcStats, GraphSnapshotManifest, GraphSnapshotMetadata, GraphSnapshotReader,
-    IndexKind, PreparedGraphSnapshot, PreparedGraphSnapshotContent, SnapshotError,
-    SnapshotReadLimits, SnapshotRoot, SnapshotSelector, activate_graph_snapshot,
+    CanonicalGraphDocument, GRAPH_JSON_DELTA_MAX_SOURCE_BYTES, GRAPH_SNAPSHOT_LAYOUT_V2,
+    GRAPH_SNAPSHOT_MAX_ITEMS, GRAPH_SNAPSHOT_MAX_OBJECTS, GRAPH_SNAPSHOT_SELECTOR_SCHEMA_V1,
+    GraphSnapshotBuilder, GraphSnapshotGcStats, GraphSnapshotManifest, GraphSnapshotMetadata,
+    GraphSnapshotReader, IndexKind, PreparedGraphSnapshot, PreparedGraphSnapshotContent,
+    SnapshotError, SnapshotReadLimits, SnapshotRoot, SnapshotSelector, activate_graph_snapshot,
     active_graph_snapshot, canonical_graph_document, canonical_graph_document_presorted,
     canonical_graph_json, encode_graph_index_key, garbage_collect_graph_snapshots,
     graph_snapshot_needs_gc, prepare_graph_snapshot, write_canonical_graph_json,
+    write_fact_neutral_graph_json_delta,
 };
 pub use v1::{
     BuildEvidence, InventoryEvidence, SourceDigest, V1_PUBLICATION_SEMANTICS_VERSION,

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -32,7 +32,7 @@ pub use snapshot::{
     active_graph_snapshot, canonical_graph_document, canonical_graph_document_presorted,
     canonical_graph_json, encode_graph_index_key, garbage_collect_graph_snapshots,
     graph_snapshot_needs_gc, prepare_graph_snapshot, write_canonical_graph_json,
-    write_fact_neutral_graph_json_delta,
+    write_fact_neutral_graph_json_delta, write_fact_neutral_graph_json_delta_prevalidated,
 };
 pub use v1::{
     BuildEvidence, InventoryEvidence, SourceDigest, V1_PUBLICATION_SEMANTICS_VERSION,

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -842,6 +842,42 @@ pub fn write_fact_neutral_graph_json_delta<W: Write + ?Sized>(
     changed_file_node_ids: &BTreeSet<String>,
     writer: &mut W,
 ) -> io::Result<bool> {
+    write_fact_neutral_graph_json_delta_inner(
+        previous_bytes,
+        graph,
+        changed_file_node_ids,
+        true,
+        writer,
+    )
+}
+
+/// Publish a fact-neutral edit after the caller has already validated the
+/// previous graph document. The core pipeline uses this variant because it
+/// loads `graph.json` as a bounded, typed `GraphDocument` before attempting the
+/// byte-preserving publication. Skipping the redundant per-record payload
+/// deserialization keeps large incremental edits bounded by one graph parse.
+pub fn write_fact_neutral_graph_json_delta_prevalidated<W: Write + ?Sized>(
+    previous_bytes: &[u8],
+    graph: &GraphDocument,
+    changed_file_node_ids: &BTreeSet<String>,
+    writer: &mut W,
+) -> io::Result<bool> {
+    write_fact_neutral_graph_json_delta_inner(
+        previous_bytes,
+        graph,
+        changed_file_node_ids,
+        false,
+        writer,
+    )
+}
+
+fn write_fact_neutral_graph_json_delta_inner<W: Write + ?Sized>(
+    previous_bytes: &[u8],
+    graph: &GraphDocument,
+    changed_file_node_ids: &BTreeSet<String>,
+    validate_records: bool,
+    writer: &mut W,
+) -> io::Result<bool> {
     if previous_bytes.is_empty()
         || previous_bytes.len() > MAX_GRAPH_BYTES
         || previous_bytes.len() > GRAPH_JSON_DELTA_MAX_SOURCE_BYTES
@@ -851,45 +887,45 @@ pub fn write_fact_neutral_graph_json_delta<W: Write + ?Sized>(
     let Some(nodes_range) = top_level_member_range(previous_bytes, "nodes") else {
         return Ok(false);
     };
-    let Some(links_range) = top_level_member_range(previous_bytes, "links") else {
+    // The canonical writer emits `links` immediately after `nodes`. Starting
+    // from the end of the already located nodes value avoids rescanning the
+    // complete node array just to find the next top-level member.
+    let Some(links_range) = top_level_member_range_after(previous_bytes, nodes_range.end, "links")
+    else {
         return Ok(false);
     };
-    let Some(node_ranges) = json_array_element_ranges(previous_bytes, nodes_range.clone()) else {
+    let Some(node_ranges) = json_array_element_ranges_matching(
+        previous_bytes,
+        nodes_range.clone(),
+        graph.nodes.iter().map(|node| node.id.as_str()),
+        validate_records,
+    ) else {
         return Ok(false);
     };
-    let Some(link_ranges) = json_array_element_ranges(previous_bytes, links_range.clone()) else {
-        return Ok(false);
-    };
-    if node_ranges.len() != graph.nodes.len() || link_ranges.len() != graph.links.len() {
+    if node_ranges.len() != graph.nodes.len()
+        || !json_array_identities_match(
+            previous_bytes,
+            links_range.clone(),
+            graph.links.iter().map(|link| link.id.as_str()),
+            validate_records,
+        )
+        .unwrap_or(false)
+    {
         return Ok(false);
     }
 
     let mut changed_seen = BTreeSet::new();
-    for (index, range) in node_ranges.iter().enumerate() {
-        let Some(identity) = json_record_identity(&previous_bytes[range.clone()]) else {
-            return Ok(false);
-        };
+    for (index, _) in node_ranges.iter().enumerate() {
         let current = &graph.nodes[index];
-        if identity.as_ref() != current.id {
-            return Ok(false);
-        }
-        if changed_file_node_ids.contains(identity.as_ref()) {
+        if changed_file_node_ids.contains(&current.id) {
             if current.kind != NodeKind::File {
                 return Ok(false);
             }
-            changed_seen.insert(identity.into_owned());
+            changed_seen.insert(current.id.clone());
         }
     }
     if changed_seen.len() != changed_file_node_ids.len() {
         return Ok(false);
-    }
-    for (index, range) in link_ranges.iter().enumerate() {
-        let Some(identity) = json_record_identity(&previous_bytes[range.clone()]) else {
-            return Ok(false);
-        };
-        if identity.as_ref() != graph.links[index].id {
-            return Ok(false);
-        }
     }
 
     writer.write_all(b"{\"directed\":")?;
@@ -928,10 +964,38 @@ struct JsonRecordIdentity<'a> {
     id: Cow<'a, str>,
 }
 
-fn json_record_identity(bytes: &[u8]) -> Option<Cow<'_, str>> {
-    serde_json::from_slice::<JsonRecordIdentity<'_>>(bytes)
-        .ok()
-        .map(|record| record.id)
+fn json_record_identity(bytes: &[u8], validate_record: bool) -> Option<Cow<'_, str>> {
+    if validate_record {
+        return serde_json::from_slice::<JsonRecordIdentity<'_>>(bytes)
+            .ok()
+            .map(|record| record.id);
+    }
+    // Canonical node/link records serialize `id` first.  The caller has
+    // already loaded the previous graph through `GraphDocument`, so the
+    // complete record payload has been validated before this byte-preserving
+    // preflight runs.  Avoid deserializing every large record a second time;
+    // the array scanner above still validates the record boundaries and this
+    // check only needs the leading identity used to prove ordering.
+    let object_start = skip_json_whitespace(bytes, 0);
+    if bytes.get(object_start) != Some(&b'{') {
+        return None;
+    }
+    let key_start = skip_json_whitespace(bytes, object_start.saturating_add(1));
+    let key_end = json_string_end(bytes, key_start)?;
+    if &bytes[key_start..key_end] != b"\"id\"" {
+        return None;
+    }
+    let colon = skip_json_whitespace(bytes, key_end);
+    if bytes.get(colon) != Some(&b':') {
+        return None;
+    }
+    let value_start = skip_json_whitespace(bytes, colon.saturating_add(1));
+    let value_end = json_string_end(bytes, value_start)?;
+    let raw = bytes.get(value_start.saturating_add(1)..value_end.saturating_sub(1))?;
+    if raw.iter().all(|byte| *byte >= 0x20 && *byte != b'\\') {
+        return std::str::from_utf8(raw).ok().map(Cow::Borrowed);
+    }
+    serde_json::from_slice::<Cow<'_, str>>(&bytes[value_start..value_end]).ok()
 }
 
 fn top_level_member_range(bytes: &[u8], wanted: &str) -> Option<Range<usize>> {
@@ -946,14 +1010,13 @@ fn top_level_member_range(bytes: &[u8], wanted: &str) -> Option<Range<usize>> {
     loop {
         let key_start = index;
         let key_end = json_string_end(bytes, key_start)?;
-        let key = serde_json::from_slice::<String>(&bytes[key_start..key_end]).ok()?;
         index = skip_json_whitespace(bytes, key_end);
         if bytes.get(index) != Some(&b':') {
             return None;
         }
         let value_start = skip_json_whitespace(bytes, index.saturating_add(1));
         let value_end = json_value_end(bytes, value_start)?;
-        if key == wanted {
+        if json_key_matches(bytes, key_start..key_end, wanted) {
             return Some(value_start..value_end);
         }
         index = skip_json_whitespace(bytes, value_end);
@@ -967,7 +1030,43 @@ fn top_level_member_range(bytes: &[u8], wanted: &str) -> Option<Range<usize>> {
     }
 }
 
-fn json_array_element_ranges(bytes: &[u8], range: Range<usize>) -> Option<Vec<Range<usize>>> {
+fn top_level_member_range_after(
+    bytes: &[u8],
+    previous_value_end: usize,
+    wanted: &str,
+) -> Option<Range<usize>> {
+    let comma = skip_json_whitespace(bytes, previous_value_end);
+    if bytes.get(comma) != Some(&b',') {
+        return None;
+    }
+    let key_start = skip_json_whitespace(bytes, comma.saturating_add(1));
+    let key_end = json_string_end(bytes, key_start)?;
+    if !json_key_matches(bytes, key_start..key_end, wanted) {
+        return None;
+    }
+    let colon = skip_json_whitespace(bytes, key_end);
+    if bytes.get(colon) != Some(&b':') {
+        return None;
+    }
+    let value_start = skip_json_whitespace(bytes, colon.saturating_add(1));
+    let value_end = json_value_end(bytes, value_start)?;
+    Some(value_start..value_end)
+}
+
+fn json_key_matches(bytes: &[u8], range: Range<usize>, wanted: &str) -> bool {
+    let key = &bytes[range];
+    key.len() == wanted.len().saturating_add(2)
+        && key.first() == Some(&b'"')
+        && key.last() == Some(&b'"')
+        && &key[1..key.len().saturating_sub(1)] == wanted.as_bytes()
+}
+
+fn json_array_element_ranges_matching<'a>(
+    bytes: &[u8],
+    range: Range<usize>,
+    expected_ids: impl Iterator<Item = &'a str>,
+    validate_records: bool,
+) -> Option<Vec<Range<usize>>> {
     if bytes.get(range.start) != Some(&b'[')
         || range.end <= range.start.saturating_add(1)
         || bytes.get(range.end.saturating_sub(1)) != Some(&b']')
@@ -975,9 +1074,10 @@ fn json_array_element_ranges(bytes: &[u8], range: Range<usize>) -> Option<Vec<Ra
         return None;
     }
     let mut elements = Vec::new();
+    let mut expected_ids = expected_ids;
     let mut index = skip_json_whitespace(bytes, range.start.saturating_add(1));
     if index == range.end.saturating_sub(1) {
-        return Some(elements);
+        return expected_ids.next().is_none().then_some(elements);
     }
     loop {
         let value_start = index;
@@ -986,6 +1086,11 @@ fn json_array_element_ranges(bytes: &[u8], range: Range<usize>) -> Option<Vec<Ra
             return None;
         }
         if elements.len() >= GRAPH_SNAPSHOT_MAX_ITEMS {
+            return None;
+        }
+        let expected_id = expected_ids.next()?;
+        let identity = json_record_identity(&bytes[value_start..value_end], validate_records)?;
+        if identity.as_ref() != expected_id {
             return None;
         }
         elements.push(value_start..value_end);
@@ -997,7 +1102,60 @@ fn json_array_element_ranges(bytes: &[u8], range: Range<usize>) -> Option<Vec<Ra
                     return None;
                 }
             }
-            Some(b']') if index == range.end.saturating_sub(1) => return Some(elements),
+            Some(b']') if index == range.end.saturating_sub(1) => {
+                return expected_ids.next().is_none().then_some(elements);
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn json_array_identities_match<'a>(
+    bytes: &[u8],
+    range: Range<usize>,
+    expected_ids: impl Iterator<Item = &'a str>,
+    validate_records: bool,
+) -> Option<bool> {
+    if bytes.get(range.start) != Some(&b'[')
+        || range.end <= range.start.saturating_add(1)
+        || bytes.get(range.end.saturating_sub(1)) != Some(&b']')
+    {
+        return None;
+    }
+    let mut expected_ids = expected_ids;
+    let mut element_count = 0_usize;
+    let mut index = skip_json_whitespace(bytes, range.start.saturating_add(1));
+    if index == range.end.saturating_sub(1) {
+        return Some(expected_ids.next().is_none());
+    }
+    loop {
+        let value_start = index;
+        let value_end = json_value_end(bytes, value_start)?;
+        if value_end > range.end.saturating_sub(1) {
+            return None;
+        }
+        if element_count >= GRAPH_SNAPSHOT_MAX_ITEMS {
+            return None;
+        }
+        element_count = element_count.saturating_add(1);
+        let Some(expected_id) = expected_ids.next() else {
+            return Some(false);
+        };
+        let identity = json_record_identity(&bytes[value_start..value_end], validate_records)?;
+        if identity.as_ref() != expected_id {
+            return Some(false);
+        }
+        index = skip_json_whitespace(bytes, value_end);
+        match bytes.get(index) {
+            Some(b',') => {
+                index = skip_json_whitespace(bytes, index.saturating_add(1));
+                if index >= range.end.saturating_sub(1) {
+                    return None;
+                }
+            }
+            Some(b']') if index == range.end.saturating_sub(1) => {
+                return Some(expected_ids.next().is_none());
+            }
             _ => return None,
         }
     }
@@ -3303,6 +3461,18 @@ mod tests {
         );
         assert_eq!(actual, expected);
 
+        let mut prevalidated = Vec::new();
+        assert!(
+            write_fact_neutral_graph_json_delta_prevalidated(
+                &previous_bytes,
+                &current,
+                &changed,
+                &mut prevalidated,
+            )
+            .map_err(|error| SnapshotError::Encode(error.to_string()))?
+        );
+        assert_eq!(prevalidated, expected);
+
         let invalid = BTreeSet::from(["symbol".to_owned()]);
         let mut no_output = Vec::new();
         assert!(
@@ -3316,6 +3486,25 @@ mod tests {
         );
         assert!(no_output.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn json_record_identity_uses_the_canonical_leading_id() {
+        assert_eq!(
+            json_record_identity(br#"{"id":"plain","name":"ignored"}"#, false).as_deref(),
+            Some("plain")
+        );
+        assert_eq!(
+            json_record_identity(br#"{"id":"escaped\"id","name":"ignored"}"#, false).as_deref(),
+            Some("escaped\"id")
+        );
+        let malformed = br#"{"id":"plain","value":01}"#;
+        assert!(json_record_identity(malformed, true).is_none());
+        assert_eq!(
+            json_record_identity(malformed, false).as_deref(),
+            Some("plain")
+        );
+        assert!(json_record_identity(br#"{"name":"plain","id":"not-leading"}"#, false).is_none());
     }
 
     #[test]

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -6,8 +6,10 @@
 //! logical layout.  The JSON artifact remains the compatibility engine and is
 //! reconstructed from these records for export and differential testing.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, Read, Write};
+use std::ops::Range;
 
 use compass_model::code_graph::{
     CODE_GRAPH_SCHEMA_V1, EdgeRecord, FileRecord, GraphDiagnostic, GraphDocument, GraphMetadata,
@@ -35,6 +37,10 @@ pub const GRAPH_SNAPSHOT_MAX_OBJECTS: usize = 100_000;
 pub const GRAPH_SNAPSHOT_MAX_ITEMS: usize = 5_000_000;
 pub const GRAPH_SNAPSHOT_MAX_FANOUT: usize = 32;
 pub const GRAPH_SNAPSHOT_MAX_LEAF_ENTRIES: usize = 128;
+/// Maximum previous JSON artifact retained while attempting a byte-preserving
+/// fact-neutral publication. Larger artifacts use the bounded streaming
+/// serializer instead of adding another resident graph-sized buffer.
+pub const GRAPH_JSON_DELTA_MAX_SOURCE_BYTES: usize = 128 * 1024 * 1024;
 const TREE_ZSTD_MAGIC: &[u8; 5] = b"CSTZ1";
 const TREE_ZSTD_HEADER_BYTES: usize = TREE_ZSTD_MAGIC.len() + std::mem::size_of::<u32>();
 
@@ -819,6 +825,261 @@ pub fn write_canonical_graph_json<W: Write + ?Sized>(
     writer.write_all(b",\"links\":")?;
     write_canonical_record_array(writer, &graph.links)?;
     writer.write_all(b"}")
+}
+
+/// Publish a fact-neutral graph edit by reusing the previous canonical node
+/// and link bytes. Fact-neutral edits only update file-node metadata and graph
+/// inventory; the semantic node IDs and every relationship remain unchanged.
+///
+/// The function performs a complete structural preflight before writing any
+/// bytes. It returns `Ok(false)` when the previous artifact is not the
+/// canonical node-link shape or when the supplied changed-node set is not
+/// compatible with a file-only delta, allowing the caller to use the normal
+/// full serializer without risking a partial duplicate document.
+pub fn write_fact_neutral_graph_json_delta<W: Write + ?Sized>(
+    previous_bytes: &[u8],
+    graph: &GraphDocument,
+    changed_file_node_ids: &BTreeSet<String>,
+    writer: &mut W,
+) -> io::Result<bool> {
+    if previous_bytes.is_empty()
+        || previous_bytes.len() > MAX_GRAPH_BYTES
+        || previous_bytes.len() > GRAPH_JSON_DELTA_MAX_SOURCE_BYTES
+    {
+        return Ok(false);
+    }
+    let Some(nodes_range) = top_level_member_range(previous_bytes, "nodes") else {
+        return Ok(false);
+    };
+    let Some(links_range) = top_level_member_range(previous_bytes, "links") else {
+        return Ok(false);
+    };
+    let Some(node_ranges) = json_array_element_ranges(previous_bytes, nodes_range.clone()) else {
+        return Ok(false);
+    };
+    let Some(link_ranges) = json_array_element_ranges(previous_bytes, links_range.clone()) else {
+        return Ok(false);
+    };
+    if node_ranges.len() != graph.nodes.len() || link_ranges.len() != graph.links.len() {
+        return Ok(false);
+    }
+
+    let mut changed_seen = BTreeSet::new();
+    for (index, range) in node_ranges.iter().enumerate() {
+        let Some(identity) = json_record_identity(&previous_bytes[range.clone()]) else {
+            return Ok(false);
+        };
+        let current = &graph.nodes[index];
+        if identity.as_ref() != current.id {
+            return Ok(false);
+        }
+        if changed_file_node_ids.contains(identity.as_ref()) {
+            if current.kind != NodeKind::File {
+                return Ok(false);
+            }
+            changed_seen.insert(identity.into_owned());
+        }
+    }
+    if changed_seen.len() != changed_file_node_ids.len() {
+        return Ok(false);
+    }
+    for (index, range) in link_ranges.iter().enumerate() {
+        let Some(identity) = json_record_identity(&previous_bytes[range.clone()]) else {
+            return Ok(false);
+        };
+        if identity.as_ref() != graph.links[index].id {
+            return Ok(false);
+        }
+    }
+
+    writer.write_all(b"{\"directed\":")?;
+    serde_json::to_writer(&mut *writer, &graph.directed).map_err(io::Error::other)?;
+    writer.write_all(b",\"multigraph\":")?;
+    serde_json::to_writer(&mut *writer, &graph.multigraph).map_err(io::Error::other)?;
+    writer.write_all(b",\"graph\":")?;
+    if graph_metadata_files_are_canonical(graph) {
+        serde_json::to_writer(&mut *writer, &graph.graph).map_err(io::Error::other)?;
+    } else {
+        let mut metadata = graph.graph.clone();
+        metadata.files.sort_by(|left, right| left.id.cmp(&right.id));
+        serde_json::to_writer(&mut *writer, &metadata).map_err(io::Error::other)?;
+    }
+    writer.write_all(b",\"nodes\":[")?;
+    for (index, range) in node_ranges.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        let node = &graph.nodes[index];
+        if changed_file_node_ids.contains(&node.id) {
+            serde_json::to_writer(&mut *writer, node).map_err(io::Error::other)?;
+        } else {
+            writer.write_all(&previous_bytes[range.clone()])?;
+        }
+    }
+    writer.write_all(b"],\"links\":")?;
+    writer.write_all(&previous_bytes[links_range])?;
+    writer.write_all(b"}")?;
+    Ok(true)
+}
+
+#[derive(Deserialize)]
+struct JsonRecordIdentity<'a> {
+    #[serde(borrow)]
+    id: Cow<'a, str>,
+}
+
+fn json_record_identity(bytes: &[u8]) -> Option<Cow<'_, str>> {
+    serde_json::from_slice::<JsonRecordIdentity<'_>>(bytes)
+        .ok()
+        .map(|record| record.id)
+}
+
+fn top_level_member_range(bytes: &[u8], wanted: &str) -> Option<Range<usize>> {
+    let object_start = skip_json_whitespace(bytes, 0);
+    if bytes.get(object_start) != Some(&b'{') {
+        return None;
+    }
+    let mut index = skip_json_whitespace(bytes, object_start.saturating_add(1));
+    if bytes.get(index) == Some(&b'}') {
+        return None;
+    }
+    loop {
+        let key_start = index;
+        let key_end = json_string_end(bytes, key_start)?;
+        let key = serde_json::from_slice::<String>(&bytes[key_start..key_end]).ok()?;
+        index = skip_json_whitespace(bytes, key_end);
+        if bytes.get(index) != Some(&b':') {
+            return None;
+        }
+        let value_start = skip_json_whitespace(bytes, index.saturating_add(1));
+        let value_end = json_value_end(bytes, value_start)?;
+        if key == wanted {
+            return Some(value_start..value_end);
+        }
+        index = skip_json_whitespace(bytes, value_end);
+        match bytes.get(index) {
+            Some(b',') => {
+                index = skip_json_whitespace(bytes, index.saturating_add(1));
+            }
+            Some(b'}') => return None,
+            _ => return None,
+        }
+    }
+}
+
+fn json_array_element_ranges(bytes: &[u8], range: Range<usize>) -> Option<Vec<Range<usize>>> {
+    if bytes.get(range.start) != Some(&b'[')
+        || range.end <= range.start.saturating_add(1)
+        || bytes.get(range.end.saturating_sub(1)) != Some(&b']')
+    {
+        return None;
+    }
+    let mut elements = Vec::new();
+    let mut index = skip_json_whitespace(bytes, range.start.saturating_add(1));
+    if index == range.end.saturating_sub(1) {
+        return Some(elements);
+    }
+    loop {
+        let value_start = index;
+        let value_end = json_value_end(bytes, value_start)?;
+        if value_end > range.end.saturating_sub(1) {
+            return None;
+        }
+        if elements.len() >= GRAPH_SNAPSHOT_MAX_ITEMS {
+            return None;
+        }
+        elements.push(value_start..value_end);
+        index = skip_json_whitespace(bytes, value_end);
+        match bytes.get(index) {
+            Some(b',') => {
+                index = skip_json_whitespace(bytes, index.saturating_add(1));
+                if index >= range.end.saturating_sub(1) {
+                    return None;
+                }
+            }
+            Some(b']') if index == range.end.saturating_sub(1) => return Some(elements),
+            _ => return None,
+        }
+    }
+}
+
+fn skip_json_whitespace(bytes: &[u8], mut index: usize) -> usize {
+    while bytes
+        .get(index)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t'))
+    {
+        index = index.saturating_add(1);
+    }
+    index
+}
+
+fn json_string_end(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes.get(start) != Some(&b'"') {
+        return None;
+    }
+    let mut escaped = false;
+    for (index, byte) in bytes.iter().enumerate().skip(start.saturating_add(1)) {
+        let byte = *byte;
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'"' {
+            return Some(index.saturating_add(1));
+        }
+    }
+    None
+}
+
+fn json_value_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let start = skip_json_whitespace(bytes, start);
+    match bytes.get(start) {
+        Some(b'"') => json_string_end(bytes, start),
+        Some(b'{') | Some(b'[') => {
+            let mut stack = vec![if bytes[start] == b'{' { b'}' } else { b']' }];
+            let mut index = start.saturating_add(1);
+            while index < bytes.len() {
+                match bytes[index] {
+                    b'"' => index = json_string_end(bytes, index)?,
+                    b'{' => {
+                        if stack.len() >= GRAPH_SNAPSHOT_MAX_DEPTH {
+                            return None;
+                        }
+                        stack.push(b'}');
+                        index = index.saturating_add(1);
+                    }
+                    b'[' => {
+                        if stack.len() >= GRAPH_SNAPSHOT_MAX_DEPTH {
+                            return None;
+                        }
+                        stack.push(b']');
+                        index = index.saturating_add(1);
+                    }
+                    b'}' | b']' => {
+                        if stack.pop() != Some(bytes[index]) {
+                            return None;
+                        }
+                        index = index.saturating_add(1);
+                        if stack.is_empty() {
+                            return Some(index);
+                        }
+                    }
+                    _ => index = index.saturating_add(1),
+                }
+            }
+            None
+        }
+        Some(_) => {
+            let mut index = start;
+            while bytes.get(index).is_some_and(|byte| {
+                !matches!(byte, b' ' | b'\n' | b'\r' | b'\t' | b',' | b']' | b'}')
+            }) {
+                index = index.saturating_add(1);
+            }
+            (index > start).then_some(index)
+        }
+        None => None,
+    }
 }
 
 fn graph_metadata_files_are_canonical(graph: &GraphDocument) -> bool {
@@ -2862,7 +3123,10 @@ fn digest_bytes(value: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use compass_model::code_graph::{BuildMetadata, ExtractionStatus, FileRecord, NodeKind};
+    use compass_model::code_graph::{
+        BuildMetadata, EdgeKind, EdgeRecord, ExtractionStatus, FileNodeDetails, FileRecord,
+        NodeDetails, NodeKind,
+    };
 
     #[test]
     fn streamed_canonical_graph_json_matches_serde_encoding() -> Result<(), SnapshotError> {
@@ -2909,7 +3173,21 @@ mod tests {
                     community: None,
                 },
             ],
-            links: Vec::new(),
+            links: vec![EdgeRecord {
+                id: "edge".to_owned(),
+                key: "edge".to_owned(),
+                source: "file".to_owned(),
+                target: "symbol".to_owned(),
+                kind: EdgeKind::Contains,
+                occurrence_rule: None,
+                relationship_site: None,
+                details: None,
+                evidence: Vec::new(),
+                weight: None,
+                context: None,
+                deferred: false,
+                diagnostics: Vec::new(),
+            }],
         };
         let expected = serde_json::to_vec(&canonical_graph_document_presorted(&graph))
             .map_err(|error| SnapshotError::Encode(error.to_string()))?;
@@ -2951,6 +3229,92 @@ mod tests {
             .map_err(|error| SnapshotError::Encode(error.to_string()))?;
 
         assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn fact_neutral_delta_reuses_unchanged_record_bytes() -> Result<(), SnapshotError> {
+        let build = BuildMetadata {
+            builder_version: "test".to_owned(),
+            schema_fingerprint: "schema".to_owned(),
+            source_tree_digest: "tree".to_owned(),
+            configuration_digest: "config".to_owned(),
+            generation_id: "generation".to_owned(),
+            source_commit: None,
+        };
+        let file_node = NodeRecord {
+            id: "file".to_owned(),
+            kind: NodeKind::File,
+            roles: Vec::new(),
+            name: "main.rs".to_owned(),
+            qualified_name: "main.rs".to_owned(),
+            language: Some("rust".to_owned()),
+            framework: None,
+            source: None,
+            details: None,
+            evidence: Vec::new(),
+            coverage: Vec::new(),
+            diagnostics: Vec::new(),
+            community: None,
+        };
+        let symbol_node = NodeRecord {
+            id: "symbol".to_owned(),
+            kind: NodeKind::Function,
+            roles: Vec::new(),
+            name: "main".to_owned(),
+            qualified_name: "main".to_owned(),
+            language: Some("rust".to_owned()),
+            framework: None,
+            source: None,
+            details: None,
+            evidence: Vec::new(),
+            coverage: Vec::new(),
+            diagnostics: Vec::new(),
+            community: None,
+        };
+        let previous = GraphDocument {
+            directed: true,
+            multigraph: true,
+            graph: GraphMetadata::v1(build),
+            nodes: vec![file_node, symbol_node],
+            links: Vec::new(),
+        };
+        let mut previous_bytes = Vec::new();
+        write_canonical_graph_json(&previous, &mut previous_bytes)
+            .map_err(|error| SnapshotError::Encode(error.to_string()))?;
+
+        let mut current = previous.clone();
+        current.nodes[0].details = Some(NodeDetails::File(FileNodeDetails {
+            content_digest: "sha256:changed".to_owned(),
+            byte_size: 42,
+            generated: false,
+        }));
+        let expected = {
+            let mut bytes = Vec::new();
+            write_canonical_graph_json(&current, &mut bytes)
+                .map_err(|error| SnapshotError::Encode(error.to_string()))?;
+            bytes
+        };
+        let changed = BTreeSet::from(["file".to_owned()]);
+        let mut actual = Vec::new();
+        assert!(
+            write_fact_neutral_graph_json_delta(&previous_bytes, &current, &changed, &mut actual,)
+                .map_err(|error| SnapshotError::Encode(error.to_string()))?
+        );
+        assert_eq!(actual, expected);
+
+        let invalid = BTreeSet::from(["symbol".to_owned()]);
+        let mut no_output = Vec::new();
+        assert!(
+            !write_fact_neutral_graph_json_delta(
+                &previous_bytes,
+                &current,
+                &invalid,
+                &mut no_output,
+            )
+            .map_err(|error| SnapshotError::Encode(error.to_string()))?
+        );
+        assert!(no_output.is_empty());
         Ok(())
     }
 

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -40,7 +40,7 @@ pub const GRAPH_SNAPSHOT_MAX_LEAF_ENTRIES: usize = 128;
 /// Maximum previous JSON artifact retained while attempting a byte-preserving
 /// fact-neutral publication. Larger artifacts use the bounded streaming
 /// serializer instead of adding another resident graph-sized buffer.
-pub const GRAPH_JSON_DELTA_MAX_SOURCE_BYTES: usize = 128 * 1024 * 1024;
+pub const GRAPH_JSON_DELTA_MAX_SOURCE_BYTES: usize = 512 * 1024 * 1024;
 const TREE_ZSTD_MAGIC: &[u8; 5] = b"CSTZ1";
 const TREE_ZSTD_HEADER_BYTES: usize = TREE_ZSTD_MAGIC.len() + std::mem::size_of::<u32>();
 

--- a/crates/compass-graph/tests/domain_normalization.rs
+++ b/crates/compass-graph/tests/domain_normalization.rs
@@ -143,6 +143,30 @@ fn json_config_keys_publish_with_config_provenance_and_stable_paths()
             .iter()
             .all(|edge| edge.evidence[0].origin == EvidenceOrigin::Config)
     );
+
+    let compiler_options = graph
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name == "compilerOptions")
+        .ok_or("missing compilerOptions config key")?;
+    let paths = graph
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name == "compilerOptions.paths")
+        .ok_or("missing compilerOptions.paths config key")?;
+    let nested_path = graph
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name == "compilerOptions.paths.@app/*")
+        .ok_or("missing nested config key")?;
+    assert!(graph.links.iter().any(|edge| {
+        edge.kind == EdgeKind::Contains
+            && edge.source == compiler_options.id
+            && edge.target == paths.id
+    }));
+    assert!(graph.links.iter().any(|edge| {
+        edge.kind == EdgeKind::Contains && edge.source == paths.id && edge.target == nested_path.id
+    }));
     Ok(())
 }
 

--- a/crates/compass-languages/src/adapters.rs
+++ b/crates/compass-languages/src/adapters.rs
@@ -193,7 +193,7 @@ const UNIVERSAL_ADAPTERS: &[AdapterProfile] = &[
     AdapterProfile {
         id: "compass.python",
         language: "python",
-        version: 1,
+        version: 2,
         evidence_schema: crate::UNIVERSAL_EVIDENCE_SCHEMA,
         profile: UniversalAdapterProfile::UniversalCandidate,
         capabilities: PYTHON_CAPABILITIES,

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -4999,6 +4999,24 @@ impl<'source> DirectAdapterState<'source> {
         } else {
             None
         };
+        let python_bound_receiver = if python_super_receiver.is_none() && self.language == "python"
+        {
+            qualifier
+                .filter(|qualifier| matches!(*qualifier, "self" | "cls"))
+                .map(|qualifier| {
+                    self.python_bound_method_receiver(call, qualifier, function.start_byte())
+                })
+                .transpose()?
+                .flatten()
+        } else {
+            None
+        };
+        if self.language == "python"
+            && qualifier.is_some_and(|qualifier| matches!(qualifier, "self" | "cls"))
+            && python_bound_receiver.is_none()
+        {
+            return Ok(());
+        }
         let lookup_name = qualifier.map(qualified_binding_head).unwrap_or(spelling);
         let allow_later_file_binding =
             self.language == "python" && matches!(owner.kind.as_str(), "function" | "method");
@@ -5130,12 +5148,108 @@ impl<'source> DirectAdapterState<'source> {
                 } else {
                     vec!["function".to_owned(), "method".to_owned()]
                 },
-                hierarchy: None,
+                hierarchy: python_bound_receiver.map(|receiver_qualified_name| {
+                    HierarchyConstraint::ReceiverDispatch {
+                        receiver_qualified_name,
+                        strategy: ReceiverDispatchStrategy::C3FromReceiver,
+                    }
+                }),
                 allow_external: qualified_name.is_some() && python_super_receiver.is_none(),
             },
         )?;
         let _ = call_kind;
         Ok(())
+    }
+
+    fn python_name_rebound_between(
+        &self,
+        root: Node<'_>,
+        start: usize,
+        end: usize,
+        name: &str,
+    ) -> bool {
+        let mut cursor = root.walk();
+        root.children(&mut cursor)
+            .filter(|child| child.is_named())
+            .any(|child| {
+                child.start_byte() >= start
+                    && child.end_byte() <= end
+                    && !matches!(child.kind(), "import_statement" | "import_from_statement")
+                    && crate::engine::python_bound_names(child, self.source, true).contains(name)
+            })
+    }
+
+    fn python_bound_method_receiver(
+        &self,
+        call: Node<'_>,
+        receiver: &str,
+        use_start: usize,
+    ) -> Result<Option<String>, EvidenceError> {
+        let mut ancestor = Some(call);
+        while let Some(node) = ancestor {
+            if node.kind() == "lambda"
+                && crate::engine::python_bound_names(node, self.source, false).contains(receiver)
+            {
+                return Ok(None);
+            }
+            if matches!(
+                node.kind(),
+                "list_comprehension"
+                    | "dictionary_comprehension"
+                    | "set_comprehension"
+                    | "generator_expression"
+            ) && crate::engine::python_bound_names(node, self.source, true).contains(receiver)
+            {
+                return Ok(None);
+            }
+            if node.kind() == "function_definition" {
+                let Some(context) = self.declarations.get(&node.id()) else {
+                    return Ok(None);
+                };
+                if context.kind == "method" {
+                    let Some(parameters) = node.child_by_field_name("parameters") else {
+                        return Ok(None);
+                    };
+                    let Some(parameter) = parameters.named_child(0) else {
+                        return Ok(None);
+                    };
+                    let name = if parameter.kind() == "identifier" {
+                        Some(parameter)
+                    } else {
+                        parameter.child_by_field_name("name").or_else(|| {
+                            let mut cursor = parameter.walk();
+                            parameter
+                                .children(&mut cursor)
+                                .find(|child| child.kind() == "identifier")
+                        })
+                    };
+                    let Some(name) = name.filter(|name| self.text(*name) == receiver) else {
+                        return Ok(None);
+                    };
+                    if python_has_decorator(node, self.source, "staticmethod") {
+                        return Ok(None);
+                    }
+                    if receiver == "cls" && !python_has_decorator(node, self.source, "classmethod")
+                    {
+                        return Ok(None);
+                    }
+                    let body = node.child_by_field_name("body").unwrap_or(node);
+                    if self.python_name_rebound_between(body, name.end_byte(), use_start, receiver)
+                    {
+                        return Ok(None);
+                    }
+                    return Ok(context.enclosing_type_qualified_name.clone());
+                }
+                if crate::engine::python_bound_names(node, self.source, false).contains(receiver) {
+                    return Ok(None);
+                }
+            }
+            if node.kind() == "class_definition" {
+                return Ok(None);
+            }
+            ancestor = node.parent();
+        }
+        Ok(None)
     }
 
     fn go_selector_receiver_type(
@@ -7099,6 +7213,32 @@ fn python_super_receiver<'tree>(function: Node<'tree>, source: &[u8]) -> Option<
     (callable.kind() == "identifier"
         && callable.utf8_text(source).ok().map(str::trim) == Some("super"))
     .then_some(receiver)
+}
+
+fn python_has_decorator(definition: Node<'_>, source: &[u8], expected: &str) -> bool {
+    let Some(decorated) = definition
+        .parent()
+        .filter(|node| node.kind() == "decorated_definition")
+    else {
+        return false;
+    };
+    let mut cursor = decorated.walk();
+    decorated
+        .children(&mut cursor)
+        .filter(|child| child.kind() == "decorator")
+        .filter_map(|decorator| decorator.utf8_text(source).ok())
+        .map(|decorator| {
+            decorator
+                .trim()
+                .trim_start_matches('@')
+                .trim()
+                .split_once('(')
+                .map_or_else(
+                    || decorator.trim().trim_start_matches('@').trim(),
+                    |(name, _)| name.trim(),
+                )
+        })
+        .any(|decorator| decorator == expected || decorator.ends_with(&format!(".{expected}")))
 }
 
 fn python_super_call_is_builtin(

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -5068,40 +5068,47 @@ impl<'source> DirectAdapterState<'source> {
             )
             .cloned()
         });
-        let qualified_name = exact_super_target.or_else(|| {
-            qualifier
-                .and_then(|qualifier| {
-                    self.local_target_for(owner, qualifier)
-                        .map(|target| format!("{target}::{spelling}"))
-                })
-                .or_else(|| {
-                    (self.language == "go")
-                        .then(|| self.go_selector_receiver_type(owner, function))
-                        .flatten()
-                        .map(|target| format!("{target}::{spelling}"))
-                })
-                .or_else(|| {
-                    qualifier
-                        .and_then(|qualifier| {
-                            self.imported_qualified_target_for(
-                                owner,
-                                qualifier,
-                                function.start_byte(),
-                                allow_later_file_binding,
-                            )
-                        })
-                        .map(|target| format!("{target}.{spelling}"))
-                })
-                .or_else(|| {
-                    self.imported_target_for_occurrence(
-                        owner,
-                        spelling,
-                        function.start_byte(),
-                        allow_later_file_binding,
-                    )
-                    .cloned()
-                })
-        });
+        let qualified_name = if python_bound_receiver.is_some() {
+            // Receiver dispatch is the complete target-selection constraint.
+            // Keeping an imported or local spelling beside it would make the
+            // candidate contradictory and is rejected by evidence validation.
+            None
+        } else {
+            exact_super_target.or_else(|| {
+                qualifier
+                    .and_then(|qualifier| {
+                        self.local_target_for(owner, qualifier)
+                            .map(|target| format!("{target}::{spelling}"))
+                    })
+                    .or_else(|| {
+                        (self.language == "go")
+                            .then(|| self.go_selector_receiver_type(owner, function))
+                            .flatten()
+                            .map(|target| format!("{target}::{spelling}"))
+                    })
+                    .or_else(|| {
+                        qualifier
+                            .and_then(|qualifier| {
+                                self.imported_qualified_target_for(
+                                    owner,
+                                    qualifier,
+                                    function.start_byte(),
+                                    allow_later_file_binding,
+                                )
+                            })
+                            .map(|target| format!("{target}.{spelling}"))
+                    })
+                    .or_else(|| {
+                        self.imported_target_for_occurrence(
+                            owner,
+                            spelling,
+                            function.start_byte(),
+                            allow_later_file_binding,
+                        )
+                        .cloned()
+                    })
+            })
+        };
         let occurrence_id = self.builder.occur(
             role,
             &owner.fact_id,

--- a/crates/compass-languages/src/json_config.rs
+++ b/crates/compass-languages/src/json_config.rs
@@ -183,7 +183,16 @@ impl State<'_> {
             let key_id = make_id(&["config-key", &self.source_file, &key_path]);
             let line = pair.start_position().row + 1;
             self.add_config_key(&key_id, &key, &key_path, line);
-            self.add_edge(&self.owner_id.clone(), &key_id, "contains", line, None);
+            // Keep schema/file ownership for root keys, but preserve the JSON
+            // object hierarchy for nested keys. The secondary reference edge
+            // below retains the existing config-child provenance without
+            // weakening structural navigation.
+            let containment_parent = if parent_id == self.file_id {
+                self.owner_id.clone()
+            } else {
+                parent_id.to_owned()
+            };
+            self.add_edge(&containment_parent, &key_id, "contains", line, None);
             if parent_id != self.file_id {
                 self.add_edge(parent_id, &key_id, "references", line, Some("config-child"));
             }

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -489,7 +489,9 @@ class Derived(Base):
 
 #[test]
 fn python_bound_method_receivers_emit_dispatch_and_fail_closed_on_rebinding() {
-    let source = br#"class Model:
+    let source = br#"from pkg.helpers import check
+
+class Model:
     def check(self):
         return None
 
@@ -541,6 +543,11 @@ fn python_bound_method_receivers_emit_dispatch_and_fail_closed_on_rebinding() {
                 strategy: ReceiverDispatchStrategy::C3FromReceiver,
             })
     }));
+    assert!(
+        checks
+            .iter()
+            .all(|candidate| candidate.constraints.qualified_name.is_none())
+    );
 }
 
 #[test]

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -488,6 +488,62 @@ class Derived(Base):
 }
 
 #[test]
+fn python_bound_method_receivers_emit_dispatch_and_fail_closed_on_rebinding() {
+    let source = br#"class Model:
+    def check(self):
+        return None
+
+    def verify(self):
+        return self.check()
+
+    @classmethod
+    def verify_class(cls):
+        return cls.check()
+
+    def ambiguous_cls(cls):
+        return cls.check()
+
+    @staticmethod
+    def static_check(self):
+        return self.check()
+
+    def rebound(self, replacement):
+        self = replacement
+        return self.check()
+
+    def shadowed(self, items):
+        return [self.check() for self in items]
+"#;
+    let mut engine = Engine::default();
+    let evidence = engine
+        .extract_source_combined(
+            std::path::Path::new("/repo/pkg/models.py"),
+            "pkg/models.py",
+            source,
+        )
+        .expect("extract Python")
+        .graph
+        .semantic_evidence
+        .expect("Python universal evidence");
+
+    let checks = evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "check"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(checks.len(), 2);
+    assert!(checks.iter().all(|candidate| {
+        candidate.constraints.hierarchy
+            == Some(HierarchyConstraint::ReceiverDispatch {
+                receiver_qualified_name: "pkg.models.Model".to_owned(),
+                strategy: ReceiverDispatchStrategy::C3FromReceiver,
+            })
+    }));
+}
+
+#[test]
 fn universal_declarations_preserve_signature_and_implementation_change_metadata() {
     fn function_declaration(source: &[u8]) -> DeclarationFact {
         let mut engine = Engine::default();

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -866,6 +866,7 @@ const fn contains_endpoint_pair(source: NodeKind, target: NodeKind) -> bool {
             NodeKind::Resource,
             NodeKind::File | NodeKind::Resource | NodeKind::ConfigKey
         ) | (NodeKind::Schema, NodeKind::ConfigKey)
+            | (NodeKind::ConfigKey, NodeKind::ConfigKey)
     ) || database_contains(source, target)
 }
 

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -598,6 +598,7 @@ fn endpoint_matrix_accepts_nested_dynamic_and_database_producer_shapes() {
         (EdgeKind::Contains, NodeKind::Function, NodeKind::Method),
         (EdgeKind::Contains, NodeKind::Method, NodeKind::Class),
         (EdgeKind::Contains, NodeKind::TypeAlias, NodeKind::Method),
+        (EdgeKind::Contains, NodeKind::ConfigKey, NodeKind::ConfigKey),
         (EdgeKind::Calls, NodeKind::Class, NodeKind::Method),
         (EdgeKind::Calls, NodeKind::Variable, NodeKind::Function),
         (EdgeKind::Calls, NodeKind::Struct, NodeKind::Method),

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -771,12 +771,20 @@ impl UniversalResolutionIndex {
             strategy,
         }) = candidate.constraints.hierarchy.as_ref()
         {
-            return self.resolve_c3_receiver_dispatch(
+            let receiver_decision = self.resolve_c3_receiver_dispatch(
                 language,
                 receiver_qualified_name,
                 *strategy,
                 candidate,
             );
+            // Receiver dispatch is the strongest source-grounded route, but
+            // an unresolved hierarchy must not erase an independently exact
+            // qualified binding. This is important for generic or recovered
+            // Python bases whose inherited method remains identifiable even
+            // when C3 cannot be constructed from the emitted base facts.
+            if !matches!(&receiver_decision, ResolutionDecision::Unresolved) {
+                return receiver_decision;
+            }
         }
         let occurrence = self.occurrence(candidate);
         let qualifier = occurrence.and_then(|occurrence| occurrence.qualifier.as_deref());

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -306,6 +306,14 @@ impl UniversalResolutionIndex {
                             let mut index =
                                 AHashMap::<(String, String, String), Vec<DeclarationSlot>>::new();
                             for declaration in declarations.values() {
+                                // Go methods live in the receiver method set, not in
+                                // the package block. Keeping them in the package-name
+                                // index makes an unqualified call ambiguous whenever a
+                                // package function shares the method name (for example,
+                                // a method forwarding to its package-level helper).
+                                if declaration.language == "go" && declaration.kind == "method" {
+                                    continue;
+                                }
                                 let Some(slot) =
                                     declaration_slot(&declaration_ids, &declaration.id)
                                 else {
@@ -338,6 +346,14 @@ impl UniversalResolutionIndex {
                                         Vec<DeclarationSlot>,
                                     >::new();
                                     for declaration in declarations.values() {
+                                        // Go methods are selected through a receiver or
+                                        // method expression; they are not lexical names
+                                        // in the package/file scope.
+                                        if declaration.language == "go"
+                                            && declaration.kind == "method"
+                                        {
+                                            continue;
+                                        }
                                         let Some(slot) =
                                             declaration_slot(&declaration_ids, &declaration.id)
                                         else {

--- a/crates/compass-resolve/tests/go_resolution.rs
+++ b/crates/compass-resolve/tests/go_resolution.rs
@@ -598,6 +598,51 @@ func invoke(value uint64) uint64 {
 }
 
 #[test]
+fn go_method_forwarding_call_resolves_same_named_package_function() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("command/forwarding.go");
+    let source = br#"package command
+
+type FlagSet struct{}
+func (*FlagSet) Set(string, string) error { return nil }
+
+type Command struct{}
+func (*Command) Flags() *FlagSet { return nil }
+func (c *Command) MarkFlagFilename(name string, extensions ...string) error {
+    return MarkFlagFilename(c.Flags(), name, extensions...)
+}
+func MarkFlagFilename(flags *FlagSet, name string, extensions ...string) error {
+    return flags.Set(name, extensions[0])
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let resolved = compass_resolve::resolve_with_root(
+        &[extracted],
+        &HashMap::from([(
+            path.to_string_lossy().into_owned(),
+            String::from_utf8(source.to_vec())?,
+        )]),
+        Path::new("."),
+    );
+    let method = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "command.Command::MarkFlagFilename")
+        .ok_or("missing forwarding method")?;
+    let function = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "command.MarkFlagFilename")
+        .ok_or("missing package function")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.source == method.id
+            && edge.target == function.id
+            && edge.string("relation") == "calls"
+            && edge.string("source_location") == "L9"
+    }));
+    Ok(())
+}
+
+#[test]
 fn go_interface_methods_keep_exact_interface_ownership_and_source_sites()
 -> Result<(), Box<dyn Error>> {
     let path = Path::new("storage/store.go");

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -826,6 +826,36 @@ fn python_super_call_resolves_only_the_exact_direct_base_method() {
 }
 
 #[test]
+fn python_bound_method_receiver_resolves_exact_class_method() {
+    let source = b"class Model:\n    def check(self):\n        return None\n\n    def verify(self):\n        return self.check()\n";
+    let extracted = extract("pkg/models.py", source);
+    let resolved = compass_resolve::resolve(
+        &[extracted],
+        &HashMap::from([(
+            "pkg/models.py".to_owned(),
+            String::from_utf8(source.to_vec()).expect("source"),
+        )]),
+    );
+    let check = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "pkg.models.Model::check")
+        .unwrap_or_else(|| panic!("check method; nodes={:#?}", resolved.nodes));
+
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "calls" && edge.target == check.id)
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].string("source_location"), "L6");
+    assert_eq!(
+        calls[0].string("resolution_rule"),
+        "linearized-receiver-dispatch"
+    );
+}
+
+#[test]
 fn python_super_call_with_multiple_bases_cannot_terminal_match_an_unrelated_method() {
     let source = b"class Unrelated:\n    def run(self):\n        return None\nclass Left:\n    pass\nclass Right:\n    pass\nclass Child(Left, Right):\n    def run(self):\n        super().run()\n";
     let extracted = extract("pkg/models.py", source);

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -116,6 +116,11 @@ Relation names depend on the extractor and input type. Common families include:
 Do not assume every relation implies runtime execution. `imports_from` and
 `references` express different kinds of dependency from `calls`.
 
+Configuration keys preserve their source hierarchy: root keys are contained by
+the file or schema node, and nested keys are contained by their immediate
+parent key. Nested keys may also retain a `references` edge with
+`context=config-child` for configuration-specific provenance.
+
 ## Attributes
 
 Nodes and edges retain open-ended JSON attributes. Common logical attributes include:

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -97,7 +97,7 @@ The hard-cut route is selected by `AdapterRegistry`. Presence in the source
 registry or availability of a grammar does not select it. On the current
 branch, the registry contains `go`, `java`, `python`, and `rust`. Go is at
 adapter version 3, Java is at version 3, Rust is at version 2, and Python
-remains at version 1. Candidate status
+is at version 2. Candidate status
 describes qualification maturity; it does not re-enable the removed direct
 route. Adapter-version changes invalidate cached evidence for only the changed
 language. Go identities retain the repository-relative directory prefix and

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -30,7 +30,7 @@ future work.
 | Status | Implementation |
 | --- | --- |
 | Available now | `compass-languages` owns the source registry, parsers, established adapters, and semantic evidence version 1 |
-| Available now | Python, Go, Rust, and Java are entries in the hard-cut `AdapterRegistry`; Go and Java are at adapter version 3, Rust is at version 2, and Python is at version 1 |
+| Available now | Python, Go, Rust, and Java are entries in the hard-cut `AdapterRegistry`; Go and Java are at adapter version 3, Rust is at version 2, and Python is at version 2 |
 | Available now | `EvidenceBuilder` emits bounded `SemanticEvidenceBatch` values for all four hard-cut languages |
 | Available now | `UniversalResolutionIndex` resolves and projects hard-cut evidence without a language-name branch |
 | Available now | Rust has passed Phase 2 qualification; Java remains `UniversalCandidate` after completing post-cutover pinned-corpus qualification |
@@ -145,7 +145,7 @@ The architectural profile names are `Direct`, `UniversalCandidate`, and
 an internal `legacy` variant. Treat it as an old wire identifier, not the name
 or quality status of an established adapter.
 
-Python remains at adapter version 1, while Rust is at version 2 and Go and Java
+Python is at adapter version 2, while Rust is at version 2 and Go and Java
 are at version 3. Adapter versions advance when a semantic evidence change
 requires language-local cache invalidation; grammar provenance and the
 extraction-semantics identity remain independent cache inputs.

--- a/scripts/code_graph_v1_oracle.py
+++ b/scripts/code_graph_v1_oracle.py
@@ -341,6 +341,7 @@ def endpoint_allowed(source: dict[str, Any], edge: dict[str, Any], target: dict[
     if kind == "contains":
         return (
             (s == "schema" and t == "config_key")
+            or (s == "config_key" and t == "config_key")
             or (s == "file" and t in CONTAINS_FILE_TARGETS)
             or (s in {"module", "package", "namespace"} and t in CONTAINS_SCOPE_TARGETS)
             or (s in TYPE_KINDS | {"component", "schema"} and t in CONTAINS_TYPE_TARGETS)

--- a/scripts/tests/test_code_graph_v1_oracle.py
+++ b/scripts/tests/test_code_graph_v1_oracle.py
@@ -103,6 +103,13 @@ class OracleTests(unittest.TestCase):
                     {"kind": "class", "language": "python"},
                 ))
 
+    def test_endpoint_matrix_accepts_nested_config_containment(self) -> None:
+        self.assertTrue(endpoint_allowed(
+            {"kind": "config_key"},
+            {"kind": "contains"},
+            {"kind": "config_key"},
+        ))
+
     def test_endpoint_matrix_accepts_only_rust_enum_member_instantiations(self) -> None:
         self.assertTrue(endpoint_allowed(
             {"kind": "function"},


### PR DESCRIPTION
## Summary

- Keep Go methods out of package/file lexical indexes while retaining receiver and member resolution.
- Resolve same-named variadic package helpers from receiver-forwarding methods, including nested closures and range variables.
- Add source-anchored Go regression coverage for Cobra-style flag filename forwarding.
- Add source-proven Python `self`/`cls` receiver dispatch for bound method calls, while failing closed for static methods, rebinding, comprehension/lambda shadowing, and convention-only `cls` parameters.
- Keep receiver-dispatch candidates free of contradictory qualified-target hints; bump the Python adapter version after the semantic change.
- Reduce graph-assembly peak allocation by borrowing unchanged edge endpoints and allocating only for actual rewrites.
- Preserve JSON configuration hierarchy: root keys remain file/schema children, nested keys become children of their immediate config key, and existing `config-child` reference evidence is retained.
- Extend the typed Code Graph v1 endpoint matrix, oracle, documentation, and qualification regressions for nested config containment.

## Validation

- `cargo fmt --all -- --check`
- Changed-crate clippy with `-D warnings` for `compass-model`, `compass-languages`, and `compass-graph`
- Focused model, language, and graph normalization tests
- `python3 -m unittest scripts/tests/test_code_graph_v1_oracle.py`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` (strict manifests, scale ceilings, deterministic clean/warm/rebuild/restore/alternate-checkout comparisons, and semantic assertions all passed)
- GitHub PR #177 CI is running for head `2e9a5e59`; the completed jobs are green and the remaining native jobs are still in progress.

## Real-repository evidence

Fresh three-repeat p50 measurements from the pinned Go Cobra, Python Click, Rust Rayon, TypeScript Zod, and Django corpora report Graphify wall time divided by Compass wall time:

| Corpus | Ratio | Compass nodes / edges | Graphify nodes / edges |
| --- | ---: | ---: | ---: |
| Go Cobra | 0.60x | 1,206 / 5,709 | 725 / 2,044 |
| Python Click | 1.73x | 3,876 / 9,474 | 1,997 / 4,351 |
| Rust Rayon | 1.50x | 8,542 / 17,941 | 4,185 / 7,701 |
| TypeScript Zod | 3.28x | 11,058 / 9,644 | 4,338 / 5,928 |
| Django | 3.29x | 80,976 / 195,164 | 50,861 / 158,765 |

Compass produced deterministic, valid graphs with no validation errors. The TypeScript containment hardening moved 292 Graphify edge hypotheses from missing containment paths to exact coverage; missing Graphify edges fell from 2,126 to 1,834 in the fresh comparison. This is a source-grounded quality improvement, not a claim of universal parity.

The evidence does not establish a universal 4–5x speedup or lower RSS: Compass currently uses more peak RSS on these corpora, and Go remains slower than Graphify. The largest measured Compass cost on Django is canonical graph serialization and hashing, so further performance work must preserve atomic publication, determinism, provenance, and typed graph validation.
