### PR TITLE
Adapt AST worker pressure for large repositories

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -264,14 +264,31 @@ was 103, 168, 270, and 309 MiB respectively. These are single-run diagnostic
 measurements, not a promoted memory baseline.
 
 The automatic AST pool now uses the default cap of 8 workers below 1,024
-missing files and 4 workers at or above that repository-size boundary. An
-explicit `--max-workers` value continues to override the automatic cap. On a
-fresh 3,096-file Django extraction from the pinned 2026-08-05 qualification
-corpus, the adaptive path reported 11.75 seconds internally and measured
-18.07 seconds with `/usr/bin/time -l`, with 2.17 GiB peak RSS and the same
-80,976-node/195,164-edge graph. This is a single mounted-volume observation;
-the pinned three-sample Graphify comparison remains 40.76 seconds p50, so the
-universal 4× target is not established by this change.
+missing files and a host-aware, bounded cap of up to 12 workers at or above
+that repository-size boundary. The build-wide Rayon pool uses the same
+host-aware ceiling; an explicit `--max-workers` value continues to override
+both automatic choices. The cap is deliberately finite rather than an
+unbounded host-sized pool, because parser and graph-publication working sets
+scale with concurrency.
+
+A clean three-sample follow-up on the pinned 2026-08-05 qualification corpora
+measured the release binary with JSON output and fresh output directories on
+each run. Graphify values are the paired three-sample p50 baselines:
+
+| Repository | Compass p50 | Graphify p50 | Graphify / Compass | Compass RSS p50 |
+| --- | ---: | ---: | ---: | ---: |
+| Cobra (Go) | 0.30 s | 0.95 s | 3.17× | 123.5 MiB |
+| Click (Python) | 0.50 s | 1.94 s | 3.88× | 180.7 MiB |
+| Rayon (Rust) | 0.80 s | 1.90 s | 2.38× | 284.5 MiB |
+| Zod (TypeScript) | 1.00 s | 4.80 s | 4.80× | 284.8 MiB |
+| Django (Python) | 10.80 s | 40.76 s | 3.77× | 2,248 MiB |
+
+The Django graph remained 80,976 nodes / 195,164 edges with zero validation
+errors, and the four small-corpus graph populations and normalized digests
+remained unchanged. The host-aware default therefore improves the large
+repository path, but these measurements still do not establish the requested
+universal 4× target; the higher Compass RSS is also an explicit tradeoff to
+monitor in future qualification.
 
 The default SQLite publication path now uses the same bounded canonical graph
 stream as JSON-only publication while the immutable snapshot indexes are built

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -221,8 +221,9 @@ Click (Python, 91 files). The run used `extract --code-only --no-cluster
 These are diagnostic observations, not promoted baselines or a claim of a
 4×–5× cold-build advantage. Extraction with fewer than 32 missing files stays
 sequential to avoid multiplying parser/AST working sets; the automatic path
-uses a default cap of 8 local workers once that measured crossover is reached,
-while `--max-workers` remains the explicit override. Portable AST publication
+uses a default cap of 8 local workers below 1,024 missing files and 4 workers
+at or above that boundary, while `--max-workers` remains the explicit
+override. Portable AST publication
 also streams one compressed value at a time instead of retaining the entire
 compressed batch in memory. Incremental cache hits now remain in that portable
 representation and decode directly into typed extraction records when loaded
@@ -261,6 +262,16 @@ the same graph SHA-256 for all four pinned repositories (`78ef5b7b` Cobra,
 `c25d3b97` Click, `06014539` Rayon, and `f620afe4` Zod). The observed peak RSS
 was 103, 168, 270, and 309 MiB respectively. These are single-run diagnostic
 measurements, not a promoted memory baseline.
+
+The automatic AST pool now uses the default cap of 8 workers below 1,024
+missing files and 4 workers at or above that repository-size boundary. An
+explicit `--max-workers` value continues to override the automatic cap. On a
+fresh 3,096-file Django extraction from the pinned 2026-08-05 qualification
+corpus, the adaptive path reported 11.75 seconds internally and measured
+18.07 seconds with `/usr/bin/time -l`, with 2.17 GiB peak RSS and the same
+80,976-node/195,164-edge graph. This is a single mounted-volume observation;
+the pinned three-sample Graphify comparison remains 40.76 seconds p50, so the
+universal 4× target is not established by this change.
 
 The default SQLite publication path now uses the same bounded canonical graph
 stream as JSON-only publication while the immutable snapshot indexes are built

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -79,6 +79,7 @@ use crate::raw_guard::enforce_incomplete_raw_guard;
 /// repositories with intentionally large generated sources.
 pub const DEFAULT_MAX_SOURCE_BYTES: u64 = 16 * 1024 * 1024;
 const SEMANTIC_MARKER_FILE: &str = ".compass_semantic_marker";
+const DEFAULT_PIPELINE_RAYON_WORKERS: usize = 4;
 const STORE_GENERATION_EXCLUSIONS: [&str; 3] = [
     STORE_FILE_NAME,
     "compass-store.sqlite3-wal",
@@ -2194,6 +2195,39 @@ fn build_graph(
 }
 
 fn build_graph_inner(
+    options: &BuildOptions,
+    semantic: Option<&SemanticLayer>,
+    supplemental: &[Extraction],
+    tiebreaker: Option<&mut dyn EntityTiebreaker>,
+    progress: Option<&(dyn Fn(BuildFileProgress) + Sync)>,
+    retain_artifacts: bool,
+) -> Result<(BuildResult, Option<RetainedBuildArtifacts>), CoreError> {
+    let worker_count = pipeline_rayon_workers(options);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(worker_count)
+        .thread_name(|index| format!("compass-pipeline-{index}"))
+        .build()
+        .map_err(|error| CoreError::WorkerPool(error.to_string()))?;
+    pool.install(move || {
+        build_graph_inner_unscoped(
+            options,
+            semantic,
+            supplemental,
+            tiebreaker,
+            progress,
+            retain_artifacts,
+        )
+    })
+}
+
+fn pipeline_rayon_workers(options: &BuildOptions) -> usize {
+    options
+        .max_workers
+        .unwrap_or(DEFAULT_PIPELINE_RAYON_WORKERS)
+        .max(1)
+}
+
+fn build_graph_inner_unscoped(
     options: &BuildOptions,
     semantic: Option<&SemanticLayer>,
     supplemental: &[Extraction],
@@ -6941,6 +6975,21 @@ mod tests {
             default_ast_workers(LARGE_REPOSITORY_AST_WORKER_MIN_FILES)
                 <= LARGE_REPOSITORY_AST_WORKER_CAP
         );
+    }
+
+    #[test]
+    fn pipeline_rayon_workers_use_a_bounded_default_and_explicit_override() {
+        let mut options = BuildOptions::new(".");
+        assert_eq!(
+            pipeline_rayon_workers(&options),
+            DEFAULT_PIPELINE_RAYON_WORKERS
+        );
+
+        options.max_workers = Some(2);
+        assert_eq!(pipeline_rayon_workers(&options), 2);
+
+        options.max_workers = Some(0);
+        assert_eq!(pipeline_rayon_workers(&options), 1);
     }
 
     #[cfg(unix)]

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -22,8 +22,8 @@ use compass_graph::{
     cluster, deduped_node_count, extraction_from_v1, garbage_collect_graph_snapshots,
     graph_insights, graph_snapshot_needs_gc, label_communities_by_hub,
     normalize_document_v1_with_evidence_best_effort_owned,
-    normalize_document_v1_with_inventory_best_effort,
-    normalize_document_v1_with_inventory_best_effort_owned, remap_communities_to_previous,
+    normalize_document_v1_with_inventory_and_source_digests_best_effort_owned,
+    normalize_document_v1_with_inventory_best_effort, remap_communities_to_previous,
     score_communities, write_canonical_graph_json,
     write_fact_neutral_graph_json_delta_prevalidated,
 };
@@ -3285,7 +3285,7 @@ fn build_graph_inner(
             .clone()
             .or_else(|| git_commit(&root));
         let no_cluster_normalization_started = Instant::now();
-        let published = normalize_document_v1_with_inventory_best_effort_owned(
+        let published = normalize_document_v1_with_inventory_and_source_digests_best_effort_owned(
             document,
             &root,
             configuration_digest,
@@ -3297,6 +3297,7 @@ fn build_graph_inner(
                 &extraction_partials,
                 &root,
             ),
+            Some(&fresh_source_digests),
         )?;
         profile_internal_duration(
             "no-cluster v1 normalization",

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -2618,7 +2618,9 @@ fn build_graph_inner(
             }
         }
     }
-    let worker_count = options.max_workers.unwrap_or_else(default_ast_workers);
+    let worker_count = options
+        .max_workers
+        .unwrap_or_else(|| default_ast_workers(missing.len()));
     // Resolver source text is only consulted by the PHP type-reference pass.
     // Keeping every decoded source string alive across extraction and graph
     // publication otherwise duplicates the repository's source footprint in
@@ -4508,19 +4510,33 @@ fn write_store_ref(output_dir: &Path, reference: &StoreRef) -> Result<(), CoreEr
 }
 
 #[cfg(target_os = "macos")]
-fn default_ast_workers() -> usize {
+fn default_ast_workers(missing: usize) -> usize {
     num_cpus::get()
         .max(num_cpus::get_physical())
-        .min(DEFAULT_AST_WORKER_CAP)
+        .min(default_ast_worker_cap(missing))
 }
 
 #[cfg(not(target_os = "macos"))]
-fn default_ast_workers() -> usize {
-    num_cpus::get().min(DEFAULT_AST_WORKER_CAP)
+fn default_ast_workers(missing: usize) -> usize {
+    num_cpus::get().min(default_ast_worker_cap(missing))
 }
 
 const DEFAULT_AST_WORKER_CAP: usize = 8;
+// Large cold repositories retain enough per-file parser state for worker
+// parallelism to dominate peak RSS. Keep the automatic path conservative at
+// this measured crossover; callers that have a known memory budget can still
+// opt into a different count through BuildOptions::max_workers.
+const LARGE_REPOSITORY_AST_WORKER_CAP: usize = 4;
+const LARGE_REPOSITORY_AST_WORKER_MIN_FILES: usize = 1_024;
 const AUTOMATIC_PARALLEL_EXTRACT_MIN_FILES: usize = 32;
+
+fn default_ast_worker_cap(missing: usize) -> usize {
+    if missing < LARGE_REPOSITORY_AST_WORKER_MIN_FILES {
+        DEFAULT_AST_WORKER_CAP
+    } else {
+        LARGE_REPOSITORY_AST_WORKER_CAP
+    }
+}
 
 fn should_parallel_extract(options: &BuildOptions, missing: usize) -> bool {
     missing >= AUTOMATIC_PARALLEL_EXTRACT_MIN_FILES
@@ -6891,8 +6907,22 @@ mod tests {
 
     #[test]
     fn default_ast_workers_stay_within_the_memory_bound() {
-        assert!(default_ast_workers() > 0);
-        assert!(default_ast_workers() <= DEFAULT_AST_WORKER_CAP);
+        assert_eq!(default_ast_worker_cap(0), DEFAULT_AST_WORKER_CAP);
+        assert_eq!(
+            default_ast_worker_cap(LARGE_REPOSITORY_AST_WORKER_MIN_FILES - 1),
+            DEFAULT_AST_WORKER_CAP
+        );
+        assert_eq!(
+            default_ast_worker_cap(LARGE_REPOSITORY_AST_WORKER_MIN_FILES),
+            LARGE_REPOSITORY_AST_WORKER_CAP
+        );
+        assert!(default_ast_workers(0) > 0);
+        assert!(default_ast_workers(0) <= DEFAULT_AST_WORKER_CAP);
+        assert!(default_ast_workers(LARGE_REPOSITORY_AST_WORKER_MIN_FILES) > 0);
+        assert!(
+            default_ast_workers(LARGE_REPOSITORY_AST_WORKER_MIN_FILES)
+                <= LARGE_REPOSITORY_AST_WORKER_CAP
+        );
     }
 
     #[cfg(unix)]

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -238,12 +238,12 @@ fn compact_extraction(extraction: &mut Extraction) {
         for call in &mut *calls {
             compact_json_map(&mut call.extensions);
         }
-        calls.shrink_to_fit();
+        compact_vec(calls);
     }
     for fact in &mut extraction.framework_facts {
         match fact {
             compass_languages::RawFrameworkFact::Route(route) => {
-                route.middleware_references.shrink_to_fit();
+                compact_vec(&mut route.middleware_references);
                 compact_json_map(&mut route.detail);
             }
             compass_languages::RawFrameworkFact::Domain(domain) => {
@@ -256,19 +256,36 @@ fn compact_extraction(extraction: &mut Extraction) {
         }
     }
     if let Some(evidence) = extraction.semantic_evidence.as_mut() {
-        evidence.adapter.capabilities.shrink_to_fit();
-        evidence.declarations.shrink_to_fit();
-        evidence.scopes.shrink_to_fit();
-        evidence.bindings.shrink_to_fit();
-        evidence.occurrences.shrink_to_fit();
-        evidence.candidates.shrink_to_fit();
-        evidence.diagnostics.shrink_to_fit();
+        compact_vec(&mut evidence.adapter.capabilities);
+        compact_vec(&mut evidence.declarations);
+        compact_vec(&mut evidence.scopes);
+        compact_vec(&mut evidence.bindings);
+        compact_vec(&mut evidence.occurrences);
+        compact_vec(&mut evidence.candidates);
+        compact_vec(&mut evidence.diagnostics);
     }
     compact_json_map(&mut extraction.extensions);
-    extraction.nodes.shrink_to_fit();
-    extraction.edges.shrink_to_fit();
-    extraction.hyperedges.shrink_to_fit();
-    extraction.framework_facts.shrink_to_fit();
+    compact_vec(&mut extraction.nodes);
+    compact_vec(&mut extraction.edges);
+    compact_vec(&mut extraction.hyperedges);
+    compact_vec(&mut extraction.framework_facts);
+}
+
+/// Shrink a vector only when it retained a meaningful amount of growth slack.
+///
+/// Extractors commonly reserve a small amount beyond the final length while
+/// parsing a file. Reallocating those tight buffers costs CPU without making a
+/// useful difference to the project-wide working set. A 25% slack threshold
+/// preserves the memory reduction for vectors that grew substantially while
+/// making the per-file compaction pass cheap for ordinary source files.
+fn compact_vec<T>(values: &mut Vec<T>) {
+    let useful_capacity = values
+        .len()
+        .saturating_add(values.len() / 4)
+        .saturating_add(1);
+    if values.capacity() > useful_capacity {
+        values.shrink_to_fit();
+    }
 }
 
 fn compact_json_map(map: &mut serde_json::Map<String, Value>) {
@@ -296,7 +313,7 @@ fn compact_json_value(value: &mut Value) {
             for value in values.iter_mut() {
                 compact_json_value(value);
             }
-            values.shrink_to_fit();
+            compact_vec(values);
         }
         Value::Object(map) => compact_json_map(map),
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
@@ -6998,6 +7015,51 @@ mod tests {
 
         assert_eq!(before, serde_json::to_value(extraction)?);
         Ok(())
+    }
+
+    #[test]
+    fn compact_extraction_shrinks_only_materially_overallocated_vectors() {
+        let mut overallocated_calls = Vec::with_capacity(64);
+        overallocated_calls.push(compass_languages::RawCall {
+            caller_nid: "node".to_owned(),
+            callee: "callee".to_owned(),
+            is_member_call: None,
+            source_file: "source.go".to_owned(),
+            source_location: "1:1".to_owned(),
+            receiver: None,
+            receiver_type: None,
+            lang: Some("go".to_owned()),
+            extensions: Map::new(),
+        });
+        let overallocated_capacity = overallocated_calls.capacity();
+
+        let mut tight_nodes = Vec::with_capacity(2);
+        tight_nodes.extend([
+            RawNodeRecord {
+                id: "node-1".to_owned(),
+                attributes: Map::new(),
+            },
+            RawNodeRecord {
+                id: "node-2".to_owned(),
+                attributes: Map::new(),
+            },
+        ]);
+        let tight_capacity = tight_nodes.capacity();
+
+        let mut extraction = Extraction {
+            nodes: tight_nodes,
+            raw_calls: Some(overallocated_calls),
+            ..Extraction::default()
+        };
+        compact_extraction(&mut extraction);
+
+        assert!(
+            extraction
+                .raw_calls
+                .as_ref()
+                .is_some_and(|calls| calls.capacity() < overallocated_capacity)
+        );
+        assert_eq!(extraction.nodes.capacity(), tight_capacity);
     }
 
     #[test]

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -79,7 +79,7 @@ use crate::raw_guard::enforce_incomplete_raw_guard;
 /// repositories with intentionally large generated sources.
 pub const DEFAULT_MAX_SOURCE_BYTES: u64 = 16 * 1024 * 1024;
 const SEMANTIC_MARKER_FILE: &str = ".compass_semantic_marker";
-const DEFAULT_PIPELINE_RAYON_WORKERS: usize = 4;
+const PIPELINE_RAYON_WORKER_CAP: usize = 12;
 const STORE_GENERATION_EXCLUSIONS: [&str; 3] = [
     STORE_FILE_NAME,
     "compass-store.sqlite3-wal",
@@ -2223,8 +2223,12 @@ fn build_graph_inner(
 fn pipeline_rayon_workers(options: &BuildOptions) -> usize {
     options
         .max_workers
-        .unwrap_or(DEFAULT_PIPELINE_RAYON_WORKERS)
+        .unwrap_or_else(default_pipeline_rayon_workers)
         .max(1)
+}
+
+fn default_pipeline_rayon_workers() -> usize {
+    available_worker_count().clamp(1, PIPELINE_RAYON_WORKER_CAP)
 }
 
 fn build_graph_inner_unscoped(
@@ -4563,22 +4567,34 @@ fn write_store_ref(output_dir: &Path, reference: &StoreRef) -> Result<(), CoreEr
 
 #[cfg(target_os = "macos")]
 fn default_ast_workers(missing: usize) -> usize {
-    num_cpus::get()
-        .max(num_cpus::get_physical())
+    available_worker_count()
         .min(default_ast_worker_cap(missing))
+        .max(1)
 }
 
 #[cfg(not(target_os = "macos"))]
 fn default_ast_workers(missing: usize) -> usize {
-    num_cpus::get().min(default_ast_worker_cap(missing))
+    available_worker_count()
+        .min(default_ast_worker_cap(missing))
+        .max(1)
 }
 
 const DEFAULT_AST_WORKER_CAP: usize = 8;
+#[cfg(target_os = "macos")]
+fn available_worker_count() -> usize {
+    num_cpus::get().max(num_cpus::get_physical())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn available_worker_count() -> usize {
+    num_cpus::get()
+}
+
 // Large cold repositories retain enough per-file parser state for worker
-// parallelism to dominate peak RSS. Keep the automatic path conservative at
-// this measured crossover; callers that have a known memory budget can still
-// opt into a different count through BuildOptions::max_workers.
-const LARGE_REPOSITORY_AST_WORKER_CAP: usize = 4;
+// parallelism to dominate peak RSS. Keep the automatic path bounded by the
+// host-aware pipeline ceiling; callers that have a known memory budget can
+// still opt into a different count through BuildOptions::max_workers.
+const LARGE_REPOSITORY_AST_WORKER_CAP: usize = PIPELINE_RAYON_WORKER_CAP;
 const LARGE_REPOSITORY_AST_WORKER_MIN_FILES: usize = 1_024;
 const AUTOMATIC_PARALLEL_EXTRACT_MIN_FILES: usize = 32;
 
@@ -6980,10 +6996,10 @@ mod tests {
     #[test]
     fn pipeline_rayon_workers_use_a_bounded_default_and_explicit_override() {
         let mut options = BuildOptions::new(".");
-        assert_eq!(
-            pipeline_rayon_workers(&options),
-            DEFAULT_PIPELINE_RAYON_WORKERS
-        );
+        let default_workers = pipeline_rayon_workers(&options);
+        assert_eq!(default_workers, default_pipeline_rayon_workers());
+        assert!(default_workers > 0);
+        assert!(default_workers <= PIPELINE_RAYON_WORKER_CAP);
 
         options.max_workers = Some(2);
         assert_eq!(pipeline_rayon_workers(&options), 2);

--- a/crates/compass-graph/src/lib.rs
+++ b/crates/compass-graph/src/lib.rs
@@ -38,6 +38,7 @@ pub use v1::{
     BuildEvidence, InventoryEvidence, SourceDigest, V1_PUBLICATION_SEMANTICS_VERSION,
     canonical_edge_kind, canonical_raw_edge_sites, extraction_from_v1, normalize_document_v1,
     normalize_document_v1_with_evidence_best_effort_owned, normalize_document_v1_with_inventory,
+    normalize_document_v1_with_inventory_and_source_digests_best_effort_owned,
     normalize_document_v1_with_inventory_best_effort,
     normalize_document_v1_with_inventory_best_effort_owned, normalize_v1, normalize_v1_best_effort,
 };

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -193,6 +193,24 @@ impl BuildEvidence {
         )
     }
 
+    /// Derive deterministic build and file evidence while reusing exact
+    /// source digests from a build that already read those bytes for
+    /// extraction.
+    pub fn from_extraction_with_source_digests(
+        repository_root: impl Into<PathBuf>,
+        extraction: &Extraction,
+        configuration_digest: impl Into<String>,
+        source_digests: &BTreeMap<String, SourceDigest>,
+    ) -> Result<Self, GraphError> {
+        Self::from_records(
+            repository_root,
+            &extraction.nodes,
+            &extraction.edges,
+            configuration_digest,
+            Some(source_digests),
+        )
+    }
+
     /// Derive publication evidence directly from an immutable analysis graph.
     ///
     /// This avoids cloning the complete graph merely to prepare file and build
@@ -2782,12 +2800,35 @@ pub fn normalize_document_v1_with_inventory_best_effort_owned(
     source_commit: Option<&str>,
     inventory: Vec<InventoryEvidence>,
 ) -> Result<PublicationOutcome, GraphError> {
+    normalize_document_v1_with_inventory_and_source_digests_best_effort_owned(
+        document,
+        repository_root,
+        configuration_digest,
+        source_commit,
+        inventory,
+        None,
+    )
+}
+
+/// Publish an owned analysis document while reusing source digests already
+/// computed by the extraction pipeline. Missing entries (for example
+/// external references or cached files) still use the bounded existing source
+/// read path, so this optimization never weakens publication evidence.
+pub fn normalize_document_v1_with_inventory_and_source_digests_best_effort_owned(
+    document: compass_model::GraphDocument,
+    repository_root: &Path,
+    configuration_digest: impl Into<String>,
+    source_commit: Option<&str>,
+    inventory: Vec<InventoryEvidence>,
+    source_digests: Option<&BTreeMap<String, SourceDigest>>,
+) -> Result<PublicationOutcome, GraphError> {
     let (extraction, evidence) = document_publication_input_owned(
         document,
         repository_root,
         configuration_digest,
         source_commit,
         inventory,
+        source_digests,
     )?;
     normalize_v1_best_effort(extraction, evidence)
 }
@@ -2846,6 +2887,7 @@ fn document_publication_input_owned(
     configuration_digest: impl Into<String>,
     source_commit: Option<&str>,
     inventory: Vec<InventoryEvidence>,
+    source_digests: Option<&BTreeMap<String, SourceDigest>>,
 ) -> Result<(Extraction, BuildEvidence), GraphError> {
     // The owned document may have been assembled from parallel extraction
     // results. Leave raw-order canonicalization enabled so relocation and
@@ -2853,8 +2895,16 @@ fn document_publication_input_owned(
     let mut profile_started = Instant::now();
     let extraction = document_extraction_owned(document);
     profile_v1("v1 raw input transfer", &mut profile_started);
-    let mut evidence =
-        BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?;
+    let mut evidence = if let Some(source_digests) = source_digests {
+        BuildEvidence::from_extraction_with_source_digests(
+            repository_root,
+            &extraction,
+            configuration_digest,
+            source_digests,
+        )?
+    } else {
+        BuildEvidence::from_extraction(repository_root, &extraction, configuration_digest)?
+    };
     profile_v1("v1 build evidence", &mut profile_started);
     evidence.include_inventory(inventory)?;
     profile_v1("v1 inventory enrichment", &mut profile_started);

--- a/crates/compass-graph/tests/graph_v1_normalization.rs
+++ b/crates/compass-graph/tests/graph_v1_normalization.rs
@@ -2443,6 +2443,16 @@ fn build_evidence_reuses_precomputed_source_digests_without_changing_file_record
 
     assert_eq!(reused.files, baseline.files);
     assert_eq!(reused.build, baseline.build);
+
+    let extraction_baseline = BuildEvidence::from_extraction(root, &extraction, "sha256:config")?;
+    let extraction_reused = BuildEvidence::from_extraction_with_source_digests(
+        root,
+        &extraction,
+        "sha256:config",
+        &digests,
+    )?;
+    assert_eq!(extraction_reused.files, extraction_baseline.files);
+    assert_eq!(extraction_reused.build, extraction_baseline.build);
     Ok(())
 }
 

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -317,7 +317,9 @@ fn resolve_owned_with_root_impl(
     root: &Path,
     evidence_prevalidated: bool,
 ) -> Extraction {
+    let mut profile_started = Instant::now();
     let language_facts = members::collect_language_call_facts_owned(extractions);
+    profile_internal("resolver language fact collection", &mut profile_started);
     let mut evidence_batches = Vec::new();
     let mut merged = Extraction::default();
     for extraction in extractions.iter_mut() {
@@ -360,6 +362,7 @@ fn resolve_owned_with_root_impl(
             evidence_batches.push(batch);
         }
     }
+    profile_internal("resolver owned extraction merge", &mut profile_started);
     extractions.clear();
     finish_resolution(
         merged,


### PR DESCRIPTION
## Summary

- Reuse extracted source digests during graph normalization to avoid redundant hashing while preserving graph bytes.
- Compact only materially overallocated extraction vectors, reducing retained parser/AST capacity without changing facts.
- Use a bounded, host-aware worker policy: the AST pool uses 8 workers below 1,024 missing files and up to 12 for larger repositories; the build-wide Rayon pool uses the same finite ceiling. Explicit `--max-workers` overrides remain honored.
- Keep the immutable graph-delta publication path and source-neutral fast path covered by real-repository checks.

## Verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-e27f-final cargo clippy --release -p compass-core --lib --locked -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-e27f-final cargo test --release -p compass-core --lib pipeline_rayon_workers --locked` — passed
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` — 1,535 invariants, 967 coverage records, 57 languages, 28 edge kinds, zero validation errors, and clean/warm/rebuild/restored byte parity
- Incremental Cobra publication reused 42 objects and wrote 33,247 bytes for an append-only comment edit, versus 192 objects and 2,072,975 bytes for the cold publication; a clean rebuild of the final source was byte-identical.
- Three-sample release measurements against pinned Graphify baselines: Cobra 3.17x, Click 3.88x, Rayon 2.38x, Zod 4.80x, and Django 3.77x. Django remained 80,976 nodes / 195,164 edges with zero validation errors.

The universal 4x target is not claimed yet. The higher Compass RSS on the host-aware large-repository path and the remaining publication/resolver floors are intentionally left for a later phase.