### PR TITLE
Accelerate deterministic cold graph builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Parallelize deterministic per-file AST fact digests for large repositories
+  and overlap unchanged pre-merge digest construction with portable AST cache
+  publication. Native-volume Django cold-build p50 improves from 9.82 seconds
+  to 8.04 seconds while preserving byte-identical graphs, reaching 5.43x
+  versus the paired Graphify sample.
+
 - Respect Rust's separate value and type/module namespaces when extracting
   scoped associated calls. A `module::Type::function()` path now retains its
   visible import binding even when a same-named value is in lexical scope;

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -725,6 +725,36 @@ when extraction and graph construction remain below their approved baseline.
 These local measurements are diagnostic evidence and do not replace a
 controlled CI baseline.
 
+### Django parallel fact-state qualification
+
+The 2026-08-05 large-repository fact-state hardening was measured from Compass
+revision `726df22ade0bcd3181b7b0e146783b781a87bd98` plus the candidate change,
+Django revision `dfc52e53f1d19a2730854d68b602fb4dba8bf0c5`, and Graphify revision
+`07b9143d4b90b1e1cb88dc71423f742a501efd29` (package 0.9.34). Both tools read
+the same pinned Django checkout and wrote each sample to a distinct fresh
+output root on the native APFS volume. The release Compass command used the
+comparison profile `--code-only --no-cluster --no-viz --store json`.
+
+Serial AST fact digest construction accounted for 1.98 seconds of the cold
+path. Indexed parallel digest collection reduced that stage to about 0.39
+seconds. Compass also constructs the unchanged pre-merge digest concurrently
+with portable AST cache publication, and deterministically recomputes it after
+any declaration/definition merge that changes facts.
+
+| Tool | Cold samples (s) | p50 | Graphify / Compass |
+| --- | --- | ---: | ---: |
+| Compass before | 9.971, 9.816, 9.821 | 9.821 s | 4.44x |
+| Compass candidate | 8.037, 8.045, 7.878 | 8.037 s | 5.43x |
+| Graphify 0.9.34 | 43.643, 43.544, 44.746 | 43.643 s | — |
+
+All three candidate runs published byte-identical 75,604-node / 203,871-edge
+graphs with SHA-256
+`a5dfcfbe8d77ba2308cf2f0585472132e16dd6f80efa428d5ecf879cb5600ea1`.
+Candidate peak RSS remained informational for this qualification and had a
+three-sample median of about 2,353 MiB. These native-volume measurements avoid
+the multi-second publication variance observed on the mounted workspace, but
+remain runner-specific rather than a cross-platform guarantee.
+
 ## Versioned history qualification
 
 Build a release binary, then measure a clean real repository:

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -51,7 +51,7 @@ use compass_output::{
 };
 use compass_resolve::{
     apply_program_projection, collect_program_projection_sites, merge_decl_def_classes_if_needed,
-    resolve_prevalidated_owned_with_root,
+    merge_decl_def_classes_if_needed_changed, resolve_prevalidated_owned_with_root,
 };
 use compass_store::{
     GRAPH_SCHEMA_V1, STORE_FILE_NAME, STORE_REF_FILE_NAME, SqliteStore, StoreRef,
@@ -1360,19 +1360,32 @@ fn ast_fact_digest_entries(
     output_dir: &Path,
     root: &Path,
 ) -> Result<BTreeMap<String, String>, CoreError> {
-    paths
-        .iter()
-        .zip(extractions)
-        .map(|(path, extraction)| {
-            let digest = extraction_fact_digest(extraction).map_err(|source| {
-                CoreError::SerializeExtraction {
-                    path: output_dir.join(AST_FACT_DIGESTS_FILE),
-                    source,
-                }
-            })?;
-            Ok((relative_fact_path(path, root), digest))
-        })
-        .collect()
+    let digest_entry = |(path, extraction): (&PathBuf, &Extraction)| {
+        let digest = extraction_fact_digest(extraction).map_err(|source| {
+            CoreError::SerializeExtraction {
+                path: output_dir.join(AST_FACT_DIGESTS_FILE),
+                source,
+            }
+        })?;
+        Ok((relative_fact_path(path, root), digest))
+    };
+    let entries = if paths.len() < 256 {
+        paths
+            .iter()
+            .zip(extractions)
+            .map(digest_entry)
+            .collect::<Vec<_>>()
+    } else {
+        paths
+            .par_iter()
+            .zip(extractions.par_iter())
+            .map(digest_entry)
+            .collect::<Vec<_>>()
+    };
+    // Indexed parallel collection preserves source order. Resolve errors and
+    // build the deterministic contract map sequentially so a malformed fact
+    // set reports the same first failure regardless of worker scheduling.
+    entries.into_iter().collect()
 }
 
 fn detected_file_sets_match(manifest: &Manifest, files: &BTreeMap<String, Vec<String>>) -> bool {
@@ -3053,18 +3066,30 @@ fn build_graph_inner_unscoped(
             fresh_paths.contains(*path) && extraction_has_cacheable_ast_facts(extraction)
         })
         .collect::<Vec<_>>();
-    let ast_cache_started = Instant::now();
-    cache.write_portable_ast_batch_ref(&ast_cache_sources)?;
-    cache.flush()?;
-    drop(ast_cache_sources);
-    profile_internal_duration(
-        "AST cache streaming publication",
-        ast_cache_started.elapsed(),
+    let ((cache_result, cache_elapsed), (premerge_digest_result, digest_elapsed)) = rayon::join(
+        || {
+            let started = Instant::now();
+            let result = cache
+                .write_portable_ast_batch_ref(&ast_cache_sources)
+                .and_then(|()| cache.flush());
+            (result, started.elapsed())
+        },
+        || {
+            let started = Instant::now();
+            let result = ast_fact_digest_entries(&ordered_paths, &ordered, &output_dir, &root);
+            (result, started.elapsed())
+        },
     );
+    cache_result?;
+    let premerge_fact_digests = premerge_digest_result?;
+    drop(ast_cache_sources);
+    profile_internal_duration("AST cache streaming publication", cache_elapsed);
+    profile_internal_duration("AST fact digest construction", digest_elapsed);
     // Declaration/definition merging is project-wide and is not idempotent.
     // Cache the portable per-file facts before applying it so a warm build
     // executes the same single merge as a cold build.
-    merge_decl_def_classes_if_needed(&mut ordered, &ordered_paths);
+    let declaration_merge_changed =
+        merge_decl_def_classes_if_needed_changed(&mut ordered, &ordered_paths);
     profile_internal("declaration merge", &mut internal_started);
     let live_sources = detection
         .files
@@ -3077,12 +3102,24 @@ fn build_graph_inner_unscoped(
         .keys()
         .map(|path| canonical_identity(Path::new(path)))
         .any(|path| !live_sources.contains(&path));
+    profile_internal("incremental source inventory", &mut internal_started);
+    let fact_digest_started = Instant::now();
+    let fact_digest_entries = if declaration_merge_changed {
+        ast_fact_digest_entries(&ordered_paths, &ordered, &output_dir, &root)?
+    } else {
+        premerge_fact_digests
+    };
+    profile_internal_duration(
+        "AST fact digest post-merge refresh",
+        fact_digest_started.elapsed(),
+    );
     let current_fact_state = AstFactDigestState {
         schema: AST_FACT_DIGESTS_SCHEMA.to_owned(),
         profile_digest: profile_digest.clone(),
         project_evidence_digest: project_evidence_digest.clone(),
-        entries: ast_fact_digest_entries(&ordered_paths, &ordered, &output_dir, &root)?,
+        entries: fact_digest_entries,
     };
+    internal_started = Instant::now();
     let fact_neutral = fact_neutral_incremental_candidate(
         options,
         semantic,
@@ -3160,6 +3197,7 @@ fn build_graph_inner_unscoped(
     };
     fresh_source_text.extend(cached_source_text);
     let source_text = fresh_source_text;
+    profile_internal("resolver source inventory", &mut internal_started);
     drop(worker_pool);
     drop(project_evidence);
     drop(fresh_paths);
@@ -3167,6 +3205,7 @@ fn build_graph_inner_unscoped(
     drop(ast_id_remap);
     drop(ast_root_marker);
     let program_projection_sites = collect_program_projection_sites(&ordered);
+    profile_internal("Program projection site collection", &mut internal_started);
     let mut resolved = resolve_prevalidated_owned_with_root(ordered, &source_text, &root);
     profile_internal("cross-file resolution total", &mut internal_started);
     drop(source_text);
@@ -7006,6 +7045,46 @@ mod tests {
 
         options.max_workers = Some(0);
         assert_eq!(pipeline_rayon_workers(&options), 1);
+    }
+
+    #[test]
+    fn parallel_ast_fact_digests_match_source_ordered_contract() -> Result<(), Box<dyn Error>> {
+        let root = Path::new("/repo");
+        let paths = (0..300)
+            .map(|index| root.join(format!("src/module_{index:03}.py")))
+            .collect::<Vec<_>>();
+        let extractions = (0..paths.len())
+            .map(|index| {
+                let mut extraction = Extraction::default();
+                extraction
+                    .extensions
+                    .insert("ordinal".to_owned(), json!(index));
+                extraction
+            })
+            .collect::<Vec<_>>();
+        let expected = paths
+            .iter()
+            .zip(&extractions)
+            .map(|(path, extraction)| {
+                Ok((
+                    relative_fact_path(path, root),
+                    extraction_fact_digest(extraction)?,
+                ))
+            })
+            .collect::<Result<BTreeMap<_, _>, serde_json::Error>>()?;
+
+        let actual = ast_fact_digest_entries(&paths, &extractions, root, root)?;
+
+        assert_eq!(actual, expected);
+        assert_eq!(
+            actual.keys().next().map(String::as_str),
+            Some("src/module_000.py")
+        );
+        assert_eq!(
+            actual.keys().next_back().map(String::as_str),
+            Some("src/module_299.py")
+        );
+        Ok(())
     }
 
     #[cfg(unix)]

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -37,6 +37,10 @@ const IMPLEMENTATION_SUFFIXES: &[&str] = &["m", "mm", "cpp", "cc", "cxx", "c"];
 /// ID collision from one directory/base-stem family with exactly one header
 /// is eligible; every other collision is left for conservative disambiguation.
 pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
+    merge_decl_def_classes_changed(extractions);
+}
+
+fn merge_decl_def_classes_changed(extractions: &mut [Extraction]) -> bool {
     let has_declaration_definition = extractions
         .iter()
         .flat_map(|extraction| &extraction.nodes)
@@ -51,7 +55,7 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
                     })
         });
     if !has_declaration_definition {
-        return;
+        return false;
     }
 
     let mut groups = HashMap::<String, Vec<(usize, usize, String)>>::new();
@@ -142,7 +146,7 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
         }
     }
     if dropped.is_empty() {
-        return;
+        return false;
     }
 
     for ((extraction_index, node_index), hashes) in definition_hashes {
@@ -171,11 +175,23 @@ pub fn merge_decl_def_classes(extractions: &mut [Extraction]) {
                 ))
         });
     }
+    true
 }
 
 /// Run declaration/definition merging only when the current source set can
 /// contain a native header/implementation pair.
 pub fn merge_decl_def_classes_if_needed(extractions: &mut [Extraction], sources: &[PathBuf]) {
+    merge_decl_def_classes_if_needed_changed(extractions, sources);
+}
+
+/// Merge declaration/definition classes when eligible and report whether facts changed.
+///
+/// This lets orchestration reuse pre-merge derived state when a corpus merely
+/// contains native-looking files but has no mergeable declaration family.
+pub fn merge_decl_def_classes_if_needed_changed(
+    extractions: &mut [Extraction],
+    sources: &[PathBuf],
+) -> bool {
     if !sources.iter().any(|source| {
         source
             .extension()
@@ -187,9 +203,9 @@ pub fn merge_decl_def_classes_if_needed(extractions: &mut [Extraction], sources:
                     .any(|suffix| extension.eq_ignore_ascii_case(suffix))
             })
     }) {
-        return;
+        return false;
     }
-    merge_decl_def_classes(extractions);
+    merge_decl_def_classes_changed(extractions)
 }
 
 fn is_declaration_source(source: &str) -> bool {
@@ -2822,7 +2838,13 @@ mod tests {
         };
         let mut extractions = vec![header, implementation, unrelated];
 
-        merge_decl_def_classes(&mut extractions);
+        assert!(merge_decl_def_classes_if_needed_changed(
+            &mut extractions,
+            &[
+                PathBuf::from("native/Widget.h"),
+                PathBuf::from("native/Widget.cpp"),
+            ],
+        ));
 
         let merged = extractions
             .iter()
@@ -2869,7 +2891,10 @@ mod tests {
             ..Extraction::default()
         }];
 
-        merge_decl_def_classes_if_needed(&mut extractions, &[PathBuf::from("package/first.py")]);
+        assert!(!merge_decl_def_classes_if_needed_changed(
+            &mut extractions,
+            &[PathBuf::from("package/first.py")],
+        ));
 
         assert_eq!(extractions[0].nodes.len(), 2);
     }


### PR DESCRIPTION
## Summary

- Parallelize deterministic per-file AST fact digest construction for large repositories.
- Overlap unchanged pre-merge digest construction with portable AST cache publication.
- Reuse pre-merge digest state when declaration/definition merging does not change facts.
- Add deterministic regression coverage and document the Django qualification.

## Why

AST fact digest construction was serial and accounted for approximately 1.98 seconds of the Django cold-build path. Cache publication and digest construction were also independent but executed sequentially.

The updated pipeline uses indexed Rayon collection to preserve source ordering and deterministic first-error behavior. It overlaps digest construction with cache publication, then recomputes derived state only when declaration/definition merging actually changes facts.

## Performance

Pinned native-APFS qualification:

- Compass baseline p50: 9.821s
- Compass candidate p50: 8.037s
- Graphify 0.9.34 p50: 43.643s
- Graphify / Compass: **5.43x**
- Candidate median peak RSS: approximately 2,353 MiB (informational)

All three candidate runs produced byte-identical graphs:

- 75,604 nodes
- 203,871 edges
- SHA-256: `a5dfcfbe8d77ba2308cf2f0585472132e16dd6f80efa428d5ecf879cb5600ea1`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- Targeted `compass-core` and `compass-resolve` tests
- Enterprise pipeline scale tests
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- 144 performance harness unit tests
- Final `git diff --check`

The code-graph fixture qualification confirmed byte-identical clean, warm, forced-rebuild, restored, and alternate-checkout output.