### PR TITLE
Publish flat compass-out artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Materialize `graph.json`, `graph.html`, `GRAPH_REPORT.md`, `manifest.json`,
+  and optional public build artifacts directly under `compass-out/`. The flat
+  paths support low-effort migration of file-based workflows while Compass's
+  immutable generations, store references, and cache encoding remain
+  independent internal protocols. Root files use atomic replacement, remove
+  stale optional outputs, and self-repair after interrupted publication.
+
 - Keep dense VS Code and HTML code graphs responsive by switching detailed
   views with at least 1,000 nodes or 4,000 relationships to a deterministic
   community-grouped layout with paused physics and reduced edge decoration.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -14,9 +14,11 @@ Graphify.
 - environment variables: `COMPASS_*`
 - MCP server and resources: `compass` and `compass://...`
 
-Legacy Graphify names are intentionally unsupported. Existing Graphify state
-must be archived or removed before creating fresh Compass artifacts. See
-[`MIGRATION.md`](MIGRATION.md) for the hard-cutover procedure.
+Legacy Graphify executable, environment, configuration, and protocol names are
+intentionally unsupported. Existing `graphify-out/` state can remain in place
+while a fresh Compass build creates `compass-out/`; the two products do not
+share caches or mutable state. See [`MIGRATION.md`](MIGRATION.md) for the
+transition procedure.
 
 ## VS Code extension compatibility
 
@@ -60,7 +62,11 @@ A user-visible incompatible change requires:
 Versioned formats use Compass-owned identifiers. Consumers should reject
 unknown major versions instead of attempting legacy fallback behavior.
 
-The current local build publishes `graph.json` (`compass.graph/1`) by default.
+The current local build publishes `graph.json` (`compass.graph/1`) directly
+under the selected output root by default. It also materializes
+`GRAPH_REPORT.md`, `manifest.json`, and optional `graph.html` at that stable
+root path. Compass retains an immutable generation behind those conventional
+paths as its coherent internal authority.
 Passing `--store sqlite` also publishes a validated `compass-store.sqlite3`
 sidecar and typed `store.ref` selector. Typed code queries use JSON by default;
 `--engine store` explicitly selects and validates the sidecar. The SQLite file

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,9 @@
 # Migrate from Graphify to Compass
 
-Compass uses its own executable, output directory, environment variable, and sidecars. The first public release makes a clean break from Graphify compatibility paths.
+Compass uses its own executable, output directory, environment variable, and
+sidecars. Its output root now preserves the familiar flat artifact shape so
+file-based workflows can transition without learning Compass's hidden
+generation or store layout.
 
 ## Install Compass
 
@@ -14,7 +17,8 @@ The release contains only the `compass` executable. It doesn't install `graphify
 
 ## Rebuild project output
 
-Compass doesn't read `graphify-out/` or `GRAPHIFY_OUT`. Run a new build to create `compass-out/`:
+Compass doesn't read `graphify-out/` or `GRAPHIFY_OUT`. Keep the old directory
+for rollback and run a new build to create `compass-out/`:
 
 ```bash
 cd your_project_directory
@@ -22,6 +26,23 @@ compass update .
 ```
 
 Set `COMPASS_OUT` before running Compass when you need a custom output directory.
+
+The new directory exposes the main artifacts directly:
+
+```text
+compass-out/
+├── graph.json
+├── graph.html        # unless --no-viz or the render limit omits it
+├── GRAPH_REPORT.md
+├── manifest.json
+└── cache/
+```
+
+Scripts that open, copy, serve, mount, or archive these conventional filenames
+only need the executable and output-directory rename. The JSON schema and
+cache payloads remain Compass contracts: do not copy `graphify-out/cache/` or
+`graphify-out/manifest.json` into `compass-out/`. Compass rebuilds them from
+source while retaining its own internal generation and store protocols.
 
 ## Opt into Program IR generation
 
@@ -104,7 +125,9 @@ when the target binary reports an unsupported major or adapter.
 
 ## Regenerate HTML graph exports
 
-Current Compass releases use the shared graph workbench for `graph.html` and
+Normal builds now write the self-contained page directly to
+`compass-out/graph.html`; `compass export html` repairs or regenerates the same
+root path. Current Compass releases use the shared graph workbench and
 do not preserve the previous export's DOM, CSS selectors, or remote
 `vis-network` script boundary. Regenerate saved HTML exports with the current
 `compass export html` command. Any private CSS overrides or browser automation

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -899,7 +899,10 @@ fn write_watch_status_mode(
             let _result = native_line!(
                 stdout,
                 "[compass watch] graph artifacts updated in {}",
-                result.output_dir.display()
+                compass_files::BuildGuard::output_container_for_artifact(
+                    &result.output_dir.join("graph.json")
+                )
+                .display()
             );
             if result.partial_graph {
                 let _result = native_line!(
@@ -1323,6 +1326,7 @@ fn command_cluster_only(_frontend: Frontend, args: &[String]) -> Outcome {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .to_path_buf();
+    let public_output_dir = compass_files::BuildGuard::output_container_for_artifact(&graph_path);
     match cluster_existing_graph(&ClusterExistingOptions {
         graph_path,
         output_dir: output_dir.clone(),
@@ -1340,7 +1344,7 @@ fn command_cluster_only(_frontend: Frontend, args: &[String]) -> Outcome {
                 result.edges,
                 result.communities,
                 result.labels_reused,
-                output_dir.display()
+                public_output_dir.display()
             ));
             if timing {
                 outcome.stderr = format!(
@@ -2149,7 +2153,10 @@ fn command_build_with_validation_inner(
                 result.nodes,
                 result.edges,
                 result.communities,
-                result.output_dir.display()
+                compass_files::BuildGuard::output_container_for_artifact(
+                    &result.output_dir.join("graph.json")
+                )
+                .display()
             );
             output.push('\n');
             output.push_str(&format_program_analysis(&result));
@@ -3155,7 +3162,23 @@ fn command_export(frontend: Frontend, args: &[String]) -> Outcome {
         _ => Err("unsupported export format".to_owned()),
     };
     match result {
-        Ok(output) => {
+        Ok(mut output) => {
+            if format == "html" {
+                let output_container =
+                    compass_files::BuildGuard::output_container_for_artifact(&graph_path);
+                if let Err(error) = compass_files::BuildGuard::publish_root_artifacts(
+                    &output_container,
+                    &["graph.html"],
+                    true,
+                ) {
+                    return Outcome::failure(format!(
+                        "error: could not publish graph.html at the output root: {error}"
+                    ));
+                }
+                if output.html_output.is_some() {
+                    output.html_output = Some(output_container.join("graph.html"));
+                }
+            }
             let outcome = Outcome::success(output.message);
             match (frontend, output.html_output) {
                 (Frontend::Compass, Some(path)) => outcome.with_html_output(path),

--- a/crates/compass-cli/tests/compass_product.rs
+++ b/crates/compass-cli/tests/compass_product.rs
@@ -28,10 +28,52 @@ fn update_writes_to_compass_out_by_default() -> Result<(), Box<dyn Error>> {
     let root = tempfile::tempdir()?;
     run_update(root.path(), |_| {})?;
 
-    assert!(
-        BuildGuard::resolve_artifact(&root.path().join("compass-out"), "graph.json")?.is_file()
-    );
+    let output = root.path().join("compass-out");
+    assert!(BuildGuard::resolve_artifact(&output, "graph.json")?.is_file());
+    assert!(output.join("graph.json").is_file());
+    assert!(output.join("GRAPH_REPORT.md").is_file());
+    assert!(output.join("manifest.json").is_file());
+    assert!(output.join("cache").is_dir());
+    assert!(!output.join("graph.html").exists());
     assert!(!root.path().join("graphify-out").exists());
+    Ok(())
+}
+
+#[test]
+fn html_export_is_materialized_directly_in_compass_out() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    run_update(root.path(), |_| {})?;
+    let output = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["export", "html"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "compass export html failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(root.path().join("compass-out/graph.html").is_file());
+    Ok(())
+}
+
+#[test]
+fn update_materializes_html_directly_in_compass_out() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    std::fs::write(root.path().join("sample.rs"), "fn sample() {}\n")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args(["update", ".", "--code-only"])
+        .current_dir(root.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "compass update failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(root.path().join("compass-out/graph.html").is_file());
     Ok(())
 }
 
@@ -47,6 +89,7 @@ fn compass_out_overrides_the_output_and_graphify_out_is_ignored() -> Result<(), 
     assert!(
         BuildGuard::resolve_artifact(&root.path().join("chosen-output"), "graph.json")?.is_file()
     );
+    assert!(root.path().join("chosen-output/graph.json").is_file());
     assert!(!root.path().join("legacy-output").exists());
     Ok(())
 }

--- a/crates/compass-core/src/cluster_existing.rs
+++ b/crates/compass-core/src/cluster_existing.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use compass_files::{write_json_atomic, write_text_atomic};
+use compass_files::{BuildGuard, write_json_atomic, write_text_atomic};
 use compass_graph::{
     ClusterOptions, Communities, GodNode, cluster, community_member_signatures, god_nodes,
     label_communities_by_hub, remap_communities_to_previous, score_communities, suggest_questions,
@@ -253,6 +253,17 @@ where
         }
         rendered.is_some()
     };
+    let output_container = BuildGuard::output_container_for_artifact(&options.graph_path);
+    BuildGuard::publish_root_artifacts(
+        &output_container,
+        &[
+            "GRAPH_REPORT.md",
+            "graph-overview.json",
+            "graph.html",
+            "graph.json",
+        ],
+        true,
+    )?;
     let export_elapsed = export_started.elapsed();
     Ok(ClusterExistingResult {
         nodes: document.nodes.len(),

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -85,6 +85,14 @@ const STORE_GENERATION_EXCLUSIONS: [&str; 3] = [
     "compass-store.sqlite3-wal",
     "compass-store.sqlite3-shm",
 ];
+const ROOT_ARTIFACTS: [&str; 6] = [
+    "GRAPH_REPORT.md",
+    "graph-overview.json",
+    "graph.html",
+    "manifest.json",
+    "program.json",
+    "graph.json",
+];
 
 #[derive(Clone, Debug)]
 pub struct BuildOptions {
@@ -1934,6 +1942,7 @@ fn publish_fact_neutral_incremental(
         options.graph_storage,
         store_metrics.is_some(),
         !options.graph_storage.publishes_store(),
+        true,
         timings,
     )?;
     timings.publish = publish_started.elapsed();
@@ -2416,6 +2425,7 @@ fn build_graph_inner_unscoped(
                 options.graph_storage,
                 store_ready,
                 false,
+                false,
                 &mut timings,
             )?;
             return Ok((
@@ -2499,6 +2509,7 @@ fn build_graph_inner_unscoped(
             &output_container,
             options.graph_storage,
             true,
+            false,
             false,
             &mut timings,
         )?;
@@ -3316,6 +3327,7 @@ fn build_graph_inner_unscoped(
             options.graph_storage,
             true,
             false,
+            false,
             &mut timings,
         )?;
         return Ok((
@@ -3497,6 +3509,7 @@ fn build_graph_inner_unscoped(
             options.graph_storage,
             true,
             !options.graph_storage.publishes_store(),
+            true,
             &mut timings,
         )?;
         profile_internal_duration(
@@ -3626,6 +3639,7 @@ fn build_graph_inner_unscoped(
                 &output_container,
                 options.graph_storage,
                 true,
+                false,
                 false,
                 &mut timings,
             )?;
@@ -4008,6 +4022,7 @@ fn build_graph_inner_unscoped(
         options.graph_storage,
         true,
         !options.graph_storage.publishes_store(),
+        true,
         &mut timings,
     )?;
     timings.publish = publish_started.elapsed();
@@ -4256,6 +4271,7 @@ fn commit_generation(
     graph_storage: GraphStorage,
     store_ready: bool,
     presealed_artifacts: bool,
+    root_artifacts_changed: bool,
     timings: &mut BuildTimings,
 ) -> Result<PathBuf, CoreError> {
     let publish_store = graph_storage.publishes_store();
@@ -4294,6 +4310,7 @@ fn commit_generation(
     } else {
         guard.commit_with_artifacts(&artifacts)?;
     }
+    BuildGuard::publish_root_artifacts(output_container, &ROOT_ARTIFACTS, root_artifacts_changed)?;
     Ok(BuildGuard::resolve_active_directory(output_container)?)
 }
 

--- a/crates/compass-files/src/build_guard.rs
+++ b/crates/compass-files/src/build_guard.rs
@@ -1,14 +1,16 @@
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufReader};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::atomic::sync_directory;
-use crate::{FileError, io_error, write_text_atomic};
+use crate::{FileError, io_error, write_atomic_with, write_text_atomic};
 
 const GENERATIONS_DIRECTORY: &str = ".compass-generations";
 const ACTIVE_GENERATION: &str = ".compass-active-generation";
 const INCOMPLETE_MARKER: &str = ".compass-build-incomplete";
+const ROOT_ARTIFACTS_COMPLETE: &str = ".compass-root-artifacts-complete";
 const RETAINED_COMPLETE_GENERATIONS: usize = 2;
 const MAX_GENERATION_DIRECTORY_ENTRIES: usize = 1_024;
 static GENERATION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -166,6 +168,78 @@ impl BuildGuard {
         }
     }
 
+    /// Return the stable output container that owns a generated artifact.
+    ///
+    /// Paths inside the active immutable generation map back to their public
+    /// output root. Standalone and legacy-root artifacts keep their immediate
+    /// parent directory.
+    #[must_use]
+    pub fn output_container_for_artifact(path: &Path) -> PathBuf {
+        let artifact_directory = path.parent().unwrap_or_else(|| Path::new("."));
+        let Some(generations_directory) = artifact_directory.parent() else {
+            return artifact_directory.to_path_buf();
+        };
+        if generations_directory
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(GENERATIONS_DIRECTORY)
+        {
+            return artifact_directory.to_path_buf();
+        }
+        let Some(output_directory) = generations_directory.parent() else {
+            return artifact_directory.to_path_buf();
+        };
+        if Self::resolve_active_directory(output_directory)
+            .is_ok_and(|active| active == artifact_directory)
+        {
+            output_directory.to_path_buf()
+        } else {
+            artifact_directory.to_path_buf()
+        }
+    }
+
+    /// Materialize selected generation files directly under the output root.
+    ///
+    /// The immutable generation remains authoritative for Compass-aware
+    /// readers. These independently atomic copies provide stable conventional
+    /// paths for browsers, scripts, archives, and other file-based consumers.
+    /// Missing optional artifacts remove an older root copy. A failed or
+    /// interrupted projection leaves no completion marker, so the next build
+    /// performs a full repair.
+    pub fn publish_root_artifacts(
+        output_directory: &Path,
+        artifacts: &[&str],
+        refresh: bool,
+    ) -> Result<(), FileError> {
+        validate_exclusions(artifacts)?;
+        let active = Self::resolve_active_directory(output_directory)?;
+        if active == output_directory {
+            return Ok(());
+        }
+
+        let completion_marker = output_directory.join(ROOT_ARTIFACTS_COMPLETE);
+        let repair_all = refresh || !completion_marker.is_file();
+        remove_file_if_exists(&completion_marker)?;
+
+        for artifact in artifacts {
+            let source = active.join(artifact);
+            let destination = output_directory.join(artifact);
+            if source.is_file() {
+                if repair_all || !destination.is_file() {
+                    copy_file_atomic(&source, &destination)?;
+                }
+            } else {
+                remove_file_if_exists(&destination)?;
+            }
+        }
+
+        let generation = active
+            .file_name()
+            .ok_or_else(|| FileError::InvalidGenerationArtifact(active.clone()))?
+            .to_string_lossy();
+        write_text_atomic(completion_marker, &generation)
+    }
+
     pub fn commit(self) -> Result<(), FileError> {
         self.commit_with_artifacts(&[])
     }
@@ -222,6 +296,24 @@ impl BuildGuard {
         )?;
         self.committed = true;
         Ok(())
+    }
+}
+
+fn copy_file_atomic(source: &Path, destination: &Path) -> Result<(), FileError> {
+    let file = File::open(source).map_err(|error| io_error(source, error))?;
+    let mut reader = BufReader::new(file);
+    write_atomic_with(destination, |writer| {
+        io::copy(&mut reader, writer)
+            .map(|_| ())
+            .map_err(|error| io_error(source, error))
+    })
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), FileError> {
+    match fs::remove_file(path) {
+        Ok(()) => sync_directory(path.parent().unwrap_or_else(|| Path::new("."))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_error(path, error)),
     }
 }
 

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -767,6 +767,64 @@ fn build_guard_publishes_atomic_artifacts_without_resealing_them() -> Result<(),
 }
 
 #[test]
+fn build_guard_materializes_and_repairs_root_artifacts() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let first = BuildGuard::begin(directory.path())?;
+    fs::write(first.staging_directory().join("graph.json"), "graph-one")?;
+    fs::write(first.staging_directory().join("graph.html"), "html-one")?;
+    first.commit_with_artifacts(&["graph.json", "graph.html"])?;
+
+    BuildGuard::publish_root_artifacts(directory.path(), &["graph.html", "graph.json"], true)?;
+    assert_eq!(
+        fs::read_to_string(directory.path().join("graph.json"))?,
+        "graph-one"
+    );
+    assert_eq!(
+        fs::read_to_string(directory.path().join("graph.html"))?,
+        "html-one"
+    );
+
+    fs::remove_file(directory.path().join("graph.json"))?;
+    BuildGuard::publish_root_artifacts(directory.path(), &["graph.html", "graph.json"], false)?;
+    assert_eq!(
+        fs::read_to_string(directory.path().join("graph.json"))?,
+        "graph-one"
+    );
+
+    let second = BuildGuard::begin(directory.path())?;
+    fs::write(second.staging_directory().join("graph.json"), "graph-two")?;
+    fs::remove_file(second.staging_directory().join("graph.html"))?;
+    second.commit_with_artifacts(&["graph.json"])?;
+    BuildGuard::publish_root_artifacts(directory.path(), &["graph.html", "graph.json"], true)?;
+    assert_eq!(
+        fs::read_to_string(directory.path().join("graph.json"))?,
+        "graph-two"
+    );
+    assert!(!directory.path().join("graph.html").exists());
+    Ok(())
+}
+
+#[test]
+fn build_guard_maps_active_artifacts_to_the_output_container() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let guard = BuildGuard::begin(directory.path())?;
+    fs::write(guard.staging_directory().join("graph.json"), "graph")?;
+    guard.commit_with_artifacts(&["graph.json"])?;
+    let graph = BuildGuard::resolve_artifact(directory.path(), "graph.json")?;
+
+    assert_eq!(
+        BuildGuard::output_container_for_artifact(&graph),
+        directory.path()
+    );
+    let standalone = directory.path().join("standalone/graph.json");
+    assert_eq!(
+        BuildGuard::output_container_for_artifact(&standalone),
+        directory.path().join("standalone")
+    );
+    Ok(())
+}
+
+#[test]
 fn build_guard_can_exclude_a_large_generation_sidecar() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let first = BuildGuard::begin(directory.path())?;

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -233,6 +233,15 @@ empty usable graph remain failures and cannot replace the active generation.
 Write paths use temporary or staged artifacts and atomic replacement where the
 contract requires it.
 
+Compass first commits the authoritative immutable generation. It then
+materializes the conventional root-level files with independent atomic
+replacement, placing `graph.json`, `graph.html`, `GRAPH_REPORT.md`, and
+`manifest.json` exactly where ordinary file-based integrations expect them.
+If that façade publication is interrupted, its completion marker is left
+absent and the next build repairs the full set. The generation protocol and
+cache encoding can therefore evolve without forcing consumers to follow a
+private storage layout.
+
 Consumers should still avoid reading files while a writer is replacing an
 artifact set. A long-lived integration can either watch for completion, invoke
 Compass itself, or open a graph snapshot only after the producing command

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,6 +44,12 @@ compass update . --out custom-output
 
 Do not point two concurrent writers at one output directory.
 
+Successful builds materialize `graph.json`, `manifest.json`,
+`GRAPH_REPORT.md`, and optional `graph.html` directly under this root. These
+stable paths are the portable integration surface. Hidden generations, store
+references, and the encoding beneath `cache/` remain Compass-owned operational
+state and should be kept opaque.
+
 ## Compass Store configuration
 
 The local build publishes `graph.json` under the selected output root. SQLite

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -10,21 +10,39 @@ Default:
 
 ```text
 compass-out/
+├── graph.json
+├── graph.html                   # unless omitted by size or --no-viz
+├── GRAPH_REPORT.md
+├── manifest.json
+├── program.json                 # only with --program or --program-artifact
+├── graph-overview.json          # clustered builds
+├── cache/                       # Compass-owned disposable cache layout
 ├── .compass-active-generation
 ├── .compass-generations/<active>/
 │   ├── graph.json
-│   └── store.ref               # with the default SQLite query index
+│   ├── graph.html, report, manifest, and optional public artifacts
+│   └── store.ref                # with the default SQLite query index
 ├── .compass-store/
 │   └── compass-store.sqlite3   # with the default SQLite query index
-├── program.json                 # only with --program or --program-artifact
-├── GRAPH_REPORT.md
-├── graph.html
-├── manifest.json
-├── cache/
 └── optional sidecars and exports
 ```
 
 `--out DIR` or compatible `COMPASS_OUT` use can select another root.
+
+The ordinary files at the root are a stable, flat consumer façade. Compass
+publishes its immutable generation first, then materializes each root file by
+atomic replacement; a completion marker makes an interrupted façade update
+self-repair on the next build. Compass-aware readers continue to resolve the
+active generation, while browsers, scripts, archive tools, and integrations
+can use literal paths such as `compass-out/graph.json` and
+`compass-out/graph.html`. Consumers that need a related set should read it only
+after the producing Compass command returns successfully.
+
+The `cache/` directory is already rooted beside these files for familiar
+incremental-build ergonomics, but its contents and encoding are private to
+Compass. Do not copy another product's cache or manifest into it. Future
+Compass storage and cache revisions can evolve independently without changing
+the flat public artifact paths.
 
 ## Authority table
 


### PR DESCRIPTION
## Summary

- materialize `graph.json`, `graph.html`, `GRAPH_REPORT.md`, `manifest.json`, and optional public artifacts directly under `compass-out/`
- retain immutable generations and store references as the coherent internal authority
- atomically replace root files, remove stale optional outputs, and repair interrupted root publication on the next build
- keep `cache/` root-level while allowing its Compass-owned encoding and storage protocol to evolve independently
- update HTML export, cluster, label, watch, migration, compatibility, and output documentation

## Why

Graphify users commonly integrate with a flat output directory containing literal `graph.json` and `graph.html` paths. Compass previously rendered these files inside a hidden active-generation directory, so ordinary scripts, mounts, archives, and browser workflows needed Compass-specific path resolution. This adds a stable flat consumer facade while preserving the transactional generation model.

## User impact

After changing the executable and output directory name, file-based workflows can use conventional paths such as `compass-out/graph.json` and `compass-out/graph.html`. Graphify caches and manifests are still not reused; Compass rebuilds its own state from source.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-files --test contracts --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `cargo test -p compass-core --lib --locked`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
