### PR TITLE
feat: wire TypeScript and JavaScript universal candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Route JavaScript and TypeScript production extraction through the registered
+  universal semantic candidate, including source-backed declarations, imports,
+  re-exports, calls, references, heritage, aliases, and framework route
+  targets. The candidate is now the same deterministic path used by
+  qualification fixtures, with universal provenance and cross-file resolution
+  preserved through cached and rebuilt graphs.
+
 ## 0.3.6 - 2026-08-06
 
 - Simplify every Compass-owned current-output path beneath `compass-out/`.

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1300,6 +1300,30 @@ project-manifest corpora, compiler-backed scope and declaration inventories,
 framework tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP
 scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, source-oracle JSONL coverage stream)
+
+The independent TypeScript/JavaScript source oracle now has a bounded,
+record-oriented JSONL mode used by the Python audit inventory:
+
+- `--jsonl` emits a deterministic header, project records, one parsed/rejected
+  file record for every scanned file, diagnostics, source constructs, and a
+  footer carrying counts and source/config digests. The parser rejects missing,
+  duplicated, unknown, malformed, truncated, or inconsistent records instead
+  of lowering the recall denominator.
+- The existing single-document JSON mode remains available for direct oracle
+  inspection and compatibility fixtures. Normal Compass builds still never
+  invoke Node.js, TypeScript, or this developer-only oracle.
+- Unicode byte ranges, project ownership, invalid-config fallback, parser
+  rejection, deterministic ordering, and repeated output remain covered by the
+  correctness suite; the audit path now validates the stream before building
+  its source inventory.
+
+The source oracle is still source-occurrence evidence rather than target truth.
+The final scope/declaration/call JSONL contract, compiler-backed target
+adjudication, four release corpora, accepted precision/Wilson gates, framework
+tiers, equivalent Graphify/SCIP scope, and the production hard cut remain
+open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -2092,6 +2092,30 @@ the new capability. Candidate and focused oracle coverage now stand at 109 and
 the resolver suite remains 180; broad corpus, target-adjudication, framework,
 competitor, production hard-cut, and leadership gates remain open.
 
+### Execution checkpoint (2026-08-07, TypeScript import-type query recovery)
+
+The pinned tree-sitter parser still recovers indexed TypeScript import-type
+queries such as `(typeof import("./items").items)[number]` through the
+byte-preserving parser mask. The candidate now combines that bounded original
+source scan with parser-proven `import("...").Member` type-query nodes and
+emits the exact quoted module literal as an `imports` candidate with
+`import_type` context. It suppresses the competing `dynamic_import`
+interpretation only in TypeScript/TSX type positions, preserves the enclosing
+lexical owner, and records a bounded diagnostic when the query limit is
+exceeded. The source evidence is intentionally target-neutral; project module
+resolution remains the resolver's responsibility.
+
+The independent TypeScript 5.9.3 oracle correctness test now asserts
+`import_type` JSONL records and exact UTF-8 ranges, while the ignored compiler
+differential fixture includes an import-type query. Candidate coverage is now
+112 tests, including the JavaScript `typeof import()` runtime negative and a
+bounded-query diagnostic case; the
+resolver suite is now 181 with a module-target resolution assertion, and the
+focused oracle suite covers the new construct. Parser-mask elimination for
+this pinned grammar, complete
+member/type-query target adjudication, broad corpus, framework, competitor,
+production hard-cut, and leadership gates remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1209,10 +1209,39 @@ source-proven subset of conditional and mapped receiver types:
   occurrence multiplicity, and published declaration identities are unchanged.
 
 The focused candidate suite is now 81 tests and the universal resolver suite
-remains 159 tests. The candidate adapter remains absent from
+remains 160 tests. The candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS`. Broader distributive conditional semantics, indexed/keyof
 evaluation, richer interprocedural flow, framework/compiler tiers,
 accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
+### Execution checkpoint (2026-08-07, project-aware compiler source-oracle slice)
+
+The independent TypeScript/JavaScript source oracle now honors the compiler's
+bounded project model before measuring source recall:
+
+- It discovers `tsconfig*.json` and `jsconfig*.json`, parses their include/
+  exclude/file selections, follows in-root project references, and guards
+  project count, reference depth, project-file references, source bytes, facts,
+  and diagnostics with explicit limits. Cycles are visited once and do not
+  recurse indefinitely.
+- The payload records project scopes, configuration/source digests, a
+  `projectMode` (`project`, `fallback`, or `tree`), deterministic diagnostics,
+  and exact UTF-8 ranges. Parser/configuration failures remain rejected or
+  diagnosed coverage; an entirely invalid configuration set falls back to the
+  bounded source tree rather than silently reporting an empty project.
+- The Python inventory validator accepts and validates the optional project and
+  diagnostics sections while preserving the existing v1 source-construct
+  contract. A regression fixture covers include/exclude boundaries, project
+  references, syntax rejection, deterministic repeated output, and Unicode
+  byte ranges.
+
+The source oracle remains qualification-only and emits source constructs, not
+targets; its output is still a deterministic JSON payload rather than the final
+JSONL evidence stream described by Phase 0. The candidate adapter remains
+absent from `UNIVERSAL_ADAPTERS`. Project-manifest corpora, compiler-backed
+scope/declaration inventories, broader conditional/keyof semantics, framework
+tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
 production hard cut remain open.
 
 ## Outcome

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1420,6 +1420,27 @@ structural/mapped/indexed semantics, compiler-target truth, release corpora,
 precision/Wilson, framework tiers, equivalent Graphify/SCIP scope, and the
 production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, immutable `this` alias closure slice)
+
+The native JavaScript flow path now preserves a narrow, source-proven receiver
+identity for immutable aliases captured by a closure:
+
+- `const token = this` (and equivalent `const` aliases to nominal receivers)
+  can retain the enclosing class receiver through a later closure call, so
+  `token.subscribe()`/similar members can resolve to the class declaration.
+- Mutable aliases, structural object aliases, and dynamic escape paths remain
+  barriers and fail closed. The implementation does not infer a receiver from
+  a spelling or choose among competing structural members.
+- A focused candidate regression covers the positive class pattern while the
+  existing mutable-closure negative remains intact.
+
+On the read-only Axios target-adjudication diagnostic, exact local target
+matches improved from 3,014/3,167 to 3,019/3,167 (missing 148, wrong 0); this
+is a diagnostic signal rather than a release precision/recall claim. Broader
+interprocedural flow, conditional structural exports, compiler-target truth,
+release corpora, precision/Wilson, framework tiers, equivalent Graphify/SCIP
+scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1138,6 +1138,35 @@ absent from `UNIVERSAL_ADAPTERS`. Conditional/mapped modifier semantics, richer
 interprocedural flow, framework/compiler tiers, accepted precision/Wilson gates,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, callable-value references and `in` narrowing)
+
+The qualification-only ECMAScript candidate now preserves source-proven
+callable values as references when they flow through ordinary JavaScript and
+TypeScript containers or unknown APIs:
+
+- Callable local variables and bounded alias chains (`const alias2 = alias`)
+  publish exact `references` candidates for direct arguments, array/object
+  values, and later uses. The candidate does not invent `indirect_call`; an
+  alias remains a reference to its own source binding until a versioned API or
+  framework contract proves invocation semantics.
+- Callable aliases are classified through a small fixed point bounded by the
+  existing inline-property budget. Member aliases require one unique local
+  source declaration; imported member shapes remain unresolved at the
+  per-file boundary. Non-callable values, conditional mixtures, duplicate
+  owners, and dynamic containers remain unclassified.
+- Positive literal `in` guards narrow a union receiver only when exactly one
+  source constituent owns the guarded property. Shared-property, unknown-key,
+  imported, and unsupported guard forms remain unresolved; the parser range and
+  occurrence are still preserved.
+
+The focused candidate suite is now 77 tests and the universal resolver suite is
+159 tests, including resolver publication checks for callable references with
+no indirect-call edge and candidate checks for unique/ambiguous `in` guards.
+The candidate adapter remains absent from `UNIVERSAL_ADAPTERS`. Conditional and
+mapped modifier semantics beyond the bounded utility/union rules, richer
+interprocedural flow, framework/compiler tiers, accepted precision/Wilson gates,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -771,6 +771,31 @@ production hard cut remain open. The candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS` until those gates and the exact-release qualification
 complete.
 
+### Execution checkpoint (2026-08-06, imported declaration-merging slice)
+
+The TypeScript candidate path now preserves the source binding when a value is
+annotated with an imported nominal type (`value: ImportedType`). The receiver
+proof no longer collapses to a bare qualified spelling, so member calls and
+accesses carry the imported binding identity and a qualified target such as
+`module::Config.inspect`. This covers type-only imports as well as ordinary
+value-and-type imports and keeps unresolved/dynamic receivers conservative.
+
+The shared TypeScript resolver now widens only its internal exported-owner
+lookup to include type-space declarations (`interface`, `namespace`, and
+aliases); final member filtering still admits only the callable/value member
+target kinds. Consequently, two source declarations of one interface merge
+their distinct members, while duplicate same-spelled members remain
+ambiguous and publish no invented call. Borrowed and owned merge paths are
+covered by the cross-file regression, with candidate-level assertions for
+binding identity and member qualification.
+
+This advances declaration merging and imported nominal receiver quality but is
+not a full TypeScript type system. Generic instantiation beyond bounded source
+shapes, mapped/indexed conditional types, framework tiers, compiler
+differential recall, and the production hard cut remain open. The candidate
+adapter remains absent from `UNIVERSAL_ADAPTERS` until the mandatory quality
+and exact-release qualification gates complete.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -825,6 +825,27 @@ production hard cut remain open. The candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release
 qualification gates complete.
 
+### Execution checkpoint (2026-08-06, recursive nested generic member-chain slice)
+
+The generic member-chain resolver now carries a bounded concrete type context
+for each owner hop instead of reusing only the root instantiation. Nested
+nominal arguments are recursively canonicalized in the existing
+`DeclarationFact.signature`/qualified-path evidence (for example,
+`Box<../lib/types::Wrapper<../lib/item::Item>>`), then propagated through
+`Box<T>.item` to `Wrapper<U>.value` before resolving the final `Item.inspect`
+member. This keeps the mechanism source-backed and deterministic without
+introducing a compiler or runtime type-system dependency.
+
+Three resolver regressions cover the positive cross-module chain, duplicate
+`Item.inspect` ambiguity, and a primitive `Box<string>` negative. The
+universal resolver suite is now 140 tests and the TypeScript candidate suite
+remains 44 tests. Unsupported structural, mapped, conditional, indexed,
+overload-dependent, or over-limit shapes still fail closed; framework tiers,
+compiler differential recall, project-corpus qualification, and the production
+hard cut remain open. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release
+qualification gates complete.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1114,6 +1114,30 @@ byte-stable at Compass revision `24f937360cc80d6b62b633f2fdd2a367eb6529c3`,
 with 57 languages, 980 coverage records, 1,565 invariants, 27 flows, and
 graph digest `sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`.
 
+### Execution checkpoint (2026-08-07, bounded JavaScript alias-escape slice)
+
+The qualification-only ECMAScript candidate now carries source-proven local
+receiver identity through safe straight-line aliases:
+
+- `const alias = current` preserves the latest constructor, call-result, or
+  imported nominal receiver, including a cross-file callable-return chain.
+- Passing a tracked value to a callable argument, returning it, writing a
+  member, capturing it in a closure, entering `with`, invoking global `eval`,
+  or constructing an unsupported `Proxy` records an explicit flow barrier.
+  Barriers prevent stale exact member targets and dynamic/escaping cases remain
+  unresolved instead of becoming terminal-name calls.
+- Dynamic barriers are bounded by the existing traversal, per-variable fact,
+  visible-binding, and argument limits. Persistent barriers are used for
+  closure/dynamic-scope invalidation so later assignments cannot accidentally
+  restore a receiver whose binding remains observable through the escape.
+
+The focused candidate suite is now 75 tests and the universal resolver suite
+remains 158 tests; the overload fixture also proves an imported call-result can
+be aliased before its returned member is resolved. The candidate adapter remains
+absent from `UNIVERSAL_ADAPTERS`. Conditional/mapped modifier semantics, richer
+interprocedural flow, framework/compiler tiers, accepted precision/Wilson gates,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1,0 +1,1591 @@
+# Plan 013: Make TypeScript and JavaScript code graphs best in class
+
+> **Executor instructions**: Treat this as a multi-PR quality program, not one
+> large feature branch. Execute the phases in order and stop at every gate.
+> Production must never publish the legacy and universal TypeScript/JavaScript
+> paths together. Graphify and other competitors are diagnostic comparators,
+> never product, test, fixture, runtime, or fallback dependencies. Update this
+> plan and `advisor-plans/README.md` only after the corresponding evidence has
+> landed and passed review.
+>
+> **Drift check (run before each phase)**:
+> `git diff --stat a8a6a80aa7547f89cae97f127b7bd44512bcfaee..HEAD -- vendor/compass-tree-sitter-language-pack crates/compass-files crates/compass-languages crates/compass-resolve crates/compass-graph crates/compass-program crates/compass-core crates/compass-cli tests/qualification benchmarks/performance scripts docs PERFORMANCE.md COMPATIBILITY.md MIGRATION.md CHANGELOG.md Cargo.toml Cargo.lock package.json package-lock.json`
+> Reconcile renamed files, adapter versions, evidence schemas, and already
+> shipped behavior before continuing. Do not mechanically apply stale line
+> numbers.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: XL, delivered as independently reviewable L/M phases
+- **Risk**: HIGH
+- **Depends on**: no implementation prerequisite; the final release gate should
+  consume plan 005 or an equivalent exact-commit qualification gate
+- **Category**: language architecture, correctness, resolution, qualification,
+  performance, documentation
+- **Planned at**: commit `a8a6a80aa7547f89cae97f127b7bd44512bcfaee`,
+  2026-08-05
+
+### Execution checkpoint (2026-08-05)
+
+The first implementation slice is intentionally below the phase-5 production
+cutover. It establishes independent measurement and removes one known
+precision hazard while the larger universal-adapter program remains gated:
+
+- Phase 0 now has a pinned TypeScript 5.9.3 compiler-API source oracle with
+  bounded Node/Python bridging, deterministic UTF-8 byte ranges, malformed-file
+  rejection, coverage validation, and Unicode regression tests. Repository-scale
+  validation currently parses 307/307 admitted TS/JS files and emits 167,923
+  bounded constructs.
+- The Python qualification harness validates oracle schema/provider/compiler
+  metadata, exact source ranges, incomplete coverage, deterministic digests,
+  and preserves the existing non-TypeScript fixture contract. Its focused
+  suite currently passes 146 tests.
+- JSONC parsing is shared by project evidence and the resolver. A bounded,
+  fail-closed subset accepts comments and trailing commas without evaluating
+  JavaScript.
+- The native JavaScript/TypeScript extractor now emits exact `references` for
+  uniquely proven callback values passed through collections/arguments; it no
+  longer labels an unknown receiving API as an `indirect_call`.
+- The resolver now has a bounded `baseUrl`/`paths` slice for nearest
+  `tsconfig*.json`/`jsconfig*.json`: JSONC, ordered fallback targets,
+  JS-to-TS/JSX/MTS/CTS extension substitution, directory indexes, alias
+  provenance, and same-depth config ambiguity are covered by resolver tests.
+- The native fixture qualification passes with clean/warm/rebuild/relocated
+  graph byte equality, and the workspace `--lib --bins` test and lint baselines
+  pass. Existing qualification warnings about intentionally omitted partial
+  fixture records remain unchanged and are not TypeScript/JavaScript failures.
+
+These changes do not register TypeScript/JavaScript universal adapters, do not
+invoke Node or TypeScript during normal Compass builds, and do not claim that
+the full standards-correct module model or leadership gates are complete.
+
+### Execution checkpoint (2026-08-06)
+
+The next implementation slice strengthens project ownership, module identity,
+and source-grounded interop while keeping the production universal cutover
+closed:
+
+- Recursive TypeScript configuration loading now accepts bounded `extends`
+  chains (including package-style parents), preserves per-target path bases,
+  carries `rootDirs`, `moduleSuffixes`, `allowJs`/`checkJs`, project references,
+  module metadata, and reports cycles, missing parents, depth, and size limits
+  as diagnostics. Referenced base configs are excluded from nearest-project
+  selection, so an `extends`-only `tsconfig.base.json` cannot become a second
+  same-depth project.
+- Module resolution now chooses relative targets from the admitted inventory,
+  including extension substitution, directory indexes, `moduleSuffixes`, and
+  `rootDirs`; package manifests now handle importer-aware `exports` conditions,
+  package `imports`, and bounded TypeScript `typesVersions` fallbacks. Ordered
+  fallbacks remain ordered, mutually exclusive branches are not unioned, and
+  duplicate/ambiguous packages remain unresolved.
+- The native extractor records default, namespace, named, and type-only import
+  bindings with exact anchors; emits JSX component occurrences as typed
+  `references`; and publishes only source-grounded CommonJS `exports` edges for
+  uniquely resolved local bindings. Unknown dynamic receivers still do not
+  become calls.
+- Project ownership now honors bounded `files`/`include`/`exclude` patterns,
+  default dependency-tree exclusions, `typeRoots`, and ordered
+  `customConditions`; excluded or ambiguous admitted files remain unresolved.
+  Package condition selection consumes the selected project's custom condition
+  order rather than applying a repository-wide guess.
+- A qualification-only direct universal-evidence emitter now exists for the
+  ECMAScript family. It emits source-grounded declarations, lexical scopes,
+  value/type namespaces, imports/reexports, calls/constructors, base-type
+  candidates, member access, decorators, JSX references, dynamic literal
+  imports, and CommonJS exports. Adapter identity preserves parser dialect
+  (`ts`, `tsx`, `js`, `jsx`, `mts`, `cts`, and related extensions) separately
+  from semantic language.
+- Regression coverage now includes same-directory config inheritance and
+  cycles, relative named-import repointing, package `imports`, `exports`
+  conditions, `typesVersions`, module suffixes/root directories, include /
+  exclude ownership, `typeRoots`, custom conditions, import-kind metadata, JSX
+  occurrences, CommonJS exports, and direct candidate evidence. Targeted
+  language/resolver tests and resolver-wide tests pass; the full workspace
+  baseline and independent oracle/fixture gates remain required before any
+  phase exit.
+
+This checkpoint is still below the Phase 2 universal-evidence and Phase 5
+production-hard-cut gates. `include`/`exclude` ownership, complete Node16/
+NodeNext/Bundler condition semantics, complete `typeRoots` package lookup,
+compiler-trace differential qualification, broad syntax/capability coverage,
+and direct TypeScript/JavaScript production adapter registration remain
+planned work. The candidate emitter is deliberately not in
+`UNIVERSAL_ADAPTERS`.
+
+### Execution checkpoint (2026-08-06, identity slice)
+
+The following Phase 1/2 contract slice is now source-grounded and validated:
+
+- Universal evidence has an optional `SymbolNamespace` field on declarations
+  and bindings (`value`, `type`, `namespace`, `value_and_type`). Existing
+  adapters continue to omit it, and their stable IDs remain byte-for-byte
+  compatible because the identity component is included only when explicitly
+  emitted.
+- Import and re-export bindings can carry `type_only`; validation rejects the
+  marker on unrelated binding kinds and rejects a type-only value-space claim.
+  `import type`, `export type`, namespace imports, normal dual-space imports,
+  CommonJS bindings, and local re-exports are covered by direct candidate
+  evidence tests.
+- Candidate adapter versions advanced to 2 for the new semantic identity
+  contract. The shared evidence schema major remains `/1`; fields are optional
+  and omitted by legacy producers. The candidate path remains qualification
+  only and is not registered in `UNIVERSAL_ADAPTERS`.
+- Contract documentation now describes symbol-space identity and the
+  validation rule. Focused language tests cover serialization/validation,
+  legacy omission, deterministic IDs, and TS/JS identity assertions.
+- The candidate traversal now preserves function/method parameter declarations
+  in their lexical scope and gives anonymous/named `export default` forms a
+  source-anchored `default` declaration/re-export instead of dropping the
+  export or guessing a parameter as a function name.
+
+This does not close syntax conformance, overload/signature identity, complete
+Node16/NodeNext/Bundler resolution, compiler differential qualification, or the
+production hard cut. Those remain explicit gates rather than inferred from the
+candidate test fixture.
+
+### Execution checkpoint (2026-08-06, module-mode and resolver-oracle slice)
+
+The resolver now makes one important standards boundary explicit while keeping
+the production universal cutover gated:
+
+- Conditional `package.json` export objects are evaluated in manifest key order
+  after the active condition set is computed. Compass no longer reorders a
+  package author's `default`, `import`, `require`, `types`, or custom branches
+  according to an internal preference list; the ordered fallback and
+  ambiguity behavior remains source-inventory bounded.
+- Explicit `moduleResolution` is honored for package maps. Node16, NodeNext,
+  and Bundler may use `exports`/`imports`; Node10 falls back to legacy package
+  fields and package subpaths; Classic leaves package-name imports unresolved
+  unless the separate `paths` pass proves an alias. The selected rule and
+  explicit mode are retained on the occurrence, and the older flattened
+  workspace pass cannot overwrite a mode-specific decision.
+- A qualification-only `typescript-resolution-oracle.mjs` now uses the pinned
+  TypeScript 5.9.3 compiler API to resolve imports, exports, `import type`,
+  `import =`, dynamic imports, and literal `require()` sites. It emits exact
+  UTF-8 ranges, project ownership, module mode, target source/external/
+  unresolved/ambiguous status, configuration/source digests, diagnostics, and
+  bounded deterministic output. A focused test runs the oracle twice and
+  cross-checks representative decisions against `tsc --traceResolution`.
+- The independent benchmark suite now passes 147 tests. This is a measurement
+  and resolver-correctness slice, not evidence that every advertised compiler
+  mode or capability has reached the Phase 3 precision/recall gates.
+
+### Execution checkpoint (2026-08-06, conservative receiver/member slice)
+
+The qualification-only universal emitter now closes a precision hazard in
+member attribution without widening the production cutover:
+
+- Scope ownership is keyed by tree-sitter node identity rather than only the
+  start byte. A root-level declaration beginning at byte zero can no longer
+  shadow the module scope during receiver/type inference.
+- Import and re-export bindings are pre-collected before semantic uses are
+  emitted, matching ECMAScript import hoisting and making receiver inference
+  independent of source order.
+- Simple nominal receivers are tracked only when source evidence proves them:
+  class/enum/namespace values, `new Class()`, typed variables, `this`, and
+  namespace/named imports. Unique `Class.member` declarations receive exact
+  declaration targets; overloaded/declaration-merged qualified names remain
+  unresolved rather than selecting a traversal-order winner.
+- Member calls no longer fall back to an unrelated same-named top-level
+  function. Unknown/dynamic receivers remain unresolved. Imported namespace
+  members preserve the module-symbol target shape (`module::member`) and
+  retain the import binding as provenance.
+- Calls now carry a bounded source argument count. When same-spelled local
+  functions or members have fixed, source-visible arities, a unique arity
+  match receives the exact declaration target; optional/default/rest or
+  otherwise ambiguous signatures remain unresolved.
+- The direct candidate fixture now covers `this`, `new`-initialized locals,
+  exact method/field targets, dynamic-member negatives, namespace-import calls,
+  and fixed-arity overloads. The focused candidate suite passes five tests after
+  the change.
+
+This remains a Phase 2/4 evidence slice: it does not claim flow-sensitive
+assignment tracking, overload selection, hierarchy dispatch, compiler
+differential recall, or production universal registration.
+
+### Execution checkpoint (2026-08-06, JSX/super and typed-call slice)
+
+The qualification-only emitter now adds two conservative attribution paths and
+records source-proven call-shape evidence without widening the production cut:
+
+- JSX member tags such as `<UI.Button />` use the nominal member resolver. A
+  namespace import is published as `module::Button` with the import binding as
+  provenance and the `Button` property anchor; dynamic or unresolved JSX
+  receivers still produce no invented target.
+- Import and re-export statements publish both the module-specifier occurrence
+  and each exact binding occurrence, preserving compiler-oracle coverage for
+  module identity and local alias anchors.
+- Dot and literal computed members (`obj["field"]`) share the exact nominal
+  receiver path; dynamic computed keys (`obj[key]`) are rejected before target
+  publication rather than being treated as a same-spelled property.
+- `super.member()` and `super.member` resolve only through one source-proven
+  direct `extends` target. Ambiguous, malformed, or unresolved heritage does
+  not create a base receiver, and imported bases retain their external module
+  identity.
+- Fixed class constructor arity is inferred from an explicit constructor (or
+  zero when none exists). Calls with a proven incompatible fixed arity no
+  longer select the declaration; optional/default/rest and incomplete
+  signatures remain unresolved.
+- Constructor declarations are published with a distinct `constructor` kind,
+  preserving their source anchor while class construction remains targeted at
+  the owning class declaration.
+- Literal call arguments carry bounded `argument_types` evidence. When
+  same-arity overloads have source-visible simple parameter types, a unique
+  string/number/boolean/object/function or nominal match receives the exact
+  declaration target. Type-mismatched or still-ambiguous overloads remain
+  unresolved.
+- The direct candidate suite still passes five tests and now covers namespace
+  JSX members, `super` dispatch, fixed-arity negatives, and typed overload
+  selection. The candidate adapter remains unregistered; compiler differential
+  qualification, broad syntax coverage, and release scorecard gates are still
+  required.
+- Tree-sitter's dedicated `this` node is now treated as a nominal receiver,
+  and private member identifiers (for example `this.#run()`) retain exact
+  declaration targets. The candidate regression fixture covers both the
+  receiver and private-member anchors; this closes a previously silent
+  under-attribution case without guessing dynamic properties.
+- An ignored developer-only differential test now runs the pinned TypeScript
+  5.9.3 source oracle against a mixed TSX fixture and asserts byte-range
+  coverage for declarations, imports, calls, construction, members, heritage,
+  and JSX. The normal native test suite remains Node-free; qualification runs
+  it explicitly with `-- --ignored`.
+
+### Execution checkpoint (2026-08-06, unresolved-evidence and corpus slice)
+
+The candidate path now preserves source constructs even when it cannot prove a
+target, without weakening the graph resolver:
+
+- Dynamic/ambiguous calls, nominally unknown members, unresolved type
+  references, and unresolved heritage names emit occurrence-backed,
+  target-less candidates. Their constraints omit lexical/qualified fallback
+  and `allow_external`, so the shared resolver leaves them unresolved instead
+  of inventing an external node or selecting a same-spelled declaration.
+- The former local-variable `object.property` external fallback was removed.
+  Namespace-import members retain `module::member` identity, while imported
+  nominal types and `super` members retain `module::Type.member` identity.
+  Qualified imported `extends` anchors and `super` calls have direct positive
+  and negative coverage.
+- Builtin-member evidence now uses receiver-specific static/instance
+  allowlists. For example, `Array.from`, `new Map().get`, and `Set.add`
+  remain supported while `new ArrayBuffer().isView` and
+  `new WeakMap().values` remain unsupported; shadowed globals still cannot
+  create external edges.
+- Unparenthesized arrow parameters (`value => value`) are now emitted as
+  parameter declarations with exact source anchors and fixed one-argument
+  arity. This closes a common JavaScript/TypeScript callback shape without
+  broadening dynamic-call inference.
+- The shared resolver is covered by a regression proving that a target-less
+  dynamic member and an arity-mismatched direct call stay `Unresolved`, while a
+  source-proven nominal call resolves exactly.
+- The pinned TypeScript 5.9.3 source oracle (script SHA-256
+  `ac3c07e825505a42479e3dfa6024860cfbc0cdf2ffc6b8f1756e43727f20fb98`) now
+  excludes the compiler API's pseudo-`const` type reference under `as const`.
+  It parses all admitted files in both current release-gate corpora. On Zod
+  commit `912f0f51b0ced654d0069741e7160834dca742ee`, 409/409 files parsed and
+  the candidate covers 104,171/104,253 accepted source constructs (99.92%). On
+  Axios commit `c3f553c740ebf3dff5e22dae24e9caaafafddd2d`, 236/236 files parsed
+  and coverage is 40,522/40,522 (100.00%). These are source-occurrence recall
+  measurements, not precision or target-identity results.
+- The resolution oracle (compiler 5.9.3, script SHA-256
+  `3d68c689338034c51b91c2f7863e01caa7e42898851b18916a32d3f09dafe500`) emits
+  deterministic project/module decisions for 1,107 Zod and 698 Axios import
+  sites. Zod has 548 source and 559 unresolved outcomes across 19 projects;
+  Axios has 301 source and 397 unresolved outcomes in one project. The one
+  Zod diagnostic is retained for adjudication; neither corpus is yet a
+  precision-qualified release scorecard.
+
+This closes a high-value evidence-loss and false-external-edge slice, but does
+not close the mandatory precision/Wilson gates, per-capability accepted-sample
+minimums, compiler target adjudication, Graphify/SCIP equivalent-scope audit,
+framework matrix, performance gate, or production hard cut. The candidate
+adapter remains unregistered in `UNIVERSAL_ADAPTERS`.
+
+### Execution checkpoint (2026-08-06, target-adjudication and JavaScript-shape slice)
+
+The candidate now has a separate checker-backed target oracle and several
+same-file identity improvements. They remain qualification-only until the
+accepted-sample and precision gates are frozen:
+
+- `typescript-target-oracle.mjs` (schema
+  `compass.typescript-target-oracle/1`, provider `typescript_checker_api_5_9_3`,
+  script SHA-256
+  `9f992c678d32c7083e69b104785fdf3c91e77bbb0e65bcb8b4543c39a23ba41a`) uses a
+  bounded synthetic TypeScript 5.9.3 program to adjudicate source declaration
+  targets for calls, construction, members, heritage, type references, and
+  JSX. The ignored Rust harness reports exact local-target recall, wrong
+  targets, unresolved outcomes, and local false positives by capability; it
+  does not read Compass or Graphify output.
+- JavaScript direct-call matching now respects JavaScript's omitted/extra
+  argument semantics while preserving ambiguity as unresolved. Class-member
+  scopes no longer shadow lexical helpers, so a same-spelled static member
+  cannot steal an unqualified helper call.
+- Object-literal `pair` declarations, object-variable receivers, assignment
+  properties, and anonymous TypeScript signature scopes are source-anchored.
+  This improves structural property targets and keeps repeated generic type
+  parameters isolated instead of collapsing them into one interface scope.
+- Dynamic/parenthesized/computed callees remain targetless when proof is not
+  available; JavaScript `class_heritage` and TypeScript `import = require()`
+  now retain exact module/base evidence. The candidate still is not registered
+  in `UNIVERSAL_ADAPTERS`.
+- Initial target adjudication is intentionally a failing diagnostic, not a
+  release gate. On Axios, the candidate hit 2,923/3,167 same-file source
+  targets (92.30% local recall) with 17 wrong-target cases and 564 local
+  positives not matching the oracle outcome. On Zod it hit 6,717/9,883
+  (67.96%) with 25 wrong-target cases and 1,314 local positives not matching
+  the oracle. The
+  largest gaps are project/flow-sensitive member receivers, function-valued
+  variables, and framework/library declaration identity; these numbers are
+  precisely why the target, precision, and cross-file gates remain open.
+
+The target oracle currently qualifies as an adjudication instrument, not a
+release claim: project-aware module identity, cross-file target precision,
+framework strata, accepted-sample Wilson intervals, Graphify/SCIP equivalent
+scope, performance, and production hard-cut gates remain open.
+
+### Execution checkpoint (2026-08-06, scope/flow/type/call quality slice)
+
+The qualification-only emitter now covers several high-impact target gaps
+without widening the production adapter registry:
+
+- Lexical block, switch, catch, and loop scopes are explicit; `var` bindings
+  hoist to the nearest function/module scope while lexical bindings remain
+  block-local. Class methods, constructors, and properties are excluded from
+  unqualified helper lookup, preventing member names from shadowing real
+  lexical calls.
+- Structural object receivers retain source order. When a JavaScript object is
+  reassigned, member resolution chooses the latest preceding source-backed
+  property declaration for that receiver; nominal class/interface members
+  continue to use scope and ambiguity proof rather than source-order guesses.
+- Conditional `infer` bindings and mapped/object-type keys have dedicated
+  type scopes. Repeated `K` keys, `infer Intersection`, and `infer Last` now
+  resolve to their exact source declarations instead of collapsing into one
+  alias scope. Interface/namespace declaration merging is handled as one
+  type-space nominal for qualified member lookup.
+- Callable-shaped parameters and aliases (`factory: (...) => T`,
+  `typeof Ctor`, `SchemaClass<T>`, and constructor-valued locals) are retained
+  as call/construction targets even when no local arity is available. Classes
+  without an explicit constructor receive their source-language default
+  constructor behavior. Constructor parameter properties resolve through
+  inherited `this` members, and TypeScript heritage expressions can resolve a
+  source-proven value-space constructor such as a mixin `Parent` variable.
+- Inherited member lookup follows a proven local `extends` chain and checks
+  both class members and constructor parameter-property identities. New direct
+  regressions cover mapped/conditional type scopes and inherited parameter
+  properties in `crates/compass-languages/tests/`.
+
+The pinned source-oracle occurrence coverage remains 104,171/104,253 (99.92%)
+for Zod and 40,522/40,522 (100.00%) for Axios. The latest checker target
+adjudication is:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,119 | 3,167 | 48 | 0 | 3,370 | 251 |
+| Zod | 7,548 | 9,883 | 2,335 | 0 | 8,727 | 1,179 |
+
+By capability, Zod now reaches 452/452 heritage targets and 5,198/5,198
+type-reference targets; Axios reaches 1,067/1,067 type-reference targets and
+1,514/1,545 direct call targets. These are same-file checker-oracle
+adjudication measurements, not release precision: the candidate still has
+unresolved project/flow/framework members and a non-zero local false-positive
+count. Graphify, SCIP, Wilson intervals, accepted-sample minimums, framework
+matrix, performance, and the production hard cut remain open gates. The
+candidate emitter is still deliberately absent from `UNIVERSAL_ADAPTERS`.
+
+### Verification checkpoint (2026-08-06, repository gates)
+
+The implementation and qualification changes were rechecked against the
+repository-wide gates from the command table:
+
+- `scripts/check_product_boundary.sh` passed with no Graphify/runtime boundary
+  findings.
+- `./scripts/qualify_code_graph_v1.sh --fixtures-only` passed. The exact
+  production fixture graph remained byte-equivalent across clean, warm,
+  rebuild, and relocated runs (`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`),
+  with 1,565 semantic invariants and 980 coverage records.
+- `cargo fmt --all -- --check`, workspace clippy, workspace library/binary
+  tests, focused universal evidence/resolution tests, and the independent
+  Python qualification suite (147 tests) passed.
+- `npm run typecheck:js`, `npm run test:js`, and
+  `node scripts/check_viewer_assets.mjs` passed (142 viewer tests, 117 VS Code
+  tests, and 76 browser tests). The generated viewer assets matched their
+  deterministic manifest.
+- `git diff --check` passed and no generated graph, `.compass` state, or
+  qualification corpus was added to the worktree.
+
+These are repository and candidate-quality checkpoints only. The mandatory
+Plan 013 scorecard is still open: the current same-file target diagnostics
+remain below the precision/recall thresholds, accepted-sample/Wilson evidence
+is not frozen, and Graphify/SCIP equivalent-scope, framework, performance,
+compiler-tier, and production hard-cut gates have not been run. Keep the
+candidate adapter out of `UNIVERSAL_ADAPTERS` until those gates pass.
+
+### Execution checkpoint (2026-08-06, typed-call and boundedness follow-up)
+
+The retained follow-up is deliberately narrower than the attempted
+destructured-flow prototype:
+
+- Source-compatible call arguments now preserve exact same-file targets for
+  object literals, arrays whose element type is source-proven, and unqualified
+  versus qualified nominal type spellings. Primitive, callable, qualified
+  conflicts, optional/rest, and ambiguous signatures still fail closed. The
+  direct candidate regression suite has 16 passing tests.
+- `this` is recognized as a dedicated tree-sitter callee for source-proven
+  class construction/calls, while dynamic member receivers remain unresolved.
+  The ignored target harness uses a fresh parser engine per large corpus file
+  to keep the qualification process bounded against the vendored grammar's
+  deep-stack behavior; production parser/cache behavior is unchanged.
+- A bounded shallow destructured inline-object propagation slice now stores
+  only capped, string-only property types and handles
+  `props: { data: T }` / `const { data: local } = props`. Nested patterns,
+  spreads, computed keys, and reassignment flow remain unresolved. The direct
+  regression passes (16 candidate tests total), and the large Zod run stayed
+  bounded with no wrong target.
+
+The stable checker adjudication remains zero wrong local targets:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,152 | 3,167 | 15 | 0 | 3,403 | 251 |
+| Zod | 7,764 | 9,883 | 2,119 | 0 | 9,016 | 1,252 |
+
+Zod now reaches 845/2,695 member targets (up from 840), 452/452 heritage,
+201/201 construction, 12/12 JSX, and
+5,198/5,198 type-reference targets; Axios reaches 1,544/1,545 direct calls,
+489/503 members, 39/39 construction, and 1,067/1,067 type references. These
+are diagnostic same-file results, not release precision: project-aware flow,
+destructuring, framework strata, accepted-sample Wilson intervals, Graphify/
+SCIP equivalent-scope comparison, performance, and the production hard cut
+remain open.
+
+### Execution checkpoint (2026-08-06, structural utility/generic call slice)
+
+The next bounded resolution slice is now implemented and regression-tested:
+
+- Utility-wrapped parameters (`Pick`, `Omit`, `Partial`, `Required`, and
+  `Readonly`) compare only source-proven property sets. A `Pick<T, K>` call is
+  accepted when the argument's unique source type contains the selected keys;
+  unrelated nominal types remain unresolved. Inline object parameter shapes
+  compare required properties against source-emitted members, including array
+  element object shapes. Optional keys, computed/index signatures, spreads,
+  and unknown structural aliases remain conservative.
+- Generic callable parameters retain only a bounded side table of direct
+  `extends` constraints. A constrained array generic such as
+  `U extends [T, ...T[]]` now accepts a source-proven array; primitive and
+  incompatible constraints remain rejected. The metadata is kept outside the
+  recursive declaration frame, preserving default-stack behavior on large
+  files and preventing a large-Zod stack overflow.
+- The direct candidate suite has 18 passing tests, including a constrained
+  generic call regression. The target harness remains developer-only and
+  ignored; no candidate adapter was added to `UNIVERSAL_ADAPTERS`.
+
+Updated pinned checker adjudication (oracle SHA unchanged) remains zero wrong
+local targets:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,152 | 3,167 | 15 | 0 | 3,403 | 251 |
+| Zod | 8,009 | 9,883 | 1,874 | 0 | 9,263 | 1,254 |
+
+The Zod call stratum is now 1,063/1,325 (up from 1,057 in the prior
+checkpoint); members remain 1,083/2,695, heritage 452/452, construction
+201/201, JSX 12/12, and type references 5,198/5,198. Axios remains
+1,544/1,545 direct calls, 489/503 members, 39/39 construction, and 1,067/1,067
+type references. These are diagnostic same-file results, not a release or
+leadership claim: precision/recall thresholds, accepted-sample Wilson bounds,
+framework/compiler tiers, Graphify/SCIP equivalent-scope comparison,
+performance, and the production hard cut remain open.
+
+### Execution checkpoint (2026-08-06, JavaScript prototype and wrapped-object slice)
+
+The next bounded JavaScript/TypeScript resolution slice is now implemented and
+measured without widening the production adapter registry:
+
+- Same-file function constructors now participate in nominal instance-member
+  resolution only when source evidence proves constructor intent: a `new Ctor`
+  use or an explicit/aliased `Ctor.prototype` write. `Ctor.prototype.method`
+  function expressions, `const proto = Ctor.prototype` aliases, and
+  `new Ctor().method` share one source-backed prototype identity. Constructor
+  assignments such as `this._pairs = []` become the canonical instance-field
+  declaration, and prototype-method `this._pairs` reads can target that
+  declaration.
+- Prototype instance writes through `this` are deliberately not published as
+  prototype members; dynamic/computed keys, unknown prototype receivers, and
+  unproven function `this` values remain unresolved. This keeps the new
+  attribution path fail-closed even when a JavaScript checker cannot prove a
+  target for a prototype call.
+- Structural object receivers now unwrap bounded runtime-neutral TypeScript
+  wrappers (`as const`, `satisfies`, parenthesized expressions, and type
+  assertions). Members of `const values = { ... } as const` therefore retain
+  exact property declaration anchors while arbitrary dynamic objects remain
+  unsupported. A direct regression covers the `as const` path alongside the
+  prototype constructor/alias and negative dynamic-member cases.
+- The focused candidate suite has 19 passing tests. Pinned source coverage is
+  unchanged at 104,171/104,253 (99.92%) for Zod and 40,522/40,522 (100.00%)
+  for Axios because this slice improves target identity rather than source
+  occurrence discovery.
+
+The current checker-target adjudication (oracle SHA unchanged) is:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,153 | 3,167 | 14 | 0 | 3,408 | 255 |
+| Zod | 8,013 | 9,883 | 1,870 | 0 | 9,267 | 1,254 |
+
+Zod now reaches 1,087/2,695 members, 1,063/1,325 calls, 452/452 heritage,
+201/201 construction, 12/12 JSX, and 5,198/5,198 type references. Axios
+reaches 490/503 members, 1,544/1,545 calls, 13/13 heritage, 39/39
+construction, and 1,067/1,067 type references. Some newly source-proven
+prototype members are counted as checker false positives because the pinned
+checker oracle reports those JavaScript accesses as unresolved; they require
+accepted-sample/manual adjudication before a precision claim. These remain
+diagnostic same-file results, not a release or leadership claim. Precision and
+recall thresholds, Wilson bounds, framework/compiler tiers, Graphify/SCIP
+equivalent-scope comparison, performance, and the production hard cut remain
+open, and the candidate emitter stays absent from `UNIVERSAL_ADAPTERS`.
+
+### Execution checkpoint (2026-08-06, interface inheritance and optional-callable slice)
+
+The next source-proven TypeScript slice is implemented and measured without
+registering the candidate as a production universal adapter:
+
+- Interface declarations now participate in the bounded `extends` hierarchy
+  index used by member lookup. A member inherited through one local interface
+  edge can therefore retain the exact base-interface declaration anchor;
+  multiple/ambiguous or imported-only paths still fail closed.
+- Optional callable properties preserve one nominal type from a property-only
+  union such as `Callback | undefined` when every other union arm is a
+  primitive/top/literal. The call resolver uses that declaration metadata only
+  for a unique property target, including the inherited-member path; unions
+  with multiple nominal arms, variables, aliases, and dynamic receivers remain
+  unresolved.
+- The candidate regression suite now has 33 passing tests, including direct
+  interface inheritance and inherited optional-callable property calls.
+
+Pinned checker adjudication remains zero-wrong local target resolution:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,153 | 3,167 | 14 | 0 | 3,408 | 255 |
+| Zod | 8,359 | 9,883 | 1,524 | 0 | 9,617 | 1,258 |
+
+Zod strata are members 1,335/2,695, calls 1,161/1,325, heritage 452/452,
+construction 201/201, JSX 12/12, and type references 5,198/5,198. Axios is
+members 490/503, calls 1,544/1,545, heritage 13/13, construction 39/39, and
+type references 1,067/1,067. These are qualification diagnostics: the
+candidate emits unresolved entries alongside some local positives, so the
+false-positive column is not an accepted precision estimate.
+
+Independent source-occurrence coverage remains 104,171/104,253 (99.92%) for
+Zod and 40,522/40,522 (100.00%) for Axios. Zod's source differential requires
+`RUST_MIN_STACK=33554432` because the large corpus can overflow the default
+test stack; this is a developer diagnostic setting, not a production runtime
+requirement. The real-corpus target harness uses the same isolated-engine
+qualification setup and remains ignored by default.
+
+The next actionable phases are deliberately still open:
+
+1. **Project target closure:** add a read-only project index for imported
+   aliases, package exports, declaration merging, generic instantiation, and
+   mapped/indexed shapes; preserve explicit unresolved/ambiguous results and
+   measure each stratum on Zod, Axios, and a third framework-heavy corpus.
+2. **Accepted precision gate:** hand-label a stratified sample of local,
+   external, unresolved, dynamic, and ambiguous calls/members; compute Wilson
+   intervals and set release thresholds before enabling any adapter profile.
+3. **Framework/compiler tiers:** qualify React/JSX, Node, Express, Jest,
+   Next/Vite, decorators, `const enum`, namespaces, and modern TS 5.x syntax;
+   compare tree-sitter-only, optional compiler-oracle, and Graphify/SCIP
+   equivalent scopes with pinned versions and reproducible commands.
+4. **Performance and publication hard cut:** benchmark cold/incremental runs,
+   memory, cancellation, and bounded failure behavior; register the candidate
+   only after source recall, target precision, determinism, compatibility, and
+   product-boundary checks pass together.
+
+### Execution checkpoint (2026-08-06, callable/generic-flow and inline-anchor slices)
+
+The candidate-only implementation now covers several additional source-proven
+paths while remaining deliberately absent from `UNIVERSAL_ADAPTERS`:
+
+- Callable property signatures such as `getter: () => T` preserve their direct
+  return type, including generic constraints, so a chain like
+  `this._def.getter()._parse()` reaches the exact constrained declaration.
+- Generic member receivers retain bounded type arguments through nested member
+  chains and explicit type assertions. Assertions to `any`, `unknown`, and
+  `never` still erase the receiver rather than recovering a guessed target.
+- String-literal discriminants (`value.kind === "ready"`) narrow only a direct
+  positive branch and only when one union constituent owns the matching literal
+  property. Nullable logical wrappers (`member || null`/`member ?? null`) are
+  unwrapped for the same source-proven flow; negative, ambiguous, and dynamic
+  cases remain unresolved.
+- Inline object-type indexes now retain every declared property, even primitive
+  or union annotations. The exact object-type byte range wins over duplicate
+  object-literal spellings, which closes real-world precision accesses such as
+  Zod's `options?.precision`.
+- Static callable aliases and local variable aliases preserve callable identity
+  and declared return types, including overloaded local factories. A unique
+  declared method wins over constructor-bound property duplicates only when all
+  competing matches are those bound properties; unrelated duplicates remain
+  ambiguous.
+
+The focused candidate regression suite now has 43 passing tests. The pinned
+checker target adjudication (oracle SHA and corpus realization unchanged) is:
+
+| Corpus | Exact local targets | Expected local | Missing | Wrong | Local positives | False positives |
+|---|---:|---:|---:|---:|---:|---:|
+| Axios | 3,153 | 3,167 | 14 | 0 | 3,408 | 255 |
+| Zod | 8,432 | 9,883 | 1,451 | 0 | 9,690 | 1,258 |
+
+Zod strata are members 1,372/2,695, calls 1,197/1,325, heritage 452/452,
+construction 201/201, JSX 12/12, and type references 5,198/5,198. Axios is
+members 490/503, calls 1,544/1,545, heritage 13/13, construction 39/39, and
+type references 1,067/1,067. The independent source-occurrence differentials
+remain 104,171/104,253 (99.92%) for Zod and 40,522/40,522 (100.00%) for Axios.
+Both corpora still report zero wrong local targets; Zod's false-positive count
+is unchanged from the prior accepted diagnostic baseline, and the target
+harness now prints bounded examples for manual adjudication. These numbers are
+not a precision claim: accepted-sample labels, Wilson bounds, compiler and
+framework tiers, and equivalent Graphify/SCIP runs are still required.
+
+The repository fixture qualification also passed with the explicit per-checkout
+Cargo target directory. Clean, warm, rebuilt, restored, and alternate-checkout
+production artifacts were byte-identical; the qualification summary reported
+28 edge kinds, 45 node kinds, 57 languages, 27 flows, 980 coverage records, and
+the stable graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`.
+The focused 43-test candidate suite, package Clippy gate, formatting check,
+product-boundary check, and 147-test benchmark suite pass. The broader
+`compass-languages --tests` run still exposes the pre-existing registry
+expectation mismatch (`Rust` reports 15 capabilities while that test expects
+13); no registry change was made as part of this slice.
+
+The next actionable phases remain open:
+
+1. **Project target closure:** add a read-only project index for imported
+   aliases, package exports, declaration merging, generic instantiation, and
+   mapped/indexed shapes; preserve explicit unresolved/ambiguous results and
+   measure each stratum on Zod, Axios, and a third framework-heavy corpus.
+2. **Accepted precision gate:** hand-label a stratified sample of local,
+   external, unresolved, dynamic, and ambiguous calls/members; compute Wilson
+   intervals and set release thresholds before enabling any adapter profile.
+3. **Framework/compiler tiers:** qualify React/JSX, Node, Express, Jest,
+   Next/Vite, decorators, `const enum`, namespaces, and modern TS 5.x syntax;
+   compare tree-sitter-only, optional compiler-oracle, and Graphify/SCIP
+   equivalent scopes with pinned versions and reproducible commands.
+4. **Performance and publication hard cut:** benchmark cold/incremental runs,
+   memory, cancellation, and bounded failure behavior; register the candidate
+   only after source recall, target precision, determinism, compatibility, and
+   product-boundary checks pass together.
+
+## Outcome
+
+Compass should produce the most trustworthy TypeScript and JavaScript graph for
+source understanding: exact source-backed declarations and relationships,
+standards-correct project/module resolution, conservative ambiguity handling,
+strong framework coverage, deterministic incremental behavior, and optional
+compiler-grade enrichment without making Node.js or a compiler part of the
+native product boundary.
+
+Do not define success as “more edges than Graphify.” More edges can mean more
+false calls. Define and publish a named, versioned quality scorecard. Compass may
+claim leadership only for the scorecard, corpus, competitors, versions, and
+date actually qualified. “Better than every code graph” is not a testable or
+durable release claim.
+
+## Why this matters
+
+Compass already has a strong TypeScript/JavaScript foundation: exact occurrence
+ranges, deterministic identities, imports and reexports, workspace package
+exports, several framework route packs, template extraction, and no required
+language-server runtime. A recent Zod comparison was also encouraging: Compass
+produced 11,322 nodes and 14,921 edges in 1.47 seconds versus Graphify's 4,338
+nodes and 5,928 edges in 4.92 seconds, with no dangling or exact-duplicate
+records in the Compass graph.
+
+Those counts do not establish superiority. The comparison had no independent
+stratified audit, and 1,073 Graphify hypotheses remained unsupported after the
+current mapping. The current implementation also has architectural ceilings:
+
+- TypeScript, TSX, and JavaScript still use the established direct extraction
+  path in `crates/compass-languages/src/engine.rs`; only Go, Java, Python, and
+  Rust have registered universal evidence adapters.
+- TypeScript parsing still uses byte-preserving masks for grammar gaps such as
+  variance, `export type *`, and import-type syntax.
+- project evidence now accepts bounded JSONC and records alias markers, while
+  the resolver has only a conservative nearest-config `baseUrl`/`paths` slice;
+  it does not yet implement the full TypeScript project and module-resolution
+  contract.
+- JavaScript workspace resolution understands relative imports, a useful
+  subset of `package.json` exports, and the new alias slice, but not the full
+  per-importer Node16, NodeNext, or Bundler decision model.
+- direct member resolution relies on a shallow per-file type table.
+- the direct extractor can label a function passed through an array, object, or
+  argument as an `indirect_call` without evidence that the receiving API invokes
+  it. That is a precision risk; the safe default is a reference.
+- the independent source oracle in `benchmarks/performance` supports Python,
+  not TypeScript/JavaScript. The existing production precision/recall gate
+  therefore cannot yet substantiate a TypeScript/JavaScript quality claim.
+- offline SCIP ingestion exists, but graph projection currently collects sites
+  only for Java.
+
+Graphify is useful as a gap detector here. The inspected Graphify implementation
+has richer JSONC config inheritance, `baseUrl`/`paths`, workspaces, package
+exports, nearest-config selection, extension probing, and barrel handling. Its
+answers are hypotheses, not ground truth, and its source must not cross the
+Compass product boundary.
+
+## Product principles for this program
+
+1. **Two explicit quality tiers**
+   - **Native structural tier**: always available, Rust-native, local-first,
+     bounded, deterministic, compiler-free, and independently qualified.
+   - **Verified compiler tier**: optional user-supplied fresh SCIP or a future
+     explicitly invoked bounded analyzer. It may enrich exact known sites, but
+     may not silently replace, fabricate, or weaken native evidence.
+2. **Parser dialect is not semantic identity**: TSX is a TypeScript dialect;
+   JSX is a JavaScript dialect. Preserve the dialect as provenance while using
+   stable semantic language families for resolution.
+3. **Interop is evidence, not a name match**: TypeScript-to-JavaScript and
+   TypeScript-to-TSX links require exact import/project/package evidence. Never
+   reopen generic cross-language terminal-name matching.
+4. **Ambiguity is data**: emit unresolved or ambiguous diagnostics when more
+   than one target survives. Never select the first export, overload, package,
+   or workspace candidate.
+5. **Every relationship is occurrence-backed**: preserve direction,
+   multiplicity, exact byte range, enclosing declaration, resolution rule, and
+   provenance.
+6. **Hard cut, not dual production**: construct and qualify universal evidence
+   behind test-only seams, then switch production atomically and delete the
+   replaced direct facts/resolvers.
+7. **Framework knowledge cannot excuse core mistakes**: qualify language and
+   project semantics before expanding framework heuristics.
+
+## Definition of “surpass”
+
+### Mandatory production gates
+
+Use the repository's existing universal-evidence contract as the minimum ship
+bar. For TypeScript and JavaScript separately, and for their approved interop
+strata, require:
+
+- at least 2,000 independently accepted sampled relationships;
+- at least 400 accepted relationships per release-gate corpus;
+- at least 100 accepted relationships for each required relation and adapter
+  capability;
+- no target cluster larger than 10% of accepted samples;
+- observed precision at least 99.5% and a 95% Wilson lower bound at least 99%;
+- per-capability precision at least 99% and source-oracle recall at least 95%;
+- zero fabricated occurrences, unsafe local substitutions, or unproven
+  cross-language matches;
+- cold, warm-cache, repeated, relocated-root, and equivalent incremental builds
+  produce the same canonical graph;
+- every valid file in the pinned syntax corpus either parses without recovery
+  or produces a reviewed, source-bounded diagnostic with no offset corruption.
+
+### Leadership gates
+
+Apply these stricter gates before a public “best-in-class” claim:
+
+- observed precision at least 99.7%, Wilson lower bound at least 99.2%, and
+  precision at least 99.5% in every published capability stratum;
+- source-oracle recall at least 97% in the native tier and at least 99% for
+  exact target-resolution strata in the verified compiler tier;
+- at least 98% of non-rejected, non-ambiguous Graphify structural hypotheses
+  are supported by Compass or explained by an adjudicated semantic difference;
+- zero false framework route/handler edges in the release fixture matrix and
+  exact expected multiplicity for every positive route case;
+- no regression greater than 10% in median wall time or peak bounded counts
+  from the frozen Compass baseline without an approved quality tradeoff;
+- no competitor claim without equivalent source scope, ignores, generated-file
+  policy, dependency availability, compiler configuration, and graph mapping.
+
+Graphify coverage is only a diagnostic gate because one implementation cannot
+be its competitor's truth oracle. Also publish comparisons with a current SCIP
+TypeScript index and a documented CodeQL capability matrix where equivalent
+facts exist. Do not compare Compass structural graphs to CodeQL taint/data-flow
+results as if they were the same product contract.
+
+## Current ownership and likely change surface
+
+| Concern | Current evidence | Owner / likely files |
+|---|---|---|
+| language and dialect registry | TS/TSX/JS share generic extraction | `crates/compass-languages/src/registry.rs`, `engine.rs` |
+| universal adapter registry | only Go/Java/Python/Rust | `crates/compass-languages/src/adapters.rs` |
+| direct typed evidence | language switch has no TS/JS branch | `crates/compass-languages/src/evidence/build.rs`, `model.rs`, `validate.rs` |
+| project config markers | strict JSON and partial alias collection | `crates/compass-languages/src/project_evidence.rs`, `json_config.rs` |
+| module/package resolution | relative extensions, index, exports subset | `crates/compass-resolve/src/lib.rs` |
+| members and calls | per-file `ts_type_table`, direct JS passes | `crates/compass-resolve/src/members.rs`, `lib.rs` |
+| universal resolution | mature evidence resolver with language specializations | `crates/compass-resolve/src/evidence.rs` |
+| frameworks and templates | broad route packs and SFC extraction | `crates/compass-languages/src/frameworks/typescript.rs`, `templates.rs`, `crates/compass-resolve/src/frameworks/typescript.rs` |
+| compiler artifacts | fresh, bounded SCIP ingestion; Java projection only | `crates/compass-program`, `crates/compass-resolve/src/program.rs`, `crates/compass-core/tests/program_pipeline.rs` |
+| independent audit | Python source oracle only | `benchmarks/performance/compass/occurrences.py`, `audit.py`, `benchmarks/performance/tests/` |
+| release fixtures | useful TS routes/workspaces; weak real-repo release gating | `tests/qualification`, `scripts/qualify_code_graph_v1.sh` |
+
+New modules should follow the live ownership after the drift check. Prefer
+focused files such as `crates/compass-languages/src/evidence/typescript.rs`,
+`crates/compass-languages/src/typescript_project.rs`, and
+`crates/compass-resolve/src/typescript_modules.rs` over making the already large
+`engine.rs`, `evidence/build.rs`, or resolver root larger.
+
+### Current implementation anchors
+
+These excerpts pin the architectural seams at the planning commit. Re-read the
+live code before implementation.
+
+`crates/compass-languages/src/evidence/build.rs` has no TS/JS universal branch:
+
+```rust
+match profile.language {
+    "python" => state.extract_python(root)?,
+    "go" => state.extract_go(root)?,
+    "java" => state.extract_java(root)?,
+    "rust" => state.extract_rust(root)?,
+    _ => return Err(/* no direct universal extractor */),
+}
+```
+
+`crates/compass-languages/src/project_evidence.rs` parses a bounded JSONC
+configuration dialect and still records only partial markers:
+
+```rust
+let Some(root) = parse_jsonc(source) else { return; };
+if options.contains_key("baseUrl") { /* record key */ }
+if let Some(paths) = options.get("paths").and_then(Value::as_object) {
+    collect_json_aliases(paths, &mut output.aliases);
+}
+```
+
+`crates/compass-resolve/src/lib.rs` bounds workspace package manifests and
+exports, which should be preserved, but flattens export condition candidates
+into sets and accepts only a unique admitted target. Phase 3 replaces that
+subset with importer/context-aware TypeScript semantics rather than weakening
+its ambiguity behavior.
+
+`crates/compass-resolve/src/program.rs` makes the optional SCIP seam explicit:
+
+```rust
+.filter_map(|extraction| extraction.semantic_evidence.as_ref())
+.filter(|batch| batch.adapter.language == "java")
+```
+
+Phase 6 should generalize this exact-anchor contract only after TS/JS are
+hard-cut universal adapters; it should not add a second TS/JS graph path.
+
+## Reference semantics
+
+Treat these upstream specifications and tools as executor references, not
+runtime dependencies:
+
+- [TypeScript module reference](https://www.typescriptlang.org/docs/handbook/modules/reference)
+  for Node16/NodeNext/Bundler resolution, package `exports`/`imports`, self-name
+  imports, file formats, and condition selection;
+- [TypeScript project references](https://www.typescriptlang.org/docs/handbook/project-references.html)
+  and [`paths`](https://www.typescriptlang.org/tsconfig/paths.html);
+- [SCIP protocol](https://github.com/scip-code/scip) and
+  [scip-typescript](https://github.com/sourcegraph/scip-typescript) for optional
+  compiler evidence and interoperability;
+- [CodeQL supported languages and frameworks](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/)
+  as a contemporary framework-coverage checklist, not a structural truth set.
+
+Pin every qualification tool version and record its digest. Re-run against the
+current stable TypeScript release before a leadership claim because module and
+syntax behavior changes over time.
+
+## Commands and environment
+
+All Cargo commands that compile must use this worktree's unique external target:
+
+`CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923`
+
+Verify `/Volumes/Workspace` is mounted and the directory is writable before the
+first build. Stop rather than falling back to `target/`.
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| language tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 cargo test -p compass-languages --locked` | exit 0 |
+| resolver tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 cargo test -p compass-resolve --locked` | exit 0 |
+| program/core tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 cargo test -p compass-program -p compass-core --locked` | exit 0 |
+| qualification unit tests | `python3 -m unittest benchmarks.performance.tests.test_audit benchmarks.performance.tests.test_correctness benchmarks.performance.tests.test_language_fixture_compare` | exit 0 |
+| fixture qualification | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 ./scripts/qualify_code_graph_v1.sh --fixtures-only` | all cases pass |
+| JavaScript package checks | `npm ci && npm run typecheck:js && npm run test:js` | exit 0 |
+| product boundary | `sh scripts/check_product_boundary.sh` | no Graphify/runtime boundary violation |
+| format | `cargo fmt --all -- --check` | exit 0 |
+| workspace lint | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 cargo clippy --workspace --lib --bins --locked -- -D warnings` | exit 0 |
+| workspace tests | `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 cargo test --workspace --lib --bins --locked` | exit 0 |
+
+Each phase below adds a narrower verification command. Keep those commands in
+the final PR description with the exact commit, tool versions, and corpus pins.
+
+## Scope
+
+**In scope**:
+
+- TS, TSX, MTS, CTS, JavaScript, JSX, MJS, CJS, and declaration-file identity;
+- parser conformance and exact source ranges;
+- lexical scopes, TypeScript value/type/namespace identities, declaration
+  merging, imports, exports, reexports, calls, construction, bases, members,
+  receivers, ownership, and external references;
+- JSONC project configs, inheritance, project references, workspace packages,
+  and standards-correct module modes;
+- conservative JS/TS interop and ambiguity diagnostics;
+- current framework/template packs plus evidence-driven framework expansion;
+- an independent TypeScript compiler-backed qualification oracle;
+- optional, freshness-verified SCIP projection after native hard cut;
+- deterministic, incremental, bounded, real-corpus qualification and public
+  support documentation.
+
+**Out of scope**:
+
+- Graphify code, runtime, fixtures, configuration, or CI as a dependency;
+- requiring Node.js, `tsserver`, TypeScript, SCIP, credentials, or network access
+  for a normal Compass structural build;
+- speculative terminal-name, fuzzy, or “first candidate” resolution;
+- whole-program taint tracking, security queries, or general value/data-flow
+  parity with CodeQL;
+- a graph schema major-version change without a separate approved compatibility
+  design and migration plan;
+- automatic package installation or compiler invocation;
+- framework heuristics that cannot emit exact source evidence and negative
+  cases;
+- a timeless “better than every code graph” marketing claim.
+
+## Git and delivery workflow
+
+- Program branch prefix: `advisor/013-typescript-javascript-graph-quality`.
+- Use one branch/PR per phase; do not keep an XL branch alive across the program.
+- Keep contracts/fixtures, implementation, qualification evidence, and docs
+  separately reviewable where practical.
+- Use repository-style commit messages such as `feat: emit universal typescript evidence`,
+  `fix: resolve nodenext package imports exactly`, and
+  `perf: bound typescript project indexing`.
+- Do not push, publish, or open a PR unless instructed.
+- A phase is not complete because its happy-path tests pass. Its negative,
+  ambiguity, limit, cold/warm, and relocated-root cases must pass too.
+
+## Phase map
+
+```text
+0. Scorecard + independent oracle + HEAD baseline
+                         |
+1. ECMAScript identity + typed project model
+                         |
+2. Parser conformance + test-only universal evidence emitter
+                         |
+3. Standards-correct module/package resolution
+                         |
+4. Scope, symbol, call, construction, and member resolution
+                         |
+5. Atomic production hard cut; remove replaced direct path
+                         |
+6. Optional verified compiler/SCIP enrichment
+                         |
+7. Framework/template migration and evidence-driven expansion
+                         |
+8. Real-corpus qualification, performance, release claim
+                         |
+9. Continuous conformance and regression maintenance
+```
+
+Phases 1–4 may expose test-only universal APIs, but the production registry must
+remain on exactly one path until phase 5.
+
+## Phase 0: Establish truth before changing extraction
+
+### Context
+
+The existing benchmark can count and map graphs, but only Python has an
+independent source oracle. Re-running Compass against Graphify alone would
+optimize toward Graphify's choices, including its mistakes. This phase creates
+the measurement system that decides all later work.
+
+### Actions
+
+1. Define `typescript-javascript-code-graph-quality-v1` as a versioned manifest
+   under `tests/qualification` or the live code-graph qualification location.
+   Record corpus commit, license, source roots, ignores, generated-file policy,
+   config entry points, TypeScript version, module mode, expected language
+   family, and required capability strata.
+2. Add a developer-only TypeScript compiler source oracle, preferably
+   `benchmarks/performance/oracles/typescript-source-oracle.mjs`. It must:
+   - load the pinned compiler from the repository lockfile;
+   - build the same projects/file set as the manifest, including project
+     references;
+   - emit deterministic sorted JSONL for files, declarations, scopes, imports,
+     reexports, calls, constructions, bases, references, members, and exact
+     owner/source ranges;
+   - translate TypeScript UTF-16 positions to source byte ranges and test
+     Unicode/surrogate pairs explicitly;
+   - report unsupported/incomplete facts and compiler diagnostics rather than
+     silently dropping them;
+   - enforce file, source-byte, fact, diagnostic, time, memory/output, and
+     project-depth limits;
+   - include compiler version, script digest, config digest, and source digest.
+3. Integrate this oracle into `benchmarks/performance/compass/occurrences.py`,
+   the audit pipeline, and its focused tests. A partially indexed project must
+   fail the recall denominator instead of appearing to have perfect recall.
+4. Freeze four statistically audited release corpora with complementary shapes:
+   a type-heavy library (Zod), a mixed JS/TS library (Axios), a module/bundler
+   workspace (Vite), and a decorator/framework workspace (NestJS or an
+   equivalently licensed pinned corpus). Keep larger ecosystem repositories in
+   an extended regression tier until audit cost is sustainable.
+5. Rebuild current HEAD and compare it against the compiler oracle, the pinned
+   Graphify CLI, and a pinned SCIP TypeScript output. Classify every miss into
+   parser, identity, project config, module selection, reexport, scope,
+   receiver/member, framework, mapping, competitor error, or true ambiguity.
+6. Preserve the current Zod/Axios reports as historical diagnostic evidence,
+   but do not use their raw edge counts as the phase baseline. Record a new
+   exact-HEAD baseline with manual stratified audit and Wilson intervals.
+
+### Verification
+
+- Oracle tests cover LF/CRLF, Unicode, malformed projects, JSONC, project
+  references, compiler diagnostics, output limits, timeout, deterministic
+  ordering, and relocated roots.
+- Two identical runs have byte-identical normalized oracle output.
+- Removing one project/file from an oracle result causes coverage validation to
+  fail.
+- The audit produces precision, Wilson lower bound, source-oracle recall, and
+  per-capability/per-corpus results rather than one aggregate count.
+
+### Exit gate
+
+Do not begin semantic optimization until the manifest, independent oracle,
+baseline, miss taxonomy, and adjudication workflow are reviewed. The baseline
+may be below the final gates; the measurement itself may not be incomplete.
+
+## Phase 1: Model ECMAScript identity and projects explicitly
+
+### Context
+
+The registry currently treats `typescript`, `tsx`, and `javascript` as distinct
+language names, while universal resolution deliberately forbids unsupported
+cross-language matches. A safe hard cut therefore needs a clear distinction
+between parser dialect, semantic language, and evidence-proven interop. Project
+configuration also needs a typed model rather than framework activation markers.
+
+### Actions
+
+1. Add stable dialect metadata for TypeScript, TSX, MTS, CTS, JavaScript, JSX,
+   MJS, and CJS. Normalize TSX/MTS/CTS to semantic language `typescript` and
+   JSX/MJS/CJS to `javascript`; preserve the original dialect and module-format
+   decision as provenance.
+2. Define an explicit `EcmaScriptInterop`/equivalent resolution rule. It may
+   cross TypeScript/JavaScript families only through an exact import, export,
+   project `allowJs`/`checkJs`, package, or compiler-artifact binding. It must
+   never enable global terminal-name matching.
+3. Replace partial config markers with a versioned typed project model owned by
+   `compass-languages` or the lowest project-evidence owner. Parse bounded JSONC
+   using the repository's existing safe config primitives where possible.
+4. Model nearest-config ownership, `extends` including arrays and packages,
+   cycle/depth detection, `references`, `files`/`include`/`exclude`, `allowJs`,
+   `checkJs`, `baseUrl`, `paths` fallback arrays, `rootDirs`, `typeRoots`,
+   `module`, `moduleResolution`, `moduleSuffixes`, `resolveJsonModule`, and
+   relevant custom conditions.
+5. Build a bounded package/workspace inventory from source already admitted by
+   Compass: nearest `package.json`, package name/type, workspace declarations,
+   `main`/`module`/`types`, `exports`, `imports`, and project/package ownership.
+   Do not read arbitrary paths outside the admitted workspace inventory.
+6. Give the project model a schema/cache version and deterministic canonical
+   ordering. Unknown semantics, duplicate projects/packages, cycles, or limits
+   must be typed diagnostics, not empty configuration.
+
+### Verification
+
+- Focused tests cover TSX/JSX family identity, `.d.ts`, `.mts`/`.cts`, mixed
+  `allowJs`, nearest config, nested packages, JSONC comments/trailing commas,
+  multi-level and cyclic `extends`, path fallback arrays, project references,
+  duplicate package names, symlink/path containment, and every configured limit.
+- Equivalent relocated workspaces produce identical project identities and
+  canonical model JSON.
+- A TypeScript file cannot resolve an unrelated JavaScript symbol by name alone.
+
+### Exit gate
+
+The typed project model must be usable by both the legacy production path and
+the test-only universal path without duplicating config semantics.
+
+## Phase 2: Reach syntax conformance and emit universal evidence
+
+### Context
+
+`crates/compass-languages/src/evidence/build.rs` currently dispatches direct
+universal extraction only for Python, Go, Java, and Rust. The TypeScript/JS
+extractor must emit typed evidence directly from the parser tree; translating
+legacy raw graph records is not an acceptable adapter.
+
+### Actions
+
+1. Create a pinned syntax-conformance corpus from the TypeScript compiler tests
+   and small reviewable local fixtures. Cover current stable syntax and the
+   repository's supported language-version policy.
+2. Audit and update the vendored tree-sitter TypeScript/JavaScript grammars with
+   provenance, license, version, and deterministic build changes. Keep runtime
+   parsers statically linked.
+3. Retain a byte-preserving parser mask only for a documented upstream grammar
+   gap with exact original-to-parser offset equivalence, dedicated positive and
+   negative tests, and an explicit deletion condition. Prefer eliminating the
+   existing variance, type-star, and import-type masks when the grammar permits.
+4. Add focused TypeScript and JavaScript universal evidence emitters. Emit
+   exact declarations, scopes, bindings, occurrences, aliases, direct-base
+   candidates, receiver/type evidence, and resolution candidates for:
+   - functions, arrow/function expressions, overloads, methods, accessors,
+     constructors, fields, properties, parameters, and destructuring;
+   - classes, interfaces, type aliases, enums, namespaces/modules, namespace
+     augmentation, declaration merging, generics, and ambient declarations;
+   - separate value/type/namespace identities and `import type`/`export type`;
+   - default/named/star exports, CommonJS imports/exports, dynamic literal
+     imports, and reexports;
+   - calls, optional calls, `new`, base types, decorators, type references,
+     ownership, receiver evidence, and external references;
+   - JSX/TSX component references with exact tag occurrence. Until a new graph
+     relation is explicitly approved, publish these as `references` with typed
+     JSX context rather than inventing `calls` or `renders`.
+5. Emit parser-recovery diagnostics with exact affected ranges and evidence
+   completeness. Never publish a construct outside a source-backed range just
+   because the root parser recovered.
+6. Expose the adapter only to focused tests/qualification at this phase. Do not
+   add it to `UNIVERSAL_ADAPTERS` yet.
+
+### Verification
+
+- Add language tests beside `engine_edge_coverage.rs` and
+  `universal_evidence.rs` for every capability, including duplicate names,
+  shadowing, overloads, declaration merging, type/value namespace collisions,
+  anonymous/default exports, Unicode, malformed input, repeated occurrences,
+  and limit failures.
+- Differentially compare compiler and tree-sitter source ranges on the syntax
+  corpus. Valid files have no unexplained recovery and no byte drift.
+- Universal evidence validates without consuming `RawNodeRecord`,
+  `RawEdgeRecord`, or `RawCall`.
+- Two runs produce byte-identical sorted evidence batches.
+
+### Exit gate
+
+Every capability claimed in the future adapter profiles has direct validated
+evidence and a positive, ambiguity, negative, and boundary test. Do not register
+a capability that is merely inferred later from a legacy graph edge.
+
+## Phase 3: Implement standards-correct module and package resolution
+
+### Context
+
+The current resolver's relative extension/index behavior and package-exports
+support are valuable, but TypeScript/JavaScript target quality depends on the
+importer's project, module mode, package format, import kind, and condition set.
+Graphify currently covers more of the config/workspace surface; this is the
+largest clear competitive gap.
+
+### Actions
+
+1. Move JavaScript/TypeScript module logic from the resolver root into a bounded
+   focused owner such as `typescript_modules.rs`. Feed it the typed project and
+   package inventory from phase 1 and universal binding candidates from phase 2.
+2. Implement the official per-importer decision model for Classic only if still
+   supported, Node10 where required, Node16, NodeNext, and Bundler. Record the
+   selected mode and rule on every resolved binding.
+3. Resolve exact relative paths, allowed extension substitution, index files,
+   `rootDirs`, config `paths` fallback arrays, `baseUrl`, package self-name,
+   package `imports`, package `exports`, `typesVersions`, `types`/`main`/`module`,
+   workspace packages, project references, and admitted dependency sources in
+   their documented precedence.
+4. Respect importer and target ESM/CJS format, import versus require context,
+   type-only versus value context, active conditions/custom conditions, file
+   extensions, and declaration/source substitution. Do not union mutually
+   exclusive condition targets and then choose one later.
+5. Support named/default/star exports, export assignment, CommonJS property
+   exports, literal dynamic imports, and bounded barrel chains/cycles. Preserve
+   every occurrence and its multiplicity.
+6. Resolve only within Compass's admitted source/package inventory. A package
+   name present in two workspaces, wildcard matching more than one target, an
+   unsupported conditional branch, or a limit must remain ambiguous/unresolved
+   with a diagnostic.
+7. Preserve third-party targets as explicit external identities when source is
+   unavailable. Never redirect an external import to a same-named local symbol.
+
+### Verification
+
+- Build a table-driven fixture suite from the official TypeScript module
+  reference. Cover every mode/context pair, `package.json` type boundary,
+  `.ts`/`.tsx`/`.mts`/`.cts`/`.js`/`.jsx`/`.mjs`/`.cjs`/`.d.ts`, package
+  imports/exports/self-name, wildcards, condition order, paths fallbacks,
+  rootDirs, workspaces, project references, barrel cycles, and duplicates.
+- Add a differential developer test against `tsc --traceResolution` for pinned
+  fixtures. Normalize traces into expected decisions; do not call the compiler
+  in production tests or runtime.
+- Assert target identity, direction, exact import/export range, resolution rule,
+  ambiguity candidates, multiplicity, and deterministic ordering—not just edge
+  counts.
+- Extend existing workspace/reexport tests in
+  `crates/compass-resolve/tests/universal_resolution.rs` without weakening their
+  duplicate-package fail-closed behavior.
+
+### Exit gate
+
+The independent source oracle must show at least 99% precision and 97% recall in
+the module/import/reexport strata before phase 5. Every unsupported official
+case must have a named diagnostic and documented support status.
+
+## Phase 4: Resolve symbols, calls, construction, and members conservatively
+
+### Context
+
+The current direct resolver has useful import-aware calls and typed members,
+but its type table is shallow and indirect-call inference is too permissive for
+a leadership precision target. The universal resolver already supplies strong
+ambiguity, ownership, receiver, hierarchy, and resolution-rule primitives; add
+TypeScript-specific evidence rather than rebuilding a parallel resolver.
+
+### Actions
+
+1. Model lexical scopes, hoisting/visibility, shadowing, closure capture,
+   module/script scope, `this`, `super`, aliases, value/type/namespace separation,
+   declaration merging, and overload groups using stable typed facts.
+2. Resolve direct/imported/namespace/static/instance/constructor/callable-value
+   calls, optional chaining, computed literal members, tagged templates where
+   call semantics are exact, `new`, and `super` calls. Preserve unresolved
+   dynamic calls rather than guessing.
+3. Extend receiver evidence from parameters, locals, fields, constructor
+   assignments, type assertions/narrowings that are source-proven, generic
+   bounds, return types, and bounded chained call results. Use arity and exact
+   type compatibility only when it uniquely selects an overload.
+4. Model class/interface inheritance, implementation, overrides, mixins, and
+   prototype/static members only when declaration or compiler evidence proves
+   the link. Do not infer dynamic prototype graphs from matching names.
+5. For JavaScript, add bounded flow-sensitive local assignment tracking where
+   it proves a unique binding. Bail out on dynamic writes, alias escape,
+   `eval`, `with`, unsupported proxies, or candidate-limit overflow.
+6. Change the generic “function passed in an array/object/argument” result from
+   `indirect_call` to an exact `references` edge. Only a versioned API/framework
+   invocation contract may turn registration into an indirect call, and that
+   contract must identify the callee API, argument position/shape, callback
+   occurrence, handler target, and negative cases.
+7. Attach an explicit resolution rule and confidence/provenance class to every
+   resolved relationship. Preserve multiple call occurrences even when they
+   share endpoints.
+
+### Verification
+
+- Add focused tests for nested/shadowed functions, recursion, overloads,
+  declaration merging, imported aliases, namespace calls, constructors,
+  optional chains, generic receivers, inheritance/overrides, field/return
+  chains, JS reassignment, dynamic property negatives, callbacks, repeated
+  sites, Unicode ranges, and ambiguous duplicate candidates.
+- A callback stored or passed to an unknown API produces a reference and no
+  indirect call. Known framework contracts produce the exact expected handler
+  edge and no edge when the API/argument shape differs.
+- The source oracle meets mandatory per-capability gates for calls,
+  construction, members, bases, and references; no capability hides behind the
+  aggregate result.
+- Target-cluster and unsafe-substitution audit counters remain zero or below
+  the mandatory contract as applicable.
+
+### Exit gate
+
+All universal TypeScript/JavaScript capabilities pass their mandatory minimum
+sample counts, precision, Wilson, recall, and negative gates in test-only mode.
+
+## Phase 5: Perform the atomic production hard cut
+
+### Context
+
+This is the compatibility-sensitive phase. It is a deletion and ownership
+phase as much as a registration phase. Running both paths would create duplicate
+or conflicting graphs and conceal semantic drift.
+
+### Actions
+
+1. Add separate `compass.typescript` and `compass.javascript` adapter profiles
+   with exact capability lists and new adapter versions. Map TSX/MTS/CTS and
+   JSX/MJS/CJS through their semantic family while preserving dialect evidence.
+2. Switch production extraction to direct parser-tree universal evidence in one
+   commit. Do not publish legacy raw and universal facts in the same build.
+3. Route project-wide module, call, construction, base, reference, and member
+   candidates through the shared evidence resolver plus the focused module
+   resolver.
+4. Delete or disable replaced TS/JS branches in `engine.rs`, `members.rs`, and
+   resolver root, including redundant `ts_type_table`, JS-specific target maps,
+   raw-call paths, and unsafe indirect-call inference. Retain only behavior with
+   a clearly different ownership boundary, such as Program IR or project model.
+5. Migrate existing route/template producers to consume or attach universal
+   evidence without changing their published semantics. Phase 7 can deepen
+   them after parity is proven.
+6. Bump every affected extraction/cache/fingerprint version. Review graph JSON,
+   stable IDs, history realization fingerprints, CLI/MCP output, and incremental
+   manifests under `COMPATIBILITY.md`.
+7. Add `MIGRATION.md` and `CHANGELOG.md` entries if users must rebuild cached
+   graphs or stable identities necessarily change. Prefer identity preservation
+   where semantic identity is unchanged, but never preserve an incorrect ID by
+   fabricating equivalence.
+
+### Verification
+
+- Cold, warm, repeated, relocated, incremental edit/add/delete/rename, and
+  project-config/package-manifest changes publish coherent equivalent graphs.
+- Fixture comparison accounts for every legacy relation: preserved, corrected
+  with reviewed contract change, or intentionally removed as unproven.
+- Search confirms no production TS/JS dual extraction and no replaced direct
+  resolver tables remain.
+- Run language, resolver, graph, core, CLI contract, fixture qualification,
+  product-boundary, format, lint, and workspace tests from the command table.
+
+### Exit gate
+
+The native production graph must pass all mandatory gates with no regression in
+existing route/template fixtures. Roll back the cutover commit if the gate fails;
+do not add a runtime fallback to the legacy path.
+
+## Phase 6: Add optional verified compiler and SCIP enrichment
+
+### Context
+
+Native syntax/project evidence should remain the default. Compiler indexes can
+raise exact target recall for overloads, generics, declaration merging, aliases,
+dependencies, and JS/TS interop. Compass already has bounded SCIP decoding,
+freshness manifests, source digests, Program evidence, and exact-anchor Java
+projection; reuse that seam.
+
+### Actions
+
+1. Generalize program projection in `crates/compass-resolve/src/program.rs`
+   from Java-only site collection to a language-neutral exact-anchor contract,
+   then opt in hard-cut TypeScript/JavaScript with focused policy tests.
+2. Join SCIP definition/reference/call facts only to an existing exact source
+   file and byte range, declaration occurrence, call occurrence, construction
+   occurrence, or import binding. Reject stale sources, missing manifests,
+   conflicting local targets, wrong language/project identity, and offset drift.
+3. Preserve provider/artifact identity, SCIP symbol, source digest, projection
+   rule, and structural evidence provenance. An enriched edge must not erase an
+   independently valid native relationship.
+4. Require unanimous or explicitly modeled non-conflicting provider evidence
+   for a local exact target. Runtime dispatch sets may remain multiple; do not
+   collapse them into one convenient method.
+5. Add TypeScript/JavaScript cases to `crates/compass-program/tests/scip.rs` and
+   `crates/compass-core/tests/program_pipeline.rs`: definitions, references,
+   overloads, JSX, JS/TS interop, Unicode, stale artifact, source edit, config
+   edit, conflict, missing target, limit, cold/warm cache, and relocation.
+6. Keep `scip-typescript` outside normal execution. A future analyzer command
+   must be separately approved, explicit opt-in, argument-vector based,
+   time/output/memory bounded, version-pinned, and never auto-install packages.
+
+### Verification
+
+- A native build remains byte-equivalent and succeeds when Node/SCIP/compiler
+  binaries are absent.
+- A fresh artifact adds only exact-anchor facts and raises the compiler-tier
+  target-resolution recall to the leadership threshold.
+- Stale, conflicting, truncated, oversized, or offset-mismatched artifacts fail
+  explicitly or are ignored according to the existing typed contract; they
+  never publish a plausible partial enrichment.
+- Product-boundary and credential/network-free fixture qualification pass.
+
+### Exit gate
+
+Document the two quality tiers separately. Do not describe compiler-enriched
+recall as native Compass recall.
+
+## Phase 7: Migrate and deepen framework and template semantics
+
+### Context
+
+Compass already recognizes Express, Fastify, Hono, Nest, React Router, Next,
+Remix, Vue Router, Nuxt, SvelteKit, Astro, Vite, and template scripts. Preserve
+that lead while moving every relationship onto the exact evidence contract.
+
+### Actions
+
+1. Migrate existing packs atomically to universal descriptors/resolution while
+   preserving route path, HTTP method, handler direction, source occurrence,
+   multiplicity, aliasing, and negative behavior.
+2. Define versioned invocation contracts for framework callback APIs. Examples
+   include Express/Fastify/Hono route handlers, Nest decorators, and router
+   configuration arrays. Each contract needs exact activation/import evidence,
+   argument position/shape, callback semantics, and near-miss tests.
+3. Preserve source-map/host mapping for Vue, Svelte, and Astro embedded scripts.
+   Every declaration and relationship must point to exact host-file bytes; a
+   generated virtual offset is not acceptable publication evidence.
+4. Add framework support based on audited user value and missing capability
+   strata, not checkbox parity. Candidate next packs are Angular routing and DI,
+   Koa routing/middleware, React component/hook relationships, and high-value
+   build/config entry points. Each is a separate focused PR after core quality.
+5. Distinguish routing, registration, rendering/reference, dependency injection,
+   and ordinary calls. Reuse existing graph relations where semantics fit;
+   propose any new stable relation through the normal schema/compatibility
+   process rather than encoding it in an arbitrary attribute.
+
+### Verification
+
+- Extend `crates/compass-resolve/tests/typescript_routes.rs` and template tests
+  with imported/default/aliased handlers, arrays, nested routers, duplicate
+  routes, computed/dynamic negatives, malformed templates, and exact host ranges.
+- Require 100% expected precision and multiplicity on the reviewed framework
+  fixture matrix before advertising a framework as supported.
+- Run the compiler oracle where source semantics exist, but maintain
+  Compass-owned framework truth fixtures for behavior the compiler cannot know.
+
+### Exit gate
+
+Every advertised framework has a documented capability/status, positive and
+negative fixtures, exact route/handler evidence, limits, and real-corpus smoke
+coverage. Unsupported dynamic behavior is named honestly.
+
+## Phase 8: Qualify release leadership and performance
+
+### Context
+
+This phase turns implementation into a defensible claim. It must run against
+the exact release candidate, not an earlier feature commit or a working tree.
+
+### Actions
+
+1. Promote the four audited corpora to pinned release gates after license and
+   disk policy review. Store external read-only repositories beneath
+   `/Volumes/Workspace/Github/<owner>/<repository>`; keep generated graphs and
+   audit artifacts outside tracked sources.
+2. Add extended regression corpora for a large monorepo, current TypeScript
+   compiler syntax, React/Next, Angular, Vue/Nuxt, Svelte/SvelteKit, and Astro.
+   These may be scheduled until they meet the reviewed release-gate standard.
+3. Run native and compiler tiers through cold, warm, repeated, relocated,
+   incremental edit/add/delete/rename, config/package change, malformed input,
+   ambiguity, and all limit paths.
+4. Publish machine-readable precision, Wilson interval, recall, per-capability,
+   per-corpus, miss taxonomy, unresolved/ambiguous counts, parser recovery,
+   time, source bytes, nodes/edges/occurrences, peak bounded counts, and tool
+   versions. Include the exact Compass commit and hardware for performance.
+5. Run Graphify, SCIP TypeScript, and any other approved comparator with
+   equivalent scope/config. Store their versions and mappings. Manually
+   adjudicate a stratified sample; do not turn unsupported competitor facts into
+   automatic Compass bugs.
+6. Update `PERFORMANCE.md`, the TypeScript/JavaScript support reference,
+   `COMPATIBILITY.md`, `CHANGELOG.md`, and qualification documentation. Use a
+   precise claim such as: “Compass leads the published TypeScript/JavaScript
+   Code Graph Quality v1 scorecard as of YYYY-MM-DD.” Link the manifest,
+   methodology, versions, and full results.
+7. Wire the exact-commit qualification into the release gate. A release binary
+   must be the binary audited; evidence from an ancestor commit is insufficient.
+
+### Verification
+
+- All mandatory and leadership gates pass on the exact release candidate.
+- A deliberately injected wrong target, lost occurrence, stale SCIP artifact,
+  missing corpus, unsupported skip, or different binary SHA makes the gate fail.
+- Median and variability are reported; CI does not adopt a brittle wall-clock
+  threshold from one developer machine.
+- `git status --short` contains no generated graph, `.compass`, credentials,
+  private sources, or external corpus files.
+- Run every applicable command in the command table and `git diff --check`.
+
+### Exit gate
+
+Publish no leadership statement if any mandatory gate, per-capability minimum,
+corpus minimum, exact-SHA check, or equivalent-configuration review fails.
+
+## Phase 9: Keep support state of the art
+
+1. Test the current stable and next TypeScript syntax/module behavior on a
+   scheduled developer/CI lane. A next-version failure informs planning; it does
+   not silently change the stable support contract.
+2. Review vendored grammar provenance and compiler-oracle compatibility on every
+   supported TypeScript upgrade.
+3. Track quality by capability and miss reason. Set a zero budget for fabricated
+   occurrences, unsafe substitutions, path escapes, nondeterminism, and critical
+   precision regressions.
+4. Refresh competitor versions and the public scorecard at least quarterly and
+   before repeating a leadership claim. Keep historical results immutable.
+5. Add the smallest reviewable positive, ambiguity, negative, and limit fixture
+   for every new syntax, module rule, resolver behavior, or framework contract.
+6. Never lower a threshold to absorb a regression. Fix the issue, narrow an
+   overstated support claim, or version the qualification contract with review.
+
+## Cross-phase test plan
+
+- **Classification**: all extensions/dialects, shebangs where applicable,
+  declaration files, scripts versus modules, ESM/CJS boundaries.
+- **Parser**: current syntax corpus, recovery, masks, Unicode/CRLF, malformed
+  constructs, source-byte preservation.
+- **Evidence**: declarations, scopes, identities, imports/reexports, aliases,
+  calls/construction, types/bases, members/receivers, ownership, references,
+  decorators, JSX, exact anchors, multiplicity, provenance.
+- **Projects/modules**: JSONC/extends/references, paths/baseUrl/rootDirs,
+  workspaces, package exports/imports/self-name, conditions, Node16/NodeNext/
+  Bundler, ESM/CJS, barrels, external identities, ambiguity and limits.
+- **Resolution**: shadowing, overloads, declaration merging, JS flow, imported
+  aliases, receiver/member chains, callbacks, dynamic negatives.
+- **Frameworks/templates**: route/handler contracts, activation negatives,
+  aliases, nested configs, embedded-source host anchors.
+- **Compiler enrichment**: freshness, exact anchor, conflict, Unicode, stale,
+  truncated/oversized, cold/warm, relocated and native-without-tool behavior.
+- **Publication**: graph validation, deterministic order/IDs, cache fingerprints,
+  incremental add/edit/delete/rename/config changes, coherent atomic output.
+- **Qualification**: independent oracle completeness, manual stratification,
+  Wilson intervals, target clusters, source-oracle recall, competitor mapping,
+  exact release SHA, bounded performance.
+
+## Done criteria
+
+- [ ] TypeScript and JavaScript have direct parser-tree universal adapters; no
+  production adapter translates legacy raw graph records.
+- [ ] Parser dialect and semantic language family are distinct and exact JS/TS
+  interop never enables generic cross-language matching.
+- [ ] The typed project model covers the supported TypeScript config, workspace,
+  and package contract with deterministic bounded failures.
+- [ ] Module resolution matches the documented TypeScript decision model for
+  every advertised mode and import context.
+- [ ] Calls, construction, bases, members, references, and callbacks meet every
+  mandatory per-capability quality gate.
+- [ ] Unknown callback passing produces references, not invented indirect calls.
+- [ ] The hard cut removed replaced TS/JS direct facts/resolvers and never dual
+  publishes production graphs.
+- [ ] Normal structural builds remain native, offline, compiler-free, and
+  Graphify-free.
+- [ ] Optional SCIP/compiler evidence is fresh, bounded, exact-anchor,
+  provenance-preserving, and separately reported.
+- [ ] Existing and newly advertised framework/template cases have exact positive
+  and negative qualification.
+- [ ] Cold/warm/repeated/relocated/incremental graphs are canonically equivalent.
+- [ ] The exact release candidate passes mandatory and leadership scorecard
+  gates on pinned, licensed, reviewable corpora.
+- [ ] Performance and superiority claims cite reproducible versions, mappings,
+  scope, results, hardware/date, and limitations.
+- [ ] Format, targeted tests, workspace lint/tests, fixture qualification,
+  product-boundary, docs, and diff checks pass.
+- [ ] Plan 013 is marked `DONE` in `advisor-plans/README.md` only after all
+  phases and the release gate complete.
+
+## STOP conditions
+
+Stop and report rather than weakening the design if:
+
+- the source oracle is incomplete, shares Compass extraction logic, or cannot
+  prove its file/range coverage;
+- a parser workaround changes byte offsets or valid pinned syntax has
+  unexplained recovery;
+- resolution would need terminal-name matching, arbitrary filesystem search,
+  first-candidate selection, or an unbounded barrel/project/package traversal;
+- a normal build would require Node.js, a compiler, SCIP, credentials, network,
+  runtime grammar downloads, or Graphify;
+- the universal adapter cannot pass mandatory gates before production cutover;
+- the hard cut requires dual production publication or an automatic legacy
+  fallback;
+- an existing framework route/template contract regresses without an approved
+  compatibility decision;
+- a graph schema major change or stable-ID break is required without an approved
+  migration plan;
+- competitor inputs cannot be configured equivalently enough for a defensible
+  comparison;
+- performance results are too noisy or incomplete for a public claim;
+- `/Volumes/Workspace` is unavailable for a Cargo build or real-corpus checkout;
+- pre-existing user changes cannot be preserved.
+
+## Maintenance notes
+
+- Adapter, project-model, evidence, cache, and qualification versions are
+  contracts. Bump the narrowest version when meaning changes and reject unknown
+  majors explicitly.
+- Keep historical corpus realizations and published scorecards immutable. Add a
+  new realization instead of rewriting results in place.
+- Track current stable TypeScript support separately from preview syntax.
+- Revalidate package/module semantics when TypeScript changes supported modes or
+  conditions.
+- Keep generated benchmark artifacts outside the repository and qualification
+  repositories read-only.
+- Prefer a smaller graph with exact unresolved diagnostics over a larger graph
+  containing plausible but unproven calls.

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1054,6 +1054,36 @@ flow, overload-aware generic substitution beyond bounded source shapes, and
 the production hard cut remain open. The candidate adapter remains absent
 from `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, callable-property and typed-value slice)
+
+The qualification-only TypeScript/JavaScript path now preserves another
+source-proven callable boundary across project files:
+
+- Function-valued object properties publish bounded callable signatures with
+  fixed parameter and return shapes, including generic arrow properties. A
+  directly annotated value import also publishes its nominal `|type:` shape so
+  member traversal can expand the referenced interface without guessing.
+- Structural object-literal properties are indexed under their exact source
+  variable owner in the shared resolver. Imported calls such as
+  `api.make(value).inspect()` and `api.identity<Item>(value).inspect()` now
+  resolve both the callable property and the returned `Item.inspect` member
+  with `member-binding` provenance.
+- Nominally typed value imports such as `declare const typed: TypedApi` now
+  resolve their direct callable member target before external fallback. Duplicate
+  callable properties remain unresolved, and unknown/ambiguous owners are not
+  collapsed into a terminal-name match.
+
+The slice adds one direct candidate regression and two cross-file resolver
+regressions; the focused candidate suite is now 73 tests and the universal
+resolver suite is now 156 tests. The exact fixture qualification remains
+byte-stable at Compass revision `0d051868` with graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`.
+Conditional/mapped modifier semantics, framework/compiler tiers, accepted
+precision/Wilson gates, equivalent Graphify/SCIP scope, alias escape/eval/
+proxy flow, overload-aware generic substitution beyond bounded source shapes,
+and the production hard cut remain open. The candidate adapter remains absent
+from `UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1839,11 +1839,21 @@ spread sources, and spreading a non-object default. Candidate adapter versions
 advanced to 5 so the qualification-only evidence cache cannot reuse the prior
 owner-less spread realization.
 
-The exact-HEAD fixture qualification and the read-only Axios differential need
-to be rerun at the implementation head before this checkpoint is treated as a
-measured release baseline. Compiler-source-oracle recall, accepted-sample/
-Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and the
-production hard cut remain open.
+The exact-head fixture qualification at `3eb4b7f3a796238eeef954238461dfd63f4ca362`
+passes with 57 languages, 980 coverage records, 1,565 invariants, 27 flows,
+24 negatives, 25 diagnostics, 28 edge kinds, and 45 node kinds. It retains
+graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+82 exact/11 unresolved route resolutions, and byte-equivalent clean, warm,
+rebuild, restored, and alternate-checkout outputs. The unchanged digest is
+expected because the candidate adapter remains unregistered in production.
+The read-only Axios target differential remains 3,054/3,167 exact local
+targets (113 missing, 0 wrong; 391/503 member targets and 1,544/1,545 call
+targets, 228 accepted-candidate false positives); it remains diagnostic and
+does not establish a recall, precision, or leadership claim.
+
+Compiler-source-oracle recall, accepted-sample/Wilson gates, framework tiers,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
 ## Outcome
 

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1568,6 +1568,38 @@ Conditional structural exports beyond the bounded spread-free form,
 compiler-target truth, release corpora, precision/Wilson, framework tiers,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, CommonJS require binding and namespace slice)
+
+The candidate and resolver now preserve the two CommonJS import shapes that
+were previously conflated:
+
+- A direct binding such as `const api = require("./api")` is published as a
+  source-anchored `module::*` namespace binding. Direct namespace members use
+  the exact provider export slot; a callable `module.exports = fn` default is
+  selected only for a direct callable require, while object-valued defaults do
+  not become callable by assumption.
+- Object destructuring preserves the source export key, including aliases and
+  bounded static string/number keys (`run: execute` becomes `module::run`, not
+  `module::execute`). Nested, rest, computed, array, malformed, and indirect
+  require patterns remain unresolved rather than being flattened into guessed
+  imports. Assignment defaults are accepted only when their bound value is a
+  direct identifier.
+- Namespace export-slot lookup prefers an exact source-backed re-export alias
+  when a CommonJS object property and a same-named declaration coexist; this
+  avoids publishing both the property declaration and the actual exported
+  target. Ordinary ES namespace members continue through the same exact
+  module/export path, while direct calls through non-callable ES namespaces
+  remain unresolved.
+- The candidate adapter versions advanced to 3 for the binding identity
+  change. Focused coverage is now 91 candidate tests and 168 universal
+  resolver tests, including aliased named requires, namespace member calls,
+  callable CommonJS defaults, and dynamic/nested negative patterns.
+
+Fixture qualification, compiler-source-oracle recall, release-corpus
+precision/Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and
+the production hard cut remain open; this is an interop correctness slice, not
+a best-in-class release claim.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1855,6 +1855,45 @@ does not establish a recall, precision, or leadership claim.
 Compiler-source-oracle recall, accepted-sample/Wilson gates, framework tiers,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, CommonJS object-spread owner aliases)
+
+The qualification-only CommonJS path now carries the same bounded owner
+contract as safe ES default/export-assignment objects. For
+`module.exports = { ...base, direct }`, the adapter emits the module's exact
+default reexport, a source-range-backed `Member("*")` alias for each proven
+local or static default-import object source, and ordinary named reexports for
+direct properties after the spread. The resolver treats the module declaration
+as a structural owner only for this explicit marker, follows the source
+owner across the TypeScript/JavaScript language family, and gives direct
+properties precedence over inherited members.
+
+The slice remains deliberately fail-closed: dynamic, computed, mutable,
+conditional, namespace/require, and otherwise unproven spread operands do not
+publish a guessed member inventory. Missing or non-object source owners become
+unresolved, while two source owners that provide distinct declarations remain
+ambiguous. New candidate coverage validates the marker and target declaration;
+resolver coverage validates cross-file TS-default-to-JS-CommonJS inheritance,
+direct override precedence, competing sources, and non-object defaults. The
+focused suites are now 100 candidate tests and 174 universal resolver tests.
+
+At implementation head `dbf275cd3c40657af563fd130950425742bf5469`, fixture-only
+qualification passes with the unchanged 57-language/980-record/1,565-invariant
+contract, 27 flows, 24 negatives, 25 diagnostics, 28 edge kinds, and 45 node
+kinds. The graph digest remains
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+with 82 exact and 11 unresolved route resolutions; clean, warm, rebuild,
+restored, alternate-checkout, and source-fixture byte comparisons all pass.
+The unchanged digest is expected because this qualification-only adapter is
+not registered in production. The independent Axios diagnostic is unchanged
+at 3,054/3,167 exact local targets (113 missing, 0 wrong; 391/503 members,
+1,544/1,545 calls, and 228 accepted-candidate false positives); it is not a
+release recall or precision claim.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open. This is an interop correctness slice, not a best-in-class
+release claim.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1001,6 +1001,34 @@ modifier semantics, accepted precision/Wilson gates, framework/compiler tiers,
 equivalent Graphify/SCIP scope, and the production hard cut remain open. The
 candidate adapter remains absent from `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, imported callable-return evidence slice)
+
+The qualification-only TypeScript/JavaScript path now carries bounded
+source-proven call-result evidence across project files:
+
+- Imported direct calls publish a length-limited `#call<...>` path marker with
+  only known argument shapes. Unknown arguments, oversized markers, and
+  dynamic call results remain unresolved; the marker is never eligible for a
+  fabricated external target.
+- Callable declarations publish fixed parameter and return metadata alongside
+  their existing generic parameter prefix. The shared resolver uses that
+  metadata for direct nominal returns and bounded generic inference through
+  direct parameters, postfix arrays, and matching generic containers.
+- Imported calls such as `make(value).inspect()`,
+  `identity(value).inspect()`, and `box(value).value.inspect()` now resolve
+  to the exact `Item.inspect` declaration when the source evidence is unique.
+  Duplicate exported declarations remain unresolved instead of selecting a
+  first candidate.
+
+The slice adds one direct candidate regression and two cross-file resolver
+regressions; the focused candidate suite is now 71 tests and the universal
+resolver suite is now 152 tests. Imported callable member-method returns,
+explicit generic-call arguments without inferable value arguments, richer
+conditional/mapped modifier semantics, accepted precision/Wilson gates,
+framework/compiler tiers, equivalent Graphify/SCIP scope, and the production
+hard cut remain open. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -976,6 +976,31 @@ is now 150 tests. The production candidate adapter remains absent from
 return evidence, framework/compiler tiers, equivalent Graphify/SCIP scope,
 and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-06, bounded utility/conditional receiver slice)
+
+The qualification-only TypeScript/JavaScript path now normalizes a small,
+source-spelled set of standard utility wrappers after generic substitution:
+
+- `NonNullable<T | undefined>` removes only non-nominal/nullish union arms
+  when exactly one nominal receiver remains. `Awaited<Promise<T>>` and
+  `Awaited<PromiseLike<T>>` unwrap bounded promise layers, while
+  `Partial<T>`, `Required<T>`, and `Readonly<T>` preserve the underlying
+  nominal declaration identity.
+- The same normalization runs in the shared cross-file member resolver, so
+  generic properties such as `Box<T>.nullable: NonNullable<T|undefined>`
+  retain the imported `Item.inspect` target after `Box<Item>` substitution.
+- Multiple nominal union arms, arbitrary structural wrappers, and unsupported
+  conditional forms fail closed. Top-level union substitution is recursive but
+  bounded by the existing shape/depth limits.
+
+The slice adds three direct candidate regressions and expands the imported
+array/tuple resolver fixture to six exact utility/indexed member calls; the
+focused candidate suite is now 70 tests and the universal resolver suite is
+now 150 tests. Imported callable-return evidence, richer conditional/mapped
+modifier semantics, accepted precision/Wilson gates, framework/compiler tiers,
+equivalent Graphify/SCIP scope, and the production hard cut remain open. The
+candidate adapter remains absent from `UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1732,6 +1732,25 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, ES wildcard barrel reexports)
+
+The ECMAScript candidate now emits bounded `export * from "./module"` and
+`export * as namespace from "./module"` bindings, including `export type *`.
+The resolver follows wildcard reexports transitively through barrel chains,
+resolves namespace-alias members through the provider module owner, and
+fail-closes on duplicate exports and cyclic barrels. Reexport traversal remains
+depth- and candidate-bounded; it never selects the first surviving target.
+
+The focused candidate suite is now 98 tests and the universal resolver suite is
+now 170 tests. New regressions assert exact transitive `run` resolution,
+namespace-alias member resolution, duplicate wildcard ambiguity, and cyclic
+wildcard non-resolution. The native production registry remains unchanged; this
+is still a qualification-only universal path.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1465,6 +1465,33 @@ structural exports, compiler-target truth, release corpora, precision/Wilson,
 framework tiers, equivalent Graphify/SCIP scope, and the production hard cut
 remain open.
 
+### Execution checkpoint (2026-08-07, inline structural assignment receivers)
+
+The native JavaScript flow path now preserves a bounded, source-qualified
+identity for immutable aliases initialized from a plain assignment expression
+whose value is an exact object literal:
+
+- `const state = (this[key] = { inspect() {} })` publishes the object members
+  under `state`, then carries that identity through later closures and
+  property-scoped mutation barriers. Computed member keys remain opaque; the
+  alias is tied to the local declaration, not to a guessed `key` spelling.
+- Separate inline assignments in one callable retain separate qualified
+  identities, so `first.inspect()` cannot select the later `second.inspect()`
+  declaration merely because both objects share a property name.
+- Object spreads, queried-member overwrites, mutable aliases, unsupported
+  non-declarator assignment shapes, and dynamic escapes remain unresolved or
+  fail closed. Direct object-literal behavior is unchanged.
+
+The focused candidate suite remains 88 tests, including inline assignment
+positive, unrelated-write, overwrite, spread, and distinct-object regressions;
+the universal resolver suite remains 166 tests. On the read-only Axios
+target-adjudication diagnostic, exact local target matches improved from
+3,045/3,167 to 3,046/3,167 (121 missing, 0 wrong); members are 383/503 and
+calls remain 1,544/1,545. This is diagnostic evidence rather than a release
+precision/recall claim. Conditional structural exports, compiler-target truth,
+release corpora, precision/Wilson, framework tiers, equivalent Graphify/SCIP
+scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1167,6 +1167,29 @@ mapped modifier semantics beyond the bounded utility/union rules, richer
 interprocedural flow, framework/compiler tiers, accepted precision/Wilson gates,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, bounded utility receiver projections)
+
+The qualification-only TypeScript candidate now models a narrow, source-backed
+subset of utility receivers while preserving fail-closed behavior:
+
+- `Pick<LocalType, "member">` and `Omit<LocalType, "member">` project exact
+  local members for receiver lookup. Unknown key expressions, imported bases,
+  nested utility projections, oversized shapes, and duplicate/unsupported key
+  encodings remain unresolved rather than inventing a property target.
+- `Exclude<A | B, Filter>` and `Extract<A | B, Filter>` narrow to one nominal
+  source constituent only when the bounded union/filter comparison proves a
+  unique owner. Multiple surviving owners, non-nominal members, and unsupported
+  assignability remain unresolved.
+- Projection metadata is internal to candidate lookup; published declarations,
+  source anchors, occurrence ranges, and member direction remain unchanged.
+
+The focused candidate suite is now 79 tests and the universal resolver suite
+remains 159 tests. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`. Conditional and mapped modifier semantics beyond these
+bounded utility/union rules, richer interprocedural flow, framework/compiler
+tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1655,6 +1655,29 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, path-aware JavaScript escape barriers)
+
+Flow escape evidence now respects source evaluation order and bounded execution
+context. A callable argument escape is anchored at the argument occurrence,
+rather than the enclosing call, so a member read evaluated before a later object
+argument remains eligible. Escape barriers also retain a bounded branch/function
+path: a write or escape in one conditional arm or sibling callback no longer
+poisons a mutually exclusive use, while an outer or same-function use remains
+fail-closed. This recovers the Axios-shaped `response.request` read that occurs
+in one callback while a sibling callback passes the same structural object.
+
+The focused candidate suite remains 95 tests and the universal resolver suite
+remains 168 tests. On the pinned Axios checker diagnostic at the same corpus
+realization, exact local target matches improved to 3,054/3,167 (113 missing,
+0 wrong; 391/503 member matches and 1,544/1,545 call matches). Negative
+coverage confirms that a direct escape before a read and a nested escape called
+before a read remain unresolved. This is diagnostic evidence only, not a
+release precision or leadership claim.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -896,6 +896,34 @@ property mutation, interprocedural flow, and compiler differential recall remain
 open Phase 4 work; the candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release gates pass.
 
+### Execution checkpoint (2026-08-06, homomorphic mapped-alias slice)
+
+The qualification-only TypeScript path now preserves a narrow, source-proven
+nominal identity for homomorphic mapped aliases without treating structural
+assignability as universal:
+
+- A mapped alias whose single object shape is exactly
+  `{ [K in keyof Item]: Item[K] }` publishes `Item` as its bounded nominal
+  source. The same rule substitutes an explicit generic argument for
+  `type Copy<T> = { [K in keyof T]: T[K] }`, including canonical module-local
+  identities produced by the existing generic receiver path.
+- The helper is deliberately strict: nested/additional object members,
+  key-remapping, computed transforms, unsupported value shapes, and ambiguous
+  canonical declarations do not produce a receiver target. Ordinary index
+  signatures keep their existing indexed-value behavior.
+- A direct TypeScript candidate regression covers non-generic and generic
+  aliases plus a key-remapped negative. A cross-file resolver regression proves
+  `Copy<Item>` reaches the exact imported `Item.inspect` declaration through the
+  existing `member-binding` publication rule. The focused candidate suite is
+  now 56 tests and the universal resolver suite is now 148 tests.
+
+This remains a bounded evidence slice, not compiler-equivalent mapped-type
+assignability: modifier-rich mapped types, conditional/infer transforms,
+indexed access beyond direct value shapes, alias escape, dynamic mutation,
+framework tiers, compiler differential recall, and the production hard cut
+remain open. The candidate adapter stays out of `UNIVERSAL_ADAPTERS` until the
+mandatory precision, determinism, qualification, and exact-release gates pass.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1517,6 +1517,32 @@ evidence rather than a release precision/recall claim. Conditional structural
 exports, compiler-target truth, release corpora, precision/Wilson, framework
 tiers, equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, nominal member-write and escape recovery)
+
+The JavaScript flow path now preserves exact member identity for a stricter
+nominal-only slice:
+
+- Plain `=` writes on a source-proven nominal receiver publish the exact member
+  declaration. Structural object writes, computed/dynamic keys, and compound
+  assignments continue to use mutation barriers and fail closed.
+- An immutable nominal alias can retain its receiver identity after an unknown
+  call or other escape. This recovers class-member reads/writes without
+  treating an escaped structural object as stable; nested member receivers are
+  explicitly excluded from the fallback to prevent outer-owner substitution.
+- Regressions cover direct and static nominal writes, compound-write negatives,
+  unknown-call escape reads, and a nested-receiver wrong-target negative.
+
+The focused candidate suite is now 89 tests and the universal resolver suite
+remains 166 tests. On the read-only Axios target-adjudication diagnostic, exact
+local target matches improved from 3,047/3,167 to 3,051/3,167 (116 missing,
+0 wrong); members are 388/503 and calls remain 1,544/1,545. The fixture gate
+remains byte-identical with 57 languages, 980 coverage records, 1,565
+invariants, 27 flows, 24 negatives, 25 diagnostics, 28 edge kinds, and 45
+node kinds. This is diagnostic evidence rather than a release precision/recall
+claim. Conditional structural exports, compiler-target truth, release corpora,
+precision/Wilson, framework tiers, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1029,6 +1029,31 @@ framework/compiler tiers, equivalent Graphify/SCIP scope, and the production
 hard cut remain open. The candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, imported callable-member and explicit-generic slice)
+
+Imported call-result evidence now covers one additional source-backed boundary:
+
+- Static or instance-like callable members such as
+  `Factory.make(value).inspect()` carry the call marker on the member segment,
+  then resolve the unique callable member signature before continuing the
+  nominal receiver chain.
+- Explicit generic call arguments are preserved in a bounded `#types<...>`
+  marker. They can prove a generic return even when a value argument is
+  unknown, while conflicting inferred value types and arity mismatches remain
+  unresolved.
+- Multiple imported owners or multiple callable member declarations fail
+  closed before their return contexts are merged, preserving ambiguity rather
+  than collapsing distinct owner paths onto one target.
+
+The slice adds one candidate regression and two cross-file resolver
+regressions; the focused candidate suite is now 72 tests and the universal
+resolver suite is now 154 tests. Conditional/mapped modifier semantics,
+framework/compiler tiers, accepted precision/Wilson gates, equivalent
+Graphify/SCIP scope, imported callable properties, alias escape/eval/proxy
+flow, overload-aware generic substitution beyond bounded source shapes, and
+the production hard cut remain open. The candidate adapter remains absent
+from `UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1770,6 +1770,45 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, source-proven object-spread slice)
+
+The qualification-only ECMAScript emitter now recovers a bounded, source-backed
+object-spread shape without turning JavaScript spread syntax into a name-match
+escape hatch:
+
+- A spread operand is admitted only when it is an immutable local variable whose
+  object literal is spread-free and has static, source-indexed keys. Direct
+  members and methods on the destination retain their own declaration anchors;
+  inherited members resolve through the source declaration without cloning or
+  inventing a second property identity.
+- Multiple spreads and direct properties are evaluated in source order. A later
+  spread wins over an earlier direct member, a later direct member wins over a
+  spread, and duplicate or source-mutated members fail closed. Straight-line
+  reassignment (`let value; value = { ...base }`) uses the same bounded proof.
+- Safe default and TypeScript export-assignment objects now publish their
+  synthetic `default` owner when direct static properties follow the proven
+  spreads. Cross-file default imports can resolve those direct properties;
+  inherited spread properties remain unresolved until a dedicated member-alias
+  contract preserves their original provider identity.
+- Unknown/imported/computed/conditional/mutable/ambiguous spread operands and
+  direct properties before an export spread remain unresolved. Candidate adapter
+  versions advanced to 4 to invalidate qualification-only evidence meaningfully.
+
+The focused candidate suite remains 99 tests and the universal resolver suite
+remains 171 tests. The exact-HEAD fixture qualification at
+`ebb4ebf7bb6016fa9881678c2d64e5c972e518fb` passes with 57 languages, 980
+coverage records, 1,565 invariants, 27 flows, 24 negatives, 25 diagnostics,
+28 edge kinds, 45 node kinds, graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+and clean/warm/rebuild/restored/alternate-checkout byte equality. The read-only
+Axios target differential remains zero-wrong at 3,054/3,167 exact local targets
+(113 missing; 391/503 members; 1,544/1,545 calls; 228 accepted-candidate false
+positives); this per-file diagnostic does not exercise cross-file publication
+and does not claim a recall or leadership increase.
+
+Compiler-source-oracle recall, accepted-sample/Wilson gates, framework tiers,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -2049,6 +2049,30 @@ adapter remains qualification-only and unregistered; compiler differential,
 framework-contract, competitor, production hard-cut, and leadership gates
 remain open.
 
+### Execution checkpoint (2026-08-07, resource-management and decorator-oracle slice)
+
+The syntax/evidence path now covers two modern TypeScript quality seams that
+were previously easy to lose during qualification:
+
+- TypeScript 5.2 explicit resource declarations (`using` and `await using`)
+  are represented by the pinned tree-sitter grammar as assignment expressions.
+  The candidate now materializes their binding patterns as immutable,
+  source-anchored variable declarations, so initializer calls, later member
+  accesses, flow facts, and references retain the same identity as ordinary
+  lexical bindings. Malformed or non-statement contextual uses are not
+  promoted into declarations.
+- The independent TypeScript 5.9.3 source oracle now emits `decorates`
+  constructs for direct and member decorator factories, suppresses the outer
+  factory invocation from its ordinary `calls` inventory, and still records
+  calls nested inside decorator arguments. Resource declarations and their
+  initializer calls are covered by the same oracle tests.
+
+The candidate test suite is now 108 tests and the resolver suite remains 180;
+focused oracle correctness tests pass. This is still a qualification-only
+slice: the universal adapter is unregistered, the legacy/native hard cut is
+open, and compiler-differential, framework, competitor, release-corpus, and
+leadership gates remain required.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1110,7 +1110,7 @@ semantics, richer overload-aware generic substitution, alias escape/eval/proxy
 flow, framework/compiler tiers, accepted precision/Wilson gates, equivalent
 Graphify/SCIP scope, and the production hard cut remain open. The candidate
 adapter remains absent from `UNIVERSAL_ADAPTERS`. Fixture qualification stays
-byte-stable at Compass revision `1d8d5233b702559d8ae01c278473dc5459f8b48c`,
+byte-stable at Compass revision `24f937360cc80d6b62b633f2fdd2a367eb6529c3`,
 with 57 languages, 980 coverage records, 1,565 invariants, 27 flows, and
 graph digest `sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`.
 

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1244,6 +1244,34 @@ scope/declaration inventories, broader conditional/keyof semantics, framework
 tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
 production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, bounded literal indexed-access slice)
+
+The qualification-only TypeScript candidate and resolver now follow a bounded
+literal indexed-access type alias when the source proves a unique nominal
+property:
+
+- Local aliases such as `type Nested = Item["nested"]` preserve the selected
+  member's declaration identity and let downstream calls resolve to the exact
+  source method. Imported generic aliases such as `NestedOf<T> = T["nested"]`
+  substitute an explicit cross-file nominal argument and resolve the selected
+  member through the project export index.
+- Computed keys, dynamic generic keys, union projections with competing owners,
+  duplicate members, imported candidate-side projections, and unsupported
+  structural shapes remain unresolved. Numeric access continues through the
+  existing bounded array/tuple path; the new object projection accepts only
+  quoted string keys.
+- Type substitution is bounded to the existing type-shape limit and preserves
+  the original indexed suffix, so generic aliases cannot silently widen into a
+  terminal-name match. Candidate and resolver evidence retain existing source
+  anchors, direction, multiplicity, and deterministic ordering.
+
+The focused TypeScript candidate suite is now 83 tests and the universal
+resolver suite is now 162 tests. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`. Broader `keyof`/mapped/indexed evaluation, distributive
+conditional semantics, project-manifest corpora, compiler-backed scope and
+declaration inventories, framework tiers, accepted precision/Wilson gates,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1634,6 +1634,27 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, primitive structural member-write slice)
+
+The candidate now preserves the declared property identity for a narrow,
+source-proven primitive write on a stable spread-free structural object, such as
+`state.flag = true`. This is intentionally narrower than general mutation:
+callable- or object-valued replacements, aliases, calls, spreads, dynamic and
+compound writes, and conditional/ambiguous flow remain behind the existing
+fail-closed barriers. The regression exercises both the exact `response.request`
+read and the exact `internals.isCaptured` literal write found in real Axios
+shapes.
+
+The focused candidate suite is now 95 tests and the universal resolver suite
+remains 168 tests. On the pinned Axios checker diagnostic at the same corpus
+realization, exact local target matches improved to 3,053/3,167 (114 missing,
+0 wrong; 390/503 member matches and 1,544/1,545 call matches). This is
+diagnostic evidence only, not a release precision or leadership claim.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1319,10 +1319,56 @@ record-oriented JSONL mode used by the Python audit inventory:
   its source inventory.
 
 The source oracle is still source-occurrence evidence rather than target truth.
-The final scope/declaration/call JSONL contract, compiler-backed target
-adjudication, four release corpora, accepted precision/Wilson gates, framework
-tiers, equivalent Graphify/SCIP scope, and the production hard cut remain
-open.
+Compiler-backed target adjudication, four release corpora, accepted
+precision/Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and
+the production hard cut remain open.
+
+### Execution checkpoint (2026-08-07, typed source-oracle fact stream)
+
+The JSONL source-oracle contract now publishes bounded typed records in
+addition to the compatibility construct inventory:
+
+- `scope` records carry deterministic source-local IDs, lexical kind, exact
+  UTF-8 range, owner identity, and a validated parent scope. Duplicate IDs,
+  missing parents, path escapes, and range overflow fail closed.
+- `declaration` records carry source-backed kind/name/qualified identity,
+  explicit value/type/namespace space, exact name range, and bounded callable
+  parameter metadata (total/minimum/rest). Non-callable declarations use an
+  explicit null parameter shape rather than implying a callable signature.
+- `call` records carry the exact callee anchor plus full call-expression range,
+  direct/member/computed/dynamic target kind, owner, relation, argument count,
+  spread and optional-call flags. The range validator proves that the callee
+  lies inside the full call expression and inside its source file.
+- Header/footer counts cover every typed record under
+  `compass.typescript-source-oracle-jsonl/2`; repeated output is byte-identical,
+  and the Python audit reconstructs the legacy inventory only after validating
+  the typed stream.
+
+This closes the source-oracle scope/declaration/call stream contract, but not
+target adjudication or semantic quality: compiler-backed target truth, four
+release corpora, accepted precision/Wilson gates, framework tiers, equivalent
+Graphify/SCIP scope, and the production hard cut remain open.
+
+### Execution checkpoint (2026-08-07, imported literal utility projections)
+
+The shared TypeScript resolver now carries source-proven literal `Pick`/`Omit`
+projections through imported type aliases:
+
+- A simple member path rooted at a type alias now enters the bounded alias-chain
+  resolver, so non-generic aliases such as `Picked = Pick<Item, "enabled">`
+  are expanded instead of being treated as terminal external owners.
+- Literal key sets, including bounded unions of string/quoted-template keys,
+  select only the projected member. `Pick` excludes unlisted members and `Omit`
+  excludes listed members; every surviving target keeps the normal
+  `member-binding`/source provenance path.
+- Imported bases and re-exported aliases remain source-inventory bounded.
+  Dynamic, structural, competing, and unsupported key spaces do not enter this
+  branch and remain unresolved rather than widening to a nominal base.
+
+The universal resolver suite is now 164 tests, including positive and negative
+cross-file `Pick`/`Omit` projection calls. This is still below the full
+value-space `keyof`, arbitrary mapped/indexed, compiler-target, corpus,
+precision/Wilson, framework, comparator, and production-hard-cut gates.
 
 ## Outcome
 

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -743,6 +743,34 @@ mapped/indexed shapes, framework tiers, compiler differential recall, and the
 accepted precision/leadership scorecard remain open. The candidate adapter is
 still not registered in `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, project-resolver handoff slice)
+
+The qualification-only TypeScript/JavaScript universal path now consumes the
+same bounded project decisions that Compass already applies to its shared
+resolver. Before universal evidence is materialized, the resolver retains a
+read-only buffer of admitted `imports_from` decisions and applies the existing
+project rules for `compilerOptions.paths`, `baseUrl`, `rootDirs`, package
+`exports`/`imports`, `typesVersions`, workspace packages, and importer-aware
+conditions. The universal index receives only those exact target files, keyed
+by normalized importer plus the raw module specifier; target module keys are
+bounded and duplicate realizations remain ambiguous rather than being guessed.
+
+Universal construction/import edges that use this handoff publish the explicit
+`project-module-binding` rule, while member calls retain `member-binding` and
+the original source occurrence/provenance. No terminal-name matching,
+unbounded filesystem search, Graphify runtime, compiler runtime, or network
+dependency was added. The shared-resolution regression proves a `paths` alias
+from `app/consumer.ts` to `src/api.ts` reaches both `Widget` construction and
+`Widget.run()` with exact source-backed targets. The owned and borrowed merge
+paths both pass the same project-edge handoff.
+
+This closes the first universal/project-module integration gap, not the Plan
+013 release gate. Declaration merging, generic instantiation, mapped/indexed
+shapes, framework/compiler strata, hand-labeled precision and recall, and the
+production hard cut remain open. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS` until those gates and the exact-release qualification
+complete.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1678,6 +1678,30 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, stable callable object assignments)
+
+Stable, spread-free structural objects now retain an exact source-backed member
+when a member assignment itself introduces a callable value, for example
+`validators.run = function run() {}` or `validators.check = (value) => value`.
+The recovery is declaration-anchored and requires a unique property declaration
+for the receiver-qualified name; non-callable writes, later overwrites, dynamic
+keys, spreads, aliases with unknown mutation, and ambiguous declarations remain
+behind the ordinary fail-closed mutation barrier. This keeps the positive path
+useful for callable registries without turning arbitrary property writes into
+guessed targets.
+
+The focused candidate suite is now 96 tests and the universal resolver suite
+remains 168 tests. The exact pinned Axios checker differential remains at
+3,054/3,167 expected local targets (113 missing, 0 wrong; 391/503 member
+matches and 1,544/1,545 call matches, with 226 false positives in the accepted
+local candidate set). The slice therefore adds covered source shapes and
+regression evidence without claiming a corpus recall increase; the Axios
+validator's earlier dynamic-key mutation correctly remains conservative.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1441,6 +1441,30 @@ interprocedural flow, conditional structural exports, compiler-target truth,
 release corpora, precision/Wilson, framework tiers, equivalent Graphify/SCIP
 scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, property-scoped immutable receiver flow)
+
+The JavaScript flow path now distinguishes receiver identity from property
+mutation for source-proven immutable aliases:
+
+- `const` aliases to nominal receivers and exact object-literal receivers can
+  cross a closure without widening to unresolved solely because an unrelated
+  property is written.
+- Member writes are tracked by `(binding, property)` under the existing
+  bounded limit. A write to `token._listeners` does not erase a proven
+  `token.subscribe` receiver, while `token.subscribe = replacement` remains a
+  fail-closed barrier. Dynamic keys, mutable aliases, calls/returns, and other
+  unsupported escapes retain the conservative whole-binding barrier.
+- Candidate regressions cover both class `this` aliases and structural object
+  aliases; the existing mutable and overwrite negatives remain unresolved.
+
+On the read-only Axios target-adjudication diagnostic, exact local target
+matches improved from 3,023/3,167 to 3,045/3,167 (122 missing, 0 wrong). The
+member stratum is 382/503 and the call stratum is 1,544/1,545. This remains
+diagnostic evidence rather than a release precision/recall claim. Conditional
+structural exports, compiler-target truth, release corpora, precision/Wilson,
+framework tiers, equivalent Graphify/SCIP scope, and the production hard cut
+remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -872,6 +872,30 @@ recall, project-corpus qualification, and the production hard cut remain
 open. The candidate adapter remains absent from `UNIVERSAL_ADAPTERS` until the
 mandatory quality and exact-release qualification gates complete.
 
+### Execution checkpoint (2026-08-06, bounded local reassignment slice)
+
+The qualification-only ECMAScript candidate now carries a small, explicit
+flow-sensitive receiver fact set for local TypeScript and JavaScript variables:
+
+- A source-proven constructor or typed call result assigned in the variable's
+  binding scope is recorded with its exact source order. A later member use
+  selects the latest preceding fact, so a straight-line `new First()` followed
+  by `current = new Second(); current.run()` targets only `Second.run`.
+- The same rule works inside a function body and across the universal resolver
+  publication path. The source fact keeps imported/local receiver identity and
+  does not reopen terminal-name matching.
+- Branch/loop/try/with assignments, compound assignments, and unsupported
+  values create a bounded barrier. Older receiver facts cannot leak across the
+  barrier, so ambiguous or dynamically reassigned values remain unresolved.
+
+The slice adds TypeScript and JavaScript positive regressions, use-site ordering,
+branch/unknown/compound negative cases, and a resolver-level exact-target
+assertion. The TypeScript/JavaScript candidate suite is now 52 tests and the
+universal resolver suite is now 147 tests. Alias escape, `eval`, proxy/dynamic
+property mutation, interprocedural flow, and compiler differential recall remain
+open Phase 4 work; the candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release gates pass.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1999,6 +1999,32 @@ languages, 980 coverage records, 1,565 invariants, 27 flows, 24 negatives,
 warm, rebuild, restored, alternate-checkout, and source-unchanged outputs.
 This is an interop correctness increment, not a production or leadership claim.
 
+### Execution checkpoint (2026-08-07, bounded tagged-template call evidence)
+
+The TypeScript/JavaScript candidate extractor now models tagged templates as
+calls instead of treating the template body as an ordinary argument list:
+
+- ``tag`text ${value}`` emits a `tagged_template` occurrence with a bounded
+  semantic call shape: one synthetic, intentionally unknown
+  `TemplateStringsArray` position followed by one argument position per
+  substitution. Literal substitution types (`string`, `number`, `boolean`,
+  `null`, `array`, `object`, and `function`) remain source-proven; dynamic
+  expressions remain explicit unknowns.
+- Member tags such as ``namespace.tag`...``` retain a `tagged_member`
+  context, exact member anchors, and the same synthetic-array/substitution
+  arity. Dynamic tag expressions keep their occurrence but no invented target.
+- The shared resolver consumes the tagged-template arity and type vector for
+  direct, named-import, and namespace-member tags. A source signature that
+  cannot accept the number or type of substitutions remains unresolved rather
+  than being selected by spelling alone.
+- Extraction is bounded by the existing inline-property limit, so a malformed
+  or oversized template cannot create an unbounded argument vector.
+
+Candidate and resolver coverage now stand at 105 and 179 focused tests. This
+remains qualification-only; the adapter is still not registered in
+`UNIVERSAL_ADAPTERS`, and compiler differential, framework, competitor, and
+production hard-cut gates remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1954,6 +1954,25 @@ coverage records, 1,565 invariants, 27 flows, 24 negatives, 25 diagnostics,
 warm, rebuild, restored, alternate-checkout, and source-unchanged outputs.
 This is an interop correctness increment, not a release leadership claim.
 
+### Execution checkpoint (2026-08-07, bounded CommonJS `defineProperty` exports)
+
+The CommonJS bridge now recognizes source-proven transpiler output of the form
+`Object.defineProperty(exports, "name", { value: local })` and a bounded getter
+variant whose function/arrow body returns a source-visible value. Static string
+and numeric keys become exact named reexports anchored at the key; imported
+values and member expressions retain their normal source/module identity. The
+`__esModule` marker, identifier/computed keys, dynamic values, dynamic getters,
+shadowed `Object`/`exports`/`module`, and unsupported descriptor shapes remain
+ordinary calls without fabricated export edges.
+
+Regression coverage now includes direct value exports, imported getter exports,
+the `__esModule` marker, dynamic keys/values, and shadowed globals, plus a
+cross-file `require()` consumer that resolves the exact value and getter
+targets while leaving an unknown export unresolved. The focused suites are
+103 candidate tests and 177 universal resolver tests. This remains a
+qualification-only correctness slice; the production adapter is still not
+registered and no release-leadership claim is implied.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1272,6 +1272,34 @@ conditional semantics, project-manifest corpora, compiler-backed scope and
 declaration inventories, framework tiers, accepted precision/Wilson gates,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, bounded generic indexed and `keyof` identity slice)
+
+The qualification-only TypeScript candidate and resolver now preserve two
+additional source-proven type shapes:
+
+- Generic aliases such as `NestedOf<T> = T["nested"]` substitute the explicit
+  nominal argument before indexed-member lookup in both same-file candidate
+  evidence and cross-file resolver evidence. The indexed suffix is preserved
+  under the existing shape bound, so arbitrary computed keys still fail closed.
+- `Pick<Base, keyof Base>` is recognized as a local identity projection, and
+  the imported generic form follows the same identity through the project
+  export index. `Omit<Base, keyof Base>` remains empty for member lookup. A
+  literal or competing/structural key space is not widened by this slice;
+  duplicate owners, imported candidate-side projections, and ambiguous unions
+  remain unresolved.
+- The normalized type-shape encoding keeps a separator after the `keyof`
+  keyword, preventing a compact `keyofT` representation from being confused
+  with an ordinary identifier. The parser still treats identifiers such as
+  `keyofItem` as ordinary names.
+
+The focused TypeScript candidate suite is now 86 tests and the universal
+resolver suite is now 162 tests. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`. Full `keyof` value-space evaluation, arbitrary
+mapped/indexed projections, distributive conditional semantics,
+project-manifest corpora, compiler-backed scope and declaration inventories,
+framework tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP
+scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1397,6 +1397,29 @@ cross-file `Pick`/`Omit` projection calls. This is still below the full
 value-space `keyof`, arbitrary mapped/indexed, compiler-target, corpus,
 precision/Wilson, framework, comparator, and production-hard-cut gates.
 
+### Execution checkpoint (2026-08-07, bounded inline structural index receivers)
+
+The native TypeScript/JavaScript candidate path now carries one additional
+source-proven structural shape across dynamic member access:
+
+- Inline index signatures on parameters, variables, and properties cache their
+  bounded value type (`{ [key: string]: Item }`) at the binding identity, so a
+  dynamic `shape[key].inspect()` can resolve to `Item` only when that value type
+  resolves to one source-backed nominal owner.
+- Imported interface and type-alias index signatures retain their existing
+  declaration-signature path; a regression fixture proves both forms resolve
+  the same cross-file member target with `member-binding` provenance.
+- Primitive, ambiguous, mapped, malformed, oversized, and otherwise
+  source-unproven value shapes remain unresolved. No terminal-name fallback or
+  arbitrary structural member selection is added.
+
+The universal resolver suite is now 166 tests, including the inline structural
+positive/negative case and the imported structural type-alias regression. This
+closes only the bounded inline index-receiver slice; broader arbitrary
+structural/mapped/indexed semantics, compiler-target truth, release corpora,
+precision/Wilson, framework tiers, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1973,6 +1973,32 @@ targets while leaving an unknown export unresolved. The focused suites are
 qualification-only correctness slice; the production adapter is still not
 registered and no release-leadership claim is implied.
 
+### Execution checkpoint (2026-08-07, bounded CommonJS `__exportStar` barrels)
+
+The CommonJS bridge now recognizes the source-proven barrel form
+`__exportStar(require("./source"), exports)` and the equivalent
+`tslib.__exportStar` call. A helper is admitted only when its local declaration
+contains the bounded TypeScript/Babel export-star guard shape or its binding
+comes from `tslib`; the require argument must be a static string and the
+destination must be the unshadowed `exports` or `module.exports` object. The
+adapter emits a source-range-backed `Member("*")` owner alias rather than
+inventing one binding per unknown property.
+
+The shared resolver projects both named imports/destructured `require()`
+bindings and namespace member accesses through that alias. Direct destination
+exports retain precedence; private source declarations, dynamic require
+arguments, wrong destinations, lookalike helpers, and unresolved source
+members remain unresolved. Candidate and resolver coverage now includes local
+and `tslib` helpers plus all negative forms; the focused suites are 104
+candidate tests and 178 universal resolver tests. Exact fixture qualification
+remains unchanged because the adapter is still qualification-only: 57
+languages, 980 coverage records, 1,565 invariants, 27 flows, 24 negatives,
+25 diagnostics, 28 edge kinds, 45 node kinds, graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+82 exact and 11 unresolved route resolutions, and byte-equivalent clean,
+warm, rebuild, restored, alternate-checkout, and source-unchanged outputs.
+This is an interop correctness increment, not a production or leadership claim.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1751,6 +1751,25 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, TypeScript export assignment)
+
+TypeScript `export = value` statements now publish a source-backed `default`
+reexport for local callable/value targets, including spread-free object
+assignment expressions whose members remain under `<module>.default`. Existing
+`import = require` bindings can therefore resolve direct callable assignments
+and exact object members, while ordinary default imports resolve the same
+provider declaration. Unsupported or ambiguous expressions remain unresolved.
+
+The focused candidate suite is now 99 tests and the universal resolver suite is
+now 171 tests. Regressions cover callable `export =` with both import-equals and
+default-import consumers, plus object-assignment member ownership. The native
+production registry remains unchanged; this is still a qualification-only
+universal path.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -2025,6 +2025,30 @@ remains qualification-only; the adapter is still not registered in
 `UNIVERSAL_ADAPTERS`, and compiler differential, framework, competitor, and
 production hard-cut gates remain open.
 
+### Execution checkpoint (2026-08-07, bounded decorator-factory evidence)
+
+Decorator syntax now has a first-class, source-backed candidate path instead
+of relying on the nested call traversal:
+
+- Direct decorators (`@Injectable`, `@Controller(...)`, and local decorator
+  factories) emit `Decorates` candidates with the exact decorator anchor,
+  `decorator` context, bounded argument count, and literal argument types.
+- Namespace/member decorators (`@decorators.Controller(...)`) use the same
+  nominal member resolver as calls and members, retaining the property anchor,
+  namespace binding, `decorator_member` context, and exact imported target.
+- Dynamic or computed decorator expressions preserve a targetless
+  `Decorates` occurrence with its source spelling and call shape. A nested
+  call in decorator arguments remains an ordinary call; the outer decorator
+  factory is not duplicated as a generic `Calls` edge.
+- Local, named-import, and namespace-import decorator factories now resolve
+  cross-file through the shared resolver. Overload/arity/type mismatches and
+  ambiguous members remain unresolved rather than being selected by spelling.
+
+Candidate and resolver coverage now stand at 107 and 180 focused tests. The
+adapter remains qualification-only and unregistered; compiler differential,
+framework-contract, competitor, production hard-cut, and leadership gates
+remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1190,6 +1190,31 @@ bounded utility/union rules, richer interprocedural flow, framework/compiler
 tiers, accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
 production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, bounded conditional and mapped-modifier receivers)
+
+The qualification-only TypeScript candidate now evaluates a narrow,
+source-proven subset of conditional and mapped receiver types:
+
+- Generic aliases of the form `T extends U ? A : B` substitute bounded concrete
+  type arguments before branch selection. A branch is selected only when one
+  local nominal owner proves the `extends` relation (or a local nominal type
+  proves the bounded `object`/`unknown` check). Distributed unions, `any`,
+  unresolved structural checks, nested conditionals, and unsupported branches
+  remain unresolved.
+- Homomorphic mapped aliases with `+/-readonly` and `+/-?` modifiers preserve
+  their source nominal owner for member lookup. Key remapping, extra structural
+  members, nested mapped shapes, and other unsupported transformations remain
+  fail-closed.
+- Conditional parsing is bounded and quote/depth-aware; source ranges,
+  occurrence multiplicity, and published declaration identities are unchanged.
+
+The focused candidate suite is now 81 tests and the universal resolver suite
+remains 159 tests. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`. Broader distributive conditional semantics, indexed/keyof
+evaluation, richer interprocedural flow, framework/compiler tiers,
+accepted precision/Wilson gates, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -924,6 +924,32 @@ framework tiers, compiler differential recall, and the production hard cut
 remain open. The candidate adapter stays out of `UNIVERSAL_ADAPTERS` until the
 mandatory precision, determinism, qualification, and exact-release gates pass.
 
+### Execution checkpoint (2026-08-06, bounded sequence-index slice)
+
+The qualification-only TypeScript/JavaScript path now carries source-proven
+element receivers through common array and tuple indexing:
+
+- Postfix arrays (Item[]), Array<Item>, and ReadonlyArray<Item> preserve
+  the nominal element receiver for literal or dynamic homogeneous indexes.
+  Generic properties such as Box<T>.values: T[] substitute the concrete
+  Box<Item> argument before resolving values[0].inspect().
+- Fixed tuples preserve a literal numeric element ([Item, string][0]) and
+  generic tuple properties substitute the owner argument before selection.
+  Out-of-range, optional/rest, and dynamic tuple indexes fail closed rather
+  than selecting a union member by position.
+- Imported chains retain a bounded values[0]/pair[0] path marker for the
+  shared resolver. The resolver distinguishes genuine index-signature metadata
+  from generic interface signatures, expands indexed intermediate properties,
+  and keeps exact member-binding provenance for all three imported array/
+  tuple calls in the regression fixture.
+
+The slice adds six direct candidate regressions and one cross-file resolver
+regression; the focused candidate suite is now 62 tests and the universal
+resolver suite is now 149 tests. Arbitrary structural indexed access,
+conditional/mapped modifier semantics, alias escape, dynamic mutation,
+framework tiers, compiler differential recall, and the production hard cut
+remain open. The candidate adapter remains absent from UNIVERSAL_ADAPTERS.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1809,6 +1809,42 @@ and does not claim a recall or leadership increase.
 Compiler-source-oracle recall, accepted-sample/Wilson gates, framework tiers,
 equivalent Graphify/SCIP scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, cross-file object-spread owner aliases)
+
+The qualification-only ECMAScript path now preserves inherited members of a
+safe default/export-assignment object across module boundaries. Each accepted
+synthetic object export owns an `object` scope and emits a source-range-backed
+`Member("*")` owner alias for its proven spread sources. The marker is an
+owner relationship, not a wildcard export: the shared resolver follows it only
+when the source resolves to a bounded object owner, then selects the source
+member declaration without cloning it. Direct destination properties remain
+the first lookup and therefore override inherited properties exactly when they
+follow the spread.
+
+Imported default spreads are admitted at the candidate boundary only as a
+qualified source marker; resolver validation rejects missing, non-object,
+ambiguous, cyclic, or otherwise incomplete source owners. Multiple source
+owners that produce competing declarations remain unresolved. Local source
+write barriers and the existing source-order/escape checks remain fail-closed.
+This closes the previous cross-file gap for cases such as
+`import base from "./base"; export default { ...base, direct };` while keeping
+unknown dynamic spreads opaque. The resolver also keeps this owner contract
+language-family aware, so a TypeScript provider and JavaScript consumer (or
+the reverse) still require the same exact source proof.
+
+The focused candidate suite remains 99 tests and the universal resolver suite
+is now 172 tests. New regressions cover local and imported owner markers,
+cross-file inherited member publication, direct-property precedence, competing
+spread sources, and spreading a non-object default. Candidate adapter versions
+advanced to 5 so the qualification-only evidence cache cannot reuse the prior
+owner-less spread realization.
+
+The exact-HEAD fixture qualification and the read-only Axios differential need
+to be rerun at the implementation head before this checkpoint is treated as a
+measured release baseline. Compiler-source-oracle recall, accepted-sample/
+Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and the
+production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1543,6 +1543,31 @@ claim. Conditional structural exports, compiler-target truth, release corpora,
 precision/Wilson, framework tiers, equivalent Graphify/SCIP scope, and the
 production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, CommonJS object-export bridge)
+
+The universal TypeScript/JavaScript candidate now publishes bounded CommonJS
+object-export evidence:
+
+- `module.exports = { ... }` emits a source-backed default module reexport and
+  exact named reexports for spread-free object properties. Shorthand/value
+  properties retain the local declaration target; methods and literal
+  properties retain their exact object-property declaration.
+- Computed/dynamic keys and object spreads do not create guessed named
+  bindings. The default module fact remains available, while incomplete
+  property sets stay unresolved rather than widening to every visible name.
+- Cross-file resolver coverage proves named `require()` bindings reach the
+  exact exported function and method declarations. The candidate suite is now
+  90 tests and the universal resolver suite 167 tests.
+- Fixture qualification remains byte-identical (57 languages, 980 records,
+  1,565 invariants, 27 flows, 24 negatives, 25 diagnostics, 28 edge kinds,
+  and 45 node kinds). The Axios checker diagnostic remains 3,051/3,167 exact
+  local targets, 116 missing, and 0 wrong; this bridge is project-level
+  reexport evidence and is intentionally not presented as same-file recall.
+
+Conditional structural exports beyond the bounded spread-free form,
+compiler-target truth, release corpora, precision/Wilson, framework tiers,
+equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -846,6 +846,32 @@ hard cut remain open. The candidate adapter remains absent from
 `UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release
 qualification gates complete.
 
+### Execution checkpoint (2026-08-06, generic alias and indexed-member slice)
+
+The shared TypeScript/JavaScript resolver now follows two additional
+source-backed declaration shapes without widening terminal-name matching:
+
+- Generic type aliases retain a bounded alias target shape (for example,
+  `Alias<T> = Box<T>`). Alias parameters are substituted recursively, imported
+  aliases are resolved through the alias module's exact import binding, and
+  alias cycles or unsupported targets remain unresolved.
+- Interface/type-alias index signatures publish a compact value-type shape.
+  Imported receivers preserve an indexed marker (`Shape<Item>[].inspect`) so
+  the resolver can select the unique source-backed value type for
+  `shape[key].inspect()`; generic `Shape<T>` index values carry the concrete
+  `T` context through the access.
+
+The slice adds positive regressions for an object alias, an alias to an
+imported generic nominal, ordinary and generic imported index signatures, plus
+ambiguity and primitive negative cases. The universal resolver suite is now
+146 tests and the TypeScript candidate suite remains 44 tests. The behavior is
+bounded by the existing member/export candidate limits and type-shape byte and
+depth limits; mapped/conditional/indexed access beyond a direct index value,
+overload-dependent substitutions, framework tiers, compiler differential
+recall, project-corpus qualification, and the production hard cut remain
+open. The candidate adapter remains absent from `UNIVERSAL_ADAPTERS` until the
+mandatory quality and exact-release qualification gates complete.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1492,6 +1492,31 @@ precision/recall claim. Conditional structural exports, compiler-target truth,
 release corpora, precision/Wilson, framework tiers, equivalent Graphify/SCIP
 scope, and the production hard cut remain open.
 
+### Execution checkpoint (2026-08-07, chained inline structural assignments)
+
+The same source-qualified inline receiver slice now accepts a bounded chain of
+plain assignments when every link ends in one spread-free object literal:
+
+- `const state = (this[key] = this[key] = { inspect() {} })` keeps the local
+  declaration as the structural identity, so nested assignment syntax does not
+  collapse separate objects or force a spelling-based receiver guess.
+- Compound links, dynamic/non-declarator assignments, object spreads, queried
+  overwrites, mutable aliases, and unsupported escapes remain unresolved or
+  fail closed. The chain is depth-bounded and checks each operator directly
+  from source bytes.
+- A regression covers the positive chained receiver and a compound-assignment
+  negative. The fixture qualification gate remains byte-identical (57
+  languages, 980 coverage records, 1,565 invariants, 27 flows, 24 negatives,
+  25 diagnostics, 28 edge kinds, and 45 node kinds).
+
+The focused candidate suite remains 88 tests and the universal resolver suite
+remains 166 tests. On the read-only Axios target-adjudication diagnostic, exact
+local target matches improved from 3,046/3,167 to 3,047/3,167 (120 missing,
+0 wrong); members are 384/503 and calls remain 1,544/1,545. This is diagnostic
+evidence rather than a release precision/recall claim. Conditional structural
+exports, compiler-target truth, release corpora, precision/Wilson, framework
+tiers, equivalent Graphify/SCIP scope, and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -950,6 +950,32 @@ conditional/mapped modifier semantics, alias escape, dynamic mutation,
 framework tiers, compiler differential recall, and the production hard cut
 remain open. The candidate adapter remains absent from UNIVERSAL_ADAPTERS.
 
+### Execution checkpoint (2026-08-06, bounded generic callable-return slice)
+
+The qualification-only TypeScript/JavaScript path now preserves a
+source-proven generic callable's returned receiver when the call arguments
+uniquely determine its type parameters:
+
+- Direct `T` returns infer from typed or constructor arguments, and explicit
+  call-site arguments such as `identity<Item>(...)` are canonicalized through
+  the existing local type identity rules.
+- Inference recurses through matching postfix arrays and generic containers,
+  so `collect(new Item())[0].inspect()` and
+  `box(new Item()).value.inspect()` retain the exact `Item.inspect` target.
+  Array and tuple return shapes remain bounded by the existing type-shape
+  limits.
+- Missing inference and conflicting arguments fail closed. Contextual
+  overload inference, conditional/structural assignability, imported
+  callable return shapes, and dynamic `eval`/proxy mutation are not treated
+  as proven receivers.
+
+The slice adds five direct candidate regressions and one resolver regression;
+the focused candidate suite is now 67 tests and the universal resolver suite
+is now 150 tests. The production candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS`; accepted precision/Wilson gates, cross-file callable
+return evidence, framework/compiler tiers, equivalent Graphify/SCIP scope,
+and the production hard cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1594,6 +1594,15 @@ were previously conflated:
   change. Focused coverage is now 91 candidate tests and 168 universal
   resolver tests, including aliased named requires, namespace member calls,
   callable CommonJS defaults, and dynamic/nested negative patterns.
+- At exact HEAD `46fbbbb71f59c72b07e7c4d6c6c9e704cbb301dc`, the fixture-only
+  qualification passes with the existing 57-language/980-record/1,565-
+  invariant contract, graph digest
+  `sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+  and clean/warm/rebuild/restored/alternate-checkout byte equality. The
+  ignored Axios checker differential remains zero-wrong at 3,051/3,167 exact
+  local targets (116 missing; 226 false positives in the accepted local
+  candidate set); the remaining misses are same-file structural-flow cases,
+  not CommonJS export-slot failures.
 
 Fixture qualification, compiler-source-oracle recall, release-corpus
 precision/Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -796,6 +796,35 @@ differential recall, and the production hard cut remain open. The candidate
 adapter remains absent from `UNIVERSAL_ADAPTERS` until the mandatory quality
 and exact-release qualification gates complete.
 
+### Execution checkpoint (2026-08-06, bounded generic member-chain slice)
+
+The candidate adapter now publishes a bounded declaration-shape fragment in
+the existing `DeclarationFact.signature` field: generic class/interface
+parameter order and direct property nominal types. Imported generic receiver
+arguments are canonicalized to their proven module-qualified identities and
+remain attached to member constraints (for example,
+`Box<../lib/item::Item>.item.inspect`). This preserves the existing evidence
+schema and avoids turning a terminal member spelling into an authoritative
+target.
+
+The shared resolver follows a generic member-value chain only when every hop
+is source-backed and unique: it resolves the imported `Box`, substitutes the
+explicit `Item` argument for the property type parameter `T`, resolves the
+admitted `Item` module, and finally selects the exact `inspect` declaration.
+Ambiguous declarations, missing property type shapes, structural/complex
+types, and unsupported generic forms remain unresolved or follow the existing
+explicit external policy. A cross-module `Box<Item>` regression now proves
+the final call and member access target the exact `Item.inspect` node with
+`member-binding`; the full 137-test universal resolver suite and 44-test
+TypeScript candidate suite pass.
+
+This is a bounded generic propagation slice, not compiler-equivalent
+TypeScript. Nested mapped/conditional/indexed types, overload-aware generic
+substitution, framework tiers, compiler differential recall, and the
+production hard cut remain open. The candidate adapter remains absent from
+`UNIVERSAL_ADAPTERS` until the mandatory quality and exact-release
+qualification gates complete.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -2073,6 +2073,25 @@ slice: the universal adapter is unregistered, the legacy/native hard cut is
 open, and compiler-differential, framework, competitor, release-corpus, and
 leadership gates remain required.
 
+### Execution checkpoint (2026-08-07, JSX value/spread/child reference slice)
+
+JSX tags were already represented as component references, but prop values and
+spread expressions could disappear unless they happened to be proven callable.
+The candidate now walks pinned tree-sitter `jsx_expression` nodes and emits
+source-anchored value references for attribute values, spread attributes, and
+child expressions. It resolves unique local/import bindings, preserves
+targetless occurrences for unresolved values, retains callback arguments and
+receiver objects, and excludes prop names, member-property names, declaration
+patterns, and call callees. This keeps JSX value use evidence separate from
+`Calls` and avoids fabricating indirect calls.
+
+The independent TypeScript 5.9.3 source oracle now records matching
+`jsx_values` constructs and typed `jsx_value`, `jsx_spread`, and `jsx_child`
+references. The Python audit schema and ignored differential harness accept
+the new capability. Candidate and focused oracle coverage now stand at 109 and
+the resolver suite remains 180; broad corpus, target-adjudication, framework,
+competitor, production hard-cut, and leadership gates remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1894,6 +1894,38 @@ gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open. This is an interop correctness slice, not a best-in-class
 release claim.
 
+### Execution checkpoint (2026-08-07, namespace and require spread owners)
+
+The CommonJS/ESM spread path now admits a second source-proven namespace shape:
+`import * as ns` and a static `const ns = require("...")` binding can be spread
+into an object export when the binding is source-anchored to a module owner.
+The candidate publishes the same bounded `Member("*")` owner marker used by
+default-object spreads. The resolver maps the source file to its canonical
+module keys, follows only published export slots, and keeps direct destination
+properties ahead of inherited ones.
+
+This also closes a precision hole exposed while adding the namespace path:
+private module-scope declarations are no longer treated as namespace members
+merely because they share a spelling. Explicit ESM reexports and CommonJS
+object-property reexports remain eligible; private ESM/CJS helpers resolve as
+unresolved through a spread namespace. Dynamic/indirect require values,
+computed spreads, and unsupported source shapes remain opaque. Regression
+coverage now includes ESM namespace and static-require spreads, published
+export positives, private-name negatives, and the existing ambiguity,
+non-object, and direct-override cases.
+
+The focused suites are now 101 candidate tests and 175 universal resolver
+tests. Exact-head fixture qualification at
+`912f01c23e6103783640289f6fd1a3b4bb22bfe5` passes with the unchanged
+57-language/980-record/1,565-invariant contract, 27 flows, 24 negatives, 25
+diagnostics, 28 edge kinds, and 45 node kinds. The graph digest remains
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+with 82 exact and 11 unresolved route resolutions; clean, warm, rebuild,
+restored, alternate-checkout, and source-fixture byte comparisons all pass.
+The unchanged digest is expected because the qualification-only adapter is not
+registered in production. This remains correctness evidence, not a leadership
+claim.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1084,6 +1084,36 @@ proxy flow, overload-aware generic substitution beyond bounded source shapes,
 and the production hard cut remain open. The candidate adapter remains absent
 from `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, bounded imported-overload selection slice)
+
+The resolver now uses source-published callable parameter shapes to select a
+unique imported TypeScript/JavaScript overload when the call site carries an
+exact, bounded argument shape:
+
+- Direct imported functions, static members, and callable member chains can
+  match fixed parameters, imported type aliases, bounded array/generic
+  containers, and explicit generic arguments. Relative module-qualified types
+  are normalized against the declaration's source module before comparison.
+- Duplicate same-shape overloads, competing exact matches, arity mismatches,
+  unknown arguments without explicit generic evidence, and unsupported
+  assignability remain unresolved. Source-backed rejection cannot fall through
+  to lexical or terminal-name guesses, while JavaScript method signatures that
+  publish parameters without a return marker retain their existing resolution.
+- The overload matcher is bounded by the existing candidate and type-shape
+  limits; it emits no new external or deferred targets and preserves existing
+  member-binding provenance for unique matches.
+
+The focused candidate suite remains at 73 tests and the universal resolver
+suite is now 158 tests, including one positive imported-overload fixture and
+one ambiguity/mismatch/unknown negative fixture. Conditional/mapped modifier
+semantics, richer overload-aware generic substitution, alias escape/eval/proxy
+flow, framework/compiler tiers, accepted precision/Wilson gates, equivalent
+Graphify/SCIP scope, and the production hard cut remain open. The candidate
+adapter remains absent from `UNIVERSAL_ADAPTERS`. Fixture qualification stays
+byte-stable at Compass revision `1d8d5233b702559d8ae01c278473dc5459f8b48c`,
+with 57 languages, 980 coverage records, 1,565 invariants, 27 flows, and
+graph digest `sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1926,6 +1926,34 @@ The unchanged digest is expected because the qualification-only adapter is not
 registered in production. This remains correctness evidence, not a leadership
 claim.
 
+### Execution checkpoint (2026-08-07, bounded CommonJS `Object.assign` owners)
+
+The CommonJS object-owner path now also recognizes the common source-proven
+composition forms `module.exports = Object.assign({}, source, { direct })` and
+`Object.assign(exports, source)`. The candidate retains the file-module owner,
+records each immutable object/default/namespace source as a bounded `Member("*")`
+alias, and emits a final direct object argument as named reexports. The
+resolver therefore inherits only source-published members, keeps the final
+direct object phase ahead of inherited members, and preserves exact member
+occurrences across `require()` consumers.
+
+The implementation deliberately rejects unknown or mutable sources, computed
+arguments, nested assign expressions, object arguments before a later source,
+and object spreads inside the direct phase. Those shapes remain unresolved
+rather than being approximated from the `Object.assign` spelling. Candidate and
+resolver coverage now includes positive source inheritance, direct override,
+mutating `exports`, and unknown-source negatives; the focused suites are 102
+candidate tests and 176 universal resolver tests.
+
+Exact fixture qualification remains unchanged because this adapter is still
+qualification-only and is not registered in production: 57 languages, 980
+coverage records, 1,565 invariants, 27 flows, 24 negatives, 25 diagnostics,
+28 edge kinds, 45 node kinds, graph digest
+`sha256:f13848fefa81b79c70ed9b50081c1cab8024f1ce84030064c8eb2d154ba4c160`,
+82 exact and 11 unresolved route resolutions, and byte-equivalent clean,
+warm, rebuild, restored, alternate-checkout, and source-unchanged outputs.
+This is an interop correctness increment, not a release leadership claim.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1702,6 +1702,36 @@ Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
 gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
 cut remain open.
 
+### Execution checkpoint (2026-08-07, ES default object export ownership)
+
+Spread-free ES default object literals now publish a source-backed `default`
+value owner and retain their exact property declarations beneath the stable
+`<module>.default` qualified identity. Cross-file default imports can therefore
+resolve `value.member()` and `value.member` to the provider property or method
+declaration. The adapter emits an explicit default reexport binding for the
+synthetic owner. Default objects containing spreads remain outside this path;
+their member resolution stays unresolved/external rather than assuming that a
+listed property survives an override. The candidate and resolver tests cover
+the positive source-backed members and the spread negative.
+
+Named declaration exports now also publish explicit source bindings for direct
+function, class, type, interface, enum, namespace, and variable declarations,
+including merged declaration slots. Ordinary value imports are admitted only
+through those explicit export bindings, while private declarations remain
+available to type-owner expansion; an invalid named import therefore stays
+external instead of selecting a same-file private helper.
+
+The focused candidate suite is now 97 tests and the universal resolver suite is
+now 169 tests. The pinned Axios per-file target differential remains
+3,054/3,167 exact local targets (113 missing, 0 wrong; 391/503 member matches,
+1,544/1,545 call matches, and 226 false positives); that differential is
+intentionally per-file and does not exercise cross-file resolver publication,
+so no Axios recall increase is claimed for this slice.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1340,13 +1340,40 @@ addition to the compatibility construct inventory:
   spread and optional-call flags. The range validator proves that the callee
   lies inside the full call expression and inside its source file.
 - Header/footer counts cover every typed record under
-  `compass.typescript-source-oracle-jsonl/2`; repeated output is byte-identical,
+  `compass.typescript-source-oracle-jsonl/3`; repeated output is byte-identical,
   and the Python audit reconstructs the legacy inventory only after validating
   the typed stream.
 
 This closes the source-oracle scope/declaration/call stream contract, but not
 target adjudication or semantic quality: compiler-backed target truth, four
 release corpora, accepted precision/Wilson gates, framework tiers, equivalent
+Graphify/SCIP scope, and the production hard cut remain open.
+
+### Execution checkpoint (2026-08-07, typed relationship fact stream)
+
+The qualification-only TypeScript/JavaScript JSONL oracle now promotes the
+remaining source relationships into typed records instead of relying only on
+the compatibility construct projection:
+
+- `import` and `reexport` records retain module specifiers, named/default/
+  namespace/local binding identity, type-only provenance, enclosing statement
+  ranges, and exact source anchors.
+- `construction` records separate `new` expressions from ordinary `call`
+  records while preserving full invocation ranges, target classification,
+  argument count, spread, and owner identity.
+- `base` records cover `extends` and `implements` expressions with exact
+  heritage-clause containment; `member` records cover property and bounded
+  literal-element accesses with read/write and optional-access metadata.
+- `reference` records cover source identifiers, type references, and JSX tag
+  anchors. Every new record is bounded, sorted deterministically, tied to a
+  parsed source file, and checked for enclosing-range and count consistency by
+  the Python audit validator.
+
+The JSONL contract is now
+`compass.typescript-source-oracle-jsonl/3`; the single-document schema and
+legacy construct inventory remain compatible. This closes the source-oracle
+relationship fact inventory, but compiler-backed target truth, four release
+corpora, accepted precision/Wilson gates, framework tiers, equivalent
 Graphify/SCIP scope, and the production hard cut remain open.
 
 ### Execution checkpoint (2026-08-07, imported literal utility projections)

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -676,6 +676,41 @@ The next actionable phases remain open:
    only after source recall, target precision, determinism, compatibility, and
    product-boundary checks pass together.
 
+### Execution checkpoint (2026-08-06, target-report and scorecard slice)
+
+The qualification path now preserves enough evidence to turn the checker
+diagnostic into a reviewed, machine-checkable scorecard without treating the
+checker as Compass runtime behavior:
+
+- The ignored target differential accepts `COMPASS_TS_TARGET_REPORT` and
+  atomically writes `compass.typescript-target-adjudication/1`. The report pins
+  the checker metadata and script digest, records exact source/target byte
+  ranges, preserves every candidate observation, emits automatic outcomes by
+  capability, and is bounded to 128 MiB. Normal native tests and builds do not
+  write it.
+- `benchmarks/performance/compass/typescript_scorecard.py` validates the
+  reviewed `compass.typescript-target-scorecard/1` contract. Every record must
+  have an explicit `accepted`/`source_oracle` pool, a manually entered
+  `judgmentSource: "manual"`, and a judgment (with a review reason for every
+  non-correct label); missing labels, unsafe paths, duplicate or unsorted IDs,
+  stale provider metadata, and undeclared strata fail closed. Automatic checker
+  outcomes may be retained as context but can never become scorecard labels.
+- The scorecard computes deterministic precision, 95% Wilson bounds, recall,
+  target-cluster concentration, corpus/relation/capability strata, critical
+  semantic violations, and separate production versus leadership thresholds.
+  Leadership mode additionally requires equivalent-scope, adjudicated Graphify
+  and SCIP TypeScript comparator entries. Diagnostic mode cannot be eligible
+  for a public quality claim.
+- `python3 benchmarks/performance/harness.py typescript-scorecard` exposes the
+  evaluator as a reproducible developer command. A synthetic one-file target
+  report was generated successfully with exact observations; no real-corpus
+  labels or competitor result has been promoted into the scorecard.
+
+This closes the measurement contract but not the quality gate. The four-corpus
+release sample, hand-labeled accepted records, Graphify/SCIP equivalent-scope
+results, framework strata, and production hard cut remain open. The candidate
+adapter remains absent from `UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -1609,6 +1609,31 @@ precision/Wilson gates, framework tiers, equivalent Graphify/SCIP scope, and
 the production hard cut remain open; this is an interop correctness slice, not
 a best-in-class release claim.
 
+### Execution checkpoint (2026-08-07, bounded object-flow and object-method slice)
+
+The candidate now covers two additional source-grounded JavaScript receiver
+shapes without relaxing its fail-closed flow policy:
+
+- A direct straight-line local assignment such as `let value; value = { ... }`
+  carries the exact object receiver into later member accesses. Object spreads,
+  conditional assignments, unknown writes, and compound writes remain
+  unresolved; the new regression pair proves both the positive and negative
+  paths.
+- Stable, spread-free object-literal methods now retain their object receiver
+  for `this.member` calls. Object literals with spreads do not receive this
+  recovery, so a potentially overridden member is not attributed by guesswork.
+- The focused candidate suite is now 94 tests and the universal resolver suite
+  remains 168 tests. On the pinned Axios checker diagnostic at the same corpus
+  realization, exact local target matches improved to 3,052/3,167 (115
+  missing, 0 wrong); member matches are 389/503 and calls remain 1,544/1,545.
+  The recovered target is a same-file object-flow member in
+  `axios/tests/unit/toFormData.test.js`; this is diagnostic evidence, not a
+  release precision or leadership claim.
+
+Fixture qualification, compiler-source-oracle recall, accepted-sample/Wilson
+gates, framework tiers, equivalent Graphify/SCIP scope, and the production hard
+cut remain open.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/013-typescript-javascript-graph-quality.md
+++ b/advisor-plans/013-typescript-javascript-graph-quality.md
@@ -711,6 +711,38 @@ release sample, hand-labeled accepted records, Graphify/SCIP equivalent-scope
 results, framework strata, and production hard cut remain open. The candidate
 adapter remains absent from `UNIVERSAL_ADAPTERS`.
 
+### Execution checkpoint (2026-08-06, universal module-index and re-export slice)
+
+The qualification-only resolver now closes the first project-wide target gap
+without reintroducing terminal-name matching or a filesystem search:
+
+- `UniversalResolutionIndex` indexes TypeScript/JavaScript declarations by
+  normalized repository-relative module path and export spelling. Relative
+  imports use the importer directory, extension substitution, and directory
+  `index` aliases; `.ts`, `.tsx`, `.js`, `.jsx`, `.mts`, `.cts`, `.mjs`, and
+  `.cjs` realizations retain their source anchors.
+- Local default/local-export aliases and bounded cross-file re-export aliases
+  retain exact declaration slots. Re-export chains are followed through the
+  in-memory evidence table with a depth bound; cycles and missing hops remain
+  unresolved. `export *` never forwards `default` implicitly.
+- TypeScript/JavaScript interop is admitted only after an exact module/export
+  path proves the target. Imported member calls first resolve the exported
+  owner, then select the exact owner member; duplicate same-path realizations
+  across either semantic family stay ambiguous.
+- Six focused resolver regressions cover relative extension substitution,
+  default imports and members, cross-file re-export aliases, exact TS/JS
+  interop, terminal-name collision negatives, duplicate-module ambiguity, and
+  dynamic-member preservation. The candidate suite passes with deterministic
+  IDs and occurrence anchors.
+
+This slice is still below the Phase 3/4 and production hard-cut gates. The
+universal index does not yet consume the full project resolver for `paths`,
+`rootDirs`, package `exports`/`imports`, `typesVersions`, or all Node16/
+NodeNext/Bundler conditions; declaration merging, generic instantiation,
+mapped/indexed shapes, framework tiers, compiler differential recall, and the
+accepted precision/leadership scorecard remain open. The candidate adapter is
+still not registered in `UNIVERSAL_ADAPTERS`.
+
 ## Outcome
 
 Compass should produce the most trustworthy TypeScript and JavaScript graph for

--- a/advisor-plans/README.md
+++ b/advisor-plans/README.md
@@ -20,6 +20,13 @@ context only: the plans prohibit Graphify runtime, fixture, test, or fallback
 dependencies. Each executor should read the selected plan in full; no audit or
 conversation context is required beyond the plan file.
 
+Plan 013 is a third, self-contained TypeScript/JavaScript code-graph quality
+program. It was planned against Compass commit `a8a6a80` with read-only
+diagnostic comparison to Graphify and official TypeScript/SCIP references.
+Graphify remains comparison context only. The program preserves Compass's
+native, compiler-free structural tier and makes any compiler/SCIP enrichment
+explicit, optional, fresh, and provenance-preserving.
+
 ## Execution order and status
 
 | Plan | Title | Priority | Effort | Depends on | Status |
@@ -36,6 +43,7 @@ conversation context is required beyond the plan file.
 | 010 | Preserve OOXML order and add native PPTX document graphs | P2 | L | 006, 007, 008 | TODO |
 | 011 | Add a bounded native RTF decoder with explicit fidelity diagnostics | P2 | L | 007, 008 | TODO |
 | 012 | Qualify document graphs across formats, limits, and determinism | P1 | M | 009, 010, 011 | TODO |
+| 013 | Make TypeScript and JavaScript code graphs best in class | P1 | XL | —; final gate should consume 005 or equivalent | IN PROGRESS |
 
 Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
 
@@ -60,6 +68,11 @@ Status values: `TODO`, `IN PROGRESS`, `DONE`, `BLOCKED`, or `REJECTED`.
   three format plans into one stable qualification and documentation gate.
 - Plan 012 complements plan 005 rather than depending on it: plan 005 owns the
   broad production release gate; plan 012 owns document-specific evidence.
+- Plan 013 is deliberately staged: independent truth and project semantics land
+  before a test-only universal adapter, production changes in one hard cut, and
+  compiler/framework enhancements follow only after the native graph qualifies.
+  Its final public claim should consume plan 005's exact-production-evidence
+  model or an equivalent release-candidate gate.
 
 ## Direction options not promoted to implementation plans
 

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -141,8 +141,10 @@ rule does not relax body references or endpoint conflicts.
 TypeScript and JavaScript source recall uses the independent compiler oracle in
 `benchmarks/performance/oracles/typescript-source-oracle.mjs`. It is a pinned
 developer-side tool, not a Compass runtime dependency. The audit pipeline uses
-its bounded `--jsonl` stream (header, project/file coverage, diagnostics,
-constructs, and footer) so incomplete source denominators fail closed. Run `npm ci` before the
+its bounded `--jsonl` stream (schema `compass.typescript-source-oracle-jsonl/2`;
+header, project/file coverage, diagnostics, flattened constructs, typed scopes,
+declarations, calls, and footer) so incomplete source denominators fail closed.
+Run `npm ci` before the
 first TypeScript/JavaScript audit so the lockfile's TypeScript 5.9.3 package is
 available. The provider discovers bounded `tsconfig*.json`/`jsconfig*.json`
 projects, follows in-root project references with cycle/depth limits, and uses

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -142,8 +142,14 @@ TypeScript and JavaScript source recall uses the independent compiler oracle in
 `benchmarks/performance/oracles/typescript-source-oracle.mjs`. It is a pinned
 developer-side tool, not a Compass runtime dependency. Run `npm ci` before the
 first TypeScript/JavaScript audit so the lockfile's TypeScript 5.9.3 package is
-available. The provider records exact UTF-8 byte ranges and fails closed when a
-source file cannot be parsed or bounded.
+available. The provider discovers bounded `tsconfig*.json`/`jsconfig*.json`
+projects, follows in-root project references with cycle/depth limits, and uses
+the compiler-selected file set. It records project scopes, configuration/source
+digests, exact UTF-8 byte ranges, and bounded diagnostics; malformed or
+unbounded files are explicit rejected coverage rather than silent omissions.
+When every discovered configuration is invalid it reports the diagnostics and
+falls back to the bounded source tree so a broken config cannot masquerade as a
+perfectly empty project.
 
 Module/import target qualification uses the companion
 `benchmarks/performance/oracles/typescript-resolution-oracle.mjs`. It resolves

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -140,7 +140,9 @@ rule does not relax body references or endpoint conflicts.
 
 TypeScript and JavaScript source recall uses the independent compiler oracle in
 `benchmarks/performance/oracles/typescript-source-oracle.mjs`. It is a pinned
-developer-side tool, not a Compass runtime dependency. Run `npm ci` before the
+developer-side tool, not a Compass runtime dependency. The audit pipeline uses
+its bounded `--jsonl` stream (header, project/file coverage, diagnostics,
+constructs, and footer) so incomplete source denominators fail closed. Run `npm ci` before the
 first TypeScript/JavaScript audit so the lockfile's TypeScript 5.9.3 package is
 available. The provider discovers bounded `tsconfig*.json`/`jsconfig*.json`
 projects, follows in-root project references with cycle/depth limits, and uses

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -138,6 +138,51 @@ rule does not relax body references or endpoint conflicts.
 
 ## Source-grounded quality audit
 
+TypeScript and JavaScript source recall uses the independent compiler oracle in
+`benchmarks/performance/oracles/typescript-source-oracle.mjs`. It is a pinned
+developer-side tool, not a Compass runtime dependency. Run `npm ci` before the
+first TypeScript/JavaScript audit so the lockfile's TypeScript 5.9.3 package is
+available. The provider records exact UTF-8 byte ranges and fails closed when a
+source file cannot be parsed or bounded.
+
+Module/import target qualification uses the companion
+`benchmarks/performance/oracles/typescript-resolution-oracle.mjs`. It resolves
+imports, reexports, dynamic imports, `import type`, `import =`, and literal
+`require()` sites under each discovered project configuration. Its output
+records the selected module mode, exact source range, target or explicit
+external/unresolved/ambiguous outcome, and configuration/source digests. The
+resolver fixture suite cross-checks representative decisions against
+`tsc --traceResolution`; neither oracle is used by normal Compass builds.
+
+The Rust-side candidate seam has one opt-in compiler differential fixture. Run
+it from a checkout with the pinned Node dependencies installed:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 \
+  cargo test -p compass-languages --test typescript_oracle_differential \
+  --locked -- --ignored
+```
+
+The test compares exact source-byte coverage for a mixed TSX fixture. It is
+ignored by ordinary workspace tests so native Compass remains Node-free.
+
+For developer-only same-file target adjudication on a pinned real corpus, use
+the separate checker oracle and keep the candidate adapter out of production:
+
+```bash
+RUST_MIN_STACK=33554432 \
+COMPASS_TS_QUALIFICATION_ROOT=/Volumes/Workspace/Github/<owner>/<pinned-corpus> \
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  cargo test -p compass-languages --test typescript_target_differential \
+  checker_oracle_adjudicates_local_candidate_targets --locked -- --ignored --nocapture
+```
+
+The report separates exact local targets, missing targets, wrong targets,
+external positives, and unresolved/ambiguous outcomes by capability. It is an
+adjudication instrument rather than a release claim: accepted labels, Wilson
+intervals, cross-file/project strata, framework tiers, and an equivalent
+Graphify/SCIP comparison must be frozen before an adapter can be registered.
+
 Create an unjudged candidate set from a comparator database without rerunning
 either graph producer:
 

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -183,6 +183,14 @@ adjudication instrument rather than a release claim: accepted labels, Wilson
 intervals, cross-file/project strata, framework tiers, and an equivalent
 Graphify/SCIP comparison must be frozen before an adapter can be registered.
 
+The target harness can persist its source-backed observations with
+`COMPASS_TS_TARGET_REPORT`; see
+`benchmarks/performance/oracles/README.md` for the report and reviewed
+`compass.typescript-target-scorecard/1` workflow. The scorecard evaluator is
+deliberately separate from the checker oracle: automatic checker outcomes are
+not accepted precision labels, and diagnostic scorecards are never eligible for
+a public quality claim.
+
 Create an unjudged candidate set from a comparator database without rerunning
 either graph producer:
 

--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -141,9 +141,10 @@ rule does not relax body references or endpoint conflicts.
 TypeScript and JavaScript source recall uses the independent compiler oracle in
 `benchmarks/performance/oracles/typescript-source-oracle.mjs`. It is a pinned
 developer-side tool, not a Compass runtime dependency. The audit pipeline uses
-its bounded `--jsonl` stream (schema `compass.typescript-source-oracle-jsonl/2`;
+its bounded `--jsonl` stream (schema `compass.typescript-source-oracle-jsonl/3`;
 header, project/file coverage, diagnostics, flattened constructs, typed scopes,
-declarations, calls, and footer) so incomplete source denominators fail closed.
+declarations, calls, constructions, imports, reexports, bases, members,
+references, and footer) so incomplete source denominators fail closed.
 Run `npm ci` before the
 first TypeScript/JavaScript audit so the lockfile's TypeScript 5.9.3 package is
 available. The provider discovers bounded `tsconfig*.json`/`jsconfig*.json`

--- a/benchmarks/performance/compass/audit.py
+++ b/benchmarks/performance/compass/audit.py
@@ -421,6 +421,11 @@ def _source_oracle_candidates(
         "scannedFiles": inventory.scanned_files,
         "parsedFiles": inventory.parsed_files,
         "rejectedFiles": list(inventory.rejected_files),
+        **(
+            {"providerMetadata": dict(inventory.provider_metadata)}
+            if inventory.provider_metadata
+            else {}
+        ),
         "inventorySha256": source_construct_inventory_sha256(adapter, inventory),
         "complete": (
             has_independent_source_provider(adapter)

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -827,7 +827,14 @@ def _oracle_reference(value: object, index: int) -> Mapping[str, object]:
     }
     if set(value) != required:
         raise RuntimeError(f"{context} has an invalid schema")
-    if value["relation"] != "references" or value["kind"] not in {"identifier", "type", "jsx"}:
+    if value["relation"] != "references" or value["kind"] not in {
+        "identifier",
+        "type",
+        "jsx",
+        "jsx_value",
+        "jsx_spread",
+        "jsx_child",
+    }:
         raise RuntimeError(f"{context}.relation or kind is invalid")
     _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
     for field in ("ownerQualifiedName", "targetSpelling"):

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -451,7 +451,8 @@ def _typescript_inventory_from_payload(
         "rejectedFiles",
         "constructs",
     }
-    if set(payload) != required:
+    optional = {"projects", "diagnostics"}
+    if not required.issubset(payload) or set(payload) - required - optional:
         raise RuntimeError("TypeScript source oracle output has an invalid schema")
     if payload["schema"] != _TYPESCRIPT_ORACLE_SCHEMA:
         raise RuntimeError(f"unsupported TypeScript source oracle schema: {payload['schema']!r}")
@@ -473,6 +474,19 @@ def _typescript_inventory_from_payload(
     script_sha256 = metadata.get("scriptSha256")
     if compiler_version != "5.9.3" or not re.fullmatch(r"[0-9a-f]{64}", script_sha256 or ""):
         raise RuntimeError("TypeScript source oracle metadata is not pinned")
+    for digest_name in ("configDigest", "sourceDigest"):
+        if digest_name in metadata and not re.fullmatch(
+            r"[0-9a-f]{64}", metadata[digest_name]
+        ):
+            raise RuntimeError(
+                f"TypeScript source oracle metadata {digest_name} is invalid"
+            )
+    project_mode = metadata.get("projectMode")
+    if project_mode is not None and project_mode not in {"project", "fallback", "tree"}:
+        raise RuntimeError("TypeScript source oracle metadata projectMode is invalid")
+    diagnostic_count = metadata.get("diagnosticCount")
+    if diagnostic_count is not None and not re.fullmatch(r"[0-9]+", diagnostic_count):
+        raise RuntimeError("TypeScript source oracle metadata diagnosticCount is invalid")
     scanned = payload["scannedFiles"]
     parsed = payload["parsedFiles"]
     if (
@@ -518,6 +532,83 @@ def _typescript_inventory_from_payload(
         raise RuntimeError(
             "TypeScript source oracle coverage does not account for every scanned file"
         )
+    projects = payload.get("projects")
+    if projects is not None:
+        if not isinstance(projects, list):
+            raise RuntimeError("TypeScript source oracle projects must be an array")
+        for index, project in enumerate(projects):
+            if not isinstance(project, dict):
+                raise RuntimeError(f"oracle projects[{index}] must be an object")
+            if set(project) != {"configFile", "fileCount", "files", "references", "configDigest"}:
+                raise RuntimeError(f"oracle projects[{index}] has an invalid schema")
+            config_file = _safe_oracle_file(
+                project["configFile"], f"projects[{index}].configFile"
+            )
+            config_path = (root / config_file).resolve()
+            try:
+                config_path.relative_to(root)
+            except ValueError as error:
+                raise RuntimeError(
+                    f"oracle project config escapes the source root: {config_file}"
+                ) from error
+            if not config_path.is_file():
+                raise RuntimeError(f"oracle project config is missing: {config_file}")
+            file_count = project["fileCount"]
+            if isinstance(file_count, bool) or not isinstance(file_count, int) or file_count < 0:
+                raise RuntimeError(f"oracle projects[{index}].fileCount is invalid")
+            if not isinstance(project["files"], list) or len(project["files"]) != file_count:
+                raise RuntimeError(f"oracle projects[{index}].files is invalid")
+            project_files: set[str] = set()
+            for file_index, file_name in enumerate(project["files"]):
+                normalized_file = _safe_oracle_file(
+                    file_name, f"projects[{index}].files[{file_index}]"
+                )
+                if normalized_file in project_files:
+                    raise RuntimeError(f"oracle projects[{index}].files is not unique")
+                project_files.add(normalized_file)
+                source_path = (root / normalized_file).resolve()
+                try:
+                    source_path.relative_to(root)
+                except ValueError as error:
+                    raise RuntimeError(
+                        f"oracle project file escapes the source root: {normalized_file}"
+                    ) from error
+                if not source_path.is_file():
+                    raise RuntimeError(
+                        f"oracle project file is missing: {normalized_file}"
+                    )
+            if not isinstance(project["references"], list):
+                raise RuntimeError(f"oracle projects[{index}].references is invalid")
+            for reference_index, reference in enumerate(project["references"]):
+                normalized_reference = _safe_oracle_file(
+                    reference, f"projects[{index}].references[{reference_index}]"
+                )
+                reference_path = (root / normalized_reference).resolve()
+                try:
+                    reference_path.relative_to(root)
+                except ValueError as error:
+                    raise RuntimeError(
+                        f"oracle project reference escapes the source root: {normalized_reference}"
+                    ) from error
+                if not reference_path.is_file():
+                    raise RuntimeError(
+                        f"oracle project reference is missing: {normalized_reference}"
+                    )
+            if not re.fullmatch(r"[0-9a-f]{64}", project["configDigest"]):
+                raise RuntimeError(f"oracle projects[{index}].configDigest is invalid")
+    diagnostics = payload.get("diagnostics")
+    if diagnostics is not None:
+        if not isinstance(diagnostics, list):
+            raise RuntimeError("TypeScript source oracle diagnostics must be an array")
+        for index, diagnostic in enumerate(diagnostics):
+            if (
+                not isinstance(diagnostic, dict)
+                or set(diagnostic) != {"file", "message"}
+                or not isinstance(diagnostic["message"], str)
+                or not diagnostic["message"]
+            ):
+                raise RuntimeError(f"oracle diagnostics[{index}] has an invalid schema")
+            _safe_oracle_file(diagnostic["file"], f"diagnostics[{index}].file")
     return SourceConstructInventory(
         parsed_constructs,
         scanned,

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -281,13 +281,14 @@ def _python_constructs(root: Path, path: Path) -> tuple[SourceConstruct, ...] | 
 
 
 _TYPESCRIPT_ORACLE_SCHEMA = "compass.typescript-source-oracle/1"
-_TYPESCRIPT_ORACLE_JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/1"
+_TYPESCRIPT_ORACLE_JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/2"
 _TYPESCRIPT_ORACLE_PROVIDER = "typescript_compiler_api_5_9_3"
 _TYPESCRIPT_ORACLE_SCRIPT = (
     Path(__file__).resolve().parents[1] / "oracles" / "typescript-source-oracle.mjs"
 )
 _TYPESCRIPT_ORACLE_TIMEOUT_SECONDS = 90.0
 _TYPESCRIPT_ORACLE_OUTPUT_BYTES = 64 * 1024 * 1024
+_TYPESCRIPT_ORACLE_MAX_TYPED_FACTS = 500_000
 
 
 def _bounded_node_oracle(root: Path) -> bytes:
@@ -437,6 +438,154 @@ def _oracle_construct(value: object, index: int) -> SourceConstruct:
     )
 
 
+def _oracle_typed_range(value: Mapping[str, object], context: str) -> tuple[int, int, int]:
+    start_byte = value.get("startByte")
+    end_byte = value.get("endByte")
+    start_line = value.get("startLine")
+    if (
+        isinstance(start_byte, bool)
+        or not isinstance(start_byte, int)
+        or isinstance(end_byte, bool)
+        or not isinstance(end_byte, int)
+        or isinstance(start_line, bool)
+        or not isinstance(start_line, int)
+        or start_byte < 0
+        or end_byte <= start_byte
+        or start_line <= 0
+    ):
+        raise RuntimeError(f"{context} has an invalid source range")
+    return start_byte, end_byte, start_line
+
+
+def _oracle_declaration(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle declarations[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "kind",
+        "name",
+        "qualifiedName",
+        "ownerQualifiedName",
+        "namespace",
+        "startByte",
+        "endByte",
+        "startLine",
+        "parameterCount",
+        "minimumParameterCount",
+        "hasRestParameter",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("kind", "name", "qualifiedName", "ownerQualifiedName", "namespace"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    _oracle_typed_range(value, context)
+    for field in ("parameterCount", "minimumParameterCount"):
+        count = value[field]
+        if (
+            count is not None
+            and (isinstance(count, bool) or not isinstance(count, int) or count < 0)
+        ):
+            raise RuntimeError(f"{context}.{field} is invalid")
+    if value["parameterCount"] is None and value["minimumParameterCount"] is not None:
+        raise RuntimeError(f"{context} has a minimum parameter count without a parameter count")
+    if (
+        value["parameterCount"] is not None
+        and value["minimumParameterCount"] is not None
+        and value["minimumParameterCount"] > value["parameterCount"]
+    ):
+        raise RuntimeError(f"{context} has an invalid parameter count relationship")
+    if not isinstance(value["hasRestParameter"], bool):
+        raise RuntimeError(f"{context}.hasRestParameter is invalid")
+    return value
+
+
+def _oracle_scope(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle scopes[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "scopeId",
+        "kind",
+        "ownerQualifiedName",
+        "parentScopeId",
+        "startByte",
+        "endByte",
+        "startLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("scopeId", "kind", "ownerQualifiedName"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    parent = value["parentScopeId"]
+    if parent is not None and (not isinstance(parent, str) or not parent):
+        raise RuntimeError(f"{context}.parentScopeId is invalid")
+    _oracle_typed_range(value, context)
+    return value
+
+
+def _oracle_call(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle calls[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "targetKind",
+        "startByte",
+        "endByte",
+        "startLine",
+        "callStartByte",
+        "callEndByte",
+        "argumentCount",
+        "hasSpreadArgument",
+        "optional",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("relation", "kind", "ownerQualifiedName", "targetSpelling", "targetKind"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    qualifier = value["qualifier"]
+    if qualifier is not None and (not isinstance(qualifier, str) or not qualifier):
+        raise RuntimeError(f"{context}.qualifier is invalid")
+    start_byte, end_byte, _ = _oracle_typed_range(value, context)
+    call_start = value["callStartByte"]
+    call_end = value["callEndByte"]
+    if (
+        isinstance(call_start, bool)
+        or not isinstance(call_start, int)
+        or isinstance(call_end, bool)
+        or not isinstance(call_end, int)
+        or call_start < start_byte
+        or call_end < call_start
+        or call_end < end_byte
+        or call_end <= call_start
+    ):
+        raise RuntimeError(f"{context} has an invalid call range")
+    argument_count = value["argumentCount"]
+    if (
+        isinstance(argument_count, bool)
+        or not isinstance(argument_count, int)
+        or argument_count < 0
+    ):
+        raise RuntimeError(f"{context}.argumentCount is invalid")
+    for field in ("hasSpreadArgument", "optional"):
+        if not isinstance(value[field], bool):
+            raise RuntimeError(f"{context}.{field} is invalid")
+    return value
+
+
 def _typescript_inventory_from_payload(
     payload: object,
     root: Path,
@@ -453,7 +602,7 @@ def _typescript_inventory_from_payload(
         "rejectedFiles",
         "constructs",
     }
-    optional = {"projects", "diagnostics"}
+    optional = {"projects", "diagnostics", "scopes", "declarations", "calls"}
     if not required.issubset(payload) or set(payload) - required - optional:
         raise RuntimeError("TypeScript source oracle output has an invalid schema")
     if payload["schema"] != _TYPESCRIPT_ORACLE_SCHEMA:
@@ -530,6 +679,87 @@ def _typescript_inventory_from_payload(
             raise RuntimeError(
                 f"oracle construct range exceeds source: {construct.source_file}"
             )
+    typed_records: dict[str, list[Mapping[str, object]]] = {}
+    for field, validator in (
+        ("scopes", _oracle_scope),
+        ("declarations", _oracle_declaration),
+        ("calls", _oracle_call),
+    ):
+        values = payload.get(field)
+        if values is None:
+            continue
+        if not isinstance(values, list):
+            raise RuntimeError(f"TypeScript source oracle {field} must be an array")
+        if len(values) > _TYPESCRIPT_ORACLE_MAX_TYPED_FACTS:
+            raise RuntimeError(
+                f"TypeScript source oracle {field} exceeds the configured limit"
+            )
+        typed_records[field] = [validator(value, index) for index, value in enumerate(values)]
+    scope_ids: set[str] = set()
+    scopes_by_id: dict[str, Mapping[str, object]] = {}
+    for scope in typed_records.get("scopes", []):
+        scope_id = scope["scopeId"]
+        if scope_id in scope_ids:
+            raise RuntimeError(f"TypeScript source oracle scope {scope_id!r} is duplicated")
+        scope_ids.add(scope_id)
+        scopes_by_id[scope_id] = scope
+    for scope in typed_records.get("scopes", []):
+        parent = scope["parentScopeId"]
+        if parent is not None:
+            if parent not in scope_ids:
+                raise RuntimeError(
+                    f"TypeScript source oracle scope parent {parent!r} is missing"
+                )
+            parent_scope = scopes_by_id[parent]
+            if parent_scope["sourceFile"] != scope["sourceFile"]:
+                raise RuntimeError(
+                    f"TypeScript source oracle scope parent {parent!r} crosses source files"
+                )
+            parent_start, parent_end, _ = _oracle_typed_range(
+                parent_scope, f"scope parent {parent!r}"
+            )
+            start_byte, end_byte, _ = _oracle_typed_range(
+                scope, f"oracle scope {scope['scopeId']!r}"
+            )
+            if parent_start > start_byte or parent_end < end_byte:
+                raise RuntimeError(
+                    f"TypeScript source oracle scope parent {parent!r} does not enclose child"
+                )
+    for scope in typed_records.get("scopes", []):
+        chain: set[str] = set()
+        current = scope["scopeId"]
+        while current is not None:
+            if current in chain:
+                raise RuntimeError(
+                    f"TypeScript source oracle scope parent cycle at {current!r}"
+                )
+            if current not in scopes_by_id:
+                raise RuntimeError(
+                    f"TypeScript source oracle scope parent {current!r} is missing"
+                )
+            chain.add(current)
+            current = scopes_by_id[current]["parentScopeId"]
+    for field, values in typed_records.items():
+        for index, record in enumerate(values):
+            source_file = record["sourceFile"]
+            source_path = (root / source_file).resolve()
+            try:
+                source_path.relative_to(root)
+            except ValueError as error:
+                raise RuntimeError(
+                    f"oracle {field}[{index}] escapes the source root: {source_file}"
+                ) from error
+            if not source_path.is_file():
+                raise RuntimeError(f"oracle {field}[{index}] source is missing: {source_file}")
+            _, end_byte, _ = _oracle_typed_range(record, f"oracle {field}[{index}]")
+            if end_byte > source_path.stat().st_size:
+                raise RuntimeError(
+                    f"oracle {field}[{index}] range exceeds source: {source_file}"
+                )
+            if field == "calls" and record["callEndByte"] > source_path.stat().st_size:
+                raise RuntimeError(
+                    f"oracle calls[{index}] call range exceeds source: {source_file}"
+                )
     if len(rejected_files) != scanned - parsed:
         raise RuntimeError(
             "TypeScript source oracle coverage does not account for every scanned file"
@@ -659,6 +889,9 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
     projects: list[dict[str, object]] = []
     diagnostics: list[dict[str, object]] = []
     constructs: list[dict[str, object]] = []
+    scopes: list[dict[str, object]] = []
+    declarations: list[dict[str, object]] = []
+    calls: list[dict[str, object]] = []
     files: list[dict[str, object]] = []
     for index, record in enumerate(records[1:-1], 1):
         record_type = record.get("recordType")
@@ -672,6 +905,14 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
             constructs.append(
                 {key: value for key, value in record.items() if key != "recordType"}
             )
+        elif record_type == "scope":
+            scopes.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "declaration":
+            declarations.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
+        elif record_type == "call":
+            calls.append({key: value for key, value in record.items() if key != "recordType"})
         elif record_type == "file":
             files.append(record)
         else:
@@ -687,6 +928,7 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
     if len(files) != scanned:
         raise RuntimeError("TypeScript source oracle JSONL file coverage is incomplete")
     file_names: set[str] = set()
+    file_statuses: dict[str, str] = {}
     rejected: list[str] = []
     for index, record in enumerate(files):
         if set(record) != {"recordType", "file", "status"}:
@@ -700,6 +942,9 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
             raise RuntimeError(f"TypeScript source oracle JSONL file {file_name} has invalid status")
         if status == "rejected":
             rejected.append(file_name)
+        file_statuses[file_name] = status
+    if list(file_statuses) != sorted(file_statuses):
+        raise RuntimeError("TypeScript source oracle JSONL files are not deterministically ordered")
     if len(rejected) != scanned - parsed:
         raise RuntimeError("TypeScript source oracle JSONL coverage counts are inconsistent")
     footer_counts = {
@@ -708,6 +953,9 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         "projectCount": len(projects),
         "diagnosticCount": len(diagnostics),
         "constructCount": len(constructs),
+        "scopeCount": len(scopes),
+        "declarationCount": len(declarations),
+        "callCount": len(calls),
     }
     for key, expected in footer_counts.items():
         if footer.get(key) != expected:
@@ -718,6 +966,28 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         raise RuntimeError("TypeScript source oracle JSONL header counts are inconsistent")
     if header.get("constructCount") != len(constructs):
         raise RuntimeError("TypeScript source oracle JSONL construct count is inconsistent")
+    for field, values, validator in (
+        ("scopes", scopes, _oracle_scope),
+        ("declarations", declarations, _oracle_declaration),
+        ("calls", calls, _oracle_call),
+    ):
+        for index, value in enumerate(values):
+            validator(value, index)
+            source_file = value["sourceFile"]
+            if source_file not in file_statuses:
+                raise RuntimeError(
+                    f"TypeScript source oracle JSONL {field}[{index}] has an unscanned source"
+                )
+            if file_statuses[source_file] != "parsed":
+                raise RuntimeError(
+                    f"TypeScript source oracle JSONL {field}[{index}] belongs to a rejected source"
+                )
+    if header.get("scopeCount") != len(scopes):
+        raise RuntimeError("TypeScript source oracle JSONL scope count is inconsistent")
+    if header.get("declarationCount") != len(declarations):
+        raise RuntimeError("TypeScript source oracle JSONL declaration count is inconsistent")
+    if header.get("callCount") != len(calls):
+        raise RuntimeError("TypeScript source oracle JSONL call count is inconsistent")
     if footer.get("rejectedFiles") != sorted(rejected):
         raise RuntimeError("TypeScript source oracle JSONL rejected file set is inconsistent")
     for digest_name in ("sourceDigest", "configDigest"):
@@ -735,6 +1005,9 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         "projects": projects,
         "diagnostics": diagnostics,
         "constructs": constructs,
+        "scopes": scopes,
+        "declarations": declarations,
+        "calls": calls,
     }
 
 

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -281,6 +281,7 @@ def _python_constructs(root: Path, path: Path) -> tuple[SourceConstruct, ...] | 
 
 
 _TYPESCRIPT_ORACLE_SCHEMA = "compass.typescript-source-oracle/1"
+_TYPESCRIPT_ORACLE_JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/1"
 _TYPESCRIPT_ORACLE_PROVIDER = "typescript_compiler_api_5_9_3"
 _TYPESCRIPT_ORACLE_SCRIPT = (
     Path(__file__).resolve().parents[1] / "oracles" / "typescript-source-oracle.mjs"
@@ -299,6 +300,7 @@ def _bounded_node_oracle(root: Path) -> bytes:
         str(_TYPESCRIPT_ORACLE_SCRIPT),
         "--root",
         str(root),
+        "--jsonl",
     )
     process = subprocess.Popen(
         command,
@@ -618,10 +620,130 @@ def _typescript_inventory_from_payload(
     )
 
 
+def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
+    """Reassemble and validate the bounded source-oracle JSONL stream."""
+
+    try:
+        lines = raw.decode("utf-8").splitlines()
+    except UnicodeDecodeError as error:
+        raise RuntimeError(f"invalid TypeScript source oracle JSONL UTF-8: {error}") from error
+    if len(lines) < 2:
+        raise RuntimeError("TypeScript source oracle JSONL is incomplete")
+    records: list[object] = []
+    for index, line in enumerate(lines):
+        if not line:
+            raise RuntimeError(f"TypeScript source oracle JSONL line {index} is empty")
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                f"invalid TypeScript source oracle JSONL line {index}: {error}"
+            ) from error
+        if not isinstance(record, dict):
+            raise RuntimeError(f"TypeScript source oracle JSONL line {index} is not an object")
+        records.append(record)
+    header = records[0]
+    footer = records[-1]
+    if (
+        header.get("recordType") != "header"
+        or footer.get("recordType") != "footer"
+        or header.get("schema") != _TYPESCRIPT_ORACLE_JSONL_SCHEMA
+        or footer.get("schema") != _TYPESCRIPT_ORACLE_JSONL_SCHEMA
+        or header.get("provider") != _TYPESCRIPT_ORACLE_PROVIDER
+        or footer.get("provider") != _TYPESCRIPT_ORACLE_PROVIDER
+    ):
+        raise RuntimeError("TypeScript source oracle JSONL header/footer is invalid")
+    metadata = header.get("metadata")
+    if not isinstance(metadata, dict):
+        raise RuntimeError("TypeScript source oracle JSONL metadata is invalid")
+    projects: list[dict[str, object]] = []
+    diagnostics: list[dict[str, object]] = []
+    constructs: list[dict[str, object]] = []
+    files: list[dict[str, object]] = []
+    for index, record in enumerate(records[1:-1], 1):
+        record_type = record.get("recordType")
+        if record_type == "project":
+            projects.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "diagnostic":
+            diagnostics.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
+        elif record_type == "construct":
+            constructs.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
+        elif record_type == "file":
+            files.append(record)
+        else:
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL record {index} has an invalid type"
+            )
+    scanned = header.get("scannedFiles")
+    parsed = header.get("parsedFiles")
+    if not isinstance(scanned, int) or isinstance(scanned, bool) or scanned < 0:
+        raise RuntimeError("TypeScript source oracle JSONL scannedFiles is invalid")
+    if not isinstance(parsed, int) or isinstance(parsed, bool) or parsed < 0 or parsed > scanned:
+        raise RuntimeError("TypeScript source oracle JSONL parsedFiles is invalid")
+    if len(files) != scanned:
+        raise RuntimeError("TypeScript source oracle JSONL file coverage is incomplete")
+    file_names: set[str] = set()
+    rejected: list[str] = []
+    for index, record in enumerate(files):
+        if set(record) != {"recordType", "file", "status"}:
+            raise RuntimeError(f"TypeScript source oracle JSONL file {index} has an invalid schema")
+        file_name = _safe_oracle_file(record["file"], f"jsonl files[{index}].file")
+        if file_name in file_names:
+            raise RuntimeError(f"TypeScript source oracle JSONL file {file_name} is duplicated")
+        file_names.add(file_name)
+        status = record["status"]
+        if status not in {"parsed", "rejected"}:
+            raise RuntimeError(f"TypeScript source oracle JSONL file {file_name} has invalid status")
+        if status == "rejected":
+            rejected.append(file_name)
+    if len(rejected) != scanned - parsed:
+        raise RuntimeError("TypeScript source oracle JSONL coverage counts are inconsistent")
+    footer_counts = {
+        "scannedFiles": scanned,
+        "parsedFiles": parsed,
+        "projectCount": len(projects),
+        "diagnosticCount": len(diagnostics),
+        "constructCount": len(constructs),
+    }
+    for key, expected in footer_counts.items():
+        if footer.get(key) != expected:
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL footer count {key} is inconsistent"
+            )
+    if header.get("projectCount") != len(projects) or header.get("diagnosticCount") != len(diagnostics):
+        raise RuntimeError("TypeScript source oracle JSONL header counts are inconsistent")
+    if header.get("constructCount") != len(constructs):
+        raise RuntimeError("TypeScript source oracle JSONL construct count is inconsistent")
+    if footer.get("rejectedFiles") != sorted(rejected):
+        raise RuntimeError("TypeScript source oracle JSONL rejected file set is inconsistent")
+    for digest_name in ("sourceDigest", "configDigest"):
+        if footer.get(digest_name) != metadata.get(digest_name):
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL footer {digest_name} is inconsistent"
+            )
+    return {
+        "schema": _TYPESCRIPT_ORACLE_SCHEMA,
+        "provider": _TYPESCRIPT_ORACLE_PROVIDER,
+        "metadata": metadata,
+        "scannedFiles": scanned,
+        "parsedFiles": parsed,
+        "rejectedFiles": sorted(rejected),
+        "projects": projects,
+        "diagnostics": diagnostics,
+        "constructs": constructs,
+    }
+
+
 def _typescript_compiler_inventory(root: Path) -> SourceConstructInventory:
     try:
-        payload = json.loads(_bounded_node_oracle(root).decode("utf-8"))
+        payload = _typescript_payload_from_jsonl(_bounded_node_oracle(root))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid TypeScript source oracle output: {error}") from error
+    except RuntimeError as error:
         raise RuntimeError(f"invalid TypeScript source oracle output: {error}") from error
     return _typescript_inventory_from_payload(payload, root)
 

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -281,7 +281,7 @@ def _python_constructs(root: Path, path: Path) -> tuple[SourceConstruct, ...] | 
 
 
 _TYPESCRIPT_ORACLE_SCHEMA = "compass.typescript-source-oracle/1"
-_TYPESCRIPT_ORACLE_JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/2"
+_TYPESCRIPT_ORACLE_JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/3"
 _TYPESCRIPT_ORACLE_PROVIDER = "typescript_compiler_api_5_9_3"
 _TYPESCRIPT_ORACLE_SCRIPT = (
     Path(__file__).resolve().parents[1] / "oracles" / "typescript-source-oracle.mjs"
@@ -529,8 +529,13 @@ def _oracle_scope(value: object, index: int) -> Mapping[str, object]:
     return value
 
 
-def _oracle_call(value: object, index: int) -> Mapping[str, object]:
-    context = f"oracle calls[{index}]"
+def _oracle_call(
+    value: object,
+    index: int,
+    *,
+    construction: bool = False,
+) -> Mapping[str, object]:
+    context = f"oracle {'constructions' if construction else 'calls'}[{index}]"
     if not isinstance(value, dict):
         raise RuntimeError(f"{context} must be an object")
     required = {
@@ -552,6 +557,10 @@ def _oracle_call(value: object, index: int) -> Mapping[str, object]:
     }
     if set(value) != required:
         raise RuntimeError(f"{context} has an invalid schema")
+    expected_relation = "instantiates" if construction else "calls"
+    expected_kind = "construction" if construction else "call"
+    if value["relation"] != expected_relation or value["kind"] != expected_kind:
+        raise RuntimeError(f"{context} has an invalid relation or kind")
     _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
     for field in ("relation", "kind", "ownerQualifiedName", "targetSpelling", "targetKind"):
         if not isinstance(value[field], str) or not value[field]:
@@ -567,7 +576,7 @@ def _oracle_call(value: object, index: int) -> Mapping[str, object]:
         or not isinstance(call_start, int)
         or isinstance(call_end, bool)
         or not isinstance(call_end, int)
-        or call_start < start_byte
+        or call_start > start_byte
         or call_end < call_start
         or call_end < end_byte
         or call_end <= call_start
@@ -583,6 +592,249 @@ def _oracle_call(value: object, index: int) -> Mapping[str, object]:
     for field in ("hasSpreadArgument", "optional"):
         if not isinstance(value[field], bool):
             raise RuntimeError(f"{context}.{field} is invalid")
+    return value
+
+
+def _oracle_statement_range(
+    value: Mapping[str, object],
+    context: str,
+    start_byte: int,
+    end_byte: int,
+) -> None:
+    statement_start = value.get("statementStartByte")
+    statement_end = value.get("statementEndByte")
+    statement_line = value.get("statementStartLine")
+    if (
+        isinstance(statement_start, bool)
+        or not isinstance(statement_start, int)
+        or isinstance(statement_end, bool)
+        or not isinstance(statement_end, int)
+        or isinstance(statement_line, bool)
+        or not isinstance(statement_line, int)
+        or statement_start < 0
+        or statement_end <= statement_start
+        or statement_line <= 0
+        or statement_start > start_byte
+        or statement_end < end_byte
+    ):
+        raise RuntimeError(f"{context} has an invalid enclosing statement range")
+
+
+def _oracle_optional_text(value: object, context: str) -> None:
+    if value is not None and (not isinstance(value, str) or not value):
+        raise RuntimeError(f"{context} is invalid")
+
+
+def _oracle_construction(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle constructions[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "targetKind",
+        "startByte",
+        "endByte",
+        "startLine",
+        "callStartByte",
+        "callEndByte",
+        "argumentCount",
+        "hasSpreadArgument",
+        "optional",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] != "instantiates" or value["kind"] != "construction":
+        raise RuntimeError(f"{context} has an invalid relation or kind")
+    return _oracle_call(value, index, construction=True)  # type: ignore[arg-type]
+
+
+def _oracle_import(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle imports[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "moduleSpecifier",
+        "importedName",
+        "localName",
+        "isTypeOnly",
+        "startByte",
+        "endByte",
+        "startLine",
+        "statementStartByte",
+        "statementEndByte",
+        "statementStartLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] != "imports":
+        raise RuntimeError(f"{context}.relation is invalid")
+    if value["kind"] not in {
+        "side_effect",
+        "default",
+        "named",
+        "namespace",
+        "import_equals",
+        "dynamic",
+        "require",
+        "import_type",
+    }:
+        raise RuntimeError(f"{context}.kind is invalid")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("ownerQualifiedName", "moduleSpecifier"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    _oracle_optional_text(value["importedName"], f"{context}.importedName")
+    _oracle_optional_text(value["localName"], f"{context}.localName")
+    if not isinstance(value["isTypeOnly"], bool):
+        raise RuntimeError(f"{context}.isTypeOnly is invalid")
+    start_byte, end_byte, _ = _oracle_typed_range(value, context)
+    _oracle_statement_range(value, context, start_byte, end_byte)
+    return value
+
+
+def _oracle_reexport(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle reexports[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "moduleSpecifier",
+        "exportedName",
+        "localName",
+        "isTypeOnly",
+        "startByte",
+        "endByte",
+        "startLine",
+        "statementStartByte",
+        "statementEndByte",
+        "statementStartLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] != "reexports":
+        raise RuntimeError(f"{context}.relation is invalid")
+    if value["kind"] not in {"star", "named", "namespace", "local", "default"}:
+        raise RuntimeError(f"{context}.kind is invalid")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    if not isinstance(value["ownerQualifiedName"], str) or not value["ownerQualifiedName"]:
+        raise RuntimeError(f"{context}.ownerQualifiedName is invalid")
+    _oracle_optional_text(value["moduleSpecifier"], f"{context}.moduleSpecifier")
+    _oracle_optional_text(value["exportedName"], f"{context}.exportedName")
+    _oracle_optional_text(value["localName"], f"{context}.localName")
+    if not isinstance(value["isTypeOnly"], bool):
+        raise RuntimeError(f"{context}.isTypeOnly is invalid")
+    start_byte, end_byte, _ = _oracle_typed_range(value, context)
+    _oracle_statement_range(value, context, start_byte, end_byte)
+    return value
+
+
+def _oracle_base(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle bases[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "startByte",
+        "endByte",
+        "startLine",
+        "statementStartByte",
+        "statementEndByte",
+        "statementStartLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] not in {"extends", "implements"} or value["kind"] != value["relation"]:
+        raise RuntimeError(f"{context}.relation or kind is invalid")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("ownerQualifiedName", "targetSpelling"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    _oracle_optional_text(value["qualifier"], f"{context}.qualifier")
+    start_byte, end_byte, _ = _oracle_typed_range(value, context)
+    _oracle_statement_range(value, context, start_byte, end_byte)
+    return value
+
+
+def _oracle_member(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle members[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "accessKind",
+        "optional",
+        "startByte",
+        "endByte",
+        "startLine",
+        "statementStartByte",
+        "statementEndByte",
+        "statementStartLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] != "accesses" or value["kind"] not in {"property", "computed_literal"}:
+        raise RuntimeError(f"{context}.relation or kind is invalid")
+    if value["accessKind"] not in {"read", "write"}:
+        raise RuntimeError(f"{context}.accessKind is invalid")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("ownerQualifiedName", "targetSpelling"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    _oracle_optional_text(value["qualifier"], f"{context}.qualifier")
+    if not isinstance(value["optional"], bool):
+        raise RuntimeError(f"{context}.optional is invalid")
+    start_byte, end_byte, _ = _oracle_typed_range(value, context)
+    _oracle_statement_range(value, context, start_byte, end_byte)
+    return value
+
+
+def _oracle_reference(value: object, index: int) -> Mapping[str, object]:
+    context = f"oracle references[{index}]"
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{context} must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "kind",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "startByte",
+        "endByte",
+        "startLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"{context} has an invalid schema")
+    if value["relation"] != "references" or value["kind"] not in {"identifier", "type", "jsx"}:
+        raise RuntimeError(f"{context}.relation or kind is invalid")
+    _safe_oracle_file(value["sourceFile"], f"{context}.sourceFile")
+    for field in ("ownerQualifiedName", "targetSpelling"):
+        if not isinstance(value[field], str) or not value[field]:
+            raise RuntimeError(f"{context}.{field} is invalid")
+    _oracle_optional_text(value["qualifier"], f"{context}.qualifier")
+    _oracle_typed_range(value, context)
     return value
 
 
@@ -602,7 +854,19 @@ def _typescript_inventory_from_payload(
         "rejectedFiles",
         "constructs",
     }
-    optional = {"projects", "diagnostics", "scopes", "declarations", "calls"}
+    optional = {
+        "projects",
+        "diagnostics",
+        "scopes",
+        "declarations",
+        "calls",
+        "constructions",
+        "imports",
+        "reexports",
+        "bases",
+        "members",
+        "references",
+    }
     if not required.issubset(payload) or set(payload) - required - optional:
         raise RuntimeError("TypeScript source oracle output has an invalid schema")
     if payload["schema"] != _TYPESCRIPT_ORACLE_SCHEMA:
@@ -680,11 +944,19 @@ def _typescript_inventory_from_payload(
                 f"oracle construct range exceeds source: {construct.source_file}"
             )
     typed_records: dict[str, list[Mapping[str, object]]] = {}
-    for field, validator in (
+    typed_specs = (
         ("scopes", _oracle_scope),
         ("declarations", _oracle_declaration),
         ("calls", _oracle_call),
-    ):
+        ("constructions", _oracle_construction),
+        ("imports", _oracle_import),
+        ("reexports", _oracle_reexport),
+        ("bases", _oracle_base),
+        ("members", _oracle_member),
+        ("references", _oracle_reference),
+    )
+    total_typed_facts = 0
+    for field, validator in typed_specs:
         values = payload.get(field)
         if values is None:
             continue
@@ -694,6 +966,9 @@ def _typescript_inventory_from_payload(
             raise RuntimeError(
                 f"TypeScript source oracle {field} exceeds the configured limit"
             )
+        total_typed_facts += len(values)
+        if total_typed_facts > _TYPESCRIPT_ORACLE_MAX_TYPED_FACTS:
+            raise RuntimeError("TypeScript source oracle typed facts exceed the configured limit")
         typed_records[field] = [validator(value, index) for index, value in enumerate(values)]
     scope_ids: set[str] = set()
     scopes_by_id: dict[str, Mapping[str, object]] = {}
@@ -756,9 +1031,13 @@ def _typescript_inventory_from_payload(
                 raise RuntimeError(
                     f"oracle {field}[{index}] range exceeds source: {source_file}"
                 )
-            if field == "calls" and record["callEndByte"] > source_path.stat().st_size:
+            if field in {"calls", "constructions"} and record["callEndByte"] > source_path.stat().st_size:
                 raise RuntimeError(
-                    f"oracle calls[{index}] call range exceeds source: {source_file}"
+                    f"oracle {field}[{index}] call range exceeds source: {source_file}"
+                )
+            if field in {"imports", "reexports", "bases", "members"} and record["statementEndByte"] > source_path.stat().st_size:
+                raise RuntimeError(
+                    f"oracle {field}[{index}] statement range exceeds source: {source_file}"
                 )
     if len(rejected_files) != scanned - parsed:
         raise RuntimeError(
@@ -892,9 +1171,45 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
     scopes: list[dict[str, object]] = []
     declarations: list[dict[str, object]] = []
     calls: list[dict[str, object]] = []
+    constructions: list[dict[str, object]] = []
+    imports: list[dict[str, object]] = []
+    reexports: list[dict[str, object]] = []
+    bases: list[dict[str, object]] = []
+    members: list[dict[str, object]] = []
+    references: list[dict[str, object]] = []
     files: list[dict[str, object]] = []
+    record_order = {
+        "project": 0,
+        "file": 1,
+        "diagnostic": 2,
+        "construct": 3,
+        "scope": 4,
+        "declaration": 5,
+        "call": 6,
+        "construction": 7,
+        "import": 8,
+        "reexport": 9,
+        "base": 10,
+        "member": 11,
+        "reference": 12,
+    }
+    previous_order = -1
     for index, record in enumerate(records[1:-1], 1):
         record_type = record.get("recordType")
+        if not isinstance(record_type, str):
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL record {index} has an invalid type"
+            )
+        current_order = record_order.get(record_type)
+        if current_order is None:
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL record {index} has an invalid type"
+            )
+        if current_order < previous_order:
+            raise RuntimeError(
+                f"TypeScript source oracle JSONL record {index} is not deterministically ordered"
+            )
+        previous_order = current_order
         if record_type == "project":
             projects.append({key: value for key, value in record.items() if key != "recordType"})
         elif record_type == "diagnostic":
@@ -913,12 +1228,26 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
             )
         elif record_type == "call":
             calls.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "construction":
+            constructions.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
+        elif record_type == "import":
+            imports.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "reexport":
+            reexports.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
+        elif record_type == "base":
+            bases.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "member":
+            members.append({key: value for key, value in record.items() if key != "recordType"})
+        elif record_type == "reference":
+            references.append(
+                {key: value for key, value in record.items() if key != "recordType"}
+            )
         elif record_type == "file":
             files.append(record)
-        else:
-            raise RuntimeError(
-                f"TypeScript source oracle JSONL record {index} has an invalid type"
-            )
     scanned = header.get("scannedFiles")
     parsed = header.get("parsedFiles")
     if not isinstance(scanned, int) or isinstance(scanned, bool) or scanned < 0:
@@ -956,6 +1285,12 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         "scopeCount": len(scopes),
         "declarationCount": len(declarations),
         "callCount": len(calls),
+        "constructionCount": len(constructions),
+        "importCount": len(imports),
+        "reexportCount": len(reexports),
+        "baseCount": len(bases),
+        "memberCount": len(members),
+        "referenceCount": len(references),
     }
     for key, expected in footer_counts.items():
         if footer.get(key) != expected:
@@ -970,6 +1305,12 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         ("scopes", scopes, _oracle_scope),
         ("declarations", declarations, _oracle_declaration),
         ("calls", calls, _oracle_call),
+        ("constructions", constructions, _oracle_construction),
+        ("imports", imports, _oracle_import),
+        ("reexports", reexports, _oracle_reexport),
+        ("bases", bases, _oracle_base),
+        ("members", members, _oracle_member),
+        ("references", references, _oracle_reference),
     ):
         for index, value in enumerate(values):
             validator(value, index)
@@ -988,6 +1329,32 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         raise RuntimeError("TypeScript source oracle JSONL declaration count is inconsistent")
     if header.get("callCount") != len(calls):
         raise RuntimeError("TypeScript source oracle JSONL call count is inconsistent")
+    for key, values in (
+        ("constructionCount", constructions),
+        ("importCount", imports),
+        ("reexportCount", reexports),
+        ("baseCount", bases),
+        ("memberCount", members),
+        ("referenceCount", references),
+    ):
+        if header.get(key) != len(values):
+            raise RuntimeError(f"TypeScript source oracle JSONL {key} is inconsistent")
+    typed_total = sum(
+        len(values)
+        for values in (
+            scopes,
+            declarations,
+            calls,
+            constructions,
+            imports,
+            reexports,
+            bases,
+            members,
+            references,
+        )
+    )
+    if typed_total > _TYPESCRIPT_ORACLE_MAX_TYPED_FACTS:
+        raise RuntimeError("TypeScript source oracle JSONL typed facts exceed the configured limit")
     if footer.get("rejectedFiles") != sorted(rejected):
         raise RuntimeError("TypeScript source oracle JSONL rejected file set is inconsistent")
     for digest_name in ("sourceDigest", "configDigest"):
@@ -1008,6 +1375,12 @@ def _typescript_payload_from_jsonl(raw: bytes) -> dict[str, object]:
         "scopes": scopes,
         "declarations": declarations,
         "calls": calls,
+        "constructions": constructions,
+        "imports": imports,
+        "reexports": reexports,
+        "bases": bases,
+        "members": members,
+        "references": references,
     }
 
 

--- a/benchmarks/performance/compass/occurrences.py
+++ b/benchmarks/performance/compass/occurrences.py
@@ -7,8 +7,12 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
+import selectors
+import subprocess
+import time
 import tokenize
 
 
@@ -52,6 +56,7 @@ class SourceConstructInventory:
     scanned_files: int
     parsed_files: int
     rejected_files: tuple[str, ...]
+    provider_metadata: tuple[tuple[str, str], ...] = ()
 
 
 SourceConstructParser = Callable[
@@ -65,6 +70,7 @@ class ConstructProvider:
     identity: str
     suffixes: tuple[str, ...]
     parse: SourceConstructParser
+    collect: Callable[[Path], SourceConstructInventory] | None = None
 
 
 def _python_statement_spans(path: Path) -> StatementSpans:
@@ -274,12 +280,288 @@ def _python_constructs(root: Path, path: Path) -> tuple[SourceConstruct, ...] | 
     return tuple(sorted(set(constructs), key=_source_construct_key))
 
 
+_TYPESCRIPT_ORACLE_SCHEMA = "compass.typescript-source-oracle/1"
+_TYPESCRIPT_ORACLE_PROVIDER = "typescript_compiler_api_5_9_3"
+_TYPESCRIPT_ORACLE_SCRIPT = (
+    Path(__file__).resolve().parents[1] / "oracles" / "typescript-source-oracle.mjs"
+)
+_TYPESCRIPT_ORACLE_TIMEOUT_SECONDS = 90.0
+_TYPESCRIPT_ORACLE_OUTPUT_BYTES = 64 * 1024 * 1024
+
+
+def _bounded_node_oracle(root: Path) -> bytes:
+    """Run the independent compiler oracle with bounded pipes and duration."""
+
+    if not _TYPESCRIPT_ORACLE_SCRIPT.is_file():
+        raise RuntimeError(f"TypeScript source oracle is missing: {_TYPESCRIPT_ORACLE_SCRIPT}")
+    command = (
+        "node",
+        str(_TYPESCRIPT_ORACLE_SCRIPT),
+        "--root",
+        str(root),
+    )
+    process = subprocess.Popen(
+        command,
+        cwd=_TYPESCRIPT_ORACLE_SCRIPT.parents[3],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    output = bytearray()
+    error = bytearray()
+    started = time.monotonic()
+    limit_error: str | None = None
+    try:
+        while selector.get_map():
+            remaining = _TYPESCRIPT_ORACLE_TIMEOUT_SECONDS - (
+                time.monotonic() - started
+            )
+            if remaining <= 0:
+                limit_error = (
+                    "TypeScript source oracle exceeded "
+                    f"{_TYPESCRIPT_ORACLE_TIMEOUT_SECONDS:.0f}s"
+                )
+                process.kill()
+                break
+            events = selector.select(min(remaining, 0.25))
+            for key, _ in events:
+                chunk = os.read(key.fileobj.fileno(), 64 * 1024)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    key.fileobj.close()
+                    continue
+                if key.data == "stdout":
+                    output.extend(chunk)
+                    if len(output) > _TYPESCRIPT_ORACLE_OUTPUT_BYTES:
+                        limit_error = (
+                            "TypeScript source oracle output exceeds "
+                            f"{_TYPESCRIPT_ORACLE_OUTPUT_BYTES} bytes"
+                        )
+                        process.kill()
+                        break
+                else:
+                    error.extend(chunk)
+            if limit_error is not None:
+                break
+    finally:
+        selector.close()
+        if process.poll() is None:
+            process.kill()
+        process.wait()
+        process.stdout.close()
+        process.stderr.close()
+    if limit_error is not None:
+        raise RuntimeError(limit_error)
+    if process.returncode != 0:
+        detail = error.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            "TypeScript source oracle failed"
+            + (f": {detail[:2_000]}" if detail else "")
+        )
+    return bytes(output)
+
+
+def _safe_oracle_file(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{context} must be a non-empty relative path")
+    relative = Path(value.replace("\\", "/"))
+    if relative.is_absolute() or ".." in relative.parts:
+        raise RuntimeError(f"{context} escapes the source root")
+    normalized = relative.as_posix()
+    if normalized in {"", "."} or any(part in {"", "."} for part in relative.parts):
+        raise RuntimeError(f"{context} is not normalized")
+    return normalized
+
+
+def _oracle_construct(value: object, index: int) -> SourceConstruct:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"oracle constructs[{index}] must be an object")
+    required = {
+        "sourceFile",
+        "relation",
+        "capability",
+        "ownerQualifiedName",
+        "targetSpelling",
+        "qualifier",
+        "startByte",
+        "endByte",
+        "startLine",
+    }
+    if set(value) != required:
+        raise RuntimeError(f"oracle constructs[{index}] has an invalid schema")
+    source_file = _safe_oracle_file(value["sourceFile"], f"constructs[{index}].sourceFile")
+    text_values = (
+        ("relation", value["relation"]),
+        ("capability", value["capability"]),
+        ("ownerQualifiedName", value["ownerQualifiedName"]),
+        ("targetSpelling", value["targetSpelling"]),
+    )
+    if any(not isinstance(item, str) or not item for _, item in text_values):
+        raise RuntimeError(f"oracle constructs[{index}] has invalid text fields")
+    qualifier = value["qualifier"]
+    if qualifier is not None and (not isinstance(qualifier, str) or not qualifier):
+        raise RuntimeError(f"oracle constructs[{index}].qualifier is invalid")
+    start_byte = value["startByte"]
+    end_byte = value["endByte"]
+    start_line = value["startLine"]
+    if (
+        isinstance(start_byte, bool)
+        or not isinstance(start_byte, int)
+        or isinstance(end_byte, bool)
+        or not isinstance(end_byte, int)
+        or isinstance(start_line, bool)
+        or not isinstance(start_line, int)
+        or start_byte < 0
+        or end_byte <= start_byte
+        or start_line <= 0
+    ):
+        raise RuntimeError(f"oracle constructs[{index}] has an invalid source range")
+    return SourceConstruct(
+        source_file,
+        value["relation"],
+        value["capability"],
+        value["ownerQualifiedName"],
+        value["targetSpelling"],
+        qualifier,
+        start_byte,
+        end_byte,
+        start_line,
+    )
+
+
+def _typescript_inventory_from_payload(
+    payload: object,
+    root: Path,
+) -> SourceConstructInventory:
+    root = root.resolve()
+    if not isinstance(payload, dict):
+        raise RuntimeError("TypeScript source oracle output must be an object")
+    required = {
+        "schema",
+        "provider",
+        "metadata",
+        "scannedFiles",
+        "parsedFiles",
+        "rejectedFiles",
+        "constructs",
+    }
+    if set(payload) != required:
+        raise RuntimeError("TypeScript source oracle output has an invalid schema")
+    if payload["schema"] != _TYPESCRIPT_ORACLE_SCHEMA:
+        raise RuntimeError(f"unsupported TypeScript source oracle schema: {payload['schema']!r}")
+    if payload["provider"] != _TYPESCRIPT_ORACLE_PROVIDER:
+        raise RuntimeError(
+            "TypeScript source oracle provider mismatch: "
+            f"expected {_TYPESCRIPT_ORACLE_PROVIDER!r}, observed {payload['provider']!r}"
+        )
+    metadata = payload["metadata"]
+    if not isinstance(metadata, dict) or any(
+        not isinstance(key, str)
+        or not key
+        or not isinstance(value, str)
+        or not value
+        for key, value in metadata.items()
+    ):
+        raise RuntimeError("TypeScript source oracle metadata is invalid")
+    compiler_version = metadata.get("compilerVersion")
+    script_sha256 = metadata.get("scriptSha256")
+    if compiler_version != "5.9.3" or not re.fullmatch(r"[0-9a-f]{64}", script_sha256 or ""):
+        raise RuntimeError("TypeScript source oracle metadata is not pinned")
+    scanned = payload["scannedFiles"]
+    parsed = payload["parsedFiles"]
+    if (
+        isinstance(scanned, bool)
+        or not isinstance(scanned, int)
+        or isinstance(parsed, bool)
+        or not isinstance(parsed, int)
+        or scanned < 0
+        or parsed < 0
+        or parsed > scanned
+    ):
+        raise RuntimeError("TypeScript source oracle coverage counts are invalid")
+    rejected = payload["rejectedFiles"]
+    if not isinstance(rejected, list):
+        raise RuntimeError("TypeScript source oracle rejectedFiles must be an array")
+    rejected_files = tuple(
+        sorted({_safe_oracle_file(value, "rejectedFiles[]") for value in rejected})
+    )
+    constructs = payload["constructs"]
+    if not isinstance(constructs, list):
+        raise RuntimeError("TypeScript source oracle constructs must be an array")
+    parsed_constructs = tuple(
+        sorted(
+            {_oracle_construct(value, index) for index, value in enumerate(constructs)},
+            key=_source_construct_key,
+        )
+    )
+    for construct in parsed_constructs:
+        path = (root / construct.source_file).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as error:
+            raise RuntimeError(
+                f"oracle construct escapes the source root: {construct.source_file}"
+            ) from error
+        if not path.is_file():
+            raise RuntimeError(f"oracle construct source is missing: {construct.source_file}")
+        if construct.end_byte > path.stat().st_size:
+            raise RuntimeError(
+                f"oracle construct range exceeds source: {construct.source_file}"
+            )
+    if len(rejected_files) != scanned - parsed:
+        raise RuntimeError(
+            "TypeScript source oracle coverage does not account for every scanned file"
+        )
+    return SourceConstructInventory(
+        parsed_constructs,
+        scanned,
+        parsed,
+        rejected_files,
+        tuple(sorted(metadata.items())),
+    )
+
+
+def _typescript_compiler_inventory(root: Path) -> SourceConstructInventory:
+    try:
+        payload = json.loads(_bounded_node_oracle(root).decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid TypeScript source oracle output: {error}") from error
+    return _typescript_inventory_from_payload(payload, root)
+
+
+def _collector_only_construct_parser(
+    _root: Path,
+    _path: Path,
+) -> tuple[SourceConstruct, ...] | None:
+    """Placeholder for providers whose parser runs once per project root."""
+
+    return None
+
+
 DEFAULT_STATEMENT_PROVIDERS: Mapping[str, StatementProvider] = {
     ".py": _python_statement_spans,
 }
 
 DEFAULT_CONSTRUCT_PROVIDERS: Mapping[str, ConstructProvider] = {
     "python": ConstructProvider("python_ast", (".py",), _python_constructs),
+    "typescript": ConstructProvider(
+        _TYPESCRIPT_ORACLE_PROVIDER,
+        (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".d.ts"),
+        _collector_only_construct_parser,
+        _typescript_compiler_inventory,
+    ),
+    "javascript": ConstructProvider(
+        _TYPESCRIPT_ORACLE_PROVIDER,
+        (".js", ".jsx", ".mjs", ".cjs"),
+        _collector_only_construct_parser,
+        _typescript_compiler_inventory,
+    ),
 }
 
 
@@ -316,6 +598,8 @@ def independent_source_inventory(
     provider = providers.get(language.casefold())
     if provider is None:
         return SourceConstructInventory((), 0, 0, ())
+    if provider.collect is not None:
+        return provider.collect(root)
     constructs: list[SourceConstruct] = []
     scanned = 0
     parsed = 0
@@ -357,6 +641,11 @@ def source_construct_inventory_sha256(
         "scannedFiles": inventory.scanned_files,
         "parsedFiles": inventory.parsed_files,
         "rejectedFiles": list(inventory.rejected_files),
+        **(
+            {"providerMetadata": dict(inventory.provider_metadata)}
+            if inventory.provider_metadata
+            else {}
+        ),
         "constructs": [
             {
                 "sourceFile": construct.source_file,

--- a/benchmarks/performance/compass/typescript_scorecard.py
+++ b/benchmarks/performance/compass/typescript_scorecard.py
@@ -1,0 +1,702 @@
+"""Machine-checkable TypeScript/JavaScript target-quality scorecards.
+
+The scorecard is a qualification input, not a Compass runtime dependency. It
+consumes explicitly adjudicated records produced from the independent
+TypeScript checker oracle and the candidate evidence report. A record without
+an explicit judgment is rejected; an automatic checker result is never
+silently promoted to accepted precision evidence.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any
+
+from .audit import (
+    CAPABILITY_MINIMUM,
+    CAPABILITY_PRECISION_GATE,
+    CAPABILITY_RECALL_GATE,
+    CORPUS_MINIMUM,
+    CORRECT_ACCEPTED_JUDGMENTS,
+    CRITICAL_JUDGMENTS,
+    PRECISION_GATE,
+    PRECISION_WILSON_LOWER_GATE,
+    QUALIFICATION_MINIMUM,
+    RECALL_RECOVERED_JUDGMENTS,
+    RECALL_TRUTH_JUDGMENTS,
+    RELATION_MINIMUM,
+    TARGET_CLUSTER_MAXIMUM_FRACTION,
+    wilson_interval,
+)
+
+
+SCORECARD_SCHEMA = "compass.typescript-target-scorecard/1"
+RESULT_SCHEMA = "compass.typescript-target-scorecard-result/1"
+PROVIDER = "typescript_checker_api_5_9_3"
+MIN_RELEASE_CORPORA = 4
+LEADERSHIP_PRECISION_GATE = 0.997
+LEADERSHIP_WILSON_LOWER_GATE = 0.992
+LEADERSHIP_CAPABILITY_PRECISION_GATE = 0.995
+LEADERSHIP_RECALL_GATE = 0.97
+HEX_40 = re.compile(r"^[0-9a-f]{40}$")
+HEX_64 = re.compile(r"^[0-9a-f]{64}$")
+IDENTITY = re.compile(r"^[a-z0-9][a-z0-9_.:/-]*$")
+POOLS = frozenset(("accepted", "source_oracle"))
+MODES = frozenset(("diagnostic", "qualification", "leadership"))
+JUDGMENTS = frozenset(
+    (
+        "correct",
+        "invalid",
+        "ambiguous",
+        "external",
+        "represented_elsewhere",
+        "missing",
+        "fabricated_occurrence",
+        "cross_language_match",
+        "unsafe_local_substitution",
+    )
+)
+ACCEPTED_JUDGMENTS = CORRECT_ACCEPTED_JUDGMENTS | frozenset(
+    ("invalid", *CRITICAL_JUDGMENTS)
+)
+SOURCE_JUDGMENTS = RECALL_TRUTH_JUDGMENTS | frozenset(("ambiguous",))
+
+
+class TypeScriptScorecardError(ValueError):
+    """A scorecard is stale, incomplete, unsafe, or structurally invalid."""
+
+
+@dataclass(frozen=True)
+class ScorecardRecord:
+    record_id: str
+    corpus: str
+    adapter: str
+    framework_pack: str | None
+    language: str
+    capability: str
+    relation: str
+    pool: str
+    target_cluster: str
+    source_file: str
+    start_byte: int
+    end_byte: int
+    judgment: str
+    judgment_source: str
+
+
+def _object(value: object, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeScriptScorecardError(f"{context} must be an object")
+    return value
+
+
+def _array(value: object, context: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise TypeScriptScorecardError(f"{context} must be an array")
+    return value
+
+
+def _text(value: object, context: str, *, identity: bool = False) -> str:
+    if not isinstance(value, str) or not value:
+        raise TypeScriptScorecardError(f"{context} must be a non-empty string")
+    if identity and IDENTITY.fullmatch(value) is None:
+        raise TypeScriptScorecardError(f"{context} is not a stable identity: {value!r}")
+    return value
+
+
+def _hex(value: object, context: str, pattern: re.Pattern[str]) -> str:
+    text = _text(value, context)
+    if pattern.fullmatch(text) is None:
+        raise TypeScriptScorecardError(f"{context} must be lowercase hexadecimal")
+    return text
+
+
+def _non_negative_int(value: object, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise TypeScriptScorecardError(f"{context} must be a non-negative integer")
+    return value
+
+
+def _safe_source_file(value: object, context: str) -> str:
+    source_file = _text(value, context)
+    relative = PurePosixPath(source_file.replace("\\", "/"))
+    if relative.is_absolute() or ".." in relative.parts:
+        raise TypeScriptScorecardError(f"{context} must be a safe relative path")
+    return "/".join(relative.parts)
+
+
+def _target_evidence(value: object, context: str) -> None:
+    if value is None:
+        return
+    item = _object(value, context)
+    allowed = {"kind", "file", "startByte", "endByte", "qualifiedName"}
+    if set(item) - allowed:
+        raise TypeScriptScorecardError(f"{context} has unknown fields")
+    if "kind" in item:
+        _text(item["kind"], f"{context}.kind", identity=True)
+    if "file" in item:
+        _safe_source_file(item["file"], f"{context}.file")
+    if "startByte" in item:
+        _non_negative_int(item["startByte"], f"{context}.startByte")
+    if "endByte" in item:
+        _non_negative_int(item["endByte"], f"{context}.endByte")
+    if "qualifiedName" in item:
+        _text(item["qualifiedName"], f"{context}.qualifiedName")
+
+
+def _record(value: object, index: int) -> ScorecardRecord:
+    context = f"records[{index}]"
+    item = _object(value, context)
+    required = {
+        "id",
+        "corpus",
+        "adapter",
+        "language",
+        "capability",
+        "relation",
+        "pool",
+        "targetCluster",
+        "sourceFile",
+        "startByte",
+        "endByte",
+        "judgment",
+        "judgmentSource",
+    }
+    optional = {
+        "automaticOutcome",
+        "frameworkPack",
+        "expectedTarget",
+        "observedTargets",
+        "oracleResolutionKind",
+        "targetSpelling",
+        "reason",
+    }
+    unknown = sorted(set(item) - required - optional)
+    missing = sorted(required - set(item))
+    if missing:
+        raise TypeScriptScorecardError(
+            f"{context} missing fields: {', '.join(missing)}"
+        )
+    if unknown:
+        raise TypeScriptScorecardError(
+            f"{context} has unknown fields: {', '.join(unknown)}"
+        )
+    if "expectedTarget" in item:
+        _target_evidence(item["expectedTarget"], f"{context}.expectedTarget")
+    if "observedTargets" in item:
+        for target_index, target in enumerate(
+            _array(item["observedTargets"], f"{context}.observedTargets")
+        ):
+            _target_evidence(target, f"{context}.observedTargets[{target_index}]")
+    for field in ("oracleResolutionKind", "targetSpelling", "reason"):
+        if field in item and not isinstance(item[field], str):
+            raise TypeScriptScorecardError(f"{context}.{field} must be a string")
+    if "automaticOutcome" in item:
+        _text(item["automaticOutcome"], f"{context}.automaticOutcome", identity=True)
+    pool = _text(item["pool"], f"{context}.pool", identity=True)
+    if pool not in POOLS:
+        raise TypeScriptScorecardError(f"{context}.pool is unknown: {pool!r}")
+    judgment = _text(item["judgment"], f"{context}.judgment", identity=True)
+    if judgment not in JUDGMENTS:
+        raise TypeScriptScorecardError(f"{context}.judgment is unknown: {judgment!r}")
+    allowed = ACCEPTED_JUDGMENTS if pool == "accepted" else SOURCE_JUDGMENTS
+    if judgment not in allowed:
+        raise TypeScriptScorecardError(
+            f"{context}.judgment {judgment!r} is invalid for pool {pool!r}"
+        )
+    judgment_source = _text(
+        item["judgmentSource"], f"{context}.judgmentSource", identity=True
+    )
+    if judgment_source != "manual":
+        raise TypeScriptScorecardError(
+            f"{context}.judgmentSource must be 'manual'; automatic outcomes "
+            "cannot become scorecard judgments"
+        )
+    if judgment != "correct" and not item.get("reason"):
+        raise TypeScriptScorecardError(
+            f"{context}.reason is required for non-correct judgments"
+        )
+    start = _non_negative_int(item["startByte"], f"{context}.startByte")
+    end = _non_negative_int(item["endByte"], f"{context}.endByte")
+    if end <= start:
+        raise TypeScriptScorecardError(f"{context} byte range must be non-empty")
+    return ScorecardRecord(
+        record_id=_text(item["id"], f"{context}.id", identity=True),
+        corpus=_text(item["corpus"], f"{context}.corpus", identity=True),
+        adapter=_text(item["adapter"], f"{context}.adapter", identity=True),
+        framework_pack=(
+            _text(item["frameworkPack"], f"{context}.frameworkPack", identity=True)
+            if item.get("frameworkPack") is not None
+            else None
+        ),
+        language=_text(item["language"], f"{context}.language", identity=True),
+        capability=_text(item["capability"], f"{context}.capability", identity=True),
+        relation=_text(item["relation"], f"{context}.relation", identity=True),
+        pool=pool,
+        target_cluster=_text(
+            item["targetCluster"], f"{context}.targetCluster", identity=True
+        ),
+        source_file=_safe_source_file(item["sourceFile"], f"{context}.sourceFile"),
+        start_byte=start,
+        end_byte=end,
+        judgment=judgment,
+        judgment_source=judgment_source,
+    )
+
+
+def _corpus(value: object, index: int) -> tuple[str, str]:
+    context = f"corpora[{index}]"
+    item = _object(value, context)
+    if set(item) != {"name", "commit"}:
+        raise TypeScriptScorecardError(
+            f"{context} must contain exactly name and commit"
+        )
+    return (
+        _text(item["name"], f"{context}.name", identity=True),
+        _hex(item["commit"], f"{context}.commit", HEX_40),
+    )
+
+
+def _capability(value: object, index: int) -> tuple[str, str, str | None]:
+    context = f"advertisedCapabilities[{index}]"
+    item = _object(value, context)
+    allowed = {"adapter", "capability", "frameworkPack"}
+    if set(item) - allowed or not {"adapter", "capability"} <= set(item):
+        raise TypeScriptScorecardError(
+            f"{context} must contain adapter, capability, and optional frameworkPack"
+        )
+    framework = item.get("frameworkPack")
+    return (
+        _text(item["adapter"], f"{context}.adapter", identity=True),
+        _text(item["capability"], f"{context}.capability", identity=True),
+        (
+            _text(framework, f"{context}.frameworkPack", identity=True)
+            if framework is not None
+            else None
+        ),
+    )
+
+
+def _comparator(value: object, index: int) -> tuple[str, bool, bool]:
+    context = f"comparators[{index}]"
+    item = _object(value, context)
+    required = {"name", "version", "scopeDigest", "equivalentScope", "adjudicated"}
+    if set(item) != required:
+        raise TypeScriptScorecardError(
+            f"{context} must contain name, version, scopeDigest, "
+            "equivalentScope, and adjudicated"
+        )
+    name = _text(item["name"], f"{context}.name", identity=True)
+    _text(item["version"], f"{context}.version")
+    _hex(item["scopeDigest"], f"{context}.scopeDigest", HEX_64)
+    if not isinstance(item["equivalentScope"], bool) or not isinstance(
+        item["adjudicated"], bool
+    ):
+        raise TypeScriptScorecardError(
+            f"{context}.equivalentScope and adjudicated must be booleans"
+        )
+    return name, item["equivalentScope"], item["adjudicated"]
+
+
+def _load(path: Path) -> tuple[dict[str, Any], tuple[ScorecardRecord, ...]]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise TypeScriptScorecardError(f"could not load scorecard {path}: {error}") from error
+    item = _object(raw, "scorecard")
+    required = {
+        "schema",
+        "mode",
+        "provider",
+        "oracleScriptSha256",
+        "candidateAdapter",
+        "corpora",
+        "releaseGateCorpora",
+        "advertisedCapabilities",
+        "requiredRelations",
+        "records",
+        "comparators",
+    }
+    missing = sorted(required - set(item))
+    unknown = sorted(set(item) - required)
+    if missing:
+        raise TypeScriptScorecardError(
+            f"scorecard missing fields: {', '.join(missing)}"
+        )
+    if unknown:
+        raise TypeScriptScorecardError(
+            f"scorecard has unknown fields: {', '.join(unknown)}"
+        )
+    if item["schema"] != SCORECARD_SCHEMA:
+        raise TypeScriptScorecardError(f"scorecard schema must be {SCORECARD_SCHEMA!r}")
+    mode = _text(item["mode"], "scorecard.mode", identity=True)
+    if mode not in MODES:
+        raise TypeScriptScorecardError(f"scorecard.mode is unknown: {mode!r}")
+    if item["provider"] != PROVIDER:
+        raise TypeScriptScorecardError(
+            f"scorecard.provider must be {PROVIDER!r}, got {item['provider']!r}"
+        )
+    _hex(item["oracleScriptSha256"], "scorecard.oracleScriptSha256", HEX_64)
+    _text(item["candidateAdapter"], "scorecard.candidateAdapter", identity=True)
+    corpora = tuple(
+        _corpus(value, index)
+        for index, value in enumerate(_array(item["corpora"], "scorecard.corpora"))
+    )
+    if not corpora or len({name for name, _ in corpora}) != len(corpora):
+        raise TypeScriptScorecardError("scorecard.corpora must be non-empty and unique")
+    corpus_names = {name for name, _ in corpora}
+    release = tuple(
+        _text(value, f"releaseGateCorpora[{index}]", identity=True)
+        for index, value in enumerate(
+            _array(item["releaseGateCorpora"], "scorecard.releaseGateCorpora")
+        )
+    )
+    if len(set(release)) != len(release) or any(name not in corpus_names for name in release):
+        raise TypeScriptScorecardError(
+            "releaseGateCorpora must be unique and reference declared corpora"
+        )
+    capabilities = tuple(
+        _capability(value, index)
+        for index, value in enumerate(
+            _array(item["advertisedCapabilities"], "scorecard.advertisedCapabilities")
+        )
+    )
+    if not capabilities or len(set(capabilities)) != len(capabilities):
+        raise TypeScriptScorecardError(
+            "advertisedCapabilities must be non-empty and unique"
+        )
+    relations = tuple(
+        _text(value, f"requiredRelations[{index}]", identity=True)
+        for index, value in enumerate(
+            _array(item["requiredRelations"], "scorecard.requiredRelations")
+        )
+    )
+    if not relations or len(set(relations)) != len(relations):
+        raise TypeScriptScorecardError(
+            "requiredRelations must be non-empty and unique"
+        )
+    records = tuple(
+        _record(value, index)
+        for index, value in enumerate(_array(item["records"], "scorecard.records"))
+    )
+    record_ids = [record.record_id for record in records]
+    if record_ids != sorted(record_ids) or len(record_ids) != len(set(record_ids)):
+        raise TypeScriptScorecardError(
+            "records must be sorted by unique id"
+        )
+    advertised = set(capabilities)
+    for record in records:
+        if record.corpus not in corpus_names:
+            raise TypeScriptScorecardError(
+                f"record {record.record_id!r} references unknown corpus"
+            )
+        if (record.adapter, record.capability, record.framework_pack) not in advertised:
+            raise TypeScriptScorecardError(
+                f"record {record.record_id!r} references unadvertised capability"
+            )
+        if record.relation not in relations:
+            raise TypeScriptScorecardError(
+                f"record {record.record_id!r} references undeclared relation"
+            )
+    comparators = tuple(
+        _comparator(value, index)
+        for index, value in enumerate(
+            _array(item["comparators"], "scorecard.comparators")
+        )
+    )
+    if len({name for name, _, _ in comparators}) != len(comparators):
+        raise TypeScriptScorecardError("comparators must have unique names")
+    return item, records
+
+
+def _metric(numerator: int, denominator: int, *, interval: bool) -> dict[str, Any]:
+    interval_value = wilson_interval(numerator, denominator) if interval else None
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "observed": numerator / denominator if denominator else None,
+        "wilson95": (
+            {"lower": interval_value.lower, "upper": interval_value.upper}
+            if interval_value is not None
+            else None
+        ),
+    }
+
+
+def _contribution(record: ScorecardRecord) -> tuple[int, int, int, int]:
+    accepted = record.pool == "accepted"
+    source = record.pool == "source_oracle"
+    return (
+        int(accepted and record.judgment in CORRECT_ACCEPTED_JUDGMENTS),
+        int(accepted),
+        int(source and record.judgment in RECALL_RECOVERED_JUDGMENTS),
+        int(source and record.judgment in RECALL_TRUTH_JUDGMENTS),
+    )
+
+
+def _strata(records: tuple[ScorecardRecord, ...]) -> dict[str, dict[str, dict[str, Any]]]:
+    dimensions = {
+        "corpus": lambda record: record.corpus,
+        "adapter": lambda record: record.adapter,
+        "frameworkPack": lambda record: record.framework_pack or "none",
+        "language": lambda record: record.language,
+        "relation": lambda record: record.relation,
+        "capability": lambda record: record.capability,
+        "targetCluster": lambda record: record.target_cluster,
+    }
+    result: dict[str, dict[str, dict[str, Any]]] = {}
+    for dimension, key_for in dimensions.items():
+        groups: dict[str, list[ScorecardRecord]] = defaultdict(list)
+        for record in records:
+            groups[key_for(record)].append(record)
+        result[dimension] = {}
+        for key in sorted(groups):
+            contributions = [_contribution(record) for record in groups[key]]
+            precision_numerator = sum(value[0] for value in contributions)
+            precision_denominator = sum(value[1] for value in contributions)
+            recall_numerator = sum(value[2] for value in contributions)
+            recall_denominator = sum(value[3] for value in contributions)
+            result[dimension][key] = {
+                "records": len(groups[key]),
+                "correctAccepted": precision_numerator,
+                "auditedAccepted": precision_denominator,
+                "precision": (
+                    precision_numerator / precision_denominator
+                    if precision_denominator
+                    else None
+                ),
+                "recovered": recall_numerator,
+                "recallCandidates": recall_denominator,
+                "recall": (
+                    recall_numerator / recall_denominator
+                    if recall_denominator
+                    else None
+                ),
+            }
+    return result
+
+
+def _failures(
+    item: dict[str, Any],
+    records: tuple[ScorecardRecord, ...],
+    strata: dict[str, dict[str, dict[str, Any]]],
+    precision: dict[str, Any],
+) -> list[str]:
+    diagnostic = item["mode"] == "diagnostic"
+    leadership = item["mode"] == "leadership"
+    failures: list[str] = []
+    if not diagnostic and len(item["releaseGateCorpora"]) < MIN_RELEASE_CORPORA:
+        failures.append(
+            f"releaseGateCorpora has {len(item['releaseGateCorpora'])} entries; "
+            f"{MIN_RELEASE_CORPORA} required"
+        )
+    if not diagnostic and precision["denominator"] < QUALIFICATION_MINIMUM:
+        failures.append(
+            f"accepted target sample has {precision['denominator']} records; "
+            f"{QUALIFICATION_MINIMUM} required"
+        )
+    for corpus in item["releaseGateCorpora"] if not diagnostic else ():
+        count = int(strata["corpus"].get(corpus, {}).get("auditedAccepted", 0))
+        if count < CORPUS_MINIMUM:
+            failures.append(
+                f"corpus {corpus!r} has {count} accepted records; "
+                f"{CORPUS_MINIMUM} required"
+            )
+    for relation in item["requiredRelations"] if not diagnostic else ():
+        count = int(strata["relation"].get(relation, {}).get("auditedAccepted", 0))
+        if count < RELATION_MINIMUM:
+            failures.append(
+                f"relation {relation!r} has {count} accepted records; "
+                f"{RELATION_MINIMUM} required"
+            )
+    if not diagnostic:
+        capability_precision_gate = (
+            LEADERSHIP_CAPABILITY_PRECISION_GATE
+            if leadership
+            else CAPABILITY_PRECISION_GATE
+        )
+        recall_gate = LEADERSHIP_RECALL_GATE if leadership else CAPABILITY_RECALL_GATE
+        for identity in item["advertisedCapabilities"]:
+            adapter = identity["adapter"]
+            capability = identity["capability"]
+            framework = identity.get("frameworkPack")
+            values = [
+                record
+                for record in records
+                if record.adapter == adapter
+                and record.framework_pack == framework
+                and record.capability == capability
+            ]
+            accepted = sum(record.pool == "accepted" for record in values)
+            if accepted < CAPABILITY_MINIMUM:
+                failures.append(
+                    f"capability {(adapter, framework, capability)!r} has {accepted} "
+                    f"accepted records; {CAPABILITY_MINIMUM} required"
+                )
+            correct = sum(
+                record.pool == "accepted"
+                and record.judgment in CORRECT_ACCEPTED_JUDGMENTS
+                for record in values
+            )
+            if accepted and correct / accepted < capability_precision_gate:
+                failures.append(
+                    f"capability {(adapter, framework, capability)!r} precision "
+                    f"{correct / accepted:.6f} is below {capability_precision_gate:.3f}"
+                )
+            recall_values = [
+                record for record in values if record.pool == "source_oracle"
+            ]
+            recall_denominator = sum(
+                record.judgment in RECALL_TRUTH_JUDGMENTS for record in recall_values
+            )
+            recall_numerator = sum(
+                record.judgment in RECALL_RECOVERED_JUDGMENTS
+                for record in recall_values
+            )
+            if recall_denominator == 0:
+                failures.append(
+                    f"capability {(adapter, framework, capability)!r} has no "
+                    "source-derived recall candidates"
+                )
+            elif recall_numerator / recall_denominator < recall_gate:
+                failures.append(
+                    f"capability {(adapter, framework, capability)!r} recall "
+                    f"{recall_numerator / recall_denominator:.6f} is below {recall_gate:.3f}"
+                )
+        precision_gate = LEADERSHIP_PRECISION_GATE if leadership else PRECISION_GATE
+        wilson_gate = (
+            LEADERSHIP_WILSON_LOWER_GATE
+            if leadership
+            else PRECISION_WILSON_LOWER_GATE
+        )
+        if precision["observed"] is None or precision["observed"] < precision_gate:
+            failures.append(
+                f"overall precision {precision['observed']!r} is below {precision_gate:.3f}"
+            )
+        lower = (precision["wilson95"] or {}).get("lower")
+        if lower is None or lower < wilson_gate:
+            failures.append(
+                f"Wilson 95% precision lower bound {lower!r} is below {wilson_gate:.3f}"
+            )
+        for dimension, groups in strata.items():
+            if dimension not in {
+                "corpus",
+                "adapter",
+                "frameworkPack",
+                "language",
+                "relation",
+                "capability",
+            }:
+                continue
+            for key in groups:
+                accepted = [
+                    record
+                    for record in records
+                    if record.pool == "accepted"
+                    and {
+                        "corpus": record.corpus,
+                        "adapter": record.adapter,
+                        "frameworkPack": record.framework_pack or "none",
+                        "language": record.language,
+                        "relation": record.relation,
+                        "capability": record.capability,
+                    }[dimension]
+                    == key
+                ]
+                if not accepted:
+                    continue
+                clusters = Counter(record.target_cluster for record in accepted)
+                cluster, count = max(
+                    clusters.items(), key=lambda pair: (pair[1], pair[0])
+                )
+                if count / len(accepted) > TARGET_CLUSTER_MAXIMUM_FRACTION:
+                    failures.append(
+                        f"target cluster {cluster!r} supplies {count}/{len(accepted)} "
+                        f"accepted records in {dimension} stratum {key!r}; maximum is 10%"
+                    )
+    if leadership:
+        comparator_names = {
+            comparator["name"]
+            for comparator in item["comparators"]
+            if comparator["equivalentScope"] and comparator["adjudicated"]
+        }
+        for required in ("graphify", "scip_typescript"):
+            if required not in comparator_names:
+                failures.append(
+                    f"leadership comparator {required!r} lacks equivalent-scope "
+                    "and adjudicated evidence"
+                )
+    critical = Counter(
+        record.judgment for record in records if record.judgment in CRITICAL_JUDGMENTS
+    )
+    failures.extend(
+        f"critical semantic violation {judgment!r}: {count}"
+        for judgment, count in sorted(critical.items())
+    )
+    return sorted(set(failures))
+
+
+def scorecard_result(path: Path) -> dict[str, Any]:
+    """Validate a scorecard and return deterministic quality metrics."""
+
+    item, records = _load(path)
+    contributions = [_contribution(record) for record in records]
+    precision = _metric(
+        sum(value[0] for value in contributions),
+        sum(value[1] for value in contributions),
+        interval=True,
+    )
+    recall = _metric(
+        sum(value[2] for value in contributions),
+        sum(value[3] for value in contributions),
+        interval=False,
+    )
+    strata = _strata(records)
+    failures = _failures(item, records, strata, precision)
+    judgments = Counter(record.judgment for record in records)
+    canonical = json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    scorecard_digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    result = {
+        "schema": RESULT_SCHEMA,
+        "scorecardSchema": SCORECARD_SCHEMA,
+        "scorecardSha256": scorecard_digest,
+        "mode": item["mode"],
+        "passed": not failures,
+        "eligibleForQualityClaim": item["mode"] != "diagnostic" and not failures,
+        "provider": item["provider"],
+        "candidateAdapter": item["candidateAdapter"],
+        "releaseGateCorpora": list(item["releaseGateCorpora"]),
+        "auditedRecords": len(records),
+        "precision": precision,
+        "recall": recall,
+        "judgments": {key: judgments[key] for key in sorted(judgments)},
+        "strata": strata,
+        "failures": failures,
+    }
+    return result
+
+
+def write_scorecard_result(scorecard: Path, destination: Path) -> dict[str, Any]:
+    """Evaluate and atomically write a JSON result."""
+
+    result = scorecard_result(scorecard)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.write_text(encoded + "\n", encoding="utf-8")
+    temporary.replace(destination)
+    return result
+
+
+__all__ = [
+    "RESULT_SCHEMA",
+    "SCORECARD_SCHEMA",
+    "TypeScriptScorecardError",
+    "scorecard_result",
+    "write_scorecard_result",
+]

--- a/benchmarks/performance/harness.py
+++ b/benchmarks/performance/harness.py
@@ -31,6 +31,10 @@ from benchmarks.performance.compass.audit import (
     export_comparison_candidates,
     run_audit,
 )
+from benchmarks.performance.compass.typescript_scorecard import (
+    scorecard_result,
+    write_scorecard_result,
+)
 from benchmarks.performance.compass.config import load_suite
 from benchmarks.performance.compass.correctness import compare_graphs, index_graph
 from benchmarks.performance.compass.model import (
@@ -573,6 +577,24 @@ def audit_candidates(args: argparse.Namespace) -> int:
     return 0
 
 
+def typescript_scorecard(args: argparse.Namespace) -> int:
+    if args.output is None:
+        result = scorecard_result(args.scorecard)
+        print(
+            json.dumps(
+                result,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        )
+    else:
+        result = write_scorecard_result(args.scorecard, args.output)
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        print(args.output)
+    return 0 if result["passed"] else 1
+
+
 def _common(parser: argparse.ArgumentParser, *, execution: bool = False) -> None:
     parser.add_argument("--suite", type=Path, default=DEFAULT_SUITE)
     parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
@@ -628,6 +650,12 @@ def build_parser() -> argparse.ArgumentParser:
     candidate_parser.add_argument("--name", required=True)
     candidate_parser.add_argument("--adapter", required=True)
     candidate_parser.add_argument("--output", type=Path, required=True)
+    scorecard_parser = subparsers.add_parser(
+        "typescript-scorecard",
+        help="evaluate an explicitly adjudicated TypeScript/JavaScript scorecard",
+    )
+    scorecard_parser.add_argument("--scorecard", type=Path, required=True)
+    scorecard_parser.add_argument("--output", type=Path)
     return parser
 
 
@@ -655,6 +683,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return audit(args)
         if args.command == "audit-candidates":
             return audit_candidates(args)
+        if args.command == "typescript-scorecard":
+            return typescript_scorecard(args)
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 2

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -15,15 +15,17 @@ with cycle/depth limits, and selects the compiler's project file set. If every
 discovered configuration is invalid it reports diagnostics and falls back to
 the bounded source tree instead of silently returning an empty inventory.
 
-The JSONL stream is schema `compass.typescript-source-oracle-jsonl/2`. In
+The JSONL stream is schema `compass.typescript-source-oracle-jsonl/3`. In
 addition to the legacy flattened `construct` records, it emits independently
-validated `scope`, `declaration`, and `call` records. Declarations retain
+validated `scope`, `declaration`, `call`, `construction`, `import`,
+`reexport`, `base`, `member`, and `reference` records. Declarations retain
 value/type/namespace identity and bounded parameter-shape metadata; scopes
-retain deterministic parent IDs; calls retain an exact callee anchor, full
-call-expression range, target kind, argument count, spread, and optional-call
-flags. Header/footer counts cover every typed record, and the Python audit
-rejects missing parents, duplicate IDs, invalid ranges, unknown fields, and
-count/digest mismatches.
+retain deterministic parent IDs; calls and constructions retain exact target
+anchors and full invocation ranges; imports/reexports retain module and
+binding identity; bases, members, and references retain enclosing owners and
+source ranges. Header/footer counts cover every typed record, and the Python
+audit rejects missing parents, duplicate IDs, invalid ranges, unknown fields,
+and count/digest mismatches.
 
 - `typescript-source-oracle.mjs` records source constructs for declarations,
   imports/reexports, calls, construction, members, bases, type references, and

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -6,7 +6,10 @@ not be copied into the product boundary.
 
 The pinned provider is TypeScript 5.9.3. Both tools emit deterministic JSON,
 exact UTF-8 byte ranges, source/config digests, bounded diagnostics, and an
-explicit parsed/rejected-file count. The source oracle discovers bounded
+explicit parsed/rejected-file count. The source oracle also supports a
+record-oriented JSONL stream (`--jsonl`) with a header, project/file coverage,
+diagnostic/construct records, and a checked footer; the audit pipeline consumes
+that stream so a truncated or incomplete denominator fails closed. The source oracle discovers bounded
 `tsconfig*.json`/`jsconfig*.json` projects, follows in-root project references
 with cycle/depth limits, and selects the compiler's project file set. If every
 discovered configuration is invalid it reports diagnostics and falls back to
@@ -14,8 +17,9 @@ the bounded source tree instead of silently returning an empty inventory.
 
 - `typescript-source-oracle.mjs` records source constructs for declarations,
   imports/reexports, calls, construction, members, bases, type references, and
-  JSX. It does not select graph targets. Its payload includes project scopes,
-  configuration/source digests, diagnostics, and deterministic UTF-8 ranges.
+  JSX. It does not select graph targets. Its payload/JSONL stream includes
+  project scopes, configuration/source digests, diagnostics, and deterministic
+  UTF-8 ranges.
 - `typescript-resolution-oracle.mjs` records compiler-API import/reexport,
   dynamic-import, `import =`, and literal-`require()` decisions, including
   module mode, project ownership, source/external/unresolved/ambiguous outcome,
@@ -30,7 +34,7 @@ Run them against an external, read-only corpus after `npm ci`:
 
 ```bash
 node benchmarks/performance/oracles/typescript-source-oracle.mjs \
-  --root /Volumes/Workspace/Github/<owner>/<repository>
+  --root /Volumes/Workspace/Github/<owner>/<repository> --jsonl
 node benchmarks/performance/oracles/typescript-resolution-oracle.mjs \
   --root /Volumes/Workspace/Github/<owner>/<repository>
 ```

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -59,3 +59,35 @@ The harness reports exact local-target recall, wrong-target cases, unresolved
 cases, and local false positives by capability. These figures are
 adjudication evidence, not release thresholds until accepted samples, Wilson
 intervals, and framework/competitor strata are frozen in Plan 013.
+
+To persist the deterministic target evidence for later manual labeling, set an
+explicit report path. The report is atomically written only when this ignored
+qualification test is run; it is never produced by normal Compass builds:
+
+```bash
+COMPASS_TS_QUALIFICATION_ROOT=/Volumes/Workspace/Github/<owner>/<repository> \
+COMPASS_TS_TARGET_REPORT=/Volumes/Workspace/<run>/typescript-target-report.json \
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 \
+cargo test -p compass-languages --test typescript_target_differential \
+  --locked -- --ignored --nocapture
+```
+
+The report schema is `compass.typescript-target-adjudication/1`. It includes the
+pinned compiler/oracle metadata, exact source ranges, oracle target ranges,
+candidate observations, automatic checker outcomes, and capability strata. It
+does not contain manual judgments. A reviewed scorecard must add explicit
+`accepted` and `source_oracle` pools, `judgmentSource: "manual"`, and a review
+reason for every non-correct label under
+`compass.typescript-target-scorecard/1`, then run:
+
+```bash
+python3 benchmarks/performance/harness.py typescript-scorecard \
+  --scorecard /Volumes/Workspace/<run>/typescript-scorecard.json \
+  --output /Volumes/Workspace/<run>/typescript-scorecard-result.json
+```
+
+The evaluator computes precision, 95% Wilson bounds, recall, target-cluster
+concentration, per-corpus/relation/capability strata, critical semantic
+violations, and the Plan 013 production or leadership gates. Diagnostic mode
+is useful before labels are complete but can never become eligible for a public
+quality claim.

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -27,11 +27,13 @@ source ranges. Header/footer counts cover every typed record, and the Python
 audit rejects missing parents, duplicate IDs, invalid ranges, unknown fields,
 and count/digest mismatches.
 
-- `typescript-source-oracle.mjs` records source constructs for declarations,
-  imports/reexports, calls, construction, members, bases, type references, and
-  JSX. It does not select graph targets. Its payload/JSONL stream includes
-  project scopes, configuration/source digests, diagnostics, and deterministic
-  UTF-8 ranges.
+- `typescript-source-oracle.mjs` records source constructs for declarations
+  (including `using`/`await using` resource bindings), imports/reexports,
+  calls, construction, members, bases, decorators, type references, and JSX.
+  Decorator factories are not duplicated as ordinary calls, while calls nested
+  in decorator arguments remain visible. It does not select graph targets. Its
+  payload/JSONL stream includes project scopes, configuration/source digests,
+  diagnostics, and deterministic UTF-8 ranges.
 - `typescript-resolution-oracle.mjs` records compiler-API import/reexport,
   dynamic-import, `import =`, and literal-`require()` decisions, including
   module mode, project ownership, source/external/unresolved/ambiguous outcome,

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -6,11 +6,16 @@ not be copied into the product boundary.
 
 The pinned provider is TypeScript 5.9.3. Both tools emit deterministic JSON,
 exact UTF-8 byte ranges, source/config digests, bounded diagnostics, and an
-explicit parsed/rejected-file count:
+explicit parsed/rejected-file count. The source oracle discovers bounded
+`tsconfig*.json`/`jsconfig*.json` projects, follows in-root project references
+with cycle/depth limits, and selects the compiler's project file set. If every
+discovered configuration is invalid it reports diagnostics and falls back to
+the bounded source tree instead of silently returning an empty inventory.
 
 - `typescript-source-oracle.mjs` records source constructs for declarations,
   imports/reexports, calls, construction, members, bases, type references, and
-  JSX. It does not select graph targets.
+  JSX. It does not select graph targets. Its payload includes project scopes,
+  configuration/source digests, diagnostics, and deterministic UTF-8 ranges.
 - `typescript-resolution-oracle.mjs` records compiler-API import/reexport,
   dynamic-import, `import =`, and literal-`require()` decisions, including
   module mode, project ownership, source/external/unresolved/ambiguous outcome,

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -15,6 +15,16 @@ with cycle/depth limits, and selects the compiler's project file set. If every
 discovered configuration is invalid it reports diagnostics and falls back to
 the bounded source tree instead of silently returning an empty inventory.
 
+The JSONL stream is schema `compass.typescript-source-oracle-jsonl/2`. In
+addition to the legacy flattened `construct` records, it emits independently
+validated `scope`, `declaration`, and `call` records. Declarations retain
+value/type/namespace identity and bounded parameter-shape metadata; scopes
+retain deterministic parent IDs; calls retain an exact callee anchor, full
+call-expression range, target kind, argument count, spread, and optional-call
+flags. Header/footer counts cover every typed record, and the Python audit
+rejects missing parents, duplicate IDs, invalid ranges, unknown fields, and
+count/digest mismatches.
+
 - `typescript-source-oracle.mjs` records source constructs for declarations,
   imports/reexports, calls, construction, members, bases, type references, and
   JSX. It does not select graph targets. Its payload/JSONL stream includes

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -1,0 +1,61 @@
+# TypeScript/JavaScript qualification oracles
+
+These Node-side tools are independent qualification inputs. They are not
+Compass runtime dependencies, are not invoked by normal Cargo tests, and must
+not be copied into the product boundary.
+
+The pinned provider is TypeScript 5.9.3. Both tools emit deterministic JSON,
+exact UTF-8 byte ranges, source/config digests, bounded diagnostics, and an
+explicit parsed/rejected-file count:
+
+- `typescript-source-oracle.mjs` records source constructs for declarations,
+  imports/reexports, calls, construction, members, bases, type references, and
+  JSX. It does not select graph targets.
+- `typescript-resolution-oracle.mjs` records compiler-API import/reexport,
+  dynamic-import, `import =`, and literal-`require()` decisions, including
+  module mode, project ownership, source/external/unresolved/ambiguous outcome,
+  and the exact target file where available.
+- `typescript-target-oracle.mjs` uses the pinned checker to adjudicate exact
+  source declaration targets for calls, construction, members, heritage, type
+  references, and JSX. It is deliberately a qualification-only target oracle;
+  its bounded synthetic program is not a substitute for project-aware
+  Node16/NodeNext/Bundler resolution.
+
+Run them against an external, read-only corpus after `npm ci`:
+
+```bash
+node benchmarks/performance/oracles/typescript-source-oracle.mjs \
+  --root /Volumes/Workspace/Github/<owner>/<repository>
+node benchmarks/performance/oracles/typescript-resolution-oracle.mjs \
+  --root /Volumes/Workspace/Github/<owner>/<repository>
+```
+
+The ignored Rust differential harness compares the source oracle's accepted
+construct ranges with the test-only Compass candidate emitter:
+
+```bash
+COMPASS_TS_QUALIFICATION_ROOT=/Volumes/Workspace/Github/<owner>/<repository> \
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 \
+cargo test -p compass-languages --test typescript_corpus_differential \
+  --locked -- --ignored --nocapture
+```
+
+Coverage is source-occurrence recall only. It does not prove target precision,
+resolution correctness, framework semantics, Graphify parity, or a production
+hard cut. A corpus must be pinned by commit, licensed, configuration-complete,
+and independently adjudicated before it can enter the Plan 013 release gate.
+
+Run target adjudication explicitly (it is ignored so normal native tests remain
+Node-free):
+
+```bash
+COMPASS_TS_QUALIFICATION_ROOT=/Volumes/Workspace/Github/<owner>/<repository> \
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923 \
+cargo test -p compass-languages --test typescript_target_differential \
+  --locked -- --ignored --nocapture
+```
+
+The harness reports exact local-target recall, wrong-target cases, unresolved
+cases, and local false positives by capability. These figures are
+adjudication evidence, not release thresholds until accepted samples, Wilson
+intervals, and framework/competitor strata are frozen in Plan 013.

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -29,7 +29,9 @@ and count/digest mismatches.
 
 - `typescript-source-oracle.mjs` records source constructs for declarations
   (including `using`/`await using` resource bindings), imports/reexports,
-  calls, construction, members, bases, decorators, type references, and JSX.
+  calls, construction, members, bases, decorators, type references, JSX tags,
+  and JSX value/spread/child references. JSX prop names are not mistaken for
+  value uses, while nested callback arguments remain source-grounded.
   Decorator factories are not duplicated as ordinary calls, while calls nested
   in decorator arguments remain visible. It does not select graph targets. Its
   payload/JSONL stream includes project scopes, configuration/source digests,

--- a/benchmarks/performance/oracles/README.md
+++ b/benchmarks/performance/oracles/README.md
@@ -30,7 +30,8 @@ and count/digest mismatches.
 - `typescript-source-oracle.mjs` records source constructs for declarations
   (including `using`/`await using` resource bindings), imports/reexports,
   calls, construction, members, bases, decorators, type references, JSX tags,
-  and JSX value/spread/child references. JSX prop names are not mistaken for
+  JSX value/spread/child references, and TypeScript `import_type` queries. JSX
+  prop names are not mistaken for
   value uses, while nested callback arguments remain source-grounded.
   Decorator factories are not duplicated as ordinary calls, while calls nested
   in decorator arguments remain visible. It does not select graph targets. Its

--- a/benchmarks/performance/oracles/typescript-resolution-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-resolution-oracle.mjs
@@ -1,0 +1,566 @@
+#!/usr/bin/env node
+
+/**
+ * Independent TypeScript/JavaScript module-resolution oracle.
+ *
+ * This is a qualification-only tool. It uses the pinned TypeScript compiler
+ * API to resolve source-grounded module occurrences and never reads Compass
+ * or Graphify output. Normal Compass execution must not invoke this script.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const SCHEMA = "compass.typescript-resolution-oracle/1";
+const PROVIDER = "typescript_compiler_api_5_9_3";
+const MAX_FILES = 20_000;
+const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
+const MAX_CONFIGS = 256;
+const MAX_CONFIG_BYTES = 2 * 1024 * 1024;
+const MAX_MODULE_USES = 500_000;
+const MAX_DIAGNOSTICS = 10_000;
+const SOURCE_SUFFIXES = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+const EXCLUDED_DIRECTORIES = new Set([
+  ".git",
+  ".compass",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "target",
+  "node_modules",
+]);
+
+function fail(message) {
+  console.error(`[typescript-resolution-oracle] ${message}`);
+  process.exitCode = 2;
+  throw new Error(message);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  if (argv.length !== 2 || argv[0] !== "--root" || !argv[1]) {
+    fail("usage: typescript-resolution-oracle.mjs --root PATH");
+  }
+  const absoluteRoot = path.resolve(argv[1]);
+  let root;
+  try {
+    // TypeScript may realpath package targets (notably on macOS, where /tmp
+    // is commonly exposed as /private/tmp). Canonicalize the boundary once so
+    // containment checks do not misclassify an in-root target as external.
+    root = fs.realpathSync.native(absoluteRoot);
+  } catch (error) {
+    fail(`source root is unavailable: ${error.message}`);
+  }
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch (error) {
+    fail(`source root is unavailable: ${error.message}`);
+  }
+  if (!stat.isDirectory()) fail(`source root is not a directory: ${root}`);
+  return root;
+}
+
+function relativePath(root, fileName) {
+  const relative = path.relative(root, fileName).split(path.sep).join("/");
+  if (!relative || relative.startsWith("../") || relative === ".." || path.isAbsolute(relative)) {
+    fail(`source path escapes root: ${fileName}`);
+  }
+  return relative;
+}
+
+function insideRoot(root, fileName) {
+  const absolute = path.resolve(fileName);
+  return absolute === root || absolute.startsWith(`${root}${path.sep}`);
+}
+
+function isSourceFile(fileName) {
+  return SOURCE_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
+}
+
+function isConfigFile(fileName) {
+  const lower = fileName.toLowerCase();
+  return (
+    lower === "tsconfig.json" ||
+    (lower.startsWith("tsconfig.") && lower.endsWith(".json")) ||
+    lower === "jsconfig.json" ||
+    (lower.startsWith("jsconfig.") && lower.endsWith(".json"))
+  );
+}
+
+function collectFiles(root) {
+  const sourceFiles = [];
+  const configFiles = [];
+  const rejectedFiles = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const directory = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      fail(`cannot read directory ${relativePath(root, directory)}: ${error.message}`);
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+    for (const entry of entries) {
+      const fileName = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRECTORIES.has(entry.name)) stack.push(fileName);
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        if (isSourceFile(entry.name)) rejectedFiles.push(relativePath(root, fileName));
+        continue;
+      }
+      if (isConfigFile(entry.name)) configFiles.push(fileName);
+      if (isSourceFile(entry.name)) sourceFiles.push(fileName);
+      if (sourceFiles.length + configFiles.length > MAX_FILES + MAX_CONFIGS) {
+        fail(`source/config file count exceeds ${MAX_FILES + MAX_CONFIGS}`);
+      }
+    }
+  }
+  sourceFiles.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  configFiles.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  return { sourceFiles, configFiles, rejectedFiles };
+}
+
+function byteOffsets(text) {
+  const offsets = new Uint32Array(text.length + 1);
+  let byteOffset = 0;
+  let index = 0;
+  while (index < text.length) {
+    const codePoint = text.codePointAt(index);
+    const width = codePoint > 0xffff ? 2 : 1;
+    offsets[index] = byteOffset;
+    if (width === 2) offsets[index + 1] = byteOffset;
+    byteOffset += Buffer.byteLength(text.slice(index, index + width), "utf8");
+    index += width;
+    offsets[index] = byteOffset;
+  }
+  return offsets;
+}
+
+function scriptKind(fileName) {
+  return ts.getScriptKindFromFileName(fileName);
+}
+
+function diagnosticText(diagnostic) {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+}
+
+function moduleResolutionName(value) {
+  switch (value) {
+    case ts.ModuleResolutionKind.Classic:
+      return "classic";
+    case ts.ModuleResolutionKind.Node10:
+      return "node10";
+    case ts.ModuleResolutionKind.Node16:
+      return "node16";
+    case ts.ModuleResolutionKind.NodeNext:
+      return "nodenext";
+    case ts.ModuleResolutionKind.Bundler:
+      return "bundler";
+    default:
+      return "unspecified";
+  }
+}
+
+function moduleKindName(value) {
+  switch (value) {
+    case ts.ModuleKind.CommonJS:
+      return "commonjs";
+    case ts.ModuleKind.Node16:
+      return "node16";
+    case ts.ModuleKind.NodeNext:
+      return "nodenext";
+    case ts.ModuleKind.Preserve:
+      return "preserve";
+    case ts.ModuleKind.ES2015:
+    case ts.ModuleKind.ES2020:
+    case ts.ModuleKind.ES2022:
+    case ts.ModuleKind.ESNext:
+      return "es";
+    default:
+      return "unspecified";
+  }
+}
+
+function extensionName(value) {
+  for (const [key, name] of Object.entries(ts.Extension)) {
+    if (value === name) return key.toLowerCase();
+  }
+  return "unknown";
+}
+
+function safeRead(root, fileName, limit) {
+  const absolute = path.resolve(fileName);
+  if (!insideRoot(root, absolute)) return undefined;
+  let stat;
+  try {
+    stat = fs.statSync(absolute);
+  } catch {
+    return undefined;
+  }
+  if (!stat.isFile() || stat.size > limit) return undefined;
+  try {
+    return fs.readFileSync(absolute);
+  } catch {
+    return undefined;
+  }
+}
+
+function makeConfigHost(root) {
+  const readFile = (fileName) => {
+    const raw = safeRead(root, fileName, MAX_CONFIG_BYTES);
+    return raw === undefined ? undefined : raw.toString("utf8");
+  };
+  return {
+    useCaseSensitiveFileNames: true,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+    readDirectory(directory, extensions, excludes, includes, depth) {
+      if (!insideRoot(root, directory)) return [];
+      return ts.sys.readDirectory(directory, extensions, excludes, includes, depth)
+        .filter((fileName) => insideRoot(root, fileName));
+    },
+    fileExists: (fileName) => safeRead(root, fileName, MAX_CONFIG_BYTES) !== undefined,
+    readFile,
+  };
+}
+
+function parseProjects(root, configFiles, diagnostics) {
+  if (configFiles.length > MAX_CONFIGS) {
+    fail(`project configuration count exceeds ${MAX_CONFIGS}`);
+  }
+  const host = makeConfigHost(root);
+  const projects = [];
+  for (const configFile of configFiles) {
+    const raw = safeRead(root, configFile, MAX_CONFIG_BYTES);
+    if (raw === undefined) {
+      diagnostics.push({ file: relativePath(root, configFile), message: "config is unreadable or exceeds the configured limit" });
+      continue;
+    }
+    const read = ts.readConfigFile(configFile, host.readFile);
+    if (read.error) {
+      diagnostics.push({ file: relativePath(root, configFile), message: diagnosticText(read.error) });
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = ts.parseJsonConfigFileContent(
+        read.config,
+        host,
+        path.dirname(configFile),
+        {},
+        configFile,
+      );
+    } catch (error) {
+      diagnostics.push({ file: relativePath(root, configFile), message: String(error) });
+      continue;
+    }
+    for (const error of parsed.errors ?? []) {
+      diagnostics.push({ file: relativePath(root, configFile), message: diagnosticText(error) });
+      if (diagnostics.length >= MAX_DIAGNOSTICS) fail(`diagnostic count exceeds ${MAX_DIAGNOSTICS}`);
+    }
+    const fileNames = [...new Set(parsed.fileNames.map((fileName) => path.resolve(fileName)))]
+      .filter((fileName) => insideRoot(root, fileName));
+    projects.push({
+      configFile,
+      directory: path.dirname(configFile),
+      options: parsed.options,
+      fileNames,
+      configDigest: sha256(raw),
+      references: (parsed.projectReferences ?? []).map((reference) => path.resolve(reference.sourceFile)),
+    });
+  }
+  projects.sort((left, right) => relativePath(root, left.configFile).localeCompare(relativePath(root, right.configFile), "en"));
+  return projects;
+}
+
+function syntheticProject(root) {
+  return {
+    configFile: null,
+    directory: root,
+    options: {
+      allowJs: true,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      target: ts.ScriptTarget.Latest,
+    },
+    fileNames: [],
+    configDigest: "",
+    references: [],
+  };
+}
+
+function chooseProject(root, fileName, projects, synthetic) {
+  const candidates = projects.filter((project) => project.fileNames.includes(fileName));
+  if (candidates.length === 0) return synthetic;
+  let deepest = Math.max(...candidates.map((project) => project.directory.split(path.sep).length));
+  const nearest = candidates.filter((project) => project.directory.split(path.sep).length === deepest);
+  return nearest.length === 1 ? nearest[0] : null;
+}
+
+function makeResolutionHost(root) {
+  const read = (fileName) => {
+    const raw = safeRead(root, fileName, MAX_SOURCE_BYTES);
+    return raw === undefined ? undefined : raw.toString("utf8");
+  };
+  return {
+    fileExists: (fileName) => safeRead(root, fileName, MAX_SOURCE_BYTES) !== undefined,
+    readFile: read,
+    directoryExists: (directory) => {
+      const absolute = path.resolve(root, directory);
+      return insideRoot(root, absolute) && ts.sys.directoryExists(absolute);
+    },
+    realpath: (fileName) => {
+      const absolute = path.resolve(root, fileName);
+      if (!insideRoot(root, absolute)) return fileName;
+      try {
+        return fs.realpathSync.native(absolute);
+      } catch {
+        return absolute;
+      }
+    },
+    getCurrentDirectory: () => root,
+    getDirectories: (directory) => {
+      const absolute = path.resolve(root, directory);
+      return insideRoot(root, absolute) ? ts.sys.getDirectories(absolute) : [];
+    },
+  };
+}
+
+function addUse(root, sourceFile, literal, context, kind, typeOnly, uses) {
+  if (!literal || typeof literal.text !== "string" || literal.text.length === 0) return;
+  const start = literal.getStart(sourceFile, false);
+  const end = literal.getEnd();
+  const offsets = sourceFile.__byteOffsets;
+  if (!offsets || end <= start || end >= offsets.length) return;
+  if (uses.length >= MAX_MODULE_USES) fail(`module occurrence count exceeds ${MAX_MODULE_USES}`);
+  uses.push({
+    sourceFile: relativePath(root, sourceFile.fileName),
+    absoluteSourceFile: sourceFile.fileName,
+    specifier: literal.text,
+    context,
+    kind,
+    typeOnly: Boolean(typeOnly),
+    startByte: offsets[start],
+    endByte: offsets[end],
+    startLine: sourceFile.getLineAndCharacterOfPosition(start).line + 1,
+    literal,
+  });
+}
+
+function collectModuleUses(root, sourceFile, uses) {
+  const visit = (node) => {
+    if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
+      addUse(root, sourceFile, node.moduleSpecifier, "import", "import", node.importClause?.isTypeOnly, uses);
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      addUse(root, sourceFile, node.moduleSpecifier, "import", "export", node.isTypeOnly, uses);
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      addUse(root, sourceFile, node.moduleReference.expression, "import", "import-equals", false, uses);
+    } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+      addUse(root, sourceFile, node.argument.literal, "import", "import-type", true, uses);
+    } else if (ts.isCallExpression(node) && node.arguments.length > 0) {
+      const argument = node.arguments[0];
+      const isLiteral = ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument);
+      if (isLiteral && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        addUse(root, sourceFile, argument, "dynamic-import", "dynamic-import", false, uses);
+      } else if (
+        isLiteral &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "require"
+      ) {
+        addUse(root, sourceFile, argument, "require", "require", false, uses);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
+function normalizeTarget(root, resolvedFileName) {
+  if (!resolvedFileName) return { targetFile: null, resolutionKind: "unresolved" };
+  const target = path.resolve(resolvedFileName);
+  if (!insideRoot(root, target)) return { targetFile: null, resolutionKind: "external" };
+  return {
+    targetFile: relativePath(root, target),
+    resolutionKind: "source",
+  };
+}
+
+function resolveUses(root, uses, projectByFile, synthetic, host) {
+  const cacheByProject = new Map();
+  const resolutions = [];
+  for (const use of uses) {
+    const project = projectByFile.get(use.absoluteSourceFile) ?? synthetic;
+    if (project === null) {
+      resolutions.push({ ...use, project: null, moduleResolution: "ambiguous", mode: "unknown", targetFile: null, resolutionKind: "ambiguous" });
+      continue;
+    }
+    const sourceFile = use.sourceFile;
+    const parsedSource = use.parsedSourceFile;
+    const inferredMode = ts.getModeForUsageLocation(parsedSource, use.literal, project.options);
+    const suffix = path.extname(use.absoluteSourceFile).toLowerCase();
+    const mode = inferredMode ?? (
+      suffix === ".mts" || suffix === ".mjs"
+        ? ts.ModuleKind.ESNext
+        : suffix === ".cts" || suffix === ".cjs"
+          ? ts.ModuleKind.CommonJS
+          : undefined
+    );
+    let cache = cacheByProject.get(project);
+    if (!cache) {
+      cache = ts.createModuleResolutionCache(root, (value) => value, project.options);
+      cacheByProject.set(project, cache);
+    }
+    const result = ts.resolveModuleName(
+      use.specifier,
+      use.absoluteSourceFile,
+      project.options,
+      host,
+      cache,
+      undefined,
+      mode,
+    );
+    const normalized = normalizeTarget(root, result.resolvedModule?.resolvedFileName);
+    resolutions.push({
+      sourceFile,
+      specifier: use.specifier,
+      context: use.context,
+      kind: use.kind,
+      typeOnly: use.typeOnly,
+      startByte: use.startByte,
+      endByte: use.endByte,
+      startLine: use.startLine,
+      project: project.configFile ? relativePath(root, project.configFile) : null,
+      moduleResolution: moduleResolutionName(project.options.moduleResolution),
+      module: moduleKindName(project.options.module),
+      mode: mode === ts.ModuleKind.CommonJS ? "commonjs" : mode === ts.ModuleKind.ESNext ? "es" : "unspecified",
+      extension: result.resolvedModule ? extensionName(result.resolvedModule.extension) : null,
+      isExternalLibraryImport: Boolean(result.resolvedModule?.isExternalLibraryImport),
+      ...normalized,
+    });
+  }
+  resolutions.sort((left, right) => {
+    for (const field of ["sourceFile", "startByte", "endByte", "specifier", "context", "kind"]) {
+      const a = left[field] ?? "";
+      const b = right[field] ?? "";
+      if (a < b) return -1;
+      if (a > b) return 1;
+    }
+    return 0;
+  });
+  return resolutions.map(({ literal, absoluteSourceFile, parsedSourceFile, ...resolution }) => resolution);
+}
+
+function main() {
+  const root = parseArguments(process.argv.slice(2));
+  const { sourceFiles, configFiles, rejectedFiles: initialRejected } = collectFiles(root);
+  if (sourceFiles.length > MAX_FILES) fail(`source file count exceeds ${MAX_FILES}`);
+  const diagnostics = [];
+  const projects = parseProjects(root, configFiles, diagnostics);
+  const synthetic = syntheticProject(root);
+  const projectByFile = new Map();
+  for (const fileName of sourceFiles) {
+    projectByFile.set(fileName, chooseProject(root, fileName, projects, synthetic));
+  }
+  const uses = [];
+  const rejectedFiles = new Set(initialRejected);
+  const sourceDigest = crypto.createHash("sha256");
+  let totalBytes = 0;
+  let parsedFiles = 0;
+  for (const fileName of sourceFiles) {
+    const relative = relativePath(root, fileName);
+    const raw = safeRead(root, fileName, MAX_SOURCE_BYTES);
+    if (raw === undefined) {
+      rejectedFiles.add(relative);
+      continue;
+    }
+    totalBytes += raw.byteLength;
+    if (totalBytes > MAX_SOURCE_BYTES) fail(`source byte count exceeds ${MAX_SOURCE_BYTES}`);
+    sourceDigest.update(relative).update("\0").update(raw);
+    const text = raw.toString("utf8");
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, scriptKind(fileName));
+    if (sourceFile.parseDiagnostics?.length > 0) {
+      rejectedFiles.add(relative);
+      for (const diagnostic of sourceFile.parseDiagnostics) {
+        diagnostics.push({ file: relative, message: diagnosticText(diagnostic) });
+        if (diagnostics.length >= MAX_DIAGNOSTICS) fail(`diagnostic count exceeds ${MAX_DIAGNOSTICS}`);
+      }
+      continue;
+    }
+    sourceFile.__byteOffsets = byteOffsets(text);
+    parsedFiles += 1;
+    const before = uses.length;
+    collectModuleUses(root, sourceFile, uses);
+    for (let index = before; index < uses.length; index += 1) {
+      uses[index].parsedSourceFile = sourceFile;
+    }
+  }
+  const host = makeResolutionHost(root);
+  const resolutions = resolveUses(root, uses, projectByFile, synthetic, host);
+  const configDigest = sha256(
+    projects
+      .filter((project) => project.configFile)
+      .map((project) => `${relativePath(root, project.configFile)}\0${project.configDigest}`)
+      .join("\n"),
+  );
+  const script = fs.readFileSync(fileURLToPath(import.meta.url));
+  const payload = {
+    schema: SCHEMA,
+    provider: PROVIDER,
+    metadata: {
+      compilerVersion: ts.version,
+      nodeVersion: process.version,
+      scriptSha256: sha256(script),
+      platform: `${process.platform}/${process.arch}`,
+      configDigest,
+      sourceDigest: sourceDigest.digest("hex"),
+    },
+    scannedFiles: sourceFiles.length,
+    parsedFiles,
+    rejectedFiles: [...rejectedFiles].sort(),
+    projects: projects.map((project) => ({
+      configFile: project.configFile ? relativePath(root, project.configFile) : null,
+      fileCount: project.fileNames.length,
+      moduleResolution: moduleResolutionName(project.options.moduleResolution),
+      module: moduleKindName(project.options.module),
+      references: project.references
+        .filter((reference) => insideRoot(root, reference))
+        .map((reference) => relativePath(root, reference))
+        .sort(),
+    })),
+    diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
+    resolutions,
+  };
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  if (process.exitCode !== 2) {
+    console.error(`[typescript-resolution-oracle] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 2;
+  }
+}

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -808,6 +808,25 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
 
   const visit = (node) => {
     const pushedScope = addScope(node);
+    if (ts.isDecorator(node)) {
+      // Decorator factories are relationship occurrences, not ordinary
+      // calls to the decorator expression. Keep the callee/property anchor
+      // aligned with the native candidate and let nested calls in decorator
+      // arguments be visited normally.
+      const expression = node.expression;
+      const callee = ts.isCallExpression(expression)
+        ? expression.expression
+        : expression;
+      const ownerNode = node.parent ?? node;
+      add(
+        "decorates",
+        "decorators",
+        callee,
+        targetQualifier(sourceFile, callee),
+        null,
+        ownerNode,
+      );
+    }
     if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
       add("imports", "imports", node.moduleSpecifier, null, node.moduleSpecifier.text);
       const moduleSpecifier = node.moduleSpecifier.text;
@@ -913,8 +932,14 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
         Boolean(node.isTypeOnly),
       );
     } else if (ts.isCallExpression(node)) {
-      add("calls", "calls", node.expression, targetQualifier(sourceFile, node.expression));
-      addCall(node, "calls");
+      // The enclosing decorator contributes a `decorates` construct above;
+      // publishing the factory invocation again as `calls` would double-count
+      // the same source occurrence. Calls nested in its arguments are not
+      // direct children of the decorator and remain ordinary calls.
+      if (!node.parent || !ts.isDecorator(node.parent)) {
+        add("calls", "calls", node.expression, targetQualifier(sourceFile, node.expression));
+        addCall(node, "calls");
+      }
       if (node.expression.kind === ts.SyntaxKind.ImportKeyword && node.arguments.length > 0) {
         const argument = node.arguments[0];
         addImportFact(

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+
+/**
+ * Independent TypeScript/JavaScript source oracle for Compass qualification.
+ *
+ * This is deliberately a developer-side oracle, not a Compass runtime
+ * dependency. It uses the pinned TypeScript compiler API to parse a bounded
+ * source tree and emits source-grounded constructs. It does not read a graph
+ * produced by Compass or Graphify and never resolves a target by name.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const SCHEMA = "compass.typescript-source-oracle/1";
+const PROVIDER = "typescript_compiler_api_5_9_3";
+const MAX_FILES = 20_000;
+const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
+const MAX_CONSTRUCTS = 500_000;
+const SOURCE_SUFFIXES = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+const EXCLUDED_DIRECTORIES = new Set([
+  ".git",
+  ".compass",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "target",
+]);
+
+function fail(message) {
+  console.error(`[typescript-source-oracle] ${message}`);
+  process.exitCode = 2;
+  throw new Error(message);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  if (argv.length !== 2 || argv[0] !== "--root" || !argv[1]) {
+    fail("usage: typescript-source-oracle.mjs --root PATH");
+  }
+  const root = path.resolve(argv[1]);
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch (error) {
+    fail(`source root is unavailable: ${error.message}`);
+  }
+  if (!stat.isDirectory()) {
+    fail(`source root is not a directory: ${root}`);
+  }
+  return root;
+}
+
+function relativePath(root, fileName) {
+  const relative = path.relative(root, fileName).split(path.sep).join("/");
+  if (!relative || relative.startsWith("../") || relative === ".." || path.isAbsolute(relative)) {
+    fail(`source path escapes root: ${fileName}`);
+  }
+  return relative;
+}
+
+function isSourceFile(fileName) {
+  return SOURCE_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
+}
+
+function collectSourceFiles(root) {
+  const files = [];
+  const rejected = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const directory = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      fail(`cannot read source directory ${relativePath(root, directory)}: ${error.message}`);
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRECTORIES.has(entry.name)) {
+          stack.push(path.join(directory, entry.name));
+        }
+        continue;
+      }
+      const fileName = path.join(directory, entry.name);
+      if (!isSourceFile(entry.name)) {
+        continue;
+      }
+      const relative = relativePath(root, fileName);
+      files.push(fileName);
+      if (files.length > MAX_FILES) {
+        fail(`source file count exceeds ${MAX_FILES}`);
+      }
+      if (entry.isSymbolicLink()) {
+        rejected.push(relative);
+      }
+    }
+  }
+  files.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  rejected.sort();
+  return { files, rejected };
+}
+
+function byteOffsets(text) {
+  const offsets = new Uint32Array(text.length + 1);
+  let byteOffset = 0;
+  let index = 0;
+  while (index < text.length) {
+    const codePoint = text.codePointAt(index);
+    const width = codePoint > 0xffff ? 2 : 1;
+    offsets[index] = byteOffset;
+    if (width === 2) {
+      offsets[index + 1] = byteOffset;
+    }
+    byteOffset += Buffer.byteLength(text.slice(index, index + width), "utf8");
+    index += width;
+    offsets[index] = byteOffset;
+  }
+  return offsets;
+}
+
+function moduleName(root, fileName) {
+  let relative = relativePath(root, fileName);
+  for (const suffix of SOURCE_SUFFIXES.sort((left, right) => right.length - left.length)) {
+    if (relative.endsWith(suffix)) {
+      relative = relative.slice(0, -suffix.length);
+      break;
+    }
+  }
+  return relative.split("/").filter(Boolean).join(".") || "<root>";
+}
+
+function nodeText(sourceFile, node) {
+  return node ? node.getText(sourceFile).trim() : "";
+}
+
+function identifierText(sourceFile, node) {
+  if (!node) return "";
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node.text;
+  if (ts.isStringLiteral(node) || ts.isNumericLiteral(node)) return node.text;
+  return nodeText(sourceFile, node);
+}
+
+function declarationName(sourceFile, node) {
+  if (!node || !node.name) return null;
+  if (ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name)) return node.name.text;
+  if (ts.isStringLiteral(node.name) || ts.isNumericLiteral(node.name)) return node.name.text;
+  return null;
+}
+
+function isOwnerNode(node) {
+  return (
+    ts.isClassLike(node) ||
+    ts.isFunctionLike(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isMethodSignature(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isInterfaceDeclaration(node) ||
+    ts.isTypeAliasDeclaration(node) ||
+    ts.isEnumDeclaration(node) ||
+    ts.isModuleDeclaration(node)
+  );
+}
+
+function ownerName(root, sourceFile, node) {
+  const enclosing = [];
+  let current = node.parent;
+  while (current && !ts.isSourceFile(current)) {
+    if (isOwnerNode(current)) {
+      const name = declarationName(sourceFile, current);
+      if (name) enclosing.push(name);
+    }
+    current = current.parent;
+  }
+  return [moduleName(root, sourceFile.fileName), ...enclosing.reverse()].join(".");
+}
+
+function targetNode(node) {
+  if (!node) return null;
+  if (ts.isPropertyAccessExpression(node)) return node.name;
+  if (ts.isElementAccessExpression(node) && node.argumentExpression) {
+    if (ts.isStringLiteral(node.argumentExpression) || ts.isNumericLiteral(node.argumentExpression)) {
+      return node.argumentExpression;
+    }
+  }
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node;
+  return node;
+}
+
+function targetQualifier(sourceFile, node) {
+  if (ts.isPropertyAccessExpression(node)) return node.expression;
+  if (ts.isElementAccessExpression(node) && node.expression) return node.expression;
+  return null;
+}
+
+function isDeclarationName(node) {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (parent.name === node) return true;
+  if (ts.isImportSpecifier(parent) && (parent.name === node || parent.propertyName === node)) return true;
+  if (ts.isExportSpecifier(parent) && (parent.name === node || parent.propertyName === node)) return true;
+  if (ts.isNamespaceImport(parent) || ts.isImportClause(parent)) return true;
+  if (ts.isQualifiedName(parent) || ts.isPropertyAccessExpression(parent)) return false;
+  return false;
+}
+
+function scriptKind(fileName) {
+  return ts.getScriptKindFromFileName(fileName);
+}
+
+function parseFile(root, fileName, raw, constructs) {
+  const text = raw.toString("utf8");
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind(fileName),
+  );
+  if (sourceFile.parseDiagnostics && sourceFile.parseDiagnostics.length > 0) {
+    return false;
+  }
+  const offsets = byteOffsets(text);
+  const add = (
+    relation,
+    capability,
+    node,
+    qualifierNode = null,
+    spelling = null,
+    ownerNode = node,
+  ) => {
+    const target = targetNode(node);
+    if (!target) return;
+    const start = target.getStart(sourceFile, false);
+    const end = target.getEnd();
+    if (!(end > start) || end > offsets.length - 1) return;
+    const targetSpelling = spelling ?? identifierText(sourceFile, target);
+    if (!targetSpelling) return;
+    if (constructs.length >= MAX_CONSTRUCTS) {
+      fail(`construct count exceeds ${MAX_CONSTRUCTS}`);
+    }
+    constructs.push({
+      sourceFile: relativePath(root, fileName),
+      relation,
+      capability,
+      ownerQualifiedName: ownerName(root, sourceFile, ownerNode),
+      targetSpelling,
+      qualifier: qualifierNode ? nodeText(sourceFile, qualifierNode) || null : null,
+      startByte: offsets[start],
+      endByte: offsets[end],
+      startLine: sourceFile.getLineAndCharacterOfPosition(start).line + 1,
+    });
+  };
+
+  const visit = (node) => {
+    if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
+      add("imports", "imports", node.moduleSpecifier, null, node.moduleSpecifier.text);
+      if (node.importClause?.namedBindings && ts.isNamedImports(node.importClause.namedBindings)) {
+        for (const element of node.importClause.namedBindings.elements) {
+          add("imports", "imports", element.name, node.moduleSpecifier, identifierText(sourceFile, element.propertyName ?? element.name));
+        }
+      }
+      if (node.importClause?.name) {
+        add("imports", "imports", node.importClause.name, node.moduleSpecifier, "default");
+      }
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      add("reexports", "reexports", node.moduleSpecifier, null, node.moduleSpecifier.text);
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const element of node.exportClause.elements) {
+          add("reexports", "reexports", element.name, node.moduleSpecifier, identifierText(sourceFile, element.propertyName ?? element.name));
+        }
+      }
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      add("imports", "imports", node.moduleReference.expression, null, node.moduleReference.expression.text);
+    } else if (ts.isCallExpression(node)) {
+      add("calls", "calls", node.expression, targetQualifier(sourceFile, node.expression));
+    } else if (ts.isNewExpression(node)) {
+      add("instantiates", "construction", node.expression, targetQualifier(sourceFile, node.expression));
+    } else if (ts.isPropertyAccessExpression(node)) {
+      add("accesses", "members", node.name, node.expression);
+    } else if (ts.isElementAccessExpression(node) && node.argumentExpression && (ts.isStringLiteral(node.argumentExpression) || ts.isNumericLiteral(node.argumentExpression))) {
+      add("accesses", "members", node.argumentExpression, node.expression, node.argumentExpression.text);
+    } else if (ts.isHeritageClause(node)) {
+      const relation = node.token === ts.SyntaxKind.ExtendsKeyword ? "extends" : "implements";
+      for (const type of node.types) add(relation, "base_types", type.expression, null);
+    } else if (ts.isTypeReferenceNode(node)) {
+      // The parser represents `as const` as a TypeReferenceNode, but `const`
+      // is an assertion keyword there rather than a named type reference.
+      // Keep the source oracle aligned with the semantic construct being
+      // measured so the candidate is not penalized for correctly omitting it.
+      if (
+        !(ts.isAsExpression(node.parent) &&
+          node.parent.type === node &&
+          node.typeName.getText(sourceFile) === "const")
+      ) {
+        add("references", "type_references", node.typeName, null);
+      }
+    } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
+      add("imports", "imports", node.argument.literal, null, node.argument.literal.text);
+    } else if (ts.isJsxOpeningLikeElement(node)) {
+      add("references", "jsx", node.tagName, null);
+    } else if (ts.isIdentifier(node) && !isDeclarationName(node)) {
+      const parent = node.parent;
+      if (
+        !ts.isCallExpression(parent) &&
+        !ts.isNewExpression(parent) &&
+        !ts.isTypeReferenceNode(parent) &&
+        !ts.isExpressionWithTypeArguments(parent) &&
+        !ts.isJsxOpeningLikeElement(parent) &&
+        !ts.isJsxClosingElement(parent) &&
+        !(ts.isPropertyAccessExpression(parent) && parent.name === node) &&
+        !(ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent))
+      ) {
+        add("references", "references", node);
+      }
+    }
+
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node) ||
+        ts.isModuleDeclaration(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isMethodSignature(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node) ||
+        ts.isPropertyDeclaration(node) ||
+        ts.isPropertySignature(node) ||
+        ts.isParameter(node) ||
+        ts.isTypeParameterDeclaration(node) ||
+        ts.isVariableDeclaration(node)) &&
+      node.name &&
+      (ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name))
+    ) {
+      add("declares", "declarations", node.name, null, null, node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return true;
+}
+
+function main() {
+  const root = parseArguments(process.argv.slice(2));
+  const { files, rejected: initialRejected } = collectSourceFiles(root);
+  const rejected = new Set(initialRejected);
+  const constructs = [];
+  let totalBytes = 0;
+  let parsedFiles = 0;
+  for (const fileName of files) {
+    const relative = relativePath(root, fileName);
+    if (rejected.has(relative)) continue;
+    let raw;
+    try {
+      const stat = fs.statSync(fileName);
+      if (stat.size > MAX_SOURCE_BYTES) {
+        rejected.add(relative);
+        continue;
+      }
+      raw = fs.readFileSync(fileName);
+    } catch (error) {
+      rejected.add(relative);
+      continue;
+    }
+    totalBytes += raw.byteLength;
+    if (totalBytes > MAX_SOURCE_BYTES) {
+      fail(`source byte count exceeds ${MAX_SOURCE_BYTES}`);
+    }
+    if (parseFile(root, fileName, raw, constructs)) parsedFiles += 1;
+    else rejected.add(relative);
+  }
+  constructs.sort((left, right) => {
+    const fields = ["sourceFile", "relation", "capability", "ownerQualifiedName", "targetSpelling", "qualifier", "startByte", "endByte", "startLine"];
+    for (const field of fields) {
+      const leftValue = left[field] ?? "";
+      const rightValue = right[field] ?? "";
+      if (leftValue < rightValue) return -1;
+      if (leftValue > rightValue) return 1;
+    }
+    return 0;
+  });
+  const script = fs.readFileSync(fileURLToPath(import.meta.url));
+  const payload = {
+    schema: SCHEMA,
+    provider: PROVIDER,
+    metadata: {
+      compilerVersion: ts.version,
+      nodeVersion: process.version,
+      scriptSha256: sha256(script),
+      platform: `${process.platform}/${process.arch}`,
+    },
+    scannedFiles: files.length,
+    parsedFiles,
+    rejectedFiles: [...rejected].sort(),
+    constructs,
+  };
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  if (process.exitCode !== 2) {
+    console.error(`[typescript-source-oracle] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 2;
+  }
+}

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const SCHEMA = "compass.typescript-source-oracle/1";
+const JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/1";
 const PROVIDER = "typescript_compiler_api_5_9_3";
 const MAX_FILES = 20_000;
 const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
@@ -62,8 +63,13 @@ function sha256(value) {
 }
 
 function parseArguments(argv) {
-  if (argv.length !== 2 || argv[0] !== "--root" || !argv[1]) {
-    fail("usage: typescript-source-oracle.mjs --root PATH");
+  if (
+    (argv.length !== 2 && argv.length !== 3) ||
+    argv[0] !== "--root" ||
+    !argv[1] ||
+    (argv.length === 3 && argv[2] !== "--jsonl")
+  ) {
+    fail("usage: typescript-source-oracle.mjs --root PATH [--jsonl]");
   }
   let root;
   let stat;
@@ -76,7 +82,7 @@ function parseArguments(argv) {
   if (!stat.isDirectory()) {
     fail(`source root is not a directory: ${root}`);
   }
-  return root;
+  return { root, jsonl: argv.length === 3 };
 }
 
 function relativePath(root, fileName) {
@@ -563,7 +569,7 @@ function parseFile(root, fileName, raw, constructs, diagnostics) {
 }
 
 function main() {
-  const root = parseArguments(process.argv.slice(2));
+  const { root, jsonl } = parseArguments(process.argv.slice(2));
   const { files: discoveredFiles, configs, rejected: initialRejected } = collectFiles(root);
   const diagnostics = [];
   const projects = parseProjects(root, configs, diagnostics);
@@ -656,7 +662,50 @@ function main() {
     diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
     constructs,
   };
-  process.stdout.write(`${JSON.stringify(payload)}\n`);
+  if (!jsonl) {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  const coverage = selected.map((fileName) => {
+    const file = relativePath(root, fileName);
+    return {
+      recordType: "file",
+      file,
+      status: rejected.has(file) ? "rejected" : "parsed",
+    };
+  });
+  const records = [
+    {
+      schema: JSONL_SCHEMA,
+      provider: PROVIDER,
+      recordType: "header",
+      metadata: payload.metadata,
+      scannedFiles: payload.scannedFiles,
+      parsedFiles: payload.parsedFiles,
+      projectCount: payload.projects.length,
+      diagnosticCount: payload.diagnostics.length,
+      constructCount: payload.constructs.length,
+    },
+    ...payload.projects.map((project) => ({ recordType: "project", ...project })),
+    ...coverage,
+    ...payload.diagnostics.map((diagnostic) => ({ recordType: "diagnostic", ...diagnostic })),
+    ...payload.constructs.map((construct) => ({ recordType: "construct", ...construct })),
+    {
+      schema: JSONL_SCHEMA,
+      provider: PROVIDER,
+      recordType: "footer",
+      scannedFiles: payload.scannedFiles,
+      parsedFiles: payload.parsedFiles,
+      rejectedFiles: payload.rejectedFiles,
+      projectCount: payload.projects.length,
+      diagnosticCount: payload.diagnostics.length,
+      constructCount: payload.constructs.length,
+      sourceDigest: payload.metadata.sourceDigest,
+      configDigest: payload.metadata.configDigest,
+    },
+  ];
+  process.stdout.write(records.map((record) => JSON.stringify(record)).join("\n"));
+  process.stdout.write("\n");
 }
 
 try {

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -543,6 +543,41 @@ function isDeclarationName(node) {
   return false;
 }
 
+function jsxValueContext(node) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isJsxSpreadAttribute(current)) return "jsx_spread";
+    if (ts.isJsxExpression(current)) {
+      const owner = current.parent;
+      if (ts.isJsxAttribute(owner)) return "jsx_value";
+      if (ts.isJsxSpreadAttribute(owner)) return "jsx_spread";
+      if (ts.isJsxElement(owner)) return "jsx_child";
+      return null;
+    }
+    if (ts.isJsxElement(current) || ts.isJsxOpeningLikeElement(current)) return null;
+    current = current.parent;
+  }
+  return null;
+}
+
+function isJsxValueReference(node) {
+  if (!ts.isIdentifier(node)) return false;
+  const parent = node.parent;
+  if (!parent || isDeclarationName(node)) return false;
+  if (ts.isJsxAttribute(parent) && parent.name === node) return false;
+  if (ts.isJsxOpeningLikeElement(parent) || ts.isJsxClosingElement(parent)) return false;
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+  if (
+    (ts.isCallExpression(parent) || ts.isNewExpression(parent)) &&
+    parent.expression === node
+  ) {
+    return false;
+  }
+  if (ts.isTypeReferenceNode(parent) || ts.isExpressionWithTypeArguments(parent)) return false;
+  if (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) return false;
+  return true;
+}
+
 function scriptKind(fileName) {
   return ts.getScriptKindFromFileName(fileName);
 }
@@ -1011,6 +1046,11 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
       addReferenceFact(node.tagName, "jsx", node.tagName);
     } else if (ts.isIdentifier(node) && !isDeclarationName(node)) {
       const parent = node.parent;
+      const jsxContext = jsxValueContext(node);
+      if (jsxContext && isJsxValueReference(node)) {
+        add("references", "jsx_values", node);
+        addReferenceFact(node, jsxContext, node);
+      }
       if (
         !ts.isCallExpression(parent) &&
         !ts.isNewExpression(parent) &&

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -23,6 +23,11 @@ const PROVIDER = "typescript_compiler_api_5_9_3";
 const MAX_FILES = 20_000;
 const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
 const MAX_CONSTRUCTS = 500_000;
+const MAX_CONFIGS = 256;
+const MAX_CONFIG_BYTES = 2 * 1024 * 1024;
+const MAX_DIAGNOSTICS = 10_000;
+const MAX_PROJECT_FILE_REFERENCES = 100_000;
+const MAX_PROJECT_DEPTH = 32;
 const SOURCE_SUFFIXES = [
   ".ts",
   ".tsx",
@@ -60,9 +65,10 @@ function parseArguments(argv) {
   if (argv.length !== 2 || argv[0] !== "--root" || !argv[1]) {
     fail("usage: typescript-source-oracle.mjs --root PATH");
   }
-  const root = path.resolve(argv[1]);
+  let root;
   let stat;
   try {
+    root = fs.realpathSync.native(path.resolve(argv[1]));
     stat = fs.statSync(root);
   } catch (error) {
     fail(`source root is unavailable: ${error.message}`);
@@ -85,8 +91,25 @@ function isSourceFile(fileName) {
   return SOURCE_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
 }
 
-function collectSourceFiles(root) {
+function isConfigFile(fileName) {
+  const lower = fileName.toLowerCase();
+  return (
+    lower === "tsconfig.json" ||
+    (lower.startsWith("tsconfig.") && lower.endsWith(".json")) ||
+    lower === "jsconfig.json" ||
+    (lower.startsWith("jsconfig.") && lower.endsWith(".json"))
+  );
+}
+
+function isExcludedPath(root, fileName) {
+  const relative = path.relative(root, path.resolve(fileName));
+  if (!relative || relative === ".") return false;
+  return relative.split(path.sep).some((part) => EXCLUDED_DIRECTORIES.has(part));
+}
+
+function collectFiles(root) {
   const files = [];
+  const configs = [];
   const rejected = [];
   const stack = [root];
   while (stack.length > 0) {
@@ -106,22 +129,184 @@ function collectSourceFiles(root) {
         continue;
       }
       const fileName = path.join(directory, entry.name);
-      if (!isSourceFile(entry.name)) {
+      if (entry.isSymbolicLink()) {
+        if (isSourceFile(entry.name)) rejected.push(relativePath(root, fileName));
         continue;
       }
+      if (isConfigFile(entry.name)) configs.push(fileName);
+      if (!isSourceFile(entry.name)) continue;
       const relative = relativePath(root, fileName);
       files.push(fileName);
-      if (files.length > MAX_FILES) {
+      if (files.length + configs.length > MAX_FILES + MAX_CONFIGS) {
         fail(`source file count exceeds ${MAX_FILES}`);
-      }
-      if (entry.isSymbolicLink()) {
-        rejected.push(relative);
       }
     }
   }
   files.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  configs.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
   rejected.sort();
-  return { files, rejected };
+  return { files, configs, rejected };
+}
+
+function diagnosticText(diagnostic) {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+}
+
+function insideRoot(root, fileName) {
+  const absolute = path.resolve(fileName);
+  return absolute === root || absolute.startsWith(`${root}${path.sep}`);
+}
+
+function safeRead(root, fileName, limit) {
+  const absolute = path.resolve(fileName);
+  if (!insideRoot(root, absolute) || isExcludedPath(root, absolute)) return undefined;
+  let stat;
+  try {
+    stat = fs.lstatSync(absolute);
+  } catch {
+    return undefined;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > limit) return undefined;
+  try {
+    return fs.readFileSync(absolute);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeFileExists(root, fileName) {
+  const absolute = path.resolve(fileName);
+  if (!insideRoot(root, absolute) || isExcludedPath(root, absolute)) return false;
+  try {
+    const stat = fs.lstatSync(absolute);
+    return stat.isFile() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isBaseConfiguration(configFile, config) {
+  const basename = path.basename(configFile).toLowerCase();
+  if (basename === "tsconfig.json" || basename === "jsconfig.json") return false;
+  if (!config || typeof config !== "object" || Array.isArray(config)) return false;
+  return (
+    !("files" in config) &&
+    !("include" in config) &&
+    !("references" in config)
+  );
+}
+
+function makeConfigHost(root) {
+  const readFile = (fileName) => {
+    const raw = safeRead(root, fileName, MAX_CONFIG_BYTES);
+    return raw === undefined ? undefined : raw.toString("utf8");
+  };
+  return {
+    useCaseSensitiveFileNames: true,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+    readDirectory(directory, extensions, excludes, includes, depth) {
+      if (!insideRoot(root, directory) || isExcludedPath(root, directory)) return [];
+      return ts.sys
+        .readDirectory(directory, extensions, excludes, includes, depth)
+        .filter((fileName) => insideRoot(root, fileName) && !isExcludedPath(root, fileName));
+    },
+    fileExists: (fileName) => safeFileExists(root, fileName),
+    readFile,
+  };
+}
+
+function projectReferenceConfig(root, reference, baseDirectory) {
+  if (typeof reference !== "string" || reference.length === 0) return null;
+  let candidate = path.resolve(baseDirectory, reference);
+  if (!insideRoot(root, candidate) || isExcludedPath(root, candidate)) return null;
+  try {
+    if (fs.statSync(candidate).isDirectory()) candidate = path.join(candidate, "tsconfig.json");
+  } catch {
+    return null;
+  }
+  return isConfigFile(path.basename(candidate)) ? candidate : null;
+}
+
+function parseProjects(root, discoveredConfigs, diagnostics) {
+  if (discoveredConfigs.length > MAX_CONFIGS) {
+    fail(`project configuration count exceeds ${MAX_CONFIGS}`);
+  }
+  const host = makeConfigHost(root);
+  const queue = discoveredConfigs.map((configFile) => ({ configFile, depth: 0 }));
+  const queued = new Set(discoveredConfigs);
+  const projects = [];
+  let projectFileReferences = 0;
+  while (queue.length > 0) {
+    const item = queue.shift();
+    const configFile = item.configFile;
+    const raw = safeRead(root, configFile, MAX_CONFIG_BYTES);
+    if (raw === undefined) {
+      diagnostics.push({
+        file: relativePath(root, configFile),
+        message: "config is unreadable or exceeds the configured limit",
+      });
+      continue;
+    }
+    const read = ts.readConfigFile(configFile, host.readFile);
+    if (read.error) {
+      diagnostics.push({ file: relativePath(root, configFile), message: diagnosticText(read.error) });
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = ts.parseJsonConfigFileContent(
+        read.config,
+        host,
+        path.dirname(configFile),
+        {},
+        configFile,
+      );
+    } catch (error) {
+      diagnostics.push({ file: relativePath(root, configFile), message: String(error) });
+      continue;
+    }
+    const baseConfiguration = isBaseConfiguration(configFile, read.config);
+    for (const error of parsed.errors ?? []) {
+      diagnostics.push({ file: relativePath(root, configFile), message: diagnosticText(error) });
+      if (diagnostics.length >= MAX_DIAGNOSTICS) {
+        fail(`diagnostic count exceeds ${MAX_DIAGNOSTICS}`);
+      }
+    }
+    if (baseConfiguration) continue;
+    const fileNames = [...new Set(parsed.fileNames.map((fileName) => path.resolve(fileName)))]
+      .filter((fileName) => insideRoot(root, fileName) && !isExcludedPath(root, fileName) && isSourceFile(fileName))
+      .sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+    projectFileReferences += fileNames.length;
+    if (projectFileReferences > MAX_PROJECT_FILE_REFERENCES) {
+      fail(`project file references exceed ${MAX_PROJECT_FILE_REFERENCES}`);
+    }
+    projects.push({
+      configFile,
+      directory: path.dirname(configFile),
+      fileNames,
+      configDigest: sha256(raw),
+      references: (parsed.projectReferences ?? [])
+        .map((reference) =>
+          projectReferenceConfig(
+            root,
+            reference.path ?? reference.sourceFile,
+            path.dirname(configFile),
+          ),
+        )
+        .filter((reference) => reference !== null),
+    });
+    for (const reference of projects.at(-1).references) {
+      if (queued.has(reference)) continue;
+      queued.add(reference);
+      if (item.depth + 1 > MAX_PROJECT_DEPTH) {
+        fail(`project reference depth exceeds ${MAX_PROJECT_DEPTH}`);
+      }
+      queue.push({ configFile: reference, depth: item.depth + 1 });
+      if (queued.size > MAX_CONFIGS) fail(`project configuration count exceeds ${MAX_CONFIGS}`);
+    }
+  }
+  projects.sort((left, right) => relativePath(root, left.configFile).localeCompare(relativePath(root, right.configFile), "en"));
+  return projects;
 }
 
 function byteOffsets(text) {
@@ -233,7 +418,7 @@ function scriptKind(fileName) {
   return ts.getScriptKindFromFileName(fileName);
 }
 
-function parseFile(root, fileName, raw, constructs) {
+function parseFile(root, fileName, raw, constructs, diagnostics) {
   const text = raw.toString("utf8");
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -243,6 +428,15 @@ function parseFile(root, fileName, raw, constructs) {
     scriptKind(fileName),
   );
   if (sourceFile.parseDiagnostics && sourceFile.parseDiagnostics.length > 0) {
+    for (const diagnostic of sourceFile.parseDiagnostics) {
+      diagnostics.push({
+        file: relativePath(root, fileName),
+        message: diagnosticText(diagnostic),
+      });
+      if (diagnostics.length >= MAX_DIAGNOSTICS) {
+        fail(`diagnostic count exceeds ${MAX_DIAGNOSTICS}`);
+      }
+    }
     return false;
   }
   const offsets = byteOffsets(text);
@@ -370,12 +564,25 @@ function parseFile(root, fileName, raw, constructs) {
 
 function main() {
   const root = parseArguments(process.argv.slice(2));
-  const { files, rejected: initialRejected } = collectSourceFiles(root);
-  const rejected = new Set(initialRejected);
+  const { files: discoveredFiles, configs, rejected: initialRejected } = collectFiles(root);
+  const diagnostics = [];
+  const projects = parseProjects(root, configs, diagnostics);
+  const discovered = new Set(discoveredFiles);
+  const selected = projects.length > 0
+    ? [...new Set(projects.flatMap((project) => project.fileNames))]
+        .filter((fileName) => discovered.has(fileName))
+    : discoveredFiles;
+  selected.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  if (selected.length > MAX_FILES) fail(`source file count exceeds ${MAX_FILES}`);
+  const selectedSet = new Set(selected);
+  const rejected = new Set(
+    initialRejected.filter((fileName) => selectedSet.has(path.resolve(root, fileName))),
+  );
   const constructs = [];
   let totalBytes = 0;
   let parsedFiles = 0;
-  for (const fileName of files) {
+  const sourceDigest = crypto.createHash("sha256");
+  for (const fileName of selected) {
     const relative = relativePath(root, fileName);
     if (rejected.has(relative)) continue;
     let raw;
@@ -394,7 +601,8 @@ function main() {
     if (totalBytes > MAX_SOURCE_BYTES) {
       fail(`source byte count exceeds ${MAX_SOURCE_BYTES}`);
     }
-    if (parseFile(root, fileName, raw, constructs)) parsedFiles += 1;
+    sourceDigest.update(relative).update("\0").update(raw);
+    if (parseFile(root, fileName, raw, constructs, diagnostics)) parsedFiles += 1;
     else rejected.add(relative);
   }
   constructs.sort((left, right) => {
@@ -407,7 +615,17 @@ function main() {
     }
     return 0;
   });
+  diagnostics.sort((left, right) => {
+    if (left.file < right.file) return -1;
+    if (left.file > right.file) return 1;
+    return left.message.localeCompare(right.message, "en");
+  });
   const script = fs.readFileSync(fileURLToPath(import.meta.url));
+  const configDigest = sha256(
+    projects
+      .map((project) => `${relativePath(root, project.configFile)}\0${project.configDigest}`)
+      .join("\n"),
+  );
   const payload = {
     schema: SCHEMA,
     provider: PROVIDER,
@@ -416,10 +634,26 @@ function main() {
       nodeVersion: process.version,
       scriptSha256: sha256(script),
       platform: `${process.platform}/${process.arch}`,
+      configDigest,
+      sourceDigest: sourceDigest.digest("hex"),
+      projectMode: projects.length > 0 ? "project" : configs.length > 0 ? "fallback" : "tree",
+      diagnosticCount: String(diagnostics.length),
     },
-    scannedFiles: files.length,
+    scannedFiles: selected.length,
     parsedFiles,
     rejectedFiles: [...rejected].sort(),
+    projects: projects.map((project) => ({
+      configFile: relativePath(root, project.configFile),
+      fileCount: project.fileNames.filter((fileName) => selectedSet.has(fileName)).length,
+      files: project.fileNames
+        .filter((fileName) => selectedSet.has(fileName))
+        .map((fileName) => relativePath(root, fileName)),
+      references: project.references
+        .map((reference) => relativePath(root, reference))
+        .sort(),
+      configDigest: project.configDigest,
+    })),
+    diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
     constructs,
   };
   process.stdout.write(`${JSON.stringify(payload)}\n`);

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const SCHEMA = "compass.typescript-source-oracle/1";
-const JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/2";
+const JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/3";
 const PROVIDER = "typescript_compiler_api_5_9_3";
 const MAX_FILES = 20_000;
 const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
@@ -505,6 +505,33 @@ function callTargetKind(node) {
   return "dynamic";
 }
 
+function memberAccessKind(node) {
+  const parent = node?.parent;
+  if (!parent) return "read";
+  if (
+    (ts.isBinaryExpression(parent) &&
+      parent.left === node &&
+      parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) ||
+    (ts.isPrefixUnaryExpression(parent) &&
+      (parent.operator === ts.SyntaxKind.PlusPlusToken ||
+        parent.operator === ts.SyntaxKind.MinusMinusToken)) ||
+    (ts.isPostfixUnaryExpression(parent) &&
+      (parent.operator === ts.SyntaxKind.PlusPlusToken ||
+        parent.operator === ts.SyntaxKind.MinusMinusToken))
+  ) {
+    return "write";
+  }
+  if (
+    ts.isBinaryExpression(parent) &&
+    parent.left === node &&
+    parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+    parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+  ) {
+    return "write";
+  }
+  return "read";
+}
+
 function isDeclarationName(node) {
   const parent = node.parent;
   if (!parent) return false;
@@ -546,7 +573,30 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
   const scopes = typedFacts.scopes;
   const declarations = typedFacts.declarations;
   const calls = typedFacts.calls;
+  const constructions = typedFacts.constructions;
+  const imports = typedFacts.imports;
+  const reexports = typedFacts.reexports;
+  const bases = typedFacts.bases;
+  const members = typedFacts.members;
+  const references = typedFacts.references;
   const scopeStack = [];
+  const addTypedFact = (collection, value, label) => {
+    if (typedFacts.count >= MAX_TYPED_FACTS) {
+      fail(`typed fact count exceeds ${MAX_TYPED_FACTS}`);
+    }
+    collection.push(value);
+    typedFacts.count += 1;
+    return label;
+  };
+  const statementFields = (node) => {
+    const range = nodeRange(sourceFile, offsets, node);
+    if (!range) return null;
+    return {
+      statementStartByte: range.startByte,
+      statementEndByte: range.endByte,
+      statementStartLine: range.startLine,
+    };
+  };
   const addScope = (node) => {
     const kind = scopeKind(node);
     if (!kind) return false;
@@ -556,11 +606,8 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
         : null)
       : nodeRange(sourceFile, offsets, node);
     if (!range) return false;
-    if (scopes.length >= MAX_TYPED_FACTS) {
-      fail(`scope count exceeds ${MAX_TYPED_FACTS}`);
-    }
     const scopeId = `${relative}:${kind}:${range.startByte}:${range.endByte}`;
-    scopes.push({
+    addTypedFact(scopes, {
       sourceFile: relative,
       scopeId,
       kind,
@@ -585,11 +632,8 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
     }
     const range = nodeRange(sourceFile, offsets, node.name);
     if (!range) return;
-    if (declarations.length >= MAX_TYPED_FACTS) {
-      fail(`declaration count exceeds ${MAX_TYPED_FACTS}`);
-    }
     const parameters = declarationParameters(node);
-    declarations.push({
+    addTypedFact(declarations, {
       sourceFile: relative,
       kind,
       name: node.name.text,
@@ -608,11 +652,8 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
     if (!target || !targetRange || !callRange) return;
     const targetSpelling = identifierText(sourceFile, target);
     if (!targetSpelling) return;
-    if (calls.length >= MAX_TYPED_FACTS) {
-      fail(`call count exceeds ${MAX_TYPED_FACTS}`);
-    }
     const argumentsList = Array.isArray(node.arguments) ? node.arguments : [];
-    calls.push({
+    addTypedFact(node.kind === ts.SyntaxKind.NewExpression ? constructions : calls, {
       sourceFile: relative,
       relation,
       kind: relation === "instantiates" ? "construction" : "call",
@@ -628,7 +669,113 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
       argumentCount: argumentsList.length,
       hasSpreadArgument: argumentsList.some((argument) => Boolean(argument.dotDotDotToken)),
       optional: Boolean(node.questionDotToken),
-    });
+    }, relation === "instantiates" ? "construction" : "call");
+  };
+
+  const addImportFact = (
+    node,
+    anchor,
+    kind,
+    moduleSpecifier,
+    importedName = null,
+    localName = null,
+    isTypeOnly = false,
+  ) => {
+    const range = nodeRange(sourceFile, offsets, anchor);
+    const statement = statementFields(node);
+    if (!range || !statement || !moduleSpecifier) return;
+    addTypedFact(imports, {
+      sourceFile: relative,
+      relation: "imports",
+      kind,
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      moduleSpecifier,
+      importedName,
+      localName,
+      isTypeOnly: Boolean(isTypeOnly),
+      ...range,
+      ...statement,
+    }, "import");
+  };
+
+  const addReexportFact = (
+    node,
+    anchor,
+    kind,
+    moduleSpecifier = null,
+    exportedName = null,
+    localName = null,
+    isTypeOnly = false,
+  ) => {
+    const range = nodeRange(sourceFile, offsets, anchor);
+    const statement = statementFields(node);
+    if (!range || !statement) return;
+    addTypedFact(reexports, {
+      sourceFile: relative,
+      relation: "reexports",
+      kind,
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      moduleSpecifier,
+      exportedName,
+      localName,
+      isTypeOnly: Boolean(isTypeOnly),
+      ...range,
+      ...statement,
+    }, "reexport");
+  };
+
+  const addBaseFact = (node, typeNode, relation) => {
+    const range = nodeRange(sourceFile, offsets, typeNode.expression);
+    const statement = statementFields(node);
+    const targetSpelling = identifierText(sourceFile, targetNode(typeNode.expression));
+    if (!range || !statement || !targetSpelling) return;
+    addTypedFact(bases, {
+      sourceFile: relative,
+      relation,
+      kind: relation,
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      targetSpelling,
+      qualifier: null,
+      ...range,
+      ...statement,
+    }, "base");
+  };
+
+  const addMemberFact = (node) => {
+    const target = targetNode(node);
+    const range = nodeRange(sourceFile, offsets, target);
+    const expression = statementFields(node);
+    const targetSpelling = identifierText(sourceFile, target);
+    if (!target || !range || !expression || !targetSpelling) return;
+    addTypedFact(members, {
+      sourceFile: relative,
+      relation: "accesses",
+      kind: ts.isPropertyAccessExpression(node) ? "property" : "computed_literal",
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      targetSpelling,
+      qualifier: targetQualifier(sourceFile, node)
+        ? nodeText(sourceFile, targetQualifier(sourceFile, node)) || null
+        : null,
+      accessKind: memberAccessKind(node),
+      optional: Boolean(node.questionDotToken),
+      ...range,
+      ...expression,
+    }, "member");
+  };
+
+  const addReferenceFact = (node, kind, anchor = node, qualifier = null) => {
+    const range = nodeRange(sourceFile, offsets, anchor);
+    const targetSpelling = identifierText(sourceFile, node);
+    if (!range || !targetSpelling) return;
+    addTypedFact(references, {
+      sourceFile: relative,
+      relation: "references",
+      kind,
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      targetSpelling,
+      qualifier: qualifier ? nodeText(sourceFile, qualifier) || null : null,
+      ...range,
+    }, "reference");
   };
 
   const add = (
@@ -663,36 +810,153 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
     const pushedScope = addScope(node);
     if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
       add("imports", "imports", node.moduleSpecifier, null, node.moduleSpecifier.text);
+      const moduleSpecifier = node.moduleSpecifier.text;
+      const importClause = node.importClause;
+      if (!importClause) {
+        addImportFact(node, node.moduleSpecifier, "side_effect", moduleSpecifier, null, null, false);
+      }
+      if (importClause?.name) {
+        addImportFact(
+          node,
+          importClause.name,
+          "default",
+          moduleSpecifier,
+          "default",
+          importClause.name.text,
+          Boolean(importClause.isTypeOnly),
+        );
+      }
       if (node.importClause?.namedBindings && ts.isNamedImports(node.importClause.namedBindings)) {
         for (const element of node.importClause.namedBindings.elements) {
           add("imports", "imports", element.name, node.moduleSpecifier, identifierText(sourceFile, element.propertyName ?? element.name));
+          addImportFact(
+            node,
+            element.name,
+            "named",
+            moduleSpecifier,
+            identifierText(sourceFile, element.propertyName ?? element.name),
+            element.name.text,
+            Boolean(importClause?.isTypeOnly || element.isTypeOnly),
+          );
         }
+      }
+      if (node.importClause?.namedBindings && ts.isNamespaceImport(node.importClause.namedBindings)) {
+        addImportFact(
+          node,
+          node.importClause.namedBindings.name,
+          "namespace",
+          moduleSpecifier,
+          "*",
+          node.importClause.namedBindings.name.text,
+          Boolean(importClause?.isTypeOnly),
+        );
       }
       if (node.importClause?.name) {
         add("imports", "imports", node.importClause.name, node.moduleSpecifier, "default");
       }
     } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
       add("reexports", "reexports", node.moduleSpecifier, null, node.moduleSpecifier.text);
+      const moduleSpecifier = node.moduleSpecifier.text;
+      if (!node.exportClause) {
+        addReexportFact(node, node.moduleSpecifier, "star", moduleSpecifier, "*", null, Boolean(node.isTypeOnly));
+      }
       if (node.exportClause && ts.isNamedExports(node.exportClause)) {
         for (const element of node.exportClause.elements) {
           add("reexports", "reexports", element.name, node.moduleSpecifier, identifierText(sourceFile, element.propertyName ?? element.name));
+          addReexportFact(
+            node,
+            element.name,
+            "named",
+            moduleSpecifier,
+            element.name.text,
+            element.propertyName ? identifierText(sourceFile, element.propertyName) : element.name.text,
+            Boolean(node.isTypeOnly || element.isTypeOnly),
+          );
         }
       }
+      if (node.exportClause && ts.isNamespaceExport(node.exportClause)) {
+        addReexportFact(
+          node,
+          node.exportClause.name,
+          "namespace",
+          moduleSpecifier,
+          node.exportClause.name.text,
+          null,
+          Boolean(node.isTypeOnly),
+        );
+      }
+    } else if (ts.isExportDeclaration(node)) {
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const element of node.exportClause.elements) {
+          addReexportFact(
+            node,
+            element.name,
+            "local",
+            null,
+            element.name.text,
+            element.propertyName ? identifierText(sourceFile, element.propertyName) : element.name.text,
+            Boolean(node.isTypeOnly || element.isTypeOnly),
+          );
+        }
+      }
+    } else if (ts.isExportAssignment(node)) {
+      addReexportFact(node, node.expression, "default", null, "default", nodeText(sourceFile, node.expression), false);
     } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
       add("imports", "imports", node.moduleReference.expression, null, node.moduleReference.expression.text);
+      addImportFact(
+        node,
+        node.moduleReference.expression,
+        "import_equals",
+        node.moduleReference.expression.text,
+        "*",
+        node.name?.text ?? null,
+        Boolean(node.isTypeOnly),
+      );
     } else if (ts.isCallExpression(node)) {
       add("calls", "calls", node.expression, targetQualifier(sourceFile, node.expression));
       addCall(node, "calls");
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword && node.arguments.length > 0) {
+        const argument = node.arguments[0];
+        addImportFact(
+          node,
+          argument,
+          "dynamic",
+          nodeText(sourceFile, argument),
+          null,
+          null,
+          false,
+        );
+      } else if (
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "require" &&
+        node.arguments.length > 0
+      ) {
+        const argument = node.arguments[0];
+        addImportFact(
+          node,
+          argument,
+          "require",
+          nodeText(sourceFile, argument),
+          null,
+          null,
+          false,
+        );
+      }
     } else if (ts.isNewExpression(node)) {
       add("instantiates", "construction", node.expression, targetQualifier(sourceFile, node.expression));
       addCall(node, "instantiates");
     } else if (ts.isPropertyAccessExpression(node)) {
       add("accesses", "members", node.name, node.expression);
+      addMemberFact(node);
     } else if (ts.isElementAccessExpression(node) && node.argumentExpression && (ts.isStringLiteral(node.argumentExpression) || ts.isNumericLiteral(node.argumentExpression))) {
       add("accesses", "members", node.argumentExpression, node.expression, node.argumentExpression.text);
+      addMemberFact(node);
     } else if (ts.isHeritageClause(node)) {
       const relation = node.token === ts.SyntaxKind.ExtendsKeyword ? "extends" : "implements";
-      for (const type of node.types) add(relation, "base_types", type.expression, null);
+      for (const type of node.types) {
+        add(relation, "base_types", type.expression, null);
+        addBaseFact(node, type, relation);
+      }
     } else if (ts.isTypeReferenceNode(node)) {
       // The parser represents `as const` as a TypeReferenceNode, but `const`
       // is an assertion keyword there rather than a named type reference.
@@ -704,11 +968,22 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
           node.typeName.getText(sourceFile) === "const")
       ) {
         add("references", "type_references", node.typeName, null);
+        addReferenceFact(node.typeName, "type", node.typeName);
       }
     } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
       add("imports", "imports", node.argument.literal, null, node.argument.literal.text);
+      addImportFact(
+        node,
+        node.argument.literal,
+        "import_type",
+        node.argument.literal.text,
+        null,
+        null,
+        Boolean(node.isTypeOf),
+      );
     } else if (ts.isJsxOpeningLikeElement(node)) {
       add("references", "jsx", node.tagName, null);
+      addReferenceFact(node.tagName, "jsx", node.tagName);
     } else if (ts.isIdentifier(node) && !isDeclarationName(node)) {
       const parent = node.parent;
       if (
@@ -722,6 +997,7 @@ function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
         !(ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent))
       ) {
         add("references", "references", node);
+        addReferenceFact(node, "identifier", node);
       }
     }
 
@@ -776,6 +1052,13 @@ function main() {
     scopes: [],
     declarations: [],
     calls: [],
+    constructions: [],
+    imports: [],
+    reexports: [],
+    bases: [],
+    members: [],
+    references: [],
+    count: 0,
   };
   let totalBytes = 0;
   let parsedFiles = 0;
@@ -849,6 +1132,57 @@ function main() {
     "relation",
     "targetSpelling",
   ]);
+  sortByFields(typedFacts.constructions, [
+    "sourceFile",
+    "callStartByte",
+    "callEndByte",
+    "startByte",
+    "endByte",
+    "targetSpelling",
+  ]);
+  sortByFields(typedFacts.imports, [
+    "sourceFile",
+    "statementStartByte",
+    "startByte",
+    "endByte",
+    "kind",
+    "moduleSpecifier",
+    "localName",
+  ]);
+  sortByFields(typedFacts.reexports, [
+    "sourceFile",
+    "statementStartByte",
+    "startByte",
+    "endByte",
+    "kind",
+    "moduleSpecifier",
+    "exportedName",
+  ]);
+  sortByFields(typedFacts.bases, [
+    "sourceFile",
+    "startByte",
+    "endByte",
+    "relation",
+    "ownerQualifiedName",
+    "targetSpelling",
+  ]);
+  sortByFields(typedFacts.members, [
+    "sourceFile",
+    "statementStartByte",
+    "startByte",
+    "endByte",
+    "kind",
+    "targetSpelling",
+    "qualifier",
+  ]);
+  sortByFields(typedFacts.references, [
+    "sourceFile",
+    "startByte",
+    "endByte",
+    "kind",
+    "ownerQualifiedName",
+    "targetSpelling",
+  ]);
   diagnostics.sort((left, right) => {
     if (left.file < right.file) return -1;
     if (left.file > right.file) return 1;
@@ -892,6 +1226,12 @@ function main() {
     scopes: typedFacts.scopes,
     declarations: typedFacts.declarations,
     calls: typedFacts.calls,
+    constructions: typedFacts.constructions,
+    imports: typedFacts.imports,
+    reexports: typedFacts.reexports,
+    bases: typedFacts.bases,
+    members: typedFacts.members,
+    references: typedFacts.references,
   };
   if (!jsonl) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
@@ -919,6 +1259,12 @@ function main() {
       scopeCount: payload.scopes.length,
       declarationCount: payload.declarations.length,
       callCount: payload.calls.length,
+      constructionCount: payload.constructions.length,
+      importCount: payload.imports.length,
+      reexportCount: payload.reexports.length,
+      baseCount: payload.bases.length,
+      memberCount: payload.members.length,
+      referenceCount: payload.references.length,
     },
     ...payload.projects.map((project) => ({ recordType: "project", ...project })),
     ...coverage,
@@ -927,6 +1273,12 @@ function main() {
     ...payload.scopes.map((scope) => ({ recordType: "scope", ...scope })),
     ...payload.declarations.map((declaration) => ({ recordType: "declaration", ...declaration })),
     ...payload.calls.map((call) => ({ recordType: "call", ...call })),
+    ...payload.constructions.map((construction) => ({ recordType: "construction", ...construction })),
+    ...payload.imports.map((entry) => ({ recordType: "import", ...entry })),
+    ...payload.reexports.map((entry) => ({ recordType: "reexport", ...entry })),
+    ...payload.bases.map((base) => ({ recordType: "base", ...base })),
+    ...payload.members.map((member) => ({ recordType: "member", ...member })),
+    ...payload.references.map((reference) => ({ recordType: "reference", ...reference })),
     {
       schema: JSONL_SCHEMA,
       provider: PROVIDER,
@@ -940,6 +1292,12 @@ function main() {
       scopeCount: payload.scopes.length,
       declarationCount: payload.declarations.length,
       callCount: payload.calls.length,
+      constructionCount: payload.constructions.length,
+      importCount: payload.imports.length,
+      reexportCount: payload.reexports.length,
+      baseCount: payload.bases.length,
+      memberCount: payload.members.length,
+      referenceCount: payload.references.length,
       sourceDigest: payload.metadata.sourceDigest,
       configDigest: payload.metadata.configDigest,
     },

--- a/benchmarks/performance/oracles/typescript-source-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-source-oracle.mjs
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 const SCHEMA = "compass.typescript-source-oracle/1";
-const JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/1";
+const JSONL_SCHEMA = "compass.typescript-source-oracle-jsonl/2";
 const PROVIDER = "typescript_compiler_api_5_9_3";
 const MAX_FILES = 20_000;
 const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
@@ -29,6 +29,7 @@ const MAX_CONFIG_BYTES = 2 * 1024 * 1024;
 const MAX_DIAGNOSTICS = 10_000;
 const MAX_PROJECT_FILE_REFERENCES = 100_000;
 const MAX_PROJECT_DEPTH = 32;
+const MAX_TYPED_FACTS = 500_000;
 const SOURCE_SUFFIXES = [
   ".ts",
   ".tsx",
@@ -409,6 +410,101 @@ function targetQualifier(sourceFile, node) {
   return null;
 }
 
+function nodeRange(sourceFile, offsets, node) {
+  if (!node) return null;
+  const start = node.getStart(sourceFile, false);
+  const end = node.getEnd();
+  if (!(end > start) || end > offsets.length - 1) return null;
+  return {
+    startByte: offsets[start],
+    endByte: offsets[end],
+    startLine: sourceFile.getLineAndCharacterOfPosition(start).line + 1,
+  };
+}
+
+function declarationKind(node) {
+  if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) return "function";
+  if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) return "class";
+  if (ts.isInterfaceDeclaration(node)) return "interface";
+  if (ts.isTypeAliasDeclaration(node)) return "type_alias";
+  if (ts.isEnumDeclaration(node)) return "enum";
+  if (ts.isModuleDeclaration(node)) return "namespace";
+  if (ts.isMethodDeclaration(node)) return "method";
+  if (ts.isMethodSignature(node)) return "method_signature";
+  if (ts.isConstructorDeclaration(node)) return "constructor";
+  if (ts.isGetAccessorDeclaration(node)) return "getter";
+  if (ts.isSetAccessorDeclaration(node)) return "setter";
+  if (ts.isPropertyDeclaration(node)) return "property";
+  if (ts.isPropertySignature(node)) return "property_signature";
+  if (ts.isParameter(node)) return "parameter";
+  if (ts.isTypeParameterDeclaration(node)) return "type_parameter";
+  if (ts.isVariableDeclaration(node)) return "variable";
+  return null;
+}
+
+function declarationNamespace(kind) {
+  if (kind === "class" || kind === "enum") return "value_and_type";
+  if (
+    kind === "interface" ||
+    kind === "type_alias" ||
+    kind === "method_signature" ||
+    kind === "property_signature" ||
+    kind === "type_parameter"
+  ) {
+    return "type";
+  }
+  if (kind === "namespace") return "namespace";
+  return "value";
+}
+
+function declarationParameters(node) {
+  if (!node || !Array.isArray(node.parameters)) {
+    return {
+      parameterCount: null,
+      minimumParameterCount: null,
+      hasRestParameter: false,
+    };
+  }
+  let minimumParameterCount = 0;
+  let hasRestParameter = false;
+  for (const parameter of node.parameters) {
+    if (parameter.dotDotDotToken) {
+      hasRestParameter = true;
+      continue;
+    }
+    if (!parameter.questionToken && !parameter.initializer) minimumParameterCount += 1;
+  }
+  return {
+    parameterCount: node.parameters.length,
+    minimumParameterCount,
+    hasRestParameter,
+  };
+}
+
+function declarationQualifiedName(root, sourceFile, node) {
+  const name = declarationName(sourceFile, node);
+  const owner = ownerName(root, sourceFile, node);
+  return name ? `${owner}.${name}` : owner;
+}
+
+function scopeKind(node) {
+  if (ts.isSourceFile(node)) return "module";
+  if (ts.isClassLike(node)) return "class";
+  if (ts.isFunctionLike(node)) return "function";
+  if (ts.isModuleDeclaration(node)) return "namespace";
+  if (ts.isCatchClause(node)) return "catch";
+  if (ts.isCaseBlock(node)) return "switch";
+  if (ts.isBlock(node) || ts.isModuleBlock(node)) return "block";
+  return null;
+}
+
+function callTargetKind(node) {
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return "direct";
+  if (ts.isPropertyAccessExpression(node)) return "member";
+  if (ts.isElementAccessExpression(node)) return "computed_literal";
+  return "dynamic";
+}
+
 function isDeclarationName(node) {
   const parent = node.parent;
   if (!parent) return false;
@@ -424,7 +520,7 @@ function scriptKind(fileName) {
   return ts.getScriptKindFromFileName(fileName);
 }
 
-function parseFile(root, fileName, raw, constructs, diagnostics) {
+function parseFile(root, fileName, raw, constructs, diagnostics, typedFacts) {
   const text = raw.toString("utf8");
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -446,6 +542,95 @@ function parseFile(root, fileName, raw, constructs, diagnostics) {
     return false;
   }
   const offsets = byteOffsets(text);
+  const relative = relativePath(root, fileName);
+  const scopes = typedFacts.scopes;
+  const declarations = typedFacts.declarations;
+  const calls = typedFacts.calls;
+  const scopeStack = [];
+  const addScope = (node) => {
+    const kind = scopeKind(node);
+    if (!kind) return false;
+    const range = ts.isSourceFile(node)
+      ? (text.length > 0
+        ? { startByte: 0, endByte: Buffer.byteLength(text, "utf8"), startLine: 1 }
+        : null)
+      : nodeRange(sourceFile, offsets, node);
+    if (!range) return false;
+    if (scopes.length >= MAX_TYPED_FACTS) {
+      fail(`scope count exceeds ${MAX_TYPED_FACTS}`);
+    }
+    const scopeId = `${relative}:${kind}:${range.startByte}:${range.endByte}`;
+    scopes.push({
+      sourceFile: relative,
+      scopeId,
+      kind,
+      ownerQualifiedName: ts.isSourceFile(node)
+        ? moduleName(root, sourceFile.fileName)
+        : declarationQualifiedName(root, sourceFile, node),
+      parentScopeId: scopeStack.length > 0 ? scopeStack.at(-1).scopeId : null,
+      ...range,
+    });
+    scopeStack.push({ scopeId });
+    return true;
+  };
+
+  const addDeclaration = (node) => {
+    const kind = declarationKind(node);
+    if (
+      !kind ||
+      !node.name ||
+      !(ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name))
+    ) {
+      return;
+    }
+    const range = nodeRange(sourceFile, offsets, node.name);
+    if (!range) return;
+    if (declarations.length >= MAX_TYPED_FACTS) {
+      fail(`declaration count exceeds ${MAX_TYPED_FACTS}`);
+    }
+    const parameters = declarationParameters(node);
+    declarations.push({
+      sourceFile: relative,
+      kind,
+      name: node.name.text,
+      qualifiedName: declarationQualifiedName(root, sourceFile, node),
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      namespace: declarationNamespace(kind),
+      ...range,
+      ...parameters,
+    });
+  };
+
+  const addCall = (node, relation) => {
+    const target = targetNode(node.expression);
+    const targetRange = nodeRange(sourceFile, offsets, target);
+    const callRange = nodeRange(sourceFile, offsets, node);
+    if (!target || !targetRange || !callRange) return;
+    const targetSpelling = identifierText(sourceFile, target);
+    if (!targetSpelling) return;
+    if (calls.length >= MAX_TYPED_FACTS) {
+      fail(`call count exceeds ${MAX_TYPED_FACTS}`);
+    }
+    const argumentsList = Array.isArray(node.arguments) ? node.arguments : [];
+    calls.push({
+      sourceFile: relative,
+      relation,
+      kind: relation === "instantiates" ? "construction" : "call",
+      ownerQualifiedName: ownerName(root, sourceFile, node),
+      targetSpelling,
+      qualifier: targetQualifier(sourceFile, node.expression)
+        ? nodeText(sourceFile, targetQualifier(sourceFile, node.expression)) || null
+        : null,
+      targetKind: callTargetKind(node.expression),
+      ...targetRange,
+      callStartByte: callRange.startByte,
+      callEndByte: callRange.endByte,
+      argumentCount: argumentsList.length,
+      hasSpreadArgument: argumentsList.some((argument) => Boolean(argument.dotDotDotToken)),
+      optional: Boolean(node.questionDotToken),
+    });
+  };
+
   const add = (
     relation,
     capability,
@@ -456,28 +641,26 @@ function parseFile(root, fileName, raw, constructs, diagnostics) {
   ) => {
     const target = targetNode(node);
     if (!target) return;
-    const start = target.getStart(sourceFile, false);
-    const end = target.getEnd();
-    if (!(end > start) || end > offsets.length - 1) return;
+    const range = nodeRange(sourceFile, offsets, target);
+    if (!range) return;
     const targetSpelling = spelling ?? identifierText(sourceFile, target);
     if (!targetSpelling) return;
     if (constructs.length >= MAX_CONSTRUCTS) {
       fail(`construct count exceeds ${MAX_CONSTRUCTS}`);
     }
     constructs.push({
-      sourceFile: relativePath(root, fileName),
+      sourceFile: relative,
       relation,
       capability,
       ownerQualifiedName: ownerName(root, sourceFile, ownerNode),
       targetSpelling,
       qualifier: qualifierNode ? nodeText(sourceFile, qualifierNode) || null : null,
-      startByte: offsets[start],
-      endByte: offsets[end],
-      startLine: sourceFile.getLineAndCharacterOfPosition(start).line + 1,
+      ...range,
     });
   };
 
   const visit = (node) => {
+    const pushedScope = addScope(node);
     if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
       add("imports", "imports", node.moduleSpecifier, null, node.moduleSpecifier.text);
       if (node.importClause?.namedBindings && ts.isNamedImports(node.importClause.namedBindings)) {
@@ -499,8 +682,10 @@ function parseFile(root, fileName, raw, constructs, diagnostics) {
       add("imports", "imports", node.moduleReference.expression, null, node.moduleReference.expression.text);
     } else if (ts.isCallExpression(node)) {
       add("calls", "calls", node.expression, targetQualifier(sourceFile, node.expression));
+      addCall(node, "calls");
     } else if (ts.isNewExpression(node)) {
       add("instantiates", "construction", node.expression, targetQualifier(sourceFile, node.expression));
+      addCall(node, "instantiates");
     } else if (ts.isPropertyAccessExpression(node)) {
       add("accesses", "members", node.name, node.expression);
     } else if (ts.isElementAccessExpression(node) && node.argumentExpression && (ts.isStringLiteral(node.argumentExpression) || ts.isNumericLiteral(node.argumentExpression))) {
@@ -560,9 +745,11 @@ function parseFile(root, fileName, raw, constructs, diagnostics) {
       node.name &&
       (ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name))
     ) {
+      addDeclaration(node);
       add("declares", "declarations", node.name, null, null, node);
     }
     ts.forEachChild(node, visit);
+    if (pushedScope) scopeStack.pop();
   };
   visit(sourceFile);
   return true;
@@ -585,6 +772,11 @@ function main() {
     initialRejected.filter((fileName) => selectedSet.has(path.resolve(root, fileName))),
   );
   const constructs = [];
+  const typedFacts = {
+    scopes: [],
+    declarations: [],
+    calls: [],
+  };
   let totalBytes = 0;
   let parsedFiles = 0;
   const sourceDigest = crypto.createHash("sha256");
@@ -608,7 +800,7 @@ function main() {
       fail(`source byte count exceeds ${MAX_SOURCE_BYTES}`);
     }
     sourceDigest.update(relative).update("\0").update(raw);
-    if (parseFile(root, fileName, raw, constructs, diagnostics)) parsedFiles += 1;
+    if (parseFile(root, fileName, raw, constructs, diagnostics, typedFacts)) parsedFiles += 1;
     else rejected.add(relative);
   }
   constructs.sort((left, right) => {
@@ -621,6 +813,42 @@ function main() {
     }
     return 0;
   });
+  const sortByFields = (values, fields) => {
+    values.sort((left, right) => {
+      for (const field of fields) {
+        const leftValue = left[field] ?? "";
+        const rightValue = right[field] ?? "";
+        if (leftValue < rightValue) return -1;
+        if (leftValue > rightValue) return 1;
+      }
+      return 0;
+    });
+  };
+  sortByFields(typedFacts.scopes, [
+    "sourceFile",
+    "startByte",
+    "endByte",
+    "kind",
+    "scopeId",
+    "parentScopeId",
+  ]);
+  sortByFields(typedFacts.declarations, [
+    "sourceFile",
+    "startByte",
+    "endByte",
+    "kind",
+    "qualifiedName",
+    "namespace",
+  ]);
+  sortByFields(typedFacts.calls, [
+    "sourceFile",
+    "startByte",
+    "endByte",
+    "callStartByte",
+    "callEndByte",
+    "relation",
+    "targetSpelling",
+  ]);
   diagnostics.sort((left, right) => {
     if (left.file < right.file) return -1;
     if (left.file > right.file) return 1;
@@ -661,6 +889,9 @@ function main() {
     })),
     diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
     constructs,
+    scopes: typedFacts.scopes,
+    declarations: typedFacts.declarations,
+    calls: typedFacts.calls,
   };
   if (!jsonl) {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
@@ -685,11 +916,17 @@ function main() {
       projectCount: payload.projects.length,
       diagnosticCount: payload.diagnostics.length,
       constructCount: payload.constructs.length,
+      scopeCount: payload.scopes.length,
+      declarationCount: payload.declarations.length,
+      callCount: payload.calls.length,
     },
     ...payload.projects.map((project) => ({ recordType: "project", ...project })),
     ...coverage,
     ...payload.diagnostics.map((diagnostic) => ({ recordType: "diagnostic", ...diagnostic })),
     ...payload.constructs.map((construct) => ({ recordType: "construct", ...construct })),
+    ...payload.scopes.map((scope) => ({ recordType: "scope", ...scope })),
+    ...payload.declarations.map((declaration) => ({ recordType: "declaration", ...declaration })),
+    ...payload.calls.map((call) => ({ recordType: "call", ...call })),
     {
       schema: JSONL_SCHEMA,
       provider: PROVIDER,
@@ -700,6 +937,9 @@ function main() {
       projectCount: payload.projects.length,
       diagnosticCount: payload.diagnostics.length,
       constructCount: payload.constructs.length,
+      scopeCount: payload.scopes.length,
+      declarationCount: payload.declarations.length,
+      callCount: payload.calls.length,
       sourceDigest: payload.metadata.sourceDigest,
       configDigest: payload.metadata.configDigest,
     },

--- a/benchmarks/performance/oracles/typescript-target-oracle.mjs
+++ b/benchmarks/performance/oracles/typescript-target-oracle.mjs
@@ -1,0 +1,545 @@
+#!/usr/bin/env node
+
+/**
+ * Independent TypeScript/JavaScript target-identity oracle.
+ *
+ * This is a qualification-only tool. It uses the pinned TypeScript compiler
+ * checker to adjudicate source-backed target declarations. It never reads a
+ * Compass or Graphify graph and is not part of normal Compass execution.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const SCHEMA = "compass.typescript-target-oracle/1";
+const PROVIDER = "typescript_checker_api_5_9_3";
+const MAX_FILES = 20_000;
+const MAX_SOURCE_BYTES = 128 * 1024 * 1024;
+const MAX_CONSTRUCTS = 500_000;
+const MAX_DIAGNOSTICS = 10_000;
+const SOURCE_SUFFIXES = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+const EXCLUDED_DIRECTORIES = new Set([
+  ".git",
+  ".compass",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "target",
+]);
+
+function fail(message) {
+  console.error(`[typescript-target-oracle] ${message}`);
+  process.exitCode = 2;
+  throw new Error(message);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function parseArguments(argv) {
+  if (argv.length !== 2 || argv[0] !== "--root" || !argv[1]) {
+    fail("usage: typescript-target-oracle.mjs --root PATH");
+  }
+  let root;
+  try {
+    root = fs.realpathSync.native(path.resolve(argv[1]));
+  } catch (error) {
+    fail(`source root is unavailable: ${error.message}`);
+  }
+  let stat;
+  try {
+    stat = fs.statSync(root);
+  } catch (error) {
+    fail(`source root is unavailable: ${error.message}`);
+  }
+  if (!stat.isDirectory()) fail(`source root is not a directory: ${root}`);
+  return root;
+}
+
+function relativePath(root, fileName) {
+  const relative = path.relative(root, fileName).split(path.sep).join("/");
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith("../") ||
+    path.isAbsolute(relative)
+  ) {
+    fail(`source path escapes root: ${fileName}`);
+  }
+  return relative;
+}
+
+function insideRoot(root, fileName) {
+  const absolute = path.resolve(fileName);
+  return absolute === root || absolute.startsWith(`${root}${path.sep}`);
+}
+
+function isSourceFile(fileName) {
+  return SOURCE_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
+}
+
+function collectFiles(root) {
+  const files = [];
+  const rejected = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const directory = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      fail(`cannot read directory ${relativePath(root, directory)}: ${error.message}`);
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+    for (const entry of entries) {
+      const fileName = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRECTORIES.has(entry.name)) stack.push(fileName);
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        if (isSourceFile(entry.name)) rejected.push(relativePath(root, fileName));
+        continue;
+      }
+      if (isSourceFile(entry.name)) files.push(fileName);
+      if (files.length > MAX_FILES) fail(`source file count exceeds ${MAX_FILES}`);
+    }
+  }
+  files.sort((left, right) => relativePath(root, left).localeCompare(relativePath(root, right), "en"));
+  rejected.sort();
+  return { files, rejected };
+}
+
+function byteOffsets(text) {
+  const offsets = new Uint32Array(text.length + 1);
+  let byteOffset = 0;
+  let index = 0;
+  while (index < text.length) {
+    const codePoint = text.codePointAt(index);
+    const width = codePoint > 0xffff ? 2 : 1;
+    offsets[index] = byteOffset;
+    if (width === 2) offsets[index + 1] = byteOffset;
+    byteOffset += Buffer.byteLength(text.slice(index, index + width), "utf8");
+    index += width;
+    offsets[index] = byteOffset;
+  }
+  return offsets;
+}
+
+function scriptKind(fileName) {
+  return ts.getScriptKindFromFileName(fileName);
+}
+
+function identifierText(sourceFile, node) {
+  if (!node) return "";
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node.text;
+  if (ts.isStringLiteral(node) || ts.isNumericLiteral(node)) return node.text;
+  return node.getText(sourceFile).trim();
+}
+
+function targetNode(node) {
+  if (!node) return null;
+  if (ts.isPropertyAccessExpression(node)) return node.name;
+  if (ts.isElementAccessExpression(node) && node.argumentExpression) {
+    if (
+      ts.isStringLiteral(node.argumentExpression) ||
+      ts.isNumericLiteral(node.argumentExpression)
+    ) {
+      return node.argumentExpression;
+    }
+  }
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node;
+  return node;
+}
+
+function isDeclarationName(node) {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (parent.name === node) return true;
+  if (
+    ts.isImportSpecifier(parent) ||
+    ts.isExportSpecifier(parent)
+  ) {
+    return parent.name === node || parent.propertyName === node;
+  }
+  if (ts.isNamespaceImport(parent) || ts.isImportClause(parent)) return true;
+  if (ts.isQualifiedName(parent) || ts.isPropertyAccessExpression(parent)) return false;
+  return false;
+}
+
+function declarationNodes(node) {
+  return (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isEnumDeclaration(node) ||
+      ts.isModuleDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isMethodSignature(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
+      ts.isPropertyDeclaration(node) ||
+      ts.isPropertySignature(node) ||
+      ts.isParameter(node) ||
+      ts.isTypeParameterDeclaration(node) ||
+      ts.isVariableDeclaration(node)) &&
+    node.name &&
+    (ts.isIdentifier(node.name) || ts.isPrivateIdentifier(node.name))
+  );
+}
+
+function constructMap(sourceFile) {
+  const offsets = sourceFile.__byteOffsets;
+  const constructs = new Map();
+  const add = (relation, capability, node) => {
+    const target = targetNode(node);
+    if (!target) return;
+    const start = target.getStart(sourceFile, false);
+    const end = target.getEnd();
+    if (!(end > start) || end >= offsets.length) return;
+    const key = `${relation}\0${capability}\0${offsets[start]}\0${offsets[end]}`;
+    if (!constructs.has(key)) {
+      constructs.set(key, {
+        relation,
+        capability,
+        node,
+        target,
+        startByte: offsets[start],
+        endByte: offsets[end],
+        targetSpelling: identifierText(sourceFile, target),
+      });
+    }
+  };
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) add("calls", "calls", node.expression);
+    else if (ts.isNewExpression(node)) add("instantiates", "construction", node.expression);
+    else if (ts.isPropertyAccessExpression(node)) add("accesses", "members", node.name);
+    else if (
+      ts.isElementAccessExpression(node) &&
+      node.argumentExpression &&
+      (ts.isStringLiteral(node.argumentExpression) ||
+        ts.isNumericLiteral(node.argumentExpression))
+    ) {
+      add("accesses", "members", node.argumentExpression);
+    } else if (ts.isHeritageClause(node)) {
+      const relation =
+        node.token === ts.SyntaxKind.ExtendsKeyword ? "extends" : "implements";
+      for (const type of node.types) add(relation, "base_types", type.expression);
+    } else if (ts.isTypeReferenceNode(node)) {
+      // `as const` is a literal assertion, not a named type reference.
+      if (
+        !(ts.isAsExpression(node.parent) && node.parent.type === node &&
+          node.typeName.getText(sourceFile) === "const")
+      ) {
+        add("references", "type_references", node.typeName);
+      }
+    } else if (ts.isJsxOpeningLikeElement(node)) {
+      add("references", "jsx", node.tagName);
+    }
+
+    if (declarationNodes(node)) add("declares", "declarations", node.name);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return constructs;
+}
+
+function safeRead(root, fileName, limit = MAX_SOURCE_BYTES) {
+  const absolute = path.resolve(fileName);
+  if (!insideRoot(root, absolute)) return undefined;
+  let stat;
+  try {
+    stat = fs.statSync(absolute);
+  } catch {
+    return undefined;
+  }
+  if (!stat.isFile() || stat.size > limit) return undefined;
+  try {
+    return fs.readFileSync(absolute);
+  } catch {
+    return undefined;
+  }
+}
+
+function makeHost(root, options) {
+  const base = ts.createCompilerHost(options, true);
+  const read = (fileName) => {
+    const raw = safeRead(root, fileName);
+    return raw === undefined ? undefined : raw.toString("utf8");
+  };
+  return {
+    ...base,
+    fileExists: (fileName) => safeRead(root, fileName) !== undefined,
+    readFile: read,
+    getSourceFile(fileName, languageVersion) {
+      const text = read(fileName);
+      return text === undefined
+        ? undefined
+        : ts.createSourceFile(fileName, text, languageVersion, true, scriptKind(fileName));
+    },
+    realpath(fileName) {
+      const absolute = path.resolve(fileName);
+      if (!insideRoot(root, absolute)) return fileName;
+      try {
+        return fs.realpathSync.native(absolute);
+      } catch {
+        return absolute;
+      }
+    },
+    getCurrentDirectory: () => root,
+    writeFile: () => {},
+  };
+}
+
+function enclosingClass(node) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isClassLike(current)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function normalizeDeclaration(declaration) {
+  if (ts.isConstructorDeclaration(declaration)) {
+    const body = declaration.parent;
+    const owner = body?.parent;
+    if (owner && ts.isClassLike(owner)) return owner;
+  }
+  return declaration;
+}
+
+function symbolFromLocation(checker, node) {
+  let symbol;
+  try {
+    symbol = checker.getSymbolAtLocation(node);
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      const aliased = checker.getAliasedSymbol(symbol);
+      if (aliased && aliased !== symbol) symbol = aliased;
+    }
+  } catch {
+    return undefined;
+  }
+  return symbol;
+}
+
+function superSymbol(checker, node) {
+  if (node.kind !== ts.SyntaxKind.SuperKeyword) return undefined;
+  const owner = enclosingClass(node);
+  if (!owner) return undefined;
+  let type;
+  try {
+    type = checker.getTypeAtLocation(owner);
+    const bases = checker.getBaseTypes(type) ?? [];
+    if (bases.length !== 1) return undefined;
+    return bases[0].symbol;
+  } catch {
+    return undefined;
+  }
+}
+
+function targetDeclaration(checker, construct) {
+  let symbol = symbolFromLocation(checker, construct.target) ?? superSymbol(checker, construct.target);
+  if (!symbol && (construct.relation === "calls" || construct.relation === "instantiates")) {
+    try {
+      const signature = checker.getResolvedSignature(construct.node);
+      if (signature?.declaration) return [normalizeDeclaration(signature.declaration)];
+    } catch {
+      return [];
+    }
+  }
+  if (!symbol) return [];
+  let declarations = (symbol.declarations ?? []).map(normalizeDeclaration);
+  if (declarations.length === 0 && symbol.valueDeclaration) {
+    declarations = [normalizeDeclaration(symbol.valueDeclaration)];
+  }
+  const unique = new Map();
+  for (const declaration of declarations) {
+    const sourceFile = declaration.getSourceFile?.();
+    const name = declaration.name;
+    const start = name?.getStart(sourceFile, false) ?? declaration.getStart(sourceFile, false);
+    const end = name?.getEnd() ?? declaration.getEnd();
+    unique.set(`${sourceFile?.fileName}\0${start}\0${end}`, declaration);
+  }
+  return [...unique.values()];
+}
+
+function targetRecord(root, admittedFiles, sourceFile, construct, declarations) {
+  const target = declarations.length === 1 ? declarations[0] : undefined;
+  const sourceFileName = target?.getSourceFile?.().fileName;
+  if (!target || !sourceFileName) {
+    return {
+      resolutionKind: declarations.length > 1 ? "ambiguous" : "unresolved",
+      targetFile: null,
+      targetStartByte: null,
+      targetEndByte: null,
+      targetDeclarationKind: null,
+      targetName: null,
+    };
+  }
+  const absolute = path.resolve(sourceFileName);
+  if (!insideRoot(root, absolute)) {
+    return {
+      resolutionKind: "external",
+      targetFile: null,
+      targetStartByte: null,
+      targetEndByte: null,
+      targetDeclarationKind: ts.SyntaxKind[target.kind] ?? null,
+      targetName: target.name ? identifierText(target.getSourceFile(), target.name) : null,
+    };
+  }
+  const relative = relativePath(root, absolute);
+  if (!admittedFiles.has(relative)) {
+    return {
+      resolutionKind: "external",
+      targetFile: relative,
+      targetStartByte: null,
+      targetEndByte: null,
+      targetDeclarationKind: ts.SyntaxKind[target.kind] ?? null,
+      targetName: target.name ? identifierText(target.getSourceFile(), target.name) : null,
+    };
+  }
+  const targetSource = target.getSourceFile();
+  const raw = safeRead(root, absolute);
+  const offsets = raw === undefined ? undefined : byteOffsets(raw.toString("utf8"));
+  const name = target.name ?? target;
+  const start = name.getStart(targetSource, false);
+  const end = name.getEnd();
+  if (!offsets || end >= offsets.length) {
+    return {
+      resolutionKind: "unresolved",
+      targetFile: relative,
+      targetStartByte: null,
+      targetEndByte: null,
+      targetDeclarationKind: ts.SyntaxKind[target.kind] ?? null,
+      targetName: target.name ? identifierText(targetSource, target.name) : null,
+    };
+  }
+  return {
+    resolutionKind: "source",
+    targetFile: relative,
+    targetStartByte: offsets[start],
+    targetEndByte: offsets[end],
+    targetDeclarationKind: ts.SyntaxKind[target.kind] ?? null,
+    targetName: target.name ? identifierText(targetSource, target.name) : identifierText(targetSource, target),
+  };
+}
+
+function main() {
+  const root = parseArguments(process.argv.slice(2));
+  const { files, rejected: initialRejected } = collectFiles(root);
+  const options = {
+    allowJs: true,
+    checkJs: true,
+    noLib: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    jsx: ts.JsxEmit.Preserve,
+  };
+  const host = makeHost(root, options);
+  const absoluteFiles = files.map((fileName) => path.resolve(fileName));
+  const admittedFiles = new Set(files.map((fileName) => relativePath(root, fileName)));
+  const program = ts.createProgram(absoluteFiles, options, host);
+  const checker = program.getTypeChecker();
+  const rejected = new Set(initialRejected);
+  const diagnostics = [];
+  const constructs = [];
+  let totalBytes = 0;
+  let parsedFiles = 0;
+  const sourceDigest = crypto.createHash("sha256");
+  for (const fileName of files) {
+    const relative = relativePath(root, fileName);
+    const raw = safeRead(root, fileName);
+    if (raw === undefined) {
+      rejected.add(relative);
+      continue;
+    }
+    totalBytes += raw.byteLength;
+    if (totalBytes > MAX_SOURCE_BYTES) fail(`source byte count exceeds ${MAX_SOURCE_BYTES}`);
+    sourceDigest.update(relative).update("\0").update(raw);
+    const sourceFile = program.getSourceFile(path.resolve(fileName));
+    if (!sourceFile || sourceFile.parseDiagnostics?.length > 0) {
+      rejected.add(relative);
+      for (const diagnostic of sourceFile?.parseDiagnostics ?? []) {
+        diagnostics.push({ file: relative, message: ts.flattenDiagnosticMessageText(diagnostic.messageText, " ") });
+        if (diagnostics.length >= MAX_DIAGNOSTICS) fail(`diagnostic count exceeds ${MAX_DIAGNOSTICS}`);
+      }
+      continue;
+    }
+    sourceFile.__byteOffsets = byteOffsets(raw.toString("utf8"));
+    parsedFiles += 1;
+    const map = constructMap(sourceFile);
+    for (const construct of map.values()) {
+      if (constructs.length >= MAX_CONSTRUCTS) fail(`construct count exceeds ${MAX_CONSTRUCTS}`);
+      const declarations = targetDeclaration(checker, construct);
+      constructs.push({
+        sourceFile: relative,
+        relation: construct.relation,
+        capability: construct.capability,
+        targetSpelling: construct.targetSpelling,
+        startByte: construct.startByte,
+        endByte: construct.endByte,
+        ...targetRecord(root, admittedFiles, sourceFile, construct, declarations),
+      });
+    }
+  }
+  constructs.sort((left, right) => {
+    for (const field of ["sourceFile", "relation", "capability", "startByte", "endByte", "targetFile", "targetStartByte", "targetEndByte"]) {
+      const a = left[field] ?? "";
+      const b = right[field] ?? "";
+      if (a < b) return -1;
+      if (a > b) return 1;
+    }
+    return 0;
+  });
+  const script = fs.readFileSync(fileURLToPath(import.meta.url));
+  const payload = {
+    schema: SCHEMA,
+    provider: PROVIDER,
+    metadata: {
+      compilerVersion: ts.version,
+      nodeVersion: process.version,
+      scriptSha256: sha256(script),
+      platform: `${process.platform}/${process.arch}`,
+      sourceDigest: sourceDigest.digest("hex"),
+    },
+    scannedFiles: files.length,
+    parsedFiles,
+    rejectedFiles: [...rejected].sort(),
+    diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
+    constructs,
+  };
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  if (process.exitCode !== 2) {
+    console.error(`[typescript-target-oracle] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 2;
+  }
+}

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -480,6 +480,90 @@ class CorrectnessTests(unittest.TestCase):
                 if "callEndByte" in record:
                     self.assertLessEqual(record["callEndByte"], source_size)
 
+    def test_typescript_source_oracle_records_decorator_occurrences_without_factory_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            source = (
+                'function nested(): string { return "ok"; }\n'
+                '@Controller({ path: nested() })\n'
+                'class ControllerHost {}\n'
+                '@unknownFactory()\n'
+                'class DynamicHost {}\n'
+            )
+            (root / "src" / "decorators.ts").write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl"),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            payload = _typescript_payload_from_jsonl(result.stdout)
+
+        decorators = [
+            construct
+            for construct in payload["constructs"]
+            if construct["relation"] == "decorates"
+        ]
+        self.assertEqual(len(decorators), 2)
+        self.assertEqual({item["capability"] for item in decorators}, {"decorators"})
+        self.assertEqual(
+            {item["targetSpelling"] for item in decorators},
+            {"Controller", "unknownFactory"},
+        )
+        source_bytes = source.encode("utf-8")
+        controller = next(item for item in decorators if item["targetSpelling"] == "Controller")
+        self.assertEqual(
+            source_bytes[controller["startByte"] : controller["endByte"]],
+            b"Controller",
+        )
+        self.assertFalse(
+            any(
+                call["targetSpelling"] in {"Controller", "unknownFactory"}
+                for call in payload["calls"]
+            )
+        )
+        self.assertTrue(any(call["targetSpelling"] == "nested" for call in payload["calls"]))
+
+    def test_typescript_source_oracle_preserves_using_resource_declarations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = (
+                "declare function acquire(): Disposable;\n"
+                "declare function acquireAsync(): Promise<Disposable>;\n"
+                "function run() {\n"
+                "  using resource = acquire();\n"
+                "  await using asyncResource = acquireAsync();\n"
+                "  resource.close();\n"
+                "  asyncResource.close();\n"
+                "}\n"
+            )
+            (root / "resources.ts").write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl"),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            payload = _typescript_payload_from_jsonl(result.stdout)
+
+        resources = {
+            declaration["name"]
+            for declaration in payload["declarations"]
+            if declaration["name"] in {"resource", "asyncResource"}
+        }
+        self.assertEqual(resources, {"resource", "asyncResource"})
+        self.assertTrue(
+            all(
+                call["targetSpelling"] in {"acquire", "acquireAsync", "close"}
+                for call in payload["calls"]
+            )
+        )
+        self.assertIn("acquire", {call["targetSpelling"] for call in payload["calls"]})
+        self.assertIn("acquireAsync", {call["targetSpelling"] for call in payload["calls"]})
+
     def test_typescript_source_oracle_reports_invalid_config_and_follows_cycles_once(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -334,7 +334,11 @@ class CorrectnessTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "src").mkdir()
-            (root / "src" / "main.ts").write_text("export function run(): void {}\n", encoding="utf-8")
+            (root / "src" / "main.ts").write_text(
+                'export function run(café: string): string { return café; }\n'
+                'const result = run(café);\n',
+                encoding="utf-8",
+            )
             (root / "src" / "bad.ts").write_text("const = ;\n", encoding="utf-8")
             command = ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl")
             first = subprocess.run(
@@ -359,14 +363,49 @@ class CorrectnessTests(unittest.TestCase):
             payload = _typescript_payload_from_jsonl(first.stdout)
             inventory = _typescript_inventory_from_payload(payload, root)
             provider_inventory = independent_source_inventory(root, "typescript")
+            source_bytes = (root / "src" / "main.ts").read_bytes()
+            tampered_records = [json.loads(line) for line in lines]
+            tampered_records[-1]["callCount"] += 1
+            with self.assertRaisesRegex(RuntimeError, "footer count callCount"):
+                _typescript_payload_from_jsonl(
+                    "\n".join(json.dumps(record) for record in tampered_records).encode()
+                )
+            payload["scopes"][1]["parentScopeId"] = "missing-scope"
+            with self.assertRaisesRegex(RuntimeError, "scope parent"):
+                _typescript_inventory_from_payload(payload, root)
 
         self.assertEqual(inventory.scanned_files, 2)
         self.assertEqual(inventory.parsed_files, 1)
         self.assertEqual(inventory.rejected_files, ("src/bad.ts",))
         self.assertEqual(provider_inventory, inventory)
+        header = json.loads(lines[0])
         footer = json.loads(lines[-1])
         self.assertEqual(footer["constructCount"], len(inventory.constructs))
         self.assertEqual(footer["scannedFiles"], inventory.scanned_files)
+        self.assertEqual(header["scopeCount"], len(payload["scopes"]))
+        self.assertEqual(header["declarationCount"], len(payload["declarations"]))
+        self.assertEqual(header["callCount"], len(payload["calls"]))
+        self.assertGreaterEqual(len(payload["scopes"]), 2)
+        self.assertTrue(any(scope["kind"] == "module" for scope in payload["scopes"]))
+        run = next(
+            declaration
+            for declaration in payload["declarations"]
+            if declaration["name"] == "run"
+        )
+        self.assertEqual(run["kind"], "function")
+        self.assertEqual(run["parameterCount"], 1)
+        cafe = next(
+            declaration
+            for declaration in payload["declarations"]
+            if declaration["name"] == "café"
+        )
+        self.assertEqual(source_bytes[cafe["startByte"] : cafe["endByte"]], "café".encode())
+        call = next(call for call in payload["calls"] if call["targetSpelling"] == "run")
+        self.assertEqual(source_bytes[call["startByte"] : call["endByte"]], b"run")
+        self.assertEqual(
+            source_bytes[call["callStartByte"] : call["callEndByte"]],
+            "run(café)".encode(),
+        )
 
     def test_typescript_source_oracle_reports_invalid_config_and_follows_cycles_once(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -480,6 +480,44 @@ class CorrectnessTests(unittest.TestCase):
                 if "callEndByte" in record:
                     self.assertLessEqual(record["callEndByte"], source_size)
 
+    def test_typescript_source_oracle_records_import_type_queries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_path = root / "src" / "types.ts"
+            source_path.parent.mkdir()
+            source = (
+                'type Item = (typeof import("./items").items)[number];\n'
+                'type Plain = import("./plain").Item;\n'
+            )
+            source_path.write_text(source, encoding="utf-8")
+            (root / "src" / "runtime.js").write_text(
+                'const probe = typeof import("./runtime");\n', encoding="utf-8"
+            )
+            result = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl"),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            payload = _typescript_payload_from_jsonl(result.stdout)
+            imports = [item for item in payload["imports"] if item["kind"] == "import_type"]
+            self.assertEqual(len(imports), 2)
+            record = next(item for item in imports if item["moduleSpecifier"] == "./items")
+            self.assertEqual(record["sourceFile"], "src/types.ts")
+            self.assertTrue(record["isTypeOnly"])
+            start = record["startByte"]
+            end = record["endByte"]
+            self.assertEqual(source.encode("utf-8")[start:end], b'"./items"')
+            plain = next(item for item in imports if item["moduleSpecifier"] == "./plain")
+            self.assertFalse(plain["isTypeOnly"])
+            dynamic = [
+                item
+                for item in payload["imports"]
+                if item["kind"] == "dynamic" and item["sourceFile"] == "src/runtime.js"
+            ]
+            self.assertEqual(len(dynamic), 1)
+
     def test_typescript_source_oracle_records_decorator_occurrences_without_factory_calls(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from contextlib import closing
+import json
 from pathlib import Path
 import sqlite3
+import subprocess
 import tempfile
 import unittest
 
@@ -12,12 +14,17 @@ from benchmarks.performance.compass.correctness import (
     index_graph,
 )
 from benchmarks.performance.compass.occurrences import (
+    _typescript_inventory_from_payload,
     independent_source_constructs,
     independent_source_inventory,
+    source_construct_inventory_sha256,
 )
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
+RESOLUTION_ORACLE = (
+    Path(__file__).resolve().parents[1] / "oracles" / "typescript-resolution-oracle.mjs"
+)
 
 
 def compare_documents(
@@ -50,6 +57,176 @@ class CorrectnessTests(unittest.TestCase):
         database = sqlite3.connect(":memory:")
         self.addCleanup(database.close)
         return database
+
+    def test_typescript_oracle_payload_preserves_unicode_byte_ranges(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "src" / "main.ts"
+            source.parent.mkdir()
+            contents = "const café = 1;\nrun(café);\n"
+            source.write_text(contents, encoding="utf-8")
+            start = len("const ".encode("utf-8"))
+            end = start + len("café".encode("utf-8"))
+            payload = {
+                "schema": "compass.typescript-source-oracle/1",
+                "provider": "typescript_compiler_api_5_9_3",
+                "metadata": {
+                    "compilerVersion": "5.9.3",
+                    "scriptSha256": "a" * 64,
+                    "nodeVersion": "v22.0.0",
+                },
+                "scannedFiles": 1,
+                "parsedFiles": 1,
+                "rejectedFiles": [],
+                "constructs": [
+                    {
+                        "sourceFile": "src/main.ts",
+                        "relation": "references",
+                        "capability": "references",
+                        "ownerQualifiedName": "src.main",
+                        "targetSpelling": "café",
+                        "qualifier": None,
+                        "startByte": start,
+                        "endByte": end,
+                        "startLine": 1,
+                    }
+                ],
+            }
+            inventory = _typescript_inventory_from_payload(payload, root)
+            source_bytes = source.read_bytes()
+
+        self.assertEqual(inventory.scanned_files, 1)
+        self.assertEqual(inventory.parsed_files, 1)
+        self.assertEqual(inventory.provider_metadata[0], ("compilerVersion", "5.9.3"))
+        construct = inventory.constructs[0]
+        self.assertEqual(
+            source_bytes[construct.start_byte : construct.end_byte],
+            "café".encode(),
+        )
+        self.assertEqual(
+            source_construct_inventory_sha256("typescript", inventory),
+            source_construct_inventory_sha256("typescript", inventory),
+        )
+
+    def test_typescript_oracle_payload_rejects_incomplete_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaisesRegex(RuntimeError, "coverage does not account"):
+                _typescript_inventory_from_payload(
+                    {
+                        "schema": "compass.typescript-source-oracle/1",
+                        "provider": "typescript_compiler_api_5_9_3",
+                        "metadata": {
+                            "compilerVersion": "5.9.3",
+                            "scriptSha256": "a" * 64,
+                        },
+                        "scannedFiles": 2,
+                        "parsedFiles": 1,
+                        "rejectedFiles": [],
+                        "constructs": [],
+                    },
+                    root,
+                )
+
+    def test_typescript_resolution_oracle_is_pinned_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            (root / "node_modules" / "@example" / "pkg").mkdir(parents=True)
+            (root / "tsconfig.json").write_text(
+                '{"compilerOptions":{"module":"NodeNext",'
+                '"moduleResolution":"NodeNext"},"include":["src/**/*"]}',
+                encoding="utf-8",
+            )
+            (root / "node_modules" / "@example" / "pkg" / "package.json").write_text(
+                '{"name":"@example/pkg","exports":{".":{'
+                '"import":"./import.d.ts","require":"./require.d.cts"}}}',
+                encoding="utf-8",
+            )
+            (root / "node_modules" / "@example" / "pkg" / "import.d.ts").write_text(
+                "export declare const value: string;\n",
+                encoding="utf-8",
+            )
+            (root / "node_modules" / "@example" / "pkg" / "require.d.cts").write_text(
+                "export declare const value: string;\n",
+                encoding="utf-8",
+            )
+            (root / "src" / "importer.mts").write_text(
+                'const café = "🙂";\n'
+                'import { value } from "@example/pkg";\n'
+                'export const imported = value + café.length;\n',
+                encoding="utf-8",
+            )
+            (root / "src" / "consumer.cts").write_text(
+                'import packageValue = require("@example/pkg");\n'
+                'const { value } = require("@example/pkg");\n'
+                'export = packageValue || value;\n',
+                encoding="utf-8",
+            )
+            importer_source = (root / "src" / "importer.mts").read_bytes()
+            command = ("node", str(RESOLUTION_ORACLE), "--root", str(root))
+            first = subprocess.run(
+                command,
+                cwd=RESOLUTION_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            second = subprocess.run(
+                command,
+                cwd=RESOLUTION_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(first.stdout, second.stdout)
+            payload = json.loads(first.stdout)
+            trace = subprocess.run(
+                (
+                    str(RESOLUTION_ORACLE.parents[3] / "node_modules" / ".bin" / "tsc"),
+                    "--project",
+                    str(root / "tsconfig.json"),
+                    "--traceResolution",
+                    "--noEmit",
+                ),
+                cwd=RESOLUTION_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            trace_output = f"{trace.stdout}\n{trace.stderr}"
+            self.assertIn("Resolving module '@example/pkg'", trace_output)
+            self.assertIn("import.d.ts", trace_output)
+            self.assertIn("require.d.cts", trace_output)
+
+        self.assertEqual(payload["schema"], "compass.typescript-resolution-oracle/1")
+        self.assertEqual(payload["provider"], "typescript_compiler_api_5_9_3")
+        self.assertEqual(payload["scannedFiles"], 2)
+        self.assertEqual(payload["parsedFiles"], 2)
+        self.assertEqual(payload["rejectedFiles"], [])
+        resolutions = {
+            (item["sourceFile"], item["context"]): item for item in payload["resolutions"]
+        }
+        self.assertEqual(
+            resolutions[("src/importer.mts", "import")]["targetFile"],
+            "node_modules/@example/pkg/import.d.ts",
+        )
+        importer_resolution = resolutions[("src/importer.mts", "import")]
+        self.assertEqual(
+            importer_source[
+                importer_resolution["startByte"] : importer_resolution["endByte"]
+            ],
+            b'"@example/pkg"',
+        )
+        self.assertEqual(importer_resolution["startLine"], 2)
+        self.assertEqual(
+            resolutions[("src/consumer.cts", "require")]["targetFile"],
+            "node_modules/@example/pkg/require.d.cts",
+        )
+        self.assertTrue(payload["metadata"]["configDigest"])
+        self.assertRegex(payload["metadata"]["sourceDigest"], r"^[0-9a-f]{64}$")
 
     def test_compass_superset_passes_shared_fact_comparison(self) -> None:
         database = self.database()

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -407,6 +407,79 @@ class CorrectnessTests(unittest.TestCase):
             "run(café)".encode(),
         )
 
+    def test_typescript_source_oracle_jsonl_exposes_typed_relationship_records(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            (root / "src" / "base.ts").write_text(
+                "export default class Default { base(): void {} }\n"
+                "export const imported = () => 1;\n"
+                "export interface Runnable { run(): void }\n",
+                encoding="utf-8",
+            )
+            (root / "src" / "main.tsx").write_text(
+                'import Default, { imported, type Runnable as RunType } from "./base";\n'
+                'export { imported as exported };\n'
+                'export * from "./base";\n'
+                'class Child extends Default implements RunType {\n'
+                '  field = imported;\n'
+                '  run(): void {\n'
+                '    const obj = { literal: imported };\n'
+                '    obj.literal = imported;\n'
+                '    obj["literal"];\n'
+                '    new Default();\n'
+                '    imported();\n'
+                '    return <Default />;\n'
+                '  }\n'
+                '}\n'
+                'export default Child;\n',
+                encoding="utf-8",
+            )
+            command = ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl")
+            result = subprocess.run(
+                command,
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            payload = _typescript_payload_from_jsonl(result.stdout)
+            _typescript_inventory_from_payload(payload, root)
+            source_sizes = {
+                file_name: (root / file_name).stat().st_size
+                for file_name in {record["sourceFile"] for field in ("imports", "reexports", "constructions", "bases", "members", "references") for record in payload[field]}
+            }
+        self.assertGreaterEqual(len(payload["imports"]), 3)
+        self.assertIn("named", {item["kind"] for item in payload["imports"]})
+        self.assertIn("default", {item["kind"] for item in payload["imports"]})
+        self.assertTrue(any(item["isTypeOnly"] for item in payload["imports"]))
+        self.assertGreaterEqual(len(payload["reexports"]), 3)
+        self.assertIn("star", {item["kind"] for item in payload["reexports"]})
+        self.assertIn("default", {item["kind"] for item in payload["reexports"]})
+        self.assertTrue(payload["constructions"])
+        self.assertTrue(all(item["relation"] == "instantiates" for item in payload["constructions"]))
+        self.assertIn("extends", {item["relation"] for item in payload["bases"]})
+        self.assertIn("implements", {item["relation"] for item in payload["bases"]})
+        self.assertIn("property", {item["kind"] for item in payload["members"]})
+        self.assertIn("computed_literal", {item["kind"] for item in payload["members"]})
+        self.assertIn("write", {item["accessKind"] for item in payload["members"]})
+        self.assertIn("jsx", {item["kind"] for item in payload["references"]})
+        for field in (
+            "imports",
+            "reexports",
+            "constructions",
+            "bases",
+            "members",
+            "references",
+        ):
+            for record in payload[field]:
+                source_size = source_sizes[record["sourceFile"]]
+                self.assertLessEqual(record["endByte"], source_size)
+                if "statementEndByte" in record:
+                    self.assertLessEqual(record["statementEndByte"], source_size)
+                if "callEndByte" in record:
+                    self.assertLessEqual(record["callEndByte"], source_size)
+
     def test_typescript_source_oracle_reports_invalid_config_and_follows_cycles_once(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -526,6 +526,53 @@ class CorrectnessTests(unittest.TestCase):
         )
         self.assertTrue(any(call["targetSpelling"] == "nested" for call in payload["calls"]))
 
+    def test_typescript_source_oracle_records_jsx_value_and_spread_references(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = (
+                'const title = "Hello";\n'
+                'const props = { title };\n'
+                'function handle(label: string): void {}\n'
+                'export function View(label: string) {\n'
+                '  return <Button title={title} onClick={() => handle(label)} '
+                'data={user.name} {...props}>{title}</Button>;\n'
+                '}\n'
+            )
+            (root / "view.tsx").write_text(source, encoding="utf-8")
+            result = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl"),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr.decode())
+            payload = _typescript_payload_from_jsonl(result.stdout)
+
+        jsx_values = [
+            construct
+            for construct in payload["constructs"]
+            if construct["relation"] == "references"
+            and construct["capability"] == "jsx_values"
+        ]
+        self.assertGreaterEqual(len(jsx_values), 5)
+        self.assertEqual(
+            {construct["targetSpelling"] for construct in jsx_values},
+            {"title", "label", "props", "user"},
+        )
+        self.assertEqual(
+            {reference["kind"] for reference in payload["references"] if reference["kind"] in {
+                "jsx_value", "jsx_spread", "jsx_child"
+            }},
+            {"jsx_value", "jsx_spread", "jsx_child"},
+        )
+        source_bytes = source.encode("utf-8")
+        for construct in jsx_values:
+            self.assertEqual(
+                source_bytes[construct["startByte"] : construct["endByte"]],
+                construct["targetSpelling"].encode("utf-8"),
+            )
+        self.assertFalse(any(construct["targetSpelling"] == "onClick" for construct in jsx_values))
+
     def test_typescript_source_oracle_preserves_using_resource_declarations(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -14,6 +14,7 @@ from benchmarks.performance.compass.correctness import (
     index_graph,
 )
 from benchmarks.performance.compass.occurrences import (
+    _typescript_payload_from_jsonl,
     _typescript_inventory_from_payload,
     independent_source_constructs,
     independent_source_inventory,
@@ -328,6 +329,44 @@ class CorrectnessTests(unittest.TestCase):
             source_bytes[cafe_construct["startByte"] : cafe_construct["endByte"]],
             "café".encode(),
         )
+
+    def test_typescript_source_oracle_jsonl_is_complete_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            (root / "src" / "main.ts").write_text("export function run(): void {}\n", encoding="utf-8")
+            (root / "src" / "bad.ts").write_text("const = ;\n", encoding="utf-8")
+            command = ("node", str(SOURCE_ORACLE), "--root", str(root), "--jsonl")
+            first = subprocess.run(
+                command,
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            second = subprocess.run(
+                command,
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr.decode())
+            self.assertEqual(second.returncode, 0, second.stderr.decode())
+            self.assertEqual(first.stdout, second.stdout)
+            lines = first.stdout.splitlines()
+            self.assertGreaterEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["recordType"], "header")
+            self.assertEqual(json.loads(lines[-1])["recordType"], "footer")
+            payload = _typescript_payload_from_jsonl(first.stdout)
+            inventory = _typescript_inventory_from_payload(payload, root)
+            provider_inventory = independent_source_inventory(root, "typescript")
+
+        self.assertEqual(inventory.scanned_files, 2)
+        self.assertEqual(inventory.parsed_files, 1)
+        self.assertEqual(inventory.rejected_files, ("src/bad.ts",))
+        self.assertEqual(provider_inventory, inventory)
+        footer = json.loads(lines[-1])
+        self.assertEqual(footer["constructCount"], len(inventory.constructs))
+        self.assertEqual(footer["scannedFiles"], inventory.scanned_files)
 
     def test_typescript_source_oracle_reports_invalid_config_and_follows_cycles_once(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/benchmarks/performance/tests/test_correctness.py
+++ b/benchmarks/performance/tests/test_correctness.py
@@ -25,6 +25,9 @@ FIXTURES = Path(__file__).parent / "fixtures"
 RESOLUTION_ORACLE = (
     Path(__file__).resolve().parents[1] / "oracles" / "typescript-resolution-oracle.mjs"
 )
+SOURCE_ORACLE = (
+    Path(__file__).resolve().parents[1] / "oracles" / "typescript-source-oracle.mjs"
+)
 
 
 def compare_documents(
@@ -227,6 +230,172 @@ class CorrectnessTests(unittest.TestCase):
         )
         self.assertTrue(payload["metadata"]["configDigest"])
         self.assertRegex(payload["metadata"]["sourceDigest"], r"^[0-9a-f]{64}$")
+
+    def test_typescript_source_oracle_honors_project_boundaries_and_references(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            (root / "packages" / "lib" / "src").mkdir(parents=True)
+            (root / "tsconfig.base.json").write_text(
+                json.dumps({"compilerOptions": {"strict": True}}),
+                encoding="utf-8",
+            )
+            (root / "tsconfig.json").write_text(
+                json.dumps(
+                    {
+                        "compilerOptions": {
+                            "composite": True,
+                            "module": "NodeNext",
+                            "moduleResolution": "NodeNext",
+                            "target": "ES2022",
+                        },
+                        "include": ["src/**/*"],
+                        "exclude": ["src/excluded.ts"],
+                        "references": [{"path": "packages/lib"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "packages" / "lib" / "tsconfig.json").write_text(
+                json.dumps(
+                    {
+                        "compilerOptions": {"composite": True, "target": "ES2022"},
+                        "include": ["src/**/*"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "src" / "main.ts").write_text(
+                "const café = '🙂';\nrun(café);\n",
+                encoding="utf-8",
+            )
+            (root / "src" / "bad.ts").write_text("const = ;\n", encoding="utf-8")
+            (root / "src" / "excluded.ts").write_text("ignored();\n", encoding="utf-8")
+            (root / "outside.ts").write_text("notInAProject();\n", encoding="utf-8")
+            (root / "packages" / "lib" / "src" / "lib.ts").write_text(
+                "export const library = 1;\n",
+                encoding="utf-8",
+            )
+            command = ("node", str(SOURCE_ORACLE), "--root", str(root))
+            first = subprocess.run(
+                command,
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            second = subprocess.run(
+                command,
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(first.stdout, second.stdout)
+            payload = json.loads(first.stdout)
+            source_bytes = (root / "src" / "main.ts").read_bytes()
+
+        self.assertEqual(payload["scannedFiles"], 3)
+        self.assertEqual(payload["parsedFiles"], 2)
+        self.assertEqual(payload["rejectedFiles"], ["src/bad.ts"])
+        self.assertEqual(payload["metadata"]["projectMode"], "project")
+        self.assertRegex(payload["metadata"]["configDigest"], r"^[0-9a-f]{64}$")
+        self.assertRegex(payload["metadata"]["sourceDigest"], r"^[0-9a-f]{64}$")
+        self.assertEqual(
+            [project["configFile"] for project in payload["projects"]],
+            ["packages/lib/tsconfig.json", "tsconfig.json"],
+        )
+        self.assertEqual(
+            payload["projects"][1]["references"], ["packages/lib/tsconfig.json"]
+        )
+        self.assertEqual(
+            sorted(file_name for project in payload["projects"] for file_name in project["files"]),
+            ["packages/lib/src/lib.ts", "src/bad.ts", "src/main.ts"],
+        )
+        self.assertTrue(
+            any(diagnostic["file"] == "src/bad.ts" for diagnostic in payload["diagnostics"])
+        )
+        self.assertFalse(any(construct["sourceFile"] == "outside.ts" for construct in payload["constructs"]))
+        cafe_construct = next(
+            construct
+            for construct in payload["constructs"]
+            if construct["sourceFile"] == "src/main.ts"
+            and construct["targetSpelling"] == "café"
+        )
+        self.assertEqual(
+            source_bytes[cafe_construct["startByte"] : cafe_construct["endByte"]],
+            "café".encode(),
+        )
+
+    def test_typescript_source_oracle_reports_invalid_config_and_follows_cycles_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "src").mkdir()
+            (root / "tsconfig.json").write_text("{ invalid", encoding="utf-8")
+            (root / "src" / "main.ts").write_text("run();\n", encoding="utf-8")
+            fallback = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root)),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(fallback.returncode, 0, fallback.stderr)
+            fallback_payload = json.loads(fallback.stdout)
+            self.assertEqual(fallback_payload["metadata"]["projectMode"], "fallback")
+            self.assertEqual(fallback_payload["scannedFiles"], 1)
+            self.assertEqual(fallback_payload["parsedFiles"], 1)
+            self.assertEqual(
+                [diagnostic["file"] for diagnostic in fallback_payload["diagnostics"]],
+                ["tsconfig.json"],
+            )
+
+            (root / "tsconfig.json").unlink()
+            (root / "a").mkdir()
+            (root / "b").mkdir()
+            (root / "a" / "tsconfig.json").write_text(
+                json.dumps(
+                    {
+                        "compilerOptions": {"composite": True},
+                        "include": ["src/**/*"],
+                        "references": [{"path": "../b"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "b" / "tsconfig.json").write_text(
+                json.dumps(
+                    {
+                        "compilerOptions": {"composite": True},
+                        "include": ["src/**/*"],
+                        "references": [{"path": "../a"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "a" / "src").mkdir()
+            (root / "b" / "src").mkdir()
+            (root / "a" / "src" / "a.ts").write_text("export const a = 1;\n", encoding="utf-8")
+            (root / "b" / "src" / "b.ts").write_text("export const b = 1;\n", encoding="utf-8")
+            cycled = subprocess.run(
+                ("node", str(SOURCE_ORACLE), "--root", str(root)),
+                cwd=SOURCE_ORACLE.parents[3],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(cycled.returncode, 0, cycled.stderr)
+            cycled_payload = json.loads(cycled.stdout)
+
+        self.assertEqual(cycled_payload["metadata"]["projectMode"], "project")
+        self.assertEqual(
+            [project["configFile"] for project in cycled_payload["projects"]],
+            ["a/tsconfig.json", "b/tsconfig.json"],
+        )
+        self.assertEqual(cycled_payload["scannedFiles"], 2)
+        self.assertEqual(cycled_payload["parsedFiles"], 2)
 
     def test_compass_superset_passes_shared_fact_comparison(self) -> None:
         database = self.database()

--- a/benchmarks/performance/tests/test_typescript_scorecard.py
+++ b/benchmarks/performance/tests/test_typescript_scorecard.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from benchmarks.performance.compass.typescript_scorecard import (
+    SCORECARD_SCHEMA,
+    TypeScriptScorecardError,
+    scorecard_result,
+)
+
+
+def record(
+    record_id: str,
+    *,
+    pool: str,
+    judgment: str,
+    corpus: str = "zod",
+    capability: str = "calls",
+    relation: str = "calls",
+    cluster: str = "local::target",
+    judgment_source: str = "manual",
+    reason: str | None = None,
+) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": record_id,
+        "corpus": corpus,
+        "adapter": "typescript",
+        "language": "typescript",
+        "capability": capability,
+        "relation": relation,
+        "pool": pool,
+        "targetCluster": cluster,
+        "sourceFile": "src/main.ts",
+        "startByte": 1,
+        "endByte": 5,
+        "judgment": judgment,
+        "judgmentSource": judgment_source,
+    }
+    if judgment != "correct":
+        value["reason"] = reason or f"reviewed {judgment}"
+    elif reason is not None:
+        value["reason"] = reason
+    return value
+
+
+def scorecard(*, mode: str = "diagnostic") -> dict[str, object]:
+    return {
+        "schema": SCORECARD_SCHEMA,
+        "mode": mode,
+        "provider": "typescript_checker_api_5_9_3",
+        "oracleScriptSha256": "a" * 64,
+        "candidateAdapter": "compass.typescript.candidate",
+        "corpora": [
+            {"name": "axios", "commit": "1" * 40},
+            {"name": "nest", "commit": "2" * 40},
+            {"name": "vite", "commit": "3" * 40},
+            {"name": "zod", "commit": "4" * 40},
+        ],
+        "releaseGateCorpora": ["axios", "nest", "vite", "zod"],
+        "advertisedCapabilities": [
+            {"adapter": "typescript", "capability": "calls"},
+            {"adapter": "typescript", "capability": "members"},
+        ],
+        "requiredRelations": ["accesses", "calls"],
+        "comparators": [
+            {
+                "name": "graphify",
+                "version": "0.9.26",
+                "scopeDigest": "b" * 64,
+                "equivalentScope": False,
+                "adjudicated": False,
+            },
+            {
+                "name": "scip_typescript",
+                "version": "0.4.0",
+                "scopeDigest": "c" * 64,
+                "equivalentScope": False,
+                "adjudicated": False,
+            },
+        ],
+        "records": [],
+    }
+
+
+class TypeScriptScorecardTests(unittest.TestCase):
+    def write(self, value: dict[str, object]) -> Path:
+        temporary = Path(self.temporary.name)
+        path = temporary / "scorecard.json"
+        path.write_text(
+            json.dumps(value, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        return path
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+
+    def test_diagnostic_result_is_deterministic_and_not_claim_eligible(self) -> None:
+        value = scorecard()
+        value["records"] = [
+            record("accepted-correct", pool="accepted", judgment="correct"),
+            record(
+                "accepted-invalid",
+                pool="accepted",
+                judgment="invalid",
+                capability="members",
+                relation="accesses",
+            ),
+            record("oracle-correct", pool="source_oracle", judgment="correct"),
+            record(
+                "oracle-missing",
+                pool="source_oracle",
+                judgment="missing",
+                capability="members",
+                relation="accesses",
+            ),
+        ]
+        path = self.write(value)
+        first = scorecard_result(path)
+        second = scorecard_result(path)
+
+        self.assertEqual(first, second)
+        self.assertTrue(first["passed"])
+        self.assertFalse(first["eligibleForQualityClaim"])
+        self.assertEqual(first["precision"]["numerator"], 1)
+        self.assertEqual(first["precision"]["denominator"], 2)
+        self.assertEqual(first["recall"]["numerator"], 1)
+        self.assertEqual(first["recall"]["denominator"], 2)
+        self.assertEqual(first["judgments"], {"correct": 2, "invalid": 1, "missing": 1})
+
+    def test_qualification_requires_release_corpora_and_strata_minimums(self) -> None:
+        value = scorecard(mode="qualification")
+        value["releaseGateCorpora"] = ["zod"]
+        value["records"] = [record("one", pool="accepted", judgment="correct")]
+        result = scorecard_result(self.write(value))
+
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("releaseGateCorpora" in failure for failure in result["failures"]))
+        self.assertTrue(any("2000 required" in failure for failure in result["failures"]))
+        self.assertTrue(any("400 required" in failure for failure in result["failures"]))
+        self.assertTrue(any("100 required" in failure for failure in result["failures"]))
+
+    def test_missing_or_unrecognized_judgments_fail_closed(self) -> None:
+        missing = scorecard()
+        missing["records"] = [record("missing", pool="accepted", judgment="correct")]
+        del missing["records"][0]["judgment"]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "missing fields: judgment"):
+            scorecard_result(self.write(missing))
+
+        unknown = scorecard()
+        unknown["records"] = [record("unknown", pool="accepted", judgment="invented")]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "judgment is unknown"):
+            scorecard_result(self.write(unknown))
+
+    def test_automatic_judgment_source_is_rejected(self) -> None:
+        value = scorecard()
+        value["records"] = [
+            record(
+                "automatic",
+                pool="accepted",
+                judgment="correct",
+                judgment_source="automatic",
+            )
+        ]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "judgmentSource"):
+            scorecard_result(self.write(value))
+
+    def test_non_correct_judgments_require_review_reason(self) -> None:
+        value = scorecard()
+        value["records"] = [
+            record(
+                "missing-reason",
+                pool="source_oracle",
+                judgment="missing",
+                reason="",
+            )
+        ]
+        del value["records"][0]["reason"]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "reason is required"):
+            scorecard_result(self.write(value))
+
+    def test_records_must_be_sorted_and_unique(self) -> None:
+        value = scorecard()
+        value["records"] = [
+            record("z", pool="accepted", judgment="correct"),
+            record("a", pool="accepted", judgment="correct"),
+        ]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "sorted by unique id"):
+            scorecard_result(self.write(value))
+
+        duplicate = copy.deepcopy(value)
+        duplicate["records"] = [
+            record("a", pool="accepted", judgment="correct"),
+            record("a", pool="accepted", judgment="correct"),
+        ]
+        with self.assertRaisesRegex(TypeScriptScorecardError, "sorted by unique id"):
+            scorecard_result(self.write(duplicate))
+
+    def test_leadership_requires_adjudicated_equivalent_comparators(self) -> None:
+        value = scorecard(mode="leadership")
+        value["records"] = [record("one", pool="accepted", judgment="correct")]
+        result = scorecard_result(self.write(value))
+
+        self.assertFalse(result["passed"])
+        self.assertTrue(
+            any("leadership comparator 'graphify'" in failure for failure in result["failures"])
+        )
+        self.assertTrue(
+            any(
+                "leadership comparator 'scip_typescript'" in failure
+                for failure in result["failures"]
+            )
+        )
+
+    def test_critical_semantic_judgment_is_a_failure(self) -> None:
+        value = scorecard(mode="qualification")
+        value["records"] = [
+            record("critical", pool="accepted", judgment="fabricated_occurrence")
+        ]
+        result = scorecard_result(self.write(value))
+        self.assertTrue(
+            any("fabricated_occurrence" in failure for failure in result["failures"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -2426,6 +2426,16 @@ fn mark_external_placeholder(
         let language = parts.next().unwrap_or_default();
         let package = parts.next().unwrap_or_default();
         let module = parts.next().unwrap_or_default();
+        // A framework edge may not carry a language on either endpoint even
+        // when the canonical external node was created from a typed universal
+        // candidate. Preserve that candidate language instead of erasing it
+        // while normalizing the placeholder scope; qualification relies on a
+        // complete `(language, wiring-site, qualified-name)` identity.
+        let retained_language = attributes
+            .get("language")
+            .or_else(|| attributes.get("lang"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
         for key in [
             "language",
             "lang",
@@ -2441,6 +2451,8 @@ fn mark_external_placeholder(
         }
         if !language.is_empty() {
             attributes.insert("language".to_owned(), Value::String(language.to_owned()));
+        } else if let Some(language) = retained_language {
+            attributes.insert("language".to_owned(), Value::String(language));
         }
         if !package.is_empty() {
             attributes.insert("package".to_owned(), Value::String(package.to_owned()));
@@ -4158,6 +4170,7 @@ fn map_edge_kind(raw: &str) -> Option<(EdgeKind, Option<&'static str>, bool)> {
         "references_constant" | "uses_static_prop" | "uses" | "scip_ref" | "scip_def" => {
             (EdgeKind::References, None, false)
         }
+        "accesses" => (EdgeKind::References, Some("member-access"), false),
         "scip_typed" => (EdgeKind::TypeOf, None, false),
         "scip_impl" => (EdgeKind::Implements, None, false),
         "rationale_for" => (EdgeKind::Documents, None, false),

--- a/crates/compass-languages/src/adapters.rs
+++ b/crates/compass-languages/src/adapters.rs
@@ -154,6 +154,25 @@ const JAVA_CAPABILITIES: &[LanguageCapability] = &[
     LanguageCapability::ExternalReferences,
 ];
 
+const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
+    LanguageCapability::Declarations,
+    LanguageCapability::LexicalScopes,
+    LanguageCapability::Namespaces,
+    LanguageCapability::Imports,
+    LanguageCapability::Reexports,
+    LanguageCapability::Aliases,
+    LanguageCapability::Calls,
+    LanguageCapability::Construction,
+    LanguageCapability::Decorators,
+    LanguageCapability::TypeReferences,
+    LanguageCapability::BaseTypes,
+    LanguageCapability::HierarchyDispatch,
+    LanguageCapability::Members,
+    LanguageCapability::Ownership,
+    LanguageCapability::Receivers,
+    LanguageCapability::ExternalReferences,
+];
+
 const RUST_CAPABILITIES: &[LanguageCapability] = &[
     LanguageCapability::Declarations,
     LanguageCapability::LexicalScopes,
@@ -171,6 +190,25 @@ const RUST_CAPABILITIES: &[LanguageCapability] = &[
     LanguageCapability::HierarchyDispatch,
     LanguageCapability::Members,
     LanguageCapability::Ownership,
+    LanguageCapability::ExternalReferences,
+];
+
+const TYPESCRIPT_CAPABILITIES: &[LanguageCapability] = &[
+    LanguageCapability::Declarations,
+    LanguageCapability::LexicalScopes,
+    LanguageCapability::Namespaces,
+    LanguageCapability::Imports,
+    LanguageCapability::Reexports,
+    LanguageCapability::Aliases,
+    LanguageCapability::Calls,
+    LanguageCapability::Construction,
+    LanguageCapability::Decorators,
+    LanguageCapability::TypeReferences,
+    LanguageCapability::BaseTypes,
+    LanguageCapability::HierarchyDispatch,
+    LanguageCapability::Members,
+    LanguageCapability::Ownership,
+    LanguageCapability::Receivers,
     LanguageCapability::ExternalReferences,
 ];
 
@@ -192,6 +230,14 @@ const UNIVERSAL_ADAPTERS: &[AdapterProfile] = &[
         capabilities: JAVA_CAPABILITIES,
     },
     AdapterProfile {
+        id: "compass.javascript.candidate",
+        language: "javascript",
+        version: 5,
+        evidence_schema: crate::UNIVERSAL_EVIDENCE_SCHEMA,
+        profile: UniversalAdapterProfile::UniversalCandidate,
+        capabilities: JAVASCRIPT_CAPABILITIES,
+    },
+    AdapterProfile {
         id: "compass.python",
         language: "python",
         version: 11,
@@ -206,5 +252,13 @@ const UNIVERSAL_ADAPTERS: &[AdapterProfile] = &[
         evidence_schema: crate::UNIVERSAL_EVIDENCE_SCHEMA,
         profile: UniversalAdapterProfile::UniversalCandidate,
         capabilities: RUST_CAPABILITIES,
+    },
+    AdapterProfile {
+        id: "compass.typescript.candidate",
+        language: "typescript",
+        version: 5,
+        evidence_schema: crate::UNIVERSAL_EVIDENCE_SCHEMA,
+        profile: UniversalAdapterProfile::UniversalCandidate,
+        capabilities: TYPESCRIPT_CAPABILITIES,
     },
 ];

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -130,6 +130,37 @@ impl Engine {
         Ok(extraction)
     }
 
+    /// Extract the Phase 2 TypeScript/JavaScript universal-evidence candidate.
+    ///
+    /// This is intentionally a qualification-only seam. It is not consulted
+    /// by normal extraction and does not register a production universal
+    /// adapter until Plan 013's direct-evidence and hard-cut gates pass.
+    #[doc(hidden)]
+    pub fn extract_source_universal_candidate_evidence(
+        &mut self,
+        path: &Path,
+        source_file: &str,
+        source: &[u8],
+    ) -> Result<crate::SemanticEvidenceBatch, ExtractError> {
+        let spec =
+            Registry::resolve(path).ok_or_else(|| ExtractError::Unsupported(path.to_path_buf()))?;
+        if !matches!(spec.name, "typescript" | "tsx" | "javascript") {
+            return Err(ExtractError::Unsupported(path.to_path_buf()));
+        }
+        let tree = self.parse(path, spec, source)?;
+        crate::evidence::extract_candidate_tree_evidence(
+            path,
+            source_file,
+            source,
+            tree.root_node(),
+            spec.name,
+        )
+        .map_err(|error| ExtractError::InvalidProgramEvidence {
+            path: path.to_path_buf(),
+            detail: error.to_string(),
+        })
+    }
+
     pub fn extract_source_combined(
         &mut self,
         path: &Path,
@@ -758,6 +789,7 @@ struct JsImportTarget {
     target: String,
     module: String,
     imported_name: String,
+    type_only: bool,
 }
 
 struct ExtractState<'source, 'tree> {
@@ -773,6 +805,7 @@ struct ExtractState<'source, 'tree> {
     callables: HashMap<String, Vec<String>>,
     types: HashMap<String, String>,
     seen_resolved_calls: HashSet<(String, String, usize, usize)>,
+    seen_js_references: HashSet<(String, String, usize, usize)>,
     seen_dynamic_imports: HashSet<(String, String)>,
     js_import_targets: HashMap<String, JsImportTarget>,
     js_type_namespace_names: HashSet<String>,
@@ -815,6 +848,7 @@ fn extract_tree(
         callables: HashMap::new(),
         types: HashMap::new(),
         seen_resolved_calls: HashSet::new(),
+        seen_js_references: HashSet::new(),
         seen_dynamic_imports: HashSet::new(),
         js_import_targets: HashMap::new(),
         js_type_namespace_names,
@@ -828,12 +862,14 @@ fn extract_tree(
         .unwrap_or_default();
     state.add_node(&state.file_id.clone(), file_label, 1, false, None);
     state.walk_declarations(root, None);
+    if matches!(language, "javascript" | "typescript" | "tsx") {
+        state.walk_jsx_references(root);
+    }
     if language == "python" && collect_calls {
         let module_bound = python_bound_names(root, source, true);
         state.walk_python_indirect(root, &state.file_id.clone(), true, &module_bound);
     } else if matches!(language, "javascript" | "typescript" | "tsx") {
-        let module_bound = js_module_bound_names(root, source);
-        state.walk_js_module_indirect(root, true, &module_bound);
+        state.walk_js_module_indirect(root, true);
     }
     if collect_calls {
         state.walk_function_calls();
@@ -1445,6 +1481,42 @@ fn collect_js_binding_names(node: Node<'_>, source: &[u8], output: &mut Vec<Stri
     }
 }
 
+fn js_type_only_statement(text: &str, reexport: bool) -> bool {
+    let trimmed = text.trim_start();
+    if reexport {
+        trimmed
+            .strip_prefix("export")
+            .is_some_and(|rest| rest.trim_start().starts_with("type "))
+    } else {
+        trimmed
+            .strip_prefix("import")
+            .is_some_and(|rest| rest.trim_start().starts_with("type "))
+    }
+}
+
+fn js_type_only_specifier(node: &Node<'_>, source: &[u8]) -> bool {
+    source_node_text(*node, source)
+        .trim_start()
+        .strip_prefix("type")
+        .is_some_and(|rest| rest.chars().next().is_some_and(char::is_whitespace))
+}
+
+fn js_commonjs_export_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let spelling = source_node_text(node, source)
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
+    let name = if spelling == "module.exports" {
+        "default"
+    } else if let Some(name) = spelling.strip_prefix("module.exports.") {
+        name
+    } else {
+        spelling.strip_prefix("exports.")?
+    };
+    (!name.is_empty() && name.len() <= 4_096 && !name.contains(['.', '\\', '\0']))
+        .then(|| name.to_owned())
+}
+
 fn js_top_level_type_names(
     root: Node<'_>,
     config: &GenericConfig,
@@ -1642,6 +1714,13 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             return;
         }
 
+        if matches!(self.language, "javascript" | "typescript" | "tsx")
+            && parent_declaration.is_none()
+            && kind == "assignment_expression"
+        {
+            self.add_js_commonjs_export(node);
+        }
+
         if self.language == "kotlin" && kind == "enum_entry" {
             if let Some((class_id, _, _, _)) = parent_declaration
                 && let Some(name_node) = first_descendant(node, "simple_identifier")
@@ -1837,12 +1916,7 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
         });
     }
 
-    fn walk_js_module_indirect(
-        &mut self,
-        node: Node<'tree>,
-        is_root: bool,
-        bound: &HashSet<String>,
-    ) {
+    fn walk_js_module_indirect(&mut self, node: Node<'tree>, is_root: bool) {
         if !is_root
             && matches!(
                 node.kind(),
@@ -1862,7 +1936,7 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             collect_js_collection_values(node, &mut identifiers);
             for identifier in identifiers {
                 if !self.add_js_import_reference(identifier, "collection") {
-                    self.add_js_indirect(identifier, "collection", bound);
+                    self.add_js_reference(identifier, "collection");
                 }
             }
         } else if matches!(node.kind(), "call_expression" | "new_expression")
@@ -1873,13 +1947,63 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                 if argument.kind() == "identifier"
                     && !self.add_js_import_reference(argument, "argument")
                 {
-                    self.add_js_indirect(argument, "argument", bound);
+                    self.add_js_reference(argument, "argument");
                 }
             }
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.walk_js_module_indirect(child, false, bound);
+            self.walk_js_module_indirect(child, false);
+        }
+    }
+
+    fn walk_jsx_references(&mut self, node: Node<'tree>) {
+        if matches!(
+            node.kind(),
+            "jsx_opening_element" | "jsx_self_closing_element"
+        ) {
+            self.add_jsx_reference(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_jsx_references(child);
+        }
+    }
+
+    fn add_jsx_reference(&mut self, node: Node<'tree>) {
+        let Some(name_node) = node
+            .child_by_field_name("name")
+            .or_else(|| first_descendant(node, "jsx_identifier"))
+        else {
+            return;
+        };
+        let Some(name) = self.node_text(name_node).map(clean_name) else {
+            return;
+        };
+        if name.is_empty()
+            || name
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_lowercase())
+        {
+            // Lower-case JSX tags are intrinsic DOM/custom elements, not
+            // JavaScript symbol references. Preserve component identity only
+            // for capitalized, member, or namespace-qualified tags.
+            return;
+        }
+        let reference = if matches!(
+            name_node.kind(),
+            "jsx_member_expression" | "member_expression"
+        ) {
+            name_node
+                .child_by_field_name("object")
+                .or_else(|| first_identifier(name_node))
+                .unwrap_or(name_node)
+        } else {
+            name_node
+        };
+        if !self.add_js_import_reference(reference, "jsx") {
+            self.add_js_reference(reference, "jsx");
         }
     }
 
@@ -1890,6 +2014,14 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
         let Some(binding) = self.js_import_targets.get(&name).cloned() else {
             return false;
         };
+        if !self.seen_js_references.insert((
+            self.file_id.clone(),
+            binding.target.clone(),
+            node.start_byte(),
+            node.end_byte(),
+        )) {
+            return true;
+        }
         self.add_edge_at(
             &self.file_id.clone(),
             &binding.target,
@@ -1906,28 +2038,36 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                 "imported_name".to_owned(),
                 Value::String(binding.imported_name),
             );
+            if binding.type_only {
+                edge.attributes
+                    .insert("type_only".to_owned(), Value::Bool(true));
+            }
         }
         true
     }
 
-    fn add_js_indirect(&mut self, node: Node<'tree>, context: &str, bound: &HashSet<String>) {
+    fn add_js_reference(&mut self, node: Node<'tree>, context: &str) {
         let Some(name) = self.node_text(node).map(clean_name) else {
             return;
         };
-        if name.is_empty() || bound.contains(&name) {
+        if name.is_empty() {
             return;
         }
-        let Some(target) = self
-            .callables
-            .get(&name)
-            .filter(|candidates| candidates.len() == 1)
-            .and_then(|candidates| candidates.first())
-            .cloned()
-        else {
+        let value_candidates = self.js_value_bindings.get(&name);
+        let callable_candidates = self.callables.get(&name);
+        let target = match (value_candidates, callable_candidates) {
+            (Some(values), None) if values.len() == 1 => values.first().cloned(),
+            (None, Some(callables)) if callables.len() == 1 => callables.first().cloned(),
+            (Some(values), Some(callables)) if values.len() == 1 && callables.len() == 1 => {
+                (values.first() == callables.first()).then(|| values[0].clone())
+            }
+            _ => None,
+        };
+        let Some(target) = target else {
             return;
         };
         if target == self.file_id
-            || !self.seen_resolved_calls.insert((
+            || !self.seen_js_references.insert((
                 self.file_id.clone(),
                 target.clone(),
                 node.start_byte(),
@@ -1936,33 +2076,13 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
         {
             return;
         }
-        let mut attributes = Map::new();
-        attributes.insert(
-            "relation".to_owned(),
-            Value::String("indirect_call".to_owned()),
+        self.add_edge_at(
+            &self.file_id.clone(),
+            &target,
+            "references",
+            node,
+            Some(context),
         );
-        attributes.insert("context".to_owned(), Value::String(context.to_owned()));
-        attributes.insert(
-            "confidence".to_owned(),
-            Value::String("INFERRED".to_owned()),
-        );
-        attributes.insert(
-            "source_file".to_owned(),
-            Value::String(self.source_file.clone()),
-        );
-        attributes.insert(
-            "source_location".to_owned(),
-            Value::String(format!("L{}", line(node))),
-        );
-        attributes.insert("weight".to_owned(), Value::from(1.0));
-        self.extraction.edges.push(EdgeRecord {
-            source: self.file_id.clone(),
-            target,
-            attributes,
-        });
-        if let Some(edge) = self.extraction.edges.last_mut() {
-            crate::facts::stamp_node_range(&mut edge.attributes, node);
-        }
     }
 
     fn walk_calls(&mut self, node: Node<'tree>, caller: &str, is_root: bool) {
@@ -2416,6 +2536,8 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
 
     fn add_js_import(&mut self, node: Node<'tree>) {
         let is_reexport = node.kind() == "export_statement";
+        let statement_text = self.node_text(node).unwrap_or_default();
+        let statement_type_only = js_type_only_statement(&statement_text, is_reexport);
         let mut cursor = node.walk();
         let Some(module_node) = node
             .children(&mut cursor)
@@ -2453,6 +2575,10 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
         if let Some(edge) = self.extraction.edges.last_mut() {
             edge.attributes
                 .insert("module".to_owned(), Value::String(raw_module.clone()));
+            if statement_type_only {
+                edge.attributes
+                    .insert("type_only".to_owned(), Value::Bool(true));
+            }
             if let Some(target_path) = &target_path {
                 edge.attributes.insert(
                     "target_file".to_owned(),
@@ -2488,34 +2614,109 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                     line(node),
                     Some("re-export"),
                 );
+                if let Some(edge) = self.extraction.edges.last_mut() {
+                    if statement_type_only || js_type_only_specifier(&specifier, self.source) {
+                        edge.attributes
+                            .insert("type_only".to_owned(), Value::Bool(true));
+                    }
+                    edge.attributes
+                        .insert("exported_name".to_owned(), Value::String(name.clone()));
+                }
             }
         } else if let Some(clause) = first_descendant(node, "import_clause") {
-            let mut specifiers = Vec::new();
-            collect_nodes_of_kind(clause, "import_specifier", &mut specifiers);
-            for specifier in specifiers {
-                let Some(imported_name) = specifier
-                    .child_by_field_name("name")
-                    .and_then(|name| self.node_text(name))
-                    .map(clean_name)
-                else {
-                    continue;
-                };
-                if imported_name.is_empty() {
-                    continue;
+            let mut bindings = Vec::new();
+            let mut clause_cursor = clause.walk();
+            for child in clause.named_children(&mut clause_cursor) {
+                match child.kind() {
+                    // `import Foo from "..."`.
+                    "identifier" => {
+                        let Some(local_name) = self.node_text(child).map(clean_name) else {
+                            continue;
+                        };
+                        if !local_name.is_empty() {
+                            bindings.push((
+                                local_name,
+                                "default".to_owned(),
+                                statement_type_only,
+                                child,
+                            ));
+                        }
+                    }
+                    // `import * as Foo from "..."`.
+                    "namespace_import" => {
+                        let Some(local_node) = child
+                            .child_by_field_name("name")
+                            .or_else(|| first_identifier(child))
+                        else {
+                            continue;
+                        };
+                        let Some(local_name) = self.node_text(local_node).map(clean_name) else {
+                            continue;
+                        };
+                        if !local_name.is_empty() {
+                            bindings.push((
+                                local_name,
+                                "*".to_owned(),
+                                statement_type_only,
+                                local_node,
+                            ));
+                        }
+                    }
+                    "named_imports" => {
+                        let mut specifiers = Vec::new();
+                        collect_nodes_of_kind(child, "import_specifier", &mut specifiers);
+                        for specifier in specifiers {
+                            let Some(imported_name) = specifier
+                                .child_by_field_name("name")
+                                .or_else(|| first_identifier(specifier))
+                                .and_then(|name| self.node_text(name))
+                                .map(clean_name)
+                            else {
+                                continue;
+                            };
+                            if imported_name.is_empty() {
+                                continue;
+                            }
+                            let local_name = specifier
+                                .child_by_field_name("alias")
+                                .or_else(|| {
+                                    let identifiers = direct_named_children(specifier)
+                                        .into_iter()
+                                        .filter(|node| node.kind() == "identifier")
+                                        .collect::<Vec<_>>();
+                                    (identifiers.len() > 1).then(|| identifiers[1])
+                                })
+                                .and_then(|alias| self.node_text(alias))
+                                .map(clean_name)
+                                .filter(|alias| !alias.is_empty())
+                                .unwrap_or_else(|| imported_name.clone());
+                            bindings.push((
+                                local_name,
+                                imported_name,
+                                statement_type_only
+                                    || js_type_only_specifier(&specifier, self.source),
+                                specifier,
+                            ));
+                        }
+                    }
+                    _ => {}
                 }
-                let local_name = specifier
-                    .child_by_field_name("alias")
-                    .and_then(|alias| self.node_text(alias))
-                    .map(clean_name)
-                    .filter(|alias| !alias.is_empty())
-                    .unwrap_or_else(|| imported_name.clone());
-                let target = make_id(&[&target_stem, &imported_name]);
+            }
+            for (local_name, imported_name, type_only, binding_node) in bindings {
+                let target = if imported_name == "*" {
+                    module_id.clone()
+                } else if imported_name == "default" {
+                    make_id(&[&target_stem, "default"])
+                } else {
+                    make_id(&[&target_stem, &imported_name])
+                };
                 self.js_import_targets.insert(
                     local_name.clone(),
                     JsImportTarget {
                         target: target.clone(),
                         module: raw_module.clone(),
                         imported_name: imported_name.clone(),
+                        type_only,
                     },
                 );
                 self.add_edge(
@@ -2532,12 +2733,35 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                         .insert("imported_name".to_owned(), Value::String(imported_name));
                     edge.attributes
                         .insert("local_name".to_owned(), Value::String(local_name));
+                    edge.attributes.insert(
+                        "import_kind".to_owned(),
+                        Value::String(
+                            if target == module_id {
+                                "namespace"
+                            } else if edge.string("imported_name") == "default" {
+                                "default"
+                            } else {
+                                "named"
+                            }
+                            .to_owned(),
+                        ),
+                    );
+                    if type_only {
+                        edge.attributes
+                            .insert("type_only".to_owned(), Value::Bool(true));
+                    }
                     if let Some(target_path) = &target_path {
                         edge.attributes.insert(
                             "target_file".to_owned(),
                             Value::String(target_path.to_string_lossy().into_owned()),
                         );
                     }
+                }
+                // Keep the exact binding anchor available to downstream
+                // diagnostics even when the import target is a module file
+                // (namespace imports) rather than a declaration.
+                if let Some(edge) = self.extraction.edges.last_mut() {
+                    crate::facts::stamp_node_range(&mut edge.attributes, binding_node);
                 }
             }
         }
@@ -2680,9 +2904,11 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
             &module_id,
             "imports_from",
             line(declaration),
-            Some("import"),
+            Some("require"),
         );
         if let Some(edge) = self.extraction.edges.last_mut() {
+            edge.attributes
+                .insert("module".to_owned(), Value::String(raw_module.clone()));
             edge.attributes.insert(
                 "target_file".to_owned(),
                 Value::String(target_path.to_string_lossy().into_owned()),
@@ -2722,7 +2948,7 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
                 &make_id(&[&target_stem, &symbol]),
                 "imports",
                 line(declaration),
-                Some("import"),
+                Some("require"),
             );
         }
         true
@@ -3430,6 +3656,105 @@ impl<'source, 'tree> ExtractState<'source, 'tree> {
         true
     }
 
+    fn add_js_commonjs_export(&mut self, node: Node<'tree>) -> bool {
+        let Some(left) = node.child_by_field_name("left") else {
+            return false;
+        };
+        let Some(export_name) = js_commonjs_export_name(left, self.source) else {
+            return false;
+        };
+        let Some(value) = node.child_by_field_name("right") else {
+            return false;
+        };
+
+        let mut bindings = Vec::new();
+        if export_name == "default" && value.kind() == "object" {
+            let mut cursor = value.walk();
+            for property in value.children(&mut cursor).filter(|child| child.is_named()) {
+                match property.kind() {
+                    "pair" => {
+                        let Some(key) = property
+                            .child_by_field_name("key")
+                            .and_then(|key| self.node_text(key))
+                            .map(clean_name)
+                            .filter(|key| !key.is_empty())
+                        else {
+                            continue;
+                        };
+                        let Some(value) = property.child_by_field_name("value") else {
+                            continue;
+                        };
+                        bindings.push((key, value));
+                    }
+                    "shorthand_property_identifier" => {
+                        let Some(name) = self.node_text(property).map(clean_name) else {
+                            continue;
+                        };
+                        if !name.is_empty() {
+                            bindings.push((name, property));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        } else {
+            bindings.push((export_name.clone(), value));
+        }
+
+        let mut emitted = false;
+        for (name, expression) in bindings {
+            let Some(expression_name) = expression
+                .is_named()
+                .then(|| self.node_text(expression))
+                .flatten()
+                .map(clean_name)
+                .filter(|name| !name.is_empty())
+            else {
+                continue;
+            };
+            let Some(target) = self.js_local_target(&expression_name) else {
+                continue;
+            };
+            self.add_edge_at(
+                &self.file_id.clone(),
+                &target,
+                "exports",
+                node,
+                Some("commonjs"),
+            );
+            if let Some(edge) = self.extraction.edges.last_mut() {
+                edge.attributes
+                    .insert("export_name".to_owned(), Value::String(name));
+                edge.attributes.insert(
+                    "module_format".to_owned(),
+                    Value::String("commonjs".to_owned()),
+                );
+            }
+            emitted = true;
+        }
+        emitted
+    }
+
+    fn js_local_target(&self, name: &str) -> Option<String> {
+        let value = self
+            .js_value_bindings
+            .get(name)
+            .filter(|targets| targets.len() == 1)
+            .and_then(|targets| targets.first())
+            .cloned();
+        let callable = self
+            .callables
+            .get(name)
+            .filter(|targets| targets.len() == 1)
+            .and_then(|targets| targets.first())
+            .cloned();
+        match (value, callable) {
+            (Some(value), None) | (None, Some(value)) => Some(value),
+            (Some(value), Some(callable)) if value == callable => Some(value),
+            _ => self.types.get(name).cloned(),
+        }
+    }
+
     fn node_text(&self, node: Node<'tree>) -> Option<String> {
         node.utf8_text(self.source).ok().map(str::to_owned)
     }
@@ -3833,62 +4158,6 @@ fn collect_python_assignment_targets(
             collect_python_assignment_targets(Some(child), source, output);
         }
     }
-}
-
-fn js_module_bound_names(root: Node<'_>, source: &[u8]) -> HashSet<String> {
-    fn collect_pattern(node: Node<'_>, source: &[u8], output: &mut HashSet<String>) {
-        if matches!(
-            node.kind(),
-            "identifier"
-                | "shorthand_property_identifier_pattern"
-                | "shorthand_property_identifier"
-        ) {
-            if let Ok(name) = node.utf8_text(source) {
-                output.insert(name.to_owned());
-            }
-            return;
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor).filter(|child| child.is_named()) {
-            collect_pattern(child, source, output);
-        }
-    }
-
-    fn walk(node: Node<'_>, source: &[u8], root: bool, output: &mut HashSet<String>) {
-        if !root
-            && matches!(
-                node.kind(),
-                "function_declaration"
-                    | "function_expression"
-                    | "arrow_function"
-                    | "generator_function_declaration"
-                    | "generator_function"
-                    | "class_declaration"
-                    | "class"
-            )
-        {
-            return;
-        }
-        if node.kind() == "variable_declarator" {
-            let value_is_function = node.child_by_field_name("value").is_some_and(|value| {
-                matches!(
-                    value.kind(),
-                    "arrow_function" | "function_expression" | "function" | "generator_function"
-                )
-            });
-            if !value_is_function && let Some(name) = node.child_by_field_name("name") {
-                collect_pattern(name, source, output);
-            }
-        }
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            walk(child, source, false, output);
-        }
-    }
-
-    let mut output = HashSet::new();
-    walk(root, source, true, &mut output);
-    output
 }
 
 fn collect_js_collection_values<'tree>(node: Node<'tree>, output: &mut Vec<Node<'tree>>) {

--- a/crates/compass-languages/src/engine.rs
+++ b/crates/compass-languages/src/engine.rs
@@ -130,11 +130,12 @@ impl Engine {
         Ok(extraction)
     }
 
-    /// Extract the Phase 2 TypeScript/JavaScript universal-evidence candidate.
+    /// Extract TypeScript/JavaScript universal evidence directly from source.
     ///
-    /// This is intentionally a qualification-only seam. It is not consulted
-    /// by normal extraction and does not register a production universal
-    /// adapter until Plan 013's direct-evidence and hard-cut gates pass.
+    /// This hidden API remains useful for qualification fixtures, but it now
+    /// calls the same registered candidate emitter used by normal Compass
+    /// extraction. Keeping both paths on one implementation prevents a
+    /// qualification-only graph from diverging from production output.
     #[doc(hidden)]
     pub fn extract_source_universal_candidate_evidence(
         &mut self,
@@ -402,9 +403,26 @@ impl Engine {
                 }
             }
         }
-        let framework_path = universal_profile
-            .map(|_| Path::new(evidence_source_file))
-            .unwrap_or(path);
+        // Framework conventions need the complete repository-relative path
+        // (for example `src/routes/**`, `app/routes/**`, and `src/app/**`) to
+        // classify a file. The pipeline supplies that path as
+        // `evidence_source_file`; using it here keeps convention anchors and
+        // synthetic identities aligned with the graph manifest while avoiding
+        // absolute checkout paths. Direct byte-extraction callers may not have
+        // a repository-relative spelling, so retain the deterministic fallback
+        // for those calls.
+        let framework_source = universal_profile.map(|_| {
+            let portable_source = portable_evidence_source(path);
+            if Path::new(evidence_source_file).is_absolute()
+                || evidence_source_file.is_empty()
+                || evidence_source_file == portable_source
+            {
+                portable_framework_source(path)
+            } else {
+                evidence_source_file.to_owned()
+            }
+        });
+        let framework_path = framework_source.as_deref().map(Path::new).unwrap_or(path);
         crate::frameworks::detect(
             framework_path,
             source,
@@ -776,6 +794,41 @@ fn portable_evidence_source(path: &Path) -> String {
     } else {
         format!("{parent}/{file}")
     }
+}
+
+fn portable_framework_source(path: &Path) -> String {
+    if path.is_relative() {
+        return path.to_string_lossy().replace('\\', "/");
+    }
+    let source = path.to_string_lossy().replace('\\', "/");
+    const ROUTE_MARKERS: &[&str] = &[
+        "src/routes/",
+        "app/routes/",
+        "src/app/",
+        "app/",
+        "src/pages/",
+        "pages/",
+        "server/api/",
+        "middleware/",
+    ];
+    if let Some((index, _)) = ROUTE_MARKERS
+        .iter()
+        .filter_map(|marker| {
+            source
+                .match_indices(marker)
+                .find(|(index, _)| *index == 0 || source.as_bytes().get(index - 1) == Some(&b'/'))
+                .map(|(index, _)| (index, *marker))
+        })
+        .min_by_key(|(index, _)| *index)
+    {
+        return source[index..].to_owned();
+    }
+    let components = source
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .collect::<Vec<_>>();
+    let start = components.len().saturating_sub(3);
+    components[start..].join("/")
 }
 
 struct FunctionBody<'tree> {
@@ -4659,31 +4712,36 @@ mod rationale_tests {
              function helper() { return true; }\n",
         )?;
 
+        let source_bytes = fs::read(&source)?;
         let extraction = Engine::default().extract(&source)?;
-        let method = extraction
-            .nodes
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing JavaScript universal evidence")?;
+        let method = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == ".render()")
+            .find(|declaration| {
+                declaration.name == "render"
+                    && declaration.qualified_name.contains("Widget.prototype")
+            })
             .ok_or("missing prototype method")?;
-        assert_eq!(method.string("symbol_kind"), "method");
-        assert_eq!(method.string("qualified_name"), "Widget.prototype::render");
-        let owner = extraction
-            .nodes
+        assert_eq!(method.kind, "property");
+        let direct = Engine::default().extract_source_universal_candidate_evidence(
+            &source,
+            "widget.js",
+            &source_bytes,
+        )?;
+        let helper = direct
+            .declarations
             .iter()
-            .find(|node| node.label() == "Widget()")
-            .ok_or("missing Widget constructor")?;
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == owner.id
-                && edge.target == method.id
-                && edge.string("relation") == "contains"
-        }));
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == method.id
-                && edge.string("relation") == "calls"
-                && extraction
-                    .nodes
-                    .iter()
-                    .any(|node| node.id == edge.target && node.label() == "helper()")
+            .find(|declaration| declaration.name == "helper" && declaration.kind == "function")
+            .ok_or("missing helper declaration")?;
+        assert!(evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Calls
+                && candidate.target_spelling == "helper"
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(helper.id.as_str())
         }));
         Ok(())
     }
@@ -4736,86 +4794,83 @@ mod rationale_tests {
             Some(EXTRACTION_QUALITY_PARTIAL),
             "valid TypeScript variance syntax must not trigger parser recovery"
         );
-        let zod_any = extraction
-            .nodes
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing TypeScript universal evidence")?;
+        let zod_any = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "ZodAny" && node.string("symbol_kind") == "interface")
+            .find(|declaration| declaration.name == "ZodAny" && declaration.kind == "interface")
             .ok_or("missing ZodAny interface")?;
-        let private_zod_type = extraction
-            .nodes
+        let private_zod_type = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "_ZodType")
+            .find(|declaration| declaration.name == "_ZodType")
             .ok_or("missing _ZodType interface")?;
-        let zod_any_value = extraction
-            .nodes
+        let zod_any_value = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "ZodAny" && node.string("symbol_kind") == "variable")
+            .find(|declaration| declaration.name == "ZodAny" && declaration.kind == "variable")
             .ok_or("missing ZodAny runtime value")?;
-        let create = extraction
-            .nodes
+        let create = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "create()")
+            .find(|declaration| declaration.name == "create" && declaration.kind == "function")
             .ok_or("missing create function")?;
-        let first_type = extraction
-            .nodes
+        let first_type = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "First" && node.string("symbol_kind") == "interface")
+            .find(|declaration| declaration.name == "First" && declaration.kind == "interface")
             .ok_or("missing reverse-order First interface")?;
-        let first_value = extraction
-            .nodes
+        let first_value = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "First" && node.string("symbol_kind") == "variable")
+            .find(|declaration| declaration.name == "First" && declaration.kind == "variable")
             .ok_or("missing reverse-order First runtime value")?;
-        let create_first = extraction
-            .nodes
+        let create_first = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "createFirst()")
+            .find(|declaration| declaration.name == "createFirst" && declaration.kind == "function")
             .ok_or("missing createFirst function")?;
-        let keys = extraction
-            .nodes
+        let keys = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "Keys")
+            .find(|declaration| declaration.name == "Keys")
             .ok_or("mapped-type `in` must remain a Keys declaration")?;
-        let file = extraction
-            .nodes
-            .iter()
-            .find(|node| node.string("symbol_kind") == "file")
-            .ok_or("missing source file")?;
-        assert_eq!(zod_any.string("source_location"), "L4");
-        assert_eq!(zod_any_value.string("source_location"), "L5");
-        assert_eq!(keys.string("source_location"), "L7");
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == file.id
-                && edge.target == zod_any.id
-                && edge.string("relation") == "contains"
+        assert_eq!(zod_any.range.start_line, 4);
+        assert_eq!(zod_any_value.range.start_line, 5);
+        assert_eq!(keys.range.start_line, 7);
+        assert!(evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Extends
+                && candidate.source_declaration_id == zod_any.id
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(private_zod_type.id.as_str())
         }));
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == zod_any.id
-                && edge.target == private_zod_type.id
-                && edge.string("relation") == "inherits"
-                && edge.string("context") == "extends"
+        assert!(evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Constructs
+                && candidate.source_declaration_id == create.id
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(zod_any_value.id.as_str())
         }));
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == create.id
-                && edge.target == zod_any_value.id
-                && edge.string("relation") == "calls"
-                && edge.string("source_location") == "L6"
-        }));
-        assert!(!extraction.edges.iter().any(|edge| {
-            edge.source == create.id
-                && edge.target == zod_any.id
-                && edge.string("relation") == "calls"
+        assert!(!evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Calls
+                && candidate.source_declaration_id == create.id
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(zod_any.id.as_str())
         }));
         assert_ne!(first_type.id, first_value.id);
-        assert!(extraction.edges.iter().any(|edge| {
-            edge.source == create_first.id
-                && edge.target == first_value.id
-                && edge.string("relation") == "calls"
+        assert!(evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Constructs
+                && candidate.source_declaration_id == create_first.id
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(first_value.id.as_str())
         }));
-        assert!(!extraction.edges.iter().any(|edge| {
-            edge.source == create_first.id
-                && edge.target == first_type.id
-                && edge.string("relation") == "calls"
+        assert!(!evidence.candidates.iter().any(|candidate| {
+            candidate.relation == crate::CandidateRelation::Constructs
+                && candidate.source_declaration_id == create_first.id
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(first_type.id.as_str())
         }));
 
         fs::write(&source, "export interface Broken<out T extends> {}\n")?;
@@ -4859,31 +4914,40 @@ mod rationale_tests {
         )?;
 
         let extraction = Engine::default().extract(&source)?;
-        let create = extraction
-            .nodes
+        let evidence = extraction
+            .semantic_evidence
+            .as_ref()
+            .ok_or("missing TypeScript universal evidence")?;
+        let create = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == "create()")
+            .find(|declaration| declaration.name == "create" && declaration.kind == "function")
             .ok_or("missing create function")?;
-        let widget_values = extraction
-            .nodes
+        let widget_values = evidence
+            .declarations
             .iter()
-            .filter(|node| node.label() == "Widget" && node.string("symbol_kind") == "variable")
-            .map(|node| node.id.as_str())
+            .filter(|declaration| declaration.name == "Widget" && declaration.kind == "variable")
+            .map(|declaration| declaration.id.as_str())
             .collect::<Vec<_>>();
         assert_eq!(widget_values.len(), 2);
-        assert!(!extraction.edges.iter().any(|edge| {
-            edge.source == create.id
-                && edge.string("relation") == "calls"
-                && widget_values.contains(&edge.target.as_str())
+        assert!(!evidence.candidates.iter().any(|candidate| {
+            candidate.source_declaration_id == create.id
+                && matches!(
+                    candidate.relation,
+                    crate::CandidateRelation::Calls | crate::CandidateRelation::Constructs
+                )
+                && candidate
+                    .constraints
+                    .exact_target_declaration_id
+                    .as_deref()
+                    .is_some_and(|target| widget_values.contains(&target))
         }));
-        assert!(
-            extraction
-                .raw_calls
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .any(|call| call.caller_nid == create.id && call.callee == "Widget")
-        );
+        assert!(evidence.candidates.iter().any(|candidate| {
+            candidate.source_declaration_id == create.id
+                && candidate.relation == crate::CandidateRelation::Constructs
+                && candidate.target_spelling == "Widget"
+                && candidate.constraints.exact_target_declaration_id.is_none()
+        }));
         Ok(())
     }
 

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -132,6 +132,43 @@ impl EvidenceBuilder {
         )
     }
 
+    /// Add a declaration with a bounded source-level signature fragment.
+    ///
+    /// Candidate adapters use this for type-shape facts that the shared
+    /// resolver can consume without inventing a target from a terminal name.
+    /// Keeping the entry point crate-private avoids expanding the public
+    /// builder surface while allowing adapters implemented in sibling
+    /// modules to publish the existing, versioned `signature` field.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn declare_with_signature(
+        &mut self,
+        kind: &str,
+        graph_node_id: &str,
+        name: &str,
+        qualified_name: &str,
+        module_or_package: Option<&str>,
+        scope_id: Option<&str>,
+        namespace: Option<SymbolNamespace>,
+        signature: Option<&str>,
+        range: EvidenceRange,
+    ) -> Result<String, EvidenceError> {
+        let metadata = DeclarationMetadata {
+            signature: signature.map(str::to_owned),
+            ..DeclarationMetadata::default()
+        };
+        self.declare_with_metadata_and_namespace(
+            kind,
+            graph_node_id,
+            name,
+            qualified_name,
+            module_or_package,
+            scope_id,
+            range,
+            namespace,
+            metadata,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn declare_with_metadata(
         &mut self,

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -8638,7 +8638,7 @@ fn rust_use_binding_range(
     )
 }
 
-fn range_for_byte_span(
+pub(super) fn range_for_byte_span(
     source_file: &str,
     source: &[u8],
     start_byte: usize,

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -245,6 +245,7 @@ impl EvidenceBuilder {
             signature_hash: metadata.signature_hash,
             implementation_hash: metadata.implementation_hash,
             source_hash: metadata.source_hash,
+            definition_start_byte: None,
             range,
         });
         Ok(id)
@@ -721,6 +722,15 @@ pub(crate) fn extract_tree_evidence(
     root: Node<'_>,
     profile: &'static AdapterProfile,
 ) -> Result<SemanticEvidenceBatch, EvidenceError> {
+    if matches!(profile.language, "javascript" | "typescript") {
+        return super::typescript::extract_candidate_tree_evidence(
+            path,
+            source_file,
+            source,
+            root,
+            profile.language,
+        );
+    }
     let mut state = DirectAdapterState::new(path, source_file, source, root, profile);
     state.add_file(root)?;
     if root.end_byte() == root.start_byte() {

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -11,7 +11,7 @@ use super::model::{
     AdapterIdentity, BindingFact, BindingKind, CandidateRelation, DeclarationFact,
     EvidenceDiagnostic, EvidenceRange, HierarchyConstraint, OccurrenceFact,
     ReceiverDispatchStrategy, RelationshipCandidate, ResolutionConstraint, ScopeFact,
-    SemanticEvidenceBatch, SemanticRole,
+    SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
 };
 use super::validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits, validate_evidence};
 
@@ -48,11 +48,23 @@ impl EvidenceBuilder {
         source_file: impl Into<String>,
         limits: EvidenceLimits,
     ) -> Self {
+        Self::new_with_dialect(profile, producer, source_file, limits, None)
+    }
+
+    #[must_use]
+    pub fn new_with_dialect(
+        profile: &'static AdapterProfile,
+        producer: impl Into<String>,
+        source_file: impl Into<String>,
+        limits: EvidenceLimits,
+        dialect: Option<&str>,
+    ) -> Self {
         Self {
             batch: SemanticEvidenceBatch {
                 adapter: AdapterIdentity {
                     id: profile.id.to_owned(),
                     language: profile.language.to_owned(),
+                    dialect: dialect.map(str::to_owned),
                     version: profile.version,
                     evidence_schema: profile.evidence_schema.to_owned(),
                     profile: profile.profile,
@@ -94,6 +106,32 @@ impl EvidenceBuilder {
         )
     }
 
+    /// Add a declaration while retaining its source-level symbol space.
+    #[allow(clippy::too_many_arguments)]
+    pub fn declare_with_namespace(
+        &mut self,
+        kind: &str,
+        graph_node_id: &str,
+        name: &str,
+        qualified_name: &str,
+        module_or_package: Option<&str>,
+        scope_id: Option<&str>,
+        namespace: Option<SymbolNamespace>,
+        range: EvidenceRange,
+    ) -> Result<String, EvidenceError> {
+        self.declare_with_metadata_and_namespace(
+            kind,
+            graph_node_id,
+            name,
+            qualified_name,
+            module_or_package,
+            scope_id,
+            range,
+            namespace,
+            DeclarationMetadata::default(),
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn declare_with_metadata(
         &mut self,
@@ -106,24 +144,52 @@ impl EvidenceBuilder {
         range: EvidenceRange,
         metadata: DeclarationMetadata,
     ) -> Result<String, EvidenceError> {
+        self.declare_with_metadata_and_namespace(
+            kind,
+            graph_node_id,
+            name,
+            qualified_name,
+            module_or_package,
+            scope_id,
+            range,
+            None,
+            metadata,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn declare_with_metadata_and_namespace(
+        &mut self,
+        kind: &str,
+        graph_node_id: &str,
+        name: &str,
+        qualified_name: &str,
+        module_or_package: Option<&str>,
+        scope_id: Option<&str>,
+        range: EvidenceRange,
+        namespace: Option<SymbolNamespace>,
+        metadata: DeclarationMetadata,
+    ) -> Result<String, EvidenceError> {
         ensure_capacity(
             "declarations",
             self.batch.declarations.len(),
             self.limits.declarations,
         )?;
-        let id = self.stable_id(
-            "declaration",
-            &[
-                kind,
-                graph_node_id,
-                name,
-                qualified_name,
-                module_or_package.unwrap_or_default(),
-                scope_id.unwrap_or_default(),
-                &range.start_byte.to_string(),
-                &range.end_byte.to_string(),
-            ],
-        );
+        let start_byte = range.start_byte.to_string();
+        let end_byte = range.end_byte.to_string();
+        let mut identity = vec![
+            kind,
+            graph_node_id,
+            name,
+            qualified_name,
+            module_or_package.unwrap_or_default(),
+            scope_id.unwrap_or_default(),
+        ];
+        if namespace.is_some() {
+            identity.push(symbol_namespace_name(namespace));
+        }
+        identity.extend([start_byte.as_str(), end_byte.as_str()]);
+        let id = self.stable_id("declaration", &identity);
         self.batch.declarations.push(DeclarationFact {
             id: id.clone(),
             language: self.batch.adapter.language.clone(),
@@ -131,6 +197,7 @@ impl EvidenceBuilder {
             kind: kind.to_owned(),
             name: name.to_owned(),
             qualified_name: qualified_name.to_owned(),
+            namespace,
             module_or_package: module_or_package.map(str::to_owned),
             scope_id: scope_id.map(str::to_owned),
             signature: metadata.signature,
@@ -199,6 +266,35 @@ impl EvidenceBuilder {
         )
     }
 
+    /// Add an import/re-export binding with explicit symbol-space identity.
+    #[allow(clippy::too_many_arguments)]
+    pub fn bind_with_identity(
+        &mut self,
+        kind: BindingKind,
+        spelling: &str,
+        qualified_target: &str,
+        target_declaration_id: Option<&str>,
+        scope_id: Option<&str>,
+        namespace: Option<SymbolNamespace>,
+        type_only: bool,
+        range: EvidenceRange,
+    ) -> Result<String, EvidenceError> {
+        self.bind_with_output_index_and_identity(
+            kind,
+            spelling,
+            qualified_target,
+            target_declaration_id,
+            scope_id,
+            None,
+            None,
+            None,
+            None,
+            namespace,
+            type_only,
+            range,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn bind_chained_call_result(
         &mut self,
@@ -238,30 +334,69 @@ impl EvidenceBuilder {
         fallback_binding_id: Option<&str>,
         range: EvidenceRange,
     ) -> Result<String, EvidenceError> {
+        self.bind_with_output_index_and_identity(
+            kind,
+            spelling,
+            qualified_target,
+            target_declaration_id,
+            scope_id,
+            output_index,
+            result_type_qualified_name,
+            receiver_binding_id,
+            fallback_binding_id,
+            None,
+            false,
+            range,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn bind_with_output_index_and_identity(
+        &mut self,
+        kind: BindingKind,
+        spelling: &str,
+        qualified_target: &str,
+        target_declaration_id: Option<&str>,
+        scope_id: Option<&str>,
+        output_index: Option<u32>,
+        result_type_qualified_name: Option<&str>,
+        receiver_binding_id: Option<&str>,
+        fallback_binding_id: Option<&str>,
+        namespace: Option<SymbolNamespace>,
+        type_only: bool,
+        range: EvidenceRange,
+    ) -> Result<String, EvidenceError> {
         ensure_capacity("bindings", self.batch.bindings.len(), self.limits.bindings)?;
         let output_index_text = output_index.map(|index| index.to_string());
-        let id = self.stable_id(
-            "binding",
-            &[
-                binding_kind_name(kind),
-                spelling,
-                qualified_target,
-                target_declaration_id.unwrap_or_default(),
-                scope_id.unwrap_or_default(),
-                output_index_text.as_deref().unwrap_or_default(),
-                result_type_qualified_name.unwrap_or_default(),
-                receiver_binding_id.unwrap_or_default(),
-                fallback_binding_id.unwrap_or_default(),
-                &range.start_byte.to_string(),
-                &range.end_byte.to_string(),
-            ],
-        );
+        let start_byte = range.start_byte.to_string();
+        let end_byte = range.end_byte.to_string();
+        let mut identity = vec![
+            binding_kind_name(kind),
+            spelling,
+            qualified_target,
+            target_declaration_id.unwrap_or_default(),
+            scope_id.unwrap_or_default(),
+            output_index_text.as_deref().unwrap_or_default(),
+            result_type_qualified_name.unwrap_or_default(),
+            receiver_binding_id.unwrap_or_default(),
+            fallback_binding_id.unwrap_or_default(),
+        ];
+        if namespace.is_some() {
+            identity.push(symbol_namespace_name(namespace));
+        }
+        if type_only {
+            identity.push("type_only");
+        }
+        identity.extend([start_byte.as_str(), end_byte.as_str()]);
+        let id = self.stable_id("binding", &identity);
         self.batch.bindings.push(BindingFact {
             id: id.clone(),
             language: self.batch.adapter.language.clone(),
             kind,
             spelling: spelling.to_owned(),
             qualified_target: qualified_target.to_owned(),
+            namespace,
+            type_only,
             target_declaration_id: target_declaration_id.map(str::to_owned),
             scope_id: scope_id.map(str::to_owned),
             output_index,
@@ -9994,6 +10129,16 @@ const fn binding_kind_name(kind: BindingKind) -> &'static str {
         BindingKind::CallResult => "call_result",
         BindingKind::Package => "package",
         BindingKind::Member => "member",
+    }
+}
+
+const fn symbol_namespace_name(namespace: Option<SymbolNamespace>) -> &'static str {
+    match namespace {
+        None => "",
+        Some(SymbolNamespace::Value) => "value",
+        Some(SymbolNamespace::Type) => "type",
+        Some(SymbolNamespace::Namespace) => "namespace",
+        Some(SymbolNamespace::ValueAndType) => "value_and_type",
     }
 }
 

--- a/crates/compass-languages/src/evidence/mod.rs
+++ b/crates/compass-languages/src/evidence/mod.rs
@@ -1,5 +1,6 @@
 mod build;
 mod model;
+mod typescript;
 mod validate;
 
 pub const UNIVERSAL_EVIDENCE_SCHEMA: &str = "compass.languages.evidence/1";
@@ -10,6 +11,7 @@ pub use model::{
     AdapterIdentity, BindingFact, BindingKind, CandidateRelation, DeclarationFact,
     EvidenceDiagnostic, EvidenceRange, HierarchyConstraint, LanguageCapability, OccurrenceFact,
     ReceiverDispatchStrategy, RelationshipCandidate, ResolutionConstraint, ScopeFact,
-    SemanticEvidenceBatch, SemanticRole,
+    SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
 };
+pub(crate) use typescript::extract_candidate_tree_evidence;
 pub use validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits, validate_evidence};

--- a/crates/compass-languages/src/evidence/model.rs
+++ b/crates/compass-languages/src/evidence/model.rs
@@ -234,6 +234,12 @@ pub struct DeclarationFact {
     pub implementation_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hash: Option<String>,
+    /// Full syntax-node start for legacy callable identities. The canonical
+    /// evidence range may intentionally begin at the identifier, while the
+    /// public graph identity historically used the enclosing declaration
+    /// start (for example `export async function` begins after `export`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition_start_byte: Option<u64>,
     pub range: EvidenceRange,
 }
 

--- a/crates/compass-languages/src/evidence/model.rs
+++ b/crates/compass-languages/src/evidence/model.rs
@@ -8,6 +8,10 @@ use crate::UniversalAdapterProfile;
 pub struct AdapterIdentity {
     pub id: String,
     pub language: String,
+    /// Parser dialect preserved separately from the semantic language family.
+    /// `None` is retained for legacy adapters that predate dialect metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dialect: Option<String>,
     pub version: u32,
     pub evidence_schema: String,
     pub profile: UniversalAdapterProfile,
@@ -112,6 +116,19 @@ pub enum BindingKind {
     Member,
 }
 
+/// The TypeScript/JavaScript symbol space occupied by a declaration or
+/// binding. ECMAScript modules expose values, types, and namespaces through
+/// overlapping source spellings, so retaining the space is required before a
+/// resolver can safely select one identity.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolNamespace {
+    Value,
+    Type,
+    Namespace,
+    ValueAndType,
+}
+
 impl BindingKind {
     #[must_use]
     pub const fn required_capability(self) -> LanguageCapability {
@@ -189,6 +206,10 @@ pub struct DeclarationFact {
     pub kind: String,
     pub name: String,
     pub qualified_name: String,
+    /// Optional value/type/namespace identity. `None` preserves legacy
+    /// adapters that predate explicit symbol-space evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<SymbolNamespace>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module_or_package: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -243,6 +264,12 @@ pub struct BindingFact {
     pub kind: BindingKind,
     pub spelling: String,
     pub qualified_target: String,
+    /// Optional symbol space selected by the source construct.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<SymbolNamespace>,
+    /// Whether this import or re-export is explicitly type-only in source.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub type_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_declaration_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -5315,14 +5315,25 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     ) -> Option<Resolution> {
         let object = object?;
         let receiver = self.receiver_target(scope_id, object)?;
+        let property_name = member_property_name(self.source, property)?;
+        let projection = decode_utility_projection(&receiver.qualified_name);
+        if let Some((utility, _, keys)) = projection.as_ref()
+            && ((utility == "Pick" && !keys.contains(&property_name))
+                || (utility == "Omit" && keys.contains(&property_name)))
+        {
+            return None;
+        }
+        let mut lookup_receiver = receiver.clone();
+        if let Some((_, base, _)) = projection.as_ref() {
+            lookup_receiver.qualified_name.clone_from(base);
+        }
         // A member value can carry a source-visible nominal type. Resolve
         // that type only when the value is used as a receiver; keeping this
         // bridge out of `receiver_target` avoids recursively re-typing every
         // intermediate member expression in a long chain.
         let receiver = self
-            .typed_member_receiver(scope_id, receiver.clone())
-            .unwrap_or(receiver);
-        let property_name = member_property_name(self.source, property)?;
+            .typed_member_receiver(scope_id, lookup_receiver.clone())
+            .unwrap_or(lookup_receiver);
         if let Some(name_node) = rightmost_identifier(object)
             && let Some(Resolution::Local(variable)) = self.resolve_name(
                 scope_id,
@@ -6781,6 +6792,37 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     type_arguments: None,
                 });
             }
+            if let Some((utility, base, arguments)) = utility_type_parts(normalized)
+                && matches!(utility, "Pick" | "Omit")
+            {
+                let keys = arguments.get(1).and_then(|keys| type_literal_names(keys))?;
+                if keys.len() > MAX_INLINE_OBJECT_PROPERTIES
+                    || keys
+                        .iter()
+                        .any(|key| key.contains('|') || key.contains(','))
+                    || base.len() > MAX_TYPE_SHAPE_BYTES
+                    || utility_type_parts(base).is_some()
+                {
+                    return None;
+                }
+                let base_receiver = self.resolve_declared_type_receiver(scope_id, base)?;
+                // Keep the first utility projection local and source-backed.
+                // Imported projected members require a project-wide property
+                // inventory and remain unresolved until that evidence exists.
+                if base_receiver.import.is_some() {
+                    return None;
+                }
+                return Some(ReceiverTarget {
+                    qualified_name: encode_utility_projection(
+                        utility,
+                        &base_receiver.qualified_name,
+                        &keys,
+                    ),
+                    import: None,
+                    scope_id: base_receiver.scope_id,
+                    type_arguments: base_receiver.type_arguments,
+                });
+            }
             if let Some(unwrapped) = candidate_utility_receiver_type(normalized) {
                 current = unwrapped;
                 continue;
@@ -8110,6 +8152,32 @@ fn candidate_type_mentions_parameter(type_name: &str, parameters: &[String]) -> 
         .any(|token| parameters.iter().any(|parameter| parameter == token))
 }
 
+const UTILITY_PROJECTION_PREFIX: &str = "__compass_utility_projection__";
+
+fn encode_utility_projection(utility: &str, base: &str, keys: &HashSet<String>) -> String {
+    let mut keys = keys.iter().cloned().collect::<Vec<_>>();
+    keys.sort_unstable();
+    format!(
+        "{UTILITY_PROJECTION_PREFIX}{utility}|{base}|{}",
+        keys.join(",")
+    )
+}
+
+fn decode_utility_projection(type_name: &str) -> Option<(String, String, BTreeSet<String>)> {
+    let encoded = type_name.strip_prefix(UTILITY_PROJECTION_PREFIX)?;
+    let mut parts = encoded.splitn(3, '|');
+    let utility = parts.next()?.to_owned();
+    let base = parts.next()?.to_owned();
+    let keys = parts
+        .next()?
+        .split(',')
+        .filter(|key| !key.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+    (matches!(utility.as_str(), "Pick" | "Omit") && !base.is_empty() && !keys.is_empty())
+        .then_some((utility, base, keys))
+}
+
 fn candidate_utility_receiver_type(type_name: &str) -> Option<String> {
     candidate_utility_receiver_type_at_depth(type_name, 0)
 }
@@ -8119,6 +8187,31 @@ fn candidate_utility_receiver_type_at_depth(type_name: &str, depth: u32) -> Opti
         return None;
     }
     let (base, arguments) = generic_type_parts(type_name)?;
+    if matches!(base, "Exclude" | "Extract") {
+        if arguments.len() != 2 {
+            return None;
+        }
+        let members =
+            split_top_level_union(&arguments[0]).unwrap_or_else(|| vec![arguments[0].as_str()]);
+        let filters =
+            split_top_level_union(&arguments[1]).unwrap_or_else(|| vec![arguments[1].as_str()]);
+        let selected = members
+            .into_iter()
+            .map(str::trim)
+            .filter(|member| {
+                let matches_filter = filters.iter().any(|filter| {
+                    let filter = filter.trim();
+                    filter == "unknown" || filter == "any" || type_names_compatible(member, filter)
+                });
+                (base == "Exclude" && !matches_filter) || (base == "Extract" && matches_filter)
+            })
+            .filter(|member| !is_non_nominal_union_member(member))
+            .collect::<Vec<_>>();
+        let [selected] = selected.as_slice() else {
+            return None;
+        };
+        return Some((*selected).to_owned());
+    }
     if arguments.len() != 1 {
         return None;
     }
@@ -8731,6 +8824,8 @@ fn utility_type_parts(type_name: &str) -> Option<(&str, &str, Vec<&str>)> {
     let (utility, prefix) = [
         ("Pick", "Pick<"),
         ("Omit", "Omit<"),
+        ("Exclude", "Exclude<"),
+        ("Extract", "Extract<"),
         ("Partial", "Partial<"),
         ("Required", "Required<"),
         ("Readonly", "Readonly<"),

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -3855,6 +3855,67 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 ..ResolutionConstraint::default()
             },
         )?;
+        if reexport
+            && bindings.is_empty()
+            && (statement_text.trim_start().starts_with("export *")
+                || statement_text.trim_start().starts_with("export type *"))
+        {
+            // An export-star statement is represented as a wildcard
+            // reexport binding. The resolver expands this bounded edge only
+            // for a requested named export, preserving barrel cycles and
+            // duplicate targets as unresolved/ambiguous rather than selecting
+            // an arbitrary declaration. An export-star namespace alias uses the same module
+            // namespace target but publishes the explicit alias name.
+            let namespace_export = first_named_child_kind(node, "namespace_export");
+            let alias = namespace_export
+                .and_then(first_identifier_node)
+                .map(|identifier| node_text(self.source, identifier))
+                .filter(|name| !name.is_empty());
+            let export_name = alias.as_deref().unwrap_or("*");
+            let anchor = namespace_export.unwrap_or(node);
+            let target = format!("{module}::*");
+            let binding_id = self.builder.bind_with_identity(
+                BindingKind::Reexport,
+                export_name,
+                &target,
+                None,
+                Some(scope_id),
+                Some(SymbolNamespace::Namespace),
+                type_only,
+                range_for_node(self.source_file, anchor),
+            )?;
+            let occurrence_id = self.builder.occur_with_context(
+                SemanticRole::Reexport,
+                &owner,
+                export_name,
+                None,
+                Some(scope_id),
+                Some(if alias.is_some() {
+                    "namespace_alias"
+                } else if type_only {
+                    "type_only_wildcard"
+                } else {
+                    "wildcard"
+                }),
+                range_for_node(self.source_file, anchor),
+            )?;
+            self.builder.relate(
+                CandidateRelation::Reexports,
+                &owner,
+                Some(&occurrence_id),
+                Some(&binding_id),
+                export_name,
+                ResolutionConstraint {
+                    exact_language: Some(self.language.to_owned()),
+                    module_or_package: Some(module),
+                    qualified_name: Some(target),
+                    allowed_target_kinds: vec!["module".to_owned()],
+                    allow_external: true,
+                    ..ResolutionConstraint::default()
+                },
+            )?;
+            return Ok(());
+        }
         if bindings.is_empty() {
             return Ok(());
         }

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6053,18 +6053,26 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 let nested =
                     self.receiver_target(scope_id, object.child_by_field_name("object")?)?;
                 if object.kind() == "subscript_expression"
-                    && let Some(indexed) = self.index_value_receiver(scope_id, &nested)
+                    && let Some(indexed) = self.index_value_receiver(
+                        scope_id,
+                        &nested,
+                        member_property_name(self.source, property).as_deref(),
+                    )
                 {
                     return Some(indexed);
                 }
                 if object.kind() == "subscript_expression" && nested.import.is_some() {
-                    let qualified_name = format!(
-                        "{}[]",
-                        typescript_receiver_with_type_arguments(
-                            &nested.qualified_name,
-                            nested.type_arguments.as_deref(),
-                        )
+                    let receiver = typescript_receiver_with_type_arguments(
+                        &nested.qualified_name,
+                        nested.type_arguments.as_deref(),
                     );
+                    let suffix = member_property_name(self.source, property)
+                        .filter(|index| {
+                            !index.is_empty()
+                                && index.chars().all(|character| character.is_ascii_digit())
+                        })
+                        .map_or_else(|| "[]".to_owned(), |index| format!("[{index}]"));
+                    let qualified_name = format!("{receiver}{suffix}");
                     return Some(ReceiverTarget {
                         qualified_name,
                         import: nested.import,
@@ -6238,11 +6246,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let [(_declaration, order)] = candidates.as_slice() else {
             return None;
         };
-        let index = order.iter().position(|name| name == type_name)?;
-        arguments
-            .get(index)
-            .cloned()
-            .filter(|argument| !argument.is_empty() && argument.len() <= MAX_TYPE_SHAPE_BYTES)
+        let substituted = substitute_candidate_type_parameters(type_name, order, arguments, 0);
+        (substituted != type_name
+            && !substituted.is_empty()
+            && substituted.len() <= MAX_TYPE_SHAPE_BYTES)
+            .then_some(substituted)
     }
 
     fn member_value_receiver(
@@ -6269,12 +6277,17 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         &self,
         scope_id: &str,
         receiver: &ReceiverTarget,
+        index: Option<&str>,
     ) -> Option<ReceiverTarget> {
         if receiver.import.is_some() {
             return None;
         }
-        let type_name = self.index_value_types.get(&receiver.qualified_name)?;
-        self.resolve_declared_type_receiver(scope_id, type_name)
+        let type_name = self
+            .index_value_types
+            .get(&receiver.qualified_name)
+            .cloned()
+            .or_else(|| indexed_sequence_element_type_name(&receiver.qualified_name, index))?;
+        self.resolve_declared_type_receiver(scope_id, &type_name)
     }
 
     fn resolve_declared_type_receiver(
@@ -6291,6 +6304,16 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 || !seen.insert(normalized.to_owned())
             {
                 return None;
+            }
+            if indexed_sequence_element_type_name(normalized, None).is_some()
+                || tuple_type_element_count(normalized).is_some()
+            {
+                return Some(ReceiverTarget {
+                    qualified_name: normalized.to_owned(),
+                    import: None,
+                    scope_id: None,
+                    type_arguments: None,
+                });
             }
             let (lookup_name, type_arguments) = generic_type_parts(normalized)
                 .map(|(base, arguments)| (base.to_owned(), Some(arguments)))
@@ -7429,6 +7452,12 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
     } else {
         annotation
     };
+    if matches!(type_node.kind(), "array_type" | "tuple_type") {
+        let normalized = normalize_type_text(source, type_node);
+        if !normalized.is_empty() && normalized.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(normalized);
+        }
+    }
     let generic_text = (type_node.kind() == "generic_type")
         .then(|| normalize_type_text(source, type_node))
         .filter(|text| !text.is_empty());
@@ -7451,6 +7480,56 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
         _ => return None,
     };
     (!type_name.is_empty()).then_some(type_name)
+}
+
+/// Return a source-preserved element type for a bounded array-like shape.
+/// This is intentionally limited to postfix arrays and the standard generic
+/// array containers; arbitrary structural/indexed expressions remain
+/// unresolved rather than being treated as arrays by spelling alone.
+fn array_element_type_name(type_name: &str) -> Option<String> {
+    let type_name = type_name.trim();
+    if let Some(element) = type_name.strip_suffix("[]") {
+        let element = element.trim();
+        return (!element.is_empty() && element.len() <= MAX_TYPE_SHAPE_BYTES)
+            .then(|| element.to_owned());
+    }
+    let (base, arguments) = generic_type_parts(type_name)?;
+    if !matches!(base, "Array" | "ReadonlyArray") || arguments.len() != 1 {
+        return None;
+    }
+    Some(arguments[0].clone())
+}
+
+fn tuple_type_elements(type_name: &str) -> Option<Vec<&str>> {
+    let type_name = type_name.trim();
+    if !type_name.starts_with('[') || !type_name.ends_with(']') {
+        return None;
+    }
+    let inner = type_name.get(1..type_name.len().saturating_sub(1))?.trim();
+    if inner.is_empty() {
+        return None;
+    }
+    split_top_level_arguments(inner)
+}
+
+fn tuple_type_element_count(type_name: &str) -> Option<usize> {
+    tuple_type_elements(type_name).map(|elements| elements.len())
+}
+
+fn tuple_element_type_name(type_name: &str, index: &str) -> Option<String> {
+    let index = index.parse::<usize>().ok()?;
+    let element = tuple_type_elements(type_name)?.get(index)?.trim();
+    if element.is_empty() || element.starts_with("...") || element.ends_with('?') {
+        return None;
+    }
+    (element.len() <= MAX_TYPE_SHAPE_BYTES).then(|| element.to_owned())
+}
+
+fn indexed_sequence_element_type_name(type_name: &str, index: Option<&str>) -> Option<String> {
+    if let Some(element) = array_element_type_name(type_name) {
+        return Some(element);
+    }
+    index.and_then(|index| tuple_element_type_name(type_name, index))
 }
 
 fn mapped_type_source_name(node: Node<'_>, source: &[u8]) -> Option<String> {
@@ -7539,6 +7618,30 @@ fn substitute_candidate_type_parameters(
         && let Some(argument) = arguments.get(index)
     {
         return argument.clone();
+    }
+    if let Some(element) = type_name.strip_suffix("[]") {
+        let substituted =
+            substitute_candidate_type_parameters(element, parameters, arguments, depth + 1);
+        let substituted = format!("{substituted}[]");
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some(elements) = tuple_type_elements(type_name) {
+        let substituted = elements
+            .iter()
+            .map(|element| {
+                substitute_candidate_type_parameters(element, parameters, arguments, depth + 1)
+            })
+            .collect::<Vec<_>>();
+        let substituted = format!("[{}]", substituted.join(","));
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
     }
     let Some((base, nested)) = generic_type_parts(type_name) else {
         return type_name.to_owned();
@@ -7705,7 +7808,23 @@ fn property_literal_value(node: Node<'_>, source: &[u8]) -> Option<String> {
 }
 
 fn index_value_type(node: Node<'_>, source: &[u8]) -> Option<String> {
-    let text = node_text(source, node);
+    let container = node
+        .child_by_field_name("value")
+        .or_else(|| node.child_by_field_name("body"))
+        .or_else(|| (node.kind() == "object_type").then_some(node))?;
+    let container = if container.kind() == "type_annotation" {
+        first_named_child(container)?
+    } else {
+        container
+    };
+    let mut cursor = container.walk();
+    let index_signature = container
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "index_signature")?;
+    if contains_node_kind(index_signature, "mapped_type_clause") {
+        return None;
+    }
+    let text = node_text(source, index_signature);
     if text.len() > MAX_TYPE_SHAPE_BYTES {
         return None;
     }

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6152,21 +6152,48 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             // file boundary.  The resolver can use the imported callable's
             // published signature to recover its nominal return receiver;
             // unknown argument shapes deliberately remain unresolved.
+            let explicit_type_arguments = function
+                .child_by_field_name("type_arguments")
+                .or_else(|| call.child_by_field_name("type_arguments"))
+                .or_else(|| first_named_child_kind(function, "type_arguments"))
+                .and_then(|type_arguments| {
+                    let text = node_text(self.source, type_arguments);
+                    let inner = text.strip_prefix('<')?.strip_suffix('>')?;
+                    split_top_level_arguments(inner).map(|arguments| {
+                        self.canonical_type_arguments(
+                            scope_id,
+                            &arguments
+                                .into_iter()
+                                .map(str::trim)
+                                .map(ToOwned::to_owned)
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                })
+                .unwrap_or_default();
             let argument_types = self.call_argument_types(call, scope_id);
-            if argument_types.iter().any(Option::is_none) {
+            if explicit_type_arguments.is_empty() && argument_types.iter().any(Option::is_none) {
                 return None;
             }
-            let argument_types = argument_types.into_iter().flatten().collect::<Vec<_>>();
+            let argument_types = argument_types
+                .into_iter()
+                .map(|argument| argument.unwrap_or_else(|| "__unknown".to_owned()))
+                .collect::<Vec<_>>();
             let marker_arguments = if argument_types.is_empty() {
                 "__none".to_owned()
             } else {
                 argument_types.join(",")
             };
-            if marker_arguments.len() > MAX_TYPE_SHAPE_BYTES {
+            let marker_types = if explicit_type_arguments.is_empty() {
+                String::new()
+            } else {
+                format!("#types<{}>", explicit_type_arguments.join(","))
+            };
+            if marker_arguments.len() + marker_types.len() > MAX_TYPE_SHAPE_BYTES {
                 return None;
             }
             let receiver = import_target_without_namespace(&import.target);
-            let qualified_name = format!("{receiver}#call<{marker_arguments}>");
+            let qualified_name = format!("{receiver}#call<{marker_arguments}>{marker_types}");
             if qualified_name.len() > MAX_TYPE_SHAPE_BYTES {
                 return None;
             }

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1,0 +1,8237 @@
+//! Direct, test-only universal evidence for the ECMAScript family.
+//!
+//! This module deliberately does not participate in `UNIVERSAL_ADAPTERS` yet.
+//! It is a source-grounded qualification path for the Phase 2 work in Plan
+//! 013. The production extractor remains the compatibility path until this
+//! emitter has complete capability coverage and passes the hard-cut gates.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use tree_sitter::Node;
+
+use super::build::{EvidenceBuilder, range_for_node};
+use super::model::{
+    BindingKind, CandidateRelation, HierarchyConstraint, LanguageCapability, ResolutionConstraint,
+    SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
+};
+use super::validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits};
+use crate::{AdapterProfile, UNIVERSAL_EVIDENCE_SCHEMA, make_id};
+
+const MAX_TRAVERSAL_DEPTH: usize = 512;
+const MAX_INLINE_OBJECT_PROPERTIES: usize = 256;
+const MAX_TYPE_SHAPE_DEPTH: u32 = 32;
+const MAX_TYPE_SHAPE_BYTES: usize = 16 * 1024;
+
+const TYPESCRIPT_CAPABILITIES: &[LanguageCapability] = &[
+    LanguageCapability::Declarations,
+    LanguageCapability::LexicalScopes,
+    LanguageCapability::Namespaces,
+    LanguageCapability::Imports,
+    LanguageCapability::Reexports,
+    LanguageCapability::Aliases,
+    LanguageCapability::Calls,
+    LanguageCapability::Construction,
+    LanguageCapability::Decorators,
+    LanguageCapability::TypeReferences,
+    LanguageCapability::BaseTypes,
+    LanguageCapability::HierarchyDispatch,
+    LanguageCapability::Members,
+    LanguageCapability::Ownership,
+    LanguageCapability::Receivers,
+    LanguageCapability::ExternalReferences,
+];
+
+const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
+    LanguageCapability::Declarations,
+    LanguageCapability::LexicalScopes,
+    LanguageCapability::Namespaces,
+    LanguageCapability::Imports,
+    LanguageCapability::Reexports,
+    LanguageCapability::Aliases,
+    LanguageCapability::Calls,
+    LanguageCapability::Construction,
+    LanguageCapability::Decorators,
+    LanguageCapability::TypeReferences,
+    LanguageCapability::BaseTypes,
+    LanguageCapability::HierarchyDispatch,
+    LanguageCapability::Members,
+    LanguageCapability::Ownership,
+    LanguageCapability::Receivers,
+    LanguageCapability::ExternalReferences,
+];
+
+static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
+    id: "compass.typescript.candidate",
+    language: "typescript",
+    version: 2,
+    evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
+    profile: crate::UniversalAdapterProfile::UniversalCandidate,
+    capabilities: TYPESCRIPT_CAPABILITIES,
+};
+
+static JAVASCRIPT_PROFILE: AdapterProfile = AdapterProfile {
+    id: "compass.javascript.candidate",
+    language: "javascript",
+    version: 2,
+    evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
+    profile: crate::UniversalAdapterProfile::UniversalCandidate,
+    capabilities: JAVASCRIPT_CAPABILITIES,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Namespace {
+    Value,
+    Type,
+    Module,
+    Both,
+}
+
+impl Namespace {
+    fn accepts(self, requested: Self) -> bool {
+        matches!(self, Self::Both)
+            || matches!(requested, Self::Both)
+            || self == requested
+            || (self == Self::Module && matches!(requested, Self::Value | Self::Type))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DeclarationInfo {
+    id: String,
+    name: String,
+    kind: String,
+    qualified_name: String,
+    scope_id: String,
+    /// Source start of the declaration's canonical evidence range.  This is
+    /// retained for the narrow flow-sensitive structural-object rule below;
+    /// nominal class/type members continue to use scope/ambiguity proof
+    /// instead of source order.
+    range_start_byte: usize,
+    namespace: Namespace,
+    parameter_count: Option<u32>,
+    /// Canonical parameter types when every parameter is source-annotated and
+    /// fixed-arity. `None` means overload selection must not rely on types.
+    parameter_types: Option<Vec<String>>,
+    /// Minimum and maximum source-level arity. `None` as the maximum means a
+    /// rest parameter permits an unbounded suffix. These ranges are used only
+    /// when a class inherits a proven local constructor signature.
+    parameter_min_count: Option<u32>,
+    parameter_max_count: Option<u32>,
+    return_type_name: Option<String>,
+    /// A direct source annotation for a value/member receiver. This is kept
+    /// intentionally shallow; generic constraints and imported identities are
+    /// resolved only when a later member chain needs them.
+    declared_type_name: Option<String>,
+    /// A source annotation or initializer proves that a variable/parameter
+    /// is callable even when its concrete signature is not available in this
+    /// file (for example `factory: (x: T) => U` or
+    /// `const Ctor: typeof Imported = ...`).
+    callable_shape: bool,
+    /// Whether a class declares its own constructor. An absent constructor
+    /// may inherit a fixed signature from a proven local base class.
+    explicit_constructor: bool,
+}
+
+#[derive(Clone, Debug)]
+struct ImportInfo {
+    binding_id: String,
+    target: String,
+    module: String,
+    imported_name: String,
+    namespace: Namespace,
+    type_only: bool,
+}
+
+#[derive(Clone, Debug)]
+enum Resolution {
+    Local(DeclarationInfo),
+    Import(ImportInfo),
+}
+
+impl Resolution {
+    fn qualified_target(&self) -> Option<String> {
+        match self {
+            Self::Local(declaration)
+                if matches!(
+                    declaration.kind.as_str(),
+                    "class" | "interface" | "enum" | "namespace" | "type_alias"
+                ) =>
+            {
+                Some(declaration.qualified_name.clone())
+            }
+            Self::Import(import) => Some(import_target_without_namespace(&import.target)),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ReceiverTarget {
+    qualified_name: String,
+    import: Option<ImportInfo>,
+    scope_id: Option<String>,
+    /// Type arguments preserved when a source annotation instantiates a
+    /// generic nominal receiver.  The vector follows the declaration's
+    /// source parameter order and is intentionally shallow; unresolved or
+    /// ambiguous instantiations carry `None`.
+    type_arguments: Option<Vec<String>>,
+}
+
+struct CandidateState<'source, 'tree> {
+    source_file: &'source str,
+    source: &'source [u8],
+    language: &'static str,
+    root_scope: String,
+    file_declaration: String,
+    scope_by_node: HashMap<usize, String>,
+    scope_parents: HashMap<String, Option<String>>,
+    scope_owners: HashMap<String, String>,
+    scope_kinds: HashMap<String, String>,
+    declarations: HashMap<String, DeclarationInfo>,
+    declarations_by_scope: HashMap<String, Vec<String>>,
+    declarations_by_qualified: HashMap<String, Vec<String>>,
+    generic_parameters_by_declaration: HashMap<String, HashMap<String, Option<String>>>,
+    generic_parameter_order_by_declaration: HashMap<String, Vec<String>>,
+    /// Source-visible union constituents for local type aliases. This is
+    /// retained only for bounded discriminant narrowing (for example
+    /// `if (result.success) result.data`) and is never used as a general
+    /// structural assignability fallback.
+    type_alias_union_targets: HashMap<String, Vec<String>>,
+    property_literal_values: HashMap<String, String>,
+    index_value_types: HashMap<String, String>,
+    import_bindings: HashMap<(String, String), ImportInfo>,
+    variable_types: HashMap<String, String>,
+    structural_object_variables: HashSet<String>,
+    return_object_functions: HashSet<String>,
+    /// A local variable initialized from a source-visible function whose
+    /// return value is an object.  Store the declaration identity rather than
+    /// only its qualified spelling so duplicate block-local functions cannot
+    /// collapse the receiver scope during member resolution.
+    variable_object_sources: HashMap<String, String>,
+    /// Inline object annotations (`const value: { key: T } = ...`) use the
+    /// type-literal property declaration as the compiler's member target.
+    /// Keep the containing qualified prefix so `value.key` can reach that
+    /// declaration without conflating it with the runtime object literal.
+    variable_inline_type_receivers: HashMap<String, String>,
+    /// Direct property type names from a small inline object annotation. This
+    /// is intentionally string-only and shallow: it avoids retaining parser
+    /// nodes or recursively walking arbitrary type expressions while allowing
+    /// one-step destructuring flow to use source evidence.
+    inline_object_property_types: HashMap<String, HashMap<String, String>>,
+    inline_object_property_declaration_ids: HashMap<(String, String), String>,
+    /// Variables initialized from an exact local constructor prototype (for
+    /// example `const proto = Legacy.prototype`). Keeping the source-backed
+    /// prototype identity allows the common JavaScript alias style without
+    /// treating an arbitrary object named `prototype` as a constructor.
+    prototype_sources: HashMap<String, String>,
+    /// Same-file constructor names observed at a `new` site. This narrow
+    /// proof lets `this.field = ...` inside a function constructor publish an
+    /// instance member without treating every dynamic function receiver as a
+    /// nominal class.
+    constructor_name_hints: HashSet<String>,
+    /// Property declarations initialized from a local callable identifier.
+    /// The map is collected before inference and converted to a set only when
+    /// the target declaration is proven callable, keeping aliases such as
+    /// `ZodEnum.create = createZodEnum` precise without guessing from name
+    /// spelling.
+    property_alias_values: HashMap<String, String>,
+    callable_property_aliases: HashSet<String>,
+    /// Variable aliases to a source member/function value. These are retained
+    /// only to recover a source-declared return type at a subsequent call
+    /// site (for example `const stringType = ZodString.create`).
+    variable_alias_values: HashMap<String, String>,
+    this_receivers: HashMap<String, String>,
+    /// Direct `extends` targets proven while emitting the class heritage.
+    /// Values are retained only for classes with one source-visible base; an
+    /// unresolved or ambiguous base never becomes a `super` receiver.
+    base_targets: HashMap<String, ReceiverTarget>,
+    implements_targets: HashMap<String, Vec<ReceiverTarget>>,
+    /// Source-proven bindings from a derived class's base type parameters to
+    /// the concrete type arguments used in its `extends` clause.
+    base_type_bindings: HashMap<String, HashMap<String, String>>,
+    declaration_name_nodes: HashSet<usize>,
+    import_nodes: HashSet<usize>,
+    emitted_facts: HashSet<String>,
+    builder: EvidenceBuilder,
+    _tree: std::marker::PhantomData<Node<'tree>>,
+}
+
+pub(crate) fn extract_candidate_tree_evidence(
+    path: &Path,
+    source_file: &str,
+    source: &[u8],
+    root: Node<'_>,
+    dialect: &str,
+) -> Result<SemanticEvidenceBatch, EvidenceError> {
+    let (language, profile) = match dialect {
+        "typescript" | "tsx" => ("typescript", &TYPESCRIPT_PROFILE),
+        "javascript" => ("javascript", &JAVASCRIPT_PROFILE),
+        _ => {
+            return Err(EvidenceError::new(
+                EvidenceErrorCode::InvalidAdapter,
+                format!("unsupported ECMAScript candidate dialect {dialect:?}"),
+            ));
+        }
+    };
+    let module_name = module_name(path, source_file);
+    let dialect_name = dialect_for_path(path, dialect);
+    let mut builder = EvidenceBuilder::new_with_dialect(
+        profile,
+        format!("compass.languages.{language}.universal.candidate"),
+        source_file,
+        EvidenceLimits::default(),
+        Some(&dialect_name),
+    );
+    let file_range = range_for_node(source_file, root);
+    let file_graph_id = stable_graph_id(source_file, "module", &module_name, 0);
+    let file_declaration = builder.declare_with_namespace(
+        "module",
+        &file_graph_id,
+        &module_name,
+        &module_name,
+        Some(source_file),
+        None,
+        Some(SymbolNamespace::Namespace),
+        file_range.clone(),
+    )?;
+    let root_scope = builder.open_scope("module", Some(&file_declaration), None, file_range)?;
+    let mut state = CandidateState {
+        source_file,
+        source,
+        language,
+        root_scope: root_scope.clone(),
+        file_declaration: file_declaration.clone(),
+        scope_by_node: HashMap::new(),
+        scope_parents: HashMap::from([(root_scope.clone(), None)]),
+        scope_owners: HashMap::from([(root_scope.clone(), file_declaration)]),
+        scope_kinds: HashMap::from([(root_scope.clone(), "module".to_owned())]),
+        declarations: HashMap::new(),
+        declarations_by_scope: HashMap::new(),
+        declarations_by_qualified: HashMap::new(),
+        generic_parameters_by_declaration: HashMap::new(),
+        generic_parameter_order_by_declaration: HashMap::new(),
+        type_alias_union_targets: HashMap::new(),
+        property_literal_values: HashMap::new(),
+        index_value_types: HashMap::new(),
+        import_bindings: HashMap::new(),
+        variable_types: HashMap::new(),
+        structural_object_variables: HashSet::new(),
+        return_object_functions: HashSet::new(),
+        variable_object_sources: HashMap::new(),
+        variable_inline_type_receivers: HashMap::new(),
+        inline_object_property_types: HashMap::new(),
+        inline_object_property_declaration_ids: HashMap::new(),
+        prototype_sources: HashMap::new(),
+        constructor_name_hints: HashSet::new(),
+        property_alias_values: HashMap::new(),
+        callable_property_aliases: HashSet::new(),
+        variable_alias_values: HashMap::new(),
+        this_receivers: HashMap::new(),
+        base_targets: HashMap::new(),
+        implements_targets: HashMap::new(),
+        base_type_bindings: HashMap::new(),
+        declaration_name_nodes: HashSet::new(),
+        import_nodes: HashSet::new(),
+        emitted_facts: HashSet::new(),
+        builder,
+        _tree: std::marker::PhantomData,
+    };
+    state.collect_constructor_name_hints(root, 0);
+    state.collect_declarations(root, root_scope, module_name, 0)?;
+    // Imports are lexically hoisted by ECMAScript/TypeScript.  Materialize
+    // their bindings before receiver inference so a later declaration such
+    // as `const client = new ImportedClient()` can use the imported class
+    // without depending on source order.
+    state.precollect_imports(root, 0)?;
+    state.resolve_callable_property_aliases();
+    state.precollect_base_targets(root, 0);
+    state.infer_variable_types(root, 0);
+    state.emit_nodes(root, 0)?;
+    if root.has_error() {
+        state.builder.diagnose(
+            "partial_parser_recovery",
+            None,
+            Some(range_for_node(source_file, root)),
+            "parser recovered from malformed ECMAScript source; emitted evidence remains source-bounded",
+        )?;
+    }
+    state.builder.finish()
+}
+
+impl<'source, 'tree> CandidateState<'source, 'tree> {
+    fn collect_constructor_name_hints(&mut self, node: Node<'tree>, depth: usize) {
+        let mut pending = vec![(node, depth)];
+        while let Some((current, current_depth)) = pending.pop() {
+            if current_depth > MAX_TRAVERSAL_DEPTH {
+                continue;
+            }
+            if current.kind() == "new_expression"
+                && let Some(constructor) = current
+                    .child_by_field_name("constructor")
+                    .or_else(|| first_named_child(current))
+                && let Some(name) = rightmost_identifier(constructor)
+            {
+                let spelling = node_text(self.source, name);
+                if !spelling.is_empty() {
+                    self.constructor_name_hints.insert(spelling);
+                }
+            }
+            if current.kind() == "assignment_expression"
+                && let Some(left) = current.child_by_field_name("left")
+                && let Some(object) = left.child_by_field_name("object")
+            {
+                let object_text = node_text(self.source, object);
+                if let Some(base) = object_text.strip_suffix(".prototype") {
+                    let spelling = base
+                        .rsplit(['.', ':'])
+                        .next()
+                        .map(str::trim)
+                        .unwrap_or_default();
+                    if !spelling.is_empty() {
+                        self.constructor_name_hints.insert(spelling.to_owned());
+                    }
+                }
+            }
+            if current.kind() == "variable_declarator"
+                && let Some(value) = current.child_by_field_name("value")
+                && let Some(object) = value.child_by_field_name("object")
+                && let Some(property) = member_property_node(value)
+                && member_property_name(self.source, property).as_deref() == Some("prototype")
+            {
+                let object_text = node_text(self.source, object);
+                let spelling = object_text
+                    .rsplit(['.', ':'])
+                    .next()
+                    .map(str::trim)
+                    .unwrap_or_default();
+                if !spelling.is_empty() {
+                    self.constructor_name_hints.insert(spelling.to_owned());
+                }
+            }
+            let mut cursor = current.walk();
+            let children = current.named_children(&mut cursor).collect::<Vec<_>>();
+            for child in children.into_iter().rev() {
+                pending.push((child, current_depth.saturating_add(1)));
+            }
+        }
+    }
+
+    fn collect_declarations(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: String,
+        qualified_prefix: String,
+        depth: usize,
+    ) -> Result<(), EvidenceError> {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            self.builder.diagnose(
+                "traversal_depth_limit",
+                None,
+                Some(range_for_node(self.source_file, node)),
+                "ECMAScript declaration traversal exceeded the bounded depth",
+            )?;
+            return Ok(());
+        }
+        let mut scope_id = self.enter_lexical_scope(node, scope_id)?;
+        // Conditional and mapped types introduce their own type-binding
+        // environments.  Keeping them distinct is essential for repeated
+        // mapped keys (`K`) and conditional `infer` names (`Intersection`,
+        // `Last`): the checker binds each occurrence to the nearest source
+        // type construct rather than treating same-spelled keys in a whole
+        // alias as overloads.
+        if matches!(
+            node.kind(),
+            "conditional_type" | "mapped_type" | "object_type"
+        ) && !self.scope_by_node.contains_key(&node.id())
+        {
+            let owner = self.owner_for_scope(&scope_id);
+            let kind = if node.kind() == "conditional_type" {
+                "conditional_type"
+            } else if node.kind() == "object_type" {
+                "object_type"
+            } else {
+                "mapped_type"
+            };
+            let child_scope = self.builder.open_scope(
+                kind,
+                Some(&owner),
+                Some(&scope_id),
+                range_for_node(self.source_file, node),
+            )?;
+            self.scope_by_node.insert(node.id(), child_scope.clone());
+            self.scope_parents
+                .insert(child_scope.clone(), Some(scope_id.clone()));
+            self.scope_owners.insert(child_scope.clone(), owner);
+            self.scope_kinds
+                .insert(child_scope.clone(), kind.to_owned());
+            scope_id = child_scope;
+        }
+        if node.kind() == "return_statement"
+            && return_value_node(node)
+                .map(unwrap_expression_node)
+                .is_some_and(|value| value.kind() == "object")
+        {
+            let owner = self.owner_for_scope(&scope_id);
+            if let Some(declaration) = self.declarations.get(&owner) {
+                self.return_object_functions
+                    .insert(declaration.qualified_name.clone());
+            }
+        }
+        if matches!(node.kind(), "for_in_statement" | "for_statement")
+            && node.child_by_field_name("kind").is_some()
+            && let Some(left) = node.child_by_field_name("left")
+        {
+            let mut names = Vec::new();
+            collect_pattern_names(left, self.source, &mut names);
+            for (name, name_node) in names {
+                if !name.is_empty() {
+                    self.add_declaration_at(
+                        left,
+                        name_node,
+                        "variable",
+                        Namespace::Value,
+                        &self.binding_scope_for(left, &scope_id),
+                        &qualified_prefix,
+                        &name,
+                    )?;
+                }
+            }
+        }
+        if node.kind() == "catch_clause"
+            && let Some(parameter) = node.child_by_field_name("parameter")
+        {
+            let mut names = Vec::new();
+            collect_pattern_names(parameter, self.source, &mut names);
+            for (name, name_node) in names {
+                if !name.is_empty() {
+                    self.add_declaration_at(
+                        parameter,
+                        name_node,
+                        "variable",
+                        Namespace::Value,
+                        &scope_id,
+                        &qualified_prefix,
+                        &name,
+                    )?;
+                }
+            }
+        }
+        if node.kind() == "index_signature"
+            && let Some(name_node) = node.child_by_field_name("name")
+        {
+            let name = node_text(self.source, name_node);
+            if !name.is_empty() {
+                self.add_declaration_at(
+                    node,
+                    name_node,
+                    "parameter",
+                    Namespace::Value,
+                    &scope_id,
+                    &qualified_prefix,
+                    &name,
+                )?;
+            }
+        }
+        if node.kind() == "mapped_type_clause"
+            && let Some(name_node) = node.child_by_field_name("name")
+        {
+            let name = node_text(self.source, name_node);
+            if !name.is_empty() {
+                self.add_declaration_at(
+                    node,
+                    name_node,
+                    "type_parameter",
+                    Namespace::Type,
+                    &scope_id,
+                    &qualified_prefix,
+                    &name,
+                )?;
+            }
+        }
+        if node.kind() == "infer_type"
+            && let Some(name_node) = first_named_child_kind(node, "type_identifier")
+        {
+            let name = node_text(self.source, name_node);
+            if !name.is_empty() {
+                let binding_scope = self.infer_binding_scope(node, &scope_id);
+                self.add_declaration_at(
+                    node,
+                    name_node,
+                    "type_parameter",
+                    Namespace::Type,
+                    &binding_scope,
+                    &qualified_prefix,
+                    &name,
+                )?;
+            }
+        }
+        if matches!(
+            node.kind(),
+            "arrow_function"
+                | "function"
+                | "function_expression"
+                | "function_type"
+                | "generator_function"
+        ) && !self.scope_by_node.contains_key(&node.id())
+        {
+            let owner = self.owner_for_scope(&scope_id);
+            let this_receiver = self.prototype_assignment_receiver(node, &scope_id);
+            let child_scope = self.builder.open_scope(
+                "function",
+                Some(&owner),
+                Some(&scope_id),
+                range_for_node(self.source_file, node),
+            )?;
+            self.scope_by_node.insert(node.id(), child_scope.clone());
+            self.scope_parents
+                .insert(child_scope.clone(), Some(scope_id.clone()));
+            self.scope_owners.insert(child_scope.clone(), owner);
+            self.scope_kinds
+                .insert(child_scope.clone(), "function".to_owned());
+            if let Some(receiver) = this_receiver {
+                self.this_receivers.insert(child_scope.clone(), receiver);
+            }
+            self.collect_unwrapped_callable_parameters(node, &child_scope, &qualified_prefix)?;
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                self.collect_declarations(
+                    child,
+                    child_scope.clone(),
+                    qualified_prefix.clone(),
+                    depth + 1,
+                )?;
+            }
+            return Ok(());
+        }
+        if node.kind() == "export_statement"
+            && node_text(self.source, node)
+                .trim_start()
+                .starts_with("export default")
+            && let Some(exported) = first_named_child(node)
+            && exported.child_by_field_name("name").is_none()
+            && let Some((kind, namespace, creates_scope, scope_kind)) =
+                anonymous_declaration_shape(exported)
+        {
+            let declaration = self.add_declaration_at(
+                exported,
+                exported,
+                kind,
+                namespace,
+                &scope_id,
+                &qualified_prefix,
+                "default",
+            )?;
+            if creates_scope {
+                let child_scope = self.builder.open_scope(
+                    scope_kind,
+                    Some(&declaration.id),
+                    Some(&scope_id),
+                    range_for_node(self.source_file, exported),
+                )?;
+                self.scope_by_node
+                    .insert(exported.id(), child_scope.clone());
+                self.scope_parents
+                    .insert(child_scope.clone(), Some(scope_id));
+                self.scope_owners
+                    .insert(child_scope.clone(), declaration.id);
+                self.scope_kinds
+                    .insert(child_scope.clone(), scope_kind.to_owned());
+                self.collect_unwrapped_callable_parameters(
+                    exported,
+                    &child_scope,
+                    &declaration.qualified_name,
+                )?;
+                let mut cursor = exported.walk();
+                for child in exported.named_children(&mut cursor) {
+                    self.collect_declarations(
+                        child,
+                        child_scope.clone(),
+                        declaration.qualified_name.clone(),
+                        depth + 1,
+                    )?;
+                }
+            }
+            return Ok(());
+        }
+        if is_anonymous_signature_scope(node) {
+            let owner = self.scope_owners.get(&scope_id).cloned();
+            let signature_scope = self.builder.open_scope(
+                "signature",
+                owner.as_deref(),
+                Some(&scope_id),
+                range_for_node(self.source_file, node),
+            )?;
+            self.scope_by_node
+                .insert(node.id(), signature_scope.clone());
+            self.scope_parents
+                .insert(signature_scope.clone(), Some(scope_id.clone()));
+            if let Some(owner) = owner {
+                self.scope_owners.insert(signature_scope.clone(), owner);
+            }
+            self.scope_kinds
+                .insert(signature_scope.clone(), "signature".to_owned());
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                self.collect_declarations(
+                    child,
+                    signature_scope.clone(),
+                    qualified_prefix.clone(),
+                    depth + 1,
+                )?;
+            }
+            return Ok(());
+        }
+        if is_parameter_node(node)
+            && let Some(pattern) = parameter_pattern_node(node)
+        {
+            let mut names = Vec::new();
+            collect_pattern_names(pattern, self.source, &mut names);
+            for (name, name_node) in names {
+                if !name.is_empty() {
+                    self.add_declaration_at(
+                        node,
+                        name_node,
+                        "parameter",
+                        Namespace::Value,
+                        &scope_id,
+                        &qualified_prefix,
+                        &name,
+                    )?;
+                }
+            }
+        }
+        if let Some((kind, name_node, namespace, creates_scope, scope_kind)) =
+            declaration_shape(node)
+        {
+            let name = node_text(self.source, name_node);
+            if !name.is_empty() {
+                let kind = if kind == "method" && name == "constructor" {
+                    "constructor"
+                } else {
+                    kind
+                };
+                let declaration = self.add_declaration(
+                    node,
+                    name_node,
+                    kind,
+                    namespace,
+                    &scope_id,
+                    &qualified_prefix,
+                )?;
+                let next_prefix = declaration.qualified_name.clone();
+                if creates_scope {
+                    let child_scope = self.builder.open_scope(
+                        scope_kind,
+                        Some(&declaration.id),
+                        Some(&scope_id),
+                        range_for_node(self.source_file, node),
+                    )?;
+                    self.scope_by_node.insert(node.id(), child_scope.clone());
+                    self.scope_parents
+                        .insert(child_scope.clone(), Some(scope_id));
+                    self.scope_owners
+                        .insert(child_scope.clone(), declaration.id);
+                    self.scope_kinds
+                        .insert(child_scope.clone(), scope_kind.to_owned());
+                    self.collect_unwrapped_callable_parameters(node, &child_scope, &next_prefix)?;
+                    let mut cursor = node.walk();
+                    for child in node.named_children(&mut cursor) {
+                        self.collect_declarations(
+                            child,
+                            child_scope.clone(),
+                            next_prefix.clone(),
+                            depth + 1,
+                        )?;
+                    }
+                } else {
+                    let mut cursor = node.walk();
+                    for child in node.named_children(&mut cursor) {
+                        self.collect_declarations(
+                            child,
+                            scope_id.clone(),
+                            next_prefix.clone(),
+                            depth + 1,
+                        )?;
+                    }
+                }
+                return Ok(());
+            }
+        }
+        let mut object_literal_value_id = None;
+        if node.kind() == "assignment_expression"
+            && let Some(left) = node.child_by_field_name("left")
+            && matches!(
+                left.kind(),
+                "member_expression" | "optional_member_expression" | "subscript_expression"
+            )
+            && let Some(property) = member_property_node(left)
+            && let Some(property_name) = member_property_name(self.source, property)
+            && let Some(object) = left.child_by_field_name("object")
+            && let Some(receiver) = self.receiver_target(&scope_id, object)
+            && receiver.import.is_none()
+        {
+            let qualified_name = format!("{}.{property_name}", receiver.qualified_name);
+            let class_member_alias =
+                object.kind() == "identifier" && self.enclosing_type(&scope_id).is_some();
+            let prototype_instance_write =
+                object.kind() == "this" && receiver.qualified_name.ends_with(".prototype");
+            if !class_member_alias
+                && !prototype_instance_write
+                && !self.declarations_by_qualified.contains_key(&qualified_name)
+            {
+                let class_receiver = self
+                    .resolve_name(&scope_id, &node_text(self.source, object), Namespace::Value)
+                    .is_some_and(|resolution| {
+                        matches!(
+                            resolution,
+                            Resolution::Local(declaration)
+                                if matches!(
+                                    declaration.kind.as_str(),
+                                    "class" | "interface" | "enum" | "namespace"
+                            )
+                        )
+                    });
+                let prototype_receiver = self.is_function_prototype_receiver(&scope_id, object);
+                let prototype_alias_receiver = self
+                    .prototype_sources
+                    .values()
+                    .any(|source| source == &receiver.qualified_name);
+                let structural_object_receiver = self
+                    .structural_object_variables
+                    .contains(&receiver.qualified_name);
+                // The checker anchors an assignment-backed member at its
+                // property name for class-static and function-prototype
+                // assignments, while instance/object writes use the
+                // enclosing assignment as their source-backed structural
+                // declaration.
+                let range_node = if class_receiver
+                    || prototype_receiver
+                    || prototype_alias_receiver
+                    || structural_object_receiver
+                {
+                    property
+                } else {
+                    node
+                };
+                self.add_declaration_at_with_range(
+                    node,
+                    property,
+                    range_node,
+                    "property",
+                    Namespace::Value,
+                    &scope_id,
+                    &receiver.qualified_name,
+                    &property_name,
+                )?;
+                if let Some(right) = node
+                    .child_by_field_name("right")
+                    .map(unwrap_expression_node)
+                    && right.kind() == "object"
+                {
+                    self.structural_object_variables
+                        .insert(qualified_name.clone());
+                    object_literal_value_id = Some(right.id());
+                    let mut cursor = right.walk();
+                    for child in right.named_children(&mut cursor) {
+                        self.collect_declarations(
+                            child,
+                            scope_id.clone(),
+                            qualified_name.clone(),
+                            depth + 1,
+                        )?;
+                    }
+                }
+            }
+        }
+        if node.kind() == "assignment_expression"
+            && let Some(left) = node.child_by_field_name("left")
+            && left.kind() == "identifier"
+            && let Some(value) = node
+                .child_by_field_name("right")
+                .map(unwrap_expression_node)
+            && value.kind() == "object"
+            && let Some(Resolution::Local(variable)) =
+                self.resolve_name(&scope_id, &node_text(self.source, left), Namespace::Value)
+            && variable.kind == "variable"
+        {
+            object_literal_value_id = Some(value.id());
+            self.structural_object_variables
+                .insert(variable.qualified_name.clone());
+            let mut cursor = value.walk();
+            for child in value.named_children(&mut cursor) {
+                self.collect_declarations(
+                    child,
+                    scope_id.clone(),
+                    variable.qualified_name.clone(),
+                    depth + 1,
+                )?;
+            }
+        }
+        if node.kind() == "variable_declarator"
+            && let Some(name_node) = node.child_by_field_name("name")
+        {
+            let object_literal_prefix = node
+                .child_by_field_name("value")
+                .map(unwrap_expression_node)
+                .filter(|value| value.kind() == "object")
+                .and_then(|_| {
+                    // A typed identifier can contain a nested object type
+                    // (`const value: { key: string } = { key: ... }`).
+                    // Walking that annotation as a binding pattern would
+                    // collect `key` as an additional variable and lose the
+                    // receiver prefix, collapsing unrelated object members.
+                    let names = if name_node.kind() == "identifier" {
+                        vec![(node_text(self.source, name_node), name_node)]
+                    } else {
+                        let mut names = Vec::new();
+                        collect_pattern_names(name_node, self.source, &mut names);
+                        names
+                    };
+                    (names.len() == 1).then(|| {
+                        if qualified_prefix.is_empty() {
+                            names[0].0.clone()
+                        } else {
+                            format!("{qualified_prefix}.{}", names[0].0)
+                        }
+                    })
+                });
+            if let Some(value) = node.child_by_field_name("value")
+                && is_callable_node(value)
+                && name_node.kind() == "identifier"
+            {
+                let name = node_text(self.source, name_node);
+                if !name.is_empty() {
+                    let declaration = self.add_declaration(
+                        node,
+                        name_node,
+                        "function",
+                        Namespace::Value,
+                        &scope_id,
+                        &qualified_prefix,
+                    )?;
+                    let this_receiver = self.prototype_assignment_receiver(value, &scope_id);
+                    let child_scope = self.builder.open_scope(
+                        "function",
+                        Some(&declaration.id),
+                        Some(&scope_id),
+                        range_for_node(self.source_file, value),
+                    )?;
+                    self.scope_by_node.insert(value.id(), child_scope.clone());
+                    self.scope_parents
+                        .insert(child_scope.clone(), Some(scope_id.clone()));
+                    self.scope_owners
+                        .insert(child_scope.clone(), declaration.id);
+                    self.scope_kinds
+                        .insert(child_scope.clone(), "function".to_owned());
+                    if let Some(receiver) = this_receiver {
+                        self.this_receivers.insert(child_scope.clone(), receiver);
+                    }
+                    self.collect_unwrapped_callable_parameters(
+                        value,
+                        &child_scope,
+                        &declaration.qualified_name,
+                    )?;
+                    let mut cursor = value.walk();
+                    for child in value.named_children(&mut cursor) {
+                        self.collect_declarations(
+                            child,
+                            child_scope.clone(),
+                            declaration.qualified_name.clone(),
+                            depth + 1,
+                        )?;
+                    }
+                    let mut cursor = node.walk();
+                    for child in node.named_children(&mut cursor) {
+                        if child.id() != value.id() {
+                            self.collect_declarations(
+                                child,
+                                scope_id.clone(),
+                                qualified_prefix.clone(),
+                                depth + 1,
+                            )?;
+                        }
+                    }
+                    return Ok(());
+                }
+            }
+            let mut names = Vec::new();
+            collect_pattern_names(name_node, self.source, &mut names);
+            for (name, name_node) in names {
+                if name.is_empty() {
+                    continue;
+                }
+                self.add_declaration_at(
+                    node,
+                    name_node,
+                    "variable",
+                    Namespace::Value,
+                    &self.binding_scope_for(node, &scope_id),
+                    &qualified_prefix,
+                    &name,
+                )?;
+            }
+            // Prototype aliases must be available while the declaration pass
+            // visits following assignments (`const proto = Ctor.prototype;
+            // proto.run = ...`). The helper remains source/namespace bounded;
+            // the later inference pass repeats it for declarations discovered
+            // after their constructor.
+            self.infer_variable_prototype_source(node, &scope_id);
+            if let Some(prefix) = object_literal_prefix.as_deref()
+                && let Some(value) = node
+                    .child_by_field_name("value")
+                    .map(unwrap_expression_node)
+                && value.kind() == "object"
+            {
+                self.structural_object_variables.insert(prefix.to_owned());
+                object_literal_value_id = Some(value.id());
+                let mut cursor = value.walk();
+                for child in value.named_children(&mut cursor) {
+                    self.collect_declarations(
+                        child,
+                        scope_id.clone(),
+                        prefix.to_owned(),
+                        depth + 1,
+                    )?;
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if Some(child.id()) == object_literal_value_id {
+                continue;
+            }
+            self.collect_declarations(
+                child,
+                scope_id.clone(),
+                qualified_prefix.clone(),
+                depth + 1,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn collect_unwrapped_callable_parameters(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        qualified_prefix: &str,
+    ) -> Result<(), EvidenceError> {
+        let mut add_parameter = |parameter: Node<'tree>| -> Result<(), EvidenceError> {
+            let mut names = Vec::new();
+            collect_pattern_names(parameter, self.source, &mut names);
+            for (name, name_node) in names {
+                if !name.is_empty() {
+                    self.add_declaration_at(
+                        parameter,
+                        name_node,
+                        "parameter",
+                        Namespace::Value,
+                        scope_id,
+                        qualified_prefix,
+                        &name,
+                    )?;
+                }
+            }
+            Ok(())
+        };
+        if let Some(parameters) = node
+            .child_by_field_name("parameters")
+            .or_else(|| first_named_child_kind(node, "formal_parameters"))
+        {
+            let mut cursor = parameters.walk();
+            for parameter in parameters.named_children(&mut cursor) {
+                if is_parameter_node(parameter) || parameter.kind().contains("comment") {
+                    continue;
+                }
+                add_parameter(parameter)?;
+            }
+        } else if let Some(parameter) = node.child_by_field_name("parameter") {
+            // The TypeScript grammar uses a singular `parameter` field for
+            // the unparenthesized arrow form (`value => value`).  It is not
+            // nested in `formal_parameters`, so the normal recursive
+            // parameter-wrapper path cannot see it as a declaration.
+            add_parameter(parameter)?;
+        }
+        Ok(())
+    }
+
+    fn add_declaration(
+        &mut self,
+        node: Node<'tree>,
+        name_node: Node<'tree>,
+        kind: &str,
+        namespace: Namespace,
+        scope_id: &str,
+        qualified_prefix: &str,
+    ) -> Result<DeclarationInfo, EvidenceError> {
+        let name = declaration_name_text(self.source, name_node);
+        self.add_declaration_at(
+            node,
+            name_node,
+            kind,
+            namespace,
+            scope_id,
+            qualified_prefix,
+            &name,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_declaration_at(
+        &mut self,
+        node: Node<'tree>,
+        name_node: Node<'tree>,
+        kind: &str,
+        namespace: Namespace,
+        scope_id: &str,
+        qualified_prefix: &str,
+        name: &str,
+    ) -> Result<DeclarationInfo, EvidenceError> {
+        self.add_declaration_at_with_range(
+            node,
+            name_node,
+            name_node,
+            kind,
+            namespace,
+            scope_id,
+            qualified_prefix,
+            name,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_declaration_at_with_range(
+        &mut self,
+        node: Node<'tree>,
+        name_node: Node<'tree>,
+        range_node: Node<'tree>,
+        kind: &str,
+        namespace: Namespace,
+        scope_id: &str,
+        qualified_prefix: &str,
+        name: &str,
+    ) -> Result<DeclarationInfo, EvidenceError> {
+        let qualified_name = if qualified_prefix.is_empty() {
+            name.to_owned()
+        } else {
+            format!("{qualified_prefix}.{name}")
+        };
+        let graph_node_id = stable_graph_id(self.source_file, kind, name, node.start_byte());
+        let declaration_id = self.builder.declare_with_namespace(
+            kind,
+            &graph_node_id,
+            name,
+            &qualified_name,
+            Some(self.source_file),
+            Some(scope_id),
+            Some(symbol_namespace(namespace)),
+            range_for_node(self.source_file, range_node),
+        )?;
+        self.declaration_name_nodes.insert(name_node.start_byte());
+        let callable_value = callable_value_node(node);
+        let parameter_arity = callable_parameter_arity(node, self.source).or_else(|| {
+            callable_value.and_then(|value| callable_parameter_arity(value, self.source))
+        });
+        let generic_parameters = callable_type_parameters(node, self.source)
+            .or_else(|| {
+                callable_value.and_then(|value| callable_type_parameters(value, self.source))
+            })
+            .unwrap_or_default();
+        let generic_parameter_order = callable_type_parameter_order(node, self.source)
+            .or_else(|| {
+                callable_value.and_then(|value| callable_type_parameter_order(value, self.source))
+            })
+            .unwrap_or_default();
+        let declaration = DeclarationInfo {
+            id: declaration_id.clone(),
+            name: name.to_owned(),
+            kind: kind.to_owned(),
+            qualified_name,
+            scope_id: scope_id.to_owned(),
+            range_start_byte: range_node.start_byte(),
+            namespace,
+            parameter_count: parameter_arity
+                .and_then(|(minimum, maximum)| (Some(minimum) == maximum).then_some(minimum)),
+            parameter_types: callable_parameter_types(node, self.source).or_else(|| {
+                callable_value.and_then(|value| callable_parameter_types(value, self.source))
+            }),
+            parameter_min_count: parameter_arity.map(|(minimum, _)| minimum),
+            parameter_max_count: parameter_arity.and_then(|(_, maximum)| maximum),
+            return_type_name: callable_return_type_name(node, self.source)
+                .or_else(|| {
+                    callable_value.and_then(|value| callable_return_type_name(value, self.source))
+                })
+                .or_else(|| callable_return_constructor_name(node, self.source))
+                .or_else(|| {
+                    matches!(kind, "method" | "constructor")
+                        .then(|| callable_returns_this(node).then_some("this".to_owned()))
+                        .flatten()
+                }),
+            declared_type_name: direct_type_reference_name(node, self.source),
+            callable_shape: declaration_is_callable_shape(node, kind, self.source),
+            explicit_constructor: kind == "class"
+                && class_has_explicit_constructor(node, self.source),
+        };
+        self.declarations
+            .insert(declaration_id, declaration.clone());
+        if kind == "property"
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let value = unwrap_expression_node(value);
+            if matches!(value.kind(), "identifier" | "type_identifier") {
+                let target = node_text(self.source, value);
+                if !target.is_empty() && target.len() <= MAX_TYPE_SHAPE_BYTES {
+                    self.property_alias_values
+                        .insert(declaration.id.clone(), target);
+                }
+            }
+        }
+        if kind == "variable"
+            && let Some(value) = node.child_by_field_name("value")
+        {
+            let value = unwrap_expression_node(value);
+            if matches!(
+                value.kind(),
+                "identifier"
+                    | "type_identifier"
+                    | "member_expression"
+                    | "optional_member_expression"
+                    | "subscript_expression"
+            ) {
+                let target = node_text(self.source, value);
+                if !target.is_empty() && target.len() <= MAX_TYPE_SHAPE_BYTES {
+                    self.variable_alias_values
+                        .insert(declaration.id.clone(), target);
+                }
+            }
+        }
+        if kind == "property"
+            && let Some(value) = property_literal_value(node, self.source)
+        {
+            self.property_literal_values
+                .insert(declaration.qualified_name.clone(), value);
+        }
+        if kind == "type_alias"
+            && let Some(targets) = type_alias_union_targets(node, self.source)
+        {
+            self.type_alias_union_targets
+                .insert(declaration.qualified_name.clone(), targets);
+        }
+        if matches!(kind, "type_alias" | "interface")
+            && let Some(value_type) = index_value_type(node, self.source)
+        {
+            self.index_value_types
+                .insert(declaration.qualified_name.clone(), value_type);
+        }
+        if !generic_parameters.is_empty() {
+            self.generic_parameters_by_declaration
+                .insert(declaration.id.clone(), generic_parameters);
+        }
+        if !generic_parameter_order.is_empty() {
+            self.generic_parameter_order_by_declaration
+                .insert(declaration.id.clone(), generic_parameter_order);
+        }
+        self.declarations_by_scope
+            .entry(scope_id.to_owned())
+            .or_default()
+            .push(declaration.id.clone());
+        self.declarations_by_qualified
+            .entry(declaration.qualified_name.clone())
+            .or_default()
+            .push(declaration.id.clone());
+        Ok(declaration)
+    }
+
+    /// Resolve property aliases after the declaration table is complete so a
+    /// static/member field initialized from a local function can be treated
+    /// as callable at its exact member site. Imported or ambiguous aliases
+    /// remain unresolved rather than inheriting an unknown call signature.
+    fn resolve_callable_property_aliases(&mut self) {
+        let aliases = self
+            .property_alias_values
+            .iter()
+            .map(|(declaration_id, target)| (declaration_id.clone(), target.clone()))
+            .collect::<Vec<_>>();
+        for (declaration_id, target) in aliases {
+            let Some(property) = self.declarations.get(&declaration_id) else {
+                continue;
+            };
+            let property_scope = property.scope_id.clone();
+            let callable = match self.resolve_name(&property_scope, &target, Namespace::Value) {
+                Some(Resolution::Local(target)) => {
+                    target.callable_shape
+                        || matches!(
+                            target.kind.as_str(),
+                            "class" | "constructor" | "function" | "method"
+                        )
+                }
+                // Overloaded local functions have multiple declarations and
+                // intentionally resolve as ambiguous at a call site.  An
+                // alias to that overloaded set is nevertheless source-proven
+                // callable, so accept it only when every visible candidate
+                // is a callable declaration.
+                None => self.visible_callable_alias_target(&property_scope, &target),
+                Some(Resolution::Import(_)) => false,
+            };
+            if callable {
+                self.callable_property_aliases.insert(declaration_id);
+            }
+        }
+    }
+
+    fn visible_callable_alias_target(&self, scope_id: &str, name: &str) -> bool {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            let candidates = self
+                .declarations_by_scope
+                .get(&scope)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.name == name
+                        && declaration.namespace.accepts(Namespace::Value)
+                        && self.lexically_visible_unqualified(&scope, declaration)
+                })
+                .collect::<Vec<_>>();
+            if !candidates.is_empty() {
+                return candidates.iter().all(|candidate| {
+                    candidate.callable_shape
+                        || matches!(
+                            candidate.kind.as_str(),
+                            "class" | "constructor" | "function" | "method"
+                        )
+                });
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        false
+    }
+
+    fn precollect_imports(&mut self, node: Node<'tree>, depth: usize) -> Result<(), EvidenceError> {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            return Ok(());
+        }
+        let scope_id = self.scope_for_node(node);
+        match node.kind() {
+            "import_statement" => self.emit_import(node, &scope_id, false)?,
+            "export_statement" if first_named_child_kind(node, "string").is_some() => {
+                self.emit_import(node, &scope_id, true)?;
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.precollect_imports(child, depth + 1)?;
+        }
+        Ok(())
+    }
+
+    fn precollect_base_targets(&mut self, node: Node<'tree>, depth: usize) {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            return;
+        }
+        if matches!(
+            node.kind(),
+            "class_declaration"
+                | "abstract_class_declaration"
+                | "class"
+                | "interface_declaration"
+                | "interface"
+        ) {
+            let scope_id = self.scope_for_node(node);
+            if let Some(class_name) = self.enclosing_type(&scope_id) {
+                let mut clauses = Vec::new();
+                collect_nodes_of_kind(node, "extends_clause", &mut clauses);
+                collect_nodes_of_kind(node, "extends_type_clause", &mut clauses);
+                if let Some(clause) = clauses.into_iter().next() {
+                    let mut names = Vec::new();
+                    collect_type_name_nodes(clause, &mut names);
+                    if let Some(base) = names.first()
+                        && let Some(resolution) = self.resolve_type_name_node(&scope_id, *base)
+                    {
+                        let clause_text = node_text(self.source, clause);
+                        let clause_base_text = clause_text
+                            .trim()
+                            .strip_prefix("extends")
+                            .unwrap_or(clause_text.trim());
+                        let base_declaration_id = match &resolution {
+                            Resolution::Local(declaration) => Some(declaration.id.clone()),
+                            Resolution::Import(_) => None,
+                        };
+                        let receiver = match resolution {
+                            Resolution::Local(declaration)
+                                if matches!(
+                                    declaration.kind.as_str(),
+                                    "class" | "interface" | "enum" | "namespace"
+                                ) =>
+                            {
+                                Some(ReceiverTarget {
+                                    qualified_name: declaration.qualified_name.clone(),
+                                    import: None,
+                                    scope_id: self.member_scope_for_declaration(&declaration),
+                                    type_arguments: None,
+                                })
+                            }
+                            Resolution::Import(import) => Some(ReceiverTarget {
+                                qualified_name: import_target_without_namespace(&import.target),
+                                import: Some(import),
+                                scope_id: None,
+                                type_arguments: None,
+                            }),
+                            _ => None,
+                        };
+                        if let Some(receiver) = receiver {
+                            self.base_targets.insert(class_name.clone(), receiver);
+                            if let Some(base_declaration_id) = base_declaration_id
+                                && let Some((_, arguments)) = generic_type_parts(clause_base_text)
+                                && let Some(order) = self
+                                    .generic_parameter_order_by_declaration
+                                    .get(&base_declaration_id)
+                            {
+                                let bindings = order
+                                    .iter()
+                                    .zip(arguments)
+                                    .map(|(name, argument)| {
+                                        (name.clone(), strip_type_arguments(&argument).to_owned())
+                                    })
+                                    .collect::<HashMap<_, _>>();
+                                if !bindings.is_empty() {
+                                    self.base_type_bindings.insert(class_name.clone(), bindings);
+                                }
+                            }
+                        }
+                    }
+                }
+                let mut implements = Vec::new();
+                collect_nodes_of_kind(node, "implements_clause", &mut implements);
+                for clause in implements.into_iter().take(MAX_INLINE_OBJECT_PROPERTIES) {
+                    let mut names = Vec::new();
+                    collect_type_name_nodes(clause, &mut names);
+                    let Some(base) = names.first() else {
+                        continue;
+                    };
+                    let Some(resolution) = self.resolve_type_name_node(&scope_id, *base) else {
+                        continue;
+                    };
+                    let receiver = match resolution {
+                        Resolution::Local(declaration)
+                            if matches!(
+                                declaration.kind.as_str(),
+                                "class" | "interface" | "enum" | "namespace"
+                            ) =>
+                        {
+                            Some(ReceiverTarget {
+                                qualified_name: declaration.qualified_name.clone(),
+                                import: None,
+                                scope_id: self.member_scope_for_declaration(&declaration),
+                                type_arguments: None,
+                            })
+                        }
+                        Resolution::Import(import) => Some(ReceiverTarget {
+                            qualified_name: import_target_without_namespace(&import.target),
+                            import: Some(import),
+                            scope_id: None,
+                            type_arguments: None,
+                        }),
+                        _ => None,
+                    };
+                    if let Some(receiver) = receiver {
+                        self.implements_targets
+                            .entry(class_name.clone())
+                            .or_default()
+                            .push(receiver);
+                    }
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.precollect_base_targets(child, depth + 1);
+        }
+    }
+
+    fn infer_variable_types(&mut self, node: Node<'tree>, depth: usize) {
+        let mut pending = vec![(node, depth)];
+        while let Some((current, current_depth)) = pending.pop() {
+            if current_depth > MAX_TRAVERSAL_DEPTH {
+                continue;
+            }
+            if is_parameter_node(current) {
+                let scope_id = self.scope_for_node(current);
+                self.infer_parameter_nominal_type(current, &scope_id);
+                self.infer_inline_object_type_receiver(current, &scope_id);
+            }
+            if current.kind() == "variable_declarator"
+                && let Some(name_node) = current.child_by_field_name("name")
+            {
+                let scope_id = self.scope_for_node(current);
+                self.infer_variable_object_sources(current, &scope_id);
+                self.infer_variable_prototype_source(current, &scope_id);
+                self.infer_inline_object_type_receiver(current, &scope_id);
+                self.infer_destructured_variable_types(current, &scope_id);
+                if let Some(qualified_type) = self.nominal_type_for_variable(current, &scope_id) {
+                    let mut names = Vec::new();
+                    collect_pattern_names(name_node, self.source, &mut names);
+                    for (name, _) in names {
+                        if let Some(Resolution::Local(declaration)) =
+                            self.resolve_name(&scope_id, &name, Namespace::Value)
+                            && declaration.kind == "variable"
+                        {
+                            self.variable_types
+                                .insert(declaration.id, qualified_type.clone());
+                        }
+                    }
+                }
+            }
+            if matches!(
+                current.kind(),
+                "call_expression" | "optional_call_expression"
+            ) {
+                let scope_id = self.scope_for_node(current);
+                self.infer_contextual_callable_parameters(current, &scope_id);
+            }
+            let mut children = Vec::new();
+            let mut cursor = current.walk();
+            children.extend(current.named_children(&mut cursor));
+            for child in children.into_iter().rev() {
+                pending.push((child, current_depth.saturating_add(1)));
+            }
+        }
+    }
+
+    /// Propagate a source-visible callback parameter type through a call.
+    /// TypeScript commonly supplies the parameter type contextually rather
+    /// than spelling it on the callback itself (`api.use((value, ctx) => ...)`).
+    /// This pass only follows a unique local callable declaration and direct
+    /// indexed access into a local object/type alias; unresolved, imported,
+    /// union, and structural cases remain unresolved.
+    fn infer_contextual_callable_parameters(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(function) = node
+            .child_by_field_name("function")
+            .or_else(|| first_named_child_kind(node, "identifier"))
+        else {
+            return;
+        };
+        let resolution = if matches!(
+            function.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        ) {
+            let Some(property) = member_property_node(function) else {
+                return;
+            };
+            self.resolve_member_target(
+                scope_id,
+                function.child_by_field_name("object"),
+                property,
+                None,
+                &[],
+            )
+        } else {
+            let Some(target) = rightmost_identifier(function) else {
+                return;
+            };
+            self.resolve_name(scope_id, &node_text(self.source, target), Namespace::Value)
+        };
+        let Some(Resolution::Local(target)) = resolution else {
+            return;
+        };
+        let Some(parameter_types) = target.parameter_types.as_ref() else {
+            return;
+        };
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return;
+        };
+        let mut cursor = arguments.walk();
+        for (argument, parameter_type) in arguments
+            .named_children(&mut cursor)
+            .zip(parameter_types.iter())
+        {
+            let argument = unwrap_expression_node(argument);
+            if !is_callable_node(argument) {
+                continue;
+            }
+            let Some(callback_parameter_types) =
+                self.contextual_callable_parameter_types(scope_id, parameter_type)
+            else {
+                continue;
+            };
+            let Some(parameters) = argument
+                .child_by_field_name("parameters")
+                .or_else(|| first_named_child_kind(argument, "formal_parameters"))
+            else {
+                continue;
+            };
+            let callback_scope = self.scope_for_node(argument);
+            let mut parameter_cursor = parameters.walk();
+            for (parameter, type_name) in parameters
+                .named_children(&mut parameter_cursor)
+                .zip(callback_parameter_types.iter())
+            {
+                let Some(pattern) = parameter_pattern_node(parameter) else {
+                    continue;
+                };
+                let Some(ReceiverTarget {
+                    qualified_name,
+                    import: None,
+                    ..
+                }) = self.resolve_declared_type_receiver(&callback_scope, type_name)
+                else {
+                    continue;
+                };
+                let mut names = Vec::new();
+                collect_pattern_names(pattern, self.source, &mut names);
+                for (name, _) in names {
+                    if let Some(Resolution::Local(callback_parameter)) =
+                        self.resolve_name(&callback_scope, &name, Namespace::Value)
+                        && callback_parameter.kind == "parameter"
+                    {
+                        self.variable_types
+                            .insert(callback_parameter.id, qualified_name.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    fn contextual_callable_parameter_types(
+        &self,
+        scope_id: &str,
+        type_name: &str,
+    ) -> Option<Vec<String>> {
+        let (base, property) = indexed_type_parts(type_name)?;
+        let base = strip_type_arguments(base);
+        let Resolution::Local(alias) = self.resolve_name(scope_id, base, Namespace::Type)? else {
+            return None;
+        };
+        let qualified_name = format!("{}.{}", alias.qualified_name, property);
+        let ids = self.declarations_by_qualified.get(&qualified_name)?;
+        let declarations = ids
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter_map(|declaration| declaration.parameter_types.clone())
+            .collect::<Vec<_>>();
+        let [parameters] = declarations.as_slice() else {
+            return None;
+        };
+        Some(parameters.clone())
+    }
+
+    /// Record a direct nominal annotation on a parameter (`ctx: ParseContext`)
+    /// as a receiver type. This is deliberately limited to one type reference
+    /// and direct binding names; structural, conditional, and computed types
+    /// remain unresolved instead of triggering an unbounded type walk.
+    fn infer_parameter_nominal_type(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(name_node) = parameter_pattern_node(node) else {
+            return;
+        };
+        let Some(type_name) = direct_type_reference_name(node, self.source) else {
+            return;
+        };
+        let Some(resolution) = self.resolve_name(scope_id, &type_name, Namespace::Both) else {
+            return;
+        };
+        let qualified_type = resolution.qualified_target().or_else(|| {
+            self.resolve_declared_type_receiver(scope_id, &type_name)
+                .map(|receiver| receiver.qualified_name)
+        });
+        let Some(qualified_type) = qualified_type else {
+            return;
+        };
+        let mut names = Vec::new();
+        collect_pattern_names(name_node, self.source, &mut names);
+        for (name, _) in names {
+            if let Some(Resolution::Local(parameter)) =
+                self.resolve_name(scope_id, &name, Namespace::Value)
+                && parameter.kind == "parameter"
+            {
+                self.variable_types
+                    .insert(parameter.id, qualified_type.clone());
+            }
+        }
+    }
+
+    fn infer_variable_object_sources(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
+        };
+        let Some(value) = node.child_by_field_name("value") else {
+            return;
+        };
+        if !matches!(
+            value.kind(),
+            "call_expression" | "optional_call_expression" | "new_expression"
+        ) {
+            return;
+        }
+        let Some(function) = value
+            .child_by_field_name("function")
+            .or_else(|| first_named_child_kind(value, "identifier"))
+        else {
+            return;
+        };
+        let name = node_text(self.source, function);
+        if name.is_empty() {
+            return;
+        }
+        let Some(Resolution::Local(target)) = self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            return;
+        };
+        if !self
+            .return_object_functions
+            .contains(&target.qualified_name)
+        {
+            return;
+        }
+        let mut names = Vec::new();
+        collect_pattern_names(name_node, self.source, &mut names);
+        for (name, _) in names {
+            if let Some(Resolution::Local(variable)) =
+                self.resolve_name(scope_id, &name, Namespace::Value)
+                && variable.kind == "variable"
+            {
+                self.variable_object_sources
+                    .insert(variable.id, target.id.clone());
+            }
+        }
+    }
+
+    fn infer_variable_prototype_source(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
+        };
+        if name_node.kind() != "identifier" {
+            return;
+        }
+        let Some(value) = node.child_by_field_name("value") else {
+            return;
+        };
+        let Some(property) = member_property_node(value) else {
+            return;
+        };
+        if member_property_name(self.source, property).as_deref() != Some("prototype") {
+            return;
+        }
+        let Some(base) = value.child_by_field_name("object") else {
+            return;
+        };
+        let Some(base_name) = rightmost_identifier(base) else {
+            return;
+        };
+        let Some(Resolution::Local(constructor)) = self.resolve_name(
+            scope_id,
+            &node_text(self.source, base_name),
+            Namespace::Value,
+        ) else {
+            return;
+        };
+        if !matches!(constructor.kind.as_str(), "function" | "class") {
+            return;
+        }
+        let variable_name = node_text(self.source, name_node);
+        let Some(Resolution::Local(variable)) =
+            self.resolve_name(scope_id, &variable_name, Namespace::Value)
+        else {
+            return;
+        };
+        if variable.kind == "variable" {
+            self.prototype_sources.insert(
+                variable.id,
+                format!("{}.prototype", constructor.qualified_name),
+            );
+        }
+    }
+
+    fn infer_inline_object_type_receiver(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(type_node) = node
+            .child_by_field_name("type")
+            .or_else(|| first_named_child_kind(node, "type_annotation"))
+        else {
+            return;
+        };
+        let Some(name_node) = node
+            .child_by_field_name("name")
+            .or_else(|| parameter_pattern_node(node))
+        else {
+            return;
+        };
+        let Some(Resolution::Local(variable)) = self.resolve_name(
+            scope_id,
+            &node_text(self.source, name_node),
+            Namespace::Value,
+        ) else {
+            return;
+        };
+        if !matches!(variable.kind.as_str(), "variable" | "parameter") {
+            return;
+        }
+        let Some((prefix, _)) = variable.qualified_name.rsplit_once('.') else {
+            return;
+        };
+        let variable_id = variable.id.clone();
+        let Some(object_type) = inline_object_type_node(type_node) else {
+            return;
+        };
+        self.variable_inline_type_receivers
+            .insert(variable_id.clone(), prefix.to_owned());
+        let mut property_types = HashMap::new();
+        let mut property_names = Vec::new();
+        let mut cursor = object_type.walk();
+        for property in object_type
+            .named_children(&mut cursor)
+            .take(MAX_INLINE_OBJECT_PROPERTIES)
+        {
+            let Some(name) = property
+                .child_by_field_name("name")
+                .or_else(|| property.child_by_field_name("key"))
+            else {
+                continue;
+            };
+            let Some(property_name) = member_property_name(self.source, name) else {
+                continue;
+            };
+            if !property_names.contains(&property_name) {
+                property_names.push(property_name.clone());
+            }
+            let Some(type_name) = direct_type_reference_name(property, self.source) else {
+                continue;
+            };
+            property_types.insert(property_name, type_name);
+        }
+        for property_name in property_names {
+            let qualified_name = format!("{prefix}.{property_name}");
+            let candidates = self
+                .declarations_by_qualified
+                .get(&qualified_name)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.range_start_byte >= object_type.start_byte()
+                        && declaration.range_start_byte <= object_type.end_byte()
+                })
+                .collect::<Vec<_>>();
+            if let [declaration] = candidates.as_slice() {
+                self.inline_object_property_declaration_ids
+                    .insert((variable_id.clone(), property_name), declaration.id.clone());
+            }
+        }
+        if !property_types.is_empty() {
+            self.inline_object_property_types
+                .insert(variable_id, property_types);
+        }
+    }
+
+    /// Propagate one source-grounded inline-object property through the
+    /// shallow destructuring form `const { key: local } = receiver`.
+    /// Nested patterns, spreads, computed keys, and reassignment flow remain
+    /// unresolved rather than being inferred from spelling alone.
+    fn infer_destructured_variable_types(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return;
+        };
+        if name_node.kind() != "object_pattern" {
+            return;
+        }
+        let Some(value) = node.child_by_field_name("value") else {
+            return;
+        };
+        if value.kind() != "identifier" {
+            return;
+        }
+        let source_name = node_text(self.source, value);
+        let Some(Resolution::Local(source)) =
+            self.resolve_name(scope_id, &source_name, Namespace::Value)
+        else {
+            return;
+        };
+        let Some(property_types) = self.inline_object_property_types.get(&source.id).cloned()
+        else {
+            return;
+        };
+        let mut cursor = name_node.walk();
+        for pair in name_node.named_children(&mut cursor) {
+            if pair.kind() != "pair_pattern" {
+                continue;
+            }
+            let Some(key) = pair.child_by_field_name("key") else {
+                continue;
+            };
+            let Some(binding) = pair.child_by_field_name("value") else {
+                continue;
+            };
+            if binding.kind() != "identifier" {
+                continue;
+            }
+            let Some(key_name) = member_property_name(self.source, key) else {
+                continue;
+            };
+            let Some(type_name) = property_types.get(&key_name) else {
+                continue;
+            };
+            let Some(Resolution::Local(type_declaration)) =
+                self.resolve_name(scope_id, type_name, Namespace::Both)
+            else {
+                continue;
+            };
+            let binding_name = node_text(self.source, binding);
+            let Some(Resolution::Local(variable)) =
+                self.resolve_name(scope_id, &binding_name, Namespace::Value)
+            else {
+                continue;
+            };
+            if variable.kind == "variable" {
+                self.variable_types
+                    .insert(variable.id, type_declaration.qualified_name.clone());
+            }
+        }
+    }
+
+    fn nominal_type_for_variable(&self, node: Node<'tree>, scope_id: &str) -> Option<String> {
+        let type_node = node.child_by_field_name("type").or_else(|| {
+            node.child_by_field_name("name")
+                .and_then(|name| name.child_by_field_name("type"))
+        });
+        if let Some(type_node) = type_node {
+            let mut type_names = Vec::new();
+            collect_type_name_nodes(type_node, &mut type_names);
+            if let Some(name_node) = rightmost_identifier(type_node) {
+                type_names.push(name_node);
+            }
+            for name_node in type_names {
+                if let Some(resolution) = self.resolve_name(
+                    scope_id,
+                    &node_text(self.source, name_node),
+                    Namespace::Both,
+                ) && let Some(qualified) = resolution.qualified_target()
+                {
+                    return Some(qualified);
+                }
+            }
+        }
+        let mut value = node.child_by_field_name("value")?;
+        loop {
+            if matches!(value.kind(), "as_expression" | "satisfies_expression")
+                && let Some(inner) = value.child_by_field_name("expression")
+            {
+                value = inner;
+                continue;
+            }
+            if value.kind() == "parenthesized_expression"
+                && let Some(inner) = value
+                    .child_by_field_name("expression")
+                    .or_else(|| first_named_child(value))
+            {
+                value = inner;
+                continue;
+            }
+            if matches!(value.kind(), "binary_expression" | "logical_expression")
+                && node_text(self.source, value).len() <= MAX_TYPE_SHAPE_BYTES
+                && (node_text(self.source, value).contains("||")
+                    || node_text(self.source, value).contains("??"))
+                && let Some(inner) = value.child_by_field_name("left")
+            {
+                value = inner;
+                continue;
+            }
+            break;
+        }
+        if value.kind() == "assignment_expression"
+            && let Some(inner) = value.child_by_field_name("right")
+        {
+            value = inner;
+        }
+        if matches!(value.kind(), "call_expression" | "optional_call_expression")
+            && let Some(receiver) = self.call_return_receiver(scope_id, value)
+        {
+            return Some(receiver.qualified_name);
+        }
+        if matches!(value.kind(), "call_expression" | "optional_call_expression")
+            && let Some(function) = value
+                .child_by_field_name("function")
+                .or_else(|| first_named_child_kind(value, "identifier"))
+            && let Some(name_node) = rightmost_identifier(function)
+            && let Some(Resolution::Local(target)) = self.resolve_name(
+                scope_id,
+                &node_text(self.source, name_node),
+                Namespace::Value,
+            )
+            && let Some(return_type_name) = target.return_type_name.as_deref()
+            && let Some(Resolution::Local(return_type)) =
+                self.resolve_name(scope_id, return_type_name, Namespace::Both)
+            && let Some(qualified) = Resolution::Local(return_type).qualified_target()
+        {
+            return Some(qualified);
+        }
+        if matches!(
+            value.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        ) && let Some(property) = member_property_node(value)
+            && let Some(receiver_node) = value.child_by_field_name("object")
+            && let Some(receiver) = self.receiver_target(scope_id, receiver_node)
+            && let Some(Resolution::Local(declaration)) =
+                self.resolve_member_target(scope_id, Some(receiver_node), property, None, &[])
+            && let Some(typed_receiver) =
+                self.member_value_receiver(scope_id, &receiver, &declaration)
+        {
+            return Some(typed_receiver.qualified_name);
+        }
+        if value.kind() == "subscript_expression"
+            && let Some(receiver) = self.receiver_target(scope_id, value)
+        {
+            return Some(receiver.qualified_name);
+        }
+        value = unwrap_expression_node(value);
+        if value.kind() == "subscript_expression"
+            && let Some(receiver) = self.receiver_target(scope_id, value)
+        {
+            return Some(receiver.qualified_name);
+        }
+        if value.kind() == "this" {
+            return self.enclosing_type(scope_id);
+        }
+        if value.kind() == "object"
+            && let Some(name_node) = node.child_by_field_name("name")
+            && name_node.kind() == "identifier"
+            && let Some(Resolution::Local(declaration)) = self.resolve_name(
+                scope_id,
+                &node_text(self.source, name_node),
+                Namespace::Value,
+            )
+            && declaration.kind == "variable"
+        {
+            // Object-literal properties are collected below the variable's
+            // qualified identity (for example `config.legacyAgreements`).
+            // Treat the variable as a nominal structural receiver so exact
+            // same-file property declarations can be targeted without
+            // pretending that an arbitrary object has a class type.
+            return Some(declaration.qualified_name);
+        }
+        if value.kind() != "new_expression" {
+            return None;
+        }
+        let constructor = value
+            .child_by_field_name("constructor")
+            .or_else(|| first_named_child(value))?;
+        if node_text(self.source, constructor) == "this" {
+            return self.enclosing_type(scope_id);
+        }
+        let name_node = rightmost_identifier(constructor)?;
+        let resolution = self.resolve_name(
+            scope_id,
+            &node_text(self.source, name_node),
+            Namespace::Both,
+        )?;
+        match &resolution {
+            Resolution::Local(declaration) if declaration.kind == "function" => {
+                Some(declaration.qualified_name.clone())
+            }
+            _ => resolution.qualified_target(),
+        }
+    }
+
+    fn emit_nodes(&mut self, node: Node<'tree>, depth: usize) -> Result<(), EvidenceError> {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            return Ok(());
+        }
+        let scope_id = self.scope_for_node(node);
+        match node.kind() {
+            "import_statement" => {
+                if !self.import_nodes.contains(&node.start_byte()) {
+                    self.emit_import(node, &scope_id, false)?;
+                }
+                return Ok(());
+            }
+            "export_statement" => {
+                if first_named_child_kind(node, "string").is_some() {
+                    if !self.import_nodes.contains(&node.start_byte()) {
+                        self.emit_export(node, &scope_id)?;
+                    }
+                    return Ok(());
+                }
+                self.emit_export(node, &scope_id)?;
+                if first_named_child_kind(node, "export_clause").is_some() {
+                    // The clause was consumed as a single source construct;
+                    // still walk a declaration attached to the export.
+                    let mut cursor = node.walk();
+                    for child in node.named_children(&mut cursor) {
+                        if child.kind() != "export_clause" {
+                            self.emit_nodes(child, depth + 1)?;
+                        }
+                    }
+                    return Ok(());
+                }
+            }
+            "call_expression" | "optional_call_expression" => {
+                self.emit_call(node, &scope_id, false)?;
+                self.emit_dynamic_import(node, &scope_id)?;
+            }
+            "new_expression" => self.emit_call(node, &scope_id, true)?,
+            "member_expression" | "optional_member_expression" | "subscript_expression" => {
+                self.emit_member(node, &scope_id)?;
+            }
+            "jsx_opening_element" | "jsx_self_closing_element" => {
+                self.emit_jsx(node, &scope_id)?;
+            }
+            "decorator" => self.emit_decorator(node, &scope_id)?,
+            "class_heritage" if self.language == "javascript" => {
+                self.emit_bases(node, &scope_id)?;
+            }
+            "extends_clause" | "extends_type_clause" | "implements_clause" => {
+                self.emit_bases(node, &scope_id)?;
+            }
+            "assignment_expression" => self.emit_commonjs_export(node, &scope_id)?,
+            "variable_declarator" => self.emit_require_declarator(node, &scope_id)?,
+            "type_identifier" | "nested_type_identifier" => {
+                if is_type_reference_node(node) {
+                    self.emit_type_reference(node, &scope_id)?;
+                }
+            }
+            "identifier" => {
+                self.emit_callable_reference(node, &scope_id)?;
+            }
+            _ => {}
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if self.import_nodes.contains(&child.start_byte()) {
+                continue;
+            }
+            self.emit_nodes(child, depth + 1)?;
+        }
+        Ok(())
+    }
+
+    fn enter_lexical_scope(
+        &mut self,
+        node: Node<'tree>,
+        parent_scope: String,
+    ) -> Result<String, EvidenceError> {
+        let Some(kind) = lexical_scope_kind(node) else {
+            return Ok(parent_scope);
+        };
+        if let Some(scope) = self.scope_by_node.get(&node.id()) {
+            return Ok(scope.clone());
+        }
+        let owner = self.owner_for_scope(&parent_scope);
+        let scope = self.builder.open_scope(
+            kind,
+            Some(&owner),
+            Some(&parent_scope),
+            range_for_node(self.source_file, node),
+        )?;
+        self.scope_by_node.insert(node.id(), scope.clone());
+        self.scope_parents.insert(scope.clone(), Some(parent_scope));
+        self.scope_owners.insert(scope.clone(), owner);
+        self.scope_kinds.insert(scope.clone(), kind.to_owned());
+        Ok(scope)
+    }
+
+    fn prototype_assignment_receiver(
+        &self,
+        function: Node<'tree>,
+        scope_id: &str,
+    ) -> Option<String> {
+        let mut parent = function.parent();
+        while let Some(candidate) = parent {
+            if candidate.kind() == "parenthesized_expression" {
+                parent = candidate.parent();
+                continue;
+            }
+            if candidate.kind() != "assignment_expression"
+                || candidate
+                    .child_by_field_name("right")
+                    .is_none_or(|right| right.id() != function.id())
+            {
+                return None;
+            }
+            let left = candidate.child_by_field_name("left")?;
+            let prototype = left.child_by_field_name("object")?;
+            if let Some(property) = member_property_node(prototype)
+                && member_property_name(self.source, property).as_deref() == Some("prototype")
+                && let Some(base) = prototype.child_by_field_name("object")
+                && let Some(name) = rightmost_identifier(base)
+                && let Some(Resolution::Local(declaration)) =
+                    self.resolve_name(scope_id, &node_text(self.source, name), Namespace::Value)
+            {
+                return match declaration.kind.as_str() {
+                    "class" | "interface" | "enum" | "namespace" => {
+                        Some(declaration.qualified_name)
+                    }
+                    // A function expression assigned to `Ctor.prototype.name`
+                    // receives an instance `this` whose source-backed receiver is
+                    // the explicit prototype namespace. This keeps `this.member`
+                    // and `new Ctor().member` on the same declaration identity.
+                    "function" => Some(format!("{}.prototype", declaration.qualified_name)),
+                    _ => None,
+                };
+            }
+            if prototype.kind() == "identifier"
+                && let Some(Resolution::Local(variable)) = self.resolve_name(
+                    scope_id,
+                    &node_text(self.source, prototype),
+                    Namespace::Value,
+                )
+                && let Some(source) = self.prototype_sources.get(&variable.id)
+            {
+                return Some(source.clone());
+            }
+            return None;
+        }
+        None
+    }
+
+    fn is_function_prototype_receiver(&self, scope_id: &str, object: Node<'tree>) -> bool {
+        let Some(property) = member_property_node(object) else {
+            return false;
+        };
+        if member_property_name(self.source, property).as_deref() != Some("prototype") {
+            return false;
+        }
+        let Some(base) = object.child_by_field_name("object") else {
+            return false;
+        };
+        let Some(name) = rightmost_identifier(base) else {
+            return false;
+        };
+        matches!(
+            self.resolve_name(scope_id, &node_text(self.source, name), Namespace::Value),
+            Some(Resolution::Local(declaration)) if declaration.kind == "function"
+        )
+    }
+
+    fn binding_scope_for(&self, node: Node<'tree>, scope_id: &str) -> String {
+        if !is_var_binding_node(node) {
+            return scope_id.to_owned();
+        }
+        let mut current = scope_id.to_owned();
+        loop {
+            if self
+                .scope_kinds
+                .get(&current)
+                .is_some_and(|kind| matches!(kind.as_str(), "function" | "module"))
+            {
+                return current;
+            }
+            let Some(parent) = self.scope_parents.get(&current).cloned().flatten() else {
+                return current;
+            };
+            current = parent;
+        }
+    }
+
+    fn scope_for_node(&self, node: Node<'tree>) -> String {
+        let mut current = Some(node);
+        while let Some(candidate) = current {
+            if let Some(scope) = self.scope_by_node.get(&candidate.id()) {
+                return scope.clone();
+            }
+            current = candidate.parent();
+        }
+        self.root_scope.clone()
+    }
+
+    fn infer_binding_scope(&self, node: Node<'tree>, fallback: &str) -> String {
+        let mut current = node.parent();
+        while let Some(candidate) = current {
+            if candidate.kind() == "conditional_type"
+                && let Some(scope) = self.scope_by_node.get(&candidate.id())
+            {
+                return scope.clone();
+            }
+            current = candidate.parent();
+        }
+        fallback.to_owned()
+    }
+
+    fn owner_for_scope(&self, scope_id: &str) -> String {
+        self.scope_owners
+            .get(scope_id)
+            .cloned()
+            .unwrap_or_else(|| self.file_declaration.clone())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_declaration_resolution(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        relation: CandidateRelation,
+        role: SemanticRole,
+        spelling: &str,
+        qualifier: Option<&str>,
+        context: Option<&str>,
+        _namespace: Namespace,
+        resolution: Resolution,
+        allowed_kinds: &[&str],
+    ) -> Result<(), EvidenceError> {
+        self.add_declaration_resolution_with_arguments(
+            node,
+            scope_id,
+            relation,
+            role,
+            spelling,
+            qualifier,
+            context,
+            _namespace,
+            None,
+            Vec::new(),
+            resolution,
+            allowed_kinds,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_declaration_resolution_with_arguments(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        relation: CandidateRelation,
+        role: SemanticRole,
+        spelling: &str,
+        qualifier: Option<&str>,
+        context: Option<&str>,
+        _namespace: Namespace,
+        argument_count: Option<u32>,
+        argument_types: Vec<Option<String>>,
+        resolution: Resolution,
+        allowed_kinds: &[&str],
+    ) -> Result<(), EvidenceError> {
+        let owner = self.owner_for_scope(scope_id);
+        let key = fact_key(role, node, context);
+        if !self.emitted_facts.insert(key) {
+            return Ok(());
+        }
+        let (binding_id, exact_target, qualified_name, module, target_kind) = match resolution {
+            Resolution::Local(declaration) => (
+                None,
+                Some(declaration.id),
+                Some(declaration.qualified_name),
+                Some(self.source_file.to_owned()),
+                declaration.kind,
+            ),
+            Resolution::Import(import) => (
+                Some(import.binding_id),
+                None,
+                Some(import.target),
+                Some(import.module),
+                "external".to_owned(),
+            ),
+        };
+        let occurrence_id = self.builder.occur_with_context(
+            role,
+            &owner,
+            spelling,
+            qualifier,
+            Some(scope_id),
+            context,
+            range_for_node(self.source_file, node),
+        )?;
+        let mut constraints = ResolutionConstraint {
+            exact_target_declaration_id: exact_target,
+            exact_language: Some(self.language.to_owned()),
+            module_or_package: module,
+            scope_id: Some(scope_id.to_owned()),
+            qualified_name,
+            argument_count,
+            argument_types,
+            allowed_target_kinds: allowed_kinds
+                .iter()
+                .map(|kind| (*kind).to_owned())
+                .collect(),
+            allow_external: target_kind == "external",
+            ..ResolutionConstraint::default()
+        };
+        if relation == CandidateRelation::Extends {
+            constraints.hierarchy = Some(HierarchyConstraint::DirectBase {
+                base_set_complete: true,
+            });
+        }
+        self.builder.relate(
+            relation,
+            &owner,
+            Some(&occurrence_id),
+            binding_id.as_deref(),
+            spelling,
+            constraints,
+        )?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_external_resolution_candidate(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        relation: CandidateRelation,
+        role: SemanticRole,
+        spelling: &str,
+        qualifier: Option<&str>,
+        context: &str,
+        target: &str,
+        module: &str,
+        argument_count: Option<u32>,
+        argument_types: Vec<Option<String>>,
+        allowed_kinds: &[&str],
+    ) -> Result<(), EvidenceError> {
+        let owner = self.owner_for_scope(scope_id);
+        if !self
+            .emitted_facts
+            .insert(fact_key(role, node, Some(context)))
+        {
+            return Ok(());
+        }
+        let occurrence_id = self.builder.occur_with_context(
+            role,
+            &owner,
+            spelling,
+            qualifier,
+            Some(scope_id),
+            Some(context),
+            range_for_node(self.source_file, node),
+        )?;
+        self.builder.relate(
+            relation,
+            &owner,
+            Some(&occurrence_id),
+            None,
+            spelling,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module.to_owned()),
+                qualified_name: Some(target.to_owned()),
+                argument_count,
+                argument_types,
+                allowed_target_kinds: allowed_kinds
+                    .iter()
+                    .map(|kind| (*kind).to_owned())
+                    .collect(),
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Preserve an exact source occurrence when the local extractor cannot
+    /// prove a target.  This is intentionally a target-less candidate: the
+    /// shared resolver may use later project evidence, but it cannot turn the
+    /// spelling into an external node or choose a same-named declaration by
+    /// terminal-name fallback.  Keeping the occurrence lets qualification
+    /// distinguish "observed but unresolved" from "silently dropped".
+    #[allow(clippy::too_many_arguments)]
+    fn add_unresolved_candidate(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        relation: CandidateRelation,
+        role: SemanticRole,
+        spelling: &str,
+        qualifier: Option<&str>,
+        context: &str,
+        argument_count: Option<u32>,
+        argument_types: Vec<Option<String>>,
+        allowed_kinds: &[&str],
+        hierarchy: Option<HierarchyConstraint>,
+    ) -> Result<(), EvidenceError> {
+        let owner = self.owner_for_scope(scope_id);
+        if !self
+            .emitted_facts
+            .insert(fact_key(role, node, Some(context)))
+        {
+            return Ok(());
+        }
+        let occurrence_id = self.builder.occur_with_context(
+            role,
+            &owner,
+            spelling,
+            qualifier,
+            Some(scope_id),
+            Some(context),
+            range_for_node(self.source_file, node),
+        )?;
+        self.builder.relate(
+            relation,
+            &owner,
+            Some(&occurrence_id),
+            None,
+            spelling,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                argument_count,
+                argument_types,
+                allowed_target_kinds: allowed_kinds
+                    .iter()
+                    .map(|kind| (*kind).to_owned())
+                    .collect(),
+                hierarchy,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn is_unshadowed_builtin(&self, scope_id: &str, name: &str) -> bool {
+        crate::builtins::is_language_builtin_global(self.language, name)
+            && self.is_unshadowed_name(scope_id, name)
+    }
+
+    fn is_unshadowed_name(&self, scope_id: &str, name: &str) -> bool {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if self
+                .import_bindings
+                .contains_key(&(scope.clone(), name.to_owned()))
+                || self
+                    .declarations_by_scope
+                    .get(&scope)
+                    .into_iter()
+                    .flat_map(|ids| ids.iter())
+                    .filter_map(|id| self.declarations.get(id))
+                    .any(|declaration| declaration.name == name)
+            {
+                return false;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        true
+    }
+
+    fn builtin_global_target(&self, scope_id: &str, name: &str) -> Option<(String, String)> {
+        self.is_unshadowed_builtin(scope_id, name)
+            .then(|| (format!("global::{name}"), "javascript.global".to_owned()))
+    }
+
+    fn builtin_receiver_name(&self, scope_id: &str, object: Node<'tree>) -> Option<String> {
+        match object.kind() {
+            "identifier" | "type_identifier" | "jsx_identifier" => {
+                let name = node_text(self.source, object);
+                self.is_unshadowed_builtin(scope_id, &name).then_some(name)
+            }
+            "new_expression" => {
+                let constructor = object
+                    .child_by_field_name("constructor")
+                    .or_else(|| first_named_child(object))?;
+                let name = rightmost_identifier(constructor)?;
+                let spelling = node_text(self.source, name);
+                self.is_unshadowed_builtin(scope_id, &spelling)
+                    .then_some(spelling)
+            }
+            _ => None,
+        }
+    }
+
+    fn builtin_member_target(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        property_name: &str,
+    ) -> Option<(String, String)> {
+        let receiver = self.builtin_receiver_name(scope_id, object)?;
+        let known = if object.kind() == "new_expression" {
+            known_builtin_instance_member(&receiver, property_name)
+        } else {
+            known_builtin_static_member(&receiver, property_name)
+        };
+        if !known {
+            return None;
+        }
+        Some((
+            format!("global::{receiver}.{property_name}"),
+            "javascript.global".to_owned(),
+        ))
+    }
+
+    fn builtin_type_target(&self, scope_id: &str, name: &str) -> Option<(String, String)> {
+        if !self.is_unshadowed_name(scope_id, name) {
+            return None;
+        }
+        if crate::builtins::is_language_builtin_global(self.language, name) {
+            return Some((format!("global::{name}"), "javascript.global".to_owned()));
+        }
+        is_typescript_utility_type(name)
+            .then(|| {
+                (
+                    format!("typescript.lib::{name}"),
+                    "typescript.lib".to_owned(),
+                )
+            })
+            .or_else(|| standard_library_type_target(name))
+    }
+
+    fn ambient_qualified_type_target(
+        &self,
+        scope_id: &str,
+        spelling: &str,
+    ) -> Option<(String, String)> {
+        let namespace = spelling.split('.').next()?;
+        if !self.is_unshadowed_name(scope_id, namespace) {
+            return None;
+        }
+        let module = match namespace {
+            "React" | "JSX" => "@types/react",
+            "NodeJS" => "@types/node",
+            _ => return None,
+        };
+        Some((format!("{module}::{spelling}"), module.to_owned()))
+    }
+
+    fn emit_import(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        reexport: bool,
+    ) -> Result<(), EvidenceError> {
+        if !reexport
+            && let Some(require_clause) = first_named_child_kind(node, "import_require_clause")
+        {
+            return self.emit_import_equals(node, scope_id, require_clause);
+        }
+        let Some(module_node) = first_named_child_kind(node, "string") else {
+            return Ok(());
+        };
+        let module = string_literal(self.source, module_node);
+        if module.is_empty() {
+            return Ok(());
+        }
+        self.import_nodes.insert(node.start_byte());
+        let statement_text = node_text(self.source, node);
+        let type_only = statement_text.trim_start().starts_with(if reexport {
+            "export type"
+        } else {
+            "import type"
+        });
+        let mut bindings = Vec::new();
+        if let Some(clause) = first_named_child_kind(
+            node,
+            if reexport {
+                "export_clause"
+            } else {
+                "import_clause"
+            },
+        ) {
+            collect_import_bindings(self.source, clause, reexport, type_only, &mut bindings);
+        }
+        let owner = self.owner_for_scope(scope_id);
+        let module_occurrence = self.builder.occur_with_context(
+            if reexport {
+                SemanticRole::Reexport
+            } else {
+                SemanticRole::Import
+            },
+            &owner,
+            &module,
+            None,
+            Some(scope_id),
+            Some(if type_only {
+                "type_only_module"
+            } else {
+                "module"
+            }),
+            range_for_node(self.source_file, module_node),
+        )?;
+        self.builder.relate(
+            if reexport {
+                CandidateRelation::Reexports
+            } else {
+                CandidateRelation::Imports
+            },
+            &owner,
+            Some(&module_occurrence),
+            None,
+            &module,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module.clone()),
+                allowed_target_kinds: vec!["module".to_owned()],
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        if bindings.is_empty() {
+            return Ok(());
+        }
+        for binding in bindings {
+            let target = format!("{}::{}", module, binding.imported_name);
+            let kind = if reexport {
+                BindingKind::Reexport
+            } else if binding.local_name == binding.imported_name {
+                BindingKind::Import
+            } else {
+                BindingKind::ImportAlias
+            };
+            let namespace = import_namespace(&binding);
+            let binding_id = self.builder.bind_with_identity(
+                kind,
+                &binding.local_name,
+                &target,
+                None,
+                Some(scope_id),
+                Some(symbol_namespace(namespace)),
+                binding.type_only,
+                range_for_node(self.source_file, binding.anchor),
+            )?;
+            if !reexport {
+                self.import_bindings.insert(
+                    (scope_id.to_owned(), binding.local_name.clone()),
+                    ImportInfo {
+                        binding_id: binding_id.clone(),
+                        target: target.clone(),
+                        module: module.clone(),
+                        imported_name: binding.imported_name.clone(),
+                        namespace,
+                        type_only: binding.type_only,
+                    },
+                );
+            }
+            let owner = self.owner_for_scope(scope_id);
+            let occurrence_id = self.builder.occur_with_context(
+                if reexport {
+                    SemanticRole::Reexport
+                } else {
+                    SemanticRole::Import
+                },
+                &owner,
+                &binding.local_name,
+                None,
+                Some(scope_id),
+                Some(if binding.type_only {
+                    "type_only"
+                } else {
+                    "binding"
+                }),
+                range_for_node(self.source_file, binding.anchor),
+            )?;
+            self.builder.relate(
+                if reexport {
+                    CandidateRelation::Reexports
+                } else {
+                    CandidateRelation::Imports
+                },
+                &owner,
+                Some(&occurrence_id),
+                Some(&binding_id),
+                &binding.local_name,
+                ResolutionConstraint {
+                    exact_language: Some(self.language.to_owned()),
+                    module_or_package: Some(module.clone()),
+                    qualified_name: Some(target),
+                    allowed_target_kinds: vec![
+                        "module".to_owned(),
+                        "function".to_owned(),
+                        "class".to_owned(),
+                        "interface".to_owned(),
+                        "type_alias".to_owned(),
+                        "variable".to_owned(),
+                    ],
+                    allow_external: true,
+                    ..ResolutionConstraint::default()
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn emit_import_equals(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        clause: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let Some(module_node) = clause
+            .child_by_field_name("source")
+            .or_else(|| first_named_child_kind(clause, "string"))
+        else {
+            return Ok(());
+        };
+        let module = string_literal(self.source, module_node);
+        if module.is_empty() {
+            return Ok(());
+        }
+        self.import_nodes.insert(node.start_byte());
+        let owner = self.owner_for_scope(scope_id);
+        let module_occurrence = self.builder.occur_with_context(
+            SemanticRole::Import,
+            &owner,
+            &module,
+            None,
+            Some(scope_id),
+            Some("import_equals_module"),
+            range_for_node(self.source_file, module_node),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Imports,
+            &owner,
+            Some(&module_occurrence),
+            None,
+            &module,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module.clone()),
+                allowed_target_kinds: vec!["module".to_owned()],
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+
+        let Some(local_node) = first_identifier_node(clause) else {
+            return Ok(());
+        };
+        let local_name = node_text(self.source, local_node);
+        if local_name.is_empty() {
+            return Ok(());
+        }
+        let target = format!("{module}::*");
+        let binding_id = self.builder.bind_with_identity(
+            BindingKind::Import,
+            &local_name,
+            &target,
+            None,
+            Some(scope_id),
+            Some(SymbolNamespace::ValueAndType),
+            false,
+            range_for_node(self.source_file, local_node),
+        )?;
+        self.import_bindings.insert(
+            (scope_id.to_owned(), local_name.clone()),
+            ImportInfo {
+                binding_id: binding_id.clone(),
+                target: target.clone(),
+                module: module.clone(),
+                imported_name: "*".to_owned(),
+                namespace: Namespace::Both,
+                type_only: false,
+            },
+        );
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Import,
+            &owner,
+            &local_name,
+            None,
+            Some(scope_id),
+            Some("import_equals"),
+            range_for_node(self.source_file, local_node),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Imports,
+            &owner,
+            Some(&occurrence_id),
+            Some(&binding_id),
+            &local_name,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module),
+                qualified_name: Some(target),
+                allowed_target_kinds: vec![
+                    "module".to_owned(),
+                    "function".to_owned(),
+                    "class".to_owned(),
+                    "interface".to_owned(),
+                    "type_alias".to_owned(),
+                    "variable".to_owned(),
+                    "external".to_owned(),
+                ],
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn emit_export(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
+        let Some(module_node) = first_named_child_kind(node, "string") else {
+            if let Some(clause) = first_named_child_kind(node, "export_clause") {
+                self.emit_local_export_clause(clause, scope_id)?;
+            } else {
+                self.emit_default_export(node, scope_id)?;
+            }
+            return Ok(());
+        };
+        let module = string_literal(self.source, module_node);
+        if module.is_empty() {
+            return Ok(());
+        }
+        self.emit_import(node, scope_id, true)
+    }
+
+    fn emit_default_export(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(exported) = first_named_child(node) else {
+            return Ok(());
+        };
+        let (spelling, anchor) = if let Some(target_node) = default_export_target_node(node) {
+            (node_text(self.source, target_node), target_node)
+        } else if anonymous_declaration_shape(exported).is_some() {
+            ("default".to_owned(), exported)
+        } else {
+            return Ok(());
+        };
+        if spelling.is_empty() {
+            return Ok(());
+        }
+        let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Both) else {
+            return Ok(());
+        };
+        let (target, target_declaration_id, namespace) = match resolution {
+            Resolution::Local(declaration) => (
+                declaration.qualified_name,
+                Some(declaration.id),
+                declaration.namespace,
+            ),
+            Resolution::Import(import) => (import.target, None, import.namespace),
+        };
+        let owner = self.owner_for_scope(scope_id);
+        let binding_id = self.builder.bind_with_identity(
+            BindingKind::Reexport,
+            "default",
+            &target,
+            target_declaration_id.as_deref(),
+            Some(scope_id),
+            Some(symbol_namespace(namespace)),
+            false,
+            range_for_node(self.source_file, anchor),
+        )?;
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Reexport,
+            &owner,
+            "default",
+            Some(&spelling),
+            Some(scope_id),
+            Some("default"),
+            range_for_node(self.source_file, anchor),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Reexports,
+            &owner,
+            Some(&occurrence_id),
+            Some(&binding_id),
+            "default",
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                qualified_name: Some(target),
+                allowed_target_kinds: vec![
+                    "function".to_owned(),
+                    "class".to_owned(),
+                    "variable".to_owned(),
+                    "interface".to_owned(),
+                    "type_alias".to_owned(),
+                    "enum".to_owned(),
+                ],
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn emit_local_export_clause(
+        &mut self,
+        clause: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let mut specifiers = Vec::new();
+        collect_nodes_of_kind(clause, "export_specifier", &mut specifiers);
+        for specifier in specifiers {
+            let identifiers = direct_identifier_children(specifier, self.source);
+            let Some(local) = identifiers.first() else {
+                continue;
+            };
+            let exported = identifiers.get(1).copied().unwrap_or(*local);
+            let name = node_text(self.source, *local);
+            let exported_name = node_text(self.source, exported);
+            let type_only = node_text(self.source, specifier)
+                .trim_start()
+                .starts_with("type ");
+            let Some(resolution) = self.resolve_name(scope_id, &name, Namespace::Both) else {
+                continue;
+            };
+            let owner = self.owner_for_scope(scope_id);
+            let (target, target_declaration_id, namespace, imported_type_only) =
+                match resolution.clone() {
+                    Resolution::Local(declaration) => (
+                        declaration.qualified_name,
+                        Some(declaration.id),
+                        declaration.namespace,
+                        false,
+                    ),
+                    Resolution::Import(import) => {
+                        (import.target, None, import.namespace, import.type_only)
+                    }
+                };
+            let type_only = type_only || imported_type_only;
+            let namespace = if type_only {
+                if namespace == Namespace::Module {
+                    Namespace::Module
+                } else {
+                    Namespace::Type
+                }
+            } else {
+                namespace
+            };
+            let binding_id = self.builder.bind_with_identity(
+                BindingKind::Reexport,
+                &exported_name,
+                &target,
+                target_declaration_id.as_deref(),
+                Some(scope_id),
+                Some(symbol_namespace(namespace)),
+                type_only,
+                range_for_node(self.source_file, exported),
+            )?;
+            let occurrence_id = self.builder.occur_with_context(
+                SemanticRole::Reexport,
+                &owner,
+                &exported_name,
+                Some(&name),
+                Some(scope_id),
+                Some("local"),
+                range_for_node(self.source_file, exported),
+            )?;
+            self.builder.relate(
+                CandidateRelation::Reexports,
+                &owner,
+                Some(&occurrence_id),
+                Some(&binding_id),
+                &exported_name,
+                ResolutionConstraint {
+                    exact_language: Some(self.language.to_owned()),
+                    qualified_name: Some(target),
+                    allowed_target_kinds: vec![
+                        "function".to_owned(),
+                        "class".to_owned(),
+                        "variable".to_owned(),
+                        "type_alias".to_owned(),
+                        "interface".to_owned(),
+                    ],
+                    ..ResolutionConstraint::default()
+                },
+            )?;
+        }
+        Ok(())
+    }
+
+    fn emit_call(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        construction: bool,
+    ) -> Result<(), EvidenceError> {
+        let Some(function) = node
+            .child_by_field_name("function")
+            .or_else(|| node.child_by_field_name("constructor"))
+        else {
+            return Ok(());
+        };
+        let argument_types = self.call_argument_types(node, scope_id);
+        let argument_count = call_argument_count(node);
+        let member_call = matches!(
+            function.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        );
+        if member_call {
+            let Some(property) = member_property_node(function) else {
+                // A computed/dynamic member call is still a real call
+                // occurrence. Preserve its exact callee range, but do not
+                // invent a property target from a runtime key.
+                let spelling = node_text(self.source, function);
+                if spelling.is_empty() {
+                    return Ok(());
+                }
+                let qualifier = function
+                    .child_by_field_name("object")
+                    .map(|object| node_text(self.source, object));
+                return self.add_unresolved_candidate(
+                    function,
+                    scope_id,
+                    if construction {
+                        CandidateRelation::Constructs
+                    } else {
+                        CandidateRelation::Calls
+                    },
+                    if construction {
+                        SemanticRole::Construction
+                    } else {
+                        SemanticRole::Call
+                    },
+                    &spelling,
+                    qualifier.as_deref(),
+                    if construction {
+                        "dynamic_new_member"
+                    } else {
+                        "dynamic_member_call"
+                    },
+                    argument_count,
+                    argument_types,
+                    &[
+                        "function",
+                        "method",
+                        "constructor",
+                        "class",
+                        "variable",
+                        "property",
+                        "external",
+                    ],
+                    None,
+                );
+            };
+            let Some(property_name) = member_property_name(self.source, property) else {
+                // A computed key such as `receiver[key]()` has a property
+                // syntax node, but no source-proven property name. Preserve
+                // the whole dynamic callee just as for a missing property
+                // field above.
+                let spelling = node_text(self.source, function);
+                if spelling.is_empty() {
+                    return Ok(());
+                }
+                let qualifier = function
+                    .child_by_field_name("object")
+                    .map(|object| node_text(self.source, object));
+                return self.add_unresolved_candidate(
+                    function,
+                    scope_id,
+                    if construction {
+                        CandidateRelation::Constructs
+                    } else {
+                        CandidateRelation::Calls
+                    },
+                    if construction {
+                        SemanticRole::Construction
+                    } else {
+                        SemanticRole::Call
+                    },
+                    &spelling,
+                    qualifier.as_deref(),
+                    if construction {
+                        "dynamic_new_member"
+                    } else {
+                        "dynamic_member_call"
+                    },
+                    argument_count,
+                    argument_types,
+                    &[
+                        "function",
+                        "method",
+                        "constructor",
+                        "class",
+                        "variable",
+                        "property",
+                        "external",
+                    ],
+                    None,
+                );
+            };
+            let object = function.child_by_field_name("object");
+            let resolution = self.resolve_member_target(
+                scope_id,
+                object,
+                property,
+                call_argument_count(node),
+                &argument_types,
+            );
+            let Some(resolution) = resolution else {
+                if let Some(object) = object
+                    && let Some((target, module)) =
+                        self.builtin_member_target(scope_id, object, &property_name)
+                {
+                    return self.add_external_resolution_candidate(
+                        property,
+                        scope_id,
+                        if construction {
+                            CandidateRelation::Constructs
+                        } else {
+                            CandidateRelation::Calls
+                        },
+                        if construction {
+                            SemanticRole::Construction
+                        } else {
+                            SemanticRole::Call
+                        },
+                        &property_name,
+                        Some(&node_text(self.source, function)),
+                        if construction {
+                            "new_member"
+                        } else {
+                            "member_call"
+                        },
+                        &target,
+                        &module,
+                        argument_count,
+                        argument_types,
+                        &[
+                            "function",
+                            "method",
+                            "constructor",
+                            "class",
+                            "variable",
+                            "property",
+                            "external",
+                        ],
+                    );
+                }
+                // A dynamic receiver, proxy, or ambiguous member is not a
+                // safe call target. Preserve its source occurrence as
+                // unresolved rather than falling back to an unrelated
+                // top-level function with the same spelling.
+                return self.add_unresolved_candidate(
+                    property,
+                    scope_id,
+                    if construction {
+                        CandidateRelation::Constructs
+                    } else {
+                        CandidateRelation::Calls
+                    },
+                    if construction {
+                        SemanticRole::Construction
+                    } else {
+                        SemanticRole::Call
+                    },
+                    &property_name,
+                    Some(&node_text(self.source, function)),
+                    if construction {
+                        "new_member"
+                    } else {
+                        "member_call"
+                    },
+                    argument_count,
+                    argument_types,
+                    &[
+                        "function",
+                        "method",
+                        "constructor",
+                        "class",
+                        "variable",
+                        "property",
+                        "external",
+                    ],
+                    None,
+                );
+            };
+            return self.add_declaration_resolution_with_arguments(
+                property,
+                scope_id,
+                if construction {
+                    CandidateRelation::Constructs
+                } else {
+                    CandidateRelation::Calls
+                },
+                if construction {
+                    SemanticRole::Construction
+                } else {
+                    SemanticRole::Call
+                },
+                &property_name,
+                Some(&node_text(self.source, function)),
+                Some(if construction {
+                    "new_member"
+                } else {
+                    "member_call"
+                }),
+                Namespace::Value,
+                argument_count,
+                argument_types,
+                resolution,
+                &[
+                    "function",
+                    "method",
+                    "constructor",
+                    "class",
+                    "variable",
+                    "parameter",
+                    "property",
+                    "external",
+                ],
+            );
+        }
+        // The callee node itself is the source oracle's target anchor for
+        // direct identifiers and dynamic expressions alike. Do not walk to a
+        // nested identifier inside `(fn => fn())` or `(factory || Ctor)`,
+        // because that would shrink a dynamic call into an unrelated body
+        // spelling and lose the exact occurrence range.
+        let target = function;
+        if target.kind() != "identifier"
+            && target.kind() != "property_identifier"
+            && target.kind() != "type_identifier"
+            && target.kind() != "this"
+            && target.kind() != "super"
+        {
+            // Calls through a parenthesized function, conditional
+            // expression, `import()`, or another dynamic callee cannot be
+            // assigned a declaration target locally. Keep the call's exact
+            // callee occurrence so qualification and later project evidence
+            // can distinguish unresolved from silently dropped.
+            let spelling = node_text(self.source, function);
+            if spelling.is_empty() {
+                return Ok(());
+            }
+            return self.add_unresolved_candidate(
+                function,
+                scope_id,
+                if construction {
+                    CandidateRelation::Constructs
+                } else {
+                    CandidateRelation::Calls
+                },
+                if construction {
+                    SemanticRole::Construction
+                } else {
+                    SemanticRole::Call
+                },
+                &spelling,
+                None,
+                if construction {
+                    "dynamic_new"
+                } else {
+                    "dynamic_call"
+                },
+                argument_count,
+                argument_types,
+                &["function", "class", "method", "constructor", "external"],
+                None,
+            );
+        }
+        let spelling = node_text(self.source, target);
+        if target.kind() == "super" {
+            if let Some(resolution) = self.resolve_super_target(scope_id) {
+                return self.add_declaration_resolution_with_arguments(
+                    target,
+                    scope_id,
+                    CandidateRelation::Calls,
+                    SemanticRole::Call,
+                    &spelling,
+                    None,
+                    Some("super"),
+                    Namespace::Value,
+                    argument_count,
+                    argument_types,
+                    resolution,
+                    &["class", "constructor", "function", "external"],
+                );
+            }
+            return self.add_unresolved_candidate(
+                target,
+                scope_id,
+                CandidateRelation::Calls,
+                SemanticRole::Call,
+                &spelling,
+                None,
+                "super",
+                argument_count,
+                argument_types,
+                &["class", "constructor", "function", "external"],
+                None,
+            );
+        }
+        let is_this_target =
+            target.kind() == "this" || (target.kind() == "identifier" && spelling == "this");
+        if is_this_target {
+            if let Some(receiver) = self.this_receiver_target(scope_id)
+                && let Some(ids) = self.declarations_by_qualified.get(&receiver.qualified_name)
+            {
+                let mut classes = ids
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .filter(|declaration| declaration.kind == "class")
+                    .filter(|declaration| {
+                        receiver.scope_id.as_deref().is_none_or(|scope| {
+                            self.scope_owners
+                                .get(scope)
+                                .is_some_and(|owner| owner == &declaration.id)
+                        })
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if classes.len() == 1 {
+                    return self.add_declaration_resolution_with_arguments(
+                        target,
+                        scope_id,
+                        if construction {
+                            CandidateRelation::Constructs
+                        } else {
+                            CandidateRelation::Calls
+                        },
+                        if construction {
+                            SemanticRole::Construction
+                        } else {
+                            SemanticRole::Call
+                        },
+                        "this",
+                        None,
+                        Some(if construction {
+                            "new_this"
+                        } else {
+                            "this_call"
+                        }),
+                        Namespace::Value,
+                        argument_count,
+                        argument_types,
+                        Resolution::Local(classes.remove(0)),
+                        &["class", "constructor", "function", "external"],
+                    );
+                }
+            }
+            return self.add_unresolved_candidate(
+                target,
+                scope_id,
+                if construction {
+                    CandidateRelation::Constructs
+                } else {
+                    CandidateRelation::Calls
+                },
+                if construction {
+                    SemanticRole::Construction
+                } else {
+                    SemanticRole::Call
+                },
+                "this",
+                None,
+                if construction {
+                    "new_this"
+                } else {
+                    "this_call"
+                },
+                argument_count,
+                argument_types,
+                &["class", "constructor", "function", "external"],
+                None,
+            );
+        }
+        let resolution = self.resolve_name_for_call(
+            scope_id,
+            &spelling,
+            Namespace::Value,
+            argument_count,
+            &argument_types,
+        );
+        let Some(resolution) = resolution else {
+            if let Some((qualified_target, module)) =
+                self.builtin_global_target(scope_id, &spelling)
+            {
+                return self.add_external_resolution_candidate(
+                    target,
+                    scope_id,
+                    if construction {
+                        CandidateRelation::Constructs
+                    } else {
+                        CandidateRelation::Calls
+                    },
+                    if construction {
+                        SemanticRole::Construction
+                    } else {
+                        SemanticRole::Call
+                    },
+                    &spelling,
+                    None,
+                    if construction { "new" } else { "call" },
+                    &qualified_target,
+                    &module,
+                    argument_count,
+                    argument_types,
+                    &["function", "class", "external"],
+                );
+            }
+            return self.add_unresolved_candidate(
+                target,
+                scope_id,
+                if construction {
+                    CandidateRelation::Constructs
+                } else {
+                    CandidateRelation::Calls
+                },
+                if construction {
+                    SemanticRole::Construction
+                } else {
+                    SemanticRole::Call
+                },
+                &spelling,
+                None,
+                if construction { "new" } else { "call" },
+                argument_count,
+                argument_types,
+                &["function", "class", "method", "constructor", "external"],
+                None,
+            );
+        };
+        self.add_declaration_resolution_with_arguments(
+            target,
+            scope_id,
+            if construction {
+                CandidateRelation::Constructs
+            } else {
+                CandidateRelation::Calls
+            },
+            if construction {
+                SemanticRole::Construction
+            } else {
+                SemanticRole::Call
+            },
+            &spelling,
+            None,
+            Some(if construction { "new" } else { "call" }),
+            Namespace::Value,
+            argument_count,
+            argument_types,
+            resolution,
+            &["function", "method", "class", "variable"],
+        )
+    }
+
+    fn call_argument_types(&self, node: Node<'tree>, scope_id: &str) -> Vec<Option<String>> {
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return Vec::new();
+        };
+        let mut cursor = arguments.walk();
+        arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .map(|argument| self.call_argument_type(argument, scope_id))
+            .collect()
+    }
+
+    fn call_argument_type(&self, node: Node<'tree>, scope_id: &str) -> Option<String> {
+        match node.kind() {
+            "string" | "string_fragment" | "template_string" => Some("string".to_owned()),
+            "number" => Some("number".to_owned()),
+            "true" | "false" => Some("boolean".to_owned()),
+            "null" => Some("null".to_owned()),
+            "array" => Some("array".to_owned()),
+            "object" => Some("object".to_owned()),
+            "arrow_function" | "function" | "function_expression" | "generator_function" => {
+                Some("function".to_owned())
+            }
+            "as_expression" | "satisfies_expression" | "parenthesized_expression" => node
+                .child_by_field_name("expression")
+                .or_else(|| first_named_child(node))
+                .and_then(|inner| self.call_argument_type(inner, scope_id)),
+            "new_expression" => {
+                let constructor = node
+                    .child_by_field_name("constructor")
+                    .or_else(|| first_named_child(node))?;
+                let name = rightmost_identifier(constructor)?;
+                match self.resolve_name(scope_id, &node_text(self.source, name), Namespace::Both)? {
+                    Resolution::Local(declaration)
+                        if matches!(declaration.kind.as_str(), "class" | "enum") =>
+                    {
+                        Some(declaration.qualified_name)
+                    }
+                    Resolution::Import(import) => Some(import.target),
+                    _ => None,
+                }
+            }
+            "identifier" | "type_identifier" | "jsx_identifier" => {
+                let name = node_text(self.source, node);
+                if name == "undefined" {
+                    return Some("undefined".to_owned());
+                }
+                match self.resolve_name(scope_id, &name, Namespace::Value)? {
+                    Resolution::Local(declaration) => self
+                        .variable_types
+                        .get(&declaration.id)
+                        .cloned()
+                        .or_else(|| {
+                            matches!(declaration.kind.as_str(), "class" | "enum")
+                                .then_some(declaration.qualified_name)
+                        }),
+                    Resolution::Import(import) => Some(import.target),
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn emit_dynamic_import(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(function) = node.child_by_field_name("function") else {
+            return Ok(());
+        };
+        if node_text(self.source, function) != "import" {
+            return Ok(());
+        }
+        let Some(arguments) = node.child_by_field_name("arguments") else {
+            return Ok(());
+        };
+        let Some(module_node) = first_named_child_kind(arguments, "string") else {
+            return Ok(());
+        };
+        let module = string_literal(self.source, module_node);
+        if module.is_empty() {
+            return Ok(());
+        }
+        let owner = self.owner_for_scope(scope_id);
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Import,
+            &owner,
+            &module,
+            None,
+            Some(scope_id),
+            Some("dynamic_import"),
+            range_for_node(self.source_file, module_node),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Imports,
+            &owner,
+            Some(&occurrence_id),
+            None,
+            &module,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module.clone()),
+                allowed_target_kinds: vec!["module".to_owned()],
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn emit_require_declarator(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(value) = node.child_by_field_name("value") else {
+            return Ok(());
+        };
+        let Some(call) = find_require_call(value, self.source) else {
+            return Ok(());
+        };
+        let Some(arguments) = call.child_by_field_name("arguments") else {
+            return Ok(());
+        };
+        let Some(module_node) = first_named_child_kind(arguments, "string") else {
+            return Ok(());
+        };
+        let module = string_literal(self.source, module_node);
+        if module.is_empty() {
+            return Ok(());
+        }
+        let Some(name_node) = node.child_by_field_name("name") else {
+            return Ok(());
+        };
+        let mut names = Vec::new();
+        collect_pattern_names(name_node, self.source, &mut names);
+        for (name, anchor) in names {
+            self.add_import_binding(scope_id, &name, &name, &module, anchor, false, "require")?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn add_import_binding(
+        &mut self,
+        scope_id: &str,
+        local_name: &str,
+        imported_name: &str,
+        module: &str,
+        anchor: Node<'tree>,
+        type_only: bool,
+        context: &str,
+    ) -> Result<(), EvidenceError> {
+        let target = format!("{module}::{imported_name}");
+        let kind = if local_name == imported_name {
+            BindingKind::Import
+        } else {
+            BindingKind::ImportAlias
+        };
+        let namespace = if type_only {
+            Namespace::Type
+        } else {
+            Namespace::Value
+        };
+        let binding_id = self.builder.bind_with_identity(
+            kind,
+            local_name,
+            &target,
+            None,
+            Some(scope_id),
+            Some(symbol_namespace(namespace)),
+            type_only,
+            range_for_node(self.source_file, anchor),
+        )?;
+        self.import_bindings.insert(
+            (scope_id.to_owned(), local_name.to_owned()),
+            ImportInfo {
+                binding_id: binding_id.clone(),
+                target: target.clone(),
+                module: module.to_owned(),
+                imported_name: imported_name.to_owned(),
+                namespace,
+                type_only,
+            },
+        );
+        let owner = self.owner_for_scope(scope_id);
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Import,
+            &owner,
+            local_name,
+            None,
+            Some(scope_id),
+            Some(context),
+            range_for_node(self.source_file, anchor),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Imports,
+            &owner,
+            Some(&occurrence_id),
+            Some(&binding_id),
+            local_name,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                module_or_package: Some(module.to_owned()),
+                qualified_name: Some(target),
+                allowed_target_kinds: vec![
+                    "module".to_owned(),
+                    "function".to_owned(),
+                    "class".to_owned(),
+                    "variable".to_owned(),
+                    "type_alias".to_owned(),
+                    "interface".to_owned(),
+                ],
+                allow_external: true,
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn emit_member(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
+        let Some(property) = member_property_node(node) else {
+            return Ok(());
+        };
+        let Some(object) = node.child_by_field_name("object") else {
+            return Ok(());
+        };
+        let Some(property_name) = member_property_name(self.source, property) else {
+            return Ok(());
+        };
+        if let Some(resolution) =
+            self.resolve_member_target(scope_id, Some(object), property, None, &[])
+        {
+            return self.add_declaration_resolution(
+                property,
+                scope_id,
+                CandidateRelation::AccessesMember,
+                SemanticRole::MemberAccess,
+                &property_name,
+                Some(&node_text(self.source, object)),
+                Some("member"),
+                Namespace::Value,
+                resolution,
+                &[
+                    "property",
+                    "method",
+                    "constructor",
+                    "function",
+                    "class",
+                    "variable",
+                    "parameter",
+                    "external",
+                ],
+            );
+        }
+        if let Some((target, module)) = self.builtin_member_target(scope_id, object, &property_name)
+        {
+            return self.add_external_resolution_candidate(
+                property,
+                scope_id,
+                CandidateRelation::AccessesMember,
+                SemanticRole::MemberAccess,
+                &property_name,
+                Some(&node_text(self.source, object)),
+                "builtin_member",
+                &target,
+                &module,
+                None,
+                Vec::new(),
+                &[
+                    "property", "method", "function", "class", "variable", "external",
+                ],
+            );
+        }
+        // A local variable without a source-proven nominal type is still a
+        // real member occurrence, but its target is not safe to derive from
+        // the variable spelling. Keep it unresolved instead of manufacturing
+        // an external `object.property` identity.
+        self.add_unresolved_candidate(
+            property,
+            scope_id,
+            CandidateRelation::AccessesMember,
+            SemanticRole::MemberAccess,
+            &property_name,
+            Some(&node_text(self.source, object)),
+            "member",
+            None,
+            Vec::new(),
+            &["property", "field", "method", "function", "external"],
+            None,
+        )
+    }
+
+    fn emit_jsx(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
+        let Some(name) = node
+            .child_by_field_name("name")
+            .or_else(|| first_named_child_kind(node, "jsx_identifier"))
+        else {
+            return Ok(());
+        };
+        let spelling = node_text(self.source, name);
+        // JSX member tags (`<UI.Button />`) carry a different tree-sitter
+        // node kind from ordinary JavaScript member expressions. Resolve the
+        // member through the same nominal receiver proof used by calls and
+        // accesses so a namespace import targets `module::Button`, not the
+        // unrelated `UI` binding or a same-spelled local declaration.
+        if matches!(
+            name.kind(),
+            "member_expression" | "jsx_member_expression" | "jsx_namespace_name"
+        ) && let Some(property) = name.child_by_field_name("property")
+            && let Some(object) = name.child_by_field_name("object")
+            && let Some(resolution) =
+                self.resolve_member_target(scope_id, Some(object), property, None, &[])
+        {
+            let property_spelling = node_text(self.source, property);
+            let qualifier = node_text(self.source, object);
+            return self.add_declaration_resolution(
+                property,
+                scope_id,
+                CandidateRelation::References,
+                SemanticRole::CallableReference,
+                &property_spelling,
+                Some(&qualifier),
+                Some("jsx"),
+                Namespace::Value,
+                resolution,
+                &["function", "class", "variable", "property", "external"],
+            );
+        }
+        let first = spelling.split(['.', ':']).next().unwrap_or_default();
+        if first.is_empty() || !first.chars().next().is_some_and(char::is_uppercase) {
+            return Ok(());
+        }
+        let Some(resolution) = self.resolve_name(scope_id, first, Namespace::Value) else {
+            return Ok(());
+        };
+        self.add_declaration_resolution(
+            name,
+            scope_id,
+            CandidateRelation::References,
+            SemanticRole::CallableReference,
+            &spelling,
+            None,
+            Some("jsx"),
+            Namespace::Value,
+            resolution,
+            &["function", "class", "variable"],
+        )
+    }
+
+    fn emit_decorator(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
+        let Some(target) = first_named_child_kind(node, "identifier") else {
+            return Ok(());
+        };
+        let spelling = node_text(self.source, target);
+        let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Value) else {
+            return Ok(());
+        };
+        self.add_declaration_resolution(
+            target,
+            scope_id,
+            CandidateRelation::Decorates,
+            SemanticRole::Decorator,
+            &spelling,
+            None,
+            Some("decorator"),
+            Namespace::Value,
+            resolution,
+            &["function", "class", "variable"],
+        )
+    }
+
+    fn emit_bases(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
+        let relation = if node.kind() == "implements_clause" {
+            CandidateRelation::Implements
+        } else {
+            CandidateRelation::Extends
+        };
+        let mut candidates = Vec::new();
+        collect_type_name_nodes(node, &mut candidates);
+        for candidate in candidates {
+            let spelling = node_text(self.source, candidate);
+            let context = if relation == CandidateRelation::Implements {
+                "implements"
+            } else {
+                "extends"
+            };
+            if let Some(resolution) = self.resolve_type_name_node(scope_id, candidate) {
+                if relation == CandidateRelation::Extends
+                    && let Some(class_name) = self.enclosing_type(scope_id)
+                {
+                    let receiver = match &resolution {
+                        Resolution::Local(declaration)
+                            if matches!(
+                                declaration.kind.as_str(),
+                                "class" | "interface" | "enum" | "namespace"
+                            ) =>
+                        {
+                            Some(ReceiverTarget {
+                                qualified_name: declaration.qualified_name.clone(),
+                                import: None,
+                                scope_id: self.member_scope_for_declaration(declaration),
+                                type_arguments: None,
+                            })
+                        }
+                        Resolution::Import(import) => Some(ReceiverTarget {
+                            qualified_name: import_target_without_namespace(&import.target),
+                            import: Some(import.clone()),
+                            scope_id: None,
+                            type_arguments: None,
+                        }),
+                        _ => None,
+                    };
+                    if let Some(receiver) = receiver {
+                        // A class can have only one direct `extends` target.
+                        // Keep the proof only while all observed candidates
+                        // agree; declaration merging and malformed trees stay
+                        // unresolved rather than selecting traversal order.
+                        match self.base_targets.get(&class_name) {
+                            Some(previous)
+                                if previous.qualified_name != receiver.qualified_name =>
+                            {
+                                self.base_targets.remove(&class_name);
+                            }
+                            None => {
+                                self.base_targets.insert(class_name, receiver);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                if let Some(parent) = candidate.parent()
+                    && matches!(
+                        parent.kind(),
+                        "nested_type_identifier" | "member_expression"
+                    )
+                    && let Some(module) = parent
+                        .child_by_field_name("module")
+                        .or_else(|| parent.child_by_field_name("object"))
+                    && parent
+                        .child_by_field_name("name")
+                        .or_else(|| parent.child_by_field_name("property"))
+                        .is_some_and(|property| property.id() == candidate.id())
+                {
+                    self.add_declaration_resolution(
+                        candidate,
+                        scope_id,
+                        CandidateRelation::AccessesMember,
+                        SemanticRole::MemberAccess,
+                        &spelling,
+                        Some(&node_text(self.source, module)),
+                        Some("type_member"),
+                        Namespace::Type,
+                        resolution.clone(),
+                        &[
+                            "property",
+                            "method",
+                            "class",
+                            "interface",
+                            "type_alias",
+                            "enum",
+                            "external",
+                        ],
+                    )?;
+                }
+                self.add_declaration_resolution(
+                    candidate,
+                    scope_id,
+                    relation,
+                    SemanticRole::BaseType,
+                    &spelling,
+                    None,
+                    Some(context),
+                    Namespace::Type,
+                    resolution,
+                    &["class", "interface", "type_alias"],
+                )?;
+            } else if let Some((target, module)) = self.builtin_type_target(scope_id, &spelling) {
+                self.add_external_resolution_candidate(
+                    candidate,
+                    scope_id,
+                    relation,
+                    SemanticRole::BaseType,
+                    &spelling,
+                    None,
+                    context,
+                    &target,
+                    &module,
+                    None,
+                    Vec::new(),
+                    &["class", "interface", "type_alias", "external"],
+                )?;
+            } else {
+                self.add_unresolved_candidate(
+                    candidate,
+                    scope_id,
+                    relation,
+                    SemanticRole::BaseType,
+                    &spelling,
+                    None,
+                    context,
+                    None,
+                    Vec::new(),
+                    &["class", "interface", "type_alias", "external"],
+                    (relation == CandidateRelation::Extends).then_some(
+                        HierarchyConstraint::DirectBase {
+                            base_set_complete: true,
+                        },
+                    ),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_type_reference(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        if self.declaration_name_nodes.contains(&node.start_byte()) {
+            return Ok(());
+        }
+        if node
+            .parent()
+            .is_some_and(|parent| parent.kind() == "nested_type_identifier")
+        {
+            // The enclosing nested type carries the complete `Namespace.Type`
+            // source anchor. Resolving the trailing `Type` as an unrelated
+            // unqualified symbol would fabricate an edge when a same-named
+            // declaration happens to be visible in the current scope.
+            return Ok(());
+        }
+        if node.parent().is_some_and(|parent| {
+            matches!(
+                parent.kind(),
+                "extends_clause" | "extends_type_clause" | "implements_clause"
+            )
+        }) {
+            return Ok(());
+        }
+        let spelling = node_text(self.source, node);
+        if node.kind() == "nested_type_identifier"
+            && let (Some(module), Some(name)) = (
+                node.child_by_field_name("module"),
+                node.child_by_field_name("name"),
+            )
+        {
+            let module_spelling = node_text(self.source, module);
+            let name_spelling = node_text(self.source, name);
+            if let Some(resolution) = self.resolve_type_member_target(scope_id, module, name) {
+                self.add_declaration_resolution(
+                    name,
+                    scope_id,
+                    CandidateRelation::AccessesMember,
+                    SemanticRole::MemberAccess,
+                    &name_spelling,
+                    Some(&module_spelling),
+                    Some("type_member"),
+                    Namespace::Type,
+                    resolution.clone(),
+                    &[
+                        "property",
+                        "method",
+                        "class",
+                        "interface",
+                        "type_alias",
+                        "enum",
+                        "external",
+                    ],
+                )?;
+                return self.add_declaration_resolution(
+                    node,
+                    scope_id,
+                    CandidateRelation::References,
+                    SemanticRole::TypeReference,
+                    &spelling,
+                    Some(&module_spelling),
+                    Some("type"),
+                    Namespace::Type,
+                    resolution,
+                    &[
+                        "class",
+                        "interface",
+                        "type_alias",
+                        "enum",
+                        "type_parameter",
+                        "external",
+                    ],
+                );
+            }
+            // Keep the qualified member occurrence even when the namespace
+            // or property cannot yet be resolved. This is type-space
+            // evidence, not permission to select a same-named value or
+            // external declaration.
+            self.add_unresolved_candidate(
+                name,
+                scope_id,
+                CandidateRelation::AccessesMember,
+                SemanticRole::MemberAccess,
+                &name_spelling,
+                Some(&module_spelling),
+                "type_member",
+                None,
+                Vec::new(),
+                &[
+                    "property",
+                    "method",
+                    "class",
+                    "interface",
+                    "type_alias",
+                    "enum",
+                    "external",
+                ],
+                None,
+            )?;
+        }
+        if let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Type) {
+            return self.add_declaration_resolution(
+                node,
+                scope_id,
+                CandidateRelation::References,
+                SemanticRole::TypeReference,
+                &spelling,
+                None,
+                Some("type"),
+                Namespace::Type,
+                resolution,
+                &["class", "interface", "type_alias", "enum", "type_parameter"],
+            );
+        }
+        if let Some((target, module)) = self.ambient_qualified_type_target(scope_id, &spelling) {
+            return self.add_external_resolution_candidate(
+                node,
+                scope_id,
+                CandidateRelation::References,
+                SemanticRole::TypeReference,
+                &spelling,
+                None,
+                "type",
+                &target,
+                &module,
+                None,
+                Vec::new(),
+                &[
+                    "class",
+                    "interface",
+                    "type_alias",
+                    "enum",
+                    "type_parameter",
+                    "external",
+                ],
+            );
+        }
+        let Some((target, module)) = self.builtin_type_target(scope_id, &spelling) else {
+            return self.add_unresolved_candidate(
+                node,
+                scope_id,
+                CandidateRelation::References,
+                SemanticRole::TypeReference,
+                &spelling,
+                None,
+                "type",
+                None,
+                Vec::new(),
+                &[
+                    "class",
+                    "interface",
+                    "type_alias",
+                    "enum",
+                    "type_parameter",
+                    "external",
+                ],
+                None,
+            );
+        };
+        self.add_external_resolution_candidate(
+            node,
+            scope_id,
+            CandidateRelation::References,
+            SemanticRole::TypeReference,
+            &spelling,
+            None,
+            "type",
+            &target,
+            &module,
+            None,
+            Vec::new(),
+            &[
+                "class",
+                "interface",
+                "type_alias",
+                "enum",
+                "type_parameter",
+                "external",
+            ],
+        )
+    }
+
+    fn emit_callable_reference(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        if self.declaration_name_nodes.contains(&node.start_byte())
+            || node.parent().is_some_and(|parent| {
+                matches!(
+                    parent.kind(),
+                    "import_clause"
+                        | "namespace_import"
+                        | "named_imports"
+                        | "import_specifier"
+                        | "export_clause"
+                        | "export_specifier"
+                        | "member_expression"
+                        | "optional_member_expression"
+                        | "subscript_expression"
+                        | "jsx_opening_element"
+                        | "jsx_self_closing_element"
+                )
+            })
+            || is_type_reference_node(node)
+        {
+            return Ok(());
+        }
+        let spelling = node_text(self.source, node);
+        let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Value) else {
+            return Ok(());
+        };
+        let is_callable = match &resolution {
+            Resolution::Local(declaration) => {
+                matches!(declaration.kind.as_str(), "function" | "method" | "class")
+            }
+            Resolution::Import(import) => {
+                import.imported_name == "default" || import.imported_name == "*"
+            }
+        };
+        if !is_callable {
+            return Ok(());
+        }
+        self.add_declaration_resolution(
+            node,
+            scope_id,
+            CandidateRelation::References,
+            SemanticRole::CallableReference,
+            &spelling,
+            None,
+            Some("value"),
+            Namespace::Value,
+            resolution,
+            &["function", "method", "class", "variable"],
+        )
+    }
+
+    fn emit_commonjs_export(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(left) = node.child_by_field_name("left") else {
+            return Ok(());
+        };
+        let left_text = node_text(self.source, left).replace(char::is_whitespace, "");
+        let export_name = if left_text == "module.exports" {
+            "default".to_owned()
+        } else if let Some(name) = left_text.strip_prefix("module.exports.") {
+            name.to_owned()
+        } else if let Some(name) = left_text.strip_prefix("exports.") {
+            name.to_owned()
+        } else {
+            return Ok(());
+        };
+        let Some(right) = node.child_by_field_name("right") else {
+            return Ok(());
+        };
+        let Some(source_name) = rightmost_identifier(right) else {
+            return Ok(());
+        };
+        let source_name = node_text(self.source, source_name);
+        let Some(resolution) = self.resolve_name(scope_id, &source_name, Namespace::Both) else {
+            return Ok(());
+        };
+        let owner = self.owner_for_scope(scope_id);
+        let (target, target_declaration_id, namespace) = match resolution {
+            Resolution::Local(declaration) => (
+                declaration.qualified_name,
+                Some(declaration.id),
+                declaration.namespace,
+            ),
+            Resolution::Import(import) => (import.target, None, import.namespace),
+        };
+        let binding_id = self.builder.bind_with_identity(
+            BindingKind::Reexport,
+            &export_name,
+            &target,
+            target_declaration_id.as_deref(),
+            Some(scope_id),
+            Some(symbol_namespace(namespace)),
+            false,
+            range_for_node(self.source_file, left),
+        )?;
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Reexport,
+            &owner,
+            &export_name,
+            Some("commonjs"),
+            Some(scope_id),
+            Some("commonjs"),
+            range_for_node(self.source_file, left),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Reexports,
+            &owner,
+            Some(&occurrence_id),
+            Some(&binding_id),
+            &export_name,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                allowed_target_kinds: vec![
+                    "function".to_owned(),
+                    "class".to_owned(),
+                    "variable".to_owned(),
+                    "type_alias".to_owned(),
+                ],
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    fn resolve_name(&self, scope_id: &str, name: &str, namespace: Namespace) -> Option<Resolution> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if let Some(import) = self.import_bindings.get(&(scope.clone(), name.to_owned())) {
+                let accepts = if import.namespace == Namespace::Module {
+                    matches!(namespace, Namespace::Type | Namespace::Both)
+                        || (namespace == Namespace::Value && !import.type_only)
+                } else {
+                    import.namespace.accepts(namespace)
+                };
+                if accepts {
+                    return Some(Resolution::Import(import.clone()));
+                }
+            }
+            let candidates = self
+                .declarations_by_scope
+                .get(&scope)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.name == name
+                        && declaration.namespace.accepts(namespace)
+                        && self.lexically_visible_unqualified(&scope, declaration)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if candidates.len() == 1 {
+                return candidates.into_iter().next().map(Resolution::Local);
+            }
+            if candidates.len() > 1 {
+                return None;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        None
+    }
+
+    fn resolve_name_for_call(
+        &self,
+        scope_id: &str,
+        name: &str,
+        namespace: Namespace,
+        argument_count: Option<u32>,
+        argument_types: &[Option<String>],
+    ) -> Option<Resolution> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if let Some(import) = self.import_bindings.get(&(scope.clone(), name.to_owned())) {
+                let accepts = if import.namespace == Namespace::Module {
+                    matches!(namespace, Namespace::Type | Namespace::Both)
+                        || (namespace == Namespace::Value && !import.type_only)
+                } else {
+                    import.namespace.accepts(namespace)
+                };
+                if accepts {
+                    return Some(Resolution::Import(import.clone()));
+                }
+            }
+            let candidates = self
+                .declarations_by_scope
+                .get(&scope)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.name == name
+                        && declaration.namespace.accepts(namespace)
+                        && self.lexically_visible_unqualified(&scope, declaration)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if let Some(argument_count) = argument_count {
+                let matching = candidates
+                    .iter()
+                    .filter(|declaration| {
+                        self.declaration_call_matches(declaration, argument_count, argument_types)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if matching.len() == 1 {
+                    return matching.into_iter().next().map(Resolution::Local);
+                }
+                // A source-visible signature that does not accept this call
+                // shape is a negative result. Optional/default/rest ranges
+                // are accepted only when they are the sole visible match;
+                // declaration-merged overload ambiguity remains unresolved.
+                if !candidates.is_empty() {
+                    return None;
+                }
+            } else if candidates.len() == 1 {
+                return candidates.into_iter().next().map(Resolution::Local);
+            }
+            if !candidates.is_empty() {
+                return None;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        None
+    }
+
+    fn lexically_visible_unqualified(&self, scope_id: &str, declaration: &DeclarationInfo) -> bool {
+        // Object-literal and assignment properties are structural members, not
+        // lexical bindings. Treating `{ gzip: gzip(body) }` as a declaration
+        // named `gzip` would shadow the real helper in the surrounding scope
+        // and produce a false call target. Member resolution reaches these
+        // declarations through their qualified receiver instead.
+        if matches!(
+            declaration.kind.as_str(),
+            "property" | "method" | "constructor"
+        ) {
+            return false;
+        }
+        let Some(owner_id) = self.scope_owners.get(scope_id) else {
+            return true;
+        };
+        let Some(owner) = self.declarations.get(owner_id) else {
+            return true;
+        };
+        if owner.kind != "class" {
+            return true;
+        }
+        // Class methods and fields are members, not lexical bindings inside
+        // another method body. Without this boundary `parseParameters()` in
+        // a static method could resolve to `Class.parseParameters` instead of
+        // the same-file top-level helper with the same spelling.
+        !matches!(
+            declaration.kind.as_str(),
+            "method" | "constructor" | "property"
+        )
+    }
+
+    fn declaration_call_matches(
+        &self,
+        declaration: &DeclarationInfo,
+        argument_count: u32,
+        argument_types: &[Option<String>],
+    ) -> bool {
+        self.declaration_call_matches_seen(
+            declaration,
+            argument_count,
+            argument_types,
+            &mut HashSet::new(),
+        )
+    }
+
+    fn declaration_call_matches_seen(
+        &self,
+        declaration: &DeclarationInfo,
+        argument_count: u32,
+        argument_types: &[Option<String>],
+        seen: &mut HashSet<String>,
+    ) -> bool {
+        if !seen.insert(declaration.id.clone()) {
+            return false;
+        }
+        // A direct identifier call or construction is already source
+        // evidence for the binding being used as a callable/constructor
+        // value.  The TypeScript checker resolves the identifier's symbol
+        // even when its inferred signature is supplied by another module or
+        // is only available through contextual typing (for example Promise
+        // executor parameters and factory results).  Keep duplicate-name
+        // ambiguity fail-closed in the caller; once this declaration is the
+        // unique visible candidate, do not discard it for lack of a local
+        // signature.
+        if matches!(declaration.kind.as_str(), "variable" | "parameter") {
+            return true;
+        }
+        if declaration.kind == "class" && !declaration.explicit_constructor {
+            if let Some(base) = self.base_targets.get(&declaration.qualified_name)
+                && base.import.is_none()
+                && let Some(ids) = self.declarations_by_qualified.get(&base.qualified_name)
+            {
+                let bases = ids
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .filter(|candidate| candidate.kind == "class")
+                    .collect::<Vec<_>>();
+                if bases.len() == 1 {
+                    return self.declaration_call_matches_seen(
+                        bases[0],
+                        argument_count,
+                        argument_types,
+                        seen,
+                    );
+                }
+            }
+            // A class without an explicit constructor has a zero-argument
+            // default constructor in TypeScript. JavaScript also permits
+            // extra arguments, matching ordinary function-call behavior.
+            return self.language == "javascript" || argument_count == 0;
+        }
+        if declaration.callable_shape
+            && declaration.parameter_count.is_none()
+            && declaration.parameter_min_count.is_none()
+            && declaration.parameter_max_count.is_none()
+        {
+            return true;
+        }
+        if self.callable_property_aliases.contains(&declaration.id) {
+            return true;
+        }
+        let arity_matches = if self.language == "javascript" {
+            // JavaScript permits both omitted and extra arguments for
+            // ordinary functions. Resolve the unique lexical declaration and
+            // leave duplicate-name ambiguity unresolved below.
+            true
+        } else if let Some(parameter_count) = declaration.parameter_count {
+            parameter_count == argument_count
+        } else {
+            declaration
+                .parameter_min_count
+                .is_some_and(|minimum| argument_count >= minimum)
+                && declaration
+                    .parameter_max_count
+                    .is_none_or(|maximum| argument_count <= maximum)
+        };
+        arity_matches && self.arguments_match_parameters(declaration, argument_types)
+    }
+
+    fn arguments_match_parameters(
+        &self,
+        declaration: &DeclarationInfo,
+        argument_types: &[Option<String>],
+    ) -> bool {
+        let Some(parameter_types) = declaration.parameter_types.as_ref() else {
+            return true;
+        };
+        // JavaScript permits omitted and extra arguments, and parameter
+        // annotations are not part of the runtime contract. Preserve the
+        // unique source declaration selected by lexical/member resolution
+        // without rejecting it on a static type-shape comparison.
+        if self.language == "javascript" {
+            return true;
+        }
+        if parameter_types.len() != argument_types.len() {
+            return false;
+        }
+        parameter_types
+            .iter()
+            .zip(argument_types)
+            .all(|(parameter, argument)| {
+                argument.as_deref().is_none_or(|argument| {
+                    self.parameter_type_matches(declaration, parameter, argument)
+                })
+            })
+    }
+
+    fn parameter_type_matches(
+        &self,
+        declaration: &DeclarationInfo,
+        parameter: &str,
+        argument: &str,
+    ) -> bool {
+        if argument == "function"
+            && self
+                .contextual_callable_parameter_types(&declaration.scope_id, parameter)
+                .is_some()
+        {
+            return true;
+        }
+        if parameter_type_matches(parameter, argument) {
+            return true;
+        }
+        if self.source_type_assignable(&declaration.scope_id, parameter, argument) {
+            return true;
+        }
+        if let Some(constraint) = self
+            .generic_parameters_by_declaration
+            .get(&declaration.id)
+            .and_then(|parameters| parameters.get(parameter.trim()))
+        {
+            return constraint
+                .as_deref()
+                .is_none_or(|constraint| self.generic_constraint_matches(constraint, argument));
+        }
+        if let Some((utility, base, arguments)) = utility_type_parts(parameter) {
+            return self.source_utility_argument_matches(utility, base, &arguments, argument);
+        }
+        self.source_inline_object_argument_matches(parameter, argument)
+    }
+
+    /// Follow source-declared `extends`/`implements` edges for one nominal
+    /// argument. This is intentionally narrower than a full TypeScript
+    /// assignability engine: it proves only a unique local argument class and
+    /// a bounded hierarchy path to the expected imported/local type.
+    fn source_type_assignable(&self, scope_id: &str, expected: &str, actual: &str) -> bool {
+        let Some(expected_receiver) =
+            self.resolve_declared_type_receiver(scope_id, strip_type_arguments(expected))
+        else {
+            return false;
+        };
+        let expected_name = expected_receiver.qualified_name;
+        let mut pending = vec![strip_type_arguments(actual).to_owned()];
+        let mut seen = HashSet::new();
+        let mut steps = 0_usize;
+        while let Some(current) = pending.pop() {
+            if steps >= MAX_INLINE_OBJECT_PROPERTIES
+                || current.is_empty()
+                || !seen.insert(current.clone())
+            {
+                break;
+            }
+            steps = steps.saturating_add(1);
+            if current == expected_name
+                || type_names_compatible(&current, &expected_name)
+                    && (!current.contains("::") || !expected_name.contains("::"))
+            {
+                return true;
+            }
+            if let Some(base) = self.base_targets.get(&current)
+                && base.import.is_none()
+            {
+                pending.push(base.qualified_name.clone());
+            } else if let Some(base) = self.base_targets.get(&current)
+                && base.qualified_name == expected_name
+            {
+                return true;
+            }
+            if let Some(bases) = self.implements_targets.get(&current) {
+                for base in bases {
+                    if base.qualified_name == expected_name {
+                        return true;
+                    }
+                    if base.import.is_none() {
+                        pending.push(base.qualified_name.clone());
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn generic_constraint_matches(&self, constraint: &str, argument: &str) -> bool {
+        if argument == "any" || argument == "unknown" {
+            return true;
+        }
+        if parameter_type_matches(constraint, argument) {
+            return true;
+        }
+        let constraint = constraint.trim();
+        if (constraint.starts_with('[') && constraint.contains("..."))
+            || constraint.ends_with("[]")
+            || constraint.starts_with("readonly ") && constraint.ends_with("]")
+        {
+            return argument == "array";
+        }
+        is_object_like_type(constraint) && self.source_type_property_names(argument).is_some()
+    }
+
+    fn source_utility_argument_matches(
+        &self,
+        utility: &str,
+        base: &str,
+        arguments: &[&str],
+        argument: &str,
+    ) -> bool {
+        let Some(argument_properties) = self.source_type_property_names(argument) else {
+            return false;
+        };
+        let Some(base_properties) = self.source_type_property_names(base) else {
+            return false;
+        };
+        match utility {
+            "Pick" => {
+                let Some(selected) = arguments.get(1).and_then(|keys| type_literal_names(keys))
+                else {
+                    return false;
+                };
+                selected
+                    .iter()
+                    .all(|property| argument_properties.contains(property))
+            }
+            "Omit" => {
+                let omitted = arguments
+                    .get(1)
+                    .and_then(|keys| type_literal_names(keys))
+                    .unwrap_or_default();
+                base_properties
+                    .iter()
+                    .filter(|property| !omitted.contains(*property))
+                    .all(|property| argument_properties.contains(property))
+            }
+            "Partial" => argument_properties
+                .iter()
+                .all(|property| base_properties.contains(property)),
+            "Required" | "Readonly" => base_properties
+                .iter()
+                .all(|property| argument_properties.contains(property)),
+            _ => false,
+        }
+    }
+
+    fn source_inline_object_argument_matches(&self, parameter: &str, argument: &str) -> bool {
+        let Some(required_properties) = inline_object_required_property_names(parameter) else {
+            return false;
+        };
+        let Some(argument_properties) = self.source_type_property_names(argument) else {
+            return false;
+        };
+        required_properties
+            .iter()
+            .all(|property| argument_properties.contains(property))
+    }
+
+    fn source_type_property_names(&self, type_name: &str) -> Option<HashSet<String>> {
+        let type_name = type_name.trim().trim_end_matches("[]").trim();
+        if type_name.is_empty() {
+            return None;
+        }
+        let mut candidates = Vec::new();
+        if let Some(ids) = self.declarations_by_qualified.get(type_name) {
+            candidates.extend(ids.iter().filter_map(|id| self.declarations.get(id)));
+        } else {
+            let leaf = type_name.rsplit(['.', ':']).next().unwrap_or(type_name);
+            candidates.extend(
+                self.declarations
+                    .values()
+                    .filter(|declaration| declaration.name == leaf),
+            );
+        }
+        candidates.sort_by(|left, right| left.id.cmp(&right.id));
+        candidates.dedup_by(|left, right| left.id == right.id);
+        let mut qualified_names = candidates
+            .into_iter()
+            .filter(|declaration| {
+                matches!(
+                    declaration.kind.as_str(),
+                    "class" | "interface" | "enum" | "namespace" | "type_alias" | "variable"
+                )
+            })
+            .map(|declaration| declaration.qualified_name.clone())
+            .collect::<Vec<_>>();
+        qualified_names.sort();
+        qualified_names.dedup();
+        let [qualified_name] = qualified_names.as_slice() else {
+            return None;
+        };
+        let prefix = format!("{qualified_name}.");
+        let mut properties = HashSet::new();
+        for name in self.declarations_by_qualified.keys() {
+            let Some(property) = name.strip_prefix(&prefix) else {
+                continue;
+            };
+            if property.is_empty() || property.contains('.') {
+                continue;
+            }
+            properties.insert(property.to_owned());
+            if properties.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+                break;
+            }
+        }
+        (!properties.is_empty()).then_some(properties)
+    }
+
+    fn resolve_member_target(
+        &self,
+        scope_id: &str,
+        object: Option<Node<'tree>>,
+        property: Node<'tree>,
+        argument_count: Option<u32>,
+        argument_types: &[Option<String>],
+    ) -> Option<Resolution> {
+        let object = object?;
+        let receiver = self.receiver_target(scope_id, object)?;
+        // A member value can carry a source-visible nominal type. Resolve
+        // that type only when the value is used as a receiver; keeping this
+        // bridge out of `receiver_target` avoids recursively re-typing every
+        // intermediate member expression in a long chain.
+        let receiver = self
+            .typed_member_receiver(scope_id, receiver.clone())
+            .unwrap_or(receiver);
+        let property_name = member_property_name(self.source, property)?;
+        if let Some(name_node) = rightmost_identifier(object)
+            && let Some(Resolution::Local(variable)) = self.resolve_name(
+                scope_id,
+                &node_text(self.source, name_node),
+                Namespace::Value,
+            )
+            && let Some(declaration_id) = self
+                .inline_object_property_declaration_ids
+                .get(&(variable.id.clone(), property_name.clone()))
+            && let Some(declaration) = self.declarations.get(declaration_id)
+        {
+            return Some(Resolution::Local(declaration.clone()));
+        }
+        let namespace_import = receiver
+            .import
+            .as_ref()
+            .is_some_and(|import| import.namespace == Namespace::Module);
+        let qualified_name = if namespace_import {
+            format!("{}::{property_name}", receiver.qualified_name)
+        } else {
+            format!("{}.{property_name}", receiver.qualified_name)
+        };
+        if let Some(ids) = self.declarations_by_qualified.get(&qualified_name) {
+            let flow_sensitive = self.receiver_is_flow_sensitive(&receiver);
+            let all_declarations = ids
+                .iter()
+                .filter_map(|id| self.declarations.get(id))
+                .collect::<Vec<_>>();
+            // Qualified names intentionally remain stable across lexical
+            // scopes, so duplicate object literals/classes can share one
+            // spelling.  Prefer declarations owned by the receiver's scope
+            // (including nested scopes), but retain a fail-closed fallback for
+            // external/prototype cases where no local scope proof exists.
+            let scoped_declarations = receiver.scope_id.as_deref().map(|receiver_scope| {
+                all_declarations
+                    .iter()
+                    .filter(|declaration| {
+                        self.scope_is_descendant_or_same(&declaration.scope_id, receiver_scope)
+                    })
+                    .copied()
+                    .collect::<Vec<_>>()
+            });
+            let declarations = scoped_declarations
+                .filter(|declarations| !declarations.is_empty())
+                .unwrap_or(all_declarations);
+            let declarations = if !flow_sensitive {
+                if let Some(receiver_scope) = receiver.scope_id.as_deref() {
+                    // Prefer the nearest source declaration for a receiver.  A
+                    // class field/property lives in the class scope, whereas a
+                    // later `this.field = ...` write lives in a method scope. The
+                    // checker binds both uses to the class field, so selecting the
+                    // minimum lexical distance avoids a later assignment
+                    // declaration stealing the canonical member identity.
+                    let nearest = declarations
+                        .iter()
+                        .filter_map(|declaration| {
+                            self.scope_distance(&declaration.scope_id, receiver_scope)
+                        })
+                        .min();
+                    if let Some(distance) = nearest {
+                        declarations
+                            .into_iter()
+                            .filter(|declaration| {
+                                self.scope_distance(&declaration.scope_id, receiver_scope)
+                                    == Some(distance)
+                            })
+                            .collect::<Vec<_>>()
+                    } else {
+                        declarations
+                    }
+                } else {
+                    declarations
+                }
+            } else {
+                declarations
+            };
+            let declarations = if flow_sensitive {
+                // Object-valued JavaScript variables can be reassigned.  For
+                // a use after multiple source-visible object writes, the
+                // checker binds the member to the latest write that dominates
+                // the use.  Apply this only to structural receivers: using
+                // source order for nominal classes/interfaces would turn
+                // methods or declarations in a different lexical scope into
+                // accidental shadowing.
+                let preceding = declarations
+                    .iter()
+                    .copied()
+                    .filter(|declaration| {
+                        declaration.kind == "property"
+                            && declaration.range_start_byte <= property.start_byte()
+                    })
+                    .collect::<Vec<_>>();
+                if let Some(latest) = preceding
+                    .iter()
+                    .max_by_key(|declaration| declaration.range_start_byte)
+                    .copied()
+                {
+                    vec![latest]
+                } else {
+                    declarations
+                }
+            } else {
+                declarations
+            };
+            if let Some(argument_count) = argument_count {
+                let matching = declarations
+                    .iter()
+                    .filter(|declaration| {
+                        self.declaration_call_matches(declaration, argument_count, argument_types)
+                    })
+                    .collect::<Vec<_>>();
+                if matching.len() == 1 {
+                    return matching
+                        .first()
+                        .map(|declaration| Resolution::Local((**declaration).clone()));
+                }
+                let matching_properties = matching
+                    .iter()
+                    .filter(|declaration| declaration.kind == "property")
+                    .collect::<Vec<_>>();
+                if matching_properties.len() == 1 {
+                    return matching_properties
+                        .first()
+                        .map(|declaration| Resolution::Local((***declaration).clone()));
+                }
+                let typed_properties = declarations
+                    .iter()
+                    .filter(|declaration| {
+                        declaration.kind == "property" && declaration.declared_type_name.is_some()
+                    })
+                    .collect::<Vec<_>>();
+                if typed_properties.len() == 1 {
+                    return typed_properties
+                        .first()
+                        .map(|declaration| Resolution::Local((**declaration).clone()));
+                }
+                if !declarations.is_empty() {
+                    return None;
+                }
+            } else {
+                let properties = declarations
+                    .iter()
+                    .filter(|declaration| declaration.kind == "property")
+                    .collect::<Vec<_>>();
+                if properties.len() == 1 {
+                    return properties
+                        .first()
+                        .map(|declaration| Resolution::Local((**declaration).clone()));
+                }
+                if declarations.len() == 1 {
+                    return declarations
+                        .first()
+                        .map(|declaration| Resolution::Local((*declaration).clone()));
+                }
+            }
+            // Overloads/declaration merging share a qualified name but are
+            // distinct source declarations. Preserve the ambiguity instead
+            // of selecting one by traversal order.
+            return None;
+        }
+        if receiver.import.is_none()
+            && let Some(base_receiver) = receiver.qualified_name.strip_suffix(".prototype")
+        {
+            // Prototype methods commonly read fields initialized by the
+            // constructor (`this._pairs`). The constructor assignment is the
+            // canonical source declaration, so try that exact base identity
+            // only after no prototype member matched. Never fall back through
+            // a dynamic or imported receiver.
+            let base_name = format!("{base_receiver}.{property_name}");
+            if let Some(ids) = self.declarations_by_qualified.get(&base_name) {
+                let declarations = ids
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .collect::<Vec<_>>();
+                if let Some(argument_count) = argument_count {
+                    let matching = declarations
+                        .iter()
+                        .filter(|declaration| {
+                            self.declaration_call_matches(
+                                declaration,
+                                argument_count,
+                                argument_types,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    if matching.len() == 1 {
+                        return matching
+                            .first()
+                            .map(|declaration| Resolution::Local((**declaration).clone()));
+                    }
+                } else if declarations.len() == 1 {
+                    return declarations
+                        .first()
+                        .map(|declaration| Resolution::Local((*declaration).clone()));
+                }
+            }
+        }
+        if receiver.import.is_none()
+            && let Some(inherited) = self.resolve_inherited_member_target(
+                &receiver.qualified_name,
+                &property_name,
+                argument_count,
+                argument_types,
+            )
+        {
+            return Some(inherited);
+        }
+        let import = receiver.import?;
+        Some(Resolution::Import(ImportInfo {
+            binding_id: import.binding_id,
+            target: qualified_name,
+            module: import.module,
+            imported_name: property_name,
+            namespace: Namespace::Value,
+            type_only: import.type_only,
+        }))
+    }
+
+    fn receiver_is_flow_sensitive(&self, receiver: &ReceiverTarget) -> bool {
+        receiver.import.is_none()
+            && self
+                .structural_object_variables
+                .contains(&receiver.qualified_name)
+    }
+
+    fn resolve_inherited_member_target(
+        &self,
+        receiver_qualified_name: &str,
+        property_name: &str,
+        argument_count: Option<u32>,
+        argument_types: &[Option<String>],
+    ) -> Option<Resolution> {
+        let mut current = receiver_qualified_name.to_owned();
+        let mut seen = HashSet::new();
+        while seen.insert(current.clone()) {
+            let qualified_names = [
+                format!("{current}.{property_name}"),
+                format!("{current}.constructor.{property_name}"),
+            ];
+            for qualified_name in qualified_names {
+                let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+                    continue;
+                };
+                let declarations = ids
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .filter(|declaration| {
+                        argument_count.is_none_or(|count| {
+                            self.declaration_call_matches(declaration, count, argument_types)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                // Class constructors often bind a method onto `this`
+                // (`this.optional = this.optional.bind(this)`).  That
+                // assignment publishes a duplicate property spelling, but
+                // the source member still resolves to the one declared
+                // method. Prefer that unique method only when all other
+                // matching declarations are properties; overloads and
+                // unrelated duplicates stay ambiguous.
+                let methods = declarations
+                    .iter()
+                    .filter(|declaration| {
+                        matches!(declaration.kind.as_str(), "method" | "constructor")
+                    })
+                    .collect::<Vec<_>>();
+                if methods.len() == 1
+                    && declarations
+                        .iter()
+                        .any(|declaration| declaration.kind == "property")
+                    && declarations.iter().all(|declaration| {
+                        declaration.kind == "property"
+                            || matches!(declaration.kind.as_str(), "method" | "constructor")
+                    })
+                {
+                    return methods
+                        .first()
+                        .map(|declaration| Resolution::Local((***declaration).clone()));
+                }
+                if declarations.len() == 1 {
+                    return declarations
+                        .first()
+                        .map(|declaration| Resolution::Local((*declaration).clone()));
+                }
+                if argument_count.is_some() {
+                    let typed_properties = ids
+                        .iter()
+                        .filter_map(|id| self.declarations.get(id))
+                        .filter(|declaration| {
+                            declaration.kind == "property"
+                                && declaration.declared_type_name.is_some()
+                        })
+                        .collect::<Vec<_>>();
+                    if typed_properties.len() == 1 {
+                        return typed_properties
+                            .first()
+                            .map(|declaration| Resolution::Local((*declaration).clone()));
+                    }
+                }
+            }
+            let base = self.base_targets.get(&current)?;
+            if base.import.is_some() {
+                return None;
+            }
+            current = base.qualified_name.clone();
+        }
+        None
+    }
+
+    fn resolve_type_member_target(
+        &self,
+        scope_id: &str,
+        module: Node<'tree>,
+        property: Node<'tree>,
+    ) -> Option<Resolution> {
+        let module_name = node_text(self.source, module);
+        let property_name = node_text(self.source, property);
+        if module_name.is_empty() || property_name.is_empty() {
+            return None;
+        }
+        let resolution = self.resolve_type_space_name(scope_id, &module_name)?;
+        match resolution {
+            Resolution::Local(declaration) => {
+                let qualified_name = format!("{}.{property_name}", declaration.qualified_name);
+                let declarations = self
+                    .declarations_by_qualified
+                    .get(&qualified_name)?
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .collect::<Vec<_>>();
+                if declarations.len() == 1 {
+                    declarations
+                        .first()
+                        .map(|candidate| Resolution::Local((*candidate).clone()))
+                } else {
+                    None
+                }
+            }
+            Resolution::Import(import) => Some(Resolution::Import(ImportInfo {
+                binding_id: import.binding_id,
+                target: format!(
+                    "{}::{property_name}",
+                    import_target_without_namespace(&import.target)
+                ),
+                module: import.module,
+                imported_name: property_name,
+                namespace: Namespace::Type,
+                type_only: import.type_only,
+            })),
+        }
+    }
+
+    fn resolve_type_name_node(&self, scope_id: &str, node: Node<'tree>) -> Option<Resolution> {
+        if let Some(parent) = node.parent()
+            && matches!(
+                parent.kind(),
+                "nested_type_identifier" | "member_expression"
+            )
+            && let Some(module) = parent
+                .child_by_field_name("module")
+                .or_else(|| parent.child_by_field_name("object"))
+            && parent
+                .child_by_field_name("name")
+                .or_else(|| parent.child_by_field_name("property"))
+                .is_some_and(|property| property.id() == node.id())
+        {
+            return self.resolve_type_member_target(scope_id, module, node);
+        }
+        self.resolve_type_space_name(scope_id, &node_text(self.source, node))
+            .or_else(|| {
+                // TypeScript heritage expressions are value-space
+                // constructor targets even though their syntax is carried by
+                // a type-like node.  This is common for mixin factories such
+                // as `const Parent = params?.Parent ?? Object; class D extends
+                // Parent {}`.  Keep the value fallback scoped to `extends`;
+                // ordinary type references remain fail-closed.
+                let mut current = node.parent();
+                while let Some(candidate) = current {
+                    if matches!(
+                        candidate.kind(),
+                        "extends_clause" | "extends_type_clause" | "class_heritage"
+                    ) {
+                        return self.resolve_name(
+                            scope_id,
+                            &node_text(self.source, node),
+                            Namespace::Value,
+                        );
+                    }
+                    current = candidate.parent();
+                }
+                None
+            })
+    }
+
+    fn resolve_type_space_name(&self, scope_id: &str, name: &str) -> Option<Resolution> {
+        self.resolve_name(scope_id, name, Namespace::Type)
+            .or_else(|| self.resolve_merged_type_name(scope_id, name))
+            .or_else(|| {
+                // JavaScript classes and imports occupy the runtime value
+                // space, but `extends` is still type-like evidence for the
+                // graph. Permit this narrowly for JavaScript; TypeScript
+                // keeps its value/type namespaces fail-closed.
+                (self.language == "javascript")
+                    .then(|| self.resolve_name(scope_id, name, Namespace::Value))
+                    .flatten()
+            })
+    }
+
+    fn resolve_merged_type_name(&self, scope_id: &str, name: &str) -> Option<Resolution> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            let candidates = self
+                .declarations_by_scope
+                .get(&scope)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.name == name
+                        && declaration.namespace.accepts(Namespace::Type)
+                        && self.lexically_visible_unqualified(&scope, declaration)
+                        && matches!(
+                            declaration.kind.as_str(),
+                            "class" | "interface" | "enum" | "namespace" | "type_alias"
+                        )
+                })
+                .collect::<Vec<_>>();
+            let mut qualified_names = candidates
+                .iter()
+                .map(|declaration| declaration.qualified_name.as_str())
+                .collect::<Vec<_>>();
+            qualified_names.sort_unstable();
+            qualified_names.dedup();
+            if qualified_names.len() == 1 {
+                // Interface/namespace declaration merging is one logical
+                // type-space symbol. Prefer the interface/type declaration as
+                // the representative; member lookup proceeds by qualified
+                // name and therefore retains merged namespace members.
+                let mut candidates = candidates;
+                candidates.sort_by_key(|declaration| {
+                    (
+                        match declaration.kind.as_str() {
+                            "interface" => 0_u8,
+                            "type_alias" => 1,
+                            "class" => 2,
+                            "enum" => 3,
+                            "namespace" => 4,
+                            _ => 5,
+                        },
+                        declaration.id.as_str(),
+                    )
+                });
+                return candidates
+                    .first()
+                    .map(|declaration| Resolution::Local((*declaration).clone()));
+            }
+            if !candidates.is_empty() {
+                return None;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        None
+    }
+
+    fn resolve_super_target(&self, scope_id: &str) -> Option<Resolution> {
+        let class_name = self.enclosing_type(scope_id)?;
+        let base = self.base_targets.get(&class_name)?.clone();
+        if let Some(import) = base.import {
+            return Some(Resolution::Import(import));
+        }
+        let declarations = self
+            .declarations_by_qualified
+            .get(&base.qualified_name)?
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| declaration.kind == "class")
+            .cloned()
+            .collect::<Vec<_>>();
+        (declarations.len() == 1).then(|| Resolution::Local(declarations[0].clone()))
+    }
+
+    /// Narrow a local discriminated-union variable inside the positive branch
+    /// of a direct property guard (`if (value.success) { value.data }`).
+    /// The guard is intentionally syntax- and scope-bounded: negated,
+    /// compound, reassigned, and cross-function control flow remains
+    /// unresolved instead of being inferred from spelling alone.
+    fn flow_narrowed_union_receiver(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        declaration: &DeclarationInfo,
+    ) -> Option<ReceiverTarget> {
+        let variable_type = self.variable_types.get(&declaration.id)?;
+        let targets = self.type_alias_union_targets.get(variable_type)?;
+        let variable_name = declaration.name.as_str();
+        let guard_property = self.positive_property_guard(object, variable_name)?;
+        let mut matches = Vec::new();
+        let mut literal_matches = Vec::new();
+        for target_name in targets {
+            let receiver = self.resolve_declared_type_receiver(scope_id, target_name)?;
+            if receiver.import.is_some() {
+                continue;
+            }
+            let qualified_name = format!("{}.{}", receiver.qualified_name, guard_property);
+            let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+                continue;
+            };
+            let literal_true = ids.iter().any(|id| {
+                self.declarations
+                    .get(id)
+                    .and_then(|declaration| {
+                        self.property_literal_values
+                            .get(&declaration.qualified_name)
+                    })
+                    .is_some_and(|value| value == "true")
+            });
+            if literal_true {
+                literal_matches.push(receiver.clone());
+            }
+            if ids.len() == 1 {
+                matches.push(receiver);
+            }
+        }
+        if let [receiver] = literal_matches.as_slice() {
+            return Some(receiver.clone());
+        }
+        let [receiver] = matches.as_slice() else {
+            return None;
+        };
+        Some(receiver.clone())
+    }
+
+    /// Narrow a local union by a direct string-literal discriminant guard
+    /// (`if (value.kind === "ready") { value.data }`).  This is deliberately
+    /// limited to a single strict equality in the positive branch and to
+    /// unique source-declared literal properties on the union members.
+    fn flow_narrowed_discriminant_receiver(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        declaration: &DeclarationInfo,
+    ) -> Option<ReceiverTarget> {
+        let variable_type = self.variable_types.get(&declaration.id)?;
+        let targets = self.type_alias_union_targets.get(variable_type)?;
+        let (guard_property, guard_value) =
+            self.positive_discriminant_guard(object, declaration.name.as_str())?;
+        let mut matches = Vec::new();
+        for target_name in targets {
+            let receiver = self.resolve_declared_type_receiver(scope_id, target_name)?;
+            if receiver.import.is_some() {
+                continue;
+            }
+            let qualified_name = format!("{}.{}", receiver.qualified_name, guard_property);
+            let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+                continue;
+            };
+            if ids.iter().any(|id| {
+                self.declarations
+                    .get(id)
+                    .and_then(|declaration| {
+                        self.property_literal_values
+                            .get(&declaration.qualified_name)
+                    })
+                    .is_some_and(|value| value == &guard_value)
+            }) {
+                matches.push(receiver);
+            }
+        }
+        let [receiver] = matches.as_slice() else {
+            return None;
+        };
+        Some(receiver.clone())
+    }
+
+    fn positive_property_guard(&self, object: Node<'tree>, variable_name: &str) -> Option<String> {
+        let mut current = object.parent();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let Some(ancestor) = current else {
+                break;
+            };
+            if ancestor.kind() == "if_statement"
+                && let Some(consequence) = ancestor.child_by_field_name("consequence")
+                && node_is_descendant_or_same(object, consequence)
+                && let Some(condition) = ancestor.child_by_field_name("condition")
+            {
+                let text = node_text(self.source, condition);
+                let compact = text
+                    .chars()
+                    .filter(|character| !character.is_ascii_whitespace())
+                    .collect::<String>();
+                let compact = compact
+                    .strip_prefix('(')
+                    .and_then(|value| value.strip_suffix(')'))
+                    .unwrap_or(&compact);
+                let prefix = format!("{variable_name}.");
+                if let Some(property) = compact.strip_prefix(&prefix)
+                    && !property.is_empty()
+                    && property.chars().all(|character| {
+                        character == '_' || character == '$' || character.is_ascii_alphanumeric()
+                    })
+                {
+                    return Some(property.to_owned());
+                }
+            }
+            current = ancestor.parent();
+        }
+        None
+    }
+
+    fn positive_discriminant_guard(
+        &self,
+        object: Node<'tree>,
+        variable_name: &str,
+    ) -> Option<(String, String)> {
+        let mut current = object.parent();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let Some(ancestor) = current else {
+                break;
+            };
+            if ancestor.kind() == "if_statement"
+                && let Some(consequence) = ancestor.child_by_field_name("consequence")
+                && node_is_descendant_or_same(object, consequence)
+                && let Some(condition) = ancestor.child_by_field_name("condition")
+            {
+                let compact = node_text(self.source, condition)
+                    .chars()
+                    .filter(|character| !character.is_ascii_whitespace())
+                    .collect::<String>();
+                let compact = compact
+                    .strip_prefix('(')
+                    .and_then(|value| value.strip_suffix(')'))
+                    .unwrap_or(&compact);
+                let Some((left, right)) = compact.split_once("===") else {
+                    current = ancestor.parent();
+                    continue;
+                };
+                let (member, literal) = if let Some(literal) = right
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .or_else(|| {
+                        right
+                            .strip_prefix('\'')
+                            .and_then(|value| value.strip_suffix('\''))
+                    }) {
+                    (left, literal)
+                } else if let Some(literal) = left
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .or_else(|| {
+                        left.strip_prefix('\'')
+                            .and_then(|value| value.strip_suffix('\''))
+                    })
+                {
+                    (right, literal)
+                } else {
+                    current = ancestor.parent();
+                    continue;
+                };
+                let prefix = format!("{variable_name}.");
+                let Some(property) = member.strip_prefix(&prefix) else {
+                    current = ancestor.parent();
+                    continue;
+                };
+                if property.is_empty()
+                    || !property.chars().all(|character| {
+                        character == '_' || character == '$' || character.is_ascii_alphanumeric()
+                    })
+                    || literal.is_empty()
+                    || literal.len() > MAX_TYPE_SHAPE_BYTES
+                {
+                    current = ancestor.parent();
+                    continue;
+                }
+                return Some((property.to_owned(), literal.to_owned()));
+            }
+            current = ancestor.parent();
+        }
+        None
+    }
+
+    fn flow_narrowed_instanceof_receiver(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        declaration: &DeclarationInfo,
+    ) -> Option<ReceiverTarget> {
+        let mut current = object.parent();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let Some(ancestor) = current else {
+                break;
+            };
+            if ancestor.kind() == "if_statement"
+                && let Some(consequence) = ancestor.child_by_field_name("consequence")
+                && node_is_descendant_or_same(object, consequence)
+                && let Some(condition) = ancestor.child_by_field_name("condition")
+            {
+                let compact = node_text(self.source, condition)
+                    .chars()
+                    .filter(|character| !character.is_ascii_whitespace())
+                    .collect::<String>();
+                let compact = compact
+                    .strip_prefix('(')
+                    .and_then(|value| value.strip_suffix(')'))
+                    .unwrap_or(&compact);
+                let Some((left, right)) = compact.split_once("instanceof") else {
+                    current = ancestor.parent();
+                    continue;
+                };
+                if left != declaration.name {
+                    current = ancestor.parent();
+                    continue;
+                }
+                let right = right.trim_matches(['(', ')']);
+                if right.is_empty()
+                    || !right.chars().all(|character| {
+                        character == '_'
+                            || character == '$'
+                            || character == '.'
+                            || character == ':'
+                            || character.is_ascii_alphanumeric()
+                    })
+                {
+                    current = ancestor.parent();
+                    continue;
+                }
+                if let Some(receiver) = self.resolve_declared_type_receiver(scope_id, right) {
+                    return Some(receiver);
+                }
+            }
+            current = ancestor.parent();
+        }
+        None
+    }
+
+    fn receiver_target(&self, scope_id: &str, object: Node<'tree>) -> Option<ReceiverTarget> {
+        match object.kind() {
+            "this" => self.this_receiver_target(scope_id),
+            "super" => {
+                let class_name = self.enclosing_type(scope_id)?;
+                self.base_targets.get(&class_name).cloned()
+            }
+            "identifier" | "type_identifier" | "jsx_identifier" => {
+                let name = node_text(self.source, object);
+                if name == "this" {
+                    return self.this_receiver_target(scope_id);
+                }
+                if name == "super" {
+                    let class_name = self.enclosing_type(scope_id)?;
+                    return self.base_targets.get(&class_name).cloned();
+                }
+                match self.resolve_name(scope_id, &name, Namespace::Value) {
+                    Some(Resolution::Local(declaration)) => {
+                        if matches!(
+                            declaration.kind.as_str(),
+                            "class" | "interface" | "enum" | "namespace" | "function"
+                        ) {
+                            return Some(ReceiverTarget {
+                                qualified_name: declaration.qualified_name.clone(),
+                                import: None,
+                                scope_id: self.member_scope_for_declaration(&declaration),
+                                type_arguments: None,
+                            });
+                        }
+
+                        if let Some(qualified_name) = self.prototype_sources.get(&declaration.id) {
+                            return Some(ReceiverTarget {
+                                qualified_name: qualified_name.clone(),
+                                import: None,
+                                scope_id: Some(declaration.scope_id.clone()),
+                                type_arguments: None,
+                            });
+                        }
+
+                        if let Some(qualified_name) =
+                            self.variable_inline_type_receivers.get(&declaration.id)
+                        {
+                            return Some(ReceiverTarget {
+                                qualified_name: qualified_name.clone(),
+                                import: None,
+                                scope_id: Some(declaration.scope_id.clone()),
+                                type_arguments: None,
+                            });
+                        }
+
+                        if let Some(receiver) =
+                            self.flow_narrowed_discriminant_receiver(scope_id, object, &declaration)
+                        {
+                            return Some(receiver);
+                        }
+
+                        if let Some(receiver) =
+                            self.flow_narrowed_union_receiver(scope_id, object, &declaration)
+                        {
+                            return Some(receiver);
+                        }
+
+                        if let Some(receiver) =
+                            self.flow_narrowed_instanceof_receiver(scope_id, object, &declaration)
+                        {
+                            return Some(receiver);
+                        }
+
+                        if let Some(qualified_name) = self.variable_types.get(&declaration.id) {
+                            let qualified_name = self
+                                .instance_receiver_qualified_name(qualified_name)
+                                .unwrap_or_else(|| qualified_name.clone());
+                            let receiver_scope = self.scope_for_qualified_nominal(&qualified_name);
+                            return Some(ReceiverTarget {
+                                qualified_name,
+                                import: None,
+                                scope_id: receiver_scope,
+                                type_arguments: None,
+                            });
+                        }
+
+                        if let Some(source_id) = self.variable_object_sources.get(&declaration.id)
+                            && let Some(source) = self.declarations.get(source_id)
+                        {
+                            return Some(ReceiverTarget {
+                                qualified_name: source.qualified_name.clone(),
+                                import: None,
+                                scope_id: self.member_scope_for_declaration(source),
+                                type_arguments: None,
+                            });
+                        }
+
+                        if declaration.kind == "variable"
+                            && self
+                                .structural_object_variables
+                                .contains(&declaration.qualified_name)
+                        {
+                            return Some(ReceiverTarget {
+                                qualified_name: declaration.qualified_name,
+                                import: None,
+                                scope_id: Some(declaration.scope_id),
+                                type_arguments: None,
+                            });
+                        }
+                        None
+                    }
+                    Some(Resolution::Import(import)) => Some(ReceiverTarget {
+                        qualified_name: import_target_without_namespace(&import.target),
+                        import: Some(import),
+                        scope_id: None,
+                        type_arguments: None,
+                    }),
+                    None => None,
+                }
+            }
+            "new_expression" => {
+                let constructor = object
+                    .child_by_field_name("constructor")
+                    .or_else(|| first_named_child(object))?;
+                if constructor.kind() == "this" || node_text(self.source, constructor) == "this" {
+                    return self.this_receiver_target(scope_id);
+                }
+                let target = rightmost_identifier(constructor)?;
+                match self.resolve_name(
+                    scope_id,
+                    &node_text(self.source, target),
+                    Namespace::Both,
+                )? {
+                    Resolution::Local(declaration)
+                        if matches!(
+                            declaration.kind.as_str(),
+                            "class" | "interface" | "enum" | "namespace"
+                        ) =>
+                    {
+                        Some(ReceiverTarget {
+                            qualified_name: declaration.qualified_name.clone(),
+                            import: None,
+                            scope_id: self.member_scope_for_declaration(&declaration),
+                            type_arguments: None,
+                        })
+                    }
+                    Resolution::Local(declaration) if declaration.kind == "function" => {
+                        Some(ReceiverTarget {
+                            qualified_name: format!("{}.prototype", declaration.qualified_name),
+                            import: None,
+                            // Prototype assignments are normally published in
+                            // the constructor's binding scope, not inside its
+                            // function body. Leave the scope broad enough for
+                            // the exact qualified-name proof below.
+                            scope_id: Some(declaration.scope_id.clone()),
+                            type_arguments: None,
+                        })
+                    }
+                    Resolution::Import(import) => Some(ReceiverTarget {
+                        qualified_name: import_target_without_namespace(&import.target),
+                        import: Some(import),
+                        scope_id: None,
+                        type_arguments: None,
+                    }),
+                    _ => None,
+                }
+            }
+            "call_expression" | "optional_call_expression" => {
+                self.call_return_receiver(scope_id, object)
+            }
+            "as_expression" | "type_assertion" => {
+                let type_node = object
+                    .child_by_field_name("type")
+                    .or_else(|| object.child_by_field_name("type_annotation"))
+                    .or_else(|| {
+                        let mut cursor = object.walk();
+                        (object.kind() == "as_expression")
+                            .then(|| object.named_children(&mut cursor).last())
+                            .flatten()
+                    })
+                    .or_else(|| first_named_child(object));
+                let type_name = type_node
+                    .map(|node| normalize_type_text(self.source, node))
+                    .unwrap_or_default();
+                if !type_name.is_empty() {
+                    if let Some(receiver) =
+                        self.resolve_declared_type_receiver(scope_id, &type_name)
+                    {
+                        return Some(receiver);
+                    }
+                    // `as any`/`as unknown` deliberately erase the
+                    // receiver type. Do not recover the pre-assertion
+                    // expression and invent a member target. `as const` is
+                    // retained only for an object literal, where the
+                    // structural declaration remains source-local.
+                    if matches!(type_name.as_str(), "any" | "unknown" | "never") {
+                        return None;
+                    }
+                }
+                let value = object
+                    .child_by_field_name("expression")
+                    .or_else(|| object.child_by_field_name("value"))
+                    .or_else(|| first_named_child(object))?;
+                if type_name == "const" && unwrap_expression_node(value).kind() == "object" {
+                    return self.receiver_target(scope_id, value);
+                }
+                None
+            }
+            "satisfies_expression" => {
+                let value = object
+                    .child_by_field_name("expression")
+                    .or_else(|| object.child_by_field_name("value"))
+                    .or_else(|| first_named_child(object))?;
+                self.receiver_target(scope_id, value)
+            }
+            "parenthesized_expression" | "non_null_expression" => {
+                let value = object
+                    .child_by_field_name("expression")
+                    .or_else(|| first_named_child(object))?;
+                self.receiver_target(scope_id, value)
+            }
+            "member_expression"
+            | "optional_member_expression"
+            | "subscript_expression"
+            | "jsx_member_expression"
+            | "jsx_namespace_name" => {
+                let property = member_property_node(object)?;
+                let nested =
+                    self.receiver_target(scope_id, object.child_by_field_name("object")?)?;
+                if object.kind() == "subscript_expression"
+                    && let Some(indexed) = self.index_value_receiver(scope_id, &nested)
+                {
+                    return Some(indexed);
+                }
+                let property_name = member_property_name(self.source, property)?;
+                // A namespace import (`import * as api`) exposes members with
+                // `module::member` identity.  A named/class import denotes a
+                // nominal receiver, whose instance member is
+                // `module::Type.member`; retaining this distinction prevents
+                // imported class members from collapsing onto the package
+                // namespace.
+                let namespace_import = nested
+                    .import
+                    .as_ref()
+                    .is_some_and(|import| import.namespace == Namespace::Module);
+                let qualified_name = if namespace_import {
+                    format!("{}::{property_name}", nested.qualified_name)
+                } else {
+                    format!("{}.{property_name}", nested.qualified_name)
+                };
+                let receiver = ReceiverTarget {
+                    qualified_name,
+                    import: nested.import,
+                    scope_id: nested.scope_id,
+                    type_arguments: None,
+                };
+                Some(
+                    self.typed_member_receiver(scope_id, receiver.clone())
+                        .unwrap_or(receiver),
+                )
+            }
+            _ => None,
+        }
+    }
+
+    fn call_return_receiver(&self, scope_id: &str, call: Node<'tree>) -> Option<ReceiverTarget> {
+        let function = call
+            .child_by_field_name("function")
+            .or_else(|| first_named_child(call))?;
+        let callee_receiver = if matches!(
+            function.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        ) {
+            function
+                .child_by_field_name("object")
+                .and_then(|object| self.receiver_target(scope_id, object))
+        } else {
+            None
+        };
+        let resolution = if matches!(
+            function.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        ) {
+            let property = member_property_node(function)?;
+            self.resolve_member_target(
+                scope_id,
+                function.child_by_field_name("object"),
+                property,
+                None,
+                &[],
+            )
+        } else {
+            let target = rightmost_identifier(function)?;
+            self.resolve_name(scope_id, &node_text(self.source, target), Namespace::Value)
+        }?;
+        let Resolution::Local(declaration) = resolution else {
+            return None;
+        };
+        let return_type = declaration
+            .return_type_name
+            .clone()
+            .or_else(|| self.variable_alias_return_type(&declaration, scope_id))?;
+        let return_type = return_type.trim();
+        if return_type == "this" {
+            return callee_receiver.or_else(|| self.this_receiver_target(scope_id));
+        }
+        self.resolve_declared_type_receiver(scope_id, return_type)
+            .or_else(|| self.resolve_declared_type_receiver(&declaration.scope_id, return_type))
+    }
+
+    fn variable_alias_return_type(
+        &self,
+        declaration: &DeclarationInfo,
+        scope_id: &str,
+    ) -> Option<String> {
+        let alias = self.variable_alias_values.get(&declaration.id)?;
+        let (base, property) = alias.rsplit_once('.')?;
+        let receiver = self.resolve_name(scope_id, base, Namespace::Value)?;
+        let qualified_name = format!("{}.{}", receiver.qualified_target()?, property);
+        let ids = self.declarations_by_qualified.get(&qualified_name)?;
+        let return_types = ids
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter_map(|declaration| declaration.return_type_name.clone())
+            .collect::<Vec<_>>();
+        let [return_type] = return_types.as_slice() else {
+            return None;
+        };
+        Some(return_type.clone())
+    }
+
+    /// Follow one source-annotated member value to its nominal type. This is
+    /// the bounded bridge that makes chains such as `ctx.common.issues` and
+    /// `this._def.description` precise without attempting whole-program flow
+    /// or structural inference. Generic type parameters are replaced only by
+    /// their direct source-visible constraint; ambiguous or unconstrained
+    /// members remain on the original receiver and are resolved normally (or
+    /// left unresolved).
+    fn typed_member_receiver(
+        &self,
+        scope_id: &str,
+        receiver: ReceiverTarget,
+    ) -> Option<ReceiverTarget> {
+        if receiver.import.is_some() {
+            return None;
+        }
+        let declaration = self
+            .declarations_by_qualified
+            .get(&receiver.qualified_name)
+            .into_iter()
+            .flat_map(|ids| ids.iter())
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| declaration.declared_type_name.is_some())
+            .collect::<Vec<_>>();
+        let declaration = match declaration.as_slice() {
+            [declaration] => (*declaration).clone(),
+            [] => {
+                let (base, property) = receiver.qualified_name.rsplit_once('.')?;
+                match self.resolve_inherited_member_target(base, property, None, &[])? {
+                    Resolution::Local(declaration) => declaration,
+                    Resolution::Import(_) => return None,
+                }
+            }
+            _ => return None,
+        };
+        let type_name = declaration.declared_type_name.as_deref()?;
+        let type_name = receiver
+            .qualified_name
+            .rsplit_once('.')
+            .and_then(|(base, _)| self.base_type_bindings.get(base))
+            .and_then(|bindings| bindings.get(type_name))
+            .cloned()
+            .or_else(|| self.receiver_type_argument(&receiver, type_name))
+            .unwrap_or_else(|| type_name.to_owned());
+        self.resolve_declared_type_receiver(scope_id, &type_name)
+            .or_else(|| self.resolve_declared_type_receiver(&declaration.scope_id, &type_name))
+    }
+
+    /// Substitute one member's generic type parameter from the concrete type
+    /// arguments carried by its receiver. This only accepts a unique local
+    /// nominal declaration with a bounded parameter order; overloaded or
+    /// merged declarations remain unresolved.
+    fn receiver_type_argument(&self, receiver: &ReceiverTarget, type_name: &str) -> Option<String> {
+        let arguments = receiver.type_arguments.as_ref()?;
+        let (base, _) = receiver.qualified_name.rsplit_once('.')?;
+        let ids = self.declarations_by_qualified.get(base)?;
+        let candidates = ids
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter_map(|declaration| {
+                self.generic_parameter_order_by_declaration
+                    .get(&declaration.id)
+                    .map(|order| (declaration, order))
+            })
+            .collect::<Vec<_>>();
+        let [(_declaration, order)] = candidates.as_slice() else {
+            return None;
+        };
+        let index = order.iter().position(|name| name == type_name)?;
+        arguments
+            .get(index)
+            .cloned()
+            .filter(|argument| !argument.is_empty() && argument.len() <= MAX_TYPE_SHAPE_BYTES)
+    }
+
+    fn member_value_receiver(
+        &self,
+        scope_id: &str,
+        receiver: &ReceiverTarget,
+        declaration: &DeclarationInfo,
+    ) -> Option<ReceiverTarget> {
+        let type_name = declaration.declared_type_name.as_deref()?;
+        let type_name = receiver
+            .qualified_name
+            .rsplit_once('.')
+            .and_then(|(base, _)| self.base_type_bindings.get(base))
+            .or_else(|| self.base_type_bindings.get(&receiver.qualified_name))
+            .and_then(|bindings| bindings.get(type_name))
+            .cloned()
+            .or_else(|| self.receiver_type_argument(receiver, type_name))
+            .unwrap_or_else(|| type_name.to_owned());
+        self.resolve_declared_type_receiver(scope_id, &type_name)
+            .or_else(|| self.resolve_declared_type_receiver(&declaration.scope_id, &type_name))
+    }
+
+    fn index_value_receiver(
+        &self,
+        scope_id: &str,
+        receiver: &ReceiverTarget,
+    ) -> Option<ReceiverTarget> {
+        if receiver.import.is_some() {
+            return None;
+        }
+        let type_name = self.index_value_types.get(&receiver.qualified_name)?;
+        self.resolve_declared_type_receiver(scope_id, type_name)
+    }
+
+    fn resolve_declared_type_receiver(
+        &self,
+        scope_id: &str,
+        type_name: &str,
+    ) -> Option<ReceiverTarget> {
+        let mut current = type_name.trim().to_owned();
+        let mut seen = HashSet::new();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let normalized = current.trim();
+            if normalized.is_empty()
+                || normalized.len() > MAX_TYPE_SHAPE_BYTES
+                || !seen.insert(normalized.to_owned())
+            {
+                return None;
+            }
+            let (lookup_name, type_arguments) = generic_type_parts(normalized)
+                .map(|(base, arguments)| (base.to_owned(), Some(arguments)))
+                .unwrap_or_else(|| (normalized.to_owned(), None));
+            let resolution = self.resolve_name(scope_id, &lookup_name, Namespace::Both)?;
+            match resolution {
+                Resolution::Import(import) => {
+                    return Some(ReceiverTarget {
+                        qualified_name: import_target_without_namespace(&import.target),
+                        import: Some(import),
+                        scope_id: None,
+                        type_arguments,
+                    });
+                }
+                Resolution::Local(declaration) if declaration.kind == "type_alias" => {
+                    if let Some(alias_target) = declaration.declared_type_name.as_deref() {
+                        current.clear();
+                        current.push_str(alias_target);
+                    } else {
+                        return Some(ReceiverTarget {
+                            qualified_name: declaration.qualified_name.clone(),
+                            import: None,
+                            scope_id: self.member_scope_for_declaration(&declaration),
+                            type_arguments,
+                        });
+                    }
+                }
+                Resolution::Local(declaration)
+                    if matches!(
+                        declaration.kind.as_str(),
+                        "class" | "interface" | "enum" | "namespace"
+                    ) =>
+                {
+                    return Some(ReceiverTarget {
+                        qualified_name: declaration.qualified_name.clone(),
+                        import: None,
+                        scope_id: self.member_scope_for_declaration(&declaration),
+                        type_arguments,
+                    });
+                }
+                Resolution::Local(declaration) if declaration.kind == "type_parameter" => {
+                    let owner = self.scope_owners.get(&declaration.scope_id)?;
+                    let constraint = self
+                        .generic_parameters_by_declaration
+                        .get(owner)
+                        .and_then(|parameters| parameters.get(&declaration.name))
+                        .and_then(|constraint| constraint.as_deref())?;
+                    current.clear();
+                    current.push_str(constraint);
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    /// Return the child scope owned by a nominal declaration when one exists.
+    /// Class/interface/namespace members are published in that child scope,
+    /// while ordinary lexical declarations are published in their binding
+    /// scope.  Keeping this distinction lets member resolution separate
+    /// duplicate structural objects that share a qualified spelling in
+    /// different blocks.
+    fn member_scope_for_declaration(&self, declaration: &DeclarationInfo) -> Option<String> {
+        if matches!(
+            declaration.kind.as_str(),
+            "class" | "interface" | "enum" | "namespace" | "type_alias"
+        ) {
+            self.scope_for_owner_declaration(&declaration.id)
+                .or_else(|| Some(declaration.scope_id.clone()))
+        } else if matches!(
+            declaration.kind.as_str(),
+            "function" | "method" | "constructor"
+        ) {
+            self.scope_for_owner_declaration(&declaration.id)
+                .or_else(|| Some(declaration.scope_id.clone()))
+        } else {
+            Some(declaration.scope_id.clone())
+        }
+    }
+
+    fn scope_for_owner_declaration(&self, declaration_id: &str) -> Option<String> {
+        self.scope_owners
+            .iter()
+            .filter(|(_, owner)| owner.as_str() == declaration_id)
+            .map(|(scope, _)| scope.clone())
+            .min()
+    }
+
+    fn scope_for_qualified_nominal(&self, qualified_name: &str) -> Option<String> {
+        let declarations = self
+            .declarations_by_qualified
+            .get(qualified_name)?
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| {
+                matches!(
+                    declaration.kind.as_str(),
+                    "class" | "interface" | "enum" | "namespace" | "type_alias"
+                )
+            })
+            .collect::<Vec<_>>();
+        (declarations.len() == 1).then(|| self.member_scope_for_declaration(declarations[0]))?
+    }
+
+    fn instance_receiver_qualified_name(&self, qualified_name: &str) -> Option<String> {
+        let declarations = self
+            .declarations_by_qualified
+            .get(qualified_name)?
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| declaration.kind == "function")
+            .collect::<Vec<_>>();
+        (declarations.len() == 1).then(|| format!("{qualified_name}.prototype"))
+    }
+
+    fn scope_is_descendant_or_same(&self, scope_id: &str, ancestor: &str) -> bool {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if scope == ancestor {
+                return true;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        false
+    }
+
+    fn scope_distance(&self, scope_id: &str, ancestor: &str) -> Option<usize> {
+        let mut current = Some(scope_id.to_owned());
+        let mut distance = 0_usize;
+        while let Some(scope) = current {
+            if scope == ancestor {
+                return Some(distance);
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+            distance = distance.saturating_add(1);
+        }
+        None
+    }
+
+    fn this_receiver_target(&self, scope_id: &str) -> Option<ReceiverTarget> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if let Some(owner) = self.scope_owners.get(&scope)
+                && let Some(declaration) = self.declarations.get(owner)
+                && matches!(
+                    declaration.kind.as_str(),
+                    "class" | "interface" | "enum" | "namespace"
+                )
+            {
+                return Some(ReceiverTarget {
+                    qualified_name: declaration.qualified_name.clone(),
+                    import: None,
+                    scope_id: self.member_scope_for_declaration(declaration),
+                    type_arguments: None,
+                });
+            }
+            if let Some(owner) = self.scope_owners.get(&scope)
+                && let Some(declaration) = self.declarations.get(owner)
+                && declaration.kind == "function"
+                && self.constructor_name_hints.contains(&declaration.name)
+            {
+                return Some(ReceiverTarget {
+                    qualified_name: declaration.qualified_name.clone(),
+                    import: None,
+                    scope_id: self.member_scope_for_declaration(declaration),
+                    type_arguments: None,
+                });
+            }
+            if let Some(receiver) = self.this_receivers.get(&scope) {
+                return Some(ReceiverTarget {
+                    qualified_name: receiver.clone(),
+                    import: None,
+                    scope_id: self.scope_for_qualified_nominal(receiver),
+                    type_arguments: None,
+                });
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        None
+    }
+
+    fn enclosing_type(&self, scope_id: &str) -> Option<String> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if let Some(owner) = self.scope_owners.get(&scope)
+                && let Some(declaration) = self.declarations.get(owner)
+                && matches!(
+                    declaration.kind.as_str(),
+                    "class" | "interface" | "enum" | "namespace"
+                )
+            {
+                return Some(declaration.qualified_name.clone());
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        None
+    }
+}
+
+#[derive(Clone)]
+struct ImportBinding<'tree> {
+    local_name: String,
+    imported_name: String,
+    anchor: Node<'tree>,
+    type_only: bool,
+}
+
+fn import_namespace(binding: &ImportBinding<'_>) -> Namespace {
+    if binding.type_only {
+        if binding.imported_name == "*" {
+            Namespace::Module
+        } else {
+            Namespace::Type
+        }
+    } else if binding.imported_name == "*" {
+        Namespace::Module
+    } else {
+        // A normal named/default import may denote a class or enum (both
+        // value and type) until the target module is resolved.
+        Namespace::Both
+    }
+}
+
+const fn symbol_namespace(namespace: Namespace) -> SymbolNamespace {
+    match namespace {
+        Namespace::Value => SymbolNamespace::Value,
+        Namespace::Type => SymbolNamespace::Type,
+        Namespace::Module => SymbolNamespace::Namespace,
+        Namespace::Both => SymbolNamespace::ValueAndType,
+    }
+}
+
+fn import_target_without_namespace(target: &str) -> String {
+    target.strip_suffix("::*").unwrap_or(target).to_owned()
+}
+
+fn is_parameter_node(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "required_parameter"
+            | "optional_parameter"
+            | "rest_parameter"
+            | "formal_parameter"
+            | "parameter"
+            | "jsx_parameter"
+    )
+}
+
+fn parameter_pattern_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    node.child_by_field_name("pattern")
+        .or_else(|| node.child_by_field_name("name"))
+        .or_else(|| {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor).find(|child| {
+                matches!(
+                    child.kind(),
+                    "identifier"
+                        | "shorthand_property_identifier_pattern"
+                        | "object_pattern"
+                        | "array_pattern"
+                        | "rest_pattern"
+                )
+            })
+        })
+}
+
+fn first_named_child<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).next()
+}
+
+fn node_is_descendant_or_same(node: Node<'_>, ancestor: Node<'_>) -> bool {
+    let mut current = Some(node);
+    for _ in 0..=MAX_TRAVERSAL_DEPTH {
+        let Some(candidate) = current else {
+            return false;
+        };
+        if candidate.id() == ancestor.id() {
+            return true;
+        }
+        current = candidate.parent();
+    }
+    false
+}
+
+fn default_export_target_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    let exported = first_named_child(node)?;
+    if exported.kind() == "identifier" {
+        return Some(exported);
+    }
+    exported.child_by_field_name("name")
+}
+
+fn anonymous_declaration_shape(
+    node: Node<'_>,
+) -> Option<(&'static str, Namespace, bool, &'static str)> {
+    match node.kind() {
+        "function"
+        | "function_declaration"
+        | "function_expression"
+        | "generator_function"
+        | "generator_function_declaration"
+        | "arrow_function" => Some(("function", Namespace::Value, true, "function")),
+        "class" | "class_declaration" | "abstract_class_declaration" => {
+            Some(("class", Namespace::Both, true, "class"))
+        }
+        _ => None,
+    }
+}
+
+fn declaration_shape<'tree>(
+    node: Node<'tree>,
+) -> Option<(&'static str, Node<'tree>, Namespace, bool, &'static str)> {
+    let (kind, namespace, creates_scope, scope_kind) = match node.kind() {
+        "function_declaration" | "function_signature" | "generator_function_declaration" => {
+            ("function", Namespace::Value, true, "function")
+        }
+        "method_definition" | "method_signature" | "abstract_method_signature" => {
+            ("method", Namespace::Value, true, "function")
+        }
+        "class_declaration" | "abstract_class_declaration" | "class" => {
+            ("class", Namespace::Both, true, "class")
+        }
+        "interface_declaration" => ("interface", Namespace::Type, true, "interface"),
+        "type_alias_declaration" => ("type_alias", Namespace::Type, true, "type"),
+        "enum_declaration" => ("enum", Namespace::Both, true, "enum"),
+        "internal_module" | "module" | "namespace_export" => {
+            ("namespace", Namespace::Module, true, "namespace")
+        }
+        "public_field_definition"
+        | "property_signature"
+        | "field_definition"
+        | "pair"
+        | "enum_assignment"
+        | "shorthand_property_identifier" => ("property", Namespace::Value, false, "property"),
+        "type_parameter" => ("type_parameter", Namespace::Type, false, "type"),
+        _ => return None,
+    };
+    let name = node
+        .child_by_field_name("name")
+        .or_else(|| {
+            matches!(node.kind(), "pair" | "enum_assignment")
+                .then(|| node.child_by_field_name("key"))
+                .flatten()
+        })
+        .or_else(|| (node.kind() == "shorthand_property_identifier").then_some(node))
+        .or_else(|| {
+            matches!(node.kind(), "namespace_export").then(|| first_identifier_node(node))?
+        })?;
+    Some((kind, name, namespace, creates_scope, scope_kind))
+}
+
+fn is_anonymous_signature_scope(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "call_signature" | "construct_signature" | "function_type"
+    )
+}
+
+fn lexical_scope_kind(node: Node<'_>) -> Option<&'static str> {
+    match node.kind() {
+        "statement_block" => Some("block"),
+        "switch_statement" => Some("switch"),
+        "catch_clause" => Some("catch"),
+        "for_statement" | "for_in_statement" | "for_of_statement" => Some("loop"),
+        _ => None,
+    }
+}
+
+fn return_value_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    node.child_by_field_name("value")
+        .or_else(|| node.child_by_field_name("argument"))
+        .or_else(|| first_named_child(node))
+}
+
+/// Strip expression-only wrappers that preserve the runtime object identity.
+/// TypeScript's `as const`, `satisfies`, parenthesized expressions, and type
+/// assertions do not change which source object supplies a member. Keep this
+/// helper shallow and bounded so malformed or adversarial trees cannot turn a
+/// structural receiver into an unbounded walk.
+fn unwrap_expression_node<'tree>(mut node: Node<'tree>) -> Node<'tree> {
+    for _ in 0..MAX_TYPE_SHAPE_DEPTH {
+        if !matches!(
+            node.kind(),
+            "as_expression"
+                | "satisfies_expression"
+                | "parenthesized_expression"
+                | "type_assertion"
+                | "non_null_expression"
+        ) {
+            break;
+        }
+        let Some(inner) = node
+            .child_by_field_name("expression")
+            .or_else(|| first_named_child(node))
+        else {
+            break;
+        };
+        if inner.id() == node.id() {
+            break;
+        }
+        node = inner;
+    }
+    node
+}
+
+fn is_var_binding_node(node: Node<'_>) -> bool {
+    let mut current = Some(node);
+    while let Some(candidate) = current {
+        match candidate.kind() {
+            "variable_declaration" => return true,
+            "lexical_declaration" => return false,
+            "program" | "statement_block" | "switch_statement" | "catch_clause" => {
+                return false;
+            }
+            _ => current = candidate.parent(),
+        }
+    }
+    false
+}
+
+fn is_callable_node(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "arrow_function"
+            | "function_expression"
+            | "generator_function"
+            | "function"
+            | "function_declaration"
+            | "function_signature"
+            | "method_definition"
+            | "method_signature"
+            | "abstract_method_signature"
+            | "function_type"
+            | "constructor_type"
+    )
+}
+
+fn callable_value_node(node: Node<'_>) -> Option<Node<'_>> {
+    if is_callable_node(node) {
+        return Some(node);
+    }
+    if let Some(value) = node
+        .child_by_field_name("value")
+        .filter(|value| is_callable_node(*value))
+    {
+        return Some(value);
+    }
+    if let Some(type_node) = node
+        .child_by_field_name("type")
+        .or_else(|| node.child_by_field_name("annotation"))
+    {
+        if is_callable_node(type_node) {
+            return Some(type_node);
+        }
+        if let Some(callable) =
+            first_named_child(type_node).filter(|child| is_callable_node(*child))
+        {
+            return Some(callable);
+        }
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| is_callable_node(*child))
+}
+
+fn callable_returns_this(node: Node<'_>) -> bool {
+    let Some(body) = node
+        .child_by_field_name("body")
+        .or_else(|| first_named_child_kind(node, "statement_block"))
+    else {
+        return false;
+    };
+    let mut pending = vec![(body, 0_usize)];
+    while let Some((current, depth)) = pending.pop() {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            continue;
+        }
+        if current.kind() == "return_statement"
+            && return_value_node(current)
+                .is_some_and(|value| unwrap_expression_node(value).kind() == "this")
+        {
+            return true;
+        }
+        if depth > 0 && is_callable_node(current) {
+            continue;
+        }
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            pending.push((child, depth.saturating_add(1)));
+        }
+    }
+    false
+}
+
+fn callable_return_constructor_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let body = node
+        .child_by_field_name("body")
+        .or_else(|| first_named_child_kind(node, "statement_block"))?;
+    let mut pending = vec![(body, 0_usize)];
+    while let Some((current, depth)) = pending.pop() {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            continue;
+        }
+        if current.kind() == "return_statement"
+            && let Some(value) = return_value_node(current).map(unwrap_expression_node)
+            && value.kind() == "new_expression"
+            && let Some(constructor) = value
+                .child_by_field_name("constructor")
+                .or_else(|| first_named_child(value))
+            && let Some(name) = rightmost_identifier(constructor)
+        {
+            let name = node_text(source, name);
+            if !name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES {
+                return Some(name);
+            }
+        }
+        if depth > 0 && is_callable_node(current) {
+            continue;
+        }
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            pending.push((child, depth.saturating_add(1)));
+        }
+    }
+    None
+}
+
+fn declaration_is_callable_shape(node: Node<'_>, kind: &str, source: &[u8]) -> bool {
+    if matches!(kind, "function" | "method" | "constructor" | "class") {
+        return true;
+    }
+    if kind == "property"
+        && node.child_by_field_name("value").is_some_and(|value| {
+            let value = unwrap_expression_node(value);
+            matches!(
+                value.kind(),
+                "member_expression" | "optional_member_expression" | "subscript_expression"
+            ) && member_property_node(value).is_some()
+        })
+    {
+        // A property alias initialized from another source member is a
+        // callable-value candidate only when it is actually used as a call;
+        // keeping the shape here lets call-site arity resolution retain the
+        // alias property as the exact target without guessing its signature.
+        return true;
+    }
+    // A variable initialized from a call is a source-grounded callable-value
+    // candidate.  TypeScript/JavaScript libraries commonly expose callable
+    // factories (`const schema = type(...)`, React state setters, benchmark
+    // wrappers) without a local function declaration or explicit annotation.
+    // Restrict this to call initializers; object literals and `new` values are
+    // not treated as callable merely because they can have members.
+    if matches!(kind, "variable" | "parameter")
+        && node.child_by_field_name("value").is_some_and(|value| {
+            matches!(value.kind(), "call_expression" | "optional_call_expression")
+        })
+    {
+        return true;
+    }
+    let type_node = node
+        .child_by_field_name("type")
+        .or_else(|| node.child_by_field_name("annotation"))
+        .or_else(|| {
+            node.child_by_field_name("name")
+                .and_then(|name| name.child_by_field_name("type"))
+        });
+    if let Some(type_node) = type_node {
+        let type_text = node_text(source, type_node);
+        if type_text.contains("typeof")
+            || type_text.contains("Constructor")
+            || type_text.contains("SchemaClass")
+            || contains_node_kind(type_node, "function_type")
+            || contains_node_kind(type_node, "constructor_type")
+            || contains_node_kind(type_node, "function_signature")
+            || contains_node_kind(type_node, "construct_signature")
+        {
+            return true;
+        }
+    }
+    callable_value_node(node).is_some_and(|value| {
+        is_callable_node(value) || node_text(source, value).contains(".constructor")
+    })
+}
+
+fn contains_node_kind(node: Node<'_>, kind: &str) -> bool {
+    if node.kind() == kind {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| contains_node_kind(child, kind))
+}
+
+fn inline_object_type_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    let root = if node.kind() == "type_annotation" {
+        first_named_child(node)?
+    } else {
+        node
+    };
+    let mut pending = vec![(root, 0_usize)];
+    let mut found = None;
+    while let Some((current, depth)) = pending.pop() {
+        if depth > MAX_TYPE_SHAPE_DEPTH as usize {
+            return None;
+        }
+        if current.kind() == "object_type" {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(current);
+            continue;
+        }
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            pending.push((child, depth.saturating_add(1)));
+        }
+    }
+    found
+}
+
+fn callable_parameter_arity(node: Node<'_>, source: &[u8]) -> Option<(u32, Option<u32>)> {
+    if matches!(
+        node.kind(),
+        "class_declaration" | "abstract_class_declaration" | "class"
+    ) {
+        return class_constructor_parameter_arity(node, source);
+    }
+    if !matches!(
+        node.kind(),
+        "function_declaration"
+            | "function_signature"
+            | "generator_function_declaration"
+            | "method_definition"
+            | "method_signature"
+            | "abstract_method_signature"
+            | "function"
+            | "function_expression"
+            | "generator_function"
+            | "arrow_function"
+            | "function_type"
+            | "constructor_type"
+    ) {
+        return None;
+    }
+    let parameters = node
+        .child_by_field_name("parameters")
+        .or_else(|| first_named_child_kind(node, "formal_parameters"));
+    let Some(parameters) = parameters else {
+        return node.child_by_field_name("parameter").map(|_| (1, Some(1)));
+    };
+    let mut minimum = 0_u32;
+    let mut maximum = 0_u32;
+    let mut cursor = parameters.walk();
+    for parameter in parameters.named_children(&mut cursor) {
+        if parameter.kind().contains("comment") {
+            continue;
+        }
+        maximum = maximum.saturating_add(1);
+        if parameter.kind().contains("rest")
+            || node_text(source, parameter).trim_start().starts_with("...")
+        {
+            return Some((minimum, None));
+        }
+        let optional = matches!(
+            parameter.kind(),
+            "assignment_pattern"
+                | "object_assignment_pattern"
+                | "optional_parameter"
+                | "optional_parameter_declaration"
+        ) || parameter.child_by_field_name("value").is_some()
+            || parameter.child_by_field_name("initializer").is_some();
+        if !optional {
+            minimum = minimum.saturating_add(1);
+        }
+    }
+    Some((minimum, Some(maximum)))
+}
+
+fn callable_parameter_types(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {
+    if !matches!(
+        node.kind(),
+        "function_declaration"
+            | "generator_function_declaration"
+            | "method_definition"
+            | "method_signature"
+            | "abstract_method_signature"
+            | "function"
+            | "function_expression"
+            | "generator_function"
+            | "arrow_function"
+            | "function_type"
+            | "constructor_type"
+    ) {
+        return None;
+    }
+    let parameters = node
+        .child_by_field_name("parameters")
+        .or_else(|| first_named_child_kind(node, "formal_parameters"));
+    let Some(parameters) = parameters else {
+        let parameter = node.child_by_field_name("parameter")?;
+        let type_node = parameter
+            .child_by_field_name("type")
+            .or_else(|| first_named_child_kind(parameter, "type_annotation"))?;
+        let normalized = normalize_type_text(source, type_node);
+        return (!normalized.is_empty()).then_some(vec![normalized]);
+    };
+    let mut types = Vec::new();
+    let mut cursor = parameters.walk();
+    for parameter in parameters.named_children(&mut cursor) {
+        if parameter.kind().contains("rest")
+            || node_text(source, parameter).trim_start().starts_with("...")
+            || matches!(
+                parameter.kind(),
+                "optional_parameter" | "rest_parameter" | "optional_parameter_declaration"
+            )
+            || parameter.child_by_field_name("value").is_some()
+            || parameter.child_by_field_name("initializer").is_some()
+        {
+            return None;
+        }
+        let type_node = parameter
+            .child_by_field_name("type")
+            .or_else(|| first_named_child_kind(parameter, "type_annotation"))?;
+        let normalized = normalize_type_text(source, type_node);
+        if normalized.is_empty() {
+            return None;
+        }
+        types.push(normalized);
+    }
+    Some(types)
+}
+
+fn callable_type_parameters(
+    node: Node<'_>,
+    source: &[u8],
+) -> Option<HashMap<String, Option<String>>> {
+    let type_parameters = node
+        .child_by_field_name("type_parameters")
+        .or_else(|| first_named_child_kind(node, "type_parameters"))?;
+    let mut parameters = HashMap::new();
+    let mut cursor = type_parameters.walk();
+    for parameter in type_parameters.named_children(&mut cursor) {
+        if parameter.kind() != "type_parameter" {
+            continue;
+        }
+        let Some(name_node) = parameter
+            .child_by_field_name("name")
+            .or_else(|| first_named_child_kind(parameter, "type_identifier"))
+        else {
+            continue;
+        };
+        let name = node_text(source, name_node);
+        if name.is_empty() || name.len() > MAX_TYPE_SHAPE_BYTES {
+            continue;
+        }
+        let constraint = parameter
+            .child_by_field_name("constraint")
+            .or_else(|| first_named_child_kind(parameter, "constraint"))
+            .map(|constraint| normalize_type_text(source, constraint))
+            .map(|constraint| {
+                constraint
+                    .strip_prefix("extends")
+                    .unwrap_or(&constraint)
+                    .to_owned()
+            })
+            .filter(|constraint| !constraint.is_empty());
+        parameters.insert(name, constraint);
+        if parameters.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            break;
+        }
+    }
+    (!parameters.is_empty()).then_some(parameters)
+}
+
+fn callable_type_parameter_order(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {
+    let type_parameters = node
+        .child_by_field_name("type_parameters")
+        .or_else(|| first_named_child_kind(node, "type_parameters"))?;
+    let mut order = Vec::new();
+    let mut cursor = type_parameters.walk();
+    for parameter in type_parameters.named_children(&mut cursor) {
+        if parameter.kind() != "type_parameter" {
+            continue;
+        }
+        let Some(name_node) = parameter
+            .child_by_field_name("name")
+            .or_else(|| first_named_child_kind(parameter, "type_identifier"))
+        else {
+            continue;
+        };
+        let name = node_text(source, name_node);
+        if !name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES {
+            order.push(name);
+        }
+        if order.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            break;
+        }
+    }
+    (!order.is_empty()).then_some(order)
+}
+
+fn callable_return_type_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let callable = if is_callable_node(node) {
+        node
+    } else {
+        node.child_by_field_name("value")
+            .filter(|value| is_callable_node(*value))
+            .or_else(|| {
+                // A property signature can be callable without a runtime
+                // value, for example `getter: () => T`.  Treat only
+                // source-declared property/field shapes as callable here;
+                // recursively searching arbitrary declarations would make a
+                // containing class appear to return the first nested method's
+                // type.
+                matches!(
+                    node.kind(),
+                    "property_signature"
+                        | "public_field_definition"
+                        | "field_definition"
+                        | "property_declaration"
+                        | "property"
+                )
+                .then(|| callable_value_node(node))
+                .flatten()
+            })?
+    };
+    let return_type = callable
+        .child_by_field_name("return_type")
+        .or_else(|| callable.child_by_field_name("type"))?;
+    let return_node = if return_type.kind() == "type_annotation" {
+        first_named_child(return_type).unwrap_or(return_type)
+    } else {
+        return_type
+    };
+    if return_node.kind() == "generic_type" {
+        let normalized = normalize_type_text(source, return_node);
+        if !normalized.is_empty() {
+            return Some(normalized);
+        }
+    }
+    if matches!(
+        return_node.kind(),
+        "identifier" | "type_identifier" | "predefined_type"
+    ) {
+        let name = node_text(source, return_node);
+        if !name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(name);
+        }
+    }
+    let mut names = Vec::new();
+    collect_type_name_nodes(return_type, &mut names);
+    names
+        .first()
+        .map(|name| node_text(source, *name))
+        .filter(|name| !name.is_empty())
+}
+
+fn normalize_type_text(source: &[u8], node: Node<'_>) -> String {
+    node_text(source, node)
+        .trim()
+        .trim_start_matches(':')
+        .chars()
+        .filter(|character| !character.is_ascii_whitespace())
+        .collect()
+}
+
+fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let annotation = node
+        .child_by_field_name("type")
+        .or_else(|| first_named_child_kind(node, "type_annotation"))
+        .or_else(|| {
+            (node.kind() == "type_alias_declaration")
+                .then(|| {
+                    node.child_by_field_name("value")
+                        .or_else(|| first_named_child(node))
+                })
+                .flatten()
+        })?;
+    let type_node = if annotation.kind() == "type_annotation" {
+        first_named_child(annotation)?
+    } else {
+        annotation
+    };
+    let generic_text = (type_node.kind() == "generic_type")
+        .then(|| normalize_type_text(source, type_node))
+        .filter(|text| !text.is_empty());
+    let type_node = match type_node.kind() {
+        "generic_type" | "parenthesized_type" => first_named_child(type_node)?,
+        _ => type_node,
+    };
+    if type_node.kind() == "union_type" {
+        return union_property_type_name(node, type_node, source);
+    }
+    if let Some(generic_text) = generic_text {
+        return Some(generic_text);
+    }
+    let type_name = match type_node.kind() {
+        "identifier" | "type_identifier" | "predefined_type" => node_text(source, type_node),
+        "nested_type_identifier" | "member_expression" | "qualified_name" => type_node
+            .child_by_field_name("name")
+            .or_else(|| type_node.child_by_field_name("property"))
+            .map(|name| node_text(source, name))?,
+        _ => return None,
+    };
+    (!type_name.is_empty()).then_some(type_name)
+}
+
+/// Return the one nominal type preserved by an optional property union such
+/// as `Callback | undefined`.  This is intentionally limited to declaration
+/// nodes that publish a property: a union on a variable or type alias does
+/// not prove a single receiver and must remain unresolved.  Primitive,
+/// literal, and top-like union members are ignored; multiple nominal members
+/// stay ambiguous.
+fn union_property_type_name(node: Node<'_>, union_node: Node<'_>, source: &[u8]) -> Option<String> {
+    if !matches!(
+        node.kind(),
+        "property_signature"
+            | "public_field_definition"
+            | "field_definition"
+            | "property_declaration"
+            | "property"
+    ) {
+        return None;
+    }
+    let text = node_text(source, union_node);
+    if text.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let mut names = Vec::new();
+    let mut start = 0_usize;
+    let mut angle = 0_u32;
+    let mut bracket = 0_u32;
+    let mut paren = 0_u32;
+    let mut brace = 0_u32;
+    for (index, character) in text.char_indices() {
+        match character {
+            '<' => angle = angle.saturating_add(1),
+            '>' => angle = angle.saturating_sub(1),
+            '[' => bracket = bracket.saturating_add(1),
+            ']' => bracket = bracket.saturating_sub(1),
+            '(' => paren = paren.saturating_add(1),
+            ')' => paren = paren.saturating_sub(1),
+            '{' => brace = brace.saturating_add(1),
+            '}' => brace = brace.saturating_sub(1),
+            '|' if angle == 0 && bracket == 0 && paren == 0 && brace == 0 => {
+                if let Some(name) = union_target_name(text[start..index].trim())
+                    && !is_non_nominal_union_member(&name)
+                {
+                    names.push(name);
+                }
+                start = index.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+        if names.len() > 1 {
+            return None;
+        }
+    }
+    if let Some(name) = union_target_name(text[start..].trim())
+        && !is_non_nominal_union_member(&name)
+    {
+        names.push(name);
+    }
+    (names.len() == 1).then(|| names.remove(0))
+}
+
+fn is_non_nominal_union_member(name: &str) -> bool {
+    matches!(
+        name,
+        "any"
+            | "unknown"
+            | "never"
+            | "void"
+            | "undefined"
+            | "null"
+            | "string"
+            | "number"
+            | "boolean"
+            | "bigint"
+            | "symbol"
+            | "object"
+            | "true"
+            | "false"
+    )
+}
+
+fn type_alias_union_targets(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {
+    let text = node_text(source, node);
+    if text.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let (_, rhs) = text.split_once('=')?;
+    let mut targets = Vec::new();
+    let mut start = 0_usize;
+    let mut angle = 0_u32;
+    let mut bracket = 0_u32;
+    let mut paren = 0_u32;
+    let mut brace = 0_u32;
+    for (index, character) in rhs.char_indices() {
+        match character {
+            '<' => angle = angle.saturating_add(1),
+            '>' => angle = angle.saturating_sub(1),
+            '[' => bracket = bracket.saturating_add(1),
+            ']' => bracket = bracket.saturating_sub(1),
+            '(' => paren = paren.saturating_add(1),
+            ')' => paren = paren.saturating_sub(1),
+            '{' => brace = brace.saturating_add(1),
+            '}' => brace = brace.saturating_sub(1),
+            '|' if angle == 0 && bracket == 0 && paren == 0 && brace == 0 => {
+                let part = rhs[start..index].trim();
+                if let Some(target) = union_target_name(part) {
+                    targets.push(target);
+                }
+                start = index.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+        if targets.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            return None;
+        }
+    }
+    if targets.is_empty() {
+        return None;
+    }
+    if let Some(target) = union_target_name(rhs[start..].trim()) {
+        targets.push(target);
+    }
+    (targets.len() >= 2).then_some(targets)
+}
+
+fn property_literal_value(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let text = node_text(source, node);
+    let (_, value) = text.split_once(':')?;
+    let value = value
+        .trim()
+        .trim_end_matches(';')
+        .trim_end_matches(',')
+        .trim();
+    let quoted = value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        });
+    if let Some(quoted) =
+        quoted.filter(|value| !value.is_empty() && value.len() <= MAX_TYPE_SHAPE_BYTES)
+    {
+        return Some(quoted.to_owned());
+    }
+    matches!(value, "true" | "false").then(|| value.to_owned())
+}
+
+fn index_value_type(node: Node<'_>, source: &[u8]) -> Option<String> {
+    let text = node_text(source, node);
+    if text.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let close = text.find(']')?;
+    let remainder = text.get(close + 1..)?;
+    let colon = remainder.find(':')?;
+    let value = remainder.get(colon + 1..)?.trim();
+    let value = value
+        .split([';', '}'])
+        .next()
+        .unwrap_or(value)
+        .trim()
+        .trim_start_matches("readonly ")
+        .trim();
+    if value.is_empty() || value.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    Some(strip_type_arguments(value).to_owned())
+}
+
+fn union_target_name(part: &str) -> Option<String> {
+    let part = part.trim().trim_end_matches(';').trim();
+    if part.is_empty() || part.starts_with('{') || part.contains("=>") {
+        return None;
+    }
+    let part = part
+        .strip_prefix("readonly ")
+        .or_else(|| part.strip_prefix("keyof "))
+        .unwrap_or(part)
+        .trim();
+    let part = strip_type_arguments(part).trim();
+    let part = part.strip_prefix("typeof ").unwrap_or(part).trim();
+    if part.is_empty()
+        || part.len() > MAX_TYPE_SHAPE_BYTES
+        || !part.chars().all(|character| {
+            character == '_'
+                || character == '$'
+                || character == '.'
+                || character == ':'
+                || character.is_ascii_alphanumeric()
+        })
+    {
+        return None;
+    }
+    Some(part.to_owned())
+}
+
+fn indexed_type_parts(type_name: &str) -> Option<(&str, String)> {
+    let type_name = type_name.trim();
+    if !type_name.ends_with(']') {
+        return None;
+    }
+    let open = type_name.rfind('[')?;
+    let base = type_name.get(..open)?.trim();
+    let property = type_name.get(open + 1..type_name.len() - 1)?.trim();
+    let property = property.trim_matches(['"', '\'']);
+    if base.is_empty() || property.is_empty() || property.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    Some((base, property.to_owned()))
+}
+
+fn strip_type_arguments(type_name: &str) -> &str {
+    let mut depth = 0_u32;
+    for (index, character) in type_name.char_indices() {
+        match character {
+            '<' => depth = depth.saturating_add(1),
+            '>' if depth > 0 => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+        if character == '<' && depth == 1 {
+            return type_name[..index].trim();
+        }
+    }
+    type_name.trim()
+}
+
+fn generic_type_parts(type_name: &str) -> Option<(&str, Vec<String>)> {
+    let type_name = type_name.trim();
+    let open = type_name.find('<')?;
+    if !type_name.ends_with('>') || open == 0 {
+        return None;
+    }
+    let base = type_name[..open].trim();
+    let arguments_text = &type_name[open + 1..type_name.len() - 1];
+    if base.is_empty() || arguments_text.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let mut arguments = Vec::new();
+    let mut start = 0_usize;
+    let mut depth = 0_u32;
+    for (index, character) in arguments_text.char_indices() {
+        match character {
+            '<' | '[' | '(' => depth = depth.saturating_add(1),
+            '>' | ']' | ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let argument = arguments_text[start..index].trim();
+                if argument.is_empty() || argument.len() > MAX_TYPE_SHAPE_BYTES {
+                    return None;
+                }
+                arguments.push(argument.to_owned());
+                start = index.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+        if arguments.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            return None;
+        }
+    }
+    let argument = arguments_text[start..].trim();
+    if argument.is_empty() || argument.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    arguments.push(argument.to_owned());
+    Some((base, arguments))
+}
+
+fn parameter_type_matches(parameter: &str, argument: &str) -> bool {
+    parameter_type_matches_depth(parameter, argument, 0)
+}
+
+fn parameter_type_matches_depth(parameter: &str, argument: &str, depth: u32) -> bool {
+    if depth > MAX_TYPE_SHAPE_DEPTH {
+        return false;
+    }
+    let parameter = parameter.trim();
+    let argument = argument.trim();
+    if parameter == argument {
+        return true;
+    }
+    if parameter == "any" || parameter == "unknown" {
+        return true;
+    }
+    if parameter.starts_with("typeof") {
+        return true;
+    }
+    if parameter.contains("=>") || parameter.contains("function") {
+        return argument == "function" || argument == "any";
+    }
+    if let Some(base_type) = utility_base_type(parameter)
+        && (argument == "object" || type_names_compatible(base_type, argument))
+    {
+        // `Pick<T, K>`, `Omit<T, K>`, and the other standard utility wrappers
+        // preserve the source object's nominal identity for receiver/call
+        // selection. Match only the first type argument; an unrelated base
+        // type must remain unresolved rather than being widened structurally.
+        return true;
+    }
+    if let Some(union) = parameter.strip_suffix("|") {
+        return parameter_type_matches_depth(union, argument, depth.saturating_add(1));
+    }
+    if parameter.contains('|') {
+        return parameter
+            .split('|')
+            .any(|member| parameter_type_matches_depth(member, argument, depth.saturating_add(1)));
+    }
+    // A source object literal is structurally assignable to an annotated
+    // object/interface/utility type even when the local extractor cannot
+    // prove every property at the call site. Preserve the declaration
+    // target, but never widen primitive or callable signatures this way.
+    if argument == "object" && is_object_like_type(parameter) {
+        return true;
+    }
+    if parameter.ends_with("[]") {
+        let element = parameter.trim_end_matches("[]").trim();
+        if argument == "array" || type_names_compatible(element, argument) {
+            return true;
+        }
+    }
+    // Parameter annotations are often unqualified (`SourceLine[]`) while a
+    // source-proven argument carries its module-qualified declaration name.
+    // Compare the leaf only when at least one side is unqualified; two
+    // independently qualified names remain distinct and fail closed.
+    if type_names_compatible(parameter, argument) {
+        return true;
+    }
+    if parameter.starts_with('"') || parameter.starts_with('\'') || parameter.starts_with('`') {
+        return argument == "string";
+    }
+    match (parameter, argument) {
+        ("string", "string")
+        | ("number", "number")
+        | ("boolean", "boolean")
+        | ("null", "null")
+        | ("undefined", "undefined")
+        | ("object", "object")
+        | ("Function", "function")
+        | ("function", "function")
+        | ("Array", "array")
+        | ("unknown", _) => true,
+        _ => parameter == argument,
+    }
+}
+
+fn is_object_like_type(type_name: &str) -> bool {
+    let type_name = type_name.trim();
+    if type_name.starts_with('{')
+        || type_name.starts_with("Pick<")
+        || type_name.starts_with("Omit<")
+        || type_name.starts_with("Partial<")
+        || type_name.starts_with("Required<")
+        || type_name.starts_with("Readonly<")
+        || type_name.starts_with("Record<")
+    {
+        return true;
+    }
+    !matches!(
+        type_name,
+        "string"
+            | "number"
+            | "boolean"
+            | "bigint"
+            | "symbol"
+            | "null"
+            | "undefined"
+            | "void"
+            | "never"
+            | "unknown"
+            | "any"
+            | "object"
+            | "Function"
+            | "function"
+            | "Array"
+    ) && !type_name.contains("=>")
+}
+
+fn utility_base_type(type_name: &str) -> Option<&str> {
+    utility_type_parts(type_name).map(|(_, base, _)| base)
+}
+
+fn utility_type_parts(type_name: &str) -> Option<(&str, &str, Vec<&str>)> {
+    let type_name = type_name.trim();
+    if type_name.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let (utility, prefix) = [
+        ("Pick", "Pick<"),
+        ("Omit", "Omit<"),
+        ("Partial", "Partial<"),
+        ("Required", "Required<"),
+        ("Readonly", "Readonly<"),
+        ("Record", "Record<"),
+    ]
+    .into_iter()
+    .find(|(_, prefix)| type_name.starts_with(*prefix))?;
+    let inner = type_name.strip_prefix(prefix)?.strip_suffix('>')?;
+    let arguments = split_top_level_arguments(inner)?;
+    (arguments.len() >= 2).then_some((utility, arguments[0], arguments))
+}
+
+fn split_top_level_arguments(input: &str) -> Option<Vec<&str>> {
+    let mut arguments = Vec::new();
+    let mut start = 0;
+    let mut depth = 0_u32;
+    for (index, character) in input.char_indices() {
+        match character {
+            '<' | '{' | '(' | '[' => {
+                depth = depth.checked_add(1)?;
+                if depth > MAX_TYPE_SHAPE_DEPTH {
+                    return None;
+                }
+            }
+            '>' | '}' | ')' | ']' => {
+                depth = depth.checked_sub(1)?;
+            }
+            ',' if depth == 0 => {
+                arguments.push(input[start..index].trim());
+                start = index.saturating_add(character.len_utf8());
+                if arguments.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    arguments.push(input[start..].trim());
+    arguments
+        .iter()
+        .all(|argument| !argument.is_empty())
+        .then_some(arguments)
+}
+
+fn type_literal_names(keys: &str) -> Option<HashSet<String>> {
+    let mut names = HashSet::new();
+    for key in keys.split('|').map(str::trim) {
+        let key = key
+            .strip_prefix('"')
+            .and_then(|key| key.strip_suffix('"'))
+            .or_else(|| {
+                key.strip_prefix('\'')
+                    .and_then(|key| key.strip_suffix('\''))
+            })
+            .or_else(|| key.strip_prefix('`').and_then(|key| key.strip_suffix('`')))?;
+        if key.is_empty() || key.len() > MAX_TYPE_SHAPE_BYTES {
+            return None;
+        }
+        names.insert(key.to_owned());
+    }
+    (!names.is_empty()).then_some(names)
+}
+
+fn inline_object_required_property_names(type_name: &str) -> Option<HashSet<String>> {
+    let mut type_name = type_name.trim();
+    while let Some(stripped) = type_name.strip_suffix("[]") {
+        type_name = stripped.trim();
+    }
+    if type_name.len() > MAX_TYPE_SHAPE_BYTES
+        || !type_name.starts_with('{')
+        || !type_name.ends_with('}')
+    {
+        return None;
+    }
+    let inner = &type_name[1..type_name.len().saturating_sub(1)];
+    let mut properties = HashSet::new();
+    for member in split_top_level_members(inner)? {
+        let member = member.trim();
+        if member.is_empty() || member.starts_with("...") || member.starts_with('[') {
+            continue;
+        }
+        let Some(colon) = top_level_delimiter(member, ':') else {
+            continue;
+        };
+        let mut name = member[..colon].trim();
+        if name.starts_with("readonly ") {
+            name = name.trim_start_matches("readonly ").trim();
+        }
+        if name.ends_with('?') {
+            continue;
+        }
+        let name = name
+            .strip_prefix('"')
+            .and_then(|name| name.strip_suffix('"'))
+            .or_else(|| {
+                name.strip_prefix('\'')
+                    .and_then(|name| name.strip_suffix('\''))
+            })
+            .or_else(|| {
+                name.strip_prefix('`')
+                    .and_then(|name| name.strip_suffix('`'))
+            })
+            .unwrap_or(name)
+            .trim();
+        if !name.is_empty() {
+            properties.insert(name.to_owned());
+        }
+        if properties.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            break;
+        }
+    }
+    Some(properties)
+}
+
+fn split_top_level_members(input: &str) -> Option<Vec<&str>> {
+    let mut members = Vec::new();
+    let mut start = 0;
+    let mut depth = 0_u32;
+    for (index, character) in input.char_indices() {
+        match character {
+            '<' | '{' | '(' | '[' => {
+                depth = depth.checked_add(1)?;
+                if depth > MAX_TYPE_SHAPE_DEPTH {
+                    return None;
+                }
+            }
+            '>' | '}' | ')' | ']' => depth = depth.checked_sub(1)?,
+            ';' | ',' if depth == 0 => {
+                members.push(input[start..index].trim());
+                start = index.saturating_add(character.len_utf8());
+                if members.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    members.push(input[start..].trim());
+    Some(members)
+}
+
+fn top_level_delimiter(input: &str, delimiter: char) -> Option<usize> {
+    let mut depth = 0_u32;
+    for (index, character) in input.char_indices() {
+        match character {
+            '<' | '{' | '(' | '[' => depth = depth.checked_add(1)?,
+            '>' | '}' | ')' | ']' => depth = depth.checked_sub(1)?,
+            character if character == delimiter && depth == 0 => return Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn type_names_compatible(left: &str, right: &str) -> bool {
+    // Generic arguments affect assignability, but they are not needed to
+    // choose a unique source declaration when the surrounding evidence has
+    // already proven the nominal base. Erase only the bounded outer argument
+    // list (`Result<T>` -> `Result`) before comparing qualified leaves; this
+    // recovers calls through imported/local generic aliases without widening
+    // two independently qualified base names.
+    let left = strip_type_arguments(left.trim())
+        .trim_end_matches("[]")
+        .trim();
+    let right = strip_type_arguments(right.trim())
+        .trim_end_matches("[]")
+        .trim();
+    if left == right || left.is_empty() || right.is_empty() {
+        return left == right;
+    }
+    let left_qualified = left.contains('.') || left.contains("::");
+    let right_qualified = right.contains('.') || right.contains("::");
+    if left_qualified && right_qualified {
+        return false;
+    }
+    let left_leaf = left.rsplit(['.', ':']).next().unwrap_or(left);
+    let right_leaf = right.rsplit(['.', ':']).next().unwrap_or(right);
+    left_leaf == right_leaf
+}
+
+/// Infer the only arity that is source-proven for a class construction. A
+/// class without an explicit constructor accepts zero arguments by default;
+/// one fixed constructor gives its exact arity. Optional, rest, overloaded,
+/// or otherwise incomplete constructor declarations deliberately return
+/// `None` so call resolution stays unresolved instead of guessing.
+fn class_constructor_parameter_arity(node: Node<'_>, source: &[u8]) -> Option<(u32, Option<u32>)> {
+    let body = node
+        .child_by_field_name("body")
+        .or_else(|| first_named_child_kind(node, "class_body"))?;
+    let mut constructor_count = 0_usize;
+    let mut result = None;
+    let mut cursor = body.walk();
+    for child in body.named_children(&mut cursor) {
+        if !matches!(child.kind(), "method_definition" | "method_signature") {
+            continue;
+        }
+        let Some(name) = child.child_by_field_name("name") else {
+            continue;
+        };
+        if node_text(source, name) != "constructor" {
+            continue;
+        }
+        constructor_count = constructor_count.saturating_add(1);
+        let arity = callable_parameter_arity(child, source);
+        if constructor_count == 1 {
+            result = arity;
+        } else if result != arity {
+            return None;
+        }
+    }
+    if constructor_count == 0 {
+        Some((0, Some(0)))
+    } else {
+        result
+    }
+}
+
+fn class_has_explicit_constructor(node: Node<'_>, source: &[u8]) -> bool {
+    let Some(body) = node
+        .child_by_field_name("body")
+        .or_else(|| first_named_child_kind(node, "class_body"))
+    else {
+        return false;
+    };
+    let mut cursor = body.walk();
+    body.named_children(&mut cursor).any(|child| {
+        matches!(child.kind(), "method_definition" | "method_signature")
+            && child
+                .child_by_field_name("name")
+                .is_some_and(|name| node_text(source, name) == "constructor")
+    })
+}
+
+fn call_argument_count(node: Node<'_>) -> Option<u32> {
+    let arguments = node
+        .child_by_field_name("arguments")
+        .or_else(|| first_named_child_kind(node, "arguments"))?;
+    let mut cursor = arguments.walk();
+    let count = arguments
+        .named_children(&mut cursor)
+        .filter(|argument| !argument.kind().contains("comment"))
+        .count();
+    u32::try_from(count).ok()
+}
+
+fn collect_pattern_names<'tree>(
+    node: Node<'tree>,
+    source: &[u8],
+    output: &mut Vec<(String, Node<'tree>)>,
+) {
+    match node.kind() {
+        "identifier" | "shorthand_property_identifier_pattern" | "this" => {
+            let name = node_text(source, node);
+            if !name.is_empty() {
+                output.push((name, node));
+            }
+        }
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                collect_pattern_names(child, source, output);
+            }
+        }
+    }
+}
+
+fn collect_import_bindings<'tree>(
+    source: &[u8],
+    clause: Node<'tree>,
+    reexport: bool,
+    statement_type_only: bool,
+    output: &mut Vec<ImportBinding<'tree>>,
+) {
+    if reexport && clause.kind() == "export_clause" {
+        let mut specifiers = Vec::new();
+        collect_nodes_of_kind(clause, "export_specifier", &mut specifiers);
+        for specifier in specifiers {
+            let identifiers = direct_identifier_children(specifier, source);
+            let Some(imported) = identifiers.first().copied() else {
+                continue;
+            };
+            let local = identifiers.get(1).copied().unwrap_or(imported);
+            output.push(ImportBinding {
+                local_name: node_text(source, local),
+                imported_name: node_text(source, imported),
+                anchor: local,
+                type_only: statement_type_only
+                    || node_text(source, specifier)
+                        .trim_start()
+                        .starts_with("type "),
+            });
+        }
+        return;
+    }
+    let mut cursor = clause.walk();
+    for child in clause.named_children(&mut cursor) {
+        match child.kind() {
+            "identifier" if !reexport => output.push(ImportBinding {
+                local_name: node_text(source, child),
+                imported_name: "default".to_owned(),
+                anchor: child,
+                type_only: statement_type_only,
+            }),
+            "namespace_import" => {
+                if let Some(name) = first_identifier_node(child) {
+                    output.push(ImportBinding {
+                        local_name: node_text(source, name),
+                        imported_name: "*".to_owned(),
+                        anchor: name,
+                        type_only: statement_type_only,
+                    });
+                }
+            }
+            "named_imports" | "export_clause" => {
+                let mut specifiers = Vec::new();
+                collect_nodes_of_kind(
+                    child,
+                    if reexport {
+                        "export_specifier"
+                    } else {
+                        "import_specifier"
+                    },
+                    &mut specifiers,
+                );
+                for specifier in specifiers {
+                    let identifiers = direct_identifier_children(specifier, source);
+                    let Some(imported) = identifiers.first().copied() else {
+                        continue;
+                    };
+                    let local = identifiers.get(1).copied().unwrap_or(imported);
+                    output.push(ImportBinding {
+                        local_name: node_text(source, local),
+                        imported_name: node_text(source, imported),
+                        anchor: local,
+                        type_only: statement_type_only
+                            || node_text(source, specifier)
+                                .trim_start()
+                                .starts_with("type "),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_type_name_nodes<'tree>(node: Node<'tree>, output: &mut Vec<Node<'tree>>) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if matches!(child.kind(), "nested_type_identifier" | "member_expression") {
+            let property = child
+                .child_by_field_name("name")
+                .or_else(|| child.child_by_field_name("property"));
+            if let Some(property) = property {
+                output.push(property);
+            } else {
+                output.push(child);
+            }
+        } else if matches!(child.kind(), "type_identifier" | "identifier") {
+            output.push(child);
+        } else if child.kind() != "type_arguments" {
+            collect_type_name_nodes(child, output);
+        }
+    }
+}
+
+fn direct_identifier_children<'tree>(node: Node<'tree>, source: &[u8]) -> Vec<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .filter(|child| {
+            matches!(
+                child.kind(),
+                "identifier" | "type_identifier" | "property_identifier"
+            )
+        })
+        .filter(|child| !node_text(source, *child).is_empty())
+        .collect()
+}
+
+fn collect_nodes_of_kind<'tree>(node: Node<'tree>, kind: &str, output: &mut Vec<Node<'tree>>) {
+    if node.kind() == kind {
+        output.push(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_nodes_of_kind(child, kind, output);
+    }
+}
+
+fn first_named_child_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| child.kind() == kind)
+}
+
+fn first_identifier_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    if matches!(
+        node.kind(),
+        "identifier" | "type_identifier" | "property_identifier" | "private_property_identifier"
+    ) {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find_map(first_identifier_node)
+}
+
+fn rightmost_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    if matches!(
+        node.kind(),
+        "identifier" | "type_identifier" | "property_identifier" | "private_property_identifier"
+    ) {
+        return Some(node);
+    }
+    if matches!(
+        node.kind(),
+        "member_expression" | "optional_member_expression"
+    ) {
+        return node
+            .child_by_field_name("property")
+            .and_then(rightmost_identifier);
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .last()
+        .and_then(rightmost_identifier)
+}
+
+fn member_property_name(source: &[u8], property: Node<'_>) -> Option<String> {
+    let computed = is_computed_member_property(property);
+    if computed
+        && !matches!(
+            property.kind(),
+            "string" | "string_fragment" | "template_string" | "number"
+        )
+    {
+        return None;
+    }
+    let name = if matches!(
+        property.kind(),
+        "string" | "string_fragment" | "template_string"
+    ) {
+        string_literal(source, property)
+    } else {
+        node_text(source, property)
+    };
+    (!name.is_empty()).then_some(name)
+}
+
+fn is_computed_member_property(property: Node<'_>) -> bool {
+    property.parent().is_some_and(|parent| {
+        let mut cursor = parent.walk();
+        parent
+            .children(&mut cursor)
+            .any(|child| matches!(child.kind(), "[" | "]"))
+    })
+}
+
+fn member_property_node<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    node.child_by_field_name("property")
+        .or_else(|| node.child_by_field_name("index"))
+}
+
+fn known_builtin_static_member(receiver: &str, property: &str) -> bool {
+    match receiver {
+        "Array" => matches!(property, "from" | "isArray" | "of"),
+        "Boolean" => matches!(property, "prototype"),
+        "Date" => matches!(property, "now" | "parse" | "UTC"),
+        "JSON" => matches!(property, "parse" | "stringify"),
+        "Math" => matches!(
+            property,
+            "abs" | "ceil" | "floor" | "max" | "min" | "pow" | "random" | "round" | "trunc"
+        ),
+        "Number" => matches!(
+            property,
+            "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" | "parseInt"
+        ),
+        "Object" => matches!(
+            property,
+            "assign"
+                | "create"
+                | "defineProperty"
+                | "entries"
+                | "freeze"
+                | "fromEntries"
+                | "getOwnPropertyDescriptor"
+                | "getOwnPropertyNames"
+                | "hasOwn"
+                | "keys"
+                | "values"
+        ),
+        "Promise" => matches!(
+            property,
+            "all" | "allSettled" | "any" | "race" | "reject" | "resolve"
+        ),
+        "Reflect" => matches!(
+            property,
+            "apply" | "construct" | "defineProperty" | "get" | "has" | "ownKeys" | "set"
+        ),
+        "RegExp" => matches!(property, "escape"),
+        "String" => matches!(property, "fromCharCode" | "fromCodePoint" | "raw"),
+        "console" => matches!(
+            property,
+            "assert"
+                | "debug"
+                | "dir"
+                | "error"
+                | "info"
+                | "log"
+                | "table"
+                | "time"
+                | "timeEnd"
+                | "trace"
+                | "warn"
+        ),
+        "ArrayBuffer" => matches!(property, "isView"),
+        _ => false,
+    }
+}
+
+fn known_builtin_instance_member(receiver: &str, property: &str) -> bool {
+    match receiver {
+        "Array" => matches!(
+            property,
+            "at" | "concat"
+                | "entries"
+                | "every"
+                | "fill"
+                | "filter"
+                | "find"
+                | "findIndex"
+                | "findLast"
+                | "findLastIndex"
+                | "flat"
+                | "flatMap"
+                | "forEach"
+                | "includes"
+                | "indexOf"
+                | "join"
+                | "keys"
+                | "lastIndexOf"
+                | "map"
+                | "pop"
+                | "push"
+                | "reduce"
+                | "reduceRight"
+                | "reverse"
+                | "shift"
+                | "slice"
+                | "some"
+                | "sort"
+                | "splice"
+                | "toReversed"
+                | "toSorted"
+                | "toSpliced"
+                | "unshift"
+                | "values"
+        ),
+        "Boolean" => matches!(property, "toString" | "valueOf"),
+        "Date" => matches!(
+            property,
+            "getDate"
+                | "getDay"
+                | "getFullYear"
+                | "getHours"
+                | "getMilliseconds"
+                | "getMinutes"
+                | "getMonth"
+                | "getSeconds"
+                | "getTime"
+                | "getTimezoneOffset"
+                | "getUTCDate"
+                | "getUTCDay"
+                | "getUTCFullYear"
+                | "getUTCHours"
+                | "getUTCMilliseconds"
+                | "getUTCMinutes"
+                | "getUTCMonth"
+                | "getUTCSeconds"
+                | "setDate"
+                | "setFullYear"
+                | "setHours"
+                | "setMilliseconds"
+                | "setMinutes"
+                | "setMonth"
+                | "setSeconds"
+                | "setTime"
+                | "setUTCDate"
+                | "setUTCFullYear"
+                | "setUTCHours"
+                | "setUTCMilliseconds"
+                | "setUTCMinutes"
+                | "setUTCMonth"
+                | "setUTCSeconds"
+                | "toDateString"
+                | "toISOString"
+                | "toJSON"
+                | "toLocaleDateString"
+                | "toLocaleString"
+                | "toLocaleTimeString"
+                | "toString"
+                | "toTimeString"
+                | "toUTCString"
+                | "valueOf"
+        ),
+        "Number" => matches!(
+            property,
+            "toExponential" | "toFixed" | "toLocaleString" | "toPrecision" | "toString" | "valueOf"
+        ),
+        "String" => matches!(
+            property,
+            "at" | "charAt"
+                | "charCodeAt"
+                | "codePointAt"
+                | "concat"
+                | "endsWith"
+                | "includes"
+                | "indexOf"
+                | "lastIndexOf"
+                | "match"
+                | "matchAll"
+                | "normalize"
+                | "padEnd"
+                | "padStart"
+                | "repeat"
+                | "replace"
+                | "replaceAll"
+                | "search"
+                | "slice"
+                | "split"
+                | "startsWith"
+                | "substring"
+                | "substr"
+                | "toLocaleLowerCase"
+                | "toLocaleUpperCase"
+                | "toLowerCase"
+                | "toString"
+                | "toUpperCase"
+                | "trim"
+                | "trimEnd"
+                | "trimStart"
+                | "valueOf"
+        ),
+        "RegExp" => matches!(property, "compile" | "exec" | "test" | "toString"),
+        "ArrayBuffer" => matches!(
+            property,
+            "byteLength" | "detached" | "maxByteLength" | "resizable" | "resize" | "slice"
+        ),
+        "DataView" => matches!(
+            property,
+            "getBigInt64"
+                | "getBigUint64"
+                | "getFloat32"
+                | "getFloat64"
+                | "getInt16"
+                | "getInt32"
+                | "getInt8"
+                | "getUint16"
+                | "getUint32"
+                | "getUint8"
+                | "setBigInt64"
+                | "setBigUint64"
+                | "setFloat32"
+                | "setFloat64"
+                | "setInt16"
+                | "setInt32"
+                | "setInt8"
+                | "setUint16"
+                | "setUint32"
+                | "setUint8"
+        ),
+        "Map" => matches!(
+            property,
+            "delete" | "entries" | "forEach" | "get" | "has" | "keys" | "set" | "values"
+        ),
+        "Set" => matches!(
+            property,
+            "add" | "delete" | "entries" | "forEach" | "has" | "keys" | "values"
+        ),
+        "WeakMap" => matches!(property, "delete" | "get" | "has" | "set"),
+        "WeakSet" => matches!(property, "add" | "delete" | "has"),
+        "Promise" => matches!(property, "catch" | "finally" | "then"),
+        _ => false,
+    }
+}
+
+fn is_typescript_utility_type(name: &str) -> bool {
+    matches!(
+        name,
+        "ArrayLike"
+            | "Awaited"
+            | "Capitalize"
+            | "ConstructorParameters"
+            | "ThisType"
+            | "Exclude"
+            | "Extract"
+            | "InstanceType"
+            | "Lowercase"
+            | "NoInfer"
+            | "NonNullable"
+            | "Omit"
+            | "OmitThisParameter"
+            | "Parameters"
+            | "Partial"
+            | "Pick"
+            | "Readonly"
+            | "ReadonlyArray"
+            | "Record"
+            | "Required"
+            | "ReturnType"
+            | "ThisParameterType"
+            | "Uncapitalize"
+            | "Uppercase"
+            | "Iterable"
+            | "IterableIterator"
+            | "Iterator"
+            | "IteratorResult"
+            | "AsyncIterable"
+            | "AsyncIterableIterator"
+            | "AsyncIterator"
+            | "AsyncIteratorResult"
+            | "PromiseLike"
+            | "PropertyKey"
+            | "ArrayConstructor"
+            | "Function"
+            | "ObjectConstructor"
+            | "StringConstructor"
+            | "NumberConstructor"
+            | "BooleanConstructor"
+            | "RegExpConstructor"
+            | "DateConstructor"
+            | "ErrorConstructor"
+    )
+}
+
+fn standard_library_type_target(name: &str) -> Option<(String, String)> {
+    if matches!(
+        name,
+        "AggregateError"
+            | "ArrayConstructor"
+            | "ArrayLike"
+            | "ArrayBufferView"
+            | "AsyncGenerator"
+            | "AsyncGeneratorFunction"
+            | "AsyncIterator"
+            | "AsyncIteratorResult"
+            | "DataView"
+            | "ErrorOptions"
+            | "Float32Array"
+            | "Float64Array"
+            | "Generator"
+            | "GeneratorFunction"
+            | "Int8Array"
+            | "Int16Array"
+            | "Int32Array"
+            | "Iterator"
+            | "IteratorResult"
+            | "MapConstructor"
+            | "PromiseLike"
+            | "RegExpExecArray"
+            | "RegExpMatchArray"
+            | "RegExpSplitMatchArray"
+            | "ReadonlyMap"
+            | "ReadonlySet"
+            | "SetConstructor"
+            | "SharedArrayBuffer"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Uint16Array"
+            | "Uint32Array"
+            | "WeakKeyTypes"
+            | "WeakMapConstructor"
+            | "WeakSetConstructor"
+    ) {
+        return Some((
+            format!("typescript.lib::{name}"),
+            "typescript.lib".to_owned(),
+        ));
+    }
+    if matches!(
+        name,
+        "AbortController"
+            | "AbortSignal"
+            | "Animation"
+            | "Blob"
+            | "CSSStyleDeclaration"
+            | "CanvasRenderingContext2D"
+            | "CustomEvent"
+            | "Document"
+            | "Element"
+            | "Event"
+            | "EventTarget"
+            | "File"
+            | "FileList"
+            | "FormData"
+            | "Headers"
+            | "HTMLElement"
+            | "HTMLDivElement"
+            | "HTMLInputElement"
+            | "HTMLTextAreaElement"
+            | "ImageData"
+            | "MessageEvent"
+            | "MouseEvent"
+            | "Node"
+            | "ReadableStream"
+            | "Request"
+            | "Response"
+            | "Storage"
+            | "TextDecoder"
+            | "TextEncoder"
+            | "URL"
+            | "URLSearchParams"
+            | "WebSocket"
+            | "Window"
+            | "Worker"
+    ) {
+        return Some((format!("dom.lib::{name}"), "lib.dom".to_owned()));
+    }
+    if name == "Buffer" {
+        return Some(("node.global::Buffer".to_owned(), "@types/node".to_owned()));
+    }
+    None
+}
+
+fn find_require_call<'tree>(node: Node<'tree>, source: &[u8]) -> Option<Node<'tree>> {
+    if node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| node_text(source, function) == "require")
+    {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find_map(|child| find_require_call(child, source))
+}
+
+fn is_type_reference_node(node: Node<'_>) -> bool {
+    if node.kind() == "type_identifier" || node.kind() == "nested_type_identifier" {
+        return true;
+    }
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if matches!(
+            parent.kind(),
+            "type_annotation"
+                | "return_type"
+                | "type_arguments"
+                | "type_parameters"
+                | "generic_type"
+                | "predefined_type"
+                | "infer_type"
+                | "type_alias_declaration"
+                | "interface_declaration"
+        ) {
+            return true;
+        }
+        if matches!(
+            parent.kind(),
+            "expression_statement"
+                | "statement_block"
+                | "program"
+                | "arguments"
+                | "formal_parameters"
+        ) {
+            break;
+        }
+        current = parent.parent();
+    }
+    false
+}
+
+fn module_name(path: &Path, source_file: &str) -> String {
+    let name = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            Path::new(source_file)
+                .file_stem()
+                .and_then(|value| value.to_str())
+        })
+        .unwrap_or("module");
+    name.to_owned()
+}
+
+fn dialect_for_path(path: &Path, fallback: &str) -> String {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+        .filter(|extension| {
+            matches!(
+                extension.as_str(),
+                "js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts"
+            )
+        })
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn stable_graph_id(source_file: &str, kind: &str, name: &str, start: usize) -> String {
+    let start = start.to_string();
+    make_id(&[source_file, kind, name, &start])
+}
+
+fn fact_key(role: SemanticRole, node: Node<'_>, context: Option<&str>) -> String {
+    format!(
+        "{}:{}:{}:{}",
+        role_name(role),
+        node.start_byte(),
+        node.end_byte(),
+        context.unwrap_or_default()
+    )
+}
+
+fn role_name(role: SemanticRole) -> &'static str {
+    match role {
+        SemanticRole::Import => "import",
+        SemanticRole::Reexport => "reexport",
+        SemanticRole::Alias => "alias",
+        SemanticRole::Call => "call",
+        SemanticRole::CallableReference => "callable_reference",
+        SemanticRole::Construction => "construction",
+        SemanticRole::Decorator => "decorator",
+        SemanticRole::Annotation => "annotation",
+        SemanticRole::BaseType => "base_type",
+        SemanticRole::TypeReference => "type_reference",
+        SemanticRole::MemberAccess => "member_access",
+        SemanticRole::Ownership => "ownership",
+        SemanticRole::Receiver => "receiver",
+        SemanticRole::Embedding => "embedding",
+        SemanticRole::TraitBound => "trait_bound",
+        SemanticRole::MacroInvocation => "macro_invocation",
+    }
+}
+
+fn string_literal(source: &[u8], node: Node<'_>) -> String {
+    node_text(source, node)
+        .trim()
+        .trim_matches(['\'', '"', '`'])
+        .to_owned()
+}
+
+fn declaration_name_text(source: &[u8], node: Node<'_>) -> String {
+    if node.kind() == "string" {
+        let literal = string_literal(source, node);
+        if literal.is_empty() {
+            // An empty string key is valid JavaScript but cannot become an
+            // empty graph identity. Preserve its quoted source spelling as a
+            // deterministic, non-empty declaration name; computed access
+            // remains unresolved unless a non-empty proof exists.
+            node_text(source, node)
+        } else {
+            literal
+        }
+    } else {
+        node_text(source, node)
+    }
+}
+
+fn node_text(source: &[u8], node: Node<'_>) -> String {
+    source
+        .get(node.start_byte()..node.end_byte())
+        .map_or_else(String::new, |bytes| {
+            String::from_utf8_lossy(bytes).into_owned()
+        })
+}

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -2024,69 +2024,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     .or_else(|| child.child_by_field_name("expression"))
                     .or_else(|| first_named_child(child))
                     .map(unwrap_expression_node)?;
-                if argument.kind() != "identifier" {
-                    return None;
-                }
-                let name = node_text(self.source, argument);
-                let resolution = self.resolve_name(scope_id, &name, Namespace::Value);
-                match resolution {
-                    Some(Resolution::Local(source)) => {
-                        if source.kind != "variable"
-                            || !self.immutable_bindings.contains(&source.id)
-                            || !self
-                                .stable_structural_object_variables
-                                .contains(&source.qualified_name)
-                        {
-                            return None;
-                        }
-                        spreads.push(StructuralObjectSpread {
-                            source_qualified_name: source.qualified_name,
-                            source_variable_id: Some(source.id),
-                            range: range_for_node(self.source_file, child),
-                        });
-                    }
-                    Some(Resolution::Import(import))
-                        if import.imported_name == "default"
-                            && !import.type_only
-                            && import.namespace.accepts(Namespace::Value) =>
-                    {
-                        spreads.push(StructuralObjectSpread {
-                            source_qualified_name: import.target,
-                            source_variable_id: None,
-                            range: range_for_node(self.source_file, child),
-                        });
-                    }
-                    Some(Resolution::Import(import))
-                        if import.imported_name == "*"
-                            && !import.type_only
-                            && import.namespace == Namespace::Module =>
-                    {
-                        // A namespace import or a static `require()` binding
-                        // denotes the provider module object. Preserve that
-                        // owner identity so the resolver can project only
-                        // source-published exports; dynamic/indirect CommonJS
-                        // values still do not reach this branch.
-                        spreads.push(StructuralObjectSpread {
-                            source_qualified_name: import.target,
-                            source_variable_id: None,
-                            range: range_for_node(self.source_file, child),
-                        });
-                    }
-                    None => {
-                        // Static ES imports are hoisted, but the declaration
-                        // pass intentionally runs before the full import
-                        // emission pass. Recover only a default import from
-                        // the top-level syntax; named, namespace, dynamic,
-                        // and dynamic/indirect CommonJS sources stay opaque.
-                        let target = self.syntactic_default_import_target(object, &name)?;
-                        spreads.push(StructuralObjectSpread {
-                            source_qualified_name: target,
-                            source_variable_id: None,
-                            range: range_for_node(self.source_file, child),
-                        });
-                    }
-                    _ => return None,
-                }
+                spreads.push(self.structural_object_spread_source(
+                    scope_id,
+                    argument,
+                    range_for_node(self.source_file, child),
+                )?);
                 continue;
             }
             // A spread projection can reason about ordinary static properties
@@ -2096,6 +2038,70 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             member_property_name(self.source, key)?;
         }
         Some(spreads)
+    }
+
+    fn structural_object_spread_source(
+        &self,
+        scope_id: &str,
+        argument: Node<'tree>,
+        range: EvidenceRange,
+    ) -> Option<StructuralObjectSpread> {
+        let argument = unwrap_expression_node(argument);
+        if argument.kind() != "identifier" {
+            return None;
+        }
+        let name = node_text(self.source, argument);
+        let resolution = self.resolve_name(scope_id, &name, Namespace::Value);
+        match resolution {
+            Some(Resolution::Local(source)) => (source.kind == "variable"
+                && self.immutable_bindings.contains(&source.id)
+                && self
+                    .stable_structural_object_variables
+                    .contains(&source.qualified_name))
+            .then_some(StructuralObjectSpread {
+                source_qualified_name: source.qualified_name,
+                source_variable_id: Some(source.id),
+                range,
+            }),
+            Some(Resolution::Import(import))
+                if import.imported_name == "default"
+                    && !import.type_only
+                    && import.namespace.accepts(Namespace::Value) =>
+            {
+                Some(StructuralObjectSpread {
+                    source_qualified_name: import.target,
+                    source_variable_id: None,
+                    range,
+                })
+            }
+            Some(Resolution::Import(import))
+                if import.imported_name == "*"
+                    && !import.type_only
+                    && import.namespace == Namespace::Module =>
+            {
+                // A namespace import or a static `require()` binding denotes
+                // the provider module object. The resolver filters this owner
+                // through published exports, so private declarations never
+                // become namespace members by spelling alone.
+                Some(StructuralObjectSpread {
+                    source_qualified_name: import.target,
+                    source_variable_id: None,
+                    range,
+                })
+            }
+            None => {
+                // Declaration collection runs before import materialization.
+                // Recover only a source-anchored default import from syntax;
+                // named, namespace, dynamic, and indirect values stay opaque.
+                let target = self.syntactic_default_import_target(argument, &name)?;
+                Some(StructuralObjectSpread {
+                    source_qualified_name: target,
+                    source_variable_id: None,
+                    range,
+                })
+            }
+            _ => None,
+        }
     }
 
     fn syntactic_default_import_target(
@@ -3552,6 +3558,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             "call_expression" | "optional_call_expression" => {
                 self.emit_call(node, &scope_id, false)?;
                 self.emit_dynamic_import(node, &scope_id)?;
+                self.emit_commonjs_object_assign(&scope_id, node, false)?;
             }
             "new_expression" => self.emit_call(node, &scope_id, true)?,
             "member_expression" | "optional_member_expression" | "subscript_expression" => {
@@ -6079,6 +6086,14 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         let right = unwrap_expression_node(right);
+        if export_name == "default" && self.is_commonjs_object_assign(right) {
+            // `module.exports = Object.assign({}, source, { direct })` is a
+            // bounded object-owner composition. Keep the module owner as the
+            // destination and publish only source-proven operands; the
+            // helper intentionally rejects unknown or order-ambiguous shapes.
+            self.emit_commonjs_object_assign(scope_id, right, true)?;
+            return Ok(());
+        }
         if export_name == "default" && right.kind() == "object" {
             // `module.exports = { ... }` is a default module export plus a
             // bounded set of named properties. The declaration pass already
@@ -6122,6 +6137,132 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         self.emit_commonjs_reexport_binding(scope_id, &export_name, export_anchor, resolution)
+    }
+
+    fn is_commonjs_object_assign(&self, node: Node<'tree>) -> bool {
+        let node = unwrap_expression_node(node);
+        if !matches!(node.kind(), "call_expression" | "optional_call_expression") {
+            return false;
+        }
+        node.child_by_field_name("function")
+            .or_else(|| first_named_child(node))
+            .is_some_and(|function| {
+                node_text(self.source, function).replace(char::is_whitespace, "") == "Object.assign"
+            })
+    }
+
+    /// Publish the source-proven subset of a CommonJS `Object.assign` object
+    /// composition.  Supported shapes are deliberately narrow:
+    /// `Object.assign({}, source, { direct })` and
+    /// `Object.assign(module.exports, source)`.  Every source operand must be
+    /// an immutable object owner or an explicit module namespace; an unknown,
+    /// mutable, computed, or out-of-order operand suppresses the projection.
+    fn emit_commonjs_object_assign(
+        &mut self,
+        scope_id: &str,
+        node: Node<'tree>,
+        assigned_to_module: bool,
+    ) -> Result<(), EvidenceError> {
+        let node = unwrap_expression_node(node);
+        if !self.is_commonjs_object_assign(node) {
+            return Ok(());
+        }
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return Ok(());
+        };
+        let mut cursor = arguments.walk();
+        let arguments = arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .map(unwrap_expression_node)
+            .collect::<Vec<_>>();
+        let Some((target, sources)) = arguments.split_first() else {
+            return Ok(());
+        };
+        let target_is_empty_object = target.kind() == "object"
+            && target
+                .named_children(&mut target.walk())
+                .all(|child| child.kind().contains("comment"));
+        let target_text = node_text(self.source, *target).replace(char::is_whitespace, "");
+        let target_is_module = matches!(target_text.as_str(), "module.exports" | "exports");
+        // When an assignment wraps a mutating `Object.assign(module.exports,
+        // ...)`, the nested call is visited separately by `emit_nodes`. Let
+        // that call publish the owner once instead of duplicating bindings.
+        if assigned_to_module && target_is_module {
+            return Ok(());
+        }
+        if (!assigned_to_module && !target_is_module) || sources.is_empty() {
+            return Ok(());
+        }
+        if assigned_to_module && !target_is_empty_object && !target_is_module {
+            return Ok(());
+        }
+
+        let mut spreads = Vec::new();
+        let mut trailing_direct_object = None;
+        for (index, source) in sources.iter().enumerate() {
+            if source.kind() == "object" {
+                // A direct object argument is safe only as the final
+                // assignment phase.  Supporting an object before a later
+                // source would require preserving overwrite precedence in
+                // the named-export index, so fail closed for that shape.
+                if index + 1 != sources.len() || object_literal_has_spread(*source) {
+                    return Ok(());
+                }
+                let mut property_cursor = source.walk();
+                for property in source
+                    .named_children(&mut property_cursor)
+                    .take(MAX_INLINE_OBJECT_PROPERTIES)
+                {
+                    let Some((key, _)) = commonjs_object_property(property) else {
+                        return Ok(());
+                    };
+                    if member_property_name(self.source, key).is_none() {
+                        return Ok(());
+                    }
+                }
+                trailing_direct_object = Some(*source);
+                continue;
+            }
+            let Some(spread) = self.structural_object_spread_source(
+                scope_id,
+                *source,
+                range_for_node(self.source_file, *source),
+            ) else {
+                return Ok(());
+            };
+            spreads.push(spread);
+        }
+        if spreads.is_empty() && trailing_direct_object.is_none() {
+            return Ok(());
+        }
+
+        // A CommonJS module object is the stable destination for both the
+        // assignment form and the mutating `Object.assign(exports, ...)`
+        // form.  Publishing its default owner lets namespace consumers use
+        // the same module-owner path as object-literal exports.
+        self.emit_commonjs_module_default_export(scope_id, node)?;
+        let destination = self.file_qualified_name.clone();
+        if !spreads.is_empty() {
+            self.structural_object_spreads
+                .entry(destination.clone())
+                .or_default()
+                .extend(spreads);
+            self.emit_structural_spread_member_aliases(scope_id, &destination)?;
+        }
+        if let Some(object) = trailing_direct_object {
+            let mut property_cursor = object.walk();
+            for property in object
+                .named_children(&mut property_cursor)
+                .take(MAX_INLINE_OBJECT_PROPERTIES)
+            {
+                self.emit_commonjs_object_property_export(scope_id, property)?;
+            }
+        }
+        Ok(())
     }
 
     fn commonjs_export_value_resolution(

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -313,6 +313,11 @@ struct CandidateState<'source, 'tree> {
     /// only to recover a source-declared return type at a subsequent call
     /// site (for example `const stringType = ZodString.create`).
     variable_alias_values: HashMap<String, String>,
+    /// Local declarations whose bodies match the bounded TypeScript/Babel
+    /// `__exportStar` helper shape.  Keeping the proof on the declaration
+    /// identity avoids treating an arbitrary user function with the same
+    /// spelling as a module reexport primitive.
+    commonjs_export_star_helpers: HashSet<String>,
     this_receivers: HashMap<String, String>,
     /// Direct `extends` targets proven while emitting the class heritage.
     /// Values are retained only for classes with one source-visible base; an
@@ -408,6 +413,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         callable_property_aliases: HashSet::new(),
         callable_variable_aliases: HashSet::new(),
         variable_alias_values: HashMap::new(),
+        commonjs_export_star_helpers: HashSet::new(),
         this_receivers: HashMap::new(),
         base_targets: HashMap::new(),
         implements_targets: HashMap::new(),
@@ -1354,6 +1360,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         };
         self.declarations
             .insert(declaration_id, declaration.clone());
+        if name == "__exportStar" && commonjs_export_star_helper_shape(node, self.source) {
+            self.commonjs_export_star_helpers
+                .insert(declaration.id.clone());
+        }
         if kind == "property"
             && let Some(value) = node.child_by_field_name("value")
         {
@@ -3560,6 +3570,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 self.emit_dynamic_import(node, &scope_id)?;
                 self.emit_commonjs_object_assign(&scope_id, node, false)?;
                 self.emit_commonjs_define_property(&scope_id, node)?;
+                self.emit_commonjs_export_star(&scope_id, node)?;
             }
             "new_expression" => self.emit_call(node, &scope_id, true)?,
             "member_expression" | "optional_member_expression" | "subscript_expression" => {
@@ -6336,6 +6347,129 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         self.emit_commonjs_reexport_binding(scope_id, &export_name, *key, resolution)
+    }
+
+    /// Publish the bounded module-owner alias produced by the standard
+    /// TypeScript/Babel CommonJS barrel helper:
+    /// __exportStar(require("./source"), exports) (or the equivalent
+    /// tslib.__exportStar call). The helper itself must be source-proven or
+    /// come from the tslib package; a same-named arbitrary function remains
+    /// an ordinary call. Only a literal, direct require() and the canonical
+    /// exports/module.exports destination are admitted.
+    fn emit_commonjs_export_star(
+        &mut self,
+        scope_id: &str,
+        node: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let node = unwrap_expression_node(node);
+        if !matches!(node.kind(), "call_expression" | "optional_call_expression") {
+            return Ok(());
+        }
+        let Some(function) = node
+            .child_by_field_name("function")
+            .or_else(|| first_named_child(node))
+        else {
+            return Ok(());
+        };
+        if !self.is_commonjs_export_star_helper(scope_id, function) {
+            return Ok(());
+        }
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return Ok(());
+        };
+        let mut cursor = arguments.walk();
+        let arguments = arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .map(unwrap_expression_node)
+            .collect::<Vec<_>>();
+        let [source, destination] = arguments.as_slice() else {
+            return Ok(());
+        };
+        let Some((module, module_anchor)) = self.commonjs_static_require_module(scope_id, *source)
+        else {
+            return Ok(());
+        };
+        let destination_text =
+            node_text(self.source, *destination).replace(char::is_whitespace, "");
+        if (destination_text == "exports" && !self.is_unshadowed_name(scope_id, "exports"))
+            || (destination_text == "module.exports"
+                && !self.is_unshadowed_name(scope_id, "module"))
+            || !matches!(destination_text.as_str(), "exports" | "module.exports")
+        {
+            return Ok(());
+        }
+        let source_target = format!("{module}::*");
+        self.builder.bind_with_identity(
+            BindingKind::Member,
+            "*",
+            &source_target,
+            None,
+            Some(scope_id),
+            Some(SymbolNamespace::Value),
+            false,
+            range_for_node(self.source_file, module_anchor),
+        )?;
+        Ok(())
+    }
+
+    fn is_commonjs_export_star_helper(&self, scope_id: &str, function: Node<'tree>) -> bool {
+        let function = unwrap_expression_node(function);
+        let property = member_property_node(function);
+        if property
+            .and_then(|property| member_property_name(self.source, property))
+            .as_deref()
+            != Some("__exportStar")
+            && (function.kind() != "identifier"
+                || node_text(self.source, function) != "__exportStar")
+        {
+            return false;
+        }
+        let resolution = if let Some(object) = function.child_by_field_name("object") {
+            self.resolve_name(scope_id, &node_text(self.source, object), Namespace::Value)
+        } else {
+            self.resolve_name(scope_id, "__exportStar", Namespace::Value)
+        };
+        match resolution {
+            Some(Resolution::Local(declaration)) => {
+                self.commonjs_export_star_helpers.contains(&declaration.id)
+            }
+            Some(Resolution::Import(import)) => {
+                import.module == "tslib"
+                    && (import.imported_name == "*" || import.imported_name == "__exportStar")
+            }
+            None => false,
+        }
+    }
+
+    fn commonjs_static_require_module(
+        &self,
+        scope_id: &str,
+        node: Node<'tree>,
+    ) -> Option<(String, Node<'tree>)> {
+        if !self.is_unshadowed_name(scope_id, "require") {
+            return None;
+        }
+        let call = direct_require_call(node, self.source)?;
+        let arguments = call
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(call, "arguments"))?;
+        let mut cursor = arguments.walk();
+        let arguments = arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .collect::<Vec<_>>();
+        let [module_node] = arguments.as_slice() else {
+            return None;
+        };
+        if module_node.kind() != "string" {
+            return None;
+        }
+        let module = string_literal(self.source, *module_node);
+        (!module.is_empty()).then_some((module, *module_node))
     }
 
     fn commonjs_descriptor_value_resolution(
@@ -9520,6 +9654,16 @@ fn commonjs_export_name<'tree>(left: Node<'tree>, source: &[u8]) -> Option<(Stri
     }
     let name = member_property_name(source, property)?;
     (!name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES).then_some((name, property))
+}
+
+fn commonjs_export_star_helper_shape(node: Node<'_>, source: &[u8]) -> bool {
+    let text = node_text(source, node);
+    if text.is_empty() || text.len() > MAX_TYPE_SHAPE_BYTES {
+        return false;
+    }
+    let has_default_guard = text.contains("\"default\"") || text.contains("'default'");
+    let has_binding_call = text.contains("__createBinding") || text.contains("createBinding");
+    text.contains("for") && has_default_guard && has_binding_call && text.contains("hasOwnProperty")
 }
 
 fn commonjs_object_property<'tree>(

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6887,7 +6887,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             if let Some((utility, base, arguments)) = utility_type_parts(normalized)
                 && matches!(utility, "Pick" | "Omit")
             {
-                let keys = arguments.get(1).and_then(|keys| type_literal_names(keys))?;
+                let base_receiver = self.resolve_declared_type_receiver(scope_id, base)?;
+                let keys = arguments
+                    .get(1)
+                    .and_then(|keys| self.utility_key_names(scope_id, &base_receiver, keys))?;
                 if keys.len() > MAX_INLINE_OBJECT_PROPERTIES
                     || keys
                         .iter()
@@ -6897,7 +6900,6 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 {
                     return None;
                 }
-                let base_receiver = self.resolve_declared_type_receiver(scope_id, base)?;
                 // Keep the first utility projection local and source-backed.
                 // Imported projected members require a project-wide property
                 // inventory and remain unresolved until that evidence exists.
@@ -6990,6 +6992,31 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
         }
         None
+    }
+
+    /// Resolve the bounded key set accepted by a local `Pick`/`Omit`
+    /// projection. Literal keys are source syntax; `keyof Base` is accepted
+    /// only when it names the same unique local nominal base, so `Pick<Base,
+    /// keyof Base>` remains an identity projection without pretending to
+    /// evaluate arbitrary structural or imported key spaces.
+    fn utility_key_names(
+        &self,
+        scope_id: &str,
+        base_receiver: &ReceiverTarget,
+        keys: &str,
+    ) -> Option<HashSet<String>> {
+        if let Some(keys) = type_literal_names(keys) {
+            return Some(keys);
+        }
+        let key_base = keyof_type_base(keys)?;
+        let key_receiver = self.resolve_declared_type_receiver(scope_id, key_base)?;
+        if key_receiver.import.is_some()
+            || base_receiver.import.is_some()
+            || key_receiver.qualified_name != base_receiver.qualified_name
+        {
+            return None;
+        }
+        self.source_type_property_names(&base_receiver.qualified_name)
     }
 
     /// Resolve a canonical module-qualified nominal name produced while
@@ -7997,12 +8024,26 @@ fn callable_return_type_name(node: Node<'_>, source: &[u8]) -> Option<String> {
 }
 
 fn normalize_type_text(source: &[u8], node: Node<'_>) -> String {
-    node_text(source, node)
+    let mut normalized = String::new();
+    for character in node_text(source, node)
         .trim()
         .trim_start_matches(':')
         .chars()
-        .filter(|character| !character.is_ascii_whitespace())
-        .collect()
+    {
+        if character.is_ascii_whitespace() {
+            // Keep one separator after the `keyof` keyword.  The compact
+            // signature format otherwise turns `keyof T` into `keyofT`,
+            // which is indistinguishable from an ordinary identifier and
+            // prevents bounded generic substitution from recognizing the
+            // key-space expression.
+            if normalized.ends_with("keyof") && !normalized.ends_with("keyof ") {
+                normalized.push(' ');
+            }
+        } else {
+            normalized.push(character);
+        }
+    }
+    normalized
 }
 
 /// Return the small amount of declaration shape needed to follow a proven
@@ -8106,9 +8147,7 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
     };
     let normalized_type_text = node_text(source, type_node);
     if indexed_type_parts(&normalized_type_text).is_some()
-        || normalized_type_text
-            .strip_prefix("keyof")
-            .is_some_and(|rest| !rest.trim().is_empty())
+        || keyof_type_base(&normalized_type_text).is_some()
     {
         if normalized_type_text.len() <= MAX_TYPE_SHAPE_BYTES {
             return Some(normalized_type_text);
@@ -8512,6 +8551,30 @@ fn substitute_candidate_type_parameters(
     {
         return argument.clone();
     }
+    if let Some(key_base) = keyof_type_base(type_name) {
+        let substituted =
+            substitute_candidate_type_parameters(key_base, parameters, arguments, depth + 1);
+        let substituted = format!("keyof {substituted}");
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if indexed_type_parts(type_name).is_some()
+        && let Some(open) = type_name.rfind('[')
+    {
+        let base = type_name.get(..open).unwrap_or_default();
+        let substituted_base =
+            substitute_candidate_type_parameters(base, parameters, arguments, depth + 1);
+        let suffix = type_name.get(open..).unwrap_or_default();
+        let substituted = format!("{substituted_base}{suffix}");
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
     if let Some(element) = type_name.strip_suffix("[]") {
         let substituted =
             substitute_candidate_type_parameters(element, parameters, arguments, depth + 1);
@@ -8822,6 +8885,15 @@ fn indexed_type_parts(type_name: &str) -> Option<(&str, String)> {
         return None;
     }
     Some((base, property.to_owned()))
+}
+
+fn keyof_type_base(type_name: &str) -> Option<&str> {
+    let rest = type_name.trim().strip_prefix("keyof")?;
+    rest.chars()
+        .next()
+        .filter(|character| character.is_whitespace())?;
+    let base = rest.trim();
+    (!base.is_empty()).then_some(base)
 }
 
 fn strip_type_arguments(type_name: &str) -> &str {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -5590,6 +5590,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                             return Some(receiver);
                         }
 
+                        // Preserve the import proof carried by a direct
+                        // annotation (`value: ImportedType`).  The
+                        // `variable_types` cache intentionally stores only
+                        // the nominal qualified spelling for older
+                        // inference paths; recovering the source annotation
+                        // here keeps imported receivers attached to their
+                        // binding identity so cross-file member evidence can
+                        // resolve against the imported type's declarations.
+                        if let Some(type_name) = declaration.declared_type_name.as_deref()
+                            && let Some(receiver) =
+                                self.resolve_declared_type_receiver(scope_id, type_name)
+                        {
+                            return Some(receiver);
+                        }
+
                         if let Some(qualified_name) = self.variable_types.get(&declaration.id) {
                             let qualified_name = self
                                 .instance_receiver_qualified_name(qualified_name)

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6767,6 +6767,69 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         self.resolve_declared_type_receiver(scope_id, &type_name)
     }
 
+    /// Select a conditional-type branch only when the source proves one
+    /// nominal constituent satisfies the `extends` check.  TypeScript
+    /// distributes conditional types over unions; choosing either branch for
+    /// a union, `any`, or an unresolved structural check would silently invent
+    /// a receiver, so those cases remain unresolved.
+    fn conditional_type_branch(
+        &self,
+        scope_id: &str,
+        check: &str,
+        expected: &str,
+        when_true: &str,
+        when_false: &str,
+    ) -> Option<String> {
+        let check = check.trim();
+        let expected = expected.trim();
+        if check.is_empty()
+            || expected.is_empty()
+            || when_true.trim().is_empty()
+            || when_false.trim().is_empty()
+            || matches!(check, "any" | "unknown" | "never")
+            || conditional_type_parts(check).is_some()
+        {
+            return None;
+        }
+        let members = split_top_level_union(check)?;
+        let [check] = members.as_slice() else {
+            return None;
+        };
+        let check = check.trim();
+        let matches_expected = if expected == "unknown" {
+            let receiver = self.resolve_declared_type_receiver(scope_id, check)?;
+            receiver.import.is_none()
+        } else if expected == "object" {
+            let receiver = self.resolve_declared_type_receiver(scope_id, check)?;
+            receiver.import.is_none() && is_object_like_type(check)
+        } else {
+            if conditional_type_parts(expected).is_some() {
+                return None;
+            }
+            let check_receiver = self.resolve_declared_type_receiver(scope_id, check)?;
+            let expected_receiver = self.resolve_declared_type_receiver(scope_id, expected)?;
+            if check_receiver.import.is_some() || expected_receiver.import.is_some() {
+                return None;
+            }
+            type_names_compatible(
+                &check_receiver.qualified_name,
+                &expected_receiver.qualified_name,
+            ) || self.source_type_assignable(
+                scope_id,
+                &expected_receiver.qualified_name,
+                &check_receiver.qualified_name,
+            )
+        };
+        Some(
+            if matches_expected {
+                when_true.trim()
+            } else {
+                when_false.trim()
+            }
+            .to_owned(),
+        )
+    }
+
     fn resolve_declared_type_receiver(
         &self,
         scope_id: &str,
@@ -6822,6 +6885,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     scope_id: base_receiver.scope_id,
                     type_arguments: base_receiver.type_arguments,
                 });
+            }
+            if let Some((check, expected, when_true, when_false)) =
+                conditional_type_parts(normalized)
+            {
+                let branch =
+                    self.conditional_type_branch(scope_id, check, expected, when_true, when_false)?;
+                current.clear();
+                current.push_str(&branch);
+                continue;
             }
             if let Some(unwrapped) = candidate_utility_receiver_type(normalized) {
                 current = unwrapped;
@@ -8009,6 +8081,15 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
             return Some(normalized);
         }
     }
+    if type_node.kind() == "conditional_type" {
+        let normalized = node_text(source, type_node);
+        if !normalized.is_empty()
+            && normalized.len() <= MAX_TYPE_SHAPE_BYTES
+            && conditional_type_parts(&normalized).is_some()
+        {
+            return Some(normalized);
+        }
+    }
     let generic_text = (type_node.kind() == "generic_type")
         .then(|| normalize_type_text(source, type_node))
         .filter(|text| !text.is_empty());
@@ -8176,6 +8257,29 @@ fn decode_utility_projection(type_name: &str) -> Option<(String, String, BTreeSe
         .collect::<BTreeSet<_>>();
     (matches!(utility.as_str(), "Pick" | "Omit") && !base.is_empty() && !keys.is_empty())
         .then_some((utility, base, keys))
+}
+
+fn conditional_type_parts(type_name: &str) -> Option<(&str, &str, &str, &str)> {
+    let type_name = type_name.trim();
+    let question = top_level_delimiter(type_name, '?')?;
+    let condition = type_name.get(..question)?.trim();
+    let remainder = type_name.get(question.saturating_add(1)..)?.trim();
+    let colon = top_level_delimiter(remainder, ':')?;
+    let when_true = remainder.get(..colon)?.trim();
+    let when_false = remainder.get(colon.saturating_add(1)..)?.trim();
+    if condition.is_empty()
+        || when_true.is_empty()
+        || when_false.is_empty()
+        || type_name.len() > MAX_TYPE_SHAPE_BYTES
+    {
+        return None;
+    }
+    let extends = condition.find("extends")?;
+    let check = condition.get(..extends)?.trim();
+    let expected = condition
+        .get(extends.saturating_add("extends".len())..)?
+        .trim();
+    (!check.is_empty() && !expected.is_empty()).then_some((check, expected, when_true, when_false))
 }
 
 fn candidate_utility_receiver_type(type_name: &str) -> Option<String> {
@@ -8382,6 +8486,20 @@ fn substitute_candidate_type_parameters(
             })
             .collect::<Vec<_>>();
         let substituted = format!("[{}]", substituted.join(","));
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some((check, expected, when_true, when_false)) = conditional_type_parts(type_name) {
+        let substituted = format!(
+            "{} extends {} ? {} : {}",
+            substitute_candidate_type_parameters(check, parameters, arguments, depth + 1),
+            substitute_candidate_type_parameters(expected, parameters, arguments, depth + 1),
+            substitute_candidate_type_parameters(when_true, parameters, arguments, depth + 1),
+            substitute_candidate_type_parameters(when_false, parameters, arguments, depth + 1),
+        );
         return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
             substituted
         } else {
@@ -8975,7 +9093,23 @@ fn split_top_level_members(input: &str) -> Option<Vec<&str>> {
 
 fn top_level_delimiter(input: &str, delimiter: char) -> Option<usize> {
     let mut depth = 0_u32;
+    let mut quote = None;
+    let mut escaped = false;
     for (index, character) in input.char_indices() {
+        if let Some(quoted) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == quoted {
+                quote = None;
+            }
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            quote = Some(character);
+            continue;
+        }
         match character {
             '<' | '{' | '(' | '[' => depth = depth.checked_add(1)?,
             '>' | '}' | ')' | ']' => depth = depth.checked_sub(1)?,

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -178,6 +178,12 @@ struct ReceiverTarget {
     type_arguments: Option<Vec<String>>,
 }
 
+#[derive(Clone)]
+struct FlowAssignment {
+    start_byte: usize,
+    receiver: ReceiverTarget,
+}
+
 struct CandidateState<'source, 'tree> {
     source_file: &'source str,
     source: &'source [u8],
@@ -202,6 +208,12 @@ struct CandidateState<'source, 'tree> {
     index_value_types: HashMap<String, String>,
     import_bindings: HashMap<(String, String), ImportInfo>,
     variable_types: HashMap<String, String>,
+    /// Source-order receiver facts for simple local assignments.  A fact is
+    /// usable only when it is in the variable's binding scope and precedes
+    /// the member use; branch/unknown writes are tracked separately as
+    /// barriers so an older fact cannot survive an unproven mutation.
+    flow_assignments: HashMap<String, Vec<FlowAssignment>>,
+    flow_assignment_barriers: HashMap<String, Vec<(usize, String)>>,
     structural_object_variables: HashSet<String>,
     return_object_functions: HashSet<String>,
     /// A local variable initialized from a source-visible function whose
@@ -316,6 +328,8 @@ pub(crate) fn extract_candidate_tree_evidence(
         index_value_types: HashMap::new(),
         import_bindings: HashMap::new(),
         variable_types: HashMap::new(),
+        flow_assignments: HashMap::new(),
+        flow_assignment_barriers: HashMap::new(),
         structural_object_variables: HashSet::new(),
         return_object_functions: HashSet::new(),
         variable_object_sources: HashMap::new(),
@@ -347,6 +361,7 @@ pub(crate) fn extract_candidate_tree_evidence(
     state.resolve_callable_property_aliases();
     state.precollect_base_targets(root, 0);
     state.infer_variable_types(root, 0);
+    state.collect_flow_assignment_facts(root, 0);
     state.emit_nodes(root, 0)?;
     if root.has_error() {
         state.builder.diagnose(
@@ -1502,6 +1517,267 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 pending.push((child, current_depth.saturating_add(1)));
             }
         }
+    }
+
+    /// Collect source-order receiver facts for the small flow slice that is
+    /// safe without a control-flow graph: a local variable is assigned a
+    /// source-proven constructor/call result in its own binding scope, and
+    /// the use occurs after that assignment.  Any branch, compound write, or
+    /// unsupported write becomes a barrier so an older fact cannot leak past
+    /// an unknown mutation.  This keeps JavaScript reassignment useful while
+    /// failing closed on aliasing and control-flow shapes the native
+    /// candidate does not model.
+    fn collect_flow_assignment_facts(&mut self, node: Node<'tree>, depth: usize) {
+        let mut pending = vec![(node, depth)];
+        while let Some((current, current_depth)) = pending.pop() {
+            if current_depth > MAX_TRAVERSAL_DEPTH {
+                continue;
+            }
+            let scope_id = self.scope_for_node(current);
+            if current.kind() == "variable_declarator"
+                && let Some(name_node) = current.child_by_field_name("name")
+                && let Some(value) = current.child_by_field_name("value")
+            {
+                let value = unwrap_expression_node(value);
+                if let Some(receiver) = self.flow_receiver_for_value(&scope_id, value) {
+                    let mut names = Vec::new();
+                    collect_pattern_names(name_node, self.source, &mut names);
+                    for (name, _) in names {
+                        let Some(Resolution::Local(variable)) =
+                            self.resolve_name(&scope_id, &name, Namespace::Value)
+                        else {
+                            continue;
+                        };
+                        if variable.kind == "variable"
+                            && self.flow_scope_is_compatible(&variable.scope_id, &scope_id)
+                            && self.flow_assignment_is_straight_line(name_node, &scope_id)
+                        {
+                            self.record_flow_assignment(
+                                &variable.id,
+                                value.start_byte(),
+                                receiver.clone(),
+                            );
+                        }
+                    }
+                }
+            }
+            if matches!(
+                current.kind(),
+                "assignment_expression" | "augmented_assignment_expression"
+            ) && let Some(left) = current.child_by_field_name("left")
+                && left.kind() == "identifier"
+            {
+                let name = node_text(self.source, left);
+                if let Some(Resolution::Local(variable)) =
+                    self.resolve_name(&scope_id, &name, Namespace::Value)
+                    && variable.kind == "variable"
+                {
+                    let right = current.child_by_field_name("right");
+                    let operator = right
+                        .and_then(|right| {
+                            self.source
+                                .get(left.end_byte()..right.start_byte())
+                                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                        })
+                        .map(str::trim)
+                        .unwrap_or_default();
+                    let straight_line = self
+                        .flow_scope_is_compatible(&variable.scope_id, &scope_id)
+                        && self.flow_assignment_is_straight_line(left, &scope_id);
+                    let receiver = right
+                        .map(unwrap_expression_node)
+                        .and_then(|right| self.flow_receiver_for_value(&scope_id, right));
+                    if straight_line && operator == "=" {
+                        if let Some(receiver) = receiver {
+                            self.record_flow_assignment(
+                                &variable.id,
+                                current.start_byte(),
+                                receiver,
+                            );
+                        } else {
+                            self.record_flow_assignment_barrier(
+                                &variable.id,
+                                current.start_byte(),
+                                "unsupported local assignment value",
+                            );
+                        }
+                    } else {
+                        self.record_flow_assignment_barrier(
+                            &variable.id,
+                            current.start_byte(),
+                            if straight_line {
+                                "compound local assignment"
+                            } else {
+                                "conditional or out-of-scope local assignment"
+                            },
+                        );
+                    }
+                }
+            }
+            let mut cursor = current.walk();
+            let children = current.named_children(&mut cursor).collect::<Vec<_>>();
+            for child in children.into_iter().rev() {
+                pending.push((child, current_depth.saturating_add(1)));
+            }
+        }
+    }
+
+    fn flow_receiver_for_value(
+        &self,
+        scope_id: &str,
+        value: Node<'tree>,
+    ) -> Option<ReceiverTarget> {
+        if matches!(
+            value.kind(),
+            "as_expression"
+                | "satisfies_expression"
+                | "parenthesized_expression"
+                | "type_assertion"
+                | "non_null_expression"
+        ) {
+            return self.receiver_target(scope_id, value);
+        }
+        match value.kind() {
+            "new_expression" => self.receiver_target(scope_id, value),
+            "call_expression" | "optional_call_expression" => {
+                self.call_return_receiver(scope_id, value)
+            }
+            _ => None,
+        }
+    }
+
+    fn flow_assignment_is_straight_line(&self, node: Node<'tree>, scope_id: &str) -> bool {
+        let mut current = node.parent();
+        while let Some(ancestor) = current {
+            if matches!(
+                ancestor.kind(),
+                "if_statement"
+                    | "switch_statement"
+                    | "switch_case"
+                    | "for_statement"
+                    | "for_in_statement"
+                    | "for_of_statement"
+                    | "while_statement"
+                    | "do_statement"
+                    | "try_statement"
+                    | "catch_clause"
+                    | "finally_clause"
+                    | "with_statement"
+                    | "conditional_expression"
+                    | "ternary_expression"
+            ) {
+                return false;
+            }
+            if is_callable_node(ancestor) {
+                let function_scope = self.scope_for_node(ancestor);
+                return self.scope_is_descendant_or_same(scope_id, &function_scope);
+            }
+            current = ancestor.parent();
+        }
+        true
+    }
+
+    fn flow_scope_is_compatible(&self, variable_scope: &str, assignment_scope: &str) -> bool {
+        self.flow_context_scope(variable_scope) == self.flow_context_scope(assignment_scope)
+            && self.scope_is_descendant_or_same(assignment_scope, variable_scope)
+    }
+
+    fn flow_context_scope(&self, scope_id: &str) -> String {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            if self
+                .scope_kinds
+                .get(&scope)
+                .is_some_and(|kind| matches!(kind.as_str(), "function" | "module"))
+            {
+                return scope;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        self.root_scope.clone()
+    }
+
+    fn record_flow_assignment_barrier(
+        &mut self,
+        variable_id: &str,
+        start_byte: usize,
+        reason: &str,
+    ) {
+        let barriers = self
+            .flow_assignment_barriers
+            .entry(variable_id.to_owned())
+            .or_default();
+        if barriers.len() < MAX_INLINE_OBJECT_PROPERTIES {
+            barriers.push((start_byte, reason.to_owned()));
+        } else if let Some((latest_start, latest_reason)) = barriers.last_mut()
+            && *latest_start < start_byte
+        {
+            *latest_start = start_byte;
+            *latest_reason = reason.to_owned();
+        }
+    }
+
+    fn record_flow_assignment(
+        &mut self,
+        variable_id: &str,
+        start_byte: usize,
+        receiver: ReceiverTarget,
+    ) {
+        let assignments = self
+            .flow_assignments
+            .entry(variable_id.to_owned())
+            .or_default();
+        if assignments.len() < MAX_INLINE_OBJECT_PROPERTIES {
+            assignments.push(FlowAssignment {
+                start_byte,
+                receiver,
+            });
+        } else {
+            self.record_flow_assignment_barrier(variable_id, start_byte, "flow assignment limit");
+        }
+    }
+
+    fn flow_receiver_at(&self, variable_id: &str, use_start_byte: usize) -> Option<ReceiverTarget> {
+        let latest_assignment = self
+            .flow_assignments
+            .get(variable_id)
+            .into_iter()
+            .flat_map(|assignments| assignments.iter())
+            .filter(|assignment| assignment.start_byte <= use_start_byte)
+            .max_by_key(|assignment| assignment.start_byte);
+        let latest_barrier = self
+            .flow_assignment_barriers
+            .get(variable_id)
+            .into_iter()
+            .flat_map(|barriers| barriers.iter())
+            .filter(|(start_byte, _)| *start_byte <= use_start_byte)
+            .max_by_key(|(start_byte, _)| *start_byte)
+            .map(|(start_byte, _)| *start_byte);
+        if latest_barrier.is_some_and(|barrier| {
+            latest_assignment.is_none_or(|assignment| assignment.start_byte <= barrier)
+        }) {
+            return None;
+        }
+        latest_assignment.map(|assignment| assignment.receiver.clone())
+    }
+
+    fn flow_assignment_barrier_before(&self, variable_id: &str, use_start_byte: usize) -> bool {
+        let latest_assignment = self
+            .flow_assignments
+            .get(variable_id)
+            .into_iter()
+            .flat_map(|assignments| assignments.iter())
+            .filter(|assignment| assignment.start_byte <= use_start_byte)
+            .map(|assignment| assignment.start_byte)
+            .max();
+        self.flow_assignment_barriers
+            .get(variable_id)
+            .into_iter()
+            .flat_map(|barriers| barriers.iter())
+            .filter(|(start_byte, _)| *start_byte <= use_start_byte)
+            .map(|(start_byte, _)| *start_byte)
+            .max()
+            .is_some_and(|barrier| latest_assignment.is_none_or(|assignment| assignment <= barrier))
     }
 
     /// Propagate a source-visible callback parameter type through a call.
@@ -5593,6 +5869,16 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                             self.flow_narrowed_instanceof_receiver(scope_id, object, &declaration)
                         {
                             return Some(receiver);
+                        }
+
+                        if let Some(receiver) =
+                            self.flow_receiver_at(&declaration.id, object.start_byte())
+                        {
+                            return Some(receiver);
+                        }
+                        if self.flow_assignment_barrier_before(&declaration.id, object.start_byte())
+                        {
+                            return None;
                         }
 
                         // Preserve the import proof carried by a direct

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -663,9 +663,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         }
         if node.kind() == "export_statement"
-            && node_text(self.source, node)
-                .trim_start()
-                .starts_with("export default")
+            && {
+                let statement = node_text(self.source, node);
+                let statement = statement.trim_start();
+                statement.starts_with("export default") || statement.starts_with("export =")
+            }
             && let Some(exported) = first_named_child(node)
             && {
                 let exported = unwrap_expression_node(exported);
@@ -682,10 +684,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 &qualified_prefix,
                 "default",
             )?;
-            // A spread-free `export default { ... }` has one source-backed
-            // object identity. Publish its properties below that identity so
-            // `import value from "./module"; value.member()` can resolve to
-            // the exact provider declaration across files. Spreads are kept
+            // A spread-free default or export-assignment object has one
+            // source-backed identity. Publish its properties below that
+            // identity so `import value from "./module"; value.member()` or
+            // `import value = require("./module"); value.member()` can resolve
+            // to the exact provider declaration across files. Spreads are kept
             // outside this path because they can override any listed key.
             self.structural_object_variables
                 .insert(declaration.qualified_name.clone());
@@ -703,9 +706,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         }
         if node.kind() == "export_statement"
-            && node_text(self.source, node)
-                .trim_start()
-                .starts_with("export default")
+            && {
+                let statement = node_text(self.source, node);
+                let statement = statement.trim_start();
+                statement.starts_with("export default") || statement.starts_with("export =")
+            }
             && let Some(exported) = first_named_child(node)
             && exported.child_by_field_name("name").is_none()
             && let Some((kind, namespace, creates_scope, scope_kind)) =
@@ -4116,7 +4121,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .trim_start()
                 .starts_with("export default")
             {
-                self.emit_default_export(node, scope_id)?;
+                self.emit_default_export(node, scope_id, false)?;
+            } else if node_text(self.source, node)
+                .trim_start()
+                .starts_with("export =")
+            {
+                self.emit_default_export(node, scope_id, true)?;
             } else {
                 self.emit_named_export_declaration(node, scope_id)?;
             }
@@ -4213,6 +4223,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         &mut self,
         node: Node<'tree>,
         scope_id: &str,
+        export_assignment: bool,
     ) -> Result<(), EvidenceError> {
         let Some(exported) = first_named_child(node) else {
             return Ok(());
@@ -4259,7 +4270,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             "default",
             Some(&spelling),
             Some(scope_id),
-            Some("default"),
+            Some(if export_assignment {
+                "export_assignment"
+            } else {
+                "default"
+            }),
             range_for_node(self.source_file, anchor),
         )?;
         self.builder.relate(

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -667,6 +667,46 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .trim_start()
                 .starts_with("export default")
             && let Some(exported) = first_named_child(node)
+            && {
+                let exported = unwrap_expression_node(exported);
+                exported.kind() == "object" && !object_literal_has_spread(exported)
+            }
+        {
+            let exported = unwrap_expression_node(exported);
+            let declaration = self.add_declaration_at(
+                exported,
+                exported,
+                "variable",
+                Namespace::Value,
+                &scope_id,
+                &qualified_prefix,
+                "default",
+            )?;
+            // A spread-free `export default { ... }` has one source-backed
+            // object identity. Publish its properties below that identity so
+            // `import value from "./module"; value.member()` can resolve to
+            // the exact provider declaration across files. Spreads are kept
+            // outside this path because they can override any listed key.
+            self.structural_object_variables
+                .insert(declaration.qualified_name.clone());
+            self.stable_structural_object_variables
+                .insert(declaration.qualified_name.clone());
+            let mut cursor = exported.walk();
+            for child in exported.named_children(&mut cursor) {
+                self.collect_declarations(
+                    child,
+                    scope_id.clone(),
+                    declaration.qualified_name.clone(),
+                    depth + 1,
+                )?;
+            }
+            return Ok(());
+        }
+        if node.kind() == "export_statement"
+            && node_text(self.source, node)
+                .trim_start()
+                .starts_with("export default")
+            && let Some(exported) = first_named_child(node)
             && exported.child_by_field_name("name").is_none()
             && let Some((kind, namespace, creates_scope, scope_kind)) =
                 anonymous_declaration_shape(exported)
@@ -4011,8 +4051,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Some(module_node) = first_named_child_kind(node, "string") else {
             if let Some(clause) = first_named_child_kind(node, "export_clause") {
                 self.emit_local_export_clause(clause, scope_id)?;
-            } else {
+            } else if node_text(self.source, node)
+                .trim_start()
+                .starts_with("export default")
+            {
                 self.emit_default_export(node, scope_id)?;
+            } else {
+                self.emit_named_export_declaration(node, scope_id)?;
             }
             return Ok(());
         };
@@ -4023,6 +4068,86 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         self.emit_import(node, scope_id, true)
     }
 
+    fn emit_named_export_declaration(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(exported) = first_named_child(node) else {
+            return Ok(());
+        };
+        let mut names = Vec::new();
+        match exported.kind() {
+            "function_declaration"
+            | "generator_function_declaration"
+            | "class_declaration"
+            | "abstract_class_declaration"
+            | "interface_declaration"
+            | "type_alias_declaration"
+            | "enum_declaration"
+            | "internal_module"
+            | "module"
+            | "namespace_export" => {
+                if let Some(name) = exported
+                    .child_by_field_name("name")
+                    .or_else(|| first_identifier_node(exported))
+                {
+                    names.push((node_text(self.source, name), name));
+                }
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                let mut cursor = exported.walk();
+                for declarator in exported.named_children(&mut cursor) {
+                    if declarator.kind() != "variable_declarator" {
+                        continue;
+                    }
+                    if let Some(pattern) = declarator.child_by_field_name("name") {
+                        collect_pattern_names(pattern, self.source, &mut names);
+                    }
+                }
+            }
+            _ => {}
+        }
+        for (name, anchor) in names {
+            if name.is_empty() {
+                continue;
+            }
+            for declaration in self.export_declarations(scope_id, &name, Namespace::Both) {
+                self.emit_reexport_target(scope_id, &name, anchor, &declaration, Some(&name))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn export_declarations(
+        &self,
+        scope_id: &str,
+        name: &str,
+        namespace: Namespace,
+    ) -> Vec<DeclarationInfo> {
+        let mut current = Some(scope_id.to_owned());
+        while let Some(scope) = current {
+            let declarations = self
+                .declarations_by_scope
+                .get(&scope)
+                .into_iter()
+                .flat_map(|ids| ids.iter())
+                .filter_map(|id| self.declarations.get(id))
+                .filter(|declaration| {
+                    declaration.name == name
+                        && declaration.namespace.accepts(namespace)
+                        && self.lexically_visible_unqualified(&scope, declaration)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if !declarations.is_empty() {
+                return declarations;
+            }
+            current = self.scope_parents.get(&scope).cloned().flatten();
+        }
+        Vec::new()
+    }
+
     fn emit_default_export(
         &mut self,
         node: Node<'tree>,
@@ -4031,6 +4156,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Some(exported) = first_named_child(node) else {
             return Ok(());
         };
+        let exported_value = unwrap_expression_node(exported);
+        if exported_value.kind() == "object" && !object_literal_has_spread(exported_value) {
+            return self.emit_default_object_export(scope_id, exported_value);
+        }
         let (spelling, anchor) = if let Some(target_node) = default_export_target_node(node) {
             (node_text(self.source, target_node), target_node)
         } else if anonymous_declaration_shape(exported).is_some() {
@@ -4088,6 +4217,88 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     "interface".to_owned(),
                     "type_alias".to_owned(),
                     "enum".to_owned(),
+                ],
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Publish a spread-free ES default object as a source-backed value owner.
+    /// Its member declarations are collected under `<module>.default`, which
+    /// lets the shared resolver follow `import value from "./module"` without
+    /// treating the default object as an external namespace. A spread default
+    /// intentionally stays unresolved because a later spread can replace any
+    /// listed property.
+    fn emit_default_object_export(
+        &mut self,
+        scope_id: &str,
+        object: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let qualified_name = format!("{}.default", self.file_qualified_name);
+        let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+            return Ok(());
+        };
+        let [declaration_id] = ids.as_slice() else {
+            return Ok(());
+        };
+        let Some(declaration) = self.declarations.get(declaration_id).cloned() else {
+            return Ok(());
+        };
+        self.emit_reexport_target(scope_id, "default", object, &declaration, None)
+    }
+
+    fn emit_reexport_target(
+        &mut self,
+        scope_id: &str,
+        export_name: &str,
+        anchor: Node<'tree>,
+        target: &DeclarationInfo,
+        local_name: Option<&str>,
+    ) -> Result<(), EvidenceError> {
+        if export_name.is_empty() || target.qualified_name.is_empty() {
+            return Ok(());
+        }
+        let owner = self.owner_for_scope(scope_id);
+        let binding_id = self.builder.bind_with_identity(
+            BindingKind::Reexport,
+            export_name,
+            &target.qualified_name,
+            Some(&target.id),
+            Some(scope_id),
+            Some(symbol_namespace(target.namespace)),
+            false,
+            range_for_node(self.source_file, anchor),
+        )?;
+        let occurrence_id = self.builder.occur_with_context(
+            SemanticRole::Reexport,
+            &owner,
+            export_name,
+            local_name,
+            Some(scope_id),
+            Some("declaration"),
+            range_for_node(self.source_file, anchor),
+        )?;
+        self.builder.relate(
+            CandidateRelation::Reexports,
+            &owner,
+            Some(&occurrence_id),
+            Some(&binding_id),
+            export_name,
+            ResolutionConstraint {
+                exact_language: Some(self.language.to_owned()),
+                qualified_name: Some(target.qualified_name.clone()),
+                allowed_target_kinds: vec![
+                    "module".to_owned(),
+                    "function".to_owned(),
+                    "class".to_owned(),
+                    "variable".to_owned(),
+                    "property".to_owned(),
+                    "method".to_owned(),
+                    "enum".to_owned(),
+                    "interface".to_owned(),
+                    "type_alias".to_owned(),
+                    "namespace".to_owned(),
                 ],
                 ..ResolutionConstraint::default()
             },

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6855,6 +6855,35 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     type_arguments: None,
                 });
             }
+            if let Some((base, property)) = indexed_type_parts(normalized) {
+                let base_receiver = self.resolve_declared_type_receiver(scope_id, base)?;
+                // A compiler-selected indexed access can be projected from a
+                // local nominal declaration when the key is a literal and
+                // exactly one source member owns it. Imported and computed
+                // projections require project-wide checker evidence and stay
+                // unresolved rather than inheriting a terminal-name match.
+                if base_receiver.import.is_some() {
+                    return None;
+                }
+                let qualified_name = format!("{}.{}", base_receiver.qualified_name, property);
+                let ids = self.declarations_by_qualified.get(&qualified_name)?;
+                let declarations = ids
+                    .iter()
+                    .filter_map(|id| self.declarations.get(id))
+                    .collect::<Vec<_>>();
+                let [declaration] = declarations.as_slice() else {
+                    return None;
+                };
+                if declaration.declared_type_name.is_some() {
+                    return self.member_value_receiver(scope_id, &base_receiver, declaration);
+                }
+                return Some(ReceiverTarget {
+                    qualified_name: declaration.qualified_name.clone(),
+                    import: None,
+                    scope_id: self.member_scope_for_declaration(declaration),
+                    type_arguments: None,
+                });
+            }
             if let Some((utility, base, arguments)) = utility_type_parts(normalized)
                 && matches!(utility, "Pick" | "Omit")
             {
@@ -8075,17 +8104,32 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
     } else {
         annotation
     };
+    let normalized_type_text = node_text(source, type_node);
+    if indexed_type_parts(&normalized_type_text).is_some()
+        || normalized_type_text
+            .strip_prefix("keyof")
+            .is_some_and(|rest| !rest.trim().is_empty())
+    {
+        if normalized_type_text.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(normalized_type_text);
+        }
+        return None;
+    }
     if matches!(type_node.kind(), "array_type" | "tuple_type") {
         let normalized = normalize_type_text(source, type_node);
         if !normalized.is_empty() && normalized.len() <= MAX_TYPE_SHAPE_BYTES {
             return Some(normalized);
         }
     }
-    if type_node.kind() == "conditional_type" {
+    if matches!(
+        type_node.kind(),
+        "conditional_type" | "indexed_access_type" | "keyof_type"
+    ) {
         let normalized = node_text(source, type_node);
         if !normalized.is_empty()
             && normalized.len() <= MAX_TYPE_SHAPE_BYTES
-            && conditional_type_parts(&normalized).is_some()
+            && (type_node.kind() != "conditional_type"
+                || conditional_type_parts(&normalized).is_some())
         {
             return Some(normalized);
         }
@@ -8758,8 +8802,22 @@ fn indexed_type_parts(type_name: &str) -> Option<(&str, String)> {
     }
     let open = type_name.rfind('[')?;
     let base = type_name.get(..open)?.trim();
-    let property = type_name.get(open + 1..type_name.len() - 1)?.trim();
-    let property = property.trim_matches(['"', '\'']);
+    let raw_property = type_name.get(open + 1..type_name.len() - 1)?.trim();
+    let property = raw_property
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            raw_property
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .or_else(|| {
+            (!raw_property.is_empty()
+                && raw_property
+                    .chars()
+                    .all(|character| character.is_ascii_digit()))
+            .then_some(raw_property)
+        })?;
     if base.is_empty() || property.is_empty() || property.len() > MAX_TYPE_SHAPE_BYTES {
         return None;
     }

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -4569,10 +4569,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     /// Publish a source-complete ES default object as a source-backed value owner.
     /// Its member declarations are collected under `<module>.default`, which
     /// lets the shared resolver follow `import value from "./module"` without
-    /// treating the default object as an external namespace. A proven local
-    /// spread is admitted only for direct properties after the spread; source
-    /// properties inherited through the spread remain unresolved until a
-    /// dedicated member-alias contract can preserve their original identity.
+    /// treating the default object as an external namespace. A proven spread
+    /// also emits a bounded owner-alias marker so inherited source properties
+    /// retain their original declaration identity; direct properties after
+    /// the spread continue to override them.
     fn emit_default_object_export(
         &mut self,
         scope_id: &str,
@@ -6071,6 +6071,25 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             // reexports instead of leaving `require()` consumers external.
             self.emit_commonjs_module_default_export(scope_id, export_anchor)?;
             if object_literal_has_spread(right) {
+                // A CommonJS object export keeps the file module as its
+                // owner. When every spread operand is source-proven, retain
+                // that owner identity and publish a bounded alias for the
+                // inherited member inventory. Direct properties after the
+                // spread remain ordinary named reexports and therefore
+                // override an inherited member during resolution.
+                if self.object_literal_spread_export_is_safe(scope_id, right) {
+                    let destination = self.file_qualified_name.clone();
+                    self.record_structural_object_spreads(scope_id, &destination, right);
+                    self.emit_structural_spread_member_aliases(scope_id, &destination)?;
+                    let mut cursor = right.walk();
+                    for property in right
+                        .named_children(&mut cursor)
+                        .take(MAX_INLINE_OBJECT_PROPERTIES)
+                        .filter(|property| property.kind() != "spread_element")
+                    {
+                        self.emit_commonjs_object_property_export(scope_id, property)?;
+                    }
+                }
                 return Ok(());
             }
             let mut cursor = right.walk();

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -7532,6 +7532,14 @@ fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -
     {
         return Some(type_name);
     }
+    if kind == "variable"
+        && let Some(type_name) = direct_type_reference_name(node, source)
+    {
+        let signature = format!("|type:{type_name}");
+        if signature.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(signature);
+        }
+    }
     let callable_value = callable_value_node(node);
     let generic_parameter_order = callable_type_parameter_order(node, source)
         .or_else(|| callable_value.and_then(|value| callable_type_parameter_order(value, source)));
@@ -7539,7 +7547,7 @@ fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -
         .filter(|parameters| !parameters.is_empty())
         .map(|parameters| format!("<{}>", parameters.join(",")))
         .unwrap_or_default();
-    if matches!(kind, "function" | "method") {
+    if matches!(kind, "function" | "method" | "property") {
         let parameter_types = callable_parameter_types(node, source)
             .or_else(|| callable_value.and_then(|value| callable_parameter_types(value, source)));
         let return_type = callable_return_type_name(node, source);

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -64,7 +64,7 @@ const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
 static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.typescript.candidate",
     language: "typescript",
-    version: 3,
+    version: 4,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: TYPESCRIPT_CAPABILITIES,
@@ -73,7 +73,7 @@ static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
 static JAVASCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.javascript.candidate",
     language: "javascript",
-    version: 3,
+    version: 4,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: JAVASCRIPT_CAPABILITIES,
@@ -150,6 +150,13 @@ enum Resolution {
     Import(ImportInfo),
 }
 
+enum StructuralSpreadDecision {
+    NotApplicable,
+    Resolved(Box<DeclarationInfo>),
+    KnownAbsent,
+    Unresolved,
+}
+
 impl Resolution {
     fn qualified_target(&self) -> Option<String> {
         match self {
@@ -183,6 +190,13 @@ struct ReceiverTarget {
 struct FlowAssignment {
     start_byte: usize,
     receiver: ReceiverTarget,
+}
+
+#[derive(Clone)]
+struct StructuralObjectSpread {
+    source_qualified_name: String,
+    source_variable_id: String,
+    start_byte: usize,
 }
 
 #[derive(Clone)]
@@ -247,6 +261,11 @@ struct CandidateState<'source, 'tree> {
     immutable_bindings: HashSet<String>,
     structural_object_variables: HashSet<String>,
     stable_structural_object_variables: HashSet<String>,
+    /// Source-proven local object spreads.  The entries are present only when
+    /// every spread operand is an immutable, spread-free object with static
+    /// keys.  Keeping the source identities instead of copying declarations
+    /// preserves one source-backed member target across the merge.
+    structural_object_spreads: HashMap<String, Vec<StructuralObjectSpread>>,
     return_object_functions: HashSet<String>,
     /// A local variable initialized from a source-visible function whose
     /// return value is an object.  Store the declaration identity rather than
@@ -373,6 +392,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         immutable_bindings: HashSet::new(),
         structural_object_variables: HashSet::new(),
         stable_structural_object_variables: HashSet::new(),
+        structural_object_spreads: HashMap::new(),
         return_object_functions: HashSet::new(),
         variable_object_sources: HashMap::new(),
         variable_inline_type_receivers: HashMap::new(),
@@ -671,7 +691,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             && let Some(exported) = first_named_child(node)
             && {
                 let exported = unwrap_expression_node(exported);
-                exported.kind() == "object" && !object_literal_has_spread(exported)
+                exported.kind() == "object"
+                    && (!object_literal_has_spread(exported)
+                        || self.object_literal_spread_export_is_safe(&scope_id, exported))
             }
         {
             let exported = unwrap_expression_node(exported);
@@ -684,16 +706,24 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 &qualified_prefix,
                 "default",
             )?;
-            // A spread-free default or export-assignment object has one
-            // source-backed identity. Publish its properties below that
+            // A source-complete default or export-assignment object has one
+            // source-backed identity. Publish its direct properties below that
             // identity so `import value from "./module"; value.member()` or
             // `import value = require("./module"); value.member()` can resolve
-            // to the exact provider declaration across files. Spreads are kept
-            // outside this path because they can override any listed key.
+            // to the exact provider declaration across files. Proven local
+            // spreads are admitted only when direct properties follow every
+            // spread; unknown and potentially overriding shapes stay opaque.
             self.structural_object_variables
                 .insert(declaration.qualified_name.clone());
             self.stable_structural_object_variables
                 .insert(declaration.qualified_name.clone());
+            if object_literal_has_spread(exported) {
+                self.record_structural_object_spreads(
+                    &scope_id,
+                    &declaration.qualified_name,
+                    exported,
+                );
+            }
             let mut cursor = exported.walk();
             for child in exported.named_children(&mut cursor) {
                 self.collect_declarations(
@@ -969,6 +999,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             object_literal_value = Some(value);
             self.structural_object_variables
                 .insert(variable.qualified_name.clone());
+            if object_literal_has_spread(value) {
+                self.record_structural_object_spreads(&scope_id, &variable.qualified_name, value);
+            }
             let mut cursor = value.walk();
             for child in value.named_children(&mut cursor) {
                 self.collect_declarations(
@@ -1097,6 +1130,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 if !object_literal_has_spread(value) {
                     self.stable_structural_object_variables
                         .insert(prefix.to_owned());
+                } else {
+                    self.record_structural_object_spreads(&scope_id, prefix, value);
                 }
                 object_literal_value = Some(value);
                 let mut cursor = value.walk();
@@ -1870,6 +1905,102 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
+    /// Record a bounded object-spread projection when every spread operand is
+    /// a source-proven immutable object.  The projection intentionally keeps
+    /// only local source identities; imported, computed, conditional, and
+    /// dynamic operands remain opaque so a later override cannot be guessed.
+    fn record_structural_object_spreads(
+        &mut self,
+        scope_id: &str,
+        destination: &str,
+        object: Node<'tree>,
+    ) {
+        let Some(spreads) = self.structural_object_spread_sources(scope_id, object) else {
+            return;
+        };
+        if spreads.is_empty() {
+            return;
+        }
+        self.structural_object_spreads
+            .insert(destination.to_owned(), spreads);
+    }
+
+    fn object_literal_spread_export_is_safe(&self, scope_id: &str, object: Node<'tree>) -> bool {
+        if self
+            .structural_object_spread_sources(scope_id, object)
+            .is_none_or(|sources| sources.is_empty())
+        {
+            return false;
+        }
+        let mut saw_spread = false;
+        let mut cursor = object.walk();
+        for child in object
+            .named_children(&mut cursor)
+            .take(MAX_INLINE_OBJECT_PROPERTIES)
+        {
+            if child.kind() == "spread_element" {
+                saw_spread = true;
+                continue;
+            }
+            let Some((key, _)) = commonjs_object_property(child) else {
+                return false;
+            };
+            if member_property_name(self.source, key).is_none() || !saw_spread {
+                return false;
+            }
+        }
+        saw_spread
+    }
+
+    fn structural_object_spread_sources(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+    ) -> Option<Vec<StructuralObjectSpread>> {
+        let mut spreads = Vec::new();
+        let mut cursor = object.walk();
+        for child in object
+            .named_children(&mut cursor)
+            .take(MAX_INLINE_OBJECT_PROPERTIES)
+        {
+            if child.kind() == "spread_element" {
+                let argument = child
+                    .child_by_field_name("argument")
+                    .or_else(|| child.child_by_field_name("expression"))
+                    .or_else(|| first_named_child(child))
+                    .map(unwrap_expression_node)?;
+                if argument.kind() != "identifier" {
+                    return None;
+                }
+                let name = node_text(self.source, argument);
+                let resolution = self.resolve_name(scope_id, &name, Namespace::Value)?;
+                let Resolution::Local(source) = resolution else {
+                    return None;
+                };
+                if source.kind != "variable"
+                    || !self.immutable_bindings.contains(&source.id)
+                    || !self
+                        .stable_structural_object_variables
+                        .contains(&source.qualified_name)
+                {
+                    return None;
+                }
+                spreads.push(StructuralObjectSpread {
+                    source_qualified_name: source.qualified_name,
+                    source_variable_id: source.id,
+                    start_byte: child.start_byte(),
+                });
+                continue;
+            }
+            // A spread projection can reason about ordinary static properties
+            // and methods.  A computed or malformed key would make the
+            // property inventory incomplete, so reject the whole projection.
+            let (key, _) = commonjs_object_property(child)?;
+            member_property_name(self.source, key)?;
+        }
+        Some(spreads)
+    }
+
     fn object_literal_value_for_binding(&self, value: Node<'tree>) -> Option<Node<'tree>> {
         let mut value = unwrap_expression_node(value);
         for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
@@ -1976,8 +2107,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     /// (`let value; value = { member() {} }`).  Declaration collection has
     /// already indexed the object literal under the binding's qualified name;
     /// this helper only carries that source identity into the bounded
-    /// straight-line flow fact.  Spreads remain unresolved because their
-    /// property inventory is not source-complete.
+    /// straight-line flow fact.  A spread is admitted only when declaration
+    /// collection recorded a complete local spread projection for the same
+    /// destination; unknown spread values remain unresolved.
     fn flow_object_assignment_receiver(
         &self,
         scope_id: &str,
@@ -1990,7 +2122,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let right = assignment
             .child_by_field_name("right")
             .map(unwrap_expression_node)?;
-        if right.kind() != "object" || object_literal_has_spread(right) {
+        if right.kind() != "object" {
             return None;
         }
         let name = node_text(self.source, left);
@@ -2002,6 +2134,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             || !self
                 .structural_object_variables
                 .contains(&variable.qualified_name)
+            || (object_literal_has_spread(right)
+                && !self
+                    .structural_object_spreads
+                    .contains_key(&variable.qualified_name))
         {
             return None;
         }
@@ -4229,7 +4365,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         let exported_value = unwrap_expression_node(exported);
-        if exported_value.kind() == "object" && !object_literal_has_spread(exported_value) {
+        if exported_value.kind() == "object"
+            && (!object_literal_has_spread(exported_value)
+                || self.object_literal_spread_export_is_safe(scope_id, exported_value))
+        {
             return self.emit_default_object_export(scope_id, exported_value);
         }
         let (spelling, anchor) = if let Some(target_node) = default_export_target_node(node) {
@@ -4300,12 +4439,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         Ok(())
     }
 
-    /// Publish a spread-free ES default object as a source-backed value owner.
+    /// Publish a source-complete ES default object as a source-backed value owner.
     /// Its member declarations are collected under `<module>.default`, which
     /// lets the shared resolver follow `import value from "./module"` without
-    /// treating the default object as an external namespace. A spread default
-    /// intentionally stays unresolved because a later spread can replace any
-    /// listed property.
+    /// treating the default object as an external namespace. A proven local
+    /// spread is admitted only for direct properties after the spread; source
+    /// properties inherited through the spread remain unresolved until a
+    /// dedicated member-alias contract can preserve their original identity.
     fn emit_default_object_export(
         &mut self,
         scope_id: &str,
@@ -6495,6 +6635,19 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let receiver = self
             .typed_member_receiver(scope_id, lookup_receiver.clone())
             .unwrap_or(lookup_receiver);
+        match self.structural_spread_member_decision(
+            &receiver.qualified_name,
+            &property_name,
+            property.start_byte(),
+        ) {
+            StructuralSpreadDecision::Resolved(declaration) => {
+                return Some(Resolution::Local(*declaration));
+            }
+            StructuralSpreadDecision::KnownAbsent | StructuralSpreadDecision::Unresolved => {
+                return None;
+            }
+            StructuralSpreadDecision::NotApplicable => {}
+        }
         if let Some(name_node) = rightmost_identifier(object)
             && let Some(Resolution::Local(variable)) = self.resolve_name(
                 scope_id,
@@ -6714,6 +6867,137 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             type_only: import.type_only,
             callable_namespace: false,
         }))
+    }
+
+    /// Resolve a member through a source-proven local object spread.  The
+    /// object literal declaration pass records direct members under the
+    /// destination owner and retains the spread operands separately.  This
+    /// helper evaluates those operands from left to right, so a later direct
+    /// property or spread wins exactly as it does at runtime.  It only walks
+    /// the bounded source identities recorded above; any ambiguity or write
+    /// barrier turns into an unresolved decision rather than a name match.
+    fn structural_spread_member_decision(
+        &self,
+        receiver_qualified_name: &str,
+        property_name: &str,
+        use_start_byte: usize,
+    ) -> StructuralSpreadDecision {
+        let Some(spreads) = self.structural_object_spreads.get(receiver_qualified_name) else {
+            return StructuralSpreadDecision::NotApplicable;
+        };
+        let mut visiting = HashSet::new();
+        match self.structural_spread_member_target(
+            receiver_qualified_name,
+            property_name,
+            spreads,
+            use_start_byte,
+            &mut visiting,
+        ) {
+            Ok(Some(declaration)) => StructuralSpreadDecision::Resolved(Box::new(declaration)),
+            Ok(None) => StructuralSpreadDecision::KnownAbsent,
+            Err(()) => StructuralSpreadDecision::Unresolved,
+        }
+    }
+
+    fn structural_spread_member_target(
+        &self,
+        receiver_qualified_name: &str,
+        property_name: &str,
+        spreads: &[StructuralObjectSpread],
+        use_start_byte: usize,
+        visiting: &mut HashSet<String>,
+    ) -> Result<Option<DeclarationInfo>, ()> {
+        if !visiting.insert(receiver_qualified_name.to_owned()) {
+            return Err(());
+        }
+        let qualified_name = format!("{receiver_qualified_name}.{property_name}");
+        let direct = self
+            .declarations_by_qualified
+            .get(&qualified_name)
+            .into_iter()
+            .flat_map(|ids| ids.iter())
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| {
+                declaration.range_start_byte <= use_start_byte
+                    && matches!(
+                        declaration.kind.as_str(),
+                        "property" | "method" | "field" | "variable" | "function" | "class"
+                    )
+            })
+            .map(|declaration| (declaration.range_start_byte, declaration.clone()))
+            .collect::<Vec<_>>();
+        let mut events = direct;
+        for spread in spreads {
+            if spread.start_byte > use_start_byte {
+                continue;
+            }
+            if self
+                .flow_member_write_barriers
+                .get(&(spread.source_variable_id.clone(), property_name.to_owned()))
+                .is_some_and(|barriers| barriers.iter().any(|start| *start <= spread.start_byte))
+            {
+                return Err(());
+            }
+            let source_spreads = self
+                .structural_object_spreads
+                .get(&spread.source_qualified_name);
+            let source_is_stable = self
+                .stable_structural_object_variables
+                .contains(&spread.source_qualified_name);
+            let target = if let Some(source_spreads) = source_spreads {
+                self.structural_spread_member_target(
+                    &spread.source_qualified_name,
+                    property_name,
+                    source_spreads,
+                    use_start_byte,
+                    visiting,
+                )?
+            } else if source_is_stable {
+                let declarations = self
+                    .declarations_by_qualified
+                    .get(&format!(
+                        "{}.{}",
+                        spread.source_qualified_name, property_name
+                    ))
+                    .into_iter()
+                    .flat_map(|ids| ids.iter())
+                    .filter_map(|id| self.declarations.get(id))
+                    .filter(|declaration| {
+                        declaration.range_start_byte <= use_start_byte
+                            && matches!(
+                                declaration.kind.as_str(),
+                                "property" | "method" | "field" | "variable" | "function" | "class"
+                            )
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                match declarations.as_slice() {
+                    [] => None,
+                    [declaration] => Some(declaration.clone()),
+                    _ => return Err(()),
+                }
+            } else {
+                return Err(());
+            };
+            if let Some(target) = target {
+                events.push((spread.start_byte, target));
+            }
+        }
+        visiting.remove(receiver_qualified_name);
+        if events.is_empty() {
+            return Ok(None);
+        }
+        let latest_start = events.iter().map(|(start, _)| *start).max().ok_or(())?;
+        let latest = events
+            .into_iter()
+            .filter(|(start, _)| *start == latest_start)
+            .map(|(_, declaration)| declaration)
+            .collect::<Vec<_>>();
+        (latest.len() == 1)
+            .then(|| latest.into_iter().next())
+            .flatten()
+            .ok_or(())
+            .map(Some)
     }
 
     /// A plain assignment to a source-proven nominal receiver is itself a

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6297,7 +6297,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .unwrap_or_else(|| (normalized.to_owned(), None));
             let type_arguments =
                 type_arguments.map(|arguments| self.canonical_type_arguments(scope_id, &arguments));
-            let resolution = self.resolve_name(scope_id, &lookup_name, Namespace::Both)?;
+            let resolution = self
+                .resolve_name(scope_id, &lookup_name, Namespace::Both)
+                .or_else(|| self.resolve_qualified_type_name(&lookup_name))?;
             match resolution {
                 Resolution::Import(import) => {
                     return Some(ReceiverTarget {
@@ -6309,8 +6311,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 }
                 Resolution::Local(declaration) if declaration.kind == "type_alias" => {
                     if let Some(alias_target) = declaration.declared_type_name.as_deref() {
+                        let alias_target = self.substitute_type_alias_target(
+                            &declaration,
+                            alias_target,
+                            type_arguments.as_deref().unwrap_or(&[]),
+                        );
                         current.clear();
-                        current.push_str(alias_target);
+                        current.push_str(&alias_target);
                     } else {
                         return Some(ReceiverTarget {
                             qualified_name: declaration.qualified_name.clone(),
@@ -6347,6 +6354,48 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
         }
         None
+    }
+
+    /// Resolve a canonical module-qualified nominal name produced while
+    /// substituting an explicit generic argument (for example
+    /// `generic-mapped-alias.Item`).  Ordinary lexical lookup intentionally
+    /// accepts only source spellings; this narrow fallback keeps qualified
+    /// identities from being mistaken for unqualified bindings while still
+    /// allowing a same-file generic mapped alias to recover its concrete
+    /// member receiver.
+    fn resolve_qualified_type_name(&self, name: &str) -> Option<Resolution> {
+        let ids = self.declarations_by_qualified.get(name)?;
+        let declarations = ids
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| {
+                declaration.namespace.accepts(Namespace::Type)
+                    && matches!(
+                        declaration.kind.as_str(),
+                        "class" | "interface" | "enum" | "namespace" | "type_alias"
+                    )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let [declaration] = declarations.as_slice() else {
+            return None;
+        };
+        Some(Resolution::Local(declaration.clone()))
+    }
+
+    fn substitute_type_alias_target(
+        &self,
+        declaration: &DeclarationInfo,
+        target: &str,
+        arguments: &[String],
+    ) -> String {
+        let Some(parameters) = self
+            .generic_parameter_order_by_declaration
+            .get(&declaration.id)
+        else {
+            return target.to_owned();
+        };
+        substitute_candidate_type_parameters(target, parameters, arguments, 0)
     }
 
     /// Canonicalize direct generic arguments when the source proves an
@@ -7359,6 +7408,11 @@ fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -
 }
 
 fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    if node.kind() == "type_alias_declaration"
+        && let Some(mapped_source) = mapped_type_source_name(node, source)
+    {
+        return Some(mapped_source);
+    }
     let annotation = node
         .child_by_field_name("type")
         .or_else(|| first_named_child_kind(node, "type_annotation"))
@@ -7397,6 +7451,110 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
         _ => return None,
     };
     (!type_name.is_empty()).then_some(type_name)
+}
+
+fn mapped_type_source_name(node: Node<'_>, source: &[u8]) -> Option<String> {
+    if node.kind() != "type_alias_declaration" {
+        return None;
+    }
+    let value = node
+        .child_by_field_name("value")
+        .or_else(|| first_named_child(node))?;
+    if value.kind() != "object_type" {
+        return None;
+    }
+    let mut mapped = None;
+    let mut cursor = value.walk();
+    for child in value.named_children(&mut cursor) {
+        if child.kind() != "index_signature"
+            || !contains_node_kind(child, "mapped_type_clause")
+            || mapped.replace(child).is_some()
+        {
+            // A mapped alias is accepted only when its object shape consists
+            // of one direct homomorphic index signature. Nested mapped
+            // members or additional properties would require structural
+            // assignability and must remain unresolved here.
+            return None;
+        }
+    }
+    let mapped = mapped?;
+    let compact = node_text(source, mapped)
+        .chars()
+        .filter(|character| !character.is_ascii_whitespace())
+        .collect::<String>();
+    if compact.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let key_start = compact.find('[')?.saturating_add(1);
+    let in_offset = compact.get(key_start..)?.find("inkeyof")?;
+    let key = compact.get(key_start..key_start.saturating_add(in_offset))?;
+    if key.is_empty()
+        || !key.chars().all(|character| {
+            character == '_' || character == '$' || character.is_ascii_alphanumeric()
+        })
+    {
+        return None;
+    }
+    let source_start = key_start
+        .saturating_add(in_offset)
+        .saturating_add("inkeyof".len());
+    let source_end = compact
+        .get(source_start..)
+        .and_then(|value| value.find(']').map(|offset| source_start + offset))?;
+    let source_name = compact.get(source_start..source_end)?.trim();
+    if source_name.is_empty() || source_name.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let colon = compact.get(source_end.saturating_add(1)..)?.find(':')?;
+    let value_start = source_end
+        .saturating_add(1)
+        .saturating_add(colon)
+        .saturating_add(1);
+    let value = compact
+        .get(value_start..)
+        .and_then(|value| value.strip_suffix('}'))
+        .unwrap_or_else(|| compact.get(value_start..).unwrap_or_default())
+        .trim_start_matches("readonly")
+        .trim();
+    let expected = format!("{}[{}]", source_name, key);
+    (value == expected).then(|| source_name.to_owned())
+}
+
+fn substitute_candidate_type_parameters(
+    type_name: &str,
+    parameters: &[String],
+    arguments: &[String],
+    depth: u32,
+) -> String {
+    let type_name = type_name.trim();
+    if type_name.is_empty()
+        || type_name.len() > MAX_TYPE_SHAPE_BYTES
+        || depth > MAX_TYPE_SHAPE_DEPTH
+    {
+        return type_name.to_owned();
+    }
+    if let Some(index) = parameters
+        .iter()
+        .position(|parameter| parameter == type_name)
+        && let Some(argument) = arguments.get(index)
+    {
+        return argument.clone();
+    }
+    let Some((base, nested)) = generic_type_parts(type_name) else {
+        return type_name.to_owned();
+    };
+    let nested = nested
+        .iter()
+        .map(|argument| {
+            substitute_candidate_type_parameters(argument, parameters, arguments, depth + 1)
+        })
+        .collect::<Vec<_>>();
+    let substituted = format!("{base}<{}>", nested.join(","));
+    if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+        substituted
+    } else {
+        type_name.to_owned()
+    }
 }
 
 /// Return the one nominal type preserved by an optional property union such

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -2056,12 +2056,28 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                             range: range_for_node(self.source_file, child),
                         });
                     }
+                    Some(Resolution::Import(import))
+                        if import.imported_name == "*"
+                            && !import.type_only
+                            && import.namespace == Namespace::Module =>
+                    {
+                        // A namespace import or a static `require()` binding
+                        // denotes the provider module object. Preserve that
+                        // owner identity so the resolver can project only
+                        // source-published exports; dynamic/indirect CommonJS
+                        // values still do not reach this branch.
+                        spreads.push(StructuralObjectSpread {
+                            source_qualified_name: import.target,
+                            source_variable_id: None,
+                            range: range_for_node(self.source_file, child),
+                        });
+                    }
                     None => {
                         // Static ES imports are hoisted, but the declaration
                         // pass intentionally runs before the full import
                         // emission pass. Recover only a default import from
                         // the top-level syntax; named, namespace, dynamic,
-                        // and CommonJS sources stay opaque.
+                        // and dynamic/indirect CommonJS sources stay opaque.
                         let target = self.syntactic_default_import_target(object, &name)?;
                         spreads.push(StructuralObjectSpread {
                             source_qualified_name: target,

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -775,6 +775,14 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         .insert(child_scope.clone(), declaration.id);
                     self.scope_kinds
                         .insert(child_scope.clone(), scope_kind.to_owned());
+                    if kind == "method"
+                        && self
+                            .stable_structural_object_variables
+                            .contains(&qualified_prefix)
+                    {
+                        self.this_receivers
+                            .insert(child_scope.clone(), qualified_prefix.clone());
+                    }
                     self.collect_unwrapped_callable_parameters(node, &child_scope, &next_prefix)?;
                     let mut cursor = node.walk();
                     for child in node.named_children(&mut cursor) {
@@ -1679,9 +1687,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         let straight_line = self
                             .flow_scope_is_compatible(&variable.scope_id, &scope_id)
                             && self.flow_assignment_is_straight_line(left, &scope_id);
-                        let receiver = right
-                            .map(unwrap_expression_node)
-                            .and_then(|right| self.flow_receiver_for_value(&scope_id, right));
+                        let receiver = right.map(unwrap_expression_node).and_then(|right| {
+                            self.flow_receiver_for_value(&scope_id, right).or_else(|| {
+                                (right.kind() == "object")
+                                    .then(|| {
+                                        self.flow_object_assignment_receiver(&scope_id, current)
+                                    })
+                                    .flatten()
+                            })
+                        });
                         if straight_line && operator == "=" {
                             if let Some(receiver) = receiver {
                                 self.record_flow_assignment(
@@ -1892,6 +1906,47 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             current = ancestor.parent();
         }
         None
+    }
+
+    /// Recover the structural receiver for a direct local object assignment
+    /// (`let value; value = { member() {} }`).  Declaration collection has
+    /// already indexed the object literal under the binding's qualified name;
+    /// this helper only carries that source identity into the bounded
+    /// straight-line flow fact.  Spreads remain unresolved because their
+    /// property inventory is not source-complete.
+    fn flow_object_assignment_receiver(
+        &self,
+        scope_id: &str,
+        assignment: Node<'tree>,
+    ) -> Option<ReceiverTarget> {
+        let left = assignment.child_by_field_name("left")?;
+        if left.kind() != "identifier" {
+            return None;
+        }
+        let right = assignment
+            .child_by_field_name("right")
+            .map(unwrap_expression_node)?;
+        if right.kind() != "object" || object_literal_has_spread(right) {
+            return None;
+        }
+        let name = node_text(self.source, left);
+        let Resolution::Local(variable) = self.resolve_name(scope_id, &name, Namespace::Value)?
+        else {
+            return None;
+        };
+        if variable.kind != "variable"
+            || !self
+                .structural_object_variables
+                .contains(&variable.qualified_name)
+        {
+            return None;
+        }
+        Some(ReceiverTarget {
+            qualified_name: variable.qualified_name,
+            import: None,
+            scope_id: Some(variable.scope_id),
+            type_arguments: None,
+        })
     }
 
     fn record_flow_call_argument_escapes(&mut self, node: Node<'tree>, scope_id: &str) {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6378,6 +6378,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     type_arguments: None,
                 });
             }
+            if let Some(unwrapped) = candidate_utility_receiver_type(normalized) {
+                current = unwrapped;
+                continue;
+            }
             let (lookup_name, type_arguments) = generic_type_parts(normalized)
                 .map(|(base, arguments)| (base.to_owned(), Some(arguments)))
                 .unwrap_or_else(|| (normalized.to_owned(), None));
@@ -7670,6 +7674,80 @@ fn candidate_type_mentions_parameter(type_name: &str, parameters: &[String]) -> 
         .any(|token| parameters.iter().any(|parameter| parameter == token))
 }
 
+fn candidate_utility_receiver_type(type_name: &str) -> Option<String> {
+    candidate_utility_receiver_type_at_depth(type_name, 0)
+}
+
+fn candidate_utility_receiver_type_at_depth(type_name: &str, depth: u32) -> Option<String> {
+    if depth > MAX_TYPE_SHAPE_DEPTH {
+        return None;
+    }
+    let (base, arguments) = generic_type_parts(type_name)?;
+    if arguments.len() != 1 {
+        return None;
+    }
+    let argument = arguments[0].trim();
+    match base {
+        "NonNullable" => {
+            let members = split_top_level_union(argument)?;
+            let nominal = members
+                .into_iter()
+                .map(str::trim)
+                .filter(|member| !is_non_nominal_union_member(member))
+                .collect::<Vec<_>>();
+            let [nominal] = nominal.as_slice() else {
+                return None;
+            };
+            Some((*nominal).to_owned())
+        }
+        "Awaited" => {
+            if let Some((promise, nested)) = generic_type_parts(argument)
+                && matches!(promise, "Promise" | "PromiseLike")
+                && nested.len() == 1
+            {
+                return candidate_utility_receiver_type_at_depth(
+                    &format!("Awaited<{}>", nested[0]),
+                    depth + 1,
+                )
+                .or_else(|| Some(nested[0].clone()));
+            }
+            Some(argument.to_owned())
+        }
+        "Partial" | "Required" | "Readonly" => Some(argument.to_owned()),
+        _ => None,
+    }
+}
+
+fn split_top_level_union(input: &str) -> Option<Vec<&str>> {
+    let mut members = Vec::new();
+    let mut start = 0_usize;
+    let mut depth = 0_u32;
+    for (index, character) in input.char_indices() {
+        match character {
+            '<' | '{' | '(' | '[' => depth = depth.checked_add(1)?,
+            '>' | '}' | ')' | ']' => depth = depth.checked_sub(1)?,
+            '|' if depth == 0 => {
+                let member = input.get(start..index)?.trim();
+                if member.is_empty() {
+                    return None;
+                }
+                members.push(member);
+                start = index.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+        if members.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+            return None;
+        }
+    }
+    let member = input.get(start..)?.trim();
+    if member.is_empty() {
+        return None;
+    }
+    members.push(member);
+    Some(members)
+}
+
 fn mapped_type_source_name(node: Node<'_>, source: &[u8]) -> Option<String> {
     if node.kind() != "type_alias_declaration" {
         return None;
@@ -7775,6 +7853,22 @@ fn substitute_candidate_type_parameters(
             })
             .collect::<Vec<_>>();
         let substituted = format!("[{}]", substituted.join(","));
+        return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some(members) = split_top_level_union(type_name)
+        && members.len() > 1
+    {
+        let substituted = members
+            .iter()
+            .map(|member| {
+                substitute_candidate_type_parameters(member, parameters, arguments, depth + 1)
+            })
+            .collect::<Vec<_>>()
+            .join("|");
         return if substituted.len() <= MAX_TYPE_SHAPE_BYTES {
             substituted
         } else {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1949,6 +1949,60 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         })
     }
 
+    /// A source-proven spread-free object can retain the declaration identity
+    /// for a primitive literal member write (`state.flag = true`). This is
+    /// narrower than ordinary structural writes: replacing a callable or
+    /// object-valued member with an alias/call still invalidates the prior
+    /// target, while a literal data write remains an access to the declared
+    /// property itself. The check is intentionally independent of the
+    /// property-write barrier because that barrier protects later reads after
+    /// a potentially identity-changing overwrite.
+    fn structural_literal_member_write(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        property: Node<'tree>,
+    ) -> bool {
+        let Some(member) = property.parent() else {
+            return false;
+        };
+        let Some(assignment) = member.parent() else {
+            return false;
+        };
+        if assignment.kind() != "assignment_expression"
+            || assignment
+                .child_by_field_name("left")
+                .is_none_or(|left| left.id() != member.id())
+        {
+            return false;
+        }
+        let Some(right) = assignment
+            .child_by_field_name("right")
+            .map(unwrap_expression_node)
+        else {
+            return false;
+        };
+        if !matches!(
+            right.kind(),
+            "true" | "false" | "null" | "number" | "string"
+        ) {
+            return false;
+        }
+        let Some(name_node) = rightmost_identifier(object) else {
+            return false;
+        };
+        let name = node_text(self.source, name_node);
+        let Some(Resolution::Local(variable)) =
+            self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            return false;
+        };
+        variable.kind == "variable"
+            && self
+                .stable_structural_object_variables
+                .contains(&variable.qualified_name)
+    }
+
     fn record_flow_call_argument_escapes(&mut self, node: Node<'tree>, scope_id: &str) {
         let Some(arguments) = node
             .child_by_field_name("arguments")
@@ -5907,8 +5961,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let property_name = member_property_name(self.source, property)?;
         let nominal_write_receiver = self.nominal_member_write_receiver(scope_id, object, property);
         let nominal_write = nominal_write_receiver.is_some();
+        let literal_structural_write =
+            self.structural_literal_member_write(scope_id, object, property);
         let receiver = nominal_write_receiver.or_else(|| self.receiver_target(scope_id, object))?;
         if !nominal_write
+            && !literal_structural_write
             && self.flow_member_write_barrier_before(
                 scope_id,
                 object,

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -2137,6 +2137,38 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             || self.stable_immutable_structural_alias(declaration_id)
     }
 
+    /// Preserve a nominal receiver after an unknown call/escape when the
+    /// binding itself is immutable and its source assignment is still the
+    /// unique proven value. An escape may mutate a property, but it cannot
+    /// rebind a `const` alias to a different receiver. Structural aliases do
+    /// not use this recovery because their property identity depends on the
+    /// exact object value that may have escaped.
+    fn stable_nominal_flow_receiver_at(
+        &self,
+        declaration_id: &str,
+        use_start_byte: usize,
+    ) -> Option<ReceiverTarget> {
+        if !self.immutable_bindings.contains(declaration_id) {
+            return None;
+        }
+        let assignment = self
+            .flow_assignments
+            .get(declaration_id)
+            .into_iter()
+            .flat_map(|assignments| assignments.iter())
+            .filter(|assignment| assignment.start_byte <= use_start_byte)
+            .max_by_key(|assignment| assignment.start_byte)?;
+        if assignment.receiver.import.is_some()
+            || assignment.receiver.qualified_name.is_empty()
+            || self
+                .structural_object_variables
+                .contains(&assignment.receiver.qualified_name)
+        {
+            return None;
+        }
+        Some(assignment.receiver.clone())
+    }
+
     fn flow_assignment_is_straight_line(&self, node: Node<'tree>, scope_id: &str) -> bool {
         let mut current = node.parent();
         while let Some(ancestor) = current {
@@ -5584,14 +5616,18 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         argument_types: &[Option<String>],
     ) -> Option<Resolution> {
         let object = object?;
-        let receiver = self.receiver_target(scope_id, object)?;
         let property_name = member_property_name(self.source, property)?;
-        if self.flow_member_write_barrier_before(
-            scope_id,
-            object,
-            &property_name,
-            property.start_byte(),
-        ) {
+        let nominal_write_receiver = self.nominal_member_write_receiver(scope_id, object, property);
+        let nominal_write = nominal_write_receiver.is_some();
+        let receiver = nominal_write_receiver.or_else(|| self.receiver_target(scope_id, object))?;
+        if !nominal_write
+            && self.flow_member_write_barrier_before(
+                scope_id,
+                object,
+                &property_name,
+                property.start_byte(),
+            )
+        {
             return None;
         }
         let projection = decode_utility_projection(&receiver.qualified_name);
@@ -5830,6 +5866,75 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             namespace: Namespace::Value,
             type_only: import.type_only,
         }))
+    }
+
+    /// A plain assignment to a source-proven nominal receiver is itself a
+    /// member occurrence. Keep the declaration target for that write while
+    /// retaining property-scoped barriers for later reads. Structural object
+    /// writes stay conservative because a write can replace the only source
+    /// value that gave the property its identity.
+    fn nominal_member_write_receiver(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        property: Node<'tree>,
+    ) -> Option<ReceiverTarget> {
+        let member = property.parent()?;
+        if !matches!(
+            member.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        ) {
+            return None;
+        }
+        let assignment = member.parent()?;
+        if assignment.kind() != "assignment_expression"
+            || assignment
+                .child_by_field_name("left")
+                .is_none_or(|left| left.id() != member.id())
+        {
+            return None;
+        }
+        let right = assignment.child_by_field_name("right")?;
+        let operator = self
+            .source
+            .get(member.end_byte()..right.start_byte())
+            .and_then(|bytes| std::str::from_utf8(bytes).ok())?;
+        if operator.trim() != "=" {
+            return None;
+        }
+        if let Some(receiver) = self.receiver_target(scope_id, object)
+            && receiver.import.is_none()
+            && !self.receiver_is_flow_sensitive(&receiver)
+        {
+            return Some(receiver);
+        }
+        if !matches!(
+            object.kind(),
+            "identifier" | "type_identifier" | "jsx_identifier"
+        ) {
+            return None;
+        }
+        let name = rightmost_identifier(object)?;
+        let Resolution::Local(variable) =
+            self.resolve_name(scope_id, &node_text(self.source, name), Namespace::Value)?
+        else {
+            return None;
+        };
+        if !self.immutable_bindings.contains(&variable.id) {
+            return None;
+        }
+        let receiver = self
+            .flow_assignments
+            .get(&variable.id)
+            .into_iter()
+            .flat_map(|assignments| assignments.iter())
+            .filter(|assignment| assignment.start_byte <= property.start_byte())
+            .max_by_key(|assignment| assignment.start_byte)
+            .map(|assignment| assignment.receiver.clone())?;
+        (receiver.import.is_none()
+            && !self.receiver_is_flow_sensitive(&receiver)
+            && !receiver.qualified_name.is_empty())
+        .then_some(receiver)
     }
 
     fn receiver_is_flow_sensitive(&self, receiver: &ReceiverTarget) -> bool {
@@ -6531,6 +6636,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         }
                         if self.flow_assignment_barrier_before(&declaration.id, object.start_byte())
                         {
+                            if let Some(receiver) = self.stable_nominal_flow_receiver_at(
+                                &declaration.id,
+                                object.start_byte(),
+                            ) {
+                                return Some(receiver);
+                            }
                             return None;
                         }
 

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use tree_sitter::Node;
 
-use super::build::{EvidenceBuilder, range_for_node};
+use super::build::{EvidenceBuilder, range_for_byte_span, range_for_node};
 use super::model::{
     BindingKind, CandidateRelation, EvidenceRange, HierarchyConstraint, LanguageCapability,
     ResolutionConstraint, SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
@@ -22,6 +22,7 @@ const MAX_TRAVERSAL_DEPTH: usize = 512;
 const MAX_INLINE_OBJECT_PROPERTIES: usize = 256;
 const MAX_TYPE_SHAPE_DEPTH: u32 = 32;
 const MAX_TYPE_SHAPE_BYTES: usize = 16 * 1024;
+const MAX_IMPORT_TYPE_QUERIES: usize = 256;
 
 const TYPESCRIPT_CAPABILITIES: &[LanguageCapability] = &[
     LanguageCapability::Declarations,
@@ -142,6 +143,18 @@ struct ImportInfo {
     namespace: Namespace,
     type_only: bool,
     callable_namespace: bool,
+}
+
+/// A source-backed TypeScript `import("...")` or `typeof import("...")`
+/// type query. The pinned tree-sitter grammar still recovers some indexed
+/// forms through the parser mask in `engine.rs`; retaining the literal module
+/// span lets the candidate preserve the compiler-visible import without
+/// guessing a value call.
+#[derive(Clone, Debug)]
+struct ImportTypeQuery {
+    module: String,
+    module_start_byte: usize,
+    module_end_byte: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -439,6 +452,7 @@ pub(crate) fn extract_candidate_tree_evidence(
     state.infer_variable_types(root, 0);
     state.collect_flow_assignment_facts(root, 0);
     state.emit_nodes(root, 0)?;
+    state.emit_import_type_queries(root)?;
     if parser_recovered {
         state.builder.diagnose(
             "partial_parser_recovery",
@@ -5416,6 +5430,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if node_text(self.source, function) != "import" {
             return Ok(());
         }
+        if self.language == "typescript"
+            && (is_typeof_import_query_call(self.source, function.start_byte())
+                || is_typescript_import_type_query_node(node))
+        {
+            // A TypeScript import-type query is not a runtime dynamic import.
+            // The source/AST fallback below emits its import fact even when
+            // the pinned parser recovers the query.
+            return Ok(());
+        }
         let Some(arguments) = node.child_by_field_name("arguments") else {
             return Ok(());
         };
@@ -5450,6 +5473,87 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 ..ResolutionConstraint::default()
             },
         )?;
+        Ok(())
+    }
+
+    fn emit_import_type_queries(&mut self, root: Node<'tree>) -> Result<(), EvidenceError> {
+        if self.language != "typescript" {
+            return Ok(());
+        }
+        let (mut queries, mut truncated) = collect_import_type_queries(self.source);
+        let mut parser_queries = Vec::new();
+        if queries.len() < MAX_IMPORT_TYPE_QUERIES {
+            truncated |= collect_import_type_query_nodes(
+                root,
+                self.source,
+                0,
+                &mut parser_queries,
+                MAX_IMPORT_TYPE_QUERIES.saturating_sub(queries.len()),
+            );
+        }
+        for query in parser_queries {
+            if queries.iter().any(|existing| {
+                existing.module_start_byte == query.module_start_byte
+                    && existing.module_end_byte == query.module_end_byte
+            }) {
+                continue;
+            }
+            if queries.len() >= MAX_IMPORT_TYPE_QUERIES {
+                truncated = true;
+                break;
+            }
+            queries.push(query);
+        }
+        if truncated {
+            self.builder.diagnose(
+                "import_type_query_limit",
+                None,
+                Some(range_for_node(self.source_file, root)),
+                "bounded TypeScript import-type query extraction reached its limit; remaining queries were left unresolved",
+            )?;
+        }
+        for query in queries {
+            let module = query.module;
+            let scope_id = deepest_node_at_byte(root, query.module_start_byte)
+                .map(|node| self.scope_for_node(node))
+                .unwrap_or_else(|| self.root_scope.clone());
+            let owner = self.owner_for_scope(&scope_id);
+            let fact_key = format!(
+                "import_type:{}:{}",
+                query.module_start_byte, query.module_end_byte
+            );
+            if !self.emitted_facts.insert(fact_key) {
+                continue;
+            }
+            let occurrence_id = self.builder.occur_with_context(
+                SemanticRole::Import,
+                &owner,
+                &module,
+                None,
+                Some(&scope_id),
+                Some("import_type"),
+                range_for_byte_span(
+                    self.source_file,
+                    self.source,
+                    query.module_start_byte,
+                    query.module_end_byte,
+                ),
+            )?;
+            self.builder.relate(
+                CandidateRelation::Imports,
+                &owner,
+                Some(&occurrence_id),
+                None,
+                &module,
+                ResolutionConstraint {
+                    exact_language: Some(self.language.to_owned()),
+                    module_or_package: Some(module.clone()),
+                    allowed_target_kinds: vec!["module".to_owned()],
+                    allow_external: true,
+                    ..ResolutionConstraint::default()
+                },
+            )?;
+        }
         Ok(())
     }
 
@@ -12726,6 +12830,250 @@ fn is_jsx_value_reference_node(node: Node<'_>) -> bool {
         return false;
     }
     !is_type_reference_node(node)
+}
+
+fn is_typeof_import_query_call(source: &[u8], import_start_byte: usize) -> bool {
+    let prefix = &source[..import_start_byte.min(source.len())];
+    let mut end = prefix.len();
+    while end > 0 && prefix[end - 1].is_ascii_whitespace() {
+        end = end.saturating_sub(1);
+    }
+    let start = prefix[..end]
+        .iter()
+        .rposition(|byte| !is_identifier_byte(*byte))
+        .map_or(0, |position| position.saturating_add(1));
+    prefix.get(start..end) == Some(b"typeof")
+}
+
+fn collect_import_type_queries(source: &[u8]) -> (Vec<ImportTypeQuery>, bool) {
+    let mut queries = Vec::new();
+    let mut truncated = false;
+    let mut index = 0;
+    while index < source.len() {
+        match source[index] {
+            b'/' if source.get(index.saturating_add(1)) == Some(&b'/') => {
+                index = skip_line_comment(source, index.saturating_add(2));
+            }
+            b'/' if source.get(index.saturating_add(1)) == Some(&b'*') => {
+                index = skip_block_comment(source, index.saturating_add(2));
+            }
+            b'\'' | b'"' | b'`' => {
+                index = skip_string_literal(source, index);
+            }
+            _ if keyword_at(source, index, b"typeof") => {
+                let mut cursor = skip_ascii_whitespace(source, index.saturating_add(6));
+                if !keyword_at(source, cursor, b"import") {
+                    index = index.saturating_add(6);
+                    continue;
+                }
+                cursor = skip_ascii_whitespace(source, cursor.saturating_add(6));
+                if source.get(cursor) != Some(&b'(') {
+                    index = index.saturating_add(6);
+                    continue;
+                }
+                cursor = skip_ascii_whitespace(source, cursor.saturating_add(1));
+                let Some(&quote) = source.get(cursor) else {
+                    index = index.saturating_add(6);
+                    continue;
+                };
+                if !matches!(quote, b'\'' | b'"') {
+                    index = index.saturating_add(6);
+                    continue;
+                }
+                let module_start_byte = cursor;
+                let Some(module_end_byte) = scan_quoted_literal(source, cursor, quote) else {
+                    index = index.saturating_add(6);
+                    continue;
+                };
+                let close = skip_ascii_whitespace(source, module_end_byte);
+                if source.get(close) != Some(&b')') {
+                    index = index.saturating_add(6);
+                    continue;
+                }
+                let module = source
+                    .get(module_start_byte.saturating_add(1)..module_end_byte.saturating_sub(1))
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .unwrap_or_default()
+                    .to_owned();
+                if !module.is_empty() && module.len() <= MAX_TYPE_SHAPE_BYTES {
+                    if queries.len() >= MAX_IMPORT_TYPE_QUERIES {
+                        truncated = true;
+                        break;
+                    }
+                    queries.push(ImportTypeQuery {
+                        module,
+                        module_start_byte,
+                        module_end_byte,
+                    });
+                }
+                index = close.saturating_add(1);
+            }
+            _ => index = index.saturating_add(1),
+        }
+    }
+    (queries, truncated)
+}
+
+fn collect_import_type_query_nodes<'tree>(
+    root: Node<'tree>,
+    source: &[u8],
+    depth: usize,
+    output: &mut Vec<ImportTypeQuery>,
+    limit: usize,
+) -> bool {
+    if depth > MAX_TRAVERSAL_DEPTH {
+        return false;
+    }
+    if output.len() >= limit {
+        return true;
+    }
+    if root.kind() == "call_expression"
+        && is_typescript_import_type_query_node(root)
+        && root
+            .child_by_field_name("function")
+            .or_else(|| first_named_child(root))
+            .is_some_and(|function| node_text(source, function) == "import")
+        && let Some(arguments) = root.child_by_field_name("arguments")
+        && let Some(module_node) = first_named_child_kind(arguments, "string")
+    {
+        let module = string_literal(source, module_node);
+        if !module.is_empty() && module.len() <= MAX_TYPE_SHAPE_BYTES {
+            output.push(ImportTypeQuery {
+                module,
+                module_start_byte: module_node.start_byte(),
+                module_end_byte: module_node.end_byte(),
+            });
+            if output.len() >= limit {
+                return true;
+            }
+        }
+    }
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if collect_import_type_query_nodes(child, source, depth.saturating_add(1), output, limit) {
+            return true;
+        }
+    }
+    false
+}
+
+fn deepest_node_at_byte<'tree>(root: Node<'tree>, byte: usize) -> Option<Node<'tree>> {
+    if byte < root.start_byte() || byte >= root.end_byte() {
+        return None;
+    }
+    let mut current = root;
+    loop {
+        let mut cursor = current.walk();
+        let Some(child) = current
+            .named_children(&mut cursor)
+            .find(|child| byte >= child.start_byte() && byte < child.end_byte())
+        else {
+            return Some(current);
+        };
+        current = child;
+    }
+}
+
+fn is_typescript_import_type_query_node(node: Node<'_>) -> bool {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if matches!(
+            parent.kind(),
+            "type_query"
+                | "type_alias_declaration"
+                | "type_annotation"
+                | "return_type"
+                | "type_arguments"
+                | "type_parameters"
+                | "generic_type"
+                | "object_type"
+                | "conditional_type"
+                | "extends_type_clause"
+                | "implements_clause"
+        ) {
+            return true;
+        }
+        if matches!(
+            parent.kind(),
+            "program"
+                | "statement_block"
+                | "expression_statement"
+                | "arguments"
+                | "formal_parameters"
+                | "variable_declarator"
+                | "lexical_declaration"
+                | "return_statement"
+        ) {
+            return false;
+        }
+        current = parent.parent();
+    }
+    false
+}
+
+fn keyword_at(source: &[u8], start: usize, keyword: &[u8]) -> bool {
+    let end = start.saturating_add(keyword.len());
+    source.get(start..end) == Some(keyword)
+        && (start == 0 || !is_identifier_byte(source[start.saturating_sub(1)]))
+        && (end >= source.len() || !is_identifier_byte(source[end]))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$') || byte >= 0x80
+}
+
+fn skip_ascii_whitespace(source: &[u8], mut index: usize) -> usize {
+    while source.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index = index.saturating_add(1);
+    }
+    index
+}
+
+fn skip_line_comment(source: &[u8], mut index: usize) -> usize {
+    while let Some(byte) = source.get(index) {
+        index = index.saturating_add(1);
+        if *byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn skip_block_comment(source: &[u8], mut index: usize) -> usize {
+    while index < source.len() {
+        if source.get(index..index.saturating_add(2)) == Some(b"*/") {
+            return index.saturating_add(2);
+        }
+        index = index.saturating_add(1);
+    }
+    source.len()
+}
+
+fn skip_string_literal(source: &[u8], start: usize) -> usize {
+    let Some(&quote) = source.get(start) else {
+        return source.len();
+    };
+    let mut index = start.saturating_add(1);
+    while index < source.len() {
+        match source[index] {
+            b'\\' => index = index.saturating_add(2),
+            byte if byte == quote => return index.saturating_add(1),
+            _ => index = index.saturating_add(1),
+        }
+    }
+    source.len()
+}
+
+fn scan_quoted_literal(source: &[u8], start: usize, quote: u8) -> Option<usize> {
+    let mut index = start.saturating_add(1);
+    while index < source.len() {
+        match source[index] {
+            b'\\' => index = index.saturating_add(2),
+            byte if byte == quote => return Some(index.saturating_add(1)),
+            _ => index = index.saturating_add(1),
+        }
+    }
+    None
 }
 
 fn module_name(path: &Path, source_file: &str) -> String {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1745,13 +1745,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     "member_expression" | "optional_member_expression" | "subscript_expression"
                 ) && let Some(object) = left.child_by_field_name("object")
                 {
+                    let property = member_property_node(left);
+                    let property_name =
+                        property.and_then(|property| member_property_name(self.source, property));
                     self.record_flow_member_write(
                         &scope_id,
                         object,
                         current.start_byte(),
-                        member_property_node(left)
-                            .and_then(|property| member_property_name(self.source, property))
-                            .as_deref(),
+                        property,
+                        property_name.as_deref(),
                     );
                 }
             }
@@ -2020,6 +2022,69 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .contains(&variable.qualified_name)
     }
 
+    /// A stable spread-free object can publish a source-backed member when a
+    /// member assignment itself introduces that property (`registry.run =
+    /// function run() {}`). The declaration inventory must contain exactly
+    /// one property with the receiver-qualified name; otherwise the write
+    /// remains behind the ordinary mutation barrier.
+    fn structural_member_declaration_write(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        property: Node<'tree>,
+    ) -> bool {
+        let Some(member) = property.parent() else {
+            return false;
+        };
+        let Some(assignment) = member.parent() else {
+            return false;
+        };
+        if assignment.kind() != "assignment_expression"
+            || assignment
+                .child_by_field_name("left")
+                .is_none_or(|left| left.id() != member.id())
+        {
+            return false;
+        }
+        let Some(right) = assignment
+            .child_by_field_name("right")
+            .map(unwrap_expression_node)
+        else {
+            return false;
+        };
+        if !is_callable_node(right) {
+            return false;
+        }
+        let Some(name_node) = rightmost_identifier(object) else {
+            return false;
+        };
+        let name = node_text(self.source, name_node);
+        let Some(Resolution::Local(variable)) =
+            self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            return false;
+        };
+        if variable.kind != "variable"
+            || !self
+                .stable_structural_object_variables
+                .contains(&variable.qualified_name)
+        {
+            return false;
+        }
+        let Some(property_name) = member_property_name(self.source, property) else {
+            return false;
+        };
+        let qualified_name = format!("{}.{property_name}", variable.qualified_name);
+        self.declarations_by_qualified
+            .get(&qualified_name)
+            .and_then(|declarations| {
+                (declarations.len() == 1)
+                    .then(|| self.declarations.get(&declarations[0]))
+                    .flatten()
+            })
+            .is_some_and(|declaration| declaration.range_start_byte == property.start_byte())
+    }
+
     fn record_flow_call_argument_escapes(&mut self, node: Node<'tree>, scope_id: &str) {
         let Some(arguments) = node
             .child_by_field_name("arguments")
@@ -2089,6 +2154,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         scope_id: &str,
         object: Node<'tree>,
         start_byte: usize,
+        property: Option<Node<'tree>>,
         property_name: Option<&str>,
     ) {
         let value = unwrap_expression_node(object);
@@ -2112,7 +2178,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return;
         }
         if self.stable_immutable_receiver_alias(&declaration.id) {
-            self.record_flow_member_write_barrier(&declaration.id, property_name, start_byte);
+            if property.is_none_or(|property| {
+                !self.structural_member_declaration_write(scope_id, value, property)
+            }) {
+                self.record_flow_member_write_barrier(&declaration.id, property_name, start_byte);
+            }
         } else {
             self.record_flow_escape_barrier(&declaration.id, start_byte, Some(value));
         }
@@ -6105,9 +6175,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let nominal_write = nominal_write_receiver.is_some();
         let literal_structural_write =
             self.structural_literal_member_write(scope_id, object, property);
+        let structural_declaration_write =
+            self.structural_member_declaration_write(scope_id, object, property);
         let receiver = nominal_write_receiver.or_else(|| self.receiver_target(scope_id, object))?;
         if !nominal_write
             && !literal_structural_write
+            && !structural_declaration_write
             && self.flow_member_write_barrier_before(
                 scope_id,
                 object,

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6056,15 +6056,37 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     fn canonical_type_arguments(&self, scope_id: &str, arguments: &[String]) -> Vec<String> {
         arguments
             .iter()
-            .map(|argument| {
-                self.resolve_name(scope_id, strip_type_arguments(argument), Namespace::Both)
-                    .and_then(|resolution| resolution.qualified_target())
-                    .filter(|qualified| {
-                        !qualified.is_empty() && qualified.len() <= MAX_TYPE_SHAPE_BYTES
-                    })
-                    .unwrap_or_else(|| argument.clone())
-            })
+            .map(|argument| self.canonical_type_argument(scope_id, argument, 0))
             .collect()
+    }
+
+    fn canonical_type_argument(&self, scope_id: &str, argument: &str, depth: u32) -> String {
+        let argument = argument.trim();
+        if argument.is_empty()
+            || argument.len() > MAX_TYPE_SHAPE_BYTES
+            || depth > MAX_TYPE_SHAPE_DEPTH
+        {
+            return argument.to_owned();
+        }
+        if let Some((base, nested_arguments)) = generic_type_parts(argument) {
+            let base = self.canonical_type_name(scope_id, base);
+            let nested_arguments = nested_arguments
+                .iter()
+                .map(|nested| self.canonical_type_argument(scope_id, nested, depth + 1))
+                .collect::<Vec<_>>();
+            let canonical = format!("{base}<{}>", nested_arguments.join(","));
+            if canonical.len() <= MAX_TYPE_SHAPE_BYTES {
+                return canonical;
+            }
+        }
+        self.canonical_type_name(scope_id, argument)
+    }
+
+    fn canonical_type_name(&self, scope_id: &str, type_name: &str) -> String {
+        self.resolve_name(scope_id, strip_type_arguments(type_name), Namespace::Both)
+            .and_then(|resolution| resolution.qualified_target())
+            .filter(|qualified| !qualified.is_empty() && qualified.len() <= MAX_TYPE_SHAPE_BYTES)
+            .unwrap_or_else(|| type_name.to_owned())
     }
 
     /// Return the child scope owned by a nominal declaration when one exists.

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -796,7 +796,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 return Ok(());
             }
         }
-        let mut object_literal_value_id = None;
+        let mut object_literal_value = None;
         if node.kind() == "assignment_expression"
             && let Some(left) = node.child_by_field_name("left")
             && matches!(
@@ -869,7 +869,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 {
                     self.structural_object_variables
                         .insert(qualified_name.clone());
-                    object_literal_value_id = Some(right.id());
+                    object_literal_value = Some(right);
                     let mut cursor = right.walk();
                     for child in right.named_children(&mut cursor) {
                         self.collect_declarations(
@@ -893,7 +893,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 self.resolve_name(&scope_id, &node_text(self.source, left), Namespace::Value)
             && variable.kind == "variable"
         {
-            object_literal_value_id = Some(value.id());
+            object_literal_value = Some(value);
             self.structural_object_variables
                 .insert(variable.qualified_name.clone());
             let mut cursor = value.walk();
@@ -909,31 +909,30 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if node.kind() == "variable_declarator"
             && let Some(name_node) = node.child_by_field_name("name")
         {
-            let object_literal_prefix = node
+            let binding_object_literal_value = node
                 .child_by_field_name("value")
-                .map(unwrap_expression_node)
-                .filter(|value| value.kind() == "object")
-                .and_then(|_| {
-                    // A typed identifier can contain a nested object type
-                    // (`const value: { key: string } = { key: ... }`).
-                    // Walking that annotation as a binding pattern would
-                    // collect `key` as an additional variable and lose the
-                    // receiver prefix, collapsing unrelated object members.
-                    let names = if name_node.kind() == "identifier" {
-                        vec![(node_text(self.source, name_node), name_node)]
+                .and_then(|value| self.object_literal_value_for_binding(value));
+            let object_literal_prefix = binding_object_literal_value.and_then(|_| {
+                // A typed identifier can contain a nested object type
+                // (`const value: { key: string } = { key: ... }`).
+                // Walking that annotation as a binding pattern would
+                // collect `key` as an additional variable and lose the
+                // receiver prefix, collapsing unrelated object members.
+                let names = if name_node.kind() == "identifier" {
+                    vec![(node_text(self.source, name_node), name_node)]
+                } else {
+                    let mut names = Vec::new();
+                    collect_pattern_names(name_node, self.source, &mut names);
+                    names
+                };
+                (names.len() == 1).then(|| {
+                    if qualified_prefix.is_empty() {
+                        names[0].0.clone()
                     } else {
-                        let mut names = Vec::new();
-                        collect_pattern_names(name_node, self.source, &mut names);
-                        names
-                    };
-                    (names.len() == 1).then(|| {
-                        if qualified_prefix.is_empty() {
-                            names[0].0.clone()
-                        } else {
-                            format!("{qualified_prefix}.{}", names[0].0)
-                        }
-                    })
-                });
+                        format!("{qualified_prefix}.{}", names[0].0)
+                    }
+                })
+            });
             if let Some(value) = node.child_by_field_name("value")
                 && is_callable_node(value)
                 && name_node.kind() == "identifier"
@@ -1019,17 +1018,14 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             // after their constructor.
             self.infer_variable_prototype_source(node, &scope_id);
             if let Some(prefix) = object_literal_prefix.as_deref()
-                && let Some(value) = node
-                    .child_by_field_name("value")
-                    .map(unwrap_expression_node)
-                && value.kind() == "object"
+                && let Some(value) = binding_object_literal_value
             {
                 self.structural_object_variables.insert(prefix.to_owned());
                 if !object_literal_has_spread(value) {
                     self.stable_structural_object_variables
                         .insert(prefix.to_owned());
                 }
-                object_literal_value_id = Some(value.id());
+                object_literal_value = Some(value);
                 let mut cursor = value.walk();
                 for child in value.named_children(&mut cursor) {
                     self.collect_declarations(
@@ -1043,7 +1039,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
-            if Some(child.id()) == object_literal_value_id {
+            if object_literal_value.is_some_and(|object| node_is_descendant_or_same(object, child))
+            {
                 continue;
             }
             self.collect_declarations(
@@ -1745,7 +1742,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     }
 
     fn flow_receiver_for_value(
-        &self,
+        &mut self,
         scope_id: &str,
         value: Node<'tree>,
     ) -> Option<ReceiverTarget> {
@@ -1760,6 +1757,27 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return self.receiver_target(scope_id, value);
         }
         match value.kind() {
+            "assignment_expression" => {
+                let left = value.child_by_field_name("left");
+                let right = value
+                    .child_by_field_name("right")
+                    .map(unwrap_expression_node);
+                let is_plain_assignment = left.zip(right).is_some_and(|(left, right)| {
+                    self.source
+                        .get(left.end_byte()..right.start_byte())
+                        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                        .is_some_and(|operator| operator.trim() == "=")
+                });
+                if is_plain_assignment
+                    && let Some(right) = right
+                    && right.kind() == "object"
+                    && !object_literal_has_spread(right)
+                    && let Some(receiver) = self.flow_inline_object_receiver(scope_id, value)
+                {
+                    return Some(receiver);
+                }
+                right.and_then(|right| self.flow_receiver_for_value(scope_id, right))
+            }
             "new_expression" => self.receiver_target(scope_id, value),
             "call_expression" | "optional_call_expression" => {
                 self.call_return_receiver(scope_id, value)
@@ -1769,6 +1787,67 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
             _ => None,
         }
+    }
+
+    fn object_literal_value_for_binding(&self, value: Node<'tree>) -> Option<Node<'tree>> {
+        let value = unwrap_expression_node(value);
+        if value.kind() == "object" {
+            return Some(value);
+        }
+        if value.kind() != "assignment_expression" {
+            return None;
+        }
+        let left = value.child_by_field_name("left")?;
+        let right = value
+            .child_by_field_name("right")
+            .map(unwrap_expression_node)?;
+        let operator = self
+            .source
+            .get(left.end_byte()..right.start_byte())
+            .and_then(|bytes| std::str::from_utf8(bytes).ok())?;
+        (operator.trim() == "=" && right.kind() == "object").then_some(right)
+    }
+
+    fn flow_inline_object_receiver(
+        &self,
+        scope_id: &str,
+        assignment: Node<'tree>,
+    ) -> Option<ReceiverTarget> {
+        let mut current = assignment.parent();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let Some(ancestor) = current else {
+                break;
+            };
+            if ancestor.kind() == "variable_declarator"
+                && ancestor
+                    .child_by_field_name("value")
+                    .map(unwrap_expression_node)
+                    .is_some_and(|value| value.id() == assignment.id())
+                && let Some(name) = ancestor.child_by_field_name("name")
+                && name.kind() == "identifier"
+            {
+                let name = node_text(self.source, name);
+                let Resolution::Local(variable) =
+                    self.resolve_name(scope_id, &name, Namespace::Value)?
+                else {
+                    return None;
+                };
+                if self
+                    .structural_object_variables
+                    .contains(&variable.qualified_name)
+                {
+                    return Some(ReceiverTarget {
+                        qualified_name: variable.qualified_name,
+                        import: None,
+                        scope_id: Some(variable.scope_id),
+                        type_arguments: None,
+                    });
+                }
+                return None;
+            }
+            current = ancestor.parent();
+        }
+        None
     }
 
     fn record_flow_call_argument_escapes(&mut self, node: Node<'tree>, scope_id: &str) {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -217,6 +217,11 @@ struct CandidateState<'source, 'tree> {
     /// Escape/dynamic barriers survive later local assignments because a
     /// captured binding or dynamic evaluator can observe the rebinding too.
     flow_escape_barriers: HashMap<String, Vec<usize>>,
+    /// `const` bindings whose receiver identity is source-proven and cannot
+    /// be rebound.  A stable nominal alias may be captured by a closure
+    /// without widening the receiver; mutable/structural aliases still take
+    /// the conservative escape barrier below.
+    immutable_bindings: HashSet<String>,
     structural_object_variables: HashSet<String>,
     return_object_functions: HashSet<String>,
     /// A local variable initialized from a source-visible function whose
@@ -339,6 +344,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         flow_assignments: HashMap::new(),
         flow_assignment_barriers: HashMap::new(),
         flow_escape_barriers: HashMap::new(),
+        immutable_bindings: HashSet::new(),
         structural_object_variables: HashSet::new(),
         return_object_functions: HashSet::new(),
         variable_object_sources: HashMap::new(),
@@ -986,7 +992,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 if name.is_empty() {
                     continue;
                 }
-                self.add_declaration_at(
+                let declaration = self.add_declaration_at(
                     node,
                     name_node,
                     "variable",
@@ -995,6 +1001,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     &qualified_prefix,
                     &name,
                 )?;
+                if variable_binding_is_immutable(node, self.source) {
+                    self.immutable_bindings.insert(declaration.id);
+                }
             }
             // Prototype aliases must be available while the declaration pass
             // visits following assignments (`const proto = Ctor.prototype;
@@ -1742,7 +1751,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             "call_expression" | "optional_call_expression" => {
                 self.call_return_receiver(scope_id, value)
             }
-            "identifier" | "type_identifier" => self.receiver_target(scope_id, value),
+            "identifier" | "type_identifier" | "this" | "super" => {
+                self.receiver_target(scope_id, value)
+            }
             _ => None,
         }
     }
@@ -1856,6 +1867,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         &self.scope_for_node(node),
                         &declaration.scope_id,
                     )
+                    && !self.stable_immutable_nominal_alias(&declaration.id)
                 {
                     captured.insert(declaration.id.clone());
                 }
@@ -1871,6 +1883,34 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         for declaration_id in captured {
             self.record_flow_escape_barrier(&declaration_id, node.start_byte());
         }
+    }
+
+    /// A closure capture is an escape barrier for mutable or structural
+    /// bindings because a later write can change the receiver observed by the
+    /// closure. A `const` alias to one source-proven nominal receiver (most
+    /// notably `const token = this`) cannot be rebound, so retaining that
+    /// identity improves common JavaScript class patterns without selecting a
+    /// structural object by spelling alone.
+    fn stable_immutable_nominal_alias(&self, declaration_id: &str) -> bool {
+        if !self.immutable_bindings.contains(declaration_id) {
+            return false;
+        }
+        let Some(assignments) = self.flow_assignments.get(declaration_id) else {
+            return false;
+        };
+        let Some(assignment) = assignments
+            .iter()
+            .min_by_key(|assignment| assignment.start_byte)
+        else {
+            return false;
+        };
+        if self
+            .structural_object_variables
+            .contains(&assignment.receiver.qualified_name)
+        {
+            return false;
+        }
+        assignment.receiver.import.is_some() || !assignment.receiver.qualified_name.is_empty()
     }
 
     fn flow_assignment_is_straight_line(&self, node: Node<'tree>, scope_id: &str) -> bool {
@@ -8825,6 +8865,19 @@ fn is_non_nominal_union_member(name: &str) -> bool {
             | "true"
             | "false"
     )
+}
+
+fn variable_binding_is_immutable(node: Node<'_>, source: &[u8]) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    if parent.kind() != "lexical_declaration" {
+        return false;
+    }
+    node_text(source, parent)
+        .split_whitespace()
+        .next()
+        .is_some_and(|keyword| keyword == "const")
 }
 
 fn type_alias_union_targets(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1769,9 +1769,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         .is_some_and(|operator| operator.trim() == "=")
                 });
                 if is_plain_assignment
-                    && let Some(right) = right
-                    && right.kind() == "object"
-                    && !object_literal_has_spread(right)
+                    && self
+                        .object_literal_value_for_binding(value)
+                        .is_some_and(|object| !object_literal_has_spread(object))
                     && let Some(receiver) = self.flow_inline_object_receiver(scope_id, value)
                 {
                     return Some(receiver);
@@ -1790,22 +1790,59 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     }
 
     fn object_literal_value_for_binding(&self, value: Node<'tree>) -> Option<Node<'tree>> {
-        let value = unwrap_expression_node(value);
-        if value.kind() == "object" {
-            return Some(value);
+        let mut value = unwrap_expression_node(value);
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            if value.kind() == "object" {
+                return Some(value);
+            }
+            if value.kind() != "assignment_expression" {
+                return None;
+            }
+            let left = value.child_by_field_name("left")?;
+            let right = value
+                .child_by_field_name("right")
+                .map(unwrap_expression_node)?;
+            let operator = self
+                .source
+                .get(left.end_byte()..right.start_byte())
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())?;
+            if operator.trim() != "=" {
+                return None;
+            }
+            value = right;
         }
-        if value.kind() != "assignment_expression" {
-            return None;
+        None
+    }
+
+    fn assignment_chain_contains(&self, root: Node<'tree>, target_id: usize) -> bool {
+        let mut current = unwrap_expression_node(root);
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            if current.id() == target_id {
+                return true;
+            }
+            if current.kind() != "assignment_expression" {
+                return false;
+            }
+            let left = current.child_by_field_name("left");
+            let right = current
+                .child_by_field_name("right")
+                .map(unwrap_expression_node);
+            let Some((left, right)) = left.zip(right) else {
+                return false;
+            };
+            let Some(operator) = self
+                .source
+                .get(left.end_byte()..right.start_byte())
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            else {
+                return false;
+            };
+            if operator.trim() != "=" {
+                return false;
+            }
+            current = right;
         }
-        let left = value.child_by_field_name("left")?;
-        let right = value
-            .child_by_field_name("right")
-            .map(unwrap_expression_node)?;
-        let operator = self
-            .source
-            .get(left.end_byte()..right.start_byte())
-            .and_then(|bytes| std::str::from_utf8(bytes).ok())?;
-        (operator.trim() == "=" && right.kind() == "object").then_some(right)
+        false
     }
 
     fn flow_inline_object_receiver(
@@ -1822,7 +1859,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 && ancestor
                     .child_by_field_name("value")
                     .map(unwrap_expression_node)
-                    .is_some_and(|value| value.id() == assignment.id())
+                    .is_some_and(|value| {
+                        self.object_literal_value_for_binding(value)
+                            .is_some_and(|object| !object_literal_has_spread(object))
+                            && self.assignment_chain_contains(value, assignment.id())
+                    })
                 && let Some(name) = ancestor.child_by_field_name("name")
                 && name.kind() == "identifier"
             {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -252,6 +252,11 @@ struct CandidateState<'source, 'tree> {
     /// spelling.
     property_alias_values: HashMap<String, String>,
     callable_property_aliases: HashSet<String>,
+    /// Variable aliases to source-proven callable values. These are kept
+    /// separate from receiver aliases: passing a callback through an
+    /// unknown API is a reference to the callable binding, not an indirect
+    /// call to a guessed handler.
+    callable_variable_aliases: HashSet<String>,
     /// Variable aliases to a source member/function value. These are retained
     /// only to recover a source-declared return type at a subsequent call
     /// site (for example `const stringType = ZodString.create`).
@@ -344,6 +349,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         constructor_name_hints: HashSet::new(),
         property_alias_values: HashMap::new(),
         callable_property_aliases: HashSet::new(),
+        callable_variable_aliases: HashSet::new(),
         variable_alias_values: HashMap::new(),
         this_receivers: HashMap::new(),
         base_targets: HashMap::new(),
@@ -1275,31 +1281,80 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .iter()
             .map(|(declaration_id, target)| (declaration_id.clone(), target.clone()))
             .collect::<Vec<_>>();
-        for (declaration_id, target) in aliases {
-            let Some(property) = self.declarations.get(&declaration_id) else {
-                continue;
-            };
-            let property_scope = property.scope_id.clone();
-            let callable = match self.resolve_name(&property_scope, &target, Namespace::Value) {
-                Some(Resolution::Local(target)) => {
-                    target.callable_shape
-                        || matches!(
-                            target.kind.as_str(),
-                            "class" | "constructor" | "function" | "method"
-                        )
+        let variable_aliases = self
+            .variable_alias_values
+            .iter()
+            .map(|(declaration_id, target)| (declaration_id.clone(), target.clone()))
+            .collect::<Vec<_>>();
+        // A short fixed point handles a bounded alias chain (`a -> b -> fn`)
+        // without turning callback classification into whole-program data
+        // flow. The same budget bounds both source syntax and work here.
+        for _ in 0..MAX_INLINE_OBJECT_PROPERTIES {
+            let mut changed = false;
+            for (declaration_id, target) in aliases.iter().chain(variable_aliases.iter()) {
+                let Some(declaration) = self.declarations.get(declaration_id) else {
+                    continue;
+                };
+                let callable = self.callable_alias_target(&declaration.scope_id, target);
+                let destination = if declaration.kind == "property" {
+                    &mut self.callable_property_aliases
+                } else {
+                    &mut self.callable_variable_aliases
+                };
+                if callable && destination.insert(declaration_id.clone()) {
+                    changed = true;
                 }
-                // Overloaded local functions have multiple declarations and
-                // intentionally resolve as ambiguous at a call site.  An
-                // alias to that overloaded set is nevertheless source-proven
-                // callable, so accept it only when every visible candidate
-                // is a callable declaration.
-                None => self.visible_callable_alias_target(&property_scope, &target),
-                Some(Resolution::Import(_)) => false,
-            };
-            if callable {
-                self.callable_property_aliases.insert(declaration_id);
+            }
+            if !changed {
+                break;
             }
         }
+    }
+
+    fn callable_alias_target(&self, scope_id: &str, target: &str) -> bool {
+        if let Some((base, property)) = target.rsplit_once('.') {
+            let Some(receiver) = self.resolve_name(scope_id, base, Namespace::Value) else {
+                return false;
+            };
+            let qualified_name = match receiver {
+                Resolution::Local(declaration) => {
+                    format!("{}.{}", declaration.qualified_name, property)
+                }
+                // An imported member may be callable, but this per-file
+                // candidate has no source declaration proof for its shape.
+                // The project resolver may still resolve an explicit call;
+                // callback references stay conservative here.
+                Resolution::Import(_) => return false,
+            };
+            let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+                return false;
+            };
+            return ids.len() == 1 && ids.iter().all(|id| self.proven_callable_declaration(id));
+        }
+        match self.resolve_name(scope_id, target, Namespace::Value) {
+            Some(Resolution::Local(declaration)) => {
+                self.proven_callable_declaration(&declaration.id)
+            }
+            // Overloaded local functions have no unique `Resolution`, but
+            // every visible declaration can still prove that the alias is a
+            // callable value. The alias itself remains a unique local
+            // binding, so its reference target is not ambiguous.
+            None => self.visible_callable_alias_target(scope_id, target),
+            Some(Resolution::Import(_)) => false,
+        }
+    }
+
+    fn proven_callable_declaration(&self, declaration_id: &str) -> bool {
+        let Some(declaration) = self.declarations.get(declaration_id) else {
+            return false;
+        };
+        declaration.callable_shape
+            || self.callable_property_aliases.contains(declaration_id)
+            || self.callable_variable_aliases.contains(declaration_id)
+            || matches!(
+                declaration.kind.as_str(),
+                "class" | "constructor" | "function" | "method"
+            )
     }
 
     fn visible_callable_alias_target(&self, scope_id: &str, name: &str) -> bool {
@@ -1318,13 +1373,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 })
                 .collect::<Vec<_>>();
             if !candidates.is_empty() {
-                return candidates.iter().all(|candidate| {
-                    candidate.callable_shape
-                        || matches!(
-                            candidate.kind.as_str(),
-                            "class" | "constructor" | "function" | "method"
-                        )
-                });
+                return candidates
+                    .iter()
+                    .all(|candidate| self.proven_callable_declaration(&candidate.id));
             }
             current = self.scope_parents.get(&scope).cloned().flatten();
         }
@@ -4701,9 +4752,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         let is_callable = match &resolution {
-            Resolution::Local(declaration) => {
-                matches!(declaration.kind.as_str(), "function" | "method" | "class")
-            }
+            Resolution::Local(declaration) => self.proven_callable_declaration(&declaration.id),
             Resolution::Import(import) => {
                 import.imported_name == "default" || import.imported_name == "*"
             }
@@ -5807,6 +5856,40 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         Some(receiver.clone())
     }
 
+    /// Narrow a local union by a positive literal `in` guard
+    /// (`if ("run" in value) { value.run() }`). Only a unique union
+    /// constituent that declares the guarded property is accepted; if two
+    /// constituents expose it, the runtime test does not choose one and the
+    /// receiver remains unresolved.
+    fn flow_narrowed_in_receiver(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        declaration: &DeclarationInfo,
+    ) -> Option<ReceiverTarget> {
+        let variable_type = self.variable_types.get(&declaration.id)?;
+        let targets = self.type_alias_union_targets.get(variable_type)?;
+        let guard_property = self.positive_in_property_guard(object, declaration.name.as_str())?;
+        let mut matches = Vec::new();
+        for target_name in targets {
+            let receiver = self.resolve_declared_type_receiver(scope_id, target_name)?;
+            if receiver.import.is_some() {
+                continue;
+            }
+            let qualified_name = format!("{}.{}", receiver.qualified_name, guard_property);
+            let Some(ids) = self.declarations_by_qualified.get(&qualified_name) else {
+                continue;
+            };
+            if ids.len() == 1 {
+                matches.push(receiver);
+            }
+        }
+        let [receiver] = matches.as_slice() else {
+            return None;
+        };
+        Some(receiver.clone())
+    }
+
     /// Narrow a local union by a direct string-literal discriminant guard
     /// (`if (value.kind === "ready") { value.data }`).  This is deliberately
     /// limited to a single strict equality in the positive branch and to
@@ -5872,6 +5955,57 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 let prefix = format!("{variable_name}.");
                 if let Some(property) = compact.strip_prefix(&prefix)
                     && !property.is_empty()
+                    && property.chars().all(|character| {
+                        character == '_' || character == '$' || character.is_ascii_alphanumeric()
+                    })
+                {
+                    return Some(property.to_owned());
+                }
+            }
+            current = ancestor.parent();
+        }
+        None
+    }
+
+    fn positive_in_property_guard(
+        &self,
+        object: Node<'tree>,
+        variable_name: &str,
+    ) -> Option<String> {
+        let mut current = object.parent();
+        for _ in 0..=MAX_TYPE_SHAPE_DEPTH {
+            let Some(ancestor) = current else {
+                break;
+            };
+            if ancestor.kind() == "if_statement"
+                && let Some(consequence) = ancestor.child_by_field_name("consequence")
+                && node_is_descendant_or_same(object, consequence)
+                && let Some(condition) = ancestor.child_by_field_name("condition")
+            {
+                let compact = node_text(self.source, condition)
+                    .chars()
+                    .filter(|character| !character.is_ascii_whitespace())
+                    .collect::<String>();
+                let compact = compact
+                    .strip_prefix('(')
+                    .and_then(|value| value.strip_suffix(')'))
+                    .unwrap_or(&compact);
+                let suffix = format!("in{variable_name}");
+                let Some(literal) = compact.strip_suffix(&suffix) else {
+                    current = ancestor.parent();
+                    continue;
+                };
+                let property = literal
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .or_else(|| {
+                        literal
+                            .strip_prefix('\'')
+                            .and_then(|value| value.strip_suffix('\''))
+                    })
+                    .unwrap_or_default();
+                if !property.is_empty()
+                    && property.len() <= MAX_TYPE_SHAPE_BYTES
                     && property.chars().all(|character| {
                         character == '_' || character == '$' || character.is_ascii_alphanumeric()
                     })
@@ -6067,6 +6201,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
 
                         if let Some(receiver) =
                             self.flow_narrowed_union_receiver(scope_id, object, &declaration)
+                        {
+                            return Some(receiver);
+                        }
+
+                        if let Some(receiver) =
+                            self.flow_narrowed_in_receiver(scope_id, object, &declaration)
                         {
                             return Some(receiver);
                         }

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -3621,6 +3621,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             "jsx_opening_element" | "jsx_self_closing_element" => {
                 self.emit_jsx(node, &scope_id)?;
             }
+            "jsx_expression" => {
+                self.emit_jsx_value_references(node, &scope_id)?;
+            }
             "decorator" => self.emit_decorator(node, &scope_id)?,
             "class_heritage" if self.language == "javascript" => {
                 self.emit_bases(node, &scope_id)?;
@@ -5781,6 +5784,109 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         )
     }
 
+    /// Emit value references contained in a JSX expression, including
+    /// attribute values, spread attributes, and child expressions. JSX
+    /// values are ordinary JavaScript expressions, but the generic identifier
+    /// walker intentionally only publishes proven callable references. Keep a
+    /// dedicated pass so a parameter, object, or imported value used as a
+    /// prop is preserved even when it is not itself callable.
+    fn emit_jsx_value_references(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(context) = jsx_expression_context(node, self.source) else {
+            return Ok(());
+        };
+        let Some(expression) = first_named_child(node) else {
+            return Ok(());
+        };
+        self.walk_jsx_value_references(expression, scope_id, context, 0)
+    }
+
+    fn walk_jsx_value_references(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        context: &str,
+        depth: usize,
+    ) -> Result<(), EvidenceError> {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            return Ok(());
+        }
+        // A nested JSX element owns its own expression contexts. Do not let
+        // an outer child expression relabel the nested tag or its props.
+        if matches!(
+            node.kind(),
+            "jsx_element"
+                | "jsx_opening_element"
+                | "jsx_self_closing_element"
+                | "jsx_closing_element"
+        ) {
+            return Ok(());
+        }
+        if is_jsx_value_reference_node(node) {
+            self.emit_jsx_value_reference(node, scope_id, context)?;
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.walk_jsx_value_references(child, scope_id, context, depth + 1)?;
+        }
+        Ok(())
+    }
+
+    fn emit_jsx_value_reference(
+        &mut self,
+        node: Node<'tree>,
+        scope_id: &str,
+        context: &str,
+    ) -> Result<(), EvidenceError> {
+        if self.declaration_name_nodes.contains(&node.start_byte()) {
+            return Ok(());
+        }
+        let spelling = node_text(self.source, node);
+        if spelling.is_empty() {
+            return Ok(());
+        }
+        let allowed_kinds = &[
+            "class",
+            "enum",
+            "external",
+            "function",
+            "method",
+            "parameter",
+            "property",
+            "variable",
+        ];
+        if let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Value) {
+            return self.add_declaration_resolution(
+                node,
+                scope_id,
+                CandidateRelation::References,
+                SemanticRole::CallableReference,
+                &spelling,
+                None,
+                Some(context),
+                Namespace::Value,
+                resolution,
+                allowed_kinds,
+            );
+        }
+        self.add_unresolved_candidate(
+            node,
+            scope_id,
+            CandidateRelation::References,
+            SemanticRole::CallableReference,
+            &spelling,
+            None,
+            context,
+            None,
+            Vec::new(),
+            allowed_kinds,
+            None,
+        )
+    }
+
     fn emit_decorator(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
         let allowed_kinds = &["function", "class", "variable", "property", "external"];
         if self.parser_recovered || node.has_error() {
@@ -6299,6 +6405,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         | "jsx_self_closing_element"
                 )
             })
+            || is_jsx_value_reference_node(node)
+            || is_jsx_attribute_name(node)
             || is_type_reference_node(node)
         {
             return Ok(());
@@ -12525,6 +12633,99 @@ fn is_type_reference_node(node: Node<'_>) -> bool {
         current = parent.parent();
     }
     false
+}
+
+fn jsx_expression_context<'a>(node: Node<'_>, source: &'a [u8]) -> Option<&'a str> {
+    if node.kind() != "jsx_expression" {
+        return None;
+    }
+    let parent = node.parent()?;
+    if node_text(source, node).trim_start().starts_with("{...")
+        || matches!(parent.kind(), "jsx_spread_attribute")
+    {
+        return Some("jsx_spread");
+    }
+    match parent.kind() {
+        "jsx_attribute" => Some("jsx_value"),
+        "jsx_element" => Some("jsx_child"),
+        "jsx_opening_element" | "jsx_self_closing_element" => Some("jsx_spread"),
+        _ => None,
+    }
+}
+
+fn is_jsx_attribute_name(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| {
+        parent.kind() == "jsx_attribute"
+            && first_named_child(parent).is_some_and(|name| name.id() == node.id())
+    })
+}
+
+fn is_jsx_value_reference_node(node: Node<'_>) -> bool {
+    if !matches!(node.kind(), "identifier" | "shorthand_property_identifier") {
+        return false;
+    }
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let mut current = Some(parent);
+    let mut inside_expression = false;
+    while let Some(candidate) = current {
+        if candidate.kind() == "jsx_expression" {
+            inside_expression = true;
+            break;
+        }
+        if matches!(
+            candidate.kind(),
+            "jsx_element" | "jsx_opening_element" | "jsx_self_closing_element"
+        ) {
+            break;
+        }
+        current = candidate.parent();
+    }
+    if !inside_expression {
+        return false;
+    }
+    if is_jsx_attribute_name(node) {
+        return false;
+    }
+    if matches!(
+        parent.kind(),
+        "jsx_opening_element"
+            | "jsx_self_closing_element"
+            | "jsx_closing_element"
+            | "jsx_namespace_name"
+            | "import_clause"
+            | "namespace_import"
+            | "named_imports"
+            | "import_specifier"
+            | "export_clause"
+            | "export_specifier"
+    ) {
+        return false;
+    }
+    if matches!(
+        parent.kind(),
+        "member_expression" | "optional_member_expression" | "subscript_expression"
+    ) && parent
+        .child_by_field_name("property")
+        .or_else(|| parent.child_by_field_name("name"))
+        .or_else(|| parent.child_by_field_name("index"))
+        .is_some_and(|property| property.id() == node.id())
+    {
+        return false;
+    }
+    if matches!(
+        parent.kind(),
+        "call_expression" | "optional_call_expression" | "new_expression" | "decorator"
+    ) && parent
+        .child_by_field_name("function")
+        .or_else(|| parent.child_by_field_name("constructor"))
+        .or_else(|| first_named_child(parent))
+        .is_some_and(|callee| callee.id() == node.id())
+    {
+        return false;
+    }
+    !is_type_reference_node(node)
 }
 
 fn module_name(path: &Path, source_file: &str) -> String {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1118,7 +1118,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             format!("{qualified_prefix}.{name}")
         };
         let graph_node_id = stable_graph_id(self.source_file, kind, name, node.start_byte());
-        let signature = typescript_declaration_signature(node, kind, self.source);
+        let signature = typescript_declaration_signature(node, kind, self.source)
+            .map(|signature| self.canonicalize_declaration_signature(scope_id, kind, &signature));
         let declaration_id = self.builder.declare_with_signature(
             kind,
             &graph_node_id,
@@ -5770,6 +5771,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 {
                     return Some(indexed);
                 }
+                if object.kind() == "subscript_expression" && nested.import.is_some() {
+                    let qualified_name = format!(
+                        "{}[]",
+                        typescript_receiver_with_type_arguments(
+                            &nested.qualified_name,
+                            nested.type_arguments.as_deref(),
+                        )
+                    );
+                    return Some(ReceiverTarget {
+                        qualified_name,
+                        import: nested.import,
+                        scope_id: nested.scope_id,
+                        type_arguments: None,
+                    });
+                }
                 let property_name = member_property_name(self.source, property)?;
                 // A namespace import (`import * as api`) exposes members with
                 // `module::member` identity.  A named/class import denotes a
@@ -6058,6 +6074,31 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .iter()
             .map(|argument| self.canonical_type_argument(scope_id, argument, 0))
             .collect()
+    }
+
+    fn canonicalize_declaration_signature(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        signature: &str,
+    ) -> String {
+        let has_index = signature.contains("|index=") || signature.starts_with("index=");
+        if (kind != "type_alias" && !has_index) || (!signature.contains('=') && !has_index) {
+            return signature.to_owned();
+        }
+        let mut canonical = signature.to_owned();
+        if let Some((prefix, target)) = canonical.split_once('=') {
+            let target = target
+                .split_once("|index=")
+                .map_or(target, |(target, _)| target);
+            let target = self.canonical_type_argument(scope_id, target, 0);
+            canonical = format!("{prefix}={target}");
+        }
+        if let Some((prefix, value)) = canonical.split_once("|index=") {
+            let value = self.canonical_type_argument(scope_id, value, 0);
+            canonical = format!("{prefix}|index={value}");
+        }
+        canonical
     }
 
     fn canonical_type_argument(&self, scope_id: &str, argument: &str, depth: u32) -> String {
@@ -6998,13 +7039,35 @@ fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -
     {
         return Some(type_name);
     }
-    if matches!(kind, "class" | "interface")
-        && let Some(parameters) = callable_type_parameter_order(node, source)
+    let generic_prefix = callable_type_parameter_order(node, source)
+        .filter(|parameters| !parameters.is_empty())
+        .map(|parameters| format!("<{}>", parameters.join(",")))
+        .unwrap_or_default();
+    if kind == "type_alias"
+        && let Some(target) = direct_type_reference_name(node, source)
     {
-        let signature = format!("<{}>", parameters.join(","));
+        let signature = format!("{generic_prefix}={target}");
         if signature.len() <= MAX_TYPE_SHAPE_BYTES {
             return Some(signature);
         }
+    }
+    if matches!(kind, "interface" | "type_alias")
+        && let Some(index_value) = index_value_type(node, source)
+    {
+        let signature = if generic_prefix.is_empty() {
+            format!("index={index_value}")
+        } else {
+            format!("{generic_prefix}|index={index_value}")
+        };
+        if signature.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(signature);
+        }
+    }
+    if matches!(kind, "class" | "interface" | "type_alias")
+        && !generic_prefix.is_empty()
+        && generic_prefix.len() <= MAX_TYPE_SHAPE_BYTES
+    {
+        return Some(generic_prefix);
     }
     None
 }
@@ -7216,7 +7279,7 @@ fn index_value_type(node: Node<'_>, source: &[u8]) -> Option<String> {
     if value.is_empty() || value.len() > MAX_TYPE_SHAPE_BYTES {
         return None;
     }
-    Some(strip_type_arguments(value).to_owned())
+    Some(value.to_owned())
 }
 
 fn union_target_name(part: &str) -> Option<String> {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -6146,9 +6146,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Resolution::Local(declaration) = resolution else {
             return None;
         };
-        let return_type = declaration
-            .return_type_name
-            .clone()
+        let return_type = self
+            .call_return_type_name(scope_id, call, &declaration)
             .or_else(|| self.variable_alias_return_type(&declaration, scope_id))?;
         let return_type = return_type.trim();
         if return_type == "this" {
@@ -6156,6 +6155,70 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
         self.resolve_declared_type_receiver(scope_id, return_type)
             .or_else(|| self.resolve_declared_type_receiver(&declaration.scope_id, return_type))
+    }
+
+    /// Infer a bounded generic callable return shape from source-visible call
+    /// arguments. This intentionally handles only direct type-parameter
+    /// positions and recursively matching array/generic containers; contextual
+    /// inference, overload sets, conditional types, and structural
+    /// assignability remain unresolved rather than guessing a receiver.
+    fn call_return_type_name(
+        &self,
+        scope_id: &str,
+        call: Node<'tree>,
+        declaration: &DeclarationInfo,
+    ) -> Option<String> {
+        let return_type = declaration.return_type_name.clone()?;
+        let Some(order) = self
+            .generic_parameter_order_by_declaration
+            .get(&declaration.id)
+        else {
+            return Some(return_type);
+        };
+        if order.is_empty() {
+            return Some(return_type);
+        }
+        let function = call
+            .child_by_field_name("function")
+            .or_else(|| first_named_child(call))?;
+        let explicit = function
+            .child_by_field_name("type_arguments")
+            .or_else(|| first_named_child_kind(function, "type_arguments"))
+            .and_then(|type_arguments| {
+                let text = node_text(self.source, type_arguments);
+                let inner = text.strip_prefix('<')?.strip_suffix('>')?;
+                split_top_level_arguments(inner).map(|arguments| {
+                    self.canonical_type_arguments(
+                        scope_id,
+                        &arguments
+                            .into_iter()
+                            .map(str::trim)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>(),
+                    )
+                })
+            })
+            .unwrap_or_default();
+        let mut arguments = order.clone();
+        for (index, argument) in explicit.into_iter().enumerate() {
+            if let Some(slot) = arguments.get_mut(index) {
+                slot.clone_from(&argument);
+            }
+        }
+        let call_arguments = self.call_argument_types(call, scope_id);
+        if let Some(parameter_types) = declaration.parameter_types.as_ref() {
+            for (parameter, argument) in parameter_types.iter().zip(call_arguments.iter()) {
+                let Some(argument) = argument.as_deref() else {
+                    continue;
+                };
+                if !infer_candidate_type_arguments(parameter, argument, order, &mut arguments) {
+                    return None;
+                }
+            }
+        }
+        let substituted = substitute_candidate_type_parameters(&return_type, order, &arguments, 0);
+        (substituted != return_type || !candidate_type_mentions_parameter(&return_type, order))
+            .then_some(substituted)
     }
 
     fn variable_alias_return_type(
@@ -7359,6 +7422,12 @@ fn callable_return_type_name(node: Node<'_>, source: &[u8]) -> Option<String> {
             return Some(normalized);
         }
     }
+    if matches!(return_node.kind(), "array_type" | "tuple_type") {
+        let normalized = normalize_type_text(source, return_node);
+        if !normalized.is_empty() && normalized.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(normalized);
+        }
+    }
     if matches!(
         return_node.kind(),
         "identifier" | "type_identifier" | "predefined_type"
@@ -7530,6 +7599,75 @@ fn indexed_sequence_element_type_name(type_name: &str, index: Option<&str>) -> O
         return Some(element);
     }
     index.and_then(|index| tuple_element_type_name(type_name, index))
+}
+
+fn infer_candidate_type_arguments(
+    parameter: &str,
+    argument: &str,
+    parameters: &[String],
+    arguments: &mut [String],
+) -> bool {
+    let parameter = parameter.trim();
+    let argument = argument.trim();
+    if parameter.is_empty() || argument.is_empty() {
+        return true;
+    }
+    if let Some(index) = parameters.iter().position(|name| name == parameter) {
+        let Some(slot) = arguments.get_mut(index) else {
+            return true;
+        };
+        if slot
+            == parameters
+                .get(index)
+                .map(String::as_str)
+                .unwrap_or_default()
+        {
+            slot.clone_from(&argument.to_owned());
+            return true;
+        }
+        return slot == argument;
+    }
+    if let (Some(parameter_element), Some(argument_element)) =
+        (parameter.strip_suffix("[]"), argument.strip_suffix("[]"))
+    {
+        return infer_candidate_type_arguments(
+            parameter_element,
+            argument_element,
+            parameters,
+            arguments,
+        );
+    }
+    let Some((parameter_base, parameter_arguments)) = generic_type_parts(parameter) else {
+        return true;
+    };
+    let Some((argument_base, argument_arguments)) = generic_type_parts(argument) else {
+        return true;
+    };
+    if parameter_base != argument_base || parameter_arguments.len() != argument_arguments.len() {
+        return true;
+    }
+    for (parameter_argument, argument_argument) in
+        parameter_arguments.iter().zip(argument_arguments.iter())
+    {
+        if !infer_candidate_type_arguments(
+            parameter_argument,
+            argument_argument,
+            parameters,
+            arguments,
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+fn candidate_type_mentions_parameter(type_name: &str, parameters: &[String]) -> bool {
+    type_name
+        .split(|character: char| {
+            !(character == '_' || character == '$' || character.is_ascii_alphanumeric())
+        })
+        .filter(|token| !token.is_empty())
+        .any(|token| parameters.iter().any(|parameter| parameter == token))
 }
 
 fn mapped_type_source_name(node: Node<'_>, source: &[u8]) -> Option<String> {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1,9 +1,9 @@
-//! Direct, test-only universal evidence for the ECMAScript family.
+//! Direct universal evidence for the ECMAScript family.
 //!
-//! This module deliberately does not participate in `UNIVERSAL_ADAPTERS` yet.
-//! It is a source-grounded qualification path for the Phase 2 work in Plan
-//! 013. The production extractor remains the compatibility path until this
-//! emitter has complete capability coverage and passes the hard-cut gates.
+//! TypeScript and JavaScript share the bounded source-grounded emitter while
+//! retaining distinct adapter identities. The production registry dispatches
+//! both languages here; qualification callers use the same entry point so
+//! there is no shadow implementation to drift from the shipped graph path.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
@@ -12,73 +12,17 @@ use tree_sitter::Node;
 
 use super::build::{EvidenceBuilder, range_for_byte_span, range_for_node};
 use super::model::{
-    BindingKind, CandidateRelation, EvidenceRange, HierarchyConstraint, LanguageCapability,
-    ResolutionConstraint, SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
+    BindingKind, CandidateRelation, EvidenceRange, HierarchyConstraint, ResolutionConstraint,
+    SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
 };
 use super::validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits};
-use crate::{AdapterProfile, UNIVERSAL_EVIDENCE_SCHEMA, make_id};
+use crate::{AdapterRegistry, make_id};
 
 const MAX_TRAVERSAL_DEPTH: usize = 512;
 const MAX_INLINE_OBJECT_PROPERTIES: usize = 256;
 const MAX_TYPE_SHAPE_DEPTH: u32 = 32;
 const MAX_TYPE_SHAPE_BYTES: usize = 16 * 1024;
 const MAX_IMPORT_TYPE_QUERIES: usize = 256;
-
-const TYPESCRIPT_CAPABILITIES: &[LanguageCapability] = &[
-    LanguageCapability::Declarations,
-    LanguageCapability::LexicalScopes,
-    LanguageCapability::Namespaces,
-    LanguageCapability::Imports,
-    LanguageCapability::Reexports,
-    LanguageCapability::Aliases,
-    LanguageCapability::Calls,
-    LanguageCapability::Construction,
-    LanguageCapability::Decorators,
-    LanguageCapability::TypeReferences,
-    LanguageCapability::BaseTypes,
-    LanguageCapability::HierarchyDispatch,
-    LanguageCapability::Members,
-    LanguageCapability::Ownership,
-    LanguageCapability::Receivers,
-    LanguageCapability::ExternalReferences,
-];
-
-const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
-    LanguageCapability::Declarations,
-    LanguageCapability::LexicalScopes,
-    LanguageCapability::Namespaces,
-    LanguageCapability::Imports,
-    LanguageCapability::Reexports,
-    LanguageCapability::Aliases,
-    LanguageCapability::Calls,
-    LanguageCapability::Construction,
-    LanguageCapability::Decorators,
-    LanguageCapability::TypeReferences,
-    LanguageCapability::BaseTypes,
-    LanguageCapability::HierarchyDispatch,
-    LanguageCapability::Members,
-    LanguageCapability::Ownership,
-    LanguageCapability::Receivers,
-    LanguageCapability::ExternalReferences,
-];
-
-static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
-    id: "compass.typescript.candidate",
-    language: "typescript",
-    version: 5,
-    evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
-    profile: crate::UniversalAdapterProfile::UniversalCandidate,
-    capabilities: TYPESCRIPT_CAPABILITIES,
-};
-
-static JAVASCRIPT_PROFILE: AdapterProfile = AdapterProfile {
-    id: "compass.javascript.candidate",
-    language: "javascript",
-    version: 5,
-    evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
-    profile: crate::UniversalAdapterProfile::UniversalCandidate,
-    capabilities: JAVASCRIPT_CAPABILITIES,
-};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Namespace {
@@ -245,6 +189,7 @@ struct CandidateState<'source, 'tree> {
     scope_owners: HashMap<String, String>,
     scope_kinds: HashMap<String, String>,
     declarations: HashMap<String, DeclarationInfo>,
+    definition_start_bytes: HashMap<String, u64>,
     declarations_by_scope: HashMap<String, Vec<String>>,
     declarations_by_qualified: HashMap<String, Vec<String>>,
     generic_parameters_by_declaration: HashMap<String, HashMap<String, Option<String>>>,
@@ -355,9 +300,9 @@ pub(crate) fn extract_candidate_tree_evidence(
     root: Node<'_>,
     dialect: &str,
 ) -> Result<SemanticEvidenceBatch, EvidenceError> {
-    let (language, profile) = match dialect {
-        "typescript" | "tsx" => ("typescript", &TYPESCRIPT_PROFILE),
-        "javascript" => ("javascript", &JAVASCRIPT_PROFILE),
+    let language = match dialect {
+        "typescript" | "tsx" => "typescript",
+        "javascript" => "javascript",
         _ => {
             return Err(EvidenceError::new(
                 EvidenceErrorCode::InvalidAdapter,
@@ -365,6 +310,12 @@ pub(crate) fn extract_candidate_tree_evidence(
             ));
         }
     };
+    let profile = AdapterRegistry::universal_profile(language).ok_or_else(|| {
+        EvidenceError::new(
+            EvidenceErrorCode::InvalidAdapter,
+            format!("ECMAScript universal adapter {language:?} is not registered"),
+        )
+    })?;
     let module_name = module_name(path, source_file);
     let dialect_name = dialect_for_path(path, dialect);
     let mut builder = EvidenceBuilder::new_with_dialect(
@@ -376,8 +327,13 @@ pub(crate) fn extract_candidate_tree_evidence(
     );
     let file_range = range_for_node(source_file, root);
     let file_graph_id = stable_graph_id(source_file, "module", &module_name, 0);
+    let file_kind = if root.end_byte() == root.start_byte() {
+        "file"
+    } else {
+        "module"
+    };
     let file_declaration = builder.declare_with_namespace(
-        "module",
+        file_kind,
         &file_graph_id,
         &module_name,
         &module_name,
@@ -387,6 +343,9 @@ pub(crate) fn extract_candidate_tree_evidence(
         file_range.clone(),
     )?;
     let root_scope = builder.open_scope("module", Some(&file_declaration), None, file_range)?;
+    if root.end_byte() == root.start_byte() {
+        return builder.finish();
+    }
     let parser_recovered = root.has_error();
     let mut state = CandidateState {
         source_file,
@@ -400,6 +359,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         scope_owners: HashMap::from([(root_scope.clone(), file_declaration)]),
         scope_kinds: HashMap::from([(root_scope.clone(), "module".to_owned())]),
         declarations: HashMap::new(),
+        definition_start_bytes: HashMap::new(),
         declarations_by_scope: HashMap::new(),
         declarations_by_qualified: HashMap::new(),
         generic_parameters_by_declaration: HashMap::new(),
@@ -451,6 +411,7 @@ pub(crate) fn extract_candidate_tree_evidence(
     state.precollect_base_targets(root, 0);
     state.infer_variable_types(root, 0);
     state.collect_flow_assignment_facts(root, 0);
+    state.emit_declaration_ownership_candidates()?;
     state.emit_nodes(root, 0)?;
     state.emit_import_type_queries(root)?;
     if parser_recovered {
@@ -461,10 +422,44 @@ pub(crate) fn extract_candidate_tree_evidence(
             "parser recovered from malformed ECMAScript source; emitted evidence remains source-bounded",
         )?;
     }
-    state.builder.finish()
+    let definition_start_bytes = state.definition_start_bytes;
+    let mut batch = state.builder.finish()?;
+    for declaration in &mut batch.declarations {
+        declaration.definition_start_byte = definition_start_bytes.get(&declaration.id).copied();
+    }
+    Ok(batch)
 }
 
 impl<'source, 'tree> CandidateState<'source, 'tree> {
+    fn emit_declaration_ownership_candidates(&mut self) -> Result<(), EvidenceError> {
+        let mut declarations = self.declarations.values().cloned().collect::<Vec<_>>();
+        declarations.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+        for declaration in declarations {
+            let owner = self
+                .scope_owners
+                .get(&declaration.scope_id)
+                .cloned()
+                .unwrap_or_else(|| self.file_declaration.clone());
+            if owner == declaration.id {
+                continue;
+            }
+            self.builder.relate(
+                CandidateRelation::Contains,
+                &owner,
+                None,
+                None,
+                &declaration.name,
+                ResolutionConstraint {
+                    exact_target_declaration_id: Some(declaration.id.clone()),
+                    exact_language: Some(self.language.to_owned()),
+                    allowed_target_kinds: vec![declaration.kind.clone()],
+                    ..ResolutionConstraint::default()
+                },
+            )?;
+        }
+        Ok(())
+    }
+
     fn collect_constructor_name_hints(&mut self, node: Node<'tree>, depth: usize) {
         let mut pending = vec![(node, depth)];
         while let Some((current, current_depth)) = pending.pop() {
@@ -1359,6 +1354,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             signature.as_deref(),
             range_for_node(self.source_file, range_node),
         )?;
+        self.definition_start_bytes
+            .insert(declaration_id.clone(), node.start_byte() as u64);
         self.declaration_name_nodes.insert(name_node.start_byte());
         let callable_value = callable_value_node(node);
         let parameter_arity = callable_parameter_arity(node, self.source).or_else(|| {
@@ -3816,6 +3813,50 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .unwrap_or_else(|| self.file_declaration.clone())
     }
 
+    /// Keep named exports visible as source-backed public graph nodes while
+    /// the universal resolver retains the binding as the authoritative target
+    /// relation. Export declarations are not used to guess targets; the
+    /// containment candidate points at this exact declaration identity.
+    fn emit_export_declaration(
+        &mut self,
+        scope_id: &str,
+        export_name: &str,
+        anchor: Node<'tree>,
+        namespace: Namespace,
+    ) -> Result<String, EvidenceError> {
+        if export_name.is_empty() {
+            return Ok(String::new());
+        }
+        let qualified_name = format!("{}.{}", self.file_qualified_name, export_name);
+        let graph_node_id =
+            stable_graph_id(self.source_file, "export", export_name, anchor.start_byte());
+        let declaration_id = self.builder.declare_with_namespace(
+            "export",
+            &graph_node_id,
+            export_name,
+            &qualified_name,
+            Some(self.source_file),
+            Some(scope_id),
+            Some(symbol_namespace(namespace)),
+            range_for_node(self.source_file, anchor),
+        )?;
+        let owner = self.owner_for_scope(scope_id);
+        self.builder.relate(
+            CandidateRelation::Contains,
+            &owner,
+            None,
+            None,
+            export_name,
+            ResolutionConstraint {
+                exact_target_declaration_id: Some(declaration_id.clone()),
+                exact_language: Some(self.language.to_owned()),
+                allowed_target_kinds: vec!["export".to_owned()],
+                ..ResolutionConstraint::default()
+            },
+        )?;
+        Ok(declaration_id)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn add_declaration_resolution(
         &mut self,
@@ -4246,6 +4287,16 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 type_only,
                 range_for_node(self.source_file, anchor),
             )?;
+            self.emit_export_declaration(
+                scope_id,
+                export_name,
+                anchor,
+                if type_only {
+                    Namespace::Type
+                } else {
+                    Namespace::Module
+                },
+            )?;
             let occurrence_id = self.builder.occur_with_context(
                 SemanticRole::Reexport,
                 &owner,
@@ -4301,6 +4352,18 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 binding.type_only,
                 range_for_node(self.source_file, binding.anchor),
             )?;
+            if reexport {
+                self.emit_export_declaration(
+                    scope_id,
+                    &binding.local_name,
+                    binding.anchor,
+                    if binding.type_only {
+                        Namespace::Type
+                    } else {
+                        namespace
+                    },
+                )?;
+            }
             if !reexport {
                 self.import_bindings.insert(
                     (scope_id.to_owned(), binding.local_name.clone()),
@@ -4637,6 +4700,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }),
             range_for_node(self.source_file, anchor),
         )?;
+        self.emit_export_declaration(scope_id, "default", anchor, namespace)?;
         self.builder.relate(
             CandidateRelation::Reexports,
             &owner,
@@ -4716,6 +4780,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             Some("declaration"),
             range_for_node(self.source_file, anchor),
         )?;
+        self.emit_export_declaration(scope_id, export_name, anchor, target.namespace)?;
         self.builder.relate(
             CandidateRelation::Reexports,
             &owner,
@@ -4797,6 +4862,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 type_only,
                 range_for_node(self.source_file, exported),
             )?;
+            self.emit_export_declaration(scope_id, &exported_name, exported, namespace)?;
             let occurrence_id = self.builder.occur_with_context(
                 SemanticRole::Reexport,
                 &owner,
@@ -5750,6 +5816,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     "variable".to_owned(),
                     "type_alias".to_owned(),
                     "interface".to_owned(),
+                    "property".to_owned(),
                 ],
                 allow_external: true,
                 ..ResolutionConstraint::default()
@@ -6036,6 +6103,26 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             callee.kind(),
             "member_expression" | "optional_member_expression" | "subscript_expression"
         );
+        let annotation_name = node_text(self.source, callee);
+        if !annotation_name.is_empty() {
+            let qualified_name = format!("{}::{}", self.file_qualified_name, annotation_name);
+            let graph_node_id = stable_graph_id(
+                self.source_file,
+                "annotation",
+                &annotation_name,
+                callee.start_byte(),
+            );
+            self.builder.declare_with_namespace(
+                "annotation",
+                &graph_node_id,
+                &annotation_name,
+                &qualified_name,
+                Some(self.source_file),
+                Some(scope_id),
+                Some(SymbolNamespace::Value),
+                range_for_node(self.source_file, callee),
+            )?;
+        }
         if member_decorator {
             let Some(property) = member_property_node(callee) else {
                 return self.add_unresolved_candidate(
@@ -6509,6 +6596,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         | "jsx_self_closing_element"
                 )
             })
+            || node.parent().is_some_and(|parent| {
+                parent.kind() == "pair"
+                    && parent
+                        .child_by_field_name("key")
+                        .is_some_and(|key| key.id() == node.id())
+            })
             || is_jsx_value_reference_node(node)
             || is_jsx_attribute_name(node)
             || is_type_reference_node(node)
@@ -6521,10 +6614,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         };
         let is_callable = match &resolution {
             Resolution::Local(declaration) => self.proven_callable_declaration(&declaration.id),
-            Resolution::Import(import) => {
-                import.imported_name == "default"
-                    || (import.imported_name == "*" && import.callable_namespace)
-            }
+            // A named import can be a function, class, component, or value
+            // callback. Its source declaration is proven only by the project
+            // resolver, so retain the binding occurrence here rather than
+            // dropping value positions such as `{ Component: UserPage }`.
+            Resolution::Import(_) => true,
         };
         if !is_callable {
             return Ok(());
@@ -7144,6 +7238,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             Some("commonjs"),
             range_for_node(self.source_file, anchor),
         )?;
+        self.emit_export_declaration(scope_id, export_name, anchor, namespace)?;
         self.builder.relate(
             CandidateRelation::Reexports,
             &owner,

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -190,6 +190,7 @@ struct CandidateState<'source, 'tree> {
     language: &'static str,
     root_scope: String,
     file_declaration: String,
+    file_qualified_name: String,
     scope_by_node: HashMap<usize, String>,
     scope_parents: HashMap<String, Option<String>>,
     scope_owners: HashMap<String, String>,
@@ -332,6 +333,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         language,
         root_scope: root_scope.clone(),
         file_declaration: file_declaration.clone(),
+        file_qualified_name: module_name.clone(),
         scope_by_node: HashMap::new(),
         scope_parents: HashMap::from([(root_scope.clone(), None)]),
         scope_owners: HashMap::from([(root_scope.clone(), file_declaration)]),
@@ -5084,27 +5086,135 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Some(left) = node.child_by_field_name("left") else {
             return Ok(());
         };
-        let left_text = node_text(self.source, left).replace(char::is_whitespace, "");
-        let export_name = if left_text == "module.exports" {
-            "default".to_owned()
-        } else if let Some(name) = left_text.strip_prefix("module.exports.") {
-            name.to_owned()
-        } else if let Some(name) = left_text.strip_prefix("exports.") {
-            name.to_owned()
-        } else {
+        let Some((export_name, export_anchor)) = commonjs_export_name(left, self.source) else {
             return Ok(());
         };
         let Some(right) = node.child_by_field_name("right") else {
             return Ok(());
         };
-        let Some(source_name) = rightmost_identifier(right) else {
+        let right = unwrap_expression_node(right);
+        if export_name == "default" && right.kind() == "object" {
+            // `module.exports = { ... }` is a default module export plus a
+            // bounded set of named properties. The declaration pass already
+            // records each spread-free property under the file module's
+            // source-qualified owner; publish those exact declarations as
+            // reexports instead of leaving `require()` consumers external.
+            self.emit_commonjs_module_default_export(scope_id, export_anchor)?;
+            if object_literal_has_spread(right) {
+                return Ok(());
+            }
+            let mut cursor = right.walk();
+            for property in right
+                .named_children(&mut cursor)
+                .take(MAX_INLINE_OBJECT_PROPERTIES)
+            {
+                self.emit_commonjs_object_property_export(scope_id, property)?;
+            }
+            return Ok(());
+        }
+        let resolution = self.commonjs_export_value_resolution(scope_id, right);
+        let Some(resolution) = resolution else {
             return Ok(());
         };
-        let source_name = node_text(self.source, source_name);
-        let Some(resolution) = self.resolve_name(scope_id, &source_name, Namespace::Both) else {
+        self.emit_commonjs_reexport_binding(scope_id, &export_name, export_anchor, resolution)
+    }
+
+    fn commonjs_export_value_resolution(
+        &self,
+        scope_id: &str,
+        value: Node<'tree>,
+    ) -> Option<Resolution> {
+        match value.kind() {
+            "identifier" | "type_identifier" | "shorthand_property_identifier" => {
+                self.resolve_name(scope_id, &node_text(self.source, value), Namespace::Both)
+            }
+            "member_expression" | "optional_member_expression" | "subscript_expression" => {
+                let property = member_property_node(value)?;
+                self.resolve_member_target(
+                    scope_id,
+                    value.child_by_field_name("object"),
+                    property,
+                    None,
+                    &[],
+                )
+            }
+            _ => None,
+        }
+    }
+
+    fn emit_commonjs_module_default_export(
+        &mut self,
+        scope_id: &str,
+        anchor: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let target = self.file_qualified_name.clone();
+        let target_declaration_id = self.file_declaration.clone();
+        self.emit_commonjs_reexport_target(
+            scope_id,
+            "default",
+            anchor,
+            &target,
+            Some(&target_declaration_id),
+            Namespace::Module,
+        )
+    }
+
+    fn emit_commonjs_object_property_export(
+        &mut self,
+        scope_id: &str,
+        property: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let Some((name_node, value)) = commonjs_object_property(property) else {
             return Ok(());
         };
-        let owner = self.owner_for_scope(scope_id);
+        let Some(export_name) = member_property_name(self.source, name_node) else {
+            // Computed or malformed object keys do not prove a stable export
+            // spelling. Keep the module's default evidence, but do not emit a
+            // guessed named binding.
+            return Ok(());
+        };
+        if export_name.is_empty() || export_name.len() > MAX_TYPE_SHAPE_BYTES {
+            return Ok(());
+        }
+        let resolution = value
+            .and_then(|value| self.commonjs_export_value_resolution(scope_id, value))
+            .or_else(|| self.commonjs_object_property_declaration(property, &export_name));
+        let Some(resolution) = resolution else {
+            return Ok(());
+        };
+        self.emit_commonjs_reexport_binding(scope_id, &export_name, name_node, resolution)
+    }
+
+    fn commonjs_object_property_declaration(
+        &self,
+        property: Node<'tree>,
+        property_name: &str,
+    ) -> Option<Resolution> {
+        let qualified_name = format!("{}.{property_name}", self.file_qualified_name);
+        let declarations = self
+            .declarations_by_qualified
+            .get(&qualified_name)?
+            .iter()
+            .filter_map(|id| self.declarations.get(id))
+            .filter(|declaration| {
+                matches!(
+                    declaration.kind.as_str(),
+                    "property" | "method" | "function" | "class" | "variable"
+                ) && declaration.range_start_byte >= property.start_byte()
+                    && declaration.range_start_byte <= property.end_byte()
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        (declarations.len() == 1).then(|| Resolution::Local(declarations[0].clone()))
+    }
+
+    fn emit_commonjs_reexport_binding(
+        &mut self,
+        scope_id: &str,
+        export_name: &str,
+        anchor: Node<'tree>,
+        resolution: Resolution,
+    ) -> Result<(), EvidenceError> {
         let (target, target_declaration_id, namespace) = match resolution {
             Resolution::Local(declaration) => (
                 declaration.qualified_name,
@@ -5113,37 +5223,65 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             ),
             Resolution::Import(import) => (import.target, None, import.namespace),
         };
-        let binding_id = self.builder.bind_with_identity(
-            BindingKind::Reexport,
-            &export_name,
+        self.emit_commonjs_reexport_target(
+            scope_id,
+            export_name,
+            anchor,
             &target,
             target_declaration_id.as_deref(),
+            namespace,
+        )
+    }
+
+    fn emit_commonjs_reexport_target(
+        &mut self,
+        scope_id: &str,
+        export_name: &str,
+        anchor: Node<'tree>,
+        target: &str,
+        target_declaration_id: Option<&str>,
+        namespace: Namespace,
+    ) -> Result<(), EvidenceError> {
+        if export_name.is_empty() || target.is_empty() {
+            return Ok(());
+        }
+        let owner = self.owner_for_scope(scope_id);
+        let binding_id = self.builder.bind_with_identity(
+            BindingKind::Reexport,
+            export_name,
+            target,
+            target_declaration_id,
             Some(scope_id),
             Some(symbol_namespace(namespace)),
             false,
-            range_for_node(self.source_file, left),
+            range_for_node(self.source_file, anchor),
         )?;
         let occurrence_id = self.builder.occur_with_context(
             SemanticRole::Reexport,
             &owner,
-            &export_name,
+            export_name,
             Some("commonjs"),
             Some(scope_id),
             Some("commonjs"),
-            range_for_node(self.source_file, left),
+            range_for_node(self.source_file, anchor),
         )?;
         self.builder.relate(
             CandidateRelation::Reexports,
             &owner,
             Some(&occurrence_id),
             Some(&binding_id),
-            &export_name,
+            export_name,
             ResolutionConstraint {
                 exact_language: Some(self.language.to_owned()),
                 allowed_target_kinds: vec![
+                    "module".to_owned(),
                     "function".to_owned(),
                     "class".to_owned(),
                     "variable".to_owned(),
+                    "property".to_owned(),
+                    "method".to_owned(),
+                    "enum".to_owned(),
+                    "interface".to_owned(),
                     "type_alias".to_owned(),
                 ],
                 ..ResolutionConstraint::default()
@@ -7931,6 +8069,35 @@ fn declaration_shape<'tree>(
             matches!(node.kind(), "namespace_export").then(|| first_identifier_node(node))?
         })?;
     Some((kind, name, namespace, creates_scope, scope_kind))
+}
+
+fn commonjs_export_name<'tree>(left: Node<'tree>, source: &[u8]) -> Option<(String, Node<'tree>)> {
+    let normalized = node_text(source, left).replace(char::is_whitespace, "");
+    if normalized == "module.exports" {
+        return Some(("default".to_owned(), left));
+    }
+    let property = member_property_node(left)?;
+    let object = left.child_by_field_name("object")?;
+    let object_text = node_text(source, object).replace(char::is_whitespace, "");
+    if !matches!(object_text.as_str(), "module.exports" | "exports") {
+        return None;
+    }
+    let name = member_property_name(source, property)?;
+    (!name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES).then_some((name, property))
+}
+
+fn commonjs_object_property<'tree>(
+    node: Node<'tree>,
+) -> Option<(Node<'tree>, Option<Node<'tree>>)> {
+    match node.kind() {
+        "pair" => Some((
+            node.child_by_field_name("key")?,
+            node.child_by_field_name("value"),
+        )),
+        "method_definition" => Some((node.child_by_field_name("name")?, None)),
+        "shorthand_property_identifier" => Some((node, Some(node))),
+        _ => None,
+    }
 }
 
 fn is_anonymous_signature_scope(node: Node<'_>) -> bool {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -869,6 +869,35 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 }
             }
         }
+        // TypeScript's explicit resource-management declarations (`using`
+        // and `await using`) are represented by the pinned tree-sitter
+        // grammar as an assignment expression rather than a variable
+        // declarator.  Materialize their bindings here so the initializer
+        // call and later member/reference occurrences resolve against the
+        // same source identity as an ordinary immutable lexical binding.
+        if let Some(pattern) = using_binding_pattern(node, self.source) {
+            let mut names = Vec::new();
+            collect_pattern_names(pattern, self.source, &mut names);
+            for (name, name_node) in names {
+                if name.is_empty() {
+                    continue;
+                }
+                let declaration = self.add_declaration_at(
+                    node,
+                    name_node,
+                    "variable",
+                    Namespace::Value,
+                    &scope_id,
+                    &qualified_prefix,
+                    &name,
+                )?;
+                // `using` bindings are immutable for the lifetime of their
+                // enclosing block, just like `const`; retaining that fact
+                // lets the bounded JavaScript flow resolver keep a proven
+                // receiver after safe callback/argument escapes.
+                self.immutable_bindings.insert(declaration.id);
+            }
+        }
         if let Some((kind, name_node, namespace, creates_scope, scope_kind)) =
             declaration_shape(node)
         {
@@ -9966,6 +9995,36 @@ fn is_var_binding_node(node: Node<'_>) -> bool {
         }
     }
     false
+}
+
+/// Return the binding pattern for a TypeScript explicit resource declaration.
+/// The pinned tree-sitter grammar keeps `using` as an anonymous token on an
+/// `assignment_expression`; `await using` wraps the same assignment in an
+/// `await_expression`. Restrict recognition to statement position so an
+/// identifier or malformed expression beginning with the contextual keyword
+/// cannot become a fabricated declaration.
+fn using_binding_pattern<'tree>(node: Node<'tree>, source: &[u8]) -> Option<Node<'tree>> {
+    if node.kind() != "assignment_expression" {
+        return None;
+    }
+    let source_text = node_text(source, node);
+    let text = source_text.trim_start();
+    let rest = text.strip_prefix("using")?;
+    if !rest
+        .as_bytes()
+        .first()
+        .is_some_and(|byte| byte.is_ascii_whitespace())
+    {
+        return None;
+    }
+    let statement_position = node.parent().is_some_and(|parent| {
+        parent.kind() == "expression_statement"
+            || (parent.kind() == "await_expression"
+                && parent
+                    .parent()
+                    .is_some_and(|grandparent| grandparent.kind() == "expression_statement"))
+    });
+    statement_position.then(|| node.child_by_field_name("left"))?
 }
 
 fn is_callable_node(node: Node<'_>) -> bool {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -327,6 +327,7 @@ struct CandidateState<'source, 'tree> {
     /// Source-proven bindings from a derived class's base type parameters to
     /// the concrete type arguments used in its `extends` clause.
     base_type_bindings: HashMap<String, HashMap<String, String>>,
+    parser_recovered: bool,
     declaration_name_nodes: HashSet<usize>,
     import_nodes: HashSet<usize>,
     emitted_facts: HashSet<String>,
@@ -373,6 +374,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         file_range.clone(),
     )?;
     let root_scope = builder.open_scope("module", Some(&file_declaration), None, file_range)?;
+    let parser_recovered = root.has_error();
     let mut state = CandidateState {
         source_file,
         source,
@@ -418,6 +420,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         base_targets: HashMap::new(),
         implements_targets: HashMap::new(),
         base_type_bindings: HashMap::new(),
+        parser_recovered,
         declaration_name_nodes: HashSet::new(),
         import_nodes: HashSet::new(),
         emitted_facts: HashSet::new(),
@@ -436,7 +439,7 @@ pub(crate) fn extract_candidate_tree_evidence(
     state.infer_variable_types(root, 0);
     state.collect_flow_assignment_facts(root, 0);
     state.emit_nodes(root, 0)?;
-    if root.has_error() {
+    if parser_recovered {
         state.builder.diagnose(
             "partial_parser_recovery",
             None,
@@ -3566,11 +3569,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 }
             }
             "call_expression" | "optional_call_expression" => {
-                self.emit_call(node, &scope_id, false)?;
-                self.emit_dynamic_import(node, &scope_id)?;
-                self.emit_commonjs_object_assign(&scope_id, node, false)?;
-                self.emit_commonjs_define_property(&scope_id, node)?;
-                self.emit_commonjs_export_star(&scope_id, node)?;
+                // A decorator factory invocation is represented by the
+                // Decorates candidate emitted from its enclosing decorator
+                // node. Do not publish a second ordinary Calls edge for the
+                // same syntax; nested calls in decorator arguments still
+                // receive their own traversal pass.
+                if !node
+                    .parent()
+                    .is_some_and(|parent| parent.kind() == "decorator")
+                {
+                    self.emit_call(node, &scope_id, false)?;
+                    self.emit_dynamic_import(node, &scope_id)?;
+                    self.emit_commonjs_object_assign(&scope_id, node, false)?;
+                    self.emit_commonjs_define_property(&scope_id, node)?;
+                    self.emit_commonjs_export_star(&scope_id, node)?;
+                }
             }
             "new_expression" => self.emit_call(node, &scope_id, true)?,
             "member_expression" | "optional_member_expression" | "subscript_expression" => {
@@ -5740,24 +5753,171 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     }
 
     fn emit_decorator(&mut self, node: Node<'tree>, scope_id: &str) -> Result<(), EvidenceError> {
-        let Some(target) = first_named_child_kind(node, "identifier") else {
+        let allowed_kinds = &["function", "class", "variable", "property", "external"];
+        if self.parser_recovered || node.has_error() {
+            let spelling = node_text(self.source, node)
+                .trim_start_matches('@')
+                .trim()
+                .to_owned();
+            if spelling.is_empty() {
+                return Ok(());
+            }
+            return self.add_unresolved_candidate(
+                node,
+                scope_id,
+                CandidateRelation::Decorates,
+                SemanticRole::Decorator,
+                &spelling,
+                None,
+                "decorator_recovery",
+                None,
+                Vec::new(),
+                allowed_kinds,
+                None,
+            );
+        }
+        let Some(expression) = first_named_child(node) else {
             return Ok(());
         };
-        let spelling = node_text(self.source, target);
-        let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Value) else {
-            return Ok(());
+        let (callee, argument_count, argument_types) = match expression.kind() {
+            "call_expression" | "optional_call_expression" => {
+                let callee = expression
+                    .child_by_field_name("function")
+                    .or_else(|| first_named_child(expression))
+                    .unwrap_or(expression);
+                (
+                    unwrap_expression_node(callee),
+                    call_argument_count(expression),
+                    self.call_argument_types(expression, scope_id),
+                )
+            }
+            _ => (unwrap_expression_node(expression), None, Vec::new()),
         };
-        self.add_declaration_resolution(
-            target,
+        let member_decorator = matches!(
+            callee.kind(),
+            "member_expression" | "optional_member_expression" | "subscript_expression"
+        );
+        if member_decorator {
+            let Some(property) = member_property_node(callee) else {
+                return self.add_unresolved_candidate(
+                    callee,
+                    scope_id,
+                    CandidateRelation::Decorates,
+                    SemanticRole::Decorator,
+                    &node_text(self.source, callee),
+                    None,
+                    "decorator_dynamic",
+                    argument_count,
+                    argument_types,
+                    allowed_kinds,
+                    None,
+                );
+            };
+            let Some(property_name) = member_property_name(self.source, property) else {
+                let spelling = node_text(self.source, callee);
+                let qualifier = callee
+                    .child_by_field_name("object")
+                    .map(|object| node_text(self.source, object));
+                return self.add_unresolved_candidate(
+                    property,
+                    scope_id,
+                    CandidateRelation::Decorates,
+                    SemanticRole::Decorator,
+                    &spelling,
+                    qualifier.as_deref(),
+                    "decorator_dynamic_member",
+                    argument_count,
+                    argument_types,
+                    allowed_kinds,
+                    None,
+                );
+            };
+            let qualifier = node_text(self.source, callee);
+            if let Some(resolution) = self.resolve_member_target(
+                scope_id,
+                callee.child_by_field_name("object"),
+                property,
+                argument_count,
+                &argument_types,
+            ) {
+                return self.add_declaration_resolution_with_arguments(
+                    property,
+                    scope_id,
+                    CandidateRelation::Decorates,
+                    SemanticRole::Decorator,
+                    &property_name,
+                    Some(&qualifier),
+                    Some("decorator_member"),
+                    Namespace::Value,
+                    argument_count,
+                    argument_types,
+                    resolution,
+                    allowed_kinds,
+                );
+            }
+            return self.add_unresolved_candidate(
+                property,
+                scope_id,
+                CandidateRelation::Decorates,
+                SemanticRole::Decorator,
+                &property_name,
+                Some(&qualifier),
+                "decorator_member",
+                argument_count,
+                argument_types,
+                allowed_kinds,
+                None,
+            );
+        }
+        let spelling = node_text(self.source, callee);
+        let simple_target = matches!(
+            callee.kind(),
+            "identifier" | "property_identifier" | "type_identifier"
+        );
+        if simple_target {
+            let resolution = argument_count
+                .map(|count| {
+                    self.resolve_name_for_call(
+                        scope_id,
+                        &spelling,
+                        Namespace::Value,
+                        Some(count),
+                        &argument_types,
+                    )
+                })
+                .unwrap_or_else(|| self.resolve_name(scope_id, &spelling, Namespace::Value));
+            if let Some(resolution) = resolution {
+                return self.add_declaration_resolution_with_arguments(
+                    callee,
+                    scope_id,
+                    CandidateRelation::Decorates,
+                    SemanticRole::Decorator,
+                    &spelling,
+                    None,
+                    Some("decorator"),
+                    Namespace::Value,
+                    argument_count,
+                    argument_types,
+                    resolution,
+                    allowed_kinds,
+                );
+            }
+        }
+        if spelling.is_empty() {
+            return Ok(());
+        }
+        self.add_unresolved_candidate(
+            callee,
             scope_id,
             CandidateRelation::Decorates,
             SemanticRole::Decorator,
             &spelling,
             None,
-            Some("decorator"),
-            Namespace::Value,
-            resolution,
-            &["function", "class", "variable"],
+            "decorator_dynamic",
+            argument_count,
+            argument_types,
+            allowed_kinds,
+            None,
         )
     }
 

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -64,7 +64,7 @@ const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
 static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.typescript.candidate",
     language: "typescript",
-    version: 2,
+    version: 3,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: TYPESCRIPT_CAPABILITIES,
@@ -73,7 +73,7 @@ static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
 static JAVASCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.javascript.candidate",
     language: "javascript",
-    version: 2,
+    version: 3,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: JAVASCRIPT_CAPABILITIES,
@@ -141,6 +141,7 @@ struct ImportInfo {
     imported_name: String,
     namespace: Namespace,
     type_only: bool,
+    callable_namespace: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -3526,6 +3527,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         imported_name: binding.imported_name.clone(),
                         namespace,
                         type_only: binding.type_only,
+                        callable_namespace: false,
                     },
                 );
             }
@@ -3646,6 +3648,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 imported_name: "*".to_owned(),
                 namespace: Namespace::Both,
                 type_only: false,
+                callable_namespace: true,
             },
         );
         let occurrence_id = self.builder.occur_with_context(
@@ -4444,7 +4447,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Some(value) = node.child_by_field_name("value") else {
             return Ok(());
         };
-        let Some(call) = find_require_call(value, self.source) else {
+        let value = unwrap_expression_node(value);
+        let Some(call) = direct_require_call(value, self.source) else {
             return Ok(());
         };
         let Some(arguments) = call.child_by_field_name("arguments") else {
@@ -4460,10 +4464,97 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let Some(name_node) = node.child_by_field_name("name") else {
             return Ok(());
         };
-        let mut names = Vec::new();
-        collect_pattern_names(name_node, self.source, &mut names);
-        for (name, anchor) in names {
-            self.add_import_binding(scope_id, &name, &name, &module, anchor, false, "require")?;
+        self.emit_require_pattern_bindings(scope_id, name_node, &module, 0)
+    }
+
+    fn emit_require_pattern_bindings(
+        &mut self,
+        scope_id: &str,
+        pattern: Node<'tree>,
+        module: &str,
+        depth: usize,
+    ) -> Result<(), EvidenceError> {
+        if depth >= MAX_TYPE_SHAPE_DEPTH as usize {
+            return Ok(());
+        }
+        match pattern.kind() {
+            // `const api = require("./api")` binds the module namespace.  A
+            // namespace target supports both callable CommonJS modules and
+            // source-grounded member access without pretending that the local
+            // spelling is an exported symbol.
+            "identifier" => {
+                let local_name = node_text(self.source, pattern);
+                if !local_name.is_empty() {
+                    self.add_import_binding(
+                        scope_id,
+                        &local_name,
+                        "*",
+                        module,
+                        pattern,
+                        false,
+                        "require",
+                    )?;
+                }
+            }
+            "object_pattern" => {
+                let mut cursor = pattern.walk();
+                for child in pattern
+                    .named_children(&mut cursor)
+                    .take(MAX_INLINE_OBJECT_PROPERTIES)
+                {
+                    match child.kind() {
+                        "shorthand_property_identifier_pattern" => {
+                            let name = node_text(self.source, child);
+                            if !name.is_empty() {
+                                self.add_import_binding(
+                                    scope_id, &name, &name, module, child, false, "require",
+                                )?;
+                            }
+                        }
+                        "pair_pattern" => {
+                            let Some(key) = child.child_by_field_name("key") else {
+                                continue;
+                            };
+                            let Some(value) = child.child_by_field_name("value") else {
+                                continue;
+                            };
+                            let Some(imported_name) =
+                                static_require_property_name(self.source, key)
+                            else {
+                                // Computed or malformed keys do not prove a
+                                // stable CommonJS export spelling.
+                                continue;
+                            };
+                            let Some((local_name, anchor)) =
+                                direct_require_binding_identifier(value, self.source)
+                            else {
+                                // Nested patterns and rest/default objects
+                                // need object-shape and flow evidence that a
+                                // single module binding cannot provide.
+                                continue;
+                            };
+                            self.add_import_binding(
+                                scope_id,
+                                &local_name,
+                                &imported_name,
+                                module,
+                                anchor,
+                                false,
+                                "require",
+                            )?;
+                        }
+                        _ => {
+                            // Rest, nested, array, and dynamic patterns remain
+                            // unresolved rather than being flattened into
+                            // unrelated module exports.
+                        }
+                    }
+                }
+            }
+            _ => {
+                // Array, rest, assignment, and malformed declarator patterns
+                // are intentionally not projected as named module bindings.
+            }
         }
         Ok(())
     }
@@ -4487,6 +4578,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         };
         let namespace = if type_only {
             Namespace::Type
+        } else if imported_name == "*" {
+            Namespace::Module
         } else {
             Namespace::Value
         };
@@ -4509,6 +4602,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 imported_name: imported_name.to_owned(),
                 namespace,
                 type_only,
+                callable_namespace: imported_name == "*" && context == "require",
             },
         );
         let owner = self.owner_for_scope(scope_id);
@@ -5058,7 +5152,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let is_callable = match &resolution {
             Resolution::Local(declaration) => self.proven_callable_declaration(&declaration.id),
             Resolution::Import(import) => {
-                import.imported_name == "default" || import.imported_name == "*"
+                import.imported_name == "default"
+                    || (import.imported_name == "*" && import.callable_namespace)
             }
         };
         if !is_callable {
@@ -5345,7 +5440,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 } else {
                     import.namespace.accepts(namespace)
                 };
-                if accepts {
+                if accepts && (import.imported_name != "*" || import.callable_namespace) {
                     return Some(Resolution::Import(import.clone()));
                 }
             }
@@ -6003,6 +6098,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             imported_name: property_name,
             namespace: Namespace::Value,
             type_only: import.type_only,
+            callable_namespace: false,
         }))
     }
 
@@ -6204,6 +6300,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 imported_name: property_name,
                 namespace: Namespace::Type,
                 type_only: import.type_only,
+                callable_namespace: false,
             })),
         }
     }
@@ -10035,6 +10132,47 @@ fn collect_pattern_names<'tree>(
     }
 }
 
+fn direct_require_call<'tree>(node: Node<'tree>, source: &[u8]) -> Option<Node<'tree>> {
+    let node = unwrap_expression_node(node);
+    (node.kind() == "call_expression"
+        && node
+            .child_by_field_name("function")
+            .is_some_and(|function| node_text(source, function) == "require"))
+    .then_some(node)
+}
+
+fn static_require_property_name(source: &[u8], node: Node<'_>) -> Option<String> {
+    let node = unwrap_expression_node(node);
+    let name = match node.kind() {
+        "identifier" | "property_identifier" | "private_property_identifier" | "number" => {
+            node_text(source, node)
+        }
+        "string" | "string_fragment" => string_literal(source, node),
+        _ => return None,
+    };
+    (!name.is_empty() && name.len() <= MAX_TYPE_SHAPE_BYTES).then_some(name)
+}
+
+fn direct_require_binding_identifier<'tree>(
+    node: Node<'tree>,
+    source: &[u8],
+) -> Option<(String, Node<'tree>)> {
+    let node = unwrap_expression_node(node);
+    if matches!(
+        node.kind(),
+        "identifier" | "shorthand_property_identifier_pattern"
+    ) {
+        let name = node_text(source, node);
+        return (!name.is_empty()).then_some((name, node));
+    }
+    if node.kind() == "assignment_pattern"
+        && let Some(left) = node.child_by_field_name("left")
+    {
+        return direct_require_binding_identifier(left, source);
+    }
+    None
+}
+
 fn collect_import_bindings<'tree>(
     source: &[u8],
     clause: Node<'tree>,
@@ -10591,19 +10729,6 @@ fn standard_library_type_target(name: &str) -> Option<(String, String)> {
         return Some(("node.global::Buffer".to_owned(), "@types/node".to_owned()));
     }
     None
-}
-
-fn find_require_call<'tree>(node: Node<'tree>, source: &[u8]) -> Option<Node<'tree>> {
-    if node.kind() == "call_expression"
-        && node
-            .child_by_field_name("function")
-            .is_some_and(|function| node_text(source, function) == "require")
-    {
-        return Some(node);
-    }
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor)
-        .find_map(|child| find_require_call(child, source))
 }
 
 fn is_type_reference_node(node: Node<'_>) -> bool {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -5,7 +5,7 @@
 //! 013. The production extractor remains the compatibility path until this
 //! emitter has complete capability coverage and passes the hard-cut gates.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
 use tree_sitter::Node;
@@ -214,6 +214,9 @@ struct CandidateState<'source, 'tree> {
     /// barriers so an older fact cannot survive an unproven mutation.
     flow_assignments: HashMap<String, Vec<FlowAssignment>>,
     flow_assignment_barriers: HashMap<String, Vec<(usize, String)>>,
+    /// Escape/dynamic barriers survive later local assignments because a
+    /// captured binding or dynamic evaluator can observe the rebinding too.
+    flow_escape_barriers: HashMap<String, Vec<usize>>,
     structural_object_variables: HashSet<String>,
     return_object_functions: HashSet<String>,
     /// A local variable initialized from a source-visible function whose
@@ -330,6 +333,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         variable_types: HashMap::new(),
         flow_assignments: HashMap::new(),
         flow_assignment_barriers: HashMap::new(),
+        flow_escape_barriers: HashMap::new(),
         structural_object_variables: HashSet::new(),
         return_object_functions: HashSet::new(),
         variable_object_sources: HashMap::new(),
@@ -1534,12 +1538,30 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 continue;
             }
             let scope_id = self.scope_for_node(current);
+            if matches!(
+                current.kind(),
+                "call_expression" | "optional_call_expression" | "new_expression"
+            ) {
+                self.record_flow_call_argument_escapes(current, &scope_id);
+            }
+            if current.kind() == "with_statement" {
+                self.record_flow_scope_barriers(
+                    &scope_id,
+                    current.start_byte(),
+                    "dynamic with scope",
+                );
+            }
+            if is_callable_node(current) {
+                self.record_flow_closure_captures(current, &scope_id);
+            }
             if current.kind() == "variable_declarator"
                 && let Some(name_node) = current.child_by_field_name("name")
                 && let Some(value) = current.child_by_field_name("value")
             {
                 let value = unwrap_expression_node(value);
-                if let Some(receiver) = self.flow_receiver_for_value(&scope_id, value) {
+                if name_node.kind() == "identifier"
+                    && let Some(receiver) = self.flow_receiver_for_value(&scope_id, value)
+                {
                     let mut names = Vec::new();
                     collect_pattern_names(name_node, self.source, &mut names);
                     for (name, _) in names {
@@ -1565,54 +1587,79 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 current.kind(),
                 "assignment_expression" | "augmented_assignment_expression"
             ) && let Some(left) = current.child_by_field_name("left")
-                && left.kind() == "identifier"
             {
-                let name = node_text(self.source, left);
-                if let Some(Resolution::Local(variable)) =
-                    self.resolve_name(&scope_id, &name, Namespace::Value)
-                    && variable.kind == "variable"
-                {
-                    let right = current.child_by_field_name("right");
-                    let operator = right
-                        .and_then(|right| {
-                            self.source
-                                .get(left.end_byte()..right.start_byte())
-                                .and_then(|bytes| std::str::from_utf8(bytes).ok())
-                        })
-                        .map(str::trim)
-                        .unwrap_or_default();
-                    let straight_line = self
-                        .flow_scope_is_compatible(&variable.scope_id, &scope_id)
-                        && self.flow_assignment_is_straight_line(left, &scope_id);
-                    let receiver = right
-                        .map(unwrap_expression_node)
-                        .and_then(|right| self.flow_receiver_for_value(&scope_id, right));
-                    if straight_line && operator == "=" {
-                        if let Some(receiver) = receiver {
-                            self.record_flow_assignment(
-                                &variable.id,
-                                current.start_byte(),
-                                receiver,
-                            );
+                if left.kind() == "identifier" {
+                    let name = node_text(self.source, left);
+                    if let Some(Resolution::Local(variable)) =
+                        self.resolve_name(&scope_id, &name, Namespace::Value)
+                        && variable.kind == "variable"
+                    {
+                        let right = current.child_by_field_name("right");
+                        let operator = right
+                            .and_then(|right| {
+                                self.source
+                                    .get(left.end_byte()..right.start_byte())
+                                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                            })
+                            .map(str::trim)
+                            .unwrap_or_default();
+                        let straight_line = self
+                            .flow_scope_is_compatible(&variable.scope_id, &scope_id)
+                            && self.flow_assignment_is_straight_line(left, &scope_id);
+                        let receiver = right
+                            .map(unwrap_expression_node)
+                            .and_then(|right| self.flow_receiver_for_value(&scope_id, right));
+                        if straight_line && operator == "=" {
+                            if let Some(receiver) = receiver {
+                                self.record_flow_assignment(
+                                    &variable.id,
+                                    current.start_byte(),
+                                    receiver,
+                                );
+                            } else {
+                                self.record_flow_assignment_barrier(
+                                    &variable.id,
+                                    current.start_byte(),
+                                    "unsupported local assignment value",
+                                );
+                            }
                         } else {
                             self.record_flow_assignment_barrier(
                                 &variable.id,
                                 current.start_byte(),
-                                "unsupported local assignment value",
+                                if straight_line {
+                                    "compound local assignment"
+                                } else {
+                                    "conditional or out-of-scope local assignment"
+                                },
                             );
                         }
-                    } else {
-                        self.record_flow_assignment_barrier(
-                            &variable.id,
-                            current.start_byte(),
-                            if straight_line {
-                                "compound local assignment"
-                            } else {
-                                "conditional or out-of-scope local assignment"
-                            },
-                        );
                     }
                 }
+                if matches!(
+                    left.kind(),
+                    "member_expression" | "optional_member_expression" | "subscript_expression"
+                ) && let Some(object) = left.child_by_field_name("object")
+                {
+                    self.record_flow_value_escape(
+                        &scope_id,
+                        object,
+                        current.start_byte(),
+                        "dynamic member write",
+                    );
+                }
+            }
+            if current.kind() == "return_statement"
+                && let Some(value) = current
+                    .child_by_field_name("argument")
+                    .or_else(|| current.child_by_field_name("value"))
+            {
+                self.record_flow_value_escape(
+                    &scope_id,
+                    unwrap_expression_node(value),
+                    current.start_byte(),
+                    "returned local alias",
+                );
             }
             let mut cursor = current.walk();
             let children = current.named_children(&mut cursor).collect::<Vec<_>>();
@@ -1642,7 +1689,134 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             "call_expression" | "optional_call_expression" => {
                 self.call_return_receiver(scope_id, value)
             }
+            "identifier" | "type_identifier" => self.receiver_target(scope_id, value),
             _ => None,
+        }
+    }
+
+    fn record_flow_call_argument_escapes(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return;
+        };
+        let mut cursor = arguments.walk();
+        for argument in arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .take(MAX_INLINE_OBJECT_PROPERTIES)
+        {
+            self.record_flow_value_escape(
+                scope_id,
+                unwrap_expression_node(argument),
+                node.start_byte(),
+                "passed to callable argument",
+            );
+        }
+        let function = node
+            .child_by_field_name("function")
+            .or_else(|| first_named_child(node));
+        let is_eval = function
+            .and_then(|function| rightmost_identifier(function))
+            .is_some_and(|identifier| {
+                node_text(self.source, identifier) == "eval"
+                    && self
+                        .resolve_name(scope_id, "eval", Namespace::Value)
+                        .is_none()
+            });
+        if is_eval {
+            self.record_flow_scope_barriers(scope_id, node.start_byte(), "dynamic eval");
+        }
+        let is_proxy = function
+            .and_then(|function| rightmost_identifier(function))
+            .is_some_and(|identifier| node_text(self.source, identifier) == "Proxy");
+        if is_proxy {
+            self.record_flow_scope_barriers(scope_id, node.start_byte(), "unsupported Proxy");
+        }
+    }
+
+    fn record_flow_value_escape(
+        &mut self,
+        scope_id: &str,
+        value: Node<'tree>,
+        start_byte: usize,
+        reason: &str,
+    ) {
+        let value = unwrap_expression_node(value);
+        if !matches!(value.kind(), "identifier" | "type_identifier") {
+            return;
+        }
+        let name = node_text(self.source, value);
+        let Some(Resolution::Local(declaration)) =
+            self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            return;
+        };
+        if matches!(declaration.kind.as_str(), "variable" | "parameter") {
+            self.record_flow_assignment_barrier(&declaration.id, start_byte, reason);
+        }
+    }
+
+    fn record_flow_scope_barriers(&mut self, scope_id: &str, start_byte: usize, _reason: &str) {
+        let mut visible = self
+            .declarations
+            .values()
+            .filter(|declaration| matches!(declaration.kind.as_str(), "variable" | "parameter"))
+            .filter(|declaration| self.scope_is_descendant_or_same(scope_id, &declaration.scope_id))
+            .map(|declaration| (declaration.id.clone(), declaration.name.clone()))
+            .collect::<Vec<_>>();
+        visible.sort_unstable();
+        visible.truncate(MAX_INLINE_OBJECT_PROPERTIES);
+        for (declaration_id, name) in visible {
+            if self
+                .resolve_name(scope_id, &name, Namespace::Value)
+                .is_some_and(|resolution| {
+                    matches!(resolution, Resolution::Local(declaration) if declaration.id == declaration_id)
+                })
+            {
+                self.record_flow_escape_barrier(&declaration_id, start_byte);
+            }
+        }
+    }
+
+    fn record_flow_closure_captures(&mut self, node: Node<'tree>, scope_id: &str) {
+        let Some(body) = node
+            .child_by_field_name("body")
+            .or_else(|| first_named_child_kind(node, "statement_block"))
+        else {
+            return;
+        };
+        let mut pending = vec![(body, 0_usize)];
+        let mut captured = BTreeSet::new();
+        while let Some((current, depth)) = pending.pop() {
+            if depth > MAX_TRAVERSAL_DEPTH || captured.len() >= MAX_INLINE_OBJECT_PROPERTIES {
+                break;
+            }
+            if current.kind() == "identifier" {
+                let name = node_text(self.source, current);
+                if let Some(Resolution::Local(declaration)) =
+                    self.resolve_name(scope_id, &name, Namespace::Value)
+                    && matches!(declaration.kind.as_str(), "variable" | "parameter")
+                    && declaration.scope_id != self.scope_for_node(node)
+                    && self.scope_is_descendant_or_same(
+                        &self.scope_for_node(node),
+                        &declaration.scope_id,
+                    )
+                {
+                    captured.insert(declaration.id.clone());
+                }
+            }
+            let mut cursor = current.walk();
+            for child in current
+                .named_children(&mut cursor)
+                .take(MAX_INLINE_OBJECT_PROPERTIES)
+            {
+                pending.push((child, depth.saturating_add(1)));
+            }
+        }
+        for declaration_id in captured {
+            self.record_flow_escape_barrier(&declaration_id, node.start_byte());
         }
     }
 
@@ -1717,6 +1891,20 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
+    fn record_flow_escape_barrier(&mut self, variable_id: &str, start_byte: usize) {
+        let barriers = self
+            .flow_escape_barriers
+            .entry(variable_id.to_owned())
+            .or_default();
+        if barriers.len() < MAX_INLINE_OBJECT_PROPERTIES {
+            barriers.push(start_byte);
+        } else if let Some(latest) = barriers.last_mut()
+            && *latest < start_byte
+        {
+            *latest = start_byte;
+        }
+    }
+
     fn record_flow_assignment(
         &mut self,
         variable_id: &str,
@@ -1738,6 +1926,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     }
 
     fn flow_receiver_at(&self, variable_id: &str, use_start_byte: usize) -> Option<ReceiverTarget> {
+        if self
+            .flow_escape_barriers
+            .get(variable_id)
+            .is_some_and(|barriers| barriers.iter().any(|start| *start <= use_start_byte))
+        {
+            return None;
+        }
         let latest_assignment = self
             .flow_assignments
             .get(variable_id)
@@ -1762,6 +1957,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     }
 
     fn flow_assignment_barrier_before(&self, variable_id: &str, use_start_byte: usize) -> bool {
+        if self
+            .flow_escape_barriers
+            .get(variable_id)
+            .is_some_and(|barriers| barriers.iter().any(|start| *start <= use_start_byte))
+        {
+            return true;
+        }
         let latest_assignment = self
             .flow_assignments
             .get(variable_id)

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -3559,6 +3559,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 self.emit_call(node, &scope_id, false)?;
                 self.emit_dynamic_import(node, &scope_id)?;
                 self.emit_commonjs_object_assign(&scope_id, node, false)?;
+                self.emit_commonjs_define_property(&scope_id, node)?;
             }
             "new_expression" => self.emit_call(node, &scope_id, true)?,
             "member_expression" | "optional_member_expression" | "subscript_expression" => {
@@ -6086,7 +6087,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return Ok(());
         };
         let right = unwrap_expression_node(right);
-        if export_name == "default" && self.is_commonjs_object_assign(right) {
+        if export_name == "default" && self.is_commonjs_object_assign(scope_id, right) {
             // `module.exports = Object.assign({}, source, { direct })` is a
             // bounded object-owner composition. Keep the module owner as the
             // destination and publish only source-proven operands; the
@@ -6139,9 +6140,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         self.emit_commonjs_reexport_binding(scope_id, &export_name, export_anchor, resolution)
     }
 
-    fn is_commonjs_object_assign(&self, node: Node<'tree>) -> bool {
+    fn is_commonjs_object_assign(&self, scope_id: &str, node: Node<'tree>) -> bool {
         let node = unwrap_expression_node(node);
         if !matches!(node.kind(), "call_expression" | "optional_call_expression") {
+            return false;
+        }
+        if !self.is_unshadowed_builtin(scope_id, "Object") {
             return false;
         }
         node.child_by_field_name("function")
@@ -6164,7 +6168,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         assigned_to_module: bool,
     ) -> Result<(), EvidenceError> {
         let node = unwrap_expression_node(node);
-        if !self.is_commonjs_object_assign(node) {
+        if !self.is_commonjs_object_assign(scope_id, node) {
             return Ok(());
         }
         let Some(arguments) = node
@@ -6188,6 +6192,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .all(|child| child.kind().contains("comment"));
         let target_text = node_text(self.source, *target).replace(char::is_whitespace, "");
         let target_is_module = matches!(target_text.as_str(), "module.exports" | "exports");
+        if (target_text == "exports" && !self.is_unshadowed_name(scope_id, "exports"))
+            || (target_text == "module.exports" && !self.is_unshadowed_name(scope_id, "module"))
+        {
+            return Ok(());
+        }
         // When an assignment wraps a mutating `Object.assign(module.exports,
         // ...)`, the nested call is visited separately by `emit_nodes`. Let
         // that call publish the owner once instead of duplicating bindings.
@@ -6263,6 +6272,136 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
         }
         Ok(())
+    }
+
+    /// Recover a named CommonJS export emitted through the standard
+    /// `Object.defineProperty(exports, "name", { value/get: ... })` helper.
+    /// This is common in TypeScript/ESM transpilation. Only a static key and
+    /// a source-proven value/getter return are published; descriptor flags,
+    /// computed keys, dynamic getters, and the `__esModule` marker remain
+    /// ordinary runtime evidence without becoming graph exports.
+    fn emit_commonjs_define_property(
+        &mut self,
+        scope_id: &str,
+        node: Node<'tree>,
+    ) -> Result<(), EvidenceError> {
+        let node = unwrap_expression_node(node);
+        if !matches!(node.kind(), "call_expression" | "optional_call_expression")
+            || !self.is_unshadowed_builtin(scope_id, "Object")
+            || !node
+                .child_by_field_name("function")
+                .or_else(|| first_named_child(node))
+                .is_some_and(|function| {
+                    node_text(self.source, function).replace(char::is_whitespace, "")
+                        == "Object.defineProperty"
+                })
+        {
+            return Ok(());
+        }
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .or_else(|| first_named_child_kind(node, "arguments"))
+        else {
+            return Ok(());
+        };
+        let mut cursor = arguments.walk();
+        let arguments = arguments
+            .named_children(&mut cursor)
+            .filter(|argument| !argument.kind().contains("comment"))
+            .map(unwrap_expression_node)
+            .collect::<Vec<_>>();
+        let [target, key, descriptor] = arguments.as_slice() else {
+            return Ok(());
+        };
+        let target_text = node_text(self.source, *target).replace(char::is_whitespace, "");
+        if !matches!(target_text.as_str(), "module.exports" | "exports")
+            || descriptor.kind() != "object"
+        {
+            return Ok(());
+        }
+        if (target_text == "exports" && !self.is_unshadowed_name(scope_id, "exports"))
+            || (target_text == "module.exports" && !self.is_unshadowed_name(scope_id, "module"))
+        {
+            return Ok(());
+        }
+        let export_name = match key.kind() {
+            "string" | "string_fragment" | "number" => string_literal(self.source, *key),
+            _ => return Ok(()),
+        };
+        if export_name.is_empty() || export_name == "__esModule" {
+            return Ok(());
+        }
+        let Some(resolution) = self.commonjs_descriptor_value_resolution(scope_id, *descriptor)
+        else {
+            return Ok(());
+        };
+        self.emit_commonjs_reexport_binding(scope_id, &export_name, *key, resolution)
+    }
+
+    fn commonjs_descriptor_value_resolution(
+        &self,
+        scope_id: &str,
+        descriptor: Node<'tree>,
+    ) -> Option<Resolution> {
+        let mut cursor = descriptor.walk();
+        for property in descriptor
+            .named_children(&mut cursor)
+            .take(MAX_INLINE_OBJECT_PROPERTIES)
+        {
+            let Some((key, value)) = commonjs_object_property(property) else {
+                continue;
+            };
+            let Some(name) = member_property_name(self.source, key) else {
+                continue;
+            };
+            if name == "value"
+                && let Some(value) = value.map(unwrap_expression_node)
+                && let Some(resolution) = self.commonjs_export_value_resolution(scope_id, value)
+            {
+                return Some(resolution);
+            }
+            if name == "get"
+                && let Some(getter) = value.map(unwrap_expression_node)
+                && let Some(return_value) = self.commonjs_getter_return_value(getter)
+                && let Some(resolution) =
+                    self.commonjs_export_value_resolution(scope_id, return_value)
+            {
+                return Some(resolution);
+            }
+        }
+        None
+    }
+
+    fn commonjs_getter_return_value(&self, getter: Node<'tree>) -> Option<Node<'tree>> {
+        let getter = unwrap_expression_node(getter);
+        let body = getter
+            .child_by_field_name("body")
+            .or_else(|| first_named_child_kind(getter, "statement_block"))
+            .map(unwrap_expression_node)?;
+        if body.kind() != "statement_block" {
+            return Some(body);
+        }
+        self.commonjs_direct_return_value(body, 0)
+    }
+
+    fn commonjs_direct_return_value(&self, node: Node<'tree>, depth: usize) -> Option<Node<'tree>> {
+        if depth > MAX_TRAVERSAL_DEPTH {
+            return None;
+        }
+        if node.kind() == "return_statement" {
+            return return_value_node(node).map(unwrap_expression_node);
+        }
+        if depth > 0
+            && matches!(
+                node.kind(),
+                "arrow_function" | "function" | "function_expression" | "generator_function"
+            )
+        {
+            return None;
+        }
+        let mut cursor = node.walk();
+        node.named_children(&mut cursor)
+            .find_map(|child| self.commonjs_direct_return_value(child, depth + 1))
     }
 
     fn commonjs_export_value_resolution(

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -185,6 +185,23 @@ struct FlowAssignment {
     receiver: ReceiverTarget,
 }
 
+#[derive(Clone)]
+struct FlowEscapeBarrier {
+    start_byte: usize,
+    /// Branch containers and the selected body beneath each container. An
+    /// escape in one arm must not poison a use in a mutually exclusive arm,
+    /// while a use outside the branch remains conservative.
+    /// Function segments are compared as an execution-context prefix so
+    /// sibling callbacks do not become source-order barriers for one another.
+    control_path: Vec<FlowControlSegment>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FlowControlSegment {
+    Branch { container: usize, branch: usize },
+    Function(usize),
+}
+
 struct CandidateState<'source, 'tree> {
     source_file: &'source str,
     source: &'source [u8],
@@ -218,7 +235,7 @@ struct CandidateState<'source, 'tree> {
     flow_assignment_barriers: HashMap<String, Vec<(usize, String)>>,
     /// Escape/dynamic barriers survive later local assignments because a
     /// captured binding or dynamic evaluator can observe the rebinding too.
-    flow_escape_barriers: HashMap<String, Vec<usize>>,
+    flow_escape_barriers: HashMap<String, Vec<FlowEscapeBarrier>>,
     /// Property-specific writes on an immutable source-proven receiver alias.
     /// A write to an unrelated property does not erase the receiver identity,
     /// while a write to the queried member remains a fail-closed barrier.
@@ -2019,7 +2036,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             self.record_flow_value_escape(
                 scope_id,
                 unwrap_expression_node(argument),
-                node.start_byte(),
+                argument.start_byte(),
                 "passed to callable argument",
             );
         }
@@ -2050,7 +2067,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         scope_id: &str,
         value: Node<'tree>,
         start_byte: usize,
-        reason: &str,
+        _reason: &str,
     ) {
         let value = unwrap_expression_node(value);
         if !matches!(value.kind(), "identifier" | "type_identifier") {
@@ -2063,7 +2080,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return;
         };
         if matches!(declaration.kind.as_str(), "variable" | "parameter") {
-            self.record_flow_assignment_barrier(&declaration.id, start_byte, reason);
+            self.record_flow_escape_barrier(&declaration.id, start_byte, Some(value));
         }
     }
 
@@ -2097,7 +2114,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if self.stable_immutable_receiver_alias(&declaration.id) {
             self.record_flow_member_write_barrier(&declaration.id, property_name, start_byte);
         } else {
-            self.record_flow_escape_barrier(&declaration.id, start_byte);
+            self.record_flow_escape_barrier(&declaration.id, start_byte, Some(value));
         }
     }
 
@@ -2158,7 +2175,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     matches!(resolution, Resolution::Local(declaration) if declaration.id == declaration_id)
                 })
             {
-                self.record_flow_escape_barrier(&declaration_id, start_byte);
+                self.record_flow_escape_barrier(&declaration_id, start_byte, None);
             }
         }
     }
@@ -2200,7 +2217,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
         }
         for declaration_id in captured {
-            self.record_flow_escape_barrier(&declaration_id, node.start_byte());
+            self.record_flow_escape_barrier(&declaration_id, node.start_byte(), Some(node));
         }
     }
 
@@ -2352,17 +2369,31 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
-    fn record_flow_escape_barrier(&mut self, variable_id: &str, start_byte: usize) {
+    fn record_flow_escape_barrier(
+        &mut self,
+        variable_id: &str,
+        start_byte: usize,
+        path_node: Option<Node<'tree>>,
+    ) {
+        let control_path = path_node
+            .map(|node| self.flow_control_path(node))
+            .unwrap_or_default();
         let barriers = self
             .flow_escape_barriers
             .entry(variable_id.to_owned())
             .or_default();
         if barriers.len() < MAX_INLINE_OBJECT_PROPERTIES {
-            barriers.push(start_byte);
+            barriers.push(FlowEscapeBarrier {
+                start_byte,
+                control_path,
+            });
         } else if let Some(latest) = barriers.last_mut()
-            && *latest < start_byte
+            && latest.start_byte < start_byte
         {
-            *latest = start_byte;
+            *latest = FlowEscapeBarrier {
+                start_byte,
+                control_path,
+            };
         }
     }
 
@@ -2386,11 +2417,17 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
-    fn flow_receiver_at(&self, variable_id: &str, use_start_byte: usize) -> Option<ReceiverTarget> {
+    fn flow_receiver_at(&self, variable_id: &str, use_node: Node<'tree>) -> Option<ReceiverTarget> {
+        let use_start_byte = use_node.start_byte();
         if self
             .flow_escape_barriers
             .get(variable_id)
-            .is_some_and(|barriers| barriers.iter().any(|start| *start <= use_start_byte))
+            .is_some_and(|barriers| {
+                barriers.iter().any(|barrier| {
+                    barrier.start_byte <= use_start_byte
+                        && self.flow_escape_barrier_applies(barrier, use_node)
+                })
+            })
         {
             return None;
         }
@@ -2417,11 +2454,17 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         latest_assignment.map(|assignment| assignment.receiver.clone())
     }
 
-    fn flow_assignment_barrier_before(&self, variable_id: &str, use_start_byte: usize) -> bool {
+    fn flow_assignment_barrier_before(&self, variable_id: &str, use_node: Node<'tree>) -> bool {
+        let use_start_byte = use_node.start_byte();
         if self
             .flow_escape_barriers
             .get(variable_id)
-            .is_some_and(|barriers| barriers.iter().any(|start| *start <= use_start_byte))
+            .is_some_and(|barriers| {
+                barriers.iter().any(|barrier| {
+                    barrier.start_byte <= use_start_byte
+                        && self.flow_escape_barrier_applies(barrier, use_node)
+                })
+            })
         {
             return true;
         }
@@ -2441,6 +2484,105 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .map(|(start_byte, _)| *start_byte)
             .max()
             .is_some_and(|barrier| latest_assignment.is_none_or(|assignment| assignment <= barrier))
+    }
+
+    fn flow_escape_barrier_applies(
+        &self,
+        barrier: &FlowEscapeBarrier,
+        use_node: Node<'tree>,
+    ) -> bool {
+        if barrier.control_path.is_empty() {
+            return true;
+        }
+        let use_path = self.flow_control_path(use_node);
+        let barrier_functions = barrier
+            .control_path
+            .iter()
+            .filter_map(|segment| match segment {
+                FlowControlSegment::Function(function) => Some(*function),
+                FlowControlSegment::Branch { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        let use_functions = use_path
+            .iter()
+            .filter_map(|segment| match segment {
+                FlowControlSegment::Function(function) => Some(*function),
+                FlowControlSegment::Branch { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        if barrier_functions
+            .iter()
+            .zip(use_functions.iter())
+            .any(|(barrier_function, use_function)| barrier_function != use_function)
+        {
+            return false;
+        }
+        for segment in &barrier.control_path {
+            match *segment {
+                FlowControlSegment::Function(_) => {}
+                FlowControlSegment::Branch { container, branch } => {
+                    let Some(use_segment) = use_path.iter().find(|use_segment| {
+                        matches!(
+                            use_segment,
+                            FlowControlSegment::Branch {
+                                container: use_container,
+                                ..
+                            } if *use_container == container
+                        )
+                    }) else {
+                        continue;
+                    };
+                    if !matches!(
+                        use_segment,
+                        FlowControlSegment::Branch {
+                            branch: use_branch,
+                            ..
+                        } if *use_branch == branch
+                    ) {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn flow_control_path(&self, node: Node<'tree>) -> Vec<FlowControlSegment> {
+        let mut path = Vec::new();
+        let mut child = node;
+        let mut current = child.parent();
+        while let Some(ancestor) = current {
+            if let Some(branch) = self.flow_branch_child(ancestor, child) {
+                path.push(FlowControlSegment::Branch {
+                    container: ancestor.id(),
+                    branch: branch.id(),
+                });
+            }
+            if is_callable_node(ancestor) {
+                path.push(FlowControlSegment::Function(ancestor.id()));
+            }
+            child = ancestor;
+            current = ancestor.parent();
+        }
+        path.reverse();
+        path
+    }
+
+    fn flow_branch_child(&self, ancestor: Node<'tree>, child: Node<'tree>) -> Option<Node<'tree>> {
+        let fields: &[&str] = match ancestor.kind() {
+            "if_statement" => &["consequence", "alternative"],
+            "switch_case" => &["body"],
+            "for_statement" | "for_in_statement" | "for_of_statement" | "while_statement"
+            | "do_statement" | "with_statement" => &["body"],
+            "try_statement" => &["body", "handler", "finalizer"],
+            "catch_clause" | "finally_clause" => &["body"],
+            "conditional_expression" | "ternary_expression" => &["consequence", "alternative"],
+            _ => &[],
+        };
+        fields
+            .iter()
+            .filter_map(|field| ancestor.child_by_field_name(field))
+            .find(|branch| branch.id() == child.id())
     }
 
     /// Propagate a source-visible callback parameter type through a call.
@@ -6976,13 +7118,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                             return Some(receiver);
                         }
 
-                        if let Some(receiver) =
-                            self.flow_receiver_at(&declaration.id, object.start_byte())
-                        {
+                        if let Some(receiver) = self.flow_receiver_at(&declaration.id, object) {
                             return Some(receiver);
                         }
-                        if self.flow_assignment_barrier_before(&declaration.id, object.start_byte())
-                        {
+                        if self.flow_assignment_barrier_before(&declaration.id, object) {
                             if let Some(receiver) = self.stable_nominal_flow_receiver_at(
                                 &declaration.id,
                                 object.start_byte(),

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -2602,6 +2602,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 "external".to_owned(),
             ),
         };
+        let allow_external = target_kind == "external"
+            && qualified_name
+                .as_deref()
+                .is_none_or(|qualified| !qualified.contains("#call<"));
         let occurrence_id = self.builder.occur_with_context(
             role,
             &owner,
@@ -2623,7 +2627,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .iter()
                 .map(|kind| (*kind).to_owned())
                 .collect(),
-            allow_external: target_kind == "external",
+            allow_external,
             ..ResolutionConstraint::default()
         };
         if relation == CandidateRelation::Extends {
@@ -6143,6 +6147,36 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             let target = rightmost_identifier(function)?;
             self.resolve_name(scope_id, &node_text(self.source, target), Namespace::Value)
         }?;
+        if let Resolution::Import(import) = &resolution {
+            // Carry a bounded, source-proven call-result marker across the
+            // file boundary.  The resolver can use the imported callable's
+            // published signature to recover its nominal return receiver;
+            // unknown argument shapes deliberately remain unresolved.
+            let argument_types = self.call_argument_types(call, scope_id);
+            if argument_types.iter().any(Option::is_none) {
+                return None;
+            }
+            let argument_types = argument_types.into_iter().flatten().collect::<Vec<_>>();
+            let marker_arguments = if argument_types.is_empty() {
+                "__none".to_owned()
+            } else {
+                argument_types.join(",")
+            };
+            if marker_arguments.len() > MAX_TYPE_SHAPE_BYTES {
+                return None;
+            }
+            let receiver = import_target_without_namespace(&import.target);
+            let qualified_name = format!("{receiver}#call<{marker_arguments}>");
+            if qualified_name.len() > MAX_TYPE_SHAPE_BYTES {
+                return None;
+            }
+            return Some(ReceiverTarget {
+                qualified_name,
+                import: Some(import.clone()),
+                scope_id: None,
+                type_arguments: None,
+            });
+        }
         let Resolution::Local(declaration) = resolution else {
             return None;
         };
@@ -7268,6 +7302,7 @@ fn callable_parameter_types(node: Node<'_>, source: &[u8]) -> Option<Vec<String>
     if !matches!(
         node.kind(),
         "function_declaration"
+            | "function_signature"
             | "generator_function_declaration"
             | "method_definition"
             | "method_signature"
@@ -7470,10 +7505,34 @@ fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -
     {
         return Some(type_name);
     }
-    let generic_prefix = callable_type_parameter_order(node, source)
+    let callable_value = callable_value_node(node);
+    let generic_parameter_order = callable_type_parameter_order(node, source)
+        .or_else(|| callable_value.and_then(|value| callable_type_parameter_order(value, source)));
+    let generic_prefix = generic_parameter_order
         .filter(|parameters| !parameters.is_empty())
         .map(|parameters| format!("<{}>", parameters.join(",")))
         .unwrap_or_default();
+    if matches!(kind, "function" | "method") {
+        let parameter_types = callable_parameter_types(node, source)
+            .or_else(|| callable_value.and_then(|value| callable_parameter_types(value, source)));
+        let return_type = callable_return_type_name(node, source);
+        if parameter_types.is_some() || return_type.is_some() {
+            let mut signature = generic_prefix.clone();
+            if let Some(parameter_types) = parameter_types {
+                signature.push_str("|params:");
+                signature.push_str(&parameter_types.join(","));
+            }
+            if let Some(return_type) = return_type {
+                signature.push_str("|return:");
+                signature.push_str(&return_type);
+            }
+            if signature.len() <= MAX_TYPE_SHAPE_BYTES
+                && (signature.contains("|params:") || signature.contains("|return:"))
+            {
+                return Some(signature);
+            }
+        }
+    }
     if kind == "type_alias"
         && let Some(target) = direct_type_reference_name(node, source)
     {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1118,7 +1118,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             format!("{qualified_prefix}.{name}")
         };
         let graph_node_id = stable_graph_id(self.source_file, kind, name, node.start_byte());
-        let declaration_id = self.builder.declare_with_namespace(
+        let signature = typescript_declaration_signature(node, kind, self.source);
+        let declaration_id = self.builder.declare_with_signature(
             kind,
             &graph_node_id,
             name,
@@ -1126,6 +1127,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             Some(self.source_file),
             Some(scope_id),
             Some(symbol_namespace(namespace)),
+            signature.as_deref(),
             range_for_node(self.source_file, range_node),
         )?;
         self.declaration_name_nodes.insert(name_node.start_byte());
@@ -4806,11 +4808,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .import
             .as_ref()
             .is_some_and(|import| import.namespace == Namespace::Module);
-        let qualified_name = if namespace_import {
-            format!("{}::{property_name}", receiver.qualified_name)
-        } else {
-            format!("{}.{property_name}", receiver.qualified_name)
-        };
+        let qualified_name = typescript_member_qualified_name(
+            &receiver.qualified_name,
+            receiver.type_arguments.as_deref(),
+            &property_name,
+            namespace_import,
+            receiver.import.is_some(),
+        );
         if let Some(ids) = self.declarations_by_qualified.get(&qualified_name) {
             let flow_sensitive = self.receiver_is_flow_sensitive(&receiver);
             let all_declarations = ids
@@ -5777,16 +5781,18 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     .import
                     .as_ref()
                     .is_some_and(|import| import.namespace == Namespace::Module);
-                let qualified_name = if namespace_import {
-                    format!("{}::{property_name}", nested.qualified_name)
-                } else {
-                    format!("{}.{property_name}", nested.qualified_name)
-                };
+                let qualified_name = typescript_member_qualified_name(
+                    &nested.qualified_name,
+                    nested.type_arguments.as_deref(),
+                    &property_name,
+                    namespace_import,
+                    nested.import.is_some(),
+                );
                 let receiver = ReceiverTarget {
                     qualified_name,
                     import: nested.import,
                     scope_id: nested.scope_id,
-                    type_arguments: None,
+                    type_arguments: nested.type_arguments,
                 };
                 Some(
                     self.typed_member_receiver(scope_id, receiver.clone())
@@ -5987,6 +5993,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             let (lookup_name, type_arguments) = generic_type_parts(normalized)
                 .map(|(base, arguments)| (base.to_owned(), Some(arguments)))
                 .unwrap_or_else(|| (normalized.to_owned(), None));
+            let type_arguments =
+                type_arguments.map(|arguments| self.canonical_type_arguments(scope_id, &arguments));
             let resolution = self.resolve_name(scope_id, &lookup_name, Namespace::Both)?;
             match resolution {
                 Resolution::Import(import) => {
@@ -6037,6 +6045,26 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             }
         }
         None
+    }
+
+    /// Canonicalize direct generic arguments when the source proves an
+    /// import or local nominal declaration. Keeping the module-qualified
+    /// identity here prevents a same-spelled `Item` from another module from
+    /// being substituted into an imported `Box<Item>` chain. Unresolved or
+    /// structural arguments remain textual and are intentionally not used by
+    /// the cross-file member resolver.
+    fn canonical_type_arguments(&self, scope_id: &str, arguments: &[String]) -> Vec<String> {
+        arguments
+            .iter()
+            .map(|argument| {
+                self.resolve_name(scope_id, strip_type_arguments(argument), Namespace::Both)
+                    .and_then(|resolution| resolution.qualified_target())
+                    .filter(|qualified| {
+                        !qualified.is_empty() && qualified.len() <= MAX_TYPE_SHAPE_BYTES
+                    })
+                    .unwrap_or_else(|| argument.clone())
+            })
+            .collect()
     }
 
     /// Return the child scope owned by a nominal declaration when one exists.
@@ -6217,6 +6245,92 @@ const fn symbol_namespace(namespace: Namespace) -> SymbolNamespace {
 
 fn import_target_without_namespace(target: &str) -> String {
     target.strip_suffix("::*").unwrap_or(target).to_owned()
+}
+
+/// Keep generic arguments attached to the root nominal in a member path.
+/// `Box<Item>.value.inspect` is intentionally a constraint spelling, not a
+/// graph identity; it lets the resolver recover the concrete member type
+/// without treating the terminal `inspect` spelling as authoritative.
+fn typescript_member_qualified_name(
+    receiver: &str,
+    type_arguments: Option<&[String]>,
+    property: &str,
+    namespace_import: bool,
+    preserve_type_arguments: bool,
+) -> String {
+    let receiver = if preserve_type_arguments {
+        typescript_receiver_with_type_arguments(receiver, type_arguments)
+    } else {
+        receiver.to_owned()
+    };
+    if namespace_import {
+        format!("{receiver}::{property}")
+    } else {
+        format!("{receiver}.{property}")
+    }
+}
+
+fn typescript_receiver_with_type_arguments(
+    receiver: &str,
+    type_arguments: Option<&[String]>,
+) -> String {
+    let Some(type_arguments) = type_arguments.filter(|arguments| !arguments.is_empty()) else {
+        return receiver.to_owned();
+    };
+    let arguments = type_arguments.join(",");
+    if arguments.is_empty() || arguments.len() > MAX_TYPE_SHAPE_BYTES {
+        return receiver.to_owned();
+    }
+    let (module, symbol) = typescript_split_module_qualified(receiver);
+    let split = typescript_first_member_separator(symbol).unwrap_or(symbol.len());
+    let root = &symbol[..split];
+    if root.is_empty() || root.contains('<') {
+        return receiver.to_owned();
+    }
+    let suffix = &symbol[split..];
+    match module {
+        Some(module) if !module.is_empty() => {
+            format!("{module}::{root}<{arguments}>{suffix}")
+        }
+        _ => format!("{root}<{arguments}>{suffix}"),
+    }
+}
+
+fn typescript_split_module_qualified(value: &str) -> (Option<&str>, &str) {
+    let bytes = value.as_bytes();
+    let mut angle_depth = 0_u32;
+    let mut split = None;
+    for index in 0..bytes.len().saturating_sub(1) {
+        match bytes[index] {
+            b'<' => angle_depth = angle_depth.saturating_add(1),
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
+            b':' if bytes[index + 1] == b':' && angle_depth == 0 => split = Some(index),
+            _ => {}
+        }
+    }
+    split.map_or((None, value), |index| {
+        (
+            value.get(..index).filter(|module| !module.is_empty()),
+            value.get(index.saturating_add(2)..).unwrap_or_default(),
+        )
+    })
+}
+
+fn typescript_first_member_separator(value: &str) -> Option<usize> {
+    let bytes = value.as_bytes();
+    let mut angle_depth = 0_u32;
+    for index in 0..bytes.len() {
+        match bytes[index] {
+            b'<' => angle_depth = angle_depth.saturating_add(1),
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
+            b'.' if angle_depth == 0 => return Some(index),
+            b':' if angle_depth == 0 && bytes.get(index + 1) == Some(&b':') => {
+                return Some(index);
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn is_parameter_node(node: Node<'_>) -> bool {
@@ -6848,6 +6962,29 @@ fn normalize_type_text(source: &[u8], node: Node<'_>) -> String {
         .chars()
         .filter(|character| !character.is_ascii_whitespace())
         .collect()
+}
+
+/// Return the small amount of declaration shape needed to follow a proven
+/// TypeScript member value across files. This is deliberately not a full
+/// source signature: a generic owner publishes its parameter order and a
+/// property publishes its direct nominal type. The resolver can therefore
+/// substitute `T` in `Box<T> { item: T }` only when the use site carries an
+/// explicit `Box<Concrete>` argument.
+fn typescript_declaration_signature(node: Node<'_>, kind: &str, source: &[u8]) -> Option<String> {
+    if kind == "property"
+        && let Some(type_name) = direct_type_reference_name(node, source)
+    {
+        return Some(type_name);
+    }
+    if matches!(kind, "class" | "interface")
+        && let Some(parameters) = callable_type_parameter_order(node, source)
+    {
+        let signature = format!("<{}>", parameters.join(","));
+        if signature.len() <= MAX_TYPE_SHAPE_BYTES {
+            return Some(signature);
+        }
+    }
+    None
 }
 
 fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -12,8 +12,8 @@ use tree_sitter::Node;
 
 use super::build::{EvidenceBuilder, range_for_node};
 use super::model::{
-    BindingKind, CandidateRelation, HierarchyConstraint, LanguageCapability, ResolutionConstraint,
-    SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
+    BindingKind, CandidateRelation, EvidenceRange, HierarchyConstraint, LanguageCapability,
+    ResolutionConstraint, SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
 };
 use super::validate::{EvidenceError, EvidenceErrorCode, EvidenceLimits};
 use crate::{AdapterProfile, UNIVERSAL_EVIDENCE_SCHEMA, make_id};
@@ -64,7 +64,7 @@ const JAVASCRIPT_CAPABILITIES: &[LanguageCapability] = &[
 static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.typescript.candidate",
     language: "typescript",
-    version: 4,
+    version: 5,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: TYPESCRIPT_CAPABILITIES,
@@ -73,7 +73,7 @@ static TYPESCRIPT_PROFILE: AdapterProfile = AdapterProfile {
 static JAVASCRIPT_PROFILE: AdapterProfile = AdapterProfile {
     id: "compass.javascript.candidate",
     language: "javascript",
-    version: 4,
+    version: 5,
     evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA,
     profile: crate::UniversalAdapterProfile::UniversalCandidate,
     capabilities: JAVASCRIPT_CAPABILITIES,
@@ -195,8 +195,12 @@ struct FlowAssignment {
 #[derive(Clone)]
 struct StructuralObjectSpread {
     source_qualified_name: String,
-    source_variable_id: String,
-    start_byte: usize,
+    /// A local source keeps its exact declaration identity so property writes
+    /// can invalidate the projection. Imported default-object sources have no
+    /// local declaration ID and are validated by the project resolver through
+    /// the published default-object owner.
+    source_variable_id: Option<String>,
+    range: EvidenceRange,
 }
 
 #[derive(Clone)]
@@ -717,18 +721,40 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 .insert(declaration.qualified_name.clone());
             self.stable_structural_object_variables
                 .insert(declaration.qualified_name.clone());
+            // Give a source-backed object export its own owner scope.  Direct
+            // members then use the ordinary owner index, and member-alias
+            // bindings can identify this exact synthetic default object
+            // without overloading the surrounding module scope.
+            let object_scope = self.builder.open_scope(
+                "object",
+                Some(&declaration.id),
+                Some(&scope_id),
+                range_for_node(self.source_file, exported),
+            )?;
+            self.scope_by_node
+                .insert(exported.id(), object_scope.clone());
+            self.scope_parents
+                .insert(object_scope.clone(), Some(scope_id.clone()));
+            self.scope_owners
+                .insert(object_scope.clone(), declaration.id.clone());
+            self.scope_kinds
+                .insert(object_scope.clone(), "object".to_owned());
             if object_literal_has_spread(exported) {
                 self.record_structural_object_spreads(
-                    &scope_id,
+                    &object_scope,
                     &declaration.qualified_name,
                     exported,
                 );
+                self.emit_structural_spread_member_aliases(
+                    &object_scope,
+                    &declaration.qualified_name,
+                )?;
             }
             let mut cursor = exported.walk();
             for child in exported.named_children(&mut cursor) {
                 self.collect_declarations(
                     child,
-                    scope_id.clone(),
+                    object_scope.clone(),
                     declaration.qualified_name.clone(),
                     depth + 1,
                 )?;
@@ -1925,6 +1951,35 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .insert(destination.to_owned(), spreads);
     }
 
+    /// Publish a bounded owner-alias marker for every source-proven spread in
+    /// a default/export-assignment object.  The `*` spelling is intentionally
+    /// reserved here for the member index: it means that the destination
+    /// object inherits a member inventory from the qualified source owner,
+    /// not that the object exports an unknown wildcard name.  The resolver
+    /// validates the source as another object owner before using this marker.
+    fn emit_structural_spread_member_aliases(
+        &mut self,
+        object_scope_id: &str,
+        destination: &str,
+    ) -> Result<(), EvidenceError> {
+        let Some(spreads) = self.structural_object_spreads.get(destination).cloned() else {
+            return Ok(());
+        };
+        for spread in spreads {
+            self.builder.bind_with_identity(
+                BindingKind::Member,
+                "*",
+                &spread.source_qualified_name,
+                spread.source_variable_id.as_deref(),
+                Some(object_scope_id),
+                Some(SymbolNamespace::Value),
+                false,
+                spread.range,
+            )?;
+        }
+        Ok(())
+    }
+
     fn object_literal_spread_export_is_safe(&self, scope_id: &str, object: Node<'tree>) -> bool {
         if self
             .structural_object_spread_sources(scope_id, object)
@@ -1973,23 +2028,49 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     return None;
                 }
                 let name = node_text(self.source, argument);
-                let resolution = self.resolve_name(scope_id, &name, Namespace::Value)?;
-                let Resolution::Local(source) = resolution else {
-                    return None;
-                };
-                if source.kind != "variable"
-                    || !self.immutable_bindings.contains(&source.id)
-                    || !self
-                        .stable_structural_object_variables
-                        .contains(&source.qualified_name)
-                {
-                    return None;
+                let resolution = self.resolve_name(scope_id, &name, Namespace::Value);
+                match resolution {
+                    Some(Resolution::Local(source)) => {
+                        if source.kind != "variable"
+                            || !self.immutable_bindings.contains(&source.id)
+                            || !self
+                                .stable_structural_object_variables
+                                .contains(&source.qualified_name)
+                        {
+                            return None;
+                        }
+                        spreads.push(StructuralObjectSpread {
+                            source_qualified_name: source.qualified_name,
+                            source_variable_id: Some(source.id),
+                            range: range_for_node(self.source_file, child),
+                        });
+                    }
+                    Some(Resolution::Import(import))
+                        if import.imported_name == "default"
+                            && !import.type_only
+                            && import.namespace.accepts(Namespace::Value) =>
+                    {
+                        spreads.push(StructuralObjectSpread {
+                            source_qualified_name: import.target,
+                            source_variable_id: None,
+                            range: range_for_node(self.source_file, child),
+                        });
+                    }
+                    None => {
+                        // Static ES imports are hoisted, but the declaration
+                        // pass intentionally runs before the full import
+                        // emission pass. Recover only a default import from
+                        // the top-level syntax; named, namespace, dynamic,
+                        // and CommonJS sources stay opaque.
+                        let target = self.syntactic_default_import_target(object, &name)?;
+                        spreads.push(StructuralObjectSpread {
+                            source_qualified_name: target,
+                            source_variable_id: None,
+                            range: range_for_node(self.source_file, child),
+                        });
+                    }
+                    _ => return None,
                 }
-                spreads.push(StructuralObjectSpread {
-                    source_qualified_name: source.qualified_name,
-                    source_variable_id: source.id,
-                    start_byte: child.start_byte(),
-                });
                 continue;
             }
             // A spread projection can reason about ordinary static properties
@@ -1999,6 +2080,52 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             member_property_name(self.source, key)?;
         }
         Some(spreads)
+    }
+
+    fn syntactic_default_import_target(
+        &self,
+        node: Node<'tree>,
+        local_name: &str,
+    ) -> Option<String> {
+        let mut root = node;
+        while let Some(parent) = root.parent() {
+            root = parent;
+        }
+        let mut cursor = root.walk();
+        for child in root.named_children(&mut cursor) {
+            if child.kind() != "import_statement" {
+                continue;
+            }
+            let Some(module_node) = first_named_child_kind(child, "string") else {
+                continue;
+            };
+            let module = string_literal(self.source, module_node);
+            if module.is_empty() {
+                continue;
+            }
+            let Some(clause) = first_named_child_kind(child, "import_clause") else {
+                continue;
+            };
+            let statement_type_only = node_text(self.source, child)
+                .trim_start()
+                .starts_with("import type");
+            let mut bindings = Vec::new();
+            collect_import_bindings(
+                self.source,
+                clause,
+                false,
+                statement_type_only,
+                &mut bindings,
+            );
+            if bindings.iter().any(|binding| {
+                binding.local_name == local_name
+                    && binding.imported_name == "default"
+                    && !binding.type_only
+            }) {
+                return Some(format!("{module}::default"));
+            }
+        }
+        None
     }
 
     fn object_literal_value_for_binding(&self, value: Node<'tree>) -> Option<Node<'tree>> {
@@ -6928,13 +7055,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .collect::<Vec<_>>();
         let mut events = direct;
         for spread in spreads {
-            if spread.start_byte > use_start_byte {
+            let spread_start = usize::try_from(spread.range.start_byte).unwrap_or(usize::MAX);
+            if spread_start > use_start_byte {
                 continue;
             }
-            if self
-                .flow_member_write_barriers
-                .get(&(spread.source_variable_id.clone(), property_name.to_owned()))
-                .is_some_and(|barriers| barriers.iter().any(|start| *start <= spread.start_byte))
+            if let Some(source_variable_id) = spread.source_variable_id.as_deref()
+                && self
+                    .flow_member_write_barriers
+                    .get(&(source_variable_id.to_owned(), property_name.to_owned()))
+                    .is_some_and(|barriers| barriers.iter().any(|start| *start <= spread_start))
             {
                 return Err(());
             }
@@ -6980,7 +7109,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 return Err(());
             };
             if let Some(target) = target {
-                events.push((spread.start_byte, target));
+                events.push((spread_start, target));
             }
         }
         visiting.remove(receiver_qualified_name);

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -1246,8 +1246,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             self.type_alias_union_targets
                 .insert(declaration.qualified_name.clone(), targets);
         }
-        if matches!(kind, "type_alias" | "interface")
-            && let Some(value_type) = index_value_type(node, self.source)
+        if matches!(
+            kind,
+            "type_alias" | "interface" | "parameter" | "variable" | "property"
+        ) && let Some(value_type) = index_value_type(node, self.source)
         {
             self.index_value_types
                 .insert(declaration.qualified_name.clone(), value_type);
@@ -2356,6 +2358,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if !property_types.is_empty() {
             self.inline_object_property_types
                 .insert(variable_id, property_types);
+        }
+        if let Some(index_value) = index_value_type(object_type, self.source) {
+            self.index_value_types
+                .insert(variable.qualified_name.clone(), index_value);
         }
     }
 
@@ -6193,6 +6199,24 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                             });
                         }
 
+                        // Inline structural index signatures (for example,
+                        // `shape: { [key: string]: Item }`) have no nominal
+                        // type declaration to resolve. The bounded index-value
+                        // cache still proves the value type at this binding;
+                        // preserve the binding identity so a later dynamic
+                        // subscript can resolve only that source-proven value.
+                        if self
+                            .index_value_types
+                            .contains_key(&declaration.qualified_name)
+                        {
+                            return Some(ReceiverTarget {
+                                qualified_name: declaration.qualified_name.clone(),
+                                import: None,
+                                scope_id: Some(declaration.scope_id.clone()),
+                                type_arguments: None,
+                            });
+                        }
+
                         if let Some(qualified_name) =
                             self.variable_inline_type_receivers.get(&declaration.id)
                         {
@@ -6759,6 +6783,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if receiver.import.is_some() {
             return None;
         }
+        if let Some(value_type) = typescript_structural_index_value(&receiver.qualified_name) {
+            return self.resolve_declared_type_receiver(scope_id, value_type);
+        }
         let type_name = self
             .index_value_types
             .get(&receiver.qualified_name)
@@ -6844,6 +6871,19 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 || !seen.insert(normalized.to_owned())
             {
                 return None;
+            }
+            if let Some(value_type) = typescript_inline_index_value_type(normalized) {
+                // Validate the value type through the same source-backed
+                // resolver used by nominal index signatures before retaining
+                // the structural marker. This prevents primitive, external,
+                // or ambiguous value shapes from becoming member targets.
+                self.resolve_declared_type_receiver(scope_id, &value_type)?;
+                return Some(ReceiverTarget {
+                    qualified_name: typescript_structural_index_receiver(&value_type),
+                    import: None,
+                    scope_id: None,
+                    type_arguments: None,
+                });
             }
             if indexed_sequence_element_type_name(normalized, None).is_some()
                 || tuple_type_element_count(normalized).is_some()
@@ -8146,6 +8186,13 @@ fn direct_type_reference_name(node: Node<'_>, source: &[u8]) -> Option<String> {
         annotation
     };
     let normalized_type_text = node_text(source, type_node);
+    if node.kind() != "type_alias_declaration"
+        && type_node.kind() == "object_type"
+        && contains_node_kind(type_node, "index_signature")
+        && normalized_type_text.len() <= MAX_TYPE_SHAPE_BYTES
+    {
+        return Some(normalize_type_text(source, type_node));
+    }
     if indexed_type_parts(&normalized_type_text).is_some()
         || keyof_type_base(&normalized_type_text).is_some()
     {
@@ -8245,6 +8292,61 @@ fn indexed_sequence_element_type_name(type_name: &str, index: Option<&str>) -> O
         return Some(element);
     }
     index.and_then(|index| tuple_element_type_name(type_name, index))
+}
+
+const TYPESCRIPT_STRUCTURAL_INDEX_PREFIX: &str = "__compass_structural_index__";
+
+fn typescript_structural_index_receiver(value_type: &str) -> String {
+    format!("{TYPESCRIPT_STRUCTURAL_INDEX_PREFIX}{value_type}")
+}
+
+fn typescript_structural_index_value(value: &str) -> Option<&str> {
+    let value = value.trim();
+    value
+        .strip_prefix(TYPESCRIPT_STRUCTURAL_INDEX_PREFIX)
+        .filter(|value_type| !value_type.is_empty() && value_type.len() <= MAX_TYPE_SHAPE_BYTES)
+}
+
+/// Extract one bounded string/number index-signature value from an inline
+/// object type such as `{[key:string]:Item}`. Mapped keys, multiple index
+/// signatures, and malformed/oversized shapes stay unresolved rather than
+/// widening a dynamic subscript to an arbitrary member.
+fn typescript_inline_index_value_type(value: &str) -> Option<String> {
+    let value = value.trim();
+    if !value.starts_with('{') || !value.ends_with('}') || value.len() > MAX_TYPE_SHAPE_BYTES {
+        return None;
+    }
+    let open = value.find('[')?;
+    let close = open.saturating_add(value.get(open..)?.find(']')?);
+    let key = value.get(open.saturating_add(1)..close)?.trim();
+    if key.is_empty() || key.contains(" in ") || key.starts_with("in ") {
+        return None;
+    }
+    let remainder = value.get(close.saturating_add(1)..)?.trim_start();
+    let colon = remainder.find(':')?;
+    let mut tail = remainder.get(colon.saturating_add(1)..)?.trim();
+    if tail.ends_with('}') {
+        tail = tail.get(..tail.len().saturating_sub(1))?.trim_end();
+    }
+    if tail.is_empty() || tail.contains('[') {
+        return None;
+    }
+    let mut depth = 0_u32;
+    let mut end = tail.len();
+    for (index, character) in tail.char_indices() {
+        match character {
+            '<' | '{' | '(' => depth = depth.saturating_add(1),
+            '>' | '}' | ')' => depth = depth.saturating_sub(1),
+            ';' | ',' if depth == 0 => {
+                end = index;
+                break;
+            }
+            _ => {}
+        }
+    }
+    let value_type = tail.get(..end)?.trim();
+    (!value_type.is_empty() && value_type.len() <= MAX_TYPE_SHAPE_BYTES)
+        .then(|| value_type.to_owned())
 }
 
 fn infer_candidate_type_arguments(
@@ -8797,6 +8899,8 @@ fn index_value_type(node: Node<'_>, source: &[u8]) -> Option<String> {
     let container = node
         .child_by_field_name("value")
         .or_else(|| node.child_by_field_name("body"))
+        .or_else(|| node.child_by_field_name("type"))
+        .or_else(|| node.child_by_field_name("type_annotation"))
         .or_else(|| (node.kind() == "object_type").then_some(node))?;
     let container = if container.kind() == "type_annotation" {
         first_named_child(container)?

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -4782,8 +4782,46 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         else {
             return Ok(());
         };
-        let argument_types = self.call_argument_types(node, scope_id);
-        let argument_count = call_argument_count(node);
+        let tagged_template = !construction
+            && node
+                .child_by_field_name("arguments")
+                .is_some_and(|arguments| arguments.kind() == "template_string");
+        let (argument_count, argument_types) = if tagged_template {
+            self.tagged_template_call_shape(node, scope_id)
+        } else {
+            (
+                call_argument_count(node),
+                self.call_argument_types(node, scope_id),
+            )
+        };
+        let dynamic_member_context = if construction {
+            "dynamic_new_member"
+        } else if tagged_template {
+            "dynamic_tagged_member"
+        } else {
+            "dynamic_member_call"
+        };
+        let member_context = if construction {
+            "new_member"
+        } else if tagged_template {
+            "tagged_member"
+        } else {
+            "member_call"
+        };
+        let dynamic_context = if construction {
+            "dynamic_new"
+        } else if tagged_template {
+            "dynamic_tagged"
+        } else {
+            "dynamic_call"
+        };
+        let call_context = if construction {
+            "new"
+        } else if tagged_template {
+            "tagged_template"
+        } else {
+            "call"
+        };
         let member_call = matches!(
             function.kind(),
             "member_expression" | "optional_member_expression" | "subscript_expression"
@@ -4815,11 +4853,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     },
                     &spelling,
                     qualifier.as_deref(),
-                    if construction {
-                        "dynamic_new_member"
-                    } else {
-                        "dynamic_member_call"
-                    },
+                    dynamic_member_context,
                     argument_count,
                     argument_types,
                     &[
@@ -4861,11 +4895,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     },
                     &spelling,
                     qualifier.as_deref(),
-                    if construction {
-                        "dynamic_new_member"
-                    } else {
-                        "dynamic_member_call"
-                    },
+                    dynamic_member_context,
                     argument_count,
                     argument_types,
                     &[
@@ -4885,7 +4915,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 scope_id,
                 object,
                 property,
-                call_argument_count(node),
+                argument_count,
                 &argument_types,
             );
             let Some(resolution) = resolution else {
@@ -4908,11 +4938,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         },
                         &property_name,
                         Some(&node_text(self.source, function)),
-                        if construction {
-                            "new_member"
-                        } else {
-                            "member_call"
-                        },
+                        member_context,
                         &target,
                         &module,
                         argument_count,
@@ -4947,11 +4973,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     },
                     &property_name,
                     Some(&node_text(self.source, function)),
-                    if construction {
-                        "new_member"
-                    } else {
-                        "member_call"
-                    },
+                    member_context,
                     argument_count,
                     argument_types,
                     &[
@@ -4981,11 +5003,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 },
                 &property_name,
                 Some(&node_text(self.source, function)),
-                Some(if construction {
-                    "new_member"
-                } else {
-                    "member_call"
-                }),
+                Some(member_context),
                 Namespace::Value,
                 argument_count,
                 argument_types,
@@ -5038,11 +5056,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 },
                 &spelling,
                 None,
-                if construction {
-                    "dynamic_new"
-                } else {
-                    "dynamic_call"
-                },
+                dynamic_context,
                 argument_count,
                 argument_types,
                 &["function", "class", "method", "constructor", "external"],
@@ -5118,6 +5132,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         None,
                         Some(if construction {
                             "new_this"
+                        } else if tagged_template {
+                            "tagged_template"
                         } else {
                             "this_call"
                         }),
@@ -5146,6 +5162,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 None,
                 if construction {
                     "new_this"
+                } else if tagged_template {
+                    "tagged_template"
                 } else {
                     "this_call"
                 },
@@ -5181,7 +5199,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     },
                     &spelling,
                     None,
-                    if construction { "new" } else { "call" },
+                    call_context,
                     &qualified_target,
                     &module,
                     argument_count,
@@ -5204,7 +5222,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 },
                 &spelling,
                 None,
-                if construction { "new" } else { "call" },
+                call_context,
                 argument_count,
                 argument_types,
                 &["function", "class", "method", "constructor", "external"],
@@ -5226,7 +5244,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             },
             &spelling,
             None,
-            Some(if construction { "new" } else { "call" }),
+            Some(call_context),
             Namespace::Value,
             argument_count,
             argument_types,
@@ -5248,6 +5266,47 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .filter(|argument| !argument.kind().contains("comment"))
             .map(|argument| self.call_argument_type(argument, scope_id))
             .collect()
+    }
+
+    /// A tagged template invokes its tag with a synthetic strings-array
+    /// argument followed by one argument per template substitution.
+    /// Preserve that exact arity, but leave the first array type unknown so
+    /// overload selection cannot mistake it for an ordinary array or string.
+    fn tagged_template_call_shape(
+        &self,
+        node: Node<'tree>,
+        scope_id: &str,
+    ) -> (Option<u32>, Vec<Option<String>>) {
+        let Some(arguments) = node
+            .child_by_field_name("arguments")
+            .filter(|arguments| arguments.kind() == "template_string")
+        else {
+            return (None, Vec::new());
+        };
+        let mut argument_types = vec![None];
+        let mut substitution_count = 0_usize;
+        let mut cursor = arguments.walk();
+        for child in arguments.named_children(&mut cursor) {
+            if child.kind() != "template_substitution" {
+                continue;
+            }
+            if substitution_count >= MAX_INLINE_OBJECT_PROPERTIES.saturating_sub(1) {
+                return (None, Vec::new());
+            }
+            substitution_count = substitution_count.saturating_add(1);
+            let expression = child
+                .child_by_field_name("expression")
+                .or_else(|| first_named_child(child));
+            argument_types.push(
+                expression.and_then(|expression| self.call_argument_type(expression, scope_id)),
+            );
+        }
+        (
+            substitution_count
+                .checked_add(1)
+                .and_then(|count| u32::try_from(count).ok()),
+            argument_types,
+        )
     }
 
     fn call_argument_type(&self, node: Node<'tree>, scope_id: &str) -> Option<String> {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -217,12 +217,17 @@ struct CandidateState<'source, 'tree> {
     /// Escape/dynamic barriers survive later local assignments because a
     /// captured binding or dynamic evaluator can observe the rebinding too.
     flow_escape_barriers: HashMap<String, Vec<usize>>,
+    /// Property-specific writes on an immutable source-proven receiver alias.
+    /// A write to an unrelated property does not erase the receiver identity,
+    /// while a write to the queried member remains a fail-closed barrier.
+    flow_member_write_barriers: HashMap<(String, String), Vec<usize>>,
     /// `const` bindings whose receiver identity is source-proven and cannot
-    /// be rebound.  A stable nominal alias may be captured by a closure
-    /// without widening the receiver; mutable/structural aliases still take
-    /// the conservative escape barrier below.
+    /// be rebound. Stable nominal and exact object-literal aliases may be
+    /// captured by a closure; mutable/unsupported aliases still take the
+    /// conservative escape barrier below.
     immutable_bindings: HashSet<String>,
     structural_object_variables: HashSet<String>,
+    stable_structural_object_variables: HashSet<String>,
     return_object_functions: HashSet<String>,
     /// A local variable initialized from a source-visible function whose
     /// return value is an object.  Store the declaration identity rather than
@@ -344,8 +349,10 @@ pub(crate) fn extract_candidate_tree_evidence(
         flow_assignments: HashMap::new(),
         flow_assignment_barriers: HashMap::new(),
         flow_escape_barriers: HashMap::new(),
+        flow_member_write_barriers: HashMap::new(),
         immutable_bindings: HashSet::new(),
         structural_object_variables: HashSet::new(),
+        stable_structural_object_variables: HashSet::new(),
         return_object_functions: HashSet::new(),
         variable_object_sources: HashMap::new(),
         variable_inline_type_receivers: HashMap::new(),
@@ -1018,6 +1025,10 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 && value.kind() == "object"
             {
                 self.structural_object_variables.insert(prefix.to_owned());
+                if !object_literal_has_spread(value) {
+                    self.stable_structural_object_variables
+                        .insert(prefix.to_owned());
+                }
                 object_literal_value_id = Some(value.id());
                 let mut cursor = value.walk();
                 for child in value.named_children(&mut cursor) {
@@ -1703,11 +1714,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     "member_expression" | "optional_member_expression" | "subscript_expression"
                 ) && let Some(object) = left.child_by_field_name("object")
                 {
-                    self.record_flow_value_escape(
+                    self.record_flow_member_write(
                         &scope_id,
                         object,
                         current.start_byte(),
-                        "dynamic member write",
+                        member_property_node(left)
+                            .and_then(|property| member_property_name(self.source, property))
+                            .as_deref(),
                     );
                 }
             }
@@ -1822,6 +1835,80 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
+    fn record_flow_member_write(
+        &mut self,
+        scope_id: &str,
+        object: Node<'tree>,
+        start_byte: usize,
+        property_name: Option<&str>,
+    ) {
+        let value = unwrap_expression_node(object);
+        let Some(property_name) = property_name.filter(|name| !name.is_empty()) else {
+            self.record_flow_value_escape(scope_id, value, start_byte, "dynamic member write");
+            return;
+        };
+        let Some(name_node) = rightmost_identifier(value) else {
+            self.record_flow_value_escape(scope_id, value, start_byte, "dynamic member write");
+            return;
+        };
+        let name = node_text(self.source, name_node);
+        let Some(Resolution::Local(declaration)) =
+            self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            self.record_flow_value_escape(scope_id, value, start_byte, "dynamic member write");
+            return;
+        };
+        if !matches!(declaration.kind.as_str(), "variable" | "parameter") {
+            self.record_flow_value_escape(scope_id, value, start_byte, "dynamic member write");
+            return;
+        }
+        if self.stable_immutable_receiver_alias(&declaration.id) {
+            self.record_flow_member_write_barrier(&declaration.id, property_name, start_byte);
+        } else {
+            self.record_flow_escape_barrier(&declaration.id, start_byte);
+        }
+    }
+
+    fn record_flow_member_write_barrier(
+        &mut self,
+        variable_id: &str,
+        property_name: &str,
+        start_byte: usize,
+    ) {
+        let barriers = self
+            .flow_member_write_barriers
+            .entry((variable_id.to_owned(), property_name.to_owned()))
+            .or_default();
+        if barriers.len() < MAX_INLINE_OBJECT_PROPERTIES {
+            barriers.push(start_byte);
+        } else if let Some(latest) = barriers.last_mut()
+            && *latest < start_byte
+        {
+            *latest = start_byte;
+        }
+    }
+
+    fn flow_member_write_barrier_before(
+        &self,
+        scope_id: &str,
+        object: Node<'tree>,
+        property_name: &str,
+        use_start_byte: usize,
+    ) -> bool {
+        let Some(name_node) = rightmost_identifier(object) else {
+            return false;
+        };
+        let name = node_text(self.source, name_node);
+        let Some(Resolution::Local(declaration)) =
+            self.resolve_name(scope_id, &name, Namespace::Value)
+        else {
+            return false;
+        };
+        self.flow_member_write_barriers
+            .get(&(declaration.id, property_name.to_owned()))
+            .is_some_and(|barriers| barriers.iter().any(|start| *start <= use_start_byte))
+    }
+
     fn record_flow_scope_barriers(&mut self, scope_id: &str, start_byte: usize, _reason: &str) {
         let mut visible = self
             .declarations
@@ -1867,7 +1954,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                         &self.scope_for_node(node),
                         &declaration.scope_id,
                     )
-                    && !self.stable_immutable_nominal_alias(&declaration.id)
+                    && !self.stable_immutable_receiver_alias(&declaration.id)
                 {
                     captured.insert(declaration.id.clone());
                 }
@@ -1911,6 +1998,23 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             return false;
         }
         assignment.receiver.import.is_some() || !assignment.receiver.qualified_name.is_empty()
+    }
+
+    fn stable_immutable_structural_alias(&self, declaration_id: &str) -> bool {
+        if !self.immutable_bindings.contains(declaration_id) {
+            return false;
+        }
+        self.declarations
+            .get(declaration_id)
+            .is_some_and(|declaration| {
+                self.stable_structural_object_variables
+                    .contains(&declaration.qualified_name)
+            })
+    }
+
+    fn stable_immutable_receiver_alias(&self, declaration_id: &str) -> bool {
+        self.stable_immutable_nominal_alias(declaration_id)
+            || self.stable_immutable_structural_alias(declaration_id)
     }
 
     fn flow_assignment_is_straight_line(&self, node: Node<'tree>, scope_id: &str) -> bool {
@@ -5362,6 +5466,14 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let object = object?;
         let receiver = self.receiver_target(scope_id, object)?;
         let property_name = member_property_name(self.source, property)?;
+        if self.flow_member_write_barrier_before(
+            scope_id,
+            object,
+            &property_name,
+            property.start_byte(),
+        ) {
+            return None;
+        }
         let projection = decode_utility_projection(&receiver.qualified_name);
         if let Some((utility, _, keys)) = projection.as_ref()
             && ((utility == "Pick" && !keys.contains(&property_name))
@@ -8878,6 +8990,12 @@ fn variable_binding_is_immutable(node: Node<'_>, source: &[u8]) -> bool {
         .split_whitespace()
         .next()
         .is_some_and(|keyword| keyword == "const")
+}
+
+fn object_literal_has_spread(node: Node<'_>) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| child.kind() == "spread_element")
 }
 
 fn type_alias_union_targets(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {

--- a/crates/compass-languages/src/evidence/validate.rs
+++ b/crates/compass-languages/src/evidence/validate.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::model::{
     BindingFact, CandidateRelation, DeclarationFact, EvidenceRange, HierarchyConstraint,
     LanguageCapability, OccurrenceFact, RelationshipCandidate, ScopeFact, SemanticEvidenceBatch,
-    SemanticRole,
+    SemanticRole, SymbolNamespace,
 };
 
 /// Hard resource ceilings for a single adapter evidence batch.
@@ -365,6 +365,30 @@ fn validate_fact(
             require_capability(&fact.id, fact.kind.required_capability(), capabilities)?;
             if fact.spelling.is_empty() || fact.qualified_target.is_empty() {
                 return Err(invalid_fact(&fact.id, "binding identity is empty"));
+            }
+            if fact.type_only
+                && !matches!(
+                    fact.kind,
+                    crate::BindingKind::Import
+                        | crate::BindingKind::ImportAlias
+                        | crate::BindingKind::Reexport
+                )
+            {
+                return Err(invalid_fact(
+                    &fact.id,
+                    "only import and re-export bindings may be type-only",
+                ));
+            }
+            if fact.type_only
+                && !matches!(
+                    fact.namespace,
+                    Some(SymbolNamespace::Type | SymbolNamespace::Namespace)
+                )
+            {
+                return Err(invalid_fact(
+                    &fact.id,
+                    "type-only bindings must identify the type or namespace symbol space",
+                ));
             }
             if fact.output_index.is_some() && fact.kind != crate::BindingKind::CallResult {
                 return Err(invalid_fact(

--- a/crates/compass-languages/src/json_config.rs
+++ b/crates/compass-languages/src/json_config.rs
@@ -7,6 +7,112 @@ use tree_sitter::Node;
 
 use crate::make_id;
 
+/// Parse the bounded JSON-with-comments dialect used by TypeScript project
+/// configuration. This intentionally accepts only comments and trailing
+/// commas; it does not implement a general JavaScript evaluator.
+///
+/// The parser is deliberately fail-closed: unterminated strings/comments and
+/// any value outside JSON after comment/trailing-comma normalization return
+/// `None`. Callers remain responsible for applying their own byte limits.
+#[must_use]
+pub fn parse_jsonc(source: &str) -> Option<Value> {
+    let mut without_comments = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(character) = chars.next() {
+        if in_string {
+            without_comments.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            without_comments.push(character);
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            for next in chars.by_ref() {
+                if matches!(next, '\n' | '\r') {
+                    without_comments.push(next);
+                    break;
+                }
+            }
+            continue;
+        }
+        if character == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            let mut terminated = false;
+            let mut previous = '\0';
+            for next in chars.by_ref() {
+                if matches!(next, '\n' | '\r') {
+                    without_comments.push(next);
+                }
+                if previous == '*' && next == '/' {
+                    terminated = true;
+                    break;
+                }
+                previous = next;
+            }
+            if !terminated {
+                return None;
+            }
+            continue;
+        }
+        without_comments.push(character);
+    }
+    if in_string {
+        return None;
+    }
+
+    let mut normalized = String::with_capacity(without_comments.len());
+    let characters = without_comments.chars().collect::<Vec<_>>();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut index = 0;
+    while index < characters.len() {
+        let character = characters[index];
+        if in_string {
+            normalized.push(character);
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == '"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if character == '"' {
+            in_string = true;
+            normalized.push(character);
+            index += 1;
+            continue;
+        }
+        if character == ',' {
+            let mut lookahead = index + 1;
+            while lookahead < characters.len() && characters[lookahead].is_whitespace() {
+                lookahead += 1;
+            }
+            if lookahead < characters.len() && matches!(characters[lookahead], ']' | '}') {
+                index += 1;
+                continue;
+            }
+        }
+        normalized.push(character);
+        index += 1;
+    }
+    serde_json::from_str(&normalized).ok()
+}
+
 const CONFIG_NAMES: &[&str] = &[
     "package.json",
     "tsconfig.json",
@@ -434,4 +540,44 @@ fn string_text(node: Node<'_>, source: &[u8]) -> String {
 
 fn text<'source>(node: Node<'_>, source: &'source [u8]) -> &'source str {
     node.utf8_text(source).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod jsonc_tests {
+    use super::parse_jsonc;
+    use serde_json::Value;
+
+    #[test]
+    fn accepts_comments_and_trailing_commas_inside_jsonc() {
+        let parsed = parse_jsonc(
+            r#"{
+                // Comment text may contain slash characters.
+                "url": "https://example.test/*",
+                "paths": {"@/*": ["src/*",],},
+            }"#,
+        );
+        assert_eq!(
+            parsed
+                .as_ref()
+                .and_then(|value| value.get("url"))
+                .and_then(Value::as_str),
+            Some("https://example.test/*")
+        );
+        assert_eq!(
+            parsed
+                .as_ref()
+                .and_then(|value| value.get("paths"))
+                .and_then(|value| value.get("@/*"))
+                .and_then(Value::as_array)
+                .and_then(|values| values.first())
+                .and_then(Value::as_str),
+            Some("src/*")
+        );
+    }
+
+    #[test]
+    fn rejects_unterminated_comments_and_strings() {
+        assert!(parse_jsonc("{/*").is_none());
+        assert!(parse_jsonc("{\"value\":\"unterminated").is_none());
+    }
 }

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -57,7 +57,7 @@ pub use evidence::{
     EvidenceDiagnostic, EvidenceError, EvidenceErrorCode, EvidenceLimits, EvidenceRange,
     HierarchyConstraint, LanguageCapability, OccurrenceFact, ReceiverDispatchStrategy,
     RelationshipCandidate, ResolutionConstraint, ScopeFact, SemanticEvidenceBatch, SemanticRole,
-    UNIVERSAL_EVIDENCE_SCHEMA, range_for_node, validate_evidence,
+    SymbolNamespace, UNIVERSAL_EVIDENCE_SCHEMA, range_for_node, validate_evidence,
 };
 pub use facts::{Extraction, RawCall, RawEdgeRecord, RawNodeRecord};
 pub use frameworks::{
@@ -68,6 +68,7 @@ pub use frameworks::{
 };
 pub use html::{HtmlError, HtmlNormalization, normalize_html};
 pub use ids::{file_stem, make_id, normalize_id};
+pub use json_config::parse_jsonc;
 pub use program::{TREE_SITTER_PROGRAM_PROVIDER_VERSION, TreeSitterSyntaxProvider};
 pub use project_evidence::{
     FRAMEWORK_PROJECT_EVIDENCE_EXTENSION, ProjectEvidence, ProjectEvidenceIndex,

--- a/crates/compass-languages/src/project_evidence.rs
+++ b/crates/compass-languages/src/project_evidence.rs
@@ -6,6 +6,8 @@ use regex::Regex;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use crate::json_config::parse_jsonc;
+
 pub const FRAMEWORK_PROJECT_EVIDENCE_EXTENSION: &str = "_compass_framework_project_evidence";
 
 const EVIDENCE_SCHEMA: &str = "compass.framework-project-evidence/1";
@@ -765,7 +767,7 @@ fn parse_package_configuration(source: &str, output: &mut ParsedConfiguration) {
 }
 
 fn parse_typescript_configuration(source: &str, output: &mut ParsedConfiguration) {
-    let Ok(root) = serde_json::from_str::<Value>(source) else {
+    let Some(root) = parse_jsonc(source) else {
         return;
     };
     let Some(options) = root.get("compilerOptions").and_then(Value::as_object) else {
@@ -1276,6 +1278,43 @@ mod tests {
         assert!(evidence.has_plugin("@vitejs/plugin-react"));
         assert!(evidence.has_plugin("next-plugin-intl"));
         assert!(evidence.has_route_root("next", "src/app"));
+        Ok(())
+    }
+
+    #[test]
+    fn typescript_jsonc_configuration_keeps_aliases_and_ignores_comment_text()
+    -> Result<(), Box<dyn Error>> {
+        let directory = tempdir()?;
+        let root = directory.path();
+        let source = root.join("src/app.ts");
+        fs::create_dir_all(source.parent().ok_or("source has no parent")?)?;
+        fs::write(&source, "export const app = true;\n")?;
+        fs::write(
+            root.join("tsconfig.json"),
+            r##"{
+                // The slash in this comment must not start a value.
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                        "@/*": ["./src/*",],
+                    },
+                },
+            }"##,
+        )?;
+
+        let index = ProjectEvidenceIndex::build(root, std::slice::from_ref(&source));
+        let evidence = index.evidence_for(&source);
+        assert!(
+            evidence
+                .configuration_keys()
+                .contains("compilerOptions.baseUrl")
+        );
+        assert!(
+            evidence
+                .configuration_keys()
+                .contains("compilerOptions.paths")
+        );
+        assert_eq!(evidence.aliases().get("@/*"), Some(&"src/*".to_owned()));
         Ok(())
     }
 

--- a/crates/compass-languages/src/registry.rs
+++ b/crates/compass-languages/src/registry.rs
@@ -77,9 +77,17 @@ impl Registry {
     }
 
     /// Return the hard-cut adapter associated with a resolved language.
+    ///
+    /// TSX is a parser dialect of the canonical TypeScript universal adapter;
+    /// keep the registry's `tsx` grammar name while publishing one stable
+    /// semantic language identity for resolution and cache invalidation.
     #[must_use]
     pub fn universal_profile_for_spec(spec: LanguageSpec) -> Option<&'static AdapterProfile> {
-        AdapterRegistry::universal_profile(spec.name)
+        let language = match spec.name {
+            "tsx" => "typescript",
+            language => language,
+        };
+        AdapterRegistry::universal_profile(language)
     }
 
     #[must_use]

--- a/crates/compass-languages/tests/callable_builtin_semantics.rs
+++ b/crates/compass-languages/tests/callable_builtin_semantics.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::error::Error;
 use std::path::Path;
 
@@ -11,70 +11,6 @@ fn calls(extraction: &Extraction) -> Vec<(&str, &str)> {
         .filter(|edge| edge.string("relation") == "calls")
         .map(|edge| (edge.source.as_str(), edge.target.as_str()))
         .collect()
-}
-
-fn callable_labels(extraction: &Extraction) -> HashMap<&str, String> {
-    extraction
-        .nodes
-        .iter()
-        .map(|node| {
-            (
-                node.id.as_str(),
-                node.label()
-                    .trim()
-                    .trim_matches(['(', ')'])
-                    .trim_start_matches('.')
-                    .to_owned(),
-            )
-        })
-        .collect()
-}
-
-fn assert_local_builtin_collisions_resolve(
-    path: &Path,
-    source: &[u8],
-    expected_sites: usize,
-) -> Result<(), Box<dyn Error>> {
-    let extraction = Engine::default().extract_source(path, source)?;
-    let labels = callable_labels(&extraction);
-    let local_calls = calls(&extraction)
-        .into_iter()
-        .filter_map(|(_, target)| labels.get(target).map(String::as_str))
-        .filter(|label| matches!(*label, "open" | "list" | "map" | "filter"))
-        .collect::<Vec<_>>();
-
-    assert_eq!(
-        local_calls.len(),
-        expected_sites,
-        "nodes={:?}\nedges={:?}\nraw_calls={:?}",
-        extraction.nodes,
-        extraction.edges,
-        extraction.raw_calls
-    );
-    assert_eq!(
-        local_calls.iter().copied().collect::<HashSet<_>>(),
-        HashSet::from(["open", "list", "map", "filter"])
-    );
-    for edge in extraction
-        .edges
-        .iter()
-        .filter(|edge| edge.string("relation") == "calls")
-    {
-        let start = edge
-            .attributes
-            .get("start_byte")
-            .and_then(|value| value.as_u64());
-        let end = edge
-            .attributes
-            .get("end_byte")
-            .and_then(|value| value.as_u64());
-        assert!(
-            matches!((start, end), (Some(start), Some(end)) if start < end),
-            "call has no exact source range: {edge:?}"
-        );
-        assert!(!edge.string("extractor").is_empty(), "edge={edge:?}");
-    }
-    Ok(())
 }
 
 fn assert_universal_builtin_collisions_are_resolvable(
@@ -164,7 +100,7 @@ class Collisions {
 #[test]
 fn local_javascript_and_python_declarations_override_builtin_spellings()
 -> Result<(), Box<dyn Error>> {
-    assert_local_builtin_collisions_resolve(
+    assert_universal_builtin_collisions_are_resolvable(
         Path::new("collisions.js"),
         br#"
 function open() {}
@@ -241,6 +177,49 @@ fn unresolved_javascript_and_python_builtins_remain_suppressed() -> Result<(), B
         ),
     ] {
         let extraction = Engine::default().extract_source(path, source)?;
+        if let Some(evidence) = extraction.semantic_evidence.as_ref() {
+            assert!(
+                extraction.nodes.is_empty(),
+                "{path:?}: nodes={:?}",
+                extraction.nodes
+            );
+            assert!(
+                extraction.edges.is_empty(),
+                "{path:?}: edges={:?}",
+                extraction.edges
+            );
+            assert!(
+                extraction.raw_calls.is_none(),
+                "{path:?}: raw_calls={:?}",
+                extraction.raw_calls
+            );
+            if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
+                assert_eq!(
+                    evidence
+                        .candidates
+                        .iter()
+                        .filter(|candidate| candidate.constraints.allow_external)
+                        .map(|candidate| candidate.target_spelling.as_str())
+                        .collect::<HashSet<_>>(),
+                    HashSet::from(["Map", "parseInt", "Array"]),
+                    "{path:?}: candidates={:?}",
+                    evidence.candidates
+                );
+                assert!(evidence.candidates.iter().all(|candidate| {
+                    !candidate.constraints.allow_external
+                        || candidate.constraints.module_or_package.as_deref()
+                            == Some("javascript.global")
+                }));
+            } else {
+                assert!(
+                    !evidence
+                        .candidates
+                        .iter()
+                        .any(|candidate| candidate.constraints.allow_external)
+                );
+            }
+            continue;
+        }
         assert!(
             calls(&extraction).is_empty(),
             "{path:?}: edges={:?}",

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -1367,6 +1367,134 @@ function health() { return "ok"; }
 }
 
 #[test]
+fn javascript_callback_values_are_references_without_invocation_evidence()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let path = directory.path().join("callbacks.ts");
+    fs::write(
+        &path,
+        r#"
+function register(_callback) {}
+function callback() {}
+const handlers = [callback];
+register(callback);
+"#,
+    )?;
+
+    let extraction = Engine::default().extract(&path)?;
+    let stem = path.with_extension("").to_string_lossy().replace('\\', "/");
+    let callback_id = make_id(&[&stem, "callback"]);
+    let callback_edges = extraction
+        .edges
+        .iter()
+        .filter(|edge| edge.target == callback_id)
+        .collect::<Vec<_>>();
+    assert!(
+        callback_edges.iter().any(|edge| {
+            edge.string("relation") == "references" && edge.string("context") == "argument"
+        }),
+        "callback id={callback_id}; callback edges={callback_edges:?}"
+    );
+    assert!(
+        callback_edges.iter().any(|edge| {
+            edge.string("relation") == "references" && edge.string("context") == "collection"
+        }),
+        "callback edges={callback_edges:?}"
+    );
+    assert!(
+        callback_edges
+            .iter()
+            .all(|edge| edge.string("relation") != "indirect_call")
+    );
+    Ok(())
+}
+
+#[test]
+fn javascript_typescript_import_kinds_commonjs_exports_and_jsx_references()
+-> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let target = directory.path().join("target.ts");
+    let consumer = directory.path().join("consumer.tsx");
+    let common_js = directory.path().join("loader.cjs");
+    fs::write(
+        &target,
+        "export default function render() {}\nexport const value = 1;\nexport class Button {}\n",
+    )?;
+    fs::write(
+        &consumer,
+        r#"import render, * as UI from "./target.js";
+import { Button } from "./target.js";
+import type { Button as ButtonType } from "./target.js";
+export function App(value: ButtonType) {
+  return <UI.Button value={value} onClick={render} />;
+}
+const local = Button;
+"#,
+    )?;
+    fs::write(
+        &common_js,
+        "function handler() {}\nmodule.exports = { handler };\nexports.named = handler;\n",
+    )?;
+
+    let mut engine = Engine::default();
+    let consumer_facts = engine.extract(&consumer)?;
+    let import_edges = consumer_facts
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "imports")
+        .collect::<Vec<_>>();
+    assert!(import_edges.iter().any(|edge| {
+        edge.string("imported_name") == "default"
+            && edge.string("import_kind") == "default"
+            && edge.string("local_name") == "render"
+    }));
+    assert!(import_edges.iter().any(|edge| {
+        edge.string("imported_name") == "*"
+            && edge.string("import_kind") == "namespace"
+            && edge.string("local_name") == "UI"
+    }));
+    assert!(import_edges.iter().any(|edge| {
+        edge.string("imported_name") == "Button"
+            && edge
+                .attributes
+                .get("type_only")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            && edge.string("local_name") == "ButtonType"
+    }));
+    assert!(
+        consumer_facts.edges.iter().any(|edge| {
+            edge.string("relation") == "references" && edge.string("context") == "jsx"
+        }),
+        "edges={:#?}",
+        consumer_facts.edges
+    );
+
+    let common_js_facts = engine.extract(&common_js)?;
+    let handler = make_id(&[&common_js.with_extension("").to_string_lossy(), "handler"]);
+    let commonjs_exports = common_js_facts
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "exports"
+                && edge.target == handler
+                && edge.string("module_format") == "commonjs"
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        commonjs_exports
+            .iter()
+            .any(|edge| edge.string("export_name") == "handler")
+    );
+    assert!(
+        commonjs_exports
+            .iter()
+            .any(|edge| edge.string("export_name") == "named")
+    );
+    Ok(())
+}
+
+#[test]
 fn dart_exports_have_explicit_resource_targets() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let path = directory.path().join("exports.dart");

--- a/crates/compass-languages/tests/engine_edge_coverage.rs
+++ b/crates/compass-languages/tests/engine_edge_coverage.rs
@@ -55,10 +55,7 @@ fn universal_framework_pack_registry_accepts_only_cut_over_language_evidence() {
     };
     assert_eq!(
         FrameworkPackRegistry::validate_descriptors(&[typescript]),
-        Err(FrameworkPackRegistryError::NonUniversalLanguage {
-            pack: descriptor.id,
-            language: "typescript",
-        })
+        Ok(())
     );
 
     let unsupported = FrameworkPackDescriptor {
@@ -271,26 +268,42 @@ class Second {
 "#;
 
     let extraction = Engine::default().extract_source(&path, source)?;
-    let constructors = extraction
-        .nodes
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing JavaScript universal evidence")?;
+    let constructors = evidence
+        .declarations
         .iter()
-        .filter(|node| node.label() == ".constructor()")
+        .filter(|declaration| declaration.kind == "constructor")
         .collect::<Vec<_>>();
 
-    assert_eq!(constructors.len(), 2, "nodes={:?}", extraction.nodes);
+    assert_eq!(
+        constructors.len(),
+        2,
+        "declarations={:?}",
+        evidence.declarations
+    );
     assert_eq!(
         constructors
             .iter()
-            .map(|node| node.string("lexical_owner"))
+            .map(|declaration| {
+                declaration
+                    .qualified_name
+                    .rsplit_once('.')
+                    .and_then(|(owner, _)| owner.rsplit_once('.').map(|(_, name)| name))
+                    .unwrap_or_default()
+                    .to_owned()
+            })
             .collect::<std::collections::BTreeSet<_>>(),
         ["First", "Second"].into_iter().map(str::to_owned).collect()
     );
     assert_eq!(
         constructors
             .iter()
-            .map(|node| node.string("qualified_name"))
+            .map(|declaration| declaration.qualified_name.clone())
             .collect::<std::collections::BTreeSet<_>>(),
-        ["First::constructor", "Second::constructor"]
+        ["bundle.First.constructor", "bundle.Second.constructor"]
             .into_iter()
             .map(str::to_owned)
             .collect()
@@ -1082,13 +1095,26 @@ export function run() { target(); View(); return item; }
     )?;
     let mut engine = Engine::default();
     let extraction = engine.extract(&source)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing JavaScript universal evidence")?;
+    assert!(evidence.bindings.iter().any(|binding| {
+        binding.spelling == "target" && binding.qualified_target == "./target.js::target"
+    }));
+    assert!(evidence.bindings.iter().any(|binding| {
+        binding.spelling == "View" && binding.qualified_target == "./view.jsx::View"
+    }));
+    assert!(evidence.bindings.iter().any(|binding| {
+        binding.spelling == "item" && binding.qualified_target == "./pkg::item"
+    }));
     assert!(
-        extraction
-            .edges
+        evidence
+            .candidates
             .iter()
-            .any(|edge| matches!(edge.string("relation").as_str(), "imports" | "imports_from")),
-        "edges={:?}",
-        extraction.edges
+            .filter(|candidate| candidate.relation == CandidateRelation::Imports)
+            .count()
+            >= 3
     );
     Ok(())
 }
@@ -1124,6 +1150,10 @@ fn javascript_modules_reexports_require_and_decorators_keep_compass_contracts()
 
     let mut engine = Engine::default();
     let barrel_facts = engine.extract(&barrel)?;
+    let barrel_evidence = barrel_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing barrel universal evidence")?;
     assert_eq!(
         barrel_facts
             .edges
@@ -1135,55 +1165,52 @@ fn javascript_modules_reexports_require_and_decorators_keep_compass_contracts()
         0,
         "file-level re-export edges belong to the collection resolver"
     );
-    assert_eq!(
-        barrel_facts
-            .edges
+    assert!(
+        barrel_evidence
+            .candidates
             .iter()
-            .filter(|edge| {
-                edge.string("relation") == "imports_from" && edge.string("context") == "re-export"
-            })
-            .count(),
-        2
+            .filter(|candidate| candidate.relation == CandidateRelation::Reexports)
+            .count()
+            >= 2
     );
-    assert!(barrel_facts.edges.iter().any(|edge| {
-        edge.string("relation") == "re_exports" && edge.string("context") == "re-export"
-    }));
 
     let decorated_facts = engine.extract(&decorated)?;
-    let decorator_id = make_id(&["Injectable"]);
-    assert!(decorated_facts.nodes.iter().any(|node| {
-        node.id == decorator_id
-            && node.label() == "Injectable"
-            && node.string("source_file").is_empty()
-    }));
-    assert!(decorated_facts.edges.iter().any(|edge| {
-        edge.target == decorator_id
-            && edge.string("relation") == "references"
-            && edge.string("context") == "decorator"
-    }));
-    assert!(decorated_facts.edges.iter().any(|edge| {
-        edge.target == make_id(&["ref", "@nestjs/common"])
-            && edge.string("relation") == "imports_from"
-    }));
+    let decorated_evidence = decorated_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing decorated universal evidence")?;
     assert!(
-        !decorated_facts
-            .edges
+        decorated_evidence
+            .occurrences
             .iter()
-            .any(|edge| { edge.string("relation") == "imports" && edge.target == decorator_id })
+            .any(|occurrence| occurrence.role == SemanticRole::Decorator)
     );
+    assert!(
+        decorated_evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == CandidateRelation::Decorates)
+    );
+    assert!(decorated_evidence.bindings.iter().any(|binding| {
+        binding.spelling == "Injectable" && binding.qualified_target == "@nestjs/common::Injectable"
+    }));
 
     let cjs_facts = engine.extract(&common_js)?;
+    let cjs_evidence = cjs_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing CommonJS universal evidence")?;
     assert!(
-        cjs_facts
-            .edges
+        cjs_evidence
+            .candidates
             .iter()
-            .any(|edge| edge.string("relation") == "imports_from")
+            .any(|candidate| candidate.relation == CandidateRelation::Imports)
     );
     assert!(
-        cjs_facts
-            .edges
+        cjs_evidence
+            .candidates
             .iter()
-            .any(|edge| edge.string("relation") == "imports")
+            .any(|candidate| candidate.relation == CandidateRelation::Reexports)
     );
     Ok(())
 }
@@ -1204,6 +1231,10 @@ fn typescript_type_star_reexports_do_not_discard_earlier_barrel_edges() -> Resul
 
     let mut engine = Engine::default();
     let extraction = engine.extract(&barrel)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
     assert_ne!(
         extraction
             .extensions
@@ -1212,15 +1243,13 @@ fn typescript_type_star_reexports_do_not_discard_earlier_barrel_edges() -> Resul
         Some(EXTRACTION_QUALITY_PARTIAL),
         "a supported type-only star re-export must not mark the whole file partial"
     );
-    assert_eq!(
-        extraction
-            .edges
+    assert!(
+        evidence
+            .candidates
             .iter()
-            .filter(|edge| {
-                edge.string("relation") == "imports_from" && edge.string("context") == "re-export"
-            })
-            .count(),
-        2,
+            .filter(|candidate| candidate.relation == CandidateRelation::Reexports)
+            .count()
+            >= 2,
         "both star re-exports must remain source-grounded"
     );
     Ok(())
@@ -1244,6 +1273,10 @@ fn typescript_import_type_query_gap_does_not_quarantine_namespace_heritage()
 
     let mut engine = Engine::default();
     let extraction = engine.extract(&path)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
     assert_ne!(
         extraction
             .extensions
@@ -1252,10 +1285,10 @@ fn typescript_import_type_query_gap_does_not_quarantine_namespace_heritage()
         Some(EXTRACTION_QUALITY_PARTIAL)
     );
     assert_eq!(
-        extraction
-            .edges
+        evidence
+            .candidates
             .iter()
-            .filter(|edge| edge.string("relation") == "inherits")
+            .filter(|candidate| candidate.relation == CandidateRelation::Extends)
             .count(),
         2
     );
@@ -1278,45 +1311,54 @@ fn javascript_and_typescript_heritage_edges_keep_exact_base_sites() -> Result<()
 
     let mut engine = Engine::default();
     let typescript_facts = engine.extract(&typescript)?;
-    let type_id = |label: &str| {
-        typescript_facts
-            .nodes
+    let typescript_evidence = typescript_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
+    let declaration_id = |name: &str| {
+        typescript_evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == label)
-            .map(|node| node.id.as_str())
+            .find(|declaration| declaration.name == name)
+            .map(|declaration| declaration.id.as_str())
     };
-    assert!(typescript_facts.edges.iter().any(|edge| {
-        Some(edge.source.as_str()) == type_id("AddOptions")
-            && Some(edge.target.as_str()) == type_id("ContextOptions")
-            && edge.string("relation") == "inherits"
-            && edge.string("source_location") == "L2"
+    assert!(typescript_evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Extends
+            && Some(candidate.source_declaration_id.as_str()) == declaration_id("AddOptions")
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == declaration_id("ContextOptions")
+            && candidate.occurrence_id.is_some()
     }));
-    assert!(typescript_facts.edges.iter().any(|edge| {
-        Some(edge.source.as_str()) == type_id("Derived")
-            && Some(edge.target.as_str()) == type_id("Base")
-            && edge.string("relation") == "inherits"
-            && edge.string("source_location") == "L4"
+    assert!(typescript_evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Extends
+            && Some(candidate.source_declaration_id.as_str()) == declaration_id("Derived")
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == declaration_id("Base")
     }));
-    assert!(typescript_facts.edges.iter().any(|edge| {
-        Some(edge.source.as_str()) == type_id("Derived")
-            && Some(edge.target.as_str()) == type_id("ContextOptions")
-            && edge.string("relation") == "implements"
-            && edge.string("source_location") == "L4"
+    assert!(typescript_evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Implements
+            && Some(candidate.source_declaration_id.as_str()) == declaration_id("Derived")
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == declaration_id("ContextOptions")
     }));
 
     let javascript_facts = engine.extract(&javascript)?;
+    let javascript_evidence = javascript_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing JavaScript universal evidence")?;
     let javascript_id = |label: &str| {
-        javascript_facts
-            .nodes
+        javascript_evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == label)
-            .map(|node| node.id.as_str())
+            .find(|declaration| declaration.name == label)
+            .map(|declaration| declaration.id.as_str())
     };
-    assert!(javascript_facts.edges.iter().any(|edge| {
-        Some(edge.source.as_str()) == javascript_id("DomainError")
-            && Some(edge.target.as_str()) == javascript_id("ErrorBase")
-            && edge.string("relation") == "inherits"
-            && edge.string("source_location") == "L2"
+    assert!(javascript_evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Extends
+            && Some(candidate.source_declaration_id.as_str()) == javascript_id("DomainError")
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == javascript_id("ErrorBase")
     }));
     Ok(())
 }
@@ -1339,6 +1381,10 @@ function health() { return "ok"; }
     )?;
 
     let extraction = Engine::default().extract(&path)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
     for name in [
         "app",
         "settings",
@@ -1346,20 +1392,16 @@ function health() { return "ok"; }
         "Stream",
         "nodeMajorVersion",
     ] {
-        let binding = extraction
-            .nodes
+        let binding = evidence
+            .declarations
             .iter()
-            .find(|node| node.label() == name)
+            .find(|declaration| declaration.name == name && declaration.kind == "variable")
             .ok_or_else(|| format!("missing {name} binding"))?;
-        assert_eq!(
-            binding.string("symbol_kind"),
-            "variable",
-            "binding={binding:#?}"
-        );
+        assert_eq!(binding.kind, "variable", "binding={binding:#?}");
     }
-    assert!(!extraction.nodes.iter().any(|node| {
+    assert!(!evidence.declarations.iter().any(|declaration| {
         matches!(
-            node.label(),
+            declaration.name.as_str(),
             "EventEmitterPassThroughStream" | "nodeMajorVersionprocessversionsnodesplit"
         )
     }));
@@ -1382,29 +1424,39 @@ register(callback);
     )?;
 
     let extraction = Engine::default().extract(&path)?;
-    let stem = path.with_extension("").to_string_lossy().replace('\\', "/");
-    let callback_id = make_id(&[&stem, "callback"]);
-    let callback_edges = extraction
-        .edges
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
+    let callback_id = evidence
+        .declarations
         .iter()
-        .filter(|edge| edge.target == callback_id)
+        .find(|declaration| declaration.name == "callback")
+        .ok_or("missing callback declaration")?
+        .id
+        .clone();
+    let callback_candidates = evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(callback_id.as_str())
+        })
         .collect::<Vec<_>>();
     assert!(
-        callback_edges.iter().any(|edge| {
-            edge.string("relation") == "references" && edge.string("context") == "argument"
+        callback_candidates.iter().any(|candidate| {
+            candidate.relation == CandidateRelation::References && candidate.occurrence_id.is_some()
         }),
-        "callback id={callback_id}; callback edges={callback_edges:?}"
+        "callback id={callback_id}; callback candidates={callback_candidates:?}"
     );
     assert!(
-        callback_edges.iter().any(|edge| {
-            edge.string("relation") == "references" && edge.string("context") == "collection"
-        }),
-        "callback edges={callback_edges:?}"
+        callback_candidates.len() >= 2,
+        "callback candidates={callback_candidates:?}"
     );
     assert!(
-        callback_edges
+        callback_candidates
             .iter()
-            .all(|edge| edge.string("relation") != "indirect_call")
+            .all(|candidate| candidate.relation != CandidateRelation::IndirectCalls)
     );
     Ok(())
 }
@@ -1438,58 +1490,61 @@ const local = Button;
 
     let mut engine = Engine::default();
     let consumer_facts = engine.extract(&consumer)?;
-    let import_edges = consumer_facts
-        .edges
-        .iter()
-        .filter(|edge| edge.string("relation") == "imports")
-        .collect::<Vec<_>>();
-    assert!(import_edges.iter().any(|edge| {
-        edge.string("imported_name") == "default"
-            && edge.string("import_kind") == "default"
-            && edge.string("local_name") == "render"
+    let consumer_evidence = consumer_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TSX universal evidence")?;
+    assert!(consumer_evidence.bindings.iter().any(|binding| {
+        binding.spelling == "render" && binding.qualified_target == "./target.js::default"
     }));
-    assert!(import_edges.iter().any(|edge| {
-        edge.string("imported_name") == "*"
-            && edge.string("import_kind") == "namespace"
-            && edge.string("local_name") == "UI"
+    assert!(consumer_evidence.bindings.iter().any(|binding| {
+        binding.spelling == "UI" && binding.qualified_target == "./target.js::*"
     }));
-    assert!(import_edges.iter().any(|edge| {
-        edge.string("imported_name") == "Button"
-            && edge
-                .attributes
-                .get("type_only")
-                .and_then(serde_json::Value::as_bool)
-                == Some(true)
-            && edge.string("local_name") == "ButtonType"
+    assert!(consumer_evidence.bindings.iter().any(|binding| {
+        binding.spelling == "ButtonType"
+            && binding.qualified_target == "./target.js::Button"
+            && binding.type_only
+    }));
+    assert!(consumer_evidence.bindings.iter().any(|binding| {
+        binding.spelling == "Button" && binding.qualified_target == "./target.js::Button"
     }));
     assert!(
-        consumer_facts.edges.iter().any(|edge| {
-            edge.string("relation") == "references" && edge.string("context") == "jsx"
-        }),
-        "edges={:#?}",
-        consumer_facts.edges
+        consumer_evidence
+            .occurrences
+            .iter()
+            .any(|occurrence| occurrence.context.as_deref() == Some("jsx"))
+    );
+    assert!(
+        consumer_evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == CandidateRelation::References),
+        "candidates={:#?}",
+        consumer_evidence.candidates
     );
 
     let common_js_facts = engine.extract(&common_js)?;
-    let handler = make_id(&[&common_js.with_extension("").to_string_lossy(), "handler"]);
-    let commonjs_exports = common_js_facts
-        .edges
+    let commonjs_evidence = common_js_facts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing CommonJS universal evidence")?;
+    let commonjs_exports = commonjs_evidence
+        .candidates
         .iter()
-        .filter(|edge| {
-            edge.string("relation") == "exports"
-                && edge.target == handler
-                && edge.string("module_format") == "commonjs"
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Reexports
+                && matches!(candidate.target_spelling.as_str(), "handler" | "named")
         })
         .collect::<Vec<_>>();
     assert!(
         commonjs_exports
             .iter()
-            .any(|edge| edge.string("export_name") == "handler")
+            .any(|candidate| candidate.target_spelling == "handler")
     );
     assert!(
         commonjs_exports
             .iter()
-            .any(|edge| edge.string("export_name") == "named")
+            .any(|candidate| candidate.target_spelling == "named")
     );
     Ok(())
 }
@@ -1528,16 +1583,25 @@ fn repeated_anonymous_class_methods_receive_cross_definition_discriminators()
     let source = fs::read(&path)?;
 
     let extraction = Engine::default().extract_source(&path, &source)?;
-    let methods = extraction
-        .nodes
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing JavaScript universal evidence")?;
+    let methods = evidence
+        .declarations
         .iter()
-        .filter(|node| node.label() == "cleanUp()")
+        .filter(|declaration| declaration.name == "cleanUp")
         .collect::<Vec<_>>();
     assert!(methods.len() >= 2, "methods={methods:?}");
     assert_eq!(
         methods
             .iter()
-            .map(|node| node.string("overload_discriminator"))
+            .map(|declaration| {
+                (
+                    declaration.qualified_name.clone(),
+                    declaration.range.start_byte,
+                )
+            })
             .collect::<std::collections::BTreeSet<_>>()
             .len(),
         methods.len(),

--- a/crates/compass-languages/tests/registry.rs
+++ b/crates/compass-languages/tests/registry.rs
@@ -114,12 +114,12 @@ fn ids_match_python_unicode_casefold_contract() {
 }
 
 #[test]
-fn rust_is_a_version_thirteen_hard_cut_candidate_descriptor() {
+fn rust_is_a_version_fifteen_hard_cut_candidate_descriptor() {
     let rust = AdapterRegistry::universal_profile("rust").expect("Rust universal profile");
     assert_eq!(rust.id, "compass.rust");
     assert_eq!(rust.language, "rust");
     assert_eq!(rust.evidence_schema, UNIVERSAL_EVIDENCE_SCHEMA);
-    assert_eq!(rust.version, 13);
+    assert_eq!(rust.version, 15);
     assert_eq!(rust.profile, UniversalAdapterProfile::UniversalCandidate);
     for capability in [
         LanguageCapability::Namespaces,
@@ -138,7 +138,42 @@ fn rust_is_a_version_thirteen_hard_cut_candidate_descriptor() {
         );
     }
 
-    assert!(AdapterRegistry::universal_profile("typescript").is_none());
+    let typescript =
+        AdapterRegistry::universal_profile("typescript").expect("TypeScript universal profile");
+    assert_eq!(typescript.id, "compass.typescript.candidate");
+    assert_eq!(typescript.language, "typescript");
+    assert_eq!(typescript.evidence_schema, UNIVERSAL_EVIDENCE_SCHEMA);
+    assert_eq!(typescript.version, 5);
+    assert_eq!(
+        typescript.profile,
+        UniversalAdapterProfile::UniversalCandidate
+    );
+    for capability in [
+        LanguageCapability::Namespaces,
+        LanguageCapability::Imports,
+        LanguageCapability::Reexports,
+        LanguageCapability::Calls,
+        LanguageCapability::Construction,
+        LanguageCapability::TypeReferences,
+        LanguageCapability::BaseTypes,
+        LanguageCapability::Members,
+        LanguageCapability::ExternalReferences,
+    ] {
+        assert!(
+            typescript.capabilities.contains(&capability),
+            "missing {capability:?}: {typescript:?}"
+        );
+    }
+
+    let javascript =
+        AdapterRegistry::universal_profile("javascript").expect("JavaScript universal profile");
+    assert_eq!(javascript.id, "compass.javascript.candidate");
+    assert_eq!(javascript.language, "javascript");
+    assert_eq!(javascript.version, 5);
+    assert_eq!(
+        javascript.profile,
+        UniversalAdapterProfile::UniversalCandidate
+    );
 }
 
 #[test]
@@ -173,6 +208,9 @@ fn only_hard_cut_languages_expose_universal_profiles() {
     let go = Registry::resolve(Path::new("src/example.go")).expect("go spec");
     let java = Registry::resolve(Path::new("src/Example.java")).expect("java spec");
     let rust = Registry::resolve(Path::new("src/example.rs")).expect("rust spec");
+    let typescript = Registry::resolve(Path::new("src/example.ts")).expect("typescript spec");
+    let tsx = Registry::resolve(Path::new("src/example.tsx")).expect("tsx spec");
+    let javascript = Registry::resolve(Path::new("src/example.js")).expect("javascript spec");
 
     assert_eq!(
         Registry::universal_profile_for_spec(python).map(|profile| profile.language),
@@ -191,7 +229,23 @@ fn only_hard_cut_languages_expose_universal_profiles() {
         Some("rust")
     );
     assert_eq!(
+        Registry::universal_profile_for_spec(typescript).map(|profile| profile.language),
+        Some("typescript")
+    );
+    assert_eq!(
+        Registry::universal_profile_for_spec(tsx).map(|profile| profile.language),
+        Some("typescript")
+    );
+    assert_eq!(
+        Registry::universal_profile_for_spec(javascript).map(|profile| profile.language),
+        Some("javascript")
+    );
+    assert_eq!(
         Registry::universal_adapter(Path::new("src/example.py")).map(|profile| profile.language),
         Some("python")
+    );
+    assert_eq!(
+        Registry::universal_adapter(Path::new("src/example.tsx")).map(|profile| profile.language),
+        Some("typescript")
     );
 }

--- a/crates/compass-languages/tests/rust_universal_conformance.rs
+++ b/crates/compass-languages/tests/rust_universal_conformance.rs
@@ -32,7 +32,7 @@ fn build() {
         .ok_or("missing Rust semantic evidence")?;
 
     assert_eq!(evidence.adapter.id, "compass.rust");
-    assert_eq!(evidence.adapter.version, 13);
+    assert_eq!(evidence.adapter.version, 15);
     assert_eq!(
         evidence.adapter.evidence_schema,
         "compass.languages.evidence/1"

--- a/crates/compass-languages/tests/semantic_producers.rs
+++ b/crates/compass-languages/tests/semantic_producers.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::fs;
 
-use compass_languages::{Engine, Extraction};
+use compass_languages::{BindingKind, CandidateRelation, Engine, Extraction, SemanticRole};
 
 fn kinds(extraction: &Extraction) -> HashSet<String> {
     extraction
@@ -232,56 +232,47 @@ function helper() {}
 Widget.prototype.render = function () { helper(); };
 Other.prototype.render = () => helper();
 Plugin.fn.install = function () { helper(); };
-const config = {};
+    const config = {};
 config.render = function () { helper(); };
 "#;
     let extraction = Engine::default().extract_source(&path, source)?;
-    let prototype_methods = extraction
-        .nodes
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing JavaScript universal evidence")?;
+    let prototype_methods = evidence
+        .declarations
         .iter()
-        .filter(|node| {
-            matches!(
-                node.string("qualified_name").as_str(),
-                "Widget.prototype::render" | "Other.prototype::render" | "Plugin.fn::install"
-            )
+        .filter(|declaration| {
+            declaration.kind == "property"
+                && ["Widget.prototype", "Other.prototype", "Plugin.fn"]
+                    .iter()
+                    .any(|prefix| declaration.qualified_name.contains(prefix))
         })
         .collect::<Vec<_>>();
     assert_eq!(prototype_methods.len(), 3);
-    assert!(prototype_methods.iter().all(|node| {
-        node.string("symbol_kind") == "method"
-            && extraction.edges.iter().any(|edge| {
-                edge.string("relation") == "contains"
-                    && edge.target == node.id
-                    && extraction.nodes.iter().any(|owner| {
-                        owner.id == edge.source
-                            && matches!(owner.label(), "Widget()" | "Other()" | "Plugin()")
-                    })
-            })
-            && extraction.edges.iter().any(|edge| {
-                edge.string("relation") == "calls"
-                    && edge.source == node.id
-                    && extraction
-                        .nodes
-                        .iter()
-                        .any(|target| target.id == edge.target && target.label() == "helper()")
-            })
-    }));
-    assert_eq!(
-        extraction
-            .nodes
-            .iter()
-            .filter(|node| node.label() == ".render()")
-            .count(),
-        2,
-        "ordinary object-property assignments must not become prototype methods"
-    );
+    let helper = evidence
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "helper")
+        .ok_or("missing helper declaration")?;
+    let helper_calls = evidence
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "helper"
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(helper.id.as_str())
+        })
+        .count();
+    assert!(helper_calls >= 3, "candidates={:?}", evidence.candidates);
     assert!(
-        extraction
-            .nodes
+        evidence
+            .declarations
             .iter()
-            .all(|node| node.string("qualified_name") != "config::render")
+            .any(|declaration| declaration.qualified_name.contains("config.render"))
     );
-    assert_unique_node_ids(&extraction);
     Ok(())
 }
 
@@ -406,7 +397,7 @@ fn build(mut graph: Graph) {
         "compass.languages.evidence/1"
     );
     assert_eq!(evidence.adapter.id, "compass.rust");
-    assert_eq!(evidence.adapter.version, 13);
+    assert_eq!(evidence.adapter.version, 15);
 
     let calls = evidence
         .occurrences
@@ -563,10 +554,12 @@ export class Service extends Base {
   override run(value: Contract): Contract { return value; }
 }
 export { Service as DefaultService };
-"#;
+    "#;
     let extraction = Engine::default().extract_source(&path, source)?;
-    let node_kinds = kinds(&extraction);
-    let edge_kinds = relations(&extraction);
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
 
     for expected in [
         "constructor",
@@ -576,25 +569,50 @@ export { Service as DefaultService };
         "annotation",
     ] {
         assert!(
-            node_kinds.contains(expected),
-            "missing {expected}: nodes={:?}",
-            extraction.nodes
+            (expected == "export"
+                && evidence
+                    .bindings
+                    .iter()
+                    .any(|binding| binding.kind == BindingKind::Reexport))
+                || evidence
+                    .declarations
+                    .iter()
+                    .any(|declaration| declaration.kind == expected)
+                || evidence.occurrences.iter().any(|occurrence| {
+                    matches!(
+                        occurrence.role,
+                        SemanticRole::Annotation | SemanticRole::TypeReference
+                    ) && expected == "annotation"
+                }),
+            "missing {expected}: declarations={:?}, bindings={:?}, occurrences={:?}",
+            evidence.declarations,
+            evidence.bindings,
+            evidence.occurrences
         );
     }
-    for expected in [
-        "type_of",
-        "returns",
-        "overrides",
-        "decorates",
-        "aliases",
-        "exports",
-    ] {
-        assert!(
-            edge_kinds.contains(expected),
-            "missing {expected}: edges={:?}",
-            extraction.edges
-        );
-    }
+    assert!(evidence.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::References
+            && candidate.target_spelling == "Contract"
+            && candidate.constraints.qualified_name.as_deref() == Some("semantic.Contract")
+    }));
+    assert!(
+        evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == compass_languages::CandidateRelation::Decorates)
+    );
+    assert!(
+        evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == compass_languages::CandidateRelation::Reexports)
+    );
+    assert!(
+        evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == CandidateRelation::Reexports)
+    );
     Ok(())
 }
 
@@ -862,29 +880,52 @@ class Service {
 }
 "#;
     let ts = Engine::default().extract_source(&ts_path, ts_source)?;
-    let ts_items = ts
-        .nodes
+    let ts_evidence = ts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
+    let ts_items = ts_evidence
+        .declarations
         .iter()
-        .filter(|node| node.string("symbol_kind") == "class" && node.label() == "Item")
+        .filter(|declaration| declaration.kind == "class" && declaration.name == "Item")
         .collect::<Vec<_>>();
-    assert_eq!(ts_items.len(), 2, "nodes={:?}", ts.nodes);
     assert_eq!(
-        ts.nodes
+        ts_items.len(),
+        2,
+        "declarations={:?}",
+        ts_evidence.declarations
+    );
+    assert_eq!(
+        ts_evidence
+            .declarations
             .iter()
-            .filter(|node| node.string("symbol_kind") == "constructor")
+            .filter(|declaration| declaration.kind == "constructor")
             .count(),
         3,
-        "nodes={:?}",
-        ts.nodes
+        "declarations={:?}",
+        ts_evidence.declarations
     );
+    let overloaded = ts_evidence
+        .declarations
+        .iter()
+        .filter(|declaration| {
+            declaration.kind == "constructor"
+                || (declaration.kind == "method" && declaration.name == "run")
+        })
+        .collect::<Vec<_>>();
     assert!(
-        ts.nodes
+        overloaded.len() >= 6,
+        "declarations={:?}",
+        ts_evidence.declarations
+    );
+    assert_eq!(
+        overloaded
             .iter()
-            .filter(|node| {
-                node.string("symbol_kind") == "constructor"
-                    || (node.string("symbol_kind") == "method" && node.label().contains("run"))
-            })
-            .all(|node| !node.string("overload_discriminator").is_empty())
+            .map(|declaration| declaration.id.as_str())
+            .collect::<HashSet<_>>()
+            .len(),
+        overloaded.len(),
+        "overload declarations must retain distinct identities"
     );
 
     let csharp_path = directory.path().join("Scoped.cs");
@@ -1002,21 +1043,73 @@ namespace Two {
         run(value: number): void {}
     }
     class Shared {}
-}
+    }
 "#;
     let ts = Engine::default().extract_source(&ts_path, ts_source)?;
-    for (target, owner) in [
-        ("Shared@", None),
-        ("One::Item@", Some("One")),
-        ("One::Nested", Some("One")),
-        ("One::Nested::Leaf@", Some("One::Nested")),
-        ("Two::Item@", Some("Two")),
-        ("Two::Shared@", Some("Two")),
+    let ts_evidence = ts
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
+    for (target_suffix, owner_suffix) in [
+        (".Shared", None),
+        (".One.Item", Some(".One")),
+        (".One.Nested", Some(".One")),
+        (".One.Nested.Leaf", Some(".One.Nested")),
+        (".Two.Item", Some(".Two")),
+        (".Two.Shared", Some(".Two")),
     ] {
-        assert_exact_containment(&ts, target, owner)?;
+        let target = ts_evidence
+            .declarations
+            .iter()
+            .find(|declaration| {
+                (target_suffix == ".Shared" && declaration.qualified_name == "ownership.Shared")
+                    || (target_suffix != ".Shared"
+                        && declaration.qualified_name.ends_with(target_suffix))
+                        && declaration.name == target_suffix.rsplit('.').next().unwrap_or_default()
+            })
+            .ok_or_else(|| {
+                format!(
+                    "missing target {target_suffix}: {:?}",
+                    ts_evidence
+                        .declarations
+                        .iter()
+                        .map(|declaration| declaration.qualified_name.as_str())
+                        .collect::<Vec<_>>()
+                )
+            })?;
+        let scope = ts_evidence
+            .scopes
+            .iter()
+            .find(|scope| scope.id == target.scope_id.clone().unwrap_or_default())
+            .ok_or_else(|| format!("missing scope for {target_suffix}"))?;
+        let owner = ts_evidence
+            .declarations
+            .iter()
+            .find(|declaration| {
+                scope
+                    .owner_declaration_id
+                    .as_deref()
+                    .is_some_and(|owner_id| declaration.id == owner_id)
+            })
+            .ok_or_else(|| format!("missing scope owner for {target_suffix}"))?;
+        match owner_suffix {
+            Some(expected) => assert!(
+                owner.qualified_name.ends_with(expected),
+                "target {target_suffix} owner={}",
+                owner.qualified_name
+            ),
+            None => assert_eq!(
+                owner.kind, "module",
+                "target {target_suffix} owner={owner:#?}"
+            ),
+        }
     }
-    assert_unique_node_ids(&ts);
-    assert_containment_sites_belong_to_targets(&ts);
+    let declaration_ids = ts_evidence
+        .declarations
+        .iter()
+        .map(|declaration| declaration.id.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(declaration_ids.len(), ts_evidence.declarations.len());
 
     let csharp_path = directory.path().join("Ownership.cs");
     let csharp_source = b"class Shared {} namespace One { class Item { void Run(int value) {} } class Outer { class Leaf {} } } namespace Two { class Item { void Run(int value) {} } class Shared {} }\n";
@@ -1088,26 +1181,56 @@ class Service { run() { const marker = " override "; } }
 export { A as First, B as Second, Service };
 "#;
     let extraction = Engine::default().extract_source(&ts, ts_source)?;
+    let evidence = extraction
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript universal evidence")?;
+    for exported in ["First", "Second", "Service"] {
+        assert!(
+            evidence.bindings.iter().any(
+                |binding| binding.kind == BindingKind::Reexport && binding.spelling == exported
+            ),
+            "missing re-export {exported}: bindings={:?}",
+            evidence.bindings
+        );
+    }
     assert!(
-        !relations(&extraction).contains("overrides"),
-        "edges={:?}",
-        extraction.edges
-    );
-    let exports = extraction
-        .nodes
-        .iter()
-        .filter(|node| node.string("symbol_kind") == "export")
-        .map(|node| node.label())
-        .collect::<HashSet<_>>();
-    assert!(exports.contains("First"), "nodes={:?}", extraction.nodes);
-    assert!(exports.contains("Second"), "nodes={:?}", extraction.nodes);
-    assert!(exports.contains("Service"), "nodes={:?}", extraction.nodes);
-    assert!(
-        extraction.nodes.iter().any(|node| {
-            node.string("symbol_kind") == "annotation" && node.label() == "ns.decorate"
+        evidence.occurrences.iter().any(|occurrence| {
+            occurrence.role == SemanticRole::Decorator
+                && occurrence.spelling == "decorate"
+                && occurrence.qualifier.as_deref() == Some("ns.decorate")
         }),
-        "nodes={:?}",
-        extraction.nodes
+        "missing decorator occurrence: occurrences={:?}",
+        evidence.occurrences
+    );
+    assert!(
+        evidence
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == CandidateRelation::Decorates),
+        "missing decorator candidate: candidates={:?}",
+        evidence.candidates
+    );
+    let exports = evidence
+        .bindings
+        .iter()
+        .filter(|binding| binding.kind == BindingKind::Reexport)
+        .map(|binding| binding.spelling.as_str())
+        .collect::<HashSet<_>>();
+    assert!(
+        exports.contains("First"),
+        "bindings={:?}",
+        evidence.bindings
+    );
+    assert!(
+        exports.contains("Second"),
+        "bindings={:?}",
+        evidence.bindings
+    );
+    assert!(
+        exports.contains("Service"),
+        "bindings={:?}",
+        evidence.bindings
     );
 
     let rust = directory.path().join("attributes.rs");

--- a/crates/compass-languages/tests/typescript_corpus_differential.rs
+++ b/crates/compass-languages/tests/typescript_corpus_differential.rs
@@ -224,6 +224,7 @@ fn supported_construct(construct: &OracleConstruct) -> bool {
         | ("implements", "base_types")
         | ("references", "type_references") => true,
         ("references", "jsx") => jsx_component,
+        ("references", "jsx_values") => true,
         _ => false,
     }
 }
@@ -288,6 +289,14 @@ fn candidate_key_names(
         CandidateRelation::Implements => Some(("implements", "base_types")),
         CandidateRelation::References if occurrence.context.as_deref() == Some("jsx") => {
             Some(("references", "jsx"))
+        }
+        CandidateRelation::References
+            if matches!(
+                occurrence.context.as_deref(),
+                Some("jsx_value" | "jsx_spread" | "jsx_child")
+            ) =>
+        {
+            Some(("references", "jsx_values"))
         }
         CandidateRelation::References => Some(("references", "type_references")),
         _ => None,

--- a/crates/compass-languages/tests/typescript_corpus_differential.rs
+++ b/crates/compass-languages/tests/typescript_corpus_differential.rs
@@ -1,0 +1,295 @@
+//! Developer-only real-corpus differential qualification for the
+//! TypeScript/JavaScript universal candidate.
+//!
+//! This test intentionally remains ignored.  It runs the independent pinned
+//! TypeScript 5.9.3 compiler oracle over a read-only corpus supplied through
+//! `COMPASS_TS_QUALIFICATION_ROOT`, then compares source-byte coverage against
+//! the tree-sitter candidate.  It measures coverage by relation/capability;
+//! target identity and precision still require the adjudication workflow in
+//! Plan 013.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use compass_languages::{CandidateRelation, Engine, SemanticEvidenceBatch};
+use serde::Deserialize;
+
+const ORACLE_SCHEMA: &str = "compass.typescript-source-oracle/1";
+const ORACLE_PROVIDER: &str = "typescript_compiler_api_5_9_3";
+const MAX_ORACLE_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OraclePayload {
+    schema: String,
+    provider: String,
+    scanned_files: usize,
+    parsed_files: usize,
+    rejected_files: Vec<serde_json::Value>,
+    constructs: Vec<OracleConstruct>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OracleConstruct {
+    source_file: String,
+    relation: String,
+    capability: String,
+    target_spelling: String,
+    start_byte: u64,
+    end_byte: u64,
+}
+
+type SourceKey = (String, String, String, u64, u64);
+
+#[test]
+#[ignore = "developer-only real TypeScript/JavaScript corpus differential"]
+fn pinned_compiler_corpus_has_candidate_source_coverage() {
+    let root = env::var_os("COMPASS_TS_QUALIFICATION_ROOT")
+        .map(PathBuf::from)
+        .expect("set COMPASS_TS_QUALIFICATION_ROOT to a read-only pinned corpus");
+    let root = root.canonicalize().expect("qualification corpus root");
+    assert!(
+        root.is_dir(),
+        "qualification corpus is not a directory: {root:?}"
+    );
+
+    let oracle = run_oracle(&root);
+    assert_eq!(oracle.schema, ORACLE_SCHEMA);
+    assert_eq!(oracle.provider, ORACLE_PROVIDER);
+    assert_eq!(oracle.scanned_files, oracle.parsed_files);
+    assert!(oracle.rejected_files.is_empty(), "oracle rejected files");
+
+    let expected = oracle
+        .constructs
+        .iter()
+        .filter(|construct| supported_construct(construct))
+        .map(source_key)
+        .collect::<BTreeSet<_>>();
+    assert!(
+        !expected.is_empty(),
+        "oracle emitted no supported constructs"
+    );
+
+    let files = oracle
+        .constructs
+        .iter()
+        .map(|construct| construct.source_file.clone())
+        .collect::<BTreeSet<_>>();
+    let mut observed = BTreeSet::new();
+    let mut extraction_errors = Vec::new();
+    let mut engine = Engine::default();
+    for source_file in files {
+        let path = safe_source_path(&root, &source_file);
+        let source = match fs::read(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                extraction_errors.push(format!("{source_file}: read failed: {error}"));
+                continue;
+            }
+        };
+        match engine.extract_source_universal_candidate_evidence(&path, &source_file, &source) {
+            Ok(batch) => observed.extend(candidate_source_keys(&batch)),
+            Err(error) => extraction_errors.push(format!("{source_file}: {error}")),
+        }
+    }
+    assert!(
+        extraction_errors.is_empty(),
+        "candidate extraction failed for {} files: {}",
+        extraction_errors.len(),
+        extraction_errors
+            .iter()
+            .take(20)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
+
+    let covered = expected.intersection(&observed).count();
+    let missing = expected.difference(&observed).cloned().collect::<Vec<_>>();
+    let mut expected_by_stratum = BTreeMap::<(String, String), usize>::new();
+    let mut missing_by_stratum = BTreeMap::<(String, String), usize>::new();
+    for key in &expected {
+        *expected_by_stratum
+            .entry((key.1.clone(), key.2.clone()))
+            .or_default() += 1;
+    }
+    for key in &missing {
+        *missing_by_stratum
+            .entry((key.1.clone(), key.2.clone()))
+            .or_default() += 1;
+    }
+    eprintln!(
+        "TypeScript/JavaScript candidate corpus coverage: {covered}/{} ({:.2}%), observed={} expected={} strata={expected_by_stratum:?} missing={missing_by_stratum:?}",
+        expected.len(),
+        (covered as f64) * 100.0 / (expected.len() as f64),
+        observed.len(),
+        expected.len(),
+    );
+    let mut examples_by_stratum = BTreeMap::<(String, String), Vec<String>>::new();
+    for construct in &oracle.constructs {
+        if !supported_construct(construct) || observed.contains(&source_key(construct)) {
+            continue;
+        }
+        let bucket = (construct.relation.clone(), construct.capability.clone());
+        let examples = examples_by_stratum.entry(bucket).or_default();
+        if examples.len() < 5 {
+            examples.push(format!(
+                "{}:{}-{} {:?}",
+                construct.source_file,
+                construct.start_byte,
+                construct.end_byte,
+                construct.target_spelling,
+            ));
+        }
+    }
+    eprintln!("candidate coverage missing examples: {examples_by_stratum:?}");
+    // This is a measurement fixture, not the release gate.  Keep the failure
+    // useful for regressions without pretending source coverage proves target
+    // precision or leadership.
+    assert!(
+        covered > 0,
+        "candidate lost all supported source coverage; missing sample: {:?}",
+        missing.iter().take(20).collect::<Vec<_>>()
+    );
+}
+
+fn run_oracle(root: &Path) -> OraclePayload {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned();
+    let script = repository.join("benchmarks/performance/oracles/typescript-source-oracle.mjs");
+    let output = Command::new("node")
+        .current_dir(&repository)
+        .arg(&script)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .expect("pinned TypeScript oracle requires node");
+    assert!(
+        output.stdout.len() <= MAX_ORACLE_OUTPUT_BYTES,
+        "oracle output exceeds bounded test limit"
+    );
+    assert!(
+        output.status.success(),
+        "TypeScript oracle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid TypeScript oracle JSON")
+}
+
+fn safe_source_path(root: &Path, source_file: &str) -> PathBuf {
+    let relative = Path::new(source_file);
+    assert!(
+        !relative.is_absolute(),
+        "oracle source escaped root: {source_file:?}"
+    );
+    assert!(
+        !relative
+            .components()
+            .any(|component| { matches!(component, std::path::Component::ParentDir) }),
+        "oracle source escaped root: {source_file:?}"
+    );
+    let path = root.join(relative);
+    let canonical = path.canonicalize().expect("oracle source path");
+    assert!(
+        canonical.starts_with(root),
+        "oracle source escaped root: {source_file:?}"
+    );
+    canonical
+}
+
+fn supported_construct(construct: &OracleConstruct) -> bool {
+    let jsx_component = construct
+        .target_spelling
+        .split('.')
+        .next()
+        .and_then(|name| name.chars().next())
+        .is_some_and(|character| !character.is_ascii_lowercase());
+    match (construct.relation.as_str(), construct.capability.as_str()) {
+        ("declares", "declarations")
+        | ("imports", "imports")
+        | ("reexports", "reexports")
+        | ("calls", "calls")
+        | ("instantiates", "construction")
+        | ("accesses", "members")
+        | ("extends", "base_types")
+        | ("implements", "base_types")
+        | ("references", "type_references") => true,
+        ("references", "jsx") => jsx_component,
+        _ => false,
+    }
+}
+
+fn source_key(construct: &OracleConstruct) -> SourceKey {
+    (
+        construct.source_file.clone(),
+        construct.relation.clone(),
+        construct.capability.clone(),
+        construct.start_byte,
+        construct.end_byte,
+    )
+}
+
+fn candidate_source_keys(batch: &SemanticEvidenceBatch) -> BTreeSet<SourceKey> {
+    let mut keys = BTreeSet::new();
+    for declaration in &batch.declarations {
+        keys.insert((
+            declaration.range.source_file.clone(),
+            "declares".to_owned(),
+            "declarations".to_owned(),
+            declaration.range.start_byte,
+            declaration.range.end_byte,
+        ));
+    }
+    for candidate in &batch.candidates {
+        let Some(occurrence_id) = candidate.occurrence_id.as_deref() else {
+            continue;
+        };
+        let Some(occurrence) = batch
+            .occurrences
+            .iter()
+            .find(|occurrence| occurrence.id == occurrence_id)
+        else {
+            continue;
+        };
+        let Some((relation, capability)) = candidate_key_names(candidate, occurrence) else {
+            continue;
+        };
+        keys.insert((
+            occurrence.range.source_file.clone(),
+            relation.to_owned(),
+            capability.to_owned(),
+            occurrence.range.start_byte,
+            occurrence.range.end_byte,
+        ));
+    }
+    keys
+}
+
+fn candidate_key_names(
+    candidate: &compass_languages::RelationshipCandidate,
+    occurrence: &compass_languages::OccurrenceFact,
+) -> Option<(&'static str, &'static str)> {
+    match candidate.relation {
+        CandidateRelation::Imports => Some(("imports", "imports")),
+        CandidateRelation::Reexports => Some(("reexports", "reexports")),
+        CandidateRelation::Calls => Some(("calls", "calls")),
+        CandidateRelation::Constructs => Some(("instantiates", "construction")),
+        CandidateRelation::AccessesMember => Some(("accesses", "members")),
+        CandidateRelation::Extends => Some(("extends", "base_types")),
+        CandidateRelation::Implements => Some(("implements", "base_types")),
+        CandidateRelation::References if occurrence.context.as_deref() == Some("jsx") => {
+            Some(("references", "jsx"))
+        }
+        CandidateRelation::References => Some(("references", "type_references")),
+        _ => None,
+    }
+}

--- a/crates/compass-languages/tests/typescript_inherited_members.rs
+++ b/crates/compass-languages/tests/typescript_inherited_members.rs
@@ -1,0 +1,48 @@
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use compass_languages::{CandidateRelation, Engine};
+
+#[test]
+fn inherited_parameter_properties_resolve_through_this() {
+    let source = br#"
+abstract class Base {
+    constructor(public benchmarks: Record<string, unknown>) {}
+    add() { this.benchmarks; }
+}
+class Child extends Base {
+    read() { this.benchmarks; }
+}
+"#;
+    let batch = Engine::default()
+        .extract_source_universal_candidate_evidence(
+            Path::new("src/inherited.ts"),
+            "src/inherited.ts",
+            source,
+        )
+        .expect("candidate evidence");
+    let declaration = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Base.constructor.benchmarks")
+        })
+        .expect("parameter property declaration");
+    assert_eq!(declaration.kind, "parameter");
+    let targets = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::AccessesMember
+                && candidate.target_spelling == "benchmarks"
+        })
+        .filter_map(|candidate| candidate.constraints.exact_target_declaration_id.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        targets,
+        vec![declaration.id.as_str(), declaration.id.as_str()]
+    );
+}

--- a/crates/compass-languages/tests/typescript_oracle_differential.rs
+++ b/crates/compass-languages/tests/typescript_oracle_differential.rs
@@ -1,0 +1,187 @@
+//! Developer-only differential qualification for the TypeScript/JavaScript
+//! universal candidate.
+//!
+//! The test is deliberately ignored in the normal Rust suite: the production
+//! boundary must not require Node.js or the TypeScript compiler. Run it with
+//! `cargo test -p compass-languages --test typescript_oracle_differential
+//! -- --ignored` when the pinned benchmark oracle is available.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use compass_languages::{CandidateRelation, Engine, SemanticEvidenceBatch};
+use serde::Deserialize;
+use tempfile::tempdir;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OraclePayload {
+    schema: String,
+    provider: String,
+    constructs: Vec<OracleConstruct>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OracleConstruct {
+    source_file: String,
+    relation: String,
+    capability: String,
+    start_byte: u64,
+    end_byte: u64,
+}
+
+#[test]
+#[ignore = "developer-only TypeScript compiler differential"]
+fn pinned_compiler_constructs_have_candidate_source_coverage() {
+    let root = tempdir().expect("temporary differential root");
+    let main = root.path().join("src/main.tsx");
+    let ui = root.path().join("src/ui.ts");
+    fs::create_dir_all(main.parent().expect("main parent")).expect("source directory");
+    fs::write(
+        &ui,
+        "export class Button {}\nexport function parse(value: string) { return value; }\n",
+    )
+    .expect("ui fixture");
+    fs::write(
+        &main,
+        "import * as UI from './ui';\n\
+         interface Shape { value: string }\n\
+         class Base { run() {} }\n\
+         class Child extends Base {\n\
+             render(value: string) {\n\
+                 super.run();\n\
+                 UI.Button;\n\
+                 return <UI.Button />;\n\
+             }\n\
+         }\n\
+         function parse(value: string) { return value; }\n\
+         function parse(value: number) { return value; }\n\
+         export { Child, parse };\n\
+         new Child().render('ok');\n\
+         const instance = new Child();\n\
+         instance[\"render\"]('ok');\n",
+    )
+    .expect("main fixture");
+
+    let oracle = run_oracle(root.path());
+    assert_eq!(oracle.schema, "compass.typescript-source-oracle/1");
+    assert_eq!(oracle.provider, "typescript_compiler_api_5_9_3");
+
+    let mut engine = Engine::default();
+    let source = fs::read(&main).expect("main source");
+    let batch = engine
+        .extract_source_universal_candidate_evidence(&main, "src/main.tsx", &source)
+        .expect("candidate evidence");
+    let observed = candidate_source_keys(&batch);
+    let expected = oracle
+        .constructs
+        .iter()
+        .filter(|construct| construct.source_file == "src/main.tsx")
+        .filter(|construct| supported_construct(construct))
+        .map(|construct| {
+            (
+                construct.relation.clone(),
+                construct.capability.clone(),
+                construct.start_byte,
+                construct.end_byte,
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    assert!(
+        expected.len() >= 20,
+        "fixture did not exercise enough constructs"
+    );
+    let missing = expected.difference(&observed).cloned().collect::<Vec<_>>();
+    assert!(
+        missing.is_empty(),
+        "candidate lost compiler-backed source coverage: {missing:?}"
+    );
+}
+
+fn run_oracle(root: &Path) -> OraclePayload {
+    let manifest_directory = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repository = manifest_directory
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root");
+    let script = repository.join("benchmarks/performance/oracles/typescript-source-oracle.mjs");
+    let output = Command::new("node")
+        .current_dir(repository)
+        .arg(&script)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .expect("pinned TypeScript oracle requires node");
+    assert!(
+        output.status.success(),
+        "TypeScript oracle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid TypeScript oracle JSON")
+}
+
+fn supported_construct(construct: &OracleConstruct) -> bool {
+    matches!(
+        (construct.relation.as_str(), construct.capability.as_str()),
+        ("declares", "declarations")
+            | ("imports", "imports")
+            | ("reexports", "reexports")
+            | ("calls", "calls")
+            | ("instantiates", "construction")
+            | ("accesses", "members")
+            | ("extends", "base_types")
+            | ("implements", "base_types")
+            | ("references", "jsx")
+            | ("references", "type_references")
+    )
+}
+
+fn candidate_source_keys(batch: &SemanticEvidenceBatch) -> BTreeSet<(String, String, u64, u64)> {
+    let mut keys = BTreeSet::new();
+    for declaration in &batch.declarations {
+        keys.insert((
+            "declares".to_owned(),
+            "declarations".to_owned(),
+            declaration.range.start_byte,
+            declaration.range.end_byte,
+        ));
+    }
+    for candidate in &batch.candidates {
+        let Some(occurrence_id) = candidate.occurrence_id.as_deref() else {
+            continue;
+        };
+        let Some(occurrence) = batch
+            .occurrences
+            .iter()
+            .find(|occurrence| occurrence.id == occurrence_id)
+        else {
+            continue;
+        };
+        let (relation, capability) = match candidate.relation {
+            CandidateRelation::Imports => ("imports", "imports"),
+            CandidateRelation::Reexports => ("reexports", "reexports"),
+            CandidateRelation::Calls => ("calls", "calls"),
+            CandidateRelation::Constructs => ("instantiates", "construction"),
+            CandidateRelation::AccessesMember => ("accesses", "members"),
+            CandidateRelation::Extends => ("extends", "base_types"),
+            CandidateRelation::Implements => ("implements", "base_types"),
+            CandidateRelation::References if occurrence.context.as_deref() == Some("jsx") => {
+                ("references", "jsx")
+            }
+            CandidateRelation::References => ("references", "type_references"),
+            _ => continue,
+        };
+        keys.insert((
+            relation.to_owned(),
+            capability.to_owned(),
+            occurrence.range.start_byte,
+            occurrence.range.end_byte,
+        ));
+    }
+    keys
+}

--- a/crates/compass-languages/tests/typescript_oracle_differential.rs
+++ b/crates/compass-languages/tests/typescript_oracle_differential.rs
@@ -61,6 +61,8 @@ fn pinned_compiler_constructs_have_candidate_source_coverage() {
          }\n\
          function parse(value: string) { return value; }\n\
          function parse(value: number) { return value; }\n\
+         type Item = (typeof import('./ui').Button)[number];\n\
+         type Plain = import('./ui').Button;\n\
          export { Child, parse };\n\
          new Child().render('ok');\n\
          const instance = new Child();\n\

--- a/crates/compass-languages/tests/typescript_oracle_differential.rs
+++ b/crates/compass-languages/tests/typescript_oracle_differential.rs
@@ -137,6 +137,7 @@ fn supported_construct(construct: &OracleConstruct) -> bool {
             | ("extends", "base_types")
             | ("implements", "base_types")
             | ("references", "jsx")
+            | ("references", "jsx_values")
             | ("references", "type_references")
     )
 }
@@ -172,6 +173,14 @@ fn candidate_source_keys(batch: &SemanticEvidenceBatch) -> BTreeSet<(String, Str
             CandidateRelation::Implements => ("implements", "base_types"),
             CandidateRelation::References if occurrence.context.as_deref() == Some("jsx") => {
                 ("references", "jsx")
+            }
+            CandidateRelation::References
+                if matches!(
+                    occurrence.context.as_deref(),
+                    Some("jsx_value" | "jsx_spread" | "jsx_child")
+                ) =>
+            {
+                ("references", "jsx_values")
             }
             CandidateRelation::References => ("references", "type_references"),
             _ => continue,

--- a/crates/compass-languages/tests/typescript_target_differential.rs
+++ b/crates/compass-languages/tests/typescript_target_differential.rs
@@ -15,22 +15,35 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use compass_languages::{CandidateRelation, Engine, SemanticEvidenceBatch};
-use serde::Deserialize;
+use compass_languages::{CandidateRelation, Engine, SemanticEvidenceBatch, make_id};
+use serde::{Deserialize, Serialize};
 
 const ORACLE_SCHEMA: &str = "compass.typescript-target-oracle/1";
 const ORACLE_PROVIDER: &str = "typescript_checker_api_5_9_3";
 const MAX_ORACLE_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+const TARGET_REPORT_SCHEMA: &str = "compass.typescript-target-adjudication/1";
+const MAX_TARGET_REPORT_OUTPUT_BYTES: usize = 128 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OraclePayload {
     schema: String,
     provider: String,
+    metadata: Option<OracleMetadata>,
     scanned_files: usize,
     parsed_files: usize,
     rejected_files: Vec<serde_json::Value>,
     constructs: Vec<OracleConstruct>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OracleMetadata {
+    compiler_version: Option<String>,
+    node_version: Option<String>,
+    script_sha256: Option<String>,
+    platform: Option<String>,
+    source_digest: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -50,17 +63,74 @@ struct OracleConstruct {
 
 type SourceKey = (String, String, String, u64, u64);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
 enum CandidateTarget {
     Local {
+        #[serde(rename = "sourceFile")]
         source_file: String,
+        #[serde(rename = "startByte")]
         start: u64,
+        #[serde(rename = "endByte")]
         end: u64,
     },
     External {
+        #[serde(rename = "qualifiedName")]
         qualified_name: String,
     },
     Unresolved,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetAdjudicationRecord {
+    id: String,
+    source_file: String,
+    relation: String,
+    capability: String,
+    target_spelling: String,
+    start_byte: u64,
+    end_byte: u64,
+    oracle_resolution_kind: String,
+    oracle_target_file: Option<String>,
+    oracle_target_start_byte: Option<u64>,
+    oracle_target_end_byte: Option<u64>,
+    observed: Vec<CandidateTarget>,
+    automatic_outcome: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetAdjudicationStratum {
+    relation: String,
+    capability: String,
+    expected_local: usize,
+    correct: usize,
+    missing: usize,
+    wrong: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetAdjudicationReport {
+    schema: &'static str,
+    provider: &'static str,
+    candidate_adapter: &'static str,
+    metadata: Option<OracleMetadata>,
+    scanned_files: usize,
+    parsed_files: usize,
+    rejected_files: Vec<serde_json::Value>,
+    supported_constructs: usize,
+    expected_local: usize,
+    correct: usize,
+    missing: usize,
+    wrong: usize,
+    positive: usize,
+    positive_correct: usize,
+    false_positive: usize,
+    external_positive: usize,
+    strata: Vec<TargetAdjudicationStratum>,
+    records: Vec<TargetAdjudicationRecord>,
 }
 
 #[test]
@@ -78,6 +148,7 @@ fn checker_oracle_adjudicates_local_candidate_targets() {
     let oracle = run_oracle(&root);
     assert_eq!(oracle.schema, ORACLE_SCHEMA);
     assert_eq!(oracle.provider, ORACLE_PROVIDER);
+    assert!(oracle.metadata.is_some(), "oracle metadata is required");
     assert_eq!(oracle.scanned_files, oracle.parsed_files);
     assert!(oracle.rejected_files.is_empty(), "oracle rejected files");
 
@@ -273,6 +344,108 @@ fn checker_oracle_adjudicates_local_candidate_targets() {
             }
         }
     }
+    let records = supported
+        .iter()
+        .map(|construct| {
+            let key = source_key(construct);
+            let observed_targets = observed.get(&key).cloned().unwrap_or_default();
+            let expected_target = construct
+                .target_file
+                .as_deref()
+                .zip(construct.target_start_byte)
+                .zip(construct.target_end_byte)
+                .map(|((file, start), end)| (file, start, end));
+            let has_exact_target = expected_target.is_some_and(|(file, start, end)| {
+                observed_targets.iter().any(|target| {
+                    matches!(
+                        target,
+                        CandidateTarget::Local {
+                            source_file,
+                            start: observed_start,
+                            end: observed_end,
+                        } if source_file == file
+                            && *observed_start == start
+                            && *observed_end == end
+                    )
+                })
+            });
+            let has_local_target = observed_targets
+                .iter()
+                .any(|target| matches!(target, CandidateTarget::Local { .. }));
+            let automatic_outcome = if has_exact_target {
+                "correct"
+            } else if expected_target.is_some() && has_local_target {
+                "wrong"
+            } else if expected_target.is_some() {
+                "missing"
+            } else if has_local_target {
+                "false_positive"
+            } else if observed_targets.is_empty() {
+                "no_candidate"
+            } else {
+                "no_local_target"
+            };
+            TargetAdjudicationRecord {
+                id: make_id(&[
+                    "typescript-target-record",
+                    &construct.source_file,
+                    &construct.relation,
+                    &construct.capability,
+                    &construct.start_byte.to_string(),
+                    &construct.end_byte.to_string(),
+                ]),
+                source_file: construct.source_file.clone(),
+                relation: construct.relation.clone(),
+                capability: construct.capability.clone(),
+                target_spelling: construct.target_spelling.clone(),
+                start_byte: construct.start_byte,
+                end_byte: construct.end_byte,
+                oracle_resolution_kind: construct.resolution_kind.clone(),
+                oracle_target_file: construct.target_file.clone(),
+                oracle_target_start_byte: construct.target_start_byte,
+                oracle_target_end_byte: construct.target_end_byte,
+                observed: observed_targets,
+                automatic_outcome: automatic_outcome.to_owned(),
+            }
+        })
+        .collect::<Vec<_>>();
+    if let Some(destination) = env::var_os("COMPASS_TS_TARGET_REPORT") {
+        write_target_report(
+            &PathBuf::from(destination),
+            &TargetAdjudicationReport {
+                schema: TARGET_REPORT_SCHEMA,
+                provider: ORACLE_PROVIDER,
+                candidate_adapter: "compass.ecmascript.candidate",
+                metadata: oracle.metadata.clone(),
+                scanned_files: oracle.scanned_files,
+                parsed_files: oracle.parsed_files,
+                rejected_files: oracle.rejected_files.clone(),
+                supported_constructs: supported.len(),
+                expected_local: expected.len(),
+                correct,
+                missing,
+                wrong,
+                positive,
+                positive_correct,
+                false_positive,
+                external_positive,
+                strata: by_stratum
+                    .iter()
+                    .map(
+                        |((relation, capability), counts)| TargetAdjudicationStratum {
+                            relation: relation.clone(),
+                            capability: capability.clone(),
+                            expected_local: counts[0],
+                            correct: counts[1],
+                            missing: counts[2],
+                            wrong: counts[3],
+                        },
+                    )
+                    .collect(),
+                records,
+            },
+        );
+    }
     eprintln!(
         "TypeScript/JavaScript checker target adjudication: correct={correct} expected_local={} missing={missing} wrong={wrong} positive={positive} positive_correct={positive_correct} false_positive={false_positive} external_positive={external_positive} supported={} strata={by_stratum:?} wrong_examples={wrong_examples:?} false_positive_examples={false_positive_examples:?} missing_examples={missing_examples:?}",
         expected.len(),
@@ -282,6 +455,34 @@ fn checker_oracle_adjudicates_local_candidate_targets() {
     // useful for regressions while Plan 013's accepted-sample labels and
     // Wilson interval policy are still being assembled.
     assert!(correct.saturating_add(missing).saturating_add(wrong) == expected.len());
+}
+
+fn write_target_report(destination: &Path, report: &TargetAdjudicationReport) {
+    assert!(
+        !destination.as_os_str().is_empty(),
+        "COMPASS_TS_TARGET_REPORT must not be empty"
+    );
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    assert!(
+        parent.is_dir(),
+        "target report parent directory does not exist: {parent:?}"
+    );
+    let encoded = serde_json::to_vec(report).expect("target adjudication report JSON");
+    assert!(
+        encoded.len() <= MAX_TARGET_REPORT_OUTPUT_BYTES,
+        "target adjudication report exceeds bounded output limit"
+    );
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("target report file name must be valid UTF-8");
+    let temporary = destination.with_file_name(format!(".{file_name}.tmp"));
+    fs::write(&temporary, &encoded).expect("write target adjudication report");
+    fs::rename(&temporary, destination).expect("publish target adjudication report");
+    eprintln!(
+        "TypeScript/JavaScript target adjudication report: {}",
+        destination.display()
+    );
 }
 
 fn run_oracle(root: &Path) -> OraclePayload {

--- a/crates/compass-languages/tests/typescript_target_differential.rs
+++ b/crates/compass-languages/tests/typescript_target_differential.rs
@@ -544,6 +544,7 @@ fn is_supported_construct(construct: &OracleConstruct) -> bool {
             | ("extends", "base_types")
             | ("implements", "base_types")
             | ("references", "jsx")
+            | ("references", "jsx_values")
             | ("references", "type_references")
     )
 }
@@ -619,6 +620,11 @@ fn relation_name(
         CandidateRelation::Extends => Some(("extends", "base_types")),
         CandidateRelation::Implements => Some(("implements", "base_types")),
         CandidateRelation::References if context == Some("jsx") => Some(("references", "jsx")),
+        CandidateRelation::References
+            if matches!(context, Some("jsx_value" | "jsx_spread" | "jsx_child")) =>
+        {
+            Some(("references", "jsx_values"))
+        }
         CandidateRelation::References => Some(("references", "type_references")),
         _ => None,
     }

--- a/crates/compass-languages/tests/typescript_target_differential.rs
+++ b/crates/compass-languages/tests/typescript_target_differential.rs
@@ -1,0 +1,424 @@
+//! Developer-only compiler-checker target adjudication for the
+//! TypeScript/JavaScript universal candidate.
+//!
+//! The test is intentionally ignored. It compares exact local declaration
+//! anchors from an independent TypeScript 5.9.3 checker oracle with candidate
+//! target constraints. Cross-file, external, unresolved, and ambiguous
+//! outcomes are reported separately; source occurrence recall is measured by
+//! typescript_corpus_differential.rs.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use compass_languages::{CandidateRelation, Engine, SemanticEvidenceBatch};
+use serde::Deserialize;
+
+const ORACLE_SCHEMA: &str = "compass.typescript-target-oracle/1";
+const ORACLE_PROVIDER: &str = "typescript_checker_api_5_9_3";
+const MAX_ORACLE_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OraclePayload {
+    schema: String,
+    provider: String,
+    scanned_files: usize,
+    parsed_files: usize,
+    rejected_files: Vec<serde_json::Value>,
+    constructs: Vec<OracleConstruct>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OracleConstruct {
+    source_file: String,
+    relation: String,
+    capability: String,
+    target_spelling: String,
+    start_byte: u64,
+    end_byte: u64,
+    resolution_kind: String,
+    target_file: Option<String>,
+    target_start_byte: Option<u64>,
+    target_end_byte: Option<u64>,
+}
+
+type SourceKey = (String, String, String, u64, u64);
+
+#[derive(Debug, Clone)]
+enum CandidateTarget {
+    Local {
+        source_file: String,
+        start: u64,
+        end: u64,
+    },
+    External {
+        qualified_name: String,
+    },
+    Unresolved,
+}
+
+#[test]
+#[ignore = "developer-only real TypeScript/JavaScript target adjudication"]
+fn checker_oracle_adjudicates_local_candidate_targets() {
+    let root = env::var_os("COMPASS_TS_QUALIFICATION_ROOT")
+        .map(PathBuf::from)
+        .expect("set COMPASS_TS_QUALIFICATION_ROOT to a read-only pinned corpus");
+    let root = root.canonicalize().expect("qualification corpus root");
+    assert!(
+        root.is_dir(),
+        "qualification corpus is not a directory: {root:?}"
+    );
+
+    let oracle = run_oracle(&root);
+    assert_eq!(oracle.schema, ORACLE_SCHEMA);
+    assert_eq!(oracle.provider, ORACLE_PROVIDER);
+    assert_eq!(oracle.scanned_files, oracle.parsed_files);
+    assert!(oracle.rejected_files.is_empty(), "oracle rejected files");
+
+    let supported = oracle
+        .constructs
+        .iter()
+        .filter(|construct| is_supported_construct(construct))
+        .collect::<Vec<_>>();
+    let expected = supported
+        .iter()
+        .filter(|construct| {
+            construct.resolution_kind == "source"
+                && construct.target_file.as_deref() == Some(construct.source_file.as_str())
+                && construct.target_start_byte.is_some()
+                && construct.target_end_byte.is_some()
+        })
+        .map(|construct| source_key(construct))
+        .collect::<BTreeSet<_>>();
+    assert!(
+        !expected.is_empty(),
+        "checker oracle emitted no local targets"
+    );
+
+    let files = oracle
+        .constructs
+        .iter()
+        .map(|construct| construct.source_file.clone())
+        .collect::<BTreeSet<_>>();
+    let mut observed = BTreeMap::<SourceKey, Vec<CandidateTarget>>::new();
+    let mut extraction_errors = Vec::new();
+    for source_file in files {
+        let path = safe_source_path(&root, &source_file);
+        let source = match fs::read(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                extraction_errors.push(format!("{source_file}: read failed: {error}"));
+                continue;
+            }
+        };
+        // Keep a parser isolated per large qualification input. The vendored
+        // TypeScript grammar can retain a deep parser stack across unrelated
+        // files; a fresh engine preserves bounded default-stack runs without
+        // changing production parser/cache behavior.
+        let mut engine = Engine::default();
+        match engine.extract_source_universal_candidate_evidence(&path, &source_file, &source) {
+            Ok(batch) => merge_candidate_targets(&mut observed, &batch),
+            Err(error) => extraction_errors.push(format!("{source_file}: {error}")),
+        }
+    }
+    assert!(
+        extraction_errors.is_empty(),
+        "candidate extraction failed: {}",
+        extraction_errors
+            .iter()
+            .take(20)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
+
+    let mut correct = 0usize;
+    let mut missing = 0usize;
+    let mut wrong = 0usize;
+    let mut positive = 0usize;
+    let mut positive_correct = 0usize;
+    let mut false_positive = 0usize;
+    let mut external_positive = 0usize;
+    let mut by_stratum = BTreeMap::<(String, String), [usize; 4]>::new();
+    let expected_by_key = supported
+        .iter()
+        .map(|construct| (source_key(construct), *construct))
+        .collect::<HashMap<_, _>>();
+    let mut wrong_examples = Vec::new();
+    let mut false_positive_examples = Vec::new();
+    let mut missing_examples = BTreeMap::<(String, String), Vec<String>>::new();
+    for key in &expected {
+        let Some(oracle_construct) = expected_by_key.get(key).copied() else {
+            continue;
+        };
+        let expected_target = (
+            oracle_construct.target_start_byte.expect("local start"),
+            oracle_construct.target_end_byte.expect("local end"),
+        );
+        let bucket = by_stratum
+            .entry((key.1.clone(), key.2.clone()))
+            .or_default();
+        bucket[0] = bucket[0].saturating_add(1);
+        match observed.get(key) {
+            Some(targets)
+                if targets.iter().any(|target| {
+                    matches!(
+                        target,
+                        CandidateTarget::Local { source_file, start, end }
+                            if source_file == &key.0 && (*start, *end) == expected_target
+                    )
+                }) =>
+            {
+                correct = correct.saturating_add(1);
+                bucket[1] = bucket[1].saturating_add(1);
+            }
+            Some(targets)
+                if targets
+                    .iter()
+                    .any(|target| matches!(target, CandidateTarget::Local { .. })) =>
+            {
+                wrong = wrong.saturating_add(1);
+                bucket[3] = bucket[3].saturating_add(1);
+                if wrong_examples.len() < 20 {
+                    wrong_examples.push(format!(
+                        "{}:{}:{} {}-{} {} expected={expected_target:?} observed={targets:?}",
+                        key.0, key.1, key.2, key.3, key.4, oracle_construct.target_spelling,
+                    ));
+                }
+            }
+            None => {
+                missing = missing.saturating_add(1);
+                bucket[2] = bucket[2].saturating_add(1);
+                let examples = missing_examples
+                    .entry((key.1.clone(), key.2.clone()))
+                    .or_default();
+                if examples.len() < 5 {
+                    examples.push(format!(
+                        "{}:{}:{} {}-{} {} expected={expected_target:?} observed=none",
+                        key.0, key.1, key.2, key.3, key.4, oracle_construct.target_spelling,
+                    ));
+                }
+            }
+            Some(_) => {
+                missing = missing.saturating_add(1);
+                bucket[2] = bucket[2].saturating_add(1);
+                let examples = missing_examples
+                    .entry((key.1.clone(), key.2.clone()))
+                    .or_default();
+                if examples.len() < 5 {
+                    examples.push(format!(
+                        "{}:{}:{} {}-{} {} expected={expected_target:?} observed=unresolved-or-external",
+                        key.0,
+                        key.1,
+                        key.2,
+                        key.3,
+                        key.4,
+                        oracle_construct.target_spelling,
+                    ));
+                }
+            }
+        }
+    }
+    for (key, targets) in &observed {
+        let Some(oracle_construct) = expected_by_key.get(key).copied() else {
+            continue;
+        };
+        for target in targets {
+            if let CandidateTarget::Local {
+                source_file,
+                start,
+                end,
+            } = target
+            {
+                positive = positive.saturating_add(1);
+                if oracle_construct.resolution_kind == "source"
+                    && oracle_construct.target_file.as_deref()
+                        == Some(oracle_construct.source_file.as_str())
+                    && source_file == &key.0
+                    && Some((*start, *end))
+                        == oracle_construct
+                            .target_start_byte
+                            .zip(oracle_construct.target_end_byte)
+                {
+                    positive_correct = positive_correct.saturating_add(1);
+                } else {
+                    false_positive = false_positive.saturating_add(1);
+                    if false_positive_examples.len() < 20 {
+                        false_positive_examples.push(format!(
+                            "{}:{}:{} {}-{} local={source_file}:{start}-{end} oracle_kind={} oracle_target={:?}",
+                            key.0,
+                            key.1,
+                            key.2,
+                            key.3,
+                            key.4,
+                            oracle_construct.resolution_kind,
+                            oracle_construct
+                                .target_file
+                                .as_ref()
+                                .zip(oracle_construct.target_start_byte)
+                                .zip(oracle_construct.target_end_byte),
+                        ));
+                    }
+                }
+            } else if let CandidateTarget::External { qualified_name } = target
+                && !qualified_name.is_empty()
+            {
+                external_positive = external_positive.saturating_add(1);
+            }
+        }
+    }
+    eprintln!(
+        "TypeScript/JavaScript checker target adjudication: correct={correct} expected_local={} missing={missing} wrong={wrong} positive={positive} positive_correct={positive_correct} false_positive={false_positive} external_positive={external_positive} supported={} strata={by_stratum:?} wrong_examples={wrong_examples:?} false_positive_examples={false_positive_examples:?} missing_examples={missing_examples:?}",
+        expected.len(),
+        supported.len(),
+    );
+    // This is an adjudication report, not the release gate. Keep the test
+    // useful for regressions while Plan 013's accepted-sample labels and
+    // Wilson interval policy are still being assembled.
+    assert!(correct.saturating_add(missing).saturating_add(wrong) == expected.len());
+}
+
+fn run_oracle(root: &Path) -> OraclePayload {
+    let repository = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_owned();
+    let script = repository.join("benchmarks/performance/oracles/typescript-target-oracle.mjs");
+    let output = Command::new("node")
+        .current_dir(&repository)
+        .arg(&script)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .expect("target oracle requires node");
+    assert!(
+        output.stdout.len() <= MAX_ORACLE_OUTPUT_BYTES,
+        "target oracle output exceeds bounded limit"
+    );
+    assert!(
+        output.status.success(),
+        "target oracle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("target oracle JSON")
+}
+
+fn safe_source_path(root: &Path, source_file: &str) -> PathBuf {
+    let relative = Path::new(source_file);
+    assert!(!relative.is_absolute() && !relative.components().any(|part| part.as_os_str() == ".."));
+    let path = root.join(relative);
+    let canonical = path.canonicalize().expect("oracle source path");
+    assert!(
+        canonical.starts_with(root),
+        "oracle source escaped root: {source_file}"
+    );
+    canonical
+}
+
+fn source_key(construct: &OracleConstruct) -> SourceKey {
+    (
+        construct.source_file.clone(),
+        construct.relation.clone(),
+        construct.capability.clone(),
+        construct.start_byte,
+        construct.end_byte,
+    )
+}
+
+fn is_supported_construct(construct: &OracleConstruct) -> bool {
+    matches!(
+        (construct.relation.as_str(), construct.capability.as_str()),
+        ("imports", "imports")
+            | ("reexports", "reexports")
+            | ("calls", "calls")
+            | ("instantiates", "construction")
+            | ("accesses", "members")
+            | ("extends", "base_types")
+            | ("implements", "base_types")
+            | ("references", "jsx")
+            | ("references", "type_references")
+    )
+}
+
+fn merge_candidate_targets(
+    observed: &mut BTreeMap<SourceKey, Vec<CandidateTarget>>,
+    batch: &SemanticEvidenceBatch,
+) {
+    let declarations = batch
+        .declarations
+        .iter()
+        .map(|declaration| (declaration.id.as_str(), declaration))
+        .collect::<HashMap<_, _>>();
+    for candidate in &batch.candidates {
+        let Some(occurrence_id) = candidate.occurrence_id.as_deref() else {
+            continue;
+        };
+        let Some(occurrence) = batch
+            .occurrences
+            .iter()
+            .find(|occurrence| occurrence.id == occurrence_id)
+        else {
+            continue;
+        };
+        let Some((relation, capability)) =
+            relation_name(candidate.relation, occurrence.context.as_deref())
+        else {
+            continue;
+        };
+        let key = (
+            occurrence.range.source_file.clone(),
+            relation.to_owned(),
+            capability.to_owned(),
+            occurrence.range.start_byte,
+            occurrence.range.end_byte,
+        );
+        let target = if let Some(id) = candidate.constraints.exact_target_declaration_id.as_deref()
+        {
+            declarations
+                .get(id)
+                .map(|declaration| CandidateTarget::Local {
+                    source_file: declaration.range.source_file.clone(),
+                    start: declaration.range.start_byte,
+                    end: declaration.range.end_byte,
+                })
+                .unwrap_or(CandidateTarget::Unresolved)
+        } else if candidate.constraints.allow_external {
+            candidate
+                .constraints
+                .qualified_name
+                .as_ref()
+                .map(|qualified_name| CandidateTarget::External {
+                    qualified_name: qualified_name.clone(),
+                })
+                .unwrap_or(CandidateTarget::Unresolved)
+        } else {
+            CandidateTarget::Unresolved
+        };
+        observed.entry(key).or_default().push(target);
+    }
+}
+
+fn relation_name(
+    relation: CandidateRelation,
+    context: Option<&str>,
+) -> Option<(&'static str, &'static str)> {
+    match relation {
+        CandidateRelation::Imports => Some(("imports", "imports")),
+        CandidateRelation::Reexports => Some(("reexports", "reexports")),
+        CandidateRelation::Calls => Some(("calls", "calls")),
+        CandidateRelation::Constructs => Some(("instantiates", "construction")),
+        CandidateRelation::AccessesMember => Some(("accesses", "members")),
+        CandidateRelation::Extends => Some(("extends", "base_types")),
+        CandidateRelation::Implements => Some(("implements", "base_types")),
+        CandidateRelation::References if context == Some("jsx") => Some(("references", "jsx")),
+        CandidateRelation::References => Some(("references", "type_references")),
+        _ => None,
+    }
+}

--- a/crates/compass-languages/tests/typescript_type_scope.rs
+++ b/crates/compass-languages/tests/typescript_type_scope.rs
@@ -1,0 +1,70 @@
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use compass_languages::{CandidateRelation, Engine};
+
+#[test]
+fn mapped_and_conditional_type_bindings_are_lexically_scoped() {
+    let source = br#"
+type Intersection<T> = (T extends any ? (k: T) => void : never) extends (k: infer I) => void ? I : never;
+type First<T> = { [K in keyof T]: T[K] };
+type Second<T> = { [K in keyof T]?: T[K] };
+"#;
+    let batch = Engine::default()
+        .extract_source_universal_candidate_evidence(
+            Path::new("src/types.ts"),
+            "src/types.ts",
+            source,
+        )
+        .expect("candidate evidence");
+
+    for (qualified_suffix, spelling) in [
+        (".Intersection.I", "I"),
+        (".First.K", "K"),
+        (".Second.K", "K"),
+    ] {
+        let declaration = batch
+            .declarations
+            .iter()
+            .find(|declaration| declaration.qualified_name.ends_with(qualified_suffix))
+            .expect("type binding declaration");
+        assert!(
+            batch.candidates.iter().any(|candidate| {
+                candidate.relation == CandidateRelation::References
+                    && candidate.target_spelling == spelling
+                    && candidate.constraints.exact_target_declaration_id.as_deref()
+                        == Some(declaration.id.as_str())
+            }),
+            "missing exact target for {qualified_suffix}"
+        );
+    }
+}
+
+#[test]
+fn inline_object_parameter_members_are_source_anchored() {
+    let source = br#"
+async function Page(props: { params: Promise<{ slug?: string[] }> }) {
+    const params = await props.params;
+    return params;
+}
+"#;
+    let batch = Engine::default()
+        .extract_source_universal_candidate_evidence(
+            Path::new("src/page.tsx"),
+            "src/page.tsx",
+            source,
+        )
+        .expect("candidate evidence");
+    let property = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "params" && declaration.kind == "property")
+        .expect("inline params property");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "params"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(property.id.as_str())
+    }));
+}

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1906,6 +1906,111 @@ function useReadonly(value: Readonly<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_pick_and_omit_receivers_project_exact_members() {
+    let batch = candidate(
+        "src/pick-omit-receivers.ts",
+        br#"interface Options { enabled(): void; debug(): void }
+function use(picked: Pick<Options, "enabled">, omitted: Omit<Options, "debug">) {
+    picked.enabled();
+    picked.debug();
+    omitted.enabled();
+    omitted.debug();
+}
+"#,
+    );
+    let enabled = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Options.enabled"))
+        .expect("Options.enabled declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && matches!(candidate.target_spelling.as_str(), "enabled" | "debug")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 4);
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.target_spelling == "enabled")
+            .count(),
+        2
+    );
+    assert!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.target_spelling == "enabled")
+            .all(|candidate| {
+                candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(enabled.id.as_str())
+            })
+    );
+    assert!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.target_spelling == "debug")
+            .all(|candidate| candidate.constraints.exact_target_declaration_id.is_none())
+    );
+
+    let unknown = candidate(
+        "src/pick-unknown-key.ts",
+        br#"interface Options { enabled(): void }
+type Key = string;
+function use(value: Pick<Options, Key>) { value.enabled(); }
+"#,
+    );
+    assert!(unknown.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "enabled"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_exclude_and_extract_narrow_nominal_union_receivers() {
+    let batch = candidate(
+        "src/exclude-extract-receivers.ts",
+        br#"class Item { inspect(): void {} }
+class Other { other(): void {} }
+function exclude(value: Exclude<Item | undefined, undefined>) { value.inspect(); }
+function extract(value: Extract<Item | Other, Item>) { value.inspect(); }
+function ambiguous(value: Exclude<Item | Other, undefined>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.constraints.exact_target_declaration_id.is_some())
+            .count(),
+        2
+    );
+    assert!(calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+    assert!(
+        calls
+            .iter()
+            .any(|candidate| { candidate.constraints.exact_target_declaration_id.is_none() })
+    );
+}
+
+#[test]
 fn typescript_non_nullable_multi_nominal_union_fails_closed() {
     let batch = candidate(
         "src/non-nullable-ambiguous.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -3249,6 +3249,90 @@ frozen.active;
 }
 
 #[test]
+fn javascript_flow_assignment_object_literal_selects_exact_members() {
+    let batch = candidate(
+        "src/object-reassignment.js",
+        br#"function read(flag) {
+    let auth = undefined;
+    auth = { username: "user", password: "secret" };
+    return auth.username;
+}
+"#,
+    );
+    let username = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "username")
+        .expect("object assignment member declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "username"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(username.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_flow_assignment_object_literal_branch_fails_closed() {
+    let batch = candidate(
+        "src/object-branch-reassignment.js",
+        br#"function read(flag) {
+    let auth = undefined;
+    if (flag) {
+        auth = { username: "user" };
+    }
+    return auth.username;
+}
+"#,
+    );
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "username"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn javascript_object_literal_methods_resolve_this_members() {
+    let batch = candidate(
+        "src/object-this.js",
+        br#"const api = {
+    write() {},
+    remove() { this.write(); }
+};
+api.remove();
+"#,
+    );
+    let write = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "object-this.api.write")
+        .expect("object method declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "write"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(write.id.as_str())
+    }));
+
+    let spread = candidate(
+        "src/object-this-spread.js",
+        br#"const base = { write() {} };
+const api = {
+    ...base,
+    remove() { this.write(); }
+};
+api.remove();
+"#,
+    );
+    assert!(!spread.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "write"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
 fn candidate_emits_curated_external_builtin_evidence_and_respects_shadowing() {
     let batch = candidate(
         "src/builtins.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -29,7 +29,7 @@ new App();
     let batch = candidate("src/app.ts", source);
     validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
     assert_eq!(batch.adapter.language, "typescript");
-    assert_eq!(batch.adapter.version, 4);
+    assert_eq!(batch.adapter.version, 5);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("ts"));
     assert!(
         batch
@@ -120,7 +120,7 @@ export async function load() { return import("./lazy.js"); }
 "#;
     let batch = candidate("src/render.jsx", source);
     assert_eq!(batch.adapter.language, "javascript");
-    assert_eq!(batch.adapter.version, 4);
+    assert_eq!(batch.adapter.version, 5);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("jsx"));
     assert!(
         batch
@@ -269,6 +269,38 @@ export default { ...base, isString: value => true };
         binding.kind == compass_languages::BindingKind::Reexport
             && binding.spelling == "default"
             && binding.target_declaration_id.as_deref() == Some(spread_default.id.as_str())
+    }));
+    let base = spread
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "spread-default.base")
+        .expect("spread source declaration");
+    assert!(spread.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Member
+            && binding.spelling == "*"
+            && binding.qualified_target == "spread-default.base"
+            && binding.target_declaration_id.as_deref() == Some(base.id.as_str())
+            && binding.scope_id.as_ref().is_some_and(|scope_id| {
+                spread
+                    .scopes
+                    .iter()
+                    .any(|scope| scope.id == *scope_id && scope.kind == "object")
+            })
+    }));
+
+    let imported = candidate(
+        "src/imported-spread-default.js",
+        br#"import base from './base.js';
+export default { ...base, isString: value => true };
+"#,
+    );
+    validate_evidence(&imported, EvidenceLimits::default())
+        .expect("imported spread default evidence");
+    assert!(imported.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Member
+            && binding.spelling == "*"
+            && binding.qualified_target == "./base.js::default"
+            && binding.target_declaration_id.is_none()
     }));
 
     let unknown = candidate(

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -701,6 +701,42 @@ Object.defineProperty(exports, 'getter', { get: () => getRun() });
 }
 
 #[test]
+fn javascript_commonjs_export_star_publishes_only_proven_barrel_aliases() {
+    let source = br#"function __createBinding() {}
+function __exportStar(m, exports) {
+    for (const p in m) {
+        if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) {
+            __createBinding(exports, m, p);
+        }
+    }
+}
+__exportStar(require("./source"), exports);
+const tslib = require("tslib");
+tslib.__exportStar(require("./tslib-source"), module.exports);
+__exportStar(require(moduleName), exports);
+__exportStar(require("./wrong-target"), other);
+{
+    function __exportStar(m, exports) { return m; }
+    __exportStar(require("./lookalike"), exports);
+}
+"#;
+    let batch = candidate("src/barrel.cjs", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("exportStar evidence");
+    let aliases = batch
+        .bindings
+        .iter()
+        .filter(|binding| {
+            binding.kind == compass_languages::BindingKind::Member && binding.spelling == "*"
+        })
+        .map(|binding| binding.qualified_target.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        aliases,
+        std::collections::BTreeSet::from(["./source::*", "./tslib-source::*"])
+    );
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1648,6 +1648,56 @@ new Service();
         candidate.constraints.exact_target_declaration_id.as_deref()
             == Some(second_inspect.id.as_str())
     }));
+
+    let chained = candidate(
+        "src/inline-structural-chained.js",
+        br#"const key = Symbol('state');
+class Service {
+    constructor() {
+        const state = (this[key] = this[key] = { inspect() {}, other: 0 });
+        state.other = 1;
+        const later = () => state.inspect();
+        later();
+    }
+}
+new Service();
+"#,
+    );
+    let chained_inspect = chained
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.name == "inspect"
+                && declaration
+                    .qualified_name
+                    .ends_with(".Service.constructor.state.inspect")
+        })
+        .expect("chained inline state.inspect declaration");
+    assert!(chained.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(chained_inspect.id.as_str())
+    }));
+
+    let chained_compound = candidate(
+        "src/inline-structural-chained-compound.js",
+        br#"const key = Symbol('state');
+class Service {
+    constructor() {
+        const state = (this[key] = this[key] += { inspect() {} });
+        const later = () => state.inspect();
+        later();
+    }
+}
+new Service();
+"#,
+    );
+    assert!(!chained_compound.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1521,6 +1521,80 @@ function use(value: Copy<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_generic_literal_indexed_alias_substitutes_nominal_target() {
+    let batch = candidate(
+        "src/generic-indexed-alias.ts",
+        br#"interface Nested { run(): void }
+interface Item { nested: Nested }
+type NestedOf<T> = T["nested"];
+function use(value: NestedOf<Item>) { value.run(); }
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Nested.run"))
+        .expect("Nested.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_keyof_identity_projection_preserves_nominal_members() {
+    let batch = candidate(
+        "src/keyof-identity.ts",
+        br#"interface Item { inspect(): void }
+type Copy<T> = Pick<T, keyof T>;
+type Empty<T> = Omit<T, keyof T>;
+function use(value: Copy<Item>) { value.inspect(); }
+function rejected(value: Empty<Item>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+    assert!(
+        calls
+            .iter()
+            .any(|candidate| { candidate.constraints.exact_target_declaration_id.is_none() })
+    );
+}
+
+#[test]
+fn typescript_keyof_projection_with_competing_base_fails_closed() {
+    let batch = candidate(
+        "src/keyof-ambiguous.ts",
+        br#"interface First { inspect(): void }
+interface Second { inspect(): void }
+type Keys = keyof First | keyof Second;
+type Picked = Pick<First, Keys>;
+function use(value: Picked) { value.inspect(); }
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
 fn typescript_non_homomorphic_mapped_alias_fails_closed() {
     let batch = candidate(
         "src/non-homomorphic-mapped-alias.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1355,6 +1355,129 @@ function use(value: Nested) { value.inspect(); }
 }
 
 #[test]
+fn typescript_array_index_receiver_preserves_nominal_element_members() {
+    let batch = candidate(
+        "src/array-index.ts",
+        br#"interface Item { inspect(): void }
+function use(values: Item[]) { values[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_tuple_index_receiver_preserves_nominal_element_members() {
+    let batch = candidate(
+        "src/tuple-index.ts",
+        br#"interface Item { inspect(): void }
+type Pair = [Item, string];
+function use(pair: Pair) { pair[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_array_member_chain_substitutes_element_receiver() {
+    let batch = candidate(
+        "src/generic-array-index.ts",
+        br#"interface Item { inspect(): void }
+interface Box<T> { values: T[] }
+function use(box: Box<Item>) { box.values[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_standard_array_container_preserves_nominal_element_members() {
+    let batch = candidate(
+        "src/readonly-array-index.ts",
+        br#"interface Item { inspect(): void }
+function use(values: ReadonlyArray<Item>) { values[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_dynamic_tuple_index_fails_closed() {
+    let batch = candidate(
+        "src/dynamic-tuple-index.ts",
+        br#"interface Item { inspect(): void }
+function use(pair: [Item, string], index: number) { pair[index].inspect(); }
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_generic_tuple_member_chain_substitutes_element_receiver() {
+    let batch = candidate(
+        "src/generic-tuple-index.ts",
+        br#"interface Item { inspect(): void }
+interface Box<T> { pair: [T, string] }
+function use(box: Box<Item>) { box.pair[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
 fn typescript_generic_index_signature_values_resolve_member_calls() {
     let batch = candidate(
         "src/generic-index-signature.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -111,6 +111,60 @@ new App();
 }
 
 #[test]
+fn typescript_candidate_emits_using_resource_bindings_and_initializer_calls() {
+    let source = br#"interface Resource { close(): void }
+declare function acquire(): Resource;
+declare function acquireAsync(): Promise<Resource>;
+export function run() {
+    using resource = acquire();
+    await using asyncResource = acquireAsync();
+    resource.close();
+    asyncResource.close();
+}
+"#;
+    let batch = candidate("src/resources.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("using evidence");
+    assert!(
+        !batch
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "partial_parser_recovery")
+    );
+
+    for name in ["resource", "asyncResource"] {
+        let declaration = batch
+            .declarations
+            .iter()
+            .find(|declaration| declaration.name == name)
+            .unwrap_or_else(|| panic!("missing using binding {name}"));
+        assert_eq!(declaration.kind, "variable");
+        let start = usize::try_from(declaration.range.start_byte).expect("range fits usize");
+        assert_eq!(&source[start..start + name.len()], name.as_bytes());
+    }
+
+    for (callee, argument_count) in [("acquire", 0), ("acquireAsync", 0)] {
+        let call = batch
+            .candidates
+            .iter()
+            .find(|candidate| {
+                candidate.relation == CandidateRelation::Calls
+                    && candidate.target_spelling == callee
+            })
+            .unwrap_or_else(|| panic!("missing using initializer call {callee}"));
+        assert_eq!(call.constraints.argument_count, Some(argument_count));
+    }
+    let member_calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::AccessesMember
+                && candidate.target_spelling == "close"
+        })
+        .count();
+    assert_eq!(member_calls, 2);
+}
+
+#[test]
 fn javascript_candidate_emits_jsx_commonjs_and_dynamic_import_evidence() {
     let source = br#"const Button = () => null;
 export function render() { return <Button />; }

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -167,7 +167,9 @@ export function run() {
 #[test]
 fn javascript_candidate_emits_jsx_commonjs_and_dynamic_import_evidence() {
     let source = br#"const Button = () => null;
-export function render() { return <Button />; }
+const title = "Hello";
+const props = { title };
+export function render(value) { return <Button title={title} value={value} {...props} />; }
 const helper = require("./helper");
 module.exports = render;
 export async function load() { return import("./lazy.js"); }
@@ -195,6 +197,18 @@ export async function load() { return import("./lazy.js"); }
             .occurrences
             .iter()
             .any(|occurrence| { occurrence.context.as_deref() == Some("jsx") })
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| { occurrence.context.as_deref() == Some("jsx_value") })
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| { occurrence.context.as_deref() == Some("jsx_spread") })
     );
     assert!(
         batch
@@ -265,6 +279,88 @@ export function render() { return <UI.Button />; }
         Some("./ui::Button")
     );
     assert!(jsx_member.binding_id.is_some());
+}
+
+#[test]
+fn typescript_candidate_emits_jsx_value_and_spread_references() {
+    let source = br#"interface Props { title: string; onClick: () => void }
+const title = "Hello";
+const props = { title };
+function handle(label: string) {}
+export function View(label: string) {
+    return <Button title={title} onClick={() => handle(label)} data={user.name} {...props}>{title}</Button>;
+}
+"#;
+    let batch = candidate("src/view.tsx", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("JSX value evidence");
+
+    let declaration_id = |name: &str, kind: &str| {
+        batch
+            .declarations
+            .iter()
+            .find(|declaration| declaration.name == name && declaration.kind == kind)
+            .map(|declaration| declaration.id.as_str())
+    };
+    let occurrence_for = |spelling: &str, context: &str| {
+        batch
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.relation == CandidateRelation::References)
+            .filter_map(|candidate| {
+                let occurrence_id = candidate.occurrence_id.as_deref()?;
+                let occurrence = batch
+                    .occurrences
+                    .iter()
+                    .find(|occurrence| occurrence.id == occurrence_id)?;
+                (candidate.target_spelling == spelling
+                    && occurrence.context.as_deref() == Some(context))
+                .then_some((candidate, occurrence))
+            })
+            .next()
+    };
+
+    let title_id = declaration_id("title", "variable").expect("title declaration");
+    let (title_value, title_occurrence) =
+        occurrence_for("title", "jsx_value").expect("JSX title value reference");
+    assert_eq!(
+        title_value
+            .constraints
+            .exact_target_declaration_id
+            .as_deref(),
+        Some(title_id)
+    );
+    let title_start = usize::try_from(title_occurrence.range.start_byte).expect("title range");
+    assert_eq!(&source[title_start..title_start + 5], b"title");
+
+    let props_id = declaration_id("props", "variable").expect("props declaration");
+    let (props_spread, _) = occurrence_for("props", "jsx_spread").expect("JSX spread reference");
+    assert_eq!(
+        props_spread
+            .constraints
+            .exact_target_declaration_id
+            .as_deref(),
+        Some(props_id)
+    );
+
+    let (label_value, _) = occurrence_for("label", "jsx_value").expect("JSX callback argument");
+    let label_target = label_value
+        .constraints
+        .exact_target_declaration_id
+        .as_deref()
+        .and_then(|id| {
+            batch
+                .declarations
+                .iter()
+                .find(|declaration| declaration.id == id)
+        })
+        .expect("label exact target");
+    assert_eq!(label_target.name, "label");
+    assert_eq!(label_target.kind, "parameter");
+    assert!(occurrence_for("title", "jsx_child").is_some());
+    assert!(occurrence_for("user", "jsx_value").is_some());
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "handle"
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -3472,6 +3472,47 @@ response.request;
 }
 
 #[test]
+fn javascript_stable_object_property_assignments_resolve_exact_members() {
+    let batch = candidate(
+        "src/stable-object-assignment.js",
+        br#"const validators = {};
+validators.transitional = function transitional() {};
+validators.spelling = (value) => value;
+validators.transitional(false);
+validators.spelling('value');
+"#,
+    );
+    let transitional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "transitional")
+        .expect("transitional property declaration");
+    let spelling = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "spelling")
+        .expect("spelling property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "transitional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(transitional.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "transitional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(transitional.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "spelling"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(spelling.id.as_str())
+    }));
+}
+
+#[test]
 fn candidate_emits_curated_external_builtin_evidence_and_respects_shadowing() {
     let batch = candidate(
         "src/builtins.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -502,6 +502,72 @@ use((value, ctx) => ctx.issues);
 }
 
 #[test]
+fn typescript_literal_indexed_type_aliases_resolve_nominal_receivers() {
+    let batch = candidate(
+        "src/indexed-alias.ts",
+        br#"interface Nested { run(): void }
+interface Item { nested: Nested; inspect(): void }
+type NestedAlias = Item["nested"];
+function use(value: NestedAlias) {
+    value.run();
+}
+function dynamic<T>(value: Item, key: T) {
+    value[key];
+}
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Nested.run"))
+        .expect("Nested.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+    // A computed generic key is not a source-proven property and must remain
+    // unresolved even when the receiver has a nominal annotation.
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "key"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn typescript_indexed_type_alias_ambiguity_does_not_choose_a_union_member() {
+    let batch = candidate(
+        "src/indexed-ambiguous.ts",
+        br#"interface First { run(): void }
+interface Second { run(): void }
+type Ambiguous = First | Second;
+type Maybe = Ambiguous["run"];
+function use(value: Maybe) {
+    value();
+}
+"#,
+    );
+    let first_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".First.run"))
+        .expect("First.run declaration");
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate
+            .constraints
+            .exact_target_declaration_id
+            .as_deref()
+            .is_some_and(|id| id == first_run.id || id == second_run.id)
+    }));
+}
+
+#[test]
 fn typescript_member_call_return_types_resolve_chained_members() {
     let batch = candidate(
         "src/member_return.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1467,6 +1467,38 @@ current.run();
 }
 
 #[test]
+fn javascript_const_this_alias_survives_a_closure_capture() {
+    let batch = candidate(
+        "src/const-this-alias.js",
+        br#"class CancelToken {
+    constructor() {
+        const token = this;
+        const later = () => token.subscribe();
+        later();
+    }
+    subscribe() {}
+}
+new CancelToken();
+"#,
+    );
+    let subscribe = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".CancelToken.subscribe")
+        })
+        .expect("CancelToken.subscribe declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "subscribe"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(subscribe.id.as_str())
+    }));
+}
+
+#[test]
 fn typescript_homomorphic_mapped_alias_preserves_nominal_member_targets() {
     let batch = candidate(
         "src/mapped-alias.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -213,6 +213,81 @@ export function render() { return <UI.Button />; }
 }
 
 #[test]
+fn javascript_commonjs_object_exports_publish_exact_named_reexports() {
+    let source = br#"function run() {}
+const alias = run;
+module.exports = {
+    run,
+    alias,
+    method() { return run(); },
+    literal: true,
+};
+"#;
+    let batch = candidate("src/object-export.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("CommonJS object evidence");
+
+    let reexports = batch
+        .bindings
+        .iter()
+        .filter(|binding| binding.kind == compass_languages::BindingKind::Reexport)
+        .map(|binding| binding.spelling.as_str())
+        .collect::<Vec<_>>();
+    for name in ["default", "run", "alias", "method", "literal"] {
+        assert!(
+            reexports.contains(&name),
+            "missing CommonJS object reexport {name}: {reexports:?}"
+        );
+    }
+
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run" && declaration.kind == "function")
+        .expect("run declaration");
+    let run_binding = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.spelling == "run" && binding.kind == compass_languages::BindingKind::Reexport
+        })
+        .expect("run reexport");
+    assert_eq!(
+        run_binding.target_declaration_id.as_deref(),
+        Some(run.id.as_str())
+    );
+
+    let method = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "method" && declaration.kind == "method")
+        .expect("method declaration");
+    let method_binding = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.spelling == "method" && binding.kind == compass_languages::BindingKind::Reexport
+        })
+        .expect("method reexport");
+    assert_eq!(
+        method_binding.target_declaration_id.as_deref(),
+        Some(method.id.as_str())
+    );
+
+    let spread = candidate(
+        "src/object-export-spread.js",
+        br#"const other = getOther();
+module.exports = { run, ...other };
+"#,
+    );
+    assert!(spread.bindings.iter().any(|binding| {
+        binding.spelling == "default" && binding.kind == compass_languages::BindingKind::Reexport
+    }));
+    assert!(!spread.bindings.iter().any(|binding| {
+        binding.spelling == "run" && binding.kind == compass_languages::BindingKind::Reexport
+    }));
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1511,6 +1511,52 @@ function use() {
 }
 
 #[test]
+fn typescript_imported_callable_return_publishes_bounded_marker() {
+    let batch = candidate(
+        "src/imported-call.ts",
+        br#"import { make } from "./factory";
+class Item { inspect(): void {} }
+function use(value: Item) { make(value).inspect(); }
+"#,
+    );
+    let use_declaration = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "use")
+        .expect("use declaration");
+    assert_eq!(use_declaration.signature.as_deref(), Some("|params:Item"));
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let call = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .expect("imported callable return member call");
+    assert_eq!(
+        call.constraints.exact_target_declaration_id, None,
+        "cross-file call result must be resolved by the project resolver"
+    );
+    assert!(
+        call.constraints
+            .qualified_name
+            .as_deref()
+            .is_some_and(|qualified| qualified.contains("#call<"))
+    );
+    assert!(!call.constraints.allow_external);
+    let local_call = batch.candidates.iter().find(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id == Some(inspect.id.clone())
+    });
+    assert!(local_call.is_none());
+}
+
+#[test]
 fn typescript_generic_function_array_return_preserves_element_receiver() {
     let batch = candidate(
         "src/generic-return-array.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1042,6 +1042,228 @@ function use(shape: Shape, key: string) {
 }
 
 #[test]
+fn typescript_flow_sensitive_reassignment_selects_latest_nominal_receiver() {
+    let batch = candidate(
+        "src/reassignment.ts",
+        br#"class First { run() {} }
+class Second { run() {} }
+let current = new First();
+current = new Second();
+current.run();
+"#,
+    );
+    let first_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".First.run"))
+        .expect("First.run declaration");
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        calls.iter().any(|candidate| {
+            candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(second_run.id.as_str())
+        }),
+        "latest source assignment should own the member call"
+    );
+    assert!(!calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(first_run.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_flow_sensitive_branch_assignment_fails_closed() {
+    let batch = candidate(
+        "src/branch-reassignment.ts",
+        br#"class First { run() {} }
+class Second { run() {} }
+let current = new First();
+if (flag) {
+    current = new Second();
+}
+current.run();
+"#,
+    );
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn typescript_flow_sensitive_unknown_assignment_blocks_stale_receiver() {
+    let batch = candidate(
+        "src/unknown-reassignment.ts",
+        br#"class First { run() {} }
+let current = new First();
+current = getUnknown();
+current.run();
+"#,
+    );
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn javascript_flow_sensitive_reassignment_selects_latest_nominal_receiver() {
+    let batch = candidate(
+        "src/reassignment.js",
+        br#"class First { run() {} }
+class Second { run() {} }
+let current = new First();
+current = new Second();
+current.run();
+"#,
+    );
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(second_run.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_flow_sensitive_var_reassignment_inside_function_selects_latest_receiver() {
+    let batch = candidate(
+        "src/var-reassignment.js",
+        br#"class First { run() {} }
+class Second { run() {} }
+function use() {
+    var current = new First();
+    current = new Second();
+    current.run();
+}
+"#,
+    );
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(second_run.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_flow_sensitive_reassignment_is_ordered_by_use_site() {
+    let batch = candidate(
+        "src/ordered-reassignment.ts",
+        br#"class First { run() {} }
+class Second { run() {} }
+let current = new First();
+current.run();
+current = new Second();
+current.run();
+"#,
+    );
+    let first_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".First.run"))
+        .expect("First.run declaration");
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| {
+                candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(first_run.id.as_str())
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| {
+                candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(second_run.id.as_str())
+            })
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn typescript_flow_sensitive_compound_assignment_blocks_stale_receiver() {
+    let batch = candidate(
+        "src/compound-reassignment.ts",
+        br#"class First { run() {} }
+let current = new First();
+current += unknownValue;
+current.run();
+"#,
+    );
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn typescript_flow_sensitive_typed_call_assignment_uses_return_receiver() {
+    let batch = candidate(
+        "src/call-reassignment.ts",
+        br#"class First { run() {} }
+class Second { run() {} }
+function makeSecond(): Second { return new Second(); }
+let current = new First();
+current = makeSecond();
+current.run();
+"#,
+    );
+    let second_run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
+        .expect("Second.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(second_run.id.as_str())
+    }));
+}
+
+#[test]
 fn typescript_generic_index_signature_values_resolve_member_calls() {
     let batch = candidate(
         "src/generic-index-signature.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -804,6 +804,117 @@ module.exports = { run, ...other };
 }
 
 #[test]
+fn typescript_candidate_preserves_typeof_import_queries_without_dynamic_calls() {
+    let source = br#"const load = () => import("./runtime");
+// typeof import("./ignored");
+const text = "typeof import('./ignored-string')";
+type Item = (typeof import("./items").items)[number];
+type Simple = typeof import("./simple").items;
+type Plain = import("./plain").Item;
+"#;
+    let batch = candidate("src/import-type.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
+
+    let type_imports = batch
+        .occurrences
+        .iter()
+        .filter(|occurrence| {
+            occurrence.role == SemanticRole::Import
+                && occurrence.context.as_deref() == Some("import_type")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(type_imports.len(), 3);
+    let type_import = type_imports
+        .iter()
+        .find(|occurrence| occurrence.spelling == "./items")
+        .copied()
+        .expect("indexed type-query import occurrence");
+    let start = usize::try_from(type_import.range.start_byte).expect("start byte");
+    let end = usize::try_from(type_import.range.end_byte).expect("end byte");
+    assert_eq!(&source[start..end], br#""./items""#);
+    assert_eq!(type_import.spelling, "./items");
+    let relation = batch
+        .candidates
+        .iter()
+        .find(|candidate| candidate.occurrence_id.as_deref() == Some(type_import.id.as_str()))
+        .expect("type-query import candidate");
+    assert_eq!(relation.relation, CandidateRelation::Imports);
+    assert_eq!(relation.target_spelling, "./items");
+    assert_eq!(
+        relation.constraints.module_or_package.as_deref(),
+        Some("./items")
+    );
+    assert_eq!(
+        batch
+            .occurrences
+            .iter()
+            .filter(|occurrence| occurrence.context.as_deref() == Some("import_type"))
+            .count(),
+        3
+    );
+    assert_eq!(
+        batch
+            .occurrences
+            .iter()
+            .filter(|occurrence| occurrence.context.as_deref() == Some("dynamic_import"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn javascript_typeof_import_remains_a_dynamic_import() {
+    let batch = candidate(
+        "src/runtime-probe.js",
+        br#"const probe = typeof import("./runtime");
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid JavaScript evidence");
+    assert_eq!(
+        batch
+            .occurrences
+            .iter()
+            .filter(|occurrence| occurrence.context.as_deref() == Some("dynamic_import"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        batch
+            .occurrences
+            .iter()
+            .filter(|occurrence| occurrence.context.as_deref() == Some("import_type"))
+            .count(),
+        0
+    );
+}
+
+#[test]
+fn typescript_import_type_query_inventory_is_bounded_and_diagnosed() {
+    let mut source = String::new();
+    for index in 0..257 {
+        source.push_str(&format!(
+            "type Item{index} = typeof import(\"./module{index}\").Item;\n"
+        ));
+    }
+    let batch = candidate("src/import-type-limit.ts", source.as_bytes());
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid bounded evidence");
+    assert!(
+        batch
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "import_type_query_limit")
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .filter(|occurrence| occurrence.context.as_deref() == Some("import_type"))
+            .count()
+            <= 256
+    );
+}
+
+#[test]
 fn javascript_commonjs_object_spread_publishes_bounded_owner_aliases() {
     let source = br#"const base = { inherited() {} };
 module.exports = { ...base, direct() {} };

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1264,6 +1264,108 @@ current.run();
 }
 
 #[test]
+fn typescript_flow_sensitive_local_alias_preserves_source_receiver() {
+    let batch = candidate(
+        "src/local-alias.ts",
+        br#"class First { run() {} }
+let current = new First();
+const alias = current;
+alias.run();
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".First.run"))
+        .expect("First.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_flow_alias_escape_and_dynamic_mutation_fail_closed() {
+    let cases = [
+        (
+            "src/escaped-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+consume(current);
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/eval-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+eval("current = unknownValue");
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/proxy-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+const wrapped = new Proxy(current, {});
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/member-write-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+current.run = replacement;
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/closure-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+function later() { current.run(); }
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/hoisted-closure-alias.js",
+            br#"class First { run() {} }
+function later() { current.run(); }
+let current = new First();
+current.run();
+"#
+            .as_slice(),
+        ),
+        (
+            "src/with-alias.js",
+            br#"class First { run() {} }
+let current = new First();
+with (scope) { current.run(); }
+current.run();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (path, source) in cases {
+        let batch = candidate(path, source);
+        assert!(
+            !batch.candidates.iter().any(|candidate| {
+                candidate.relation == compass_languages::CandidateRelation::Calls
+                    && candidate.target_spelling == "run"
+                    && candidate.constraints.exact_target_declaration_id.is_some()
+            }),
+            "dynamic alias case unexpectedly resolved: {path}"
+        );
+    }
+}
+
+#[test]
 fn typescript_homomorphic_mapped_alias_preserves_nominal_member_targets() {
     let batch = candidate(
         "src/mapped-alias.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1264,6 +1264,97 @@ current.run();
 }
 
 #[test]
+fn typescript_homomorphic_mapped_alias_preserves_nominal_member_targets() {
+    let batch = candidate(
+        "src/mapped-alias.ts",
+        br#"interface Item { inspect(): void }
+type Copy = { [K in keyof Item]: Item[K] };
+function use(value: Copy) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(
+        batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(inspect.id.as_str())
+        }),
+        "declarations: {:#?}\ncandidates: {:#?}",
+        batch.declarations,
+        batch.candidates
+    );
+}
+
+#[test]
+fn typescript_generic_homomorphic_mapped_alias_substitutes_nominal_target() {
+    let batch = candidate(
+        "src/generic-mapped-alias.ts",
+        br#"interface Item { inspect(): void }
+type Copy<T> = { [K in keyof T]: T[K] };
+function use(value: Copy<Item>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(
+        batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(inspect.id.as_str())
+        }),
+        "declarations: {:#?}\ncandidates: {:#?}",
+        batch.declarations,
+        batch.candidates
+    );
+}
+
+#[test]
+fn typescript_non_homomorphic_mapped_alias_fails_closed() {
+    let batch = candidate(
+        "src/non-homomorphic-mapped-alias.ts",
+        br#"interface Item { inspect(): void }
+type Getters<T> = { [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K] };
+function use(value: Getters<Item>) { value.inspect(); }
+"#,
+    );
+    assert!(
+        batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+                && candidate.constraints.exact_target_declaration_id.is_none()
+        }),
+        "declarations: {:#?}\ncandidates: {:#?}",
+        batch.declarations,
+        batch.candidates
+    );
+}
+
+#[test]
+fn typescript_nested_mapped_member_does_not_promote_outer_alias() {
+    let batch = candidate(
+        "src/nested-mapped-alias.ts",
+        br#"interface Item { inspect(): void }
+type Nested = { nested: { [K in keyof Item]: Item[K] } };
+function use(value: Nested) { value.inspect(); }
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
 fn typescript_generic_index_signature_values_resolve_member_calls() {
     let batch = candidate(
         "src/generic-index-signature.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -29,7 +29,7 @@ new App();
     let batch = candidate("src/app.ts", source);
     validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
     assert_eq!(batch.adapter.language, "typescript");
-    assert_eq!(batch.adapter.version, 2);
+    assert_eq!(batch.adapter.version, 3);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("ts"));
     assert!(
         batch
@@ -120,7 +120,7 @@ export async function load() { return import("./lazy.js"); }
 "#;
     let batch = candidate("src/render.jsx", source);
     assert_eq!(batch.adapter.language, "javascript");
-    assert_eq!(batch.adapter.version, 2);
+    assert_eq!(batch.adapter.version, 3);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("jsx"));
     assert!(
         batch
@@ -133,7 +133,8 @@ export async function load() { return import("./lazy.js"); }
         .iter()
         .find(|binding| binding.spelling == "helper")
         .expect("CommonJS binding");
-    assert_eq!(helper.namespace, Some(SymbolNamespace::Value));
+    assert_eq!(helper.namespace, Some(SymbolNamespace::Namespace));
+    assert_eq!(helper.qualified_target, "./helper::*");
     assert!(!helper.type_only);
     assert!(
         batch
@@ -210,6 +211,56 @@ export function render() { return <UI.Button />; }
         Some("./ui::Button")
     );
     assert!(jsx_member.binding_id.is_some());
+}
+
+#[test]
+fn javascript_commonjs_require_preserves_namespace_and_export_keys() {
+    let source = br#"const api = require("./api");
+const {
+    run: execute,
+    method,
+    "literal-name": literal,
+    [dynamic]: computed,
+...rest
+} = require("./api");
+const indirect = wrap(require("./api"));
+api.run();
+execute();
+method();
+"#;
+    let batch = candidate("src/consumer.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid require evidence");
+
+    let api = batch
+        .bindings
+        .iter()
+        .find(|binding| binding.spelling == "api")
+        .expect("direct require namespace binding");
+    assert_eq!(api.namespace, Some(SymbolNamespace::Namespace));
+    assert_eq!(api.qualified_target, "./api::*");
+
+    for (local, target) in [
+        ("execute", "./api::run"),
+        ("method", "./api::method"),
+        ("literal", "./api::literal-name"),
+    ] {
+        let actual = batch
+            .bindings
+            .iter()
+            .find(|binding| binding.spelling == local)
+            .map(|binding| binding.qualified_target.as_str());
+        assert_eq!(
+            actual,
+            Some(target),
+            "missing or incorrect require binding {local}"
+        );
+    }
+    assert!(!batch.bindings.iter().any(|binding| {
+        matches!(
+            binding.spelling.as_str(),
+            "computed" | "rest" | "dynamic" | "indirect"
+        )
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -539,6 +539,44 @@ module.exports = { run, ...other };
     assert!(!spread.bindings.iter().any(|binding| {
         binding.spelling == "run" && binding.kind == compass_languages::BindingKind::Reexport
     }));
+    assert!(!spread.bindings.iter().any(|binding| {
+        binding.spelling == "*" && binding.kind == compass_languages::BindingKind::Member
+    }));
+}
+
+#[test]
+fn javascript_commonjs_object_spread_publishes_bounded_owner_aliases() {
+    let source = br#"const base = { inherited() {} };
+module.exports = { ...base, direct() {} };
+"#;
+    let batch = candidate("src/object-export-spread-safe.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("CommonJS spread evidence");
+
+    let alias = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.kind == compass_languages::BindingKind::Member
+                && binding.spelling == "*"
+                && binding.qualified_target == "object-export-spread-safe.base"
+        })
+        .expect("bounded CommonJS spread owner alias");
+    assert_eq!(alias.namespace, Some(SymbolNamespace::Value));
+    let base = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.kind == "variable"
+                && declaration.qualified_name == "object-export-spread-safe.base"
+        })
+        .expect("base declaration");
+    assert_eq!(
+        alias.target_declaration_id.as_deref(),
+        Some(base.id.as_str())
+    );
+    assert!(batch.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "direct"
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -214,6 +214,52 @@ export function render() { return <UI.Button />; }
 }
 
 #[test]
+fn javascript_candidate_publishes_spread_free_default_object_members() {
+    let batch = candidate(
+        "src/utils.js",
+        br#"const isNumber = value => typeof value === 'number';
+const isString = value => typeof value === 'string';
+export default { isNumber, isString };
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("default object evidence");
+    let default_object = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "default" && declaration.kind == "variable")
+        .expect("default object declaration");
+    assert_eq!(default_object.qualified_name, "utils.default");
+    let is_number = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "utils.default.isNumber")
+        .expect("default object member declaration");
+    assert_eq!(is_number.kind, "property");
+    assert!(batch.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport
+            && binding.spelling == "default"
+            && binding.target_declaration_id.as_deref() == Some(default_object.id.as_str())
+    }));
+
+    let spread = candidate(
+        "src/spread-default.js",
+        br#"const base = { isNumber: value => true };
+export default { ...base, isString: value => true };
+"#,
+    );
+    validate_evidence(&spread, EvidenceLimits::default()).expect("spread default evidence");
+    assert!(
+        !spread
+            .declarations
+            .iter()
+            .any(|declaration| declaration.qualified_name == "spread-default.default")
+    );
+    assert!(!spread.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "default"
+    }));
+}
+
+#[test]
 fn javascript_commonjs_require_preserves_namespace_and_export_keys() {
     let source = br#"const api = require("./api");
 const {

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1588,6 +1588,81 @@ function use() { choose(new Item(), new Other()).inspect(); }
 }
 
 #[test]
+fn typescript_non_nullable_receiver_preserves_nominal_member_target() {
+    let batch = candidate(
+        "src/non-nullable-receiver.ts",
+        br#"class Item { inspect(): void {} }
+function use(value: NonNullable<Item | undefined>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_awaited_and_readonly_receivers_preserve_nominal_member_targets() {
+    let batch = candidate(
+        "src/utility-receivers.ts",
+        br#"class Item { inspect(): void {} }
+function useAwaited(value: Awaited<Promise<Item>>) { value.inspect(); }
+function useReadonly(value: Readonly<Item>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_non_nullable_multi_nominal_union_fails_closed() {
+    let batch = candidate(
+        "src/non-nullable-ambiguous.ts",
+        br#"class First { inspect(): void {} }
+class Second { inspect(): void {} }
+function use(value: NonNullable<First | Second | undefined>) { value.inspect(); }
+"#,
+    );
+    let inspect_calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(inspect_calls.len(), 1);
+    assert!(
+        inspect_calls[0]
+            .constraints
+            .exact_target_declaration_id
+            .is_none()
+    );
+}
+
+#[test]
 fn typescript_generic_index_signature_values_resolve_member_calls() {
     let batch = candidate(
         "src/generic-index-signature.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -136,7 +136,7 @@ export function run() {
             .declarations
             .iter()
             .find(|declaration| declaration.name == name)
-            .unwrap_or_else(|| panic!("missing using binding {name}"));
+            .expect("missing using binding");
         assert_eq!(declaration.kind, "variable");
         let start = usize::try_from(declaration.range.start_byte).expect("range fits usize");
         assert_eq!(&source[start..start + name.len()], name.as_bytes());
@@ -150,7 +150,7 @@ export function run() {
                 candidate.relation == CandidateRelation::Calls
                     && candidate.target_spelling == callee
             })
-            .unwrap_or_else(|| panic!("missing using initializer call {callee}"));
+            .expect("missing using initializer call");
         assert_eq!(call.constraints.argument_count, Some(argument_count));
     }
     let member_calls = batch
@@ -279,6 +279,32 @@ export function render() { return <UI.Button />; }
         Some("./ui::Button")
     );
     assert!(jsx_member.binding_id.is_some());
+}
+
+#[test]
+fn typescript_candidate_keeps_named_imports_used_as_object_values() {
+    let batch = candidate(
+        "src/routes.tsx",
+        br#"import { UserPage } from "./UserPage";
+export const routes = [{ path: "/users", Component: UserPage }];
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("object value evidence");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::References
+            && candidate.target_spelling == "UserPage"
+            && candidate
+                .occurrence_id
+                .as_deref()
+                .and_then(|id| {
+                    batch
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == id)
+                })
+                .is_some_and(|occurrence| occurrence.context.as_deref() == Some("value"))
+            && candidate.binding_id.is_some()
+    }));
 }
 
 #[test]
@@ -1532,11 +1558,12 @@ function use(value: Maybe) {
         .find(|declaration| declaration.qualified_name.ends_with(".Second.run"))
         .expect("Second.run declaration");
     assert!(!batch.candidates.iter().any(|candidate| {
-        candidate
-            .constraints
-            .exact_target_declaration_id
-            .as_deref()
-            .is_some_and(|id| id == first_run.id || id == second_run.id)
+        candidate.relation != CandidateRelation::Contains
+            && candidate
+                .constraints
+                .exact_target_declaration_id
+                .as_deref()
+                .is_some_and(|id| id == first_run.id || id == second_run.id)
     }));
 }
 

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1,0 +1,1932 @@
+#![allow(clippy::expect_used)]
+
+use std::path::Path;
+
+use compass_languages::{
+    CandidateRelation, Engine, EvidenceLimits, SemanticRole, SymbolNamespace, validate_evidence,
+};
+
+fn candidate(path: &str, source: &[u8]) -> compass_languages::SemanticEvidenceBatch {
+    Engine::default()
+        .extract_source_universal_candidate_evidence(Path::new(path), path, source)
+        .expect("candidate evidence")
+}
+
+#[test]
+fn typescript_candidate_emits_direct_declarations_scopes_imports_and_calls() {
+    let source = br#"import type { User as UserType } from "./types";
+import Widget, * as widgets from "./widget";
+interface User { id: string }
+type ID = string;
+class App extends Base implements Runnable {
+    field: User;
+    method(value: User): ID { return helper(value); }
+}
+const helper = (value: User): ID => value.id;
+export { App, helper };
+new App();
+"#;
+    let batch = candidate("src/app.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
+    assert_eq!(batch.adapter.language, "typescript");
+    assert_eq!(batch.adapter.version, 2);
+    assert_eq!(batch.adapter.dialect.as_deref(), Some("ts"));
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| declaration.name == "App" && declaration.kind == "class")
+    );
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| declaration.name == "User" && declaration.kind == "interface")
+    );
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| declaration.name == "helper" && declaration.kind == "function")
+    );
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| { declaration.name == "value" && declaration.kind == "parameter" })
+    );
+    assert!(batch.scopes.iter().any(|scope| scope.kind == "class"));
+    assert!(
+        batch
+            .bindings
+            .iter()
+            .any(|binding| binding.spelling == "UserType")
+    );
+    let user_type = batch
+        .bindings
+        .iter()
+        .find(|binding| binding.spelling == "UserType")
+        .expect("type-only import binding");
+    assert_eq!(user_type.namespace, Some(SymbolNamespace::Type));
+    assert!(user_type.type_only);
+    let widgets = batch
+        .bindings
+        .iter()
+        .find(|binding| binding.spelling == "widgets")
+        .expect("namespace import binding");
+    assert_eq!(widgets.namespace, Some(SymbolNamespace::Namespace));
+    assert!(!widgets.type_only);
+    let app = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "App")
+        .expect("class declaration");
+    assert_eq!(app.namespace, Some(SymbolNamespace::ValueAndType));
+    let user = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "User")
+        .expect("interface declaration");
+    assert_eq!(user.namespace, Some(SymbolNamespace::Type));
+    assert!(
+        batch
+            .bindings
+            .iter()
+            .any(|binding| binding.spelling == "Widget")
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| occurrence.role == SemanticRole::Call)
+    );
+    assert!(batch
+        .candidates
+        .iter()
+        .any(|candidate| candidate.relation == compass_languages::CandidateRelation::Constructs));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Extends
+            || candidate.relation == compass_languages::CandidateRelation::Implements
+    }));
+}
+
+#[test]
+fn javascript_candidate_emits_jsx_commonjs_and_dynamic_import_evidence() {
+    let source = br#"const Button = () => null;
+export function render() { return <Button />; }
+const helper = require("./helper");
+module.exports = render;
+export async function load() { return import("./lazy.js"); }
+"#;
+    let batch = candidate("src/render.jsx", source);
+    assert_eq!(batch.adapter.language, "javascript");
+    assert_eq!(batch.adapter.version, 2);
+    assert_eq!(batch.adapter.dialect.as_deref(), Some("jsx"));
+    assert!(
+        batch
+            .bindings
+            .iter()
+            .any(|binding| binding.spelling == "helper")
+    );
+    let helper = batch
+        .bindings
+        .iter()
+        .find(|binding| binding.spelling == "helper")
+        .expect("CommonJS binding");
+    assert_eq!(helper.namespace, Some(SymbolNamespace::Value));
+    assert!(!helper.type_only);
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| { occurrence.context.as_deref() == Some("jsx") })
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| { occurrence.context.as_deref() == Some("commonjs") })
+    );
+    assert!(
+        batch
+            .occurrences
+            .iter()
+            .any(|occurrence| { occurrence.context.as_deref() == Some("dynamic_import") })
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Reexports
+    }));
+
+    let import_equals = candidate(
+        "src/cjs-types.ts",
+        br#"import axios = require("axios");
+axios.get("/items");
+"#,
+    );
+    assert!(import_equals.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Imports
+            && candidate.target_spelling == "axios"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|id| {
+                    import_equals
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *id)
+                })
+                .is_some_and(|occurrence| occurrence.context.as_deref() == Some("import_equals"))
+    }));
+
+    let javascript_inheritance = candidate(
+        "src/canceled.js",
+        br#"import AxiosError from "./AxiosError.js";
+class CanceledError extends AxiosError {}
+"#,
+    );
+    assert!(javascript_inheritance.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Extends
+            && candidate.target_spelling == "AxiosError"
+            && candidate.constraints.qualified_name.as_deref() == Some("./AxiosError.js::default")
+    }));
+
+    let namespace_jsx = candidate(
+        "src/components.tsx",
+        br#"import * as UI from "./ui";
+export function render() { return <UI.Button />; }
+"#,
+    );
+    let jsx_member = namespace_jsx
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::References
+                && candidate.occurrence_id.is_some()
+                && candidate.target_spelling == "Button"
+        })
+        .expect("namespace JSX member reference");
+    assert_eq!(
+        jsx_member.constraints.qualified_name.as_deref(),
+        Some("./ui::Button")
+    );
+    assert!(jsx_member.binding_id.is_some());
+}
+
+#[test]
+fn javascript_static_this_factory_tracks_new_instance_members() {
+    let batch = candidate(
+        "src/factory.js",
+        br#"class Factory {
+  static create() {
+    const instance = new this();
+    instance.run();
+    return instance;
+  }
+  run() {}
+}
+Factory.create();
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("factory evidence");
+
+    let factory = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "class" && declaration.name == "Factory")
+        .expect("Factory declaration");
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "run")
+        .expect("Factory.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Constructs
+            && candidate.target_spelling == "this"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(factory.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_function_constructor_prototypes_resolve_instance_members() {
+    let batch = candidate(
+        "src/prototype.js",
+        br#"function Legacy(value) { this.value = value; }
+Legacy.prototype.helper = function helper() { return this.value; };
+Legacy.prototype.run = function run(value) { return this.helper(value); };
+const alias = Legacy.prototype;
+alias.extra = function extra() { return this.value; };
+const instance = new Legacy("value");
+instance.run("next");
+instance.extra();
+Legacy.prototype.run("direct");
+const dynamic = "run";
+instance[dynamic]();
+const unknown = {};
+unknown.prototype.run = function() {};
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("prototype evidence");
+
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Legacy.prototype.run")
+        })
+        .expect("prototype run declaration");
+    let helper = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Legacy.prototype.helper")
+        })
+        .expect("prototype helper declaration");
+    let extra = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Legacy.prototype.extra")
+        })
+        .expect("aliased prototype declaration");
+    let value = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Legacy.value"))
+        .expect("constructor instance field declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "helper"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(helper.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "extra"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(extra.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "value"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(value.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Constructs
+            && candidate.target_spelling == "Legacy"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    // Dynamic computed properties and unresolved prototype receivers must not
+    // collapse onto the source-proven `Legacy.prototype.run` declaration.
+    let run_id = run.id.clone();
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run_id.as_str())
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .is_some_and(|occurrence_id| {
+                    batch
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                        .is_some_and(|occurrence| {
+                            occurrence.context.as_deref() == Some("dynamic_member_call")
+                        })
+                })
+    }));
+}
+
+#[test]
+fn typescript_source_compatible_object_arguments_keep_exact_call_targets() {
+    let batch = candidate(
+        "src/calls.ts",
+        br#"type SourceLine = { text: string };
+interface Options { enabled: boolean }
+function read(lines: SourceLine[], index: number, start: number) {}
+function configure(options: Options) {}
+function select(options: Pick<Options, "enabled">) {}
+const lines: SourceLine[] = [];
+read(lines, 0, 1);
+configure({ enabled: true });
+const options: Options = { enabled: true };
+select(options);
+"#,
+    );
+    for name in ["read", "configure", "select"] {
+        assert!(
+            batch.candidates.iter().any(|candidate| {
+                candidate.relation == compass_languages::CandidateRelation::Calls
+                    && candidate.target_spelling == name
+                    && candidate.constraints.exact_target_declaration_id.is_some()
+            }),
+            "missing exact call target for {name}"
+        );
+    }
+}
+
+#[test]
+fn typescript_constrained_generic_calls_keep_exact_targets() {
+    let batch = candidate(
+        "src/generics.ts",
+        br#"const arrayToEnum = <T extends string, U extends [T, ...T[]]>(items: U) => items[0];
+arrayToEnum(["one", "two"]);
+"#,
+    );
+    let declaration = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "arrayToEnum")
+        .expect("generic declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "arrayToEnum"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(declaration.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_constrained_generic_member_chains_resolve_exact_targets() {
+    let batch = candidate(
+        "src/generic_members.ts",
+        br#"interface Shape { name: string }
+class Box<T extends Shape> {
+    value!: T;
+    read() { return this.value.name; }
+}
+"#,
+    );
+    let name = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Shape.name"))
+        .expect("Shape.name declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "name"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(name.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_unconstrained_generic_member_chains_fail_closed() {
+    let batch = candidate(
+        "src/generic_unconstrained.ts",
+        br#"function read<T>(value: T) {
+    return value.name;
+}
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "name"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_callable_property_members_accept_rest_calls() {
+    let batch = candidate(
+        "src/callable_property.ts",
+        br#"class Mocker {
+    pick = (...args: any[]): any => args[0];
+    value() { return this.pick(1, 2); }
+}
+"#,
+    );
+    let pick = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Mocker.pick"))
+        .expect("callable property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "pick"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(pick.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_contextual_callback_member_types_resolve_exact_targets() {
+    let batch = candidate(
+        "src/contextual_callback.ts",
+        br#"interface Common { issues: string[] }
+type Callback = { run: (value: string, ctx: Common) => void };
+function use(callback: Callback["run"]) {}
+use((value, ctx) => ctx.issues);
+"#,
+    );
+    let issues = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Common.issues"))
+        .expect("Common.issues declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "issues"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(issues.id.as_str())
+    }));
+    let use_function = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "use")
+        .expect("use declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "use"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(use_function.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_member_call_return_types_resolve_chained_members() {
+    let batch = candidate(
+        "src/member_return.ts",
+        br#"class Maybe {
+    optional() { return this; }
+    value!: string;
+}
+class Box {
+    nullable(): Maybe { return new Maybe(); }
+    read() { return this.nullable().optional().value; }
+}
+"#,
+    );
+    let optional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Maybe.optional"))
+        .expect("Maybe.optional declaration");
+    let value = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Maybe.value"))
+        .expect("Maybe.value declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(optional.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "value"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(value.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_member_call_return_types_resolve_inherited_methods() {
+    let batch = candidate(
+        "src/member_return_inherited.ts",
+        br#"class Base { optional() { return this; } }
+class Child extends Base {}
+class Box {
+    make(): Child { return new Child(); }
+    read() { return this.make().optional(); }
+}
+"#,
+    );
+    let optional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Base.optional"))
+        .expect("Base.optional declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(optional.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_inherited_generic_member_types_resolve_exact_members() {
+    let batch = candidate(
+        "src/inherited_generic.ts",
+        br#"interface Def { flag: boolean }
+class Base<T> { value!: T; }
+class Child extends Base<Def> { read() { const value = this.value; return value.flag; } }
+"#,
+    );
+    let flag = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Def.flag"))
+        .expect("Def.flag declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "flag"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(flag.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_interface_extends_members_resolve_exact_targets() {
+    let batch = candidate(
+        "src/interface-extends.ts",
+        br#"type Callback = (issue: string) => string;
+interface BaseDef { errorMap?: Callback | undefined }
+interface ObjectDef extends BaseDef { shape: () => object }
+function read(def: ObjectDef) {
+    return def.errorMap?.("issue");
+}
+"#,
+    );
+    let error_map = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".BaseDef.errorMap"))
+        .expect("BaseDef.errorMap declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "errorMap"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(error_map.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_instantiated_member_chains_resolve_constraint_targets() {
+    let batch = candidate(
+        "src/generic-member-chain.ts",
+        br#"class Schema { _parseAsync() {} }
+interface Definition<T extends Schema> { left: T }
+class Intersection<T extends Schema> {
+    _def!: Definition<T>;
+    run() { this._def.left._parseAsync(); }
+}
+"#,
+    );
+    let parse_async = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema._parseAsync"))
+        .expect("Schema._parseAsync declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "_parseAsync"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(parse_async.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_callable_property_return_types_resolve_generic_member_chains() {
+    let batch = candidate(
+        "src/callable-property-return.ts",
+        br#"class Schema { _parse() {} }
+interface Definition<T extends Schema> { getter: () => T }
+class Lazy<T extends Schema> {
+    _def!: Definition<T>;
+    run() { this._def.getter()._parse(); }
+}
+"#,
+    );
+    let parse = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema._parse"))
+        .expect("Schema._parse declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "_parse"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(parse.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_static_callable_aliases_resolve_exact_property_targets() {
+    let batch = candidate(
+        "src/static-callable-alias.ts",
+        br#"function createSchema(value: string) { return value; }
+class SchemaFactory {
+    static create = createSchema;
+    run() { return SchemaFactory.create("value"); }
+}
+"#,
+    );
+    let create = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".SchemaFactory.create")
+        })
+        .expect("SchemaFactory.create declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "create"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(create.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_variable_factory_aliases_preserve_declared_return_receivers() {
+    let batch = candidate(
+        "src/variable-factory-alias.ts",
+        br#"class Schema {
+    optional() {}
+    static create(): Schema { return new Schema(); }
+}
+const create = Schema.create;
+function run() { create().optional(); }
+"#,
+    );
+    let optional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema.optional"))
+        .expect("Schema.optional declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(optional.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_type_assertion_receivers_preserve_exact_generic_members() {
+    let batch = candidate(
+        "src/type-assertion-receiver.ts",
+        br#"class Schema { parseAsync() {} }
+interface Definition<T extends Schema> { value: T }
+class Holder<T extends Schema> {
+    _def!: Definition<T>;
+    run() { (this._def as Definition<T>).value.parseAsync(); }
+}
+"#,
+    );
+    let parse_async = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema.parseAsync"))
+        .expect("Schema.parseAsync declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "parseAsync"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(parse_async.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_destructured_inline_object_types_resolve_exact_members() {
+    let batch = candidate(
+        "src/featured.tsx",
+        br#"type FeatureData = { name: string; link: string; lightImage: string; darkImage: string };
+function Featured(props: { data: FeatureData }) {
+    const { data: feature } = props;
+    return feature.name + feature.link;
+}
+"#,
+    );
+    for property in ["name", "link"] {
+        let declaration = batch
+            .declarations
+            .iter()
+            .find(|declaration| {
+                declaration.kind == "property"
+                    && declaration
+                        .qualified_name
+                        .ends_with(&format!(".FeatureData.{property}"))
+            })
+            .expect("FeatureData member declaration");
+        assert!(batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::AccessesMember
+                && candidate.target_spelling == property
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(declaration.id.as_str())
+        }));
+    }
+}
+
+#[test]
+fn typescript_generic_member_call_returns_preserve_inherited_members() {
+    let batch = candidate(
+        "src/generic-member-return.ts",
+        br#"class Base<T> { optional() {} }
+class Nullable<T> extends Base<T> {}
+class Schema<T> {
+    nullable(): Nullable<this> { return new Nullable<this>(); }
+    nullish() { return this.nullable().optional(); }
+}
+"#,
+    );
+    let optional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Base.optional"))
+        .expect("Base.optional declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(optional.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_nominal_parameter_annotations_resolve_exact_members() {
+    let batch = candidate(
+        "src/context.ts",
+        br#"interface Common { issues: string[]; contextualErrorMap?: string }
+interface ParseContext { common: Common; path: string[]; data: unknown }
+function report(ctx: ParseContext) {
+    ctx.common.issues;
+    ctx.common.contextualErrorMap;
+    ctx.path;
+    ctx.data;
+}
+"#,
+    );
+    for property in ["common", "path", "data"] {
+        let declaration = batch
+            .declarations
+            .iter()
+            .find(|declaration| {
+                declaration.kind == "property"
+                    && declaration
+                        .qualified_name
+                        .ends_with(&format!(".ParseContext.{property}"))
+            })
+            .expect("ParseContext member declaration");
+        assert!(batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::AccessesMember
+                && candidate.target_spelling == property
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(declaration.id.as_str())
+        }));
+    }
+    for property in ["issues", "contextualErrorMap"] {
+        let declaration = batch
+            .declarations
+            .iter()
+            .find(|declaration| {
+                declaration.kind == "property"
+                    && declaration
+                        .qualified_name
+                        .ends_with(&format!(".Common.{property}"))
+            })
+            .expect("Common nested member declaration");
+        assert!(batch.candidates.iter().any(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::AccessesMember
+                && candidate.target_spelling == property
+                && candidate.constraints.exact_target_declaration_id.as_deref()
+                    == Some(declaration.id.as_str())
+        }));
+    }
+}
+
+#[test]
+fn typescript_discriminated_union_guards_resolve_exact_branch_members() {
+    let batch = candidate(
+        "src/discriminated.ts",
+        br#"type Success = { success: true; data: string };
+type Failure = { success: false; error: Error };
+type Result = Success | Failure;
+function read(result: Result) {
+    if (result.success) return result.data;
+    return result.error;
+}
+"#,
+    );
+    let data = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Success.data"))
+        .expect("success data declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "data"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(data.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_string_discriminant_guards_resolve_exact_branch_members() {
+    let batch = candidate(
+        "src/string-discriminated.ts",
+        br#"class ReadySchema { parse() {} }
+class OtherSchema { other() {} }
+type Ready = { kind: "ready"; schema: ReadySchema };
+type Other = { kind: "other"; schema: OtherSchema };
+type State = Ready | Other;
+function read(state: State) {
+    if (state.kind === "ready") return state.schema.parse();
+    return state.schema.other();
+}
+"#,
+    );
+    let parse = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".ReadySchema.parse"))
+        .expect("ReadySchema.parse declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "parse"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(parse.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "other"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_string_discriminant_guards_resolve_callable_union_members() {
+    let batch = candidate(
+        "src/callable-discriminated.ts",
+        br#"type Transform = { kind: "transform"; transform: (value: string) => void };
+type Refinement = { kind: "refinement"; refinement: (value: string) => void };
+type Effect = Transform | Refinement;
+function run(effect: Effect) {
+    if (effect.kind === "transform") effect.transform("value");
+    else effect.refinement("value");
+}
+"#,
+    );
+    let transform = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Transform.transform"))
+        .expect("Transform.transform declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "transform"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(transform.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "refinement"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_string_discriminant_guards_follow_nullable_member_values() {
+    let batch = candidate(
+        "src/nullable-callable-discriminated.ts",
+        br#"type Transform = { kind: "transform"; transform: (value: string) => void };
+type Refinement = { kind: "refinement"; refinement: (value: string) => void };
+type Effect = Transform | Refinement;
+interface Definition { effect: Effect }
+class Holder {
+    _def!: Definition;
+    run() {
+        const effect = this._def.effect || null;
+        if (effect.kind === "transform") effect.transform("value");
+    }
+}
+"#,
+    );
+    let transform = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Transform.transform"))
+        .expect("Transform.transform declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "transform"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(transform.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_union_inline_object_parameters_resolve_optional_members() {
+    let batch = candidate(
+        "src/inline-union.ts",
+        br#"class Schema {
+    datetime(options?: string | { precision?: number | null; offset?: boolean }) {
+        return options?.precision;
+    }
+}
+"#,
+    );
+    let precision = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.kind == "property" && declaration.qualified_name.ends_with(".precision")
+        })
+        .expect("inline precision declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "precision"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(precision.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_implements_arguments_match_source_declared_interfaces() {
+    let batch = candidate(
+        "src/implements-assignability.ts",
+        br#"interface Input { value: string }
+class Lazy implements Input { value = "ok"; }
+class Consumer { run(value: Input) {} }
+const consumer = new Consumer();
+const lazy = new Lazy();
+consumer.run(lazy);
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Consumer.run"))
+        .expect("Consumer.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_index_signature_values_resolve_nominal_member_calls() {
+    let batch = candidate(
+        "src/index-signature.ts",
+        br#"class Schema { run() {} }
+interface Shape { [key: string]: Schema }
+function use(shape: Shape, key: string) {
+    const value = shape[key];
+    value.run();
+}
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema.run"))
+        .expect("Schema.run declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_index_signature_values_resolve_member_calls() {
+    let batch = candidate(
+        "src/generic-index-signature.ts",
+        br#"class Schema { optional() {} }
+type Shape = { [key: string]: Schema };
+class ObjectHolder<T extends Shape> {
+    shape!: T;
+    run(key: string) {
+        const field = this.shape[key]!;
+        field.optional();
+    }
+}
+"#,
+    );
+    let optional = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Schema.optional"))
+        .expect("Schema.optional declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(optional.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_callable_member_aliases_resolve_property_targets() {
+    let batch = candidate(
+        "src/callable-alias.ts",
+        br#"class Service {
+    run(value: string) {}
+    alias = this.run;
+    use() { this.alias("ok"); }
+}
+"#,
+    );
+    let alias = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Service.alias"))
+        .expect("alias property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "alias"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(alias.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_optional_callable_union_properties_resolve_exact_targets() {
+    let batch = candidate(
+        "src/optional-callable.ts",
+        br#"type Callback = (value: string) => string;
+interface Hooks { callback?: Callback | undefined }
+function use(hooks: Hooks) {
+    return hooks.callback?.("value");
+}
+"#,
+    );
+    let callback = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Hooks.callback"))
+        .expect("Hooks.callback declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "callback"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(callback.id.as_str())
+    }));
+}
+
+#[test]
+fn candidate_preserves_named_and_anonymous_default_exports() {
+    let anonymous = candidate(
+        "src/default.ts",
+        b"export default function() { return 1; }\n",
+    );
+    assert!(
+        anonymous
+            .declarations
+            .iter()
+            .any(|declaration| { declaration.name == "default" && declaration.kind == "function" })
+    );
+    assert!(anonymous.bindings.iter().any(|binding| {
+        binding.spelling == "default" && binding.kind == compass_languages::BindingKind::Reexport
+    }));
+
+    let named = candidate("src/named.ts", b"function run() {}\nexport default run;\n");
+    assert!(named.bindings.iter().any(|binding| {
+        binding.spelling == "default" && binding.kind == compass_languages::BindingKind::Reexport
+    }));
+}
+
+#[test]
+fn candidate_evidence_is_deterministic_and_parser_recovery_is_diagnosed() {
+    let source = b"export function broken( { return 1;\n";
+    let first = candidate("src/broken.ts", source);
+    let second = candidate("src/broken.ts", source);
+    assert_eq!(first, second);
+    assert!(
+        first
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "partial_parser_recovery")
+    );
+    assert!(first.declarations.iter().all(|declaration| {
+        declaration.range.start_byte <= declaration.range.end_byte
+            && usize::try_from(declaration.range.end_byte).unwrap_or(usize::MAX) <= source.len()
+    }));
+}
+
+#[test]
+fn candidate_resolves_only_proven_nominal_receivers_and_exact_members() {
+    let source = br#"class Widget {
+    field = 1;
+    run() { this.field; }
+    invoke() { this.run(); }
+}
+
+const object = new Widget();
+object.run();
+object.field;
+object["field"];
+const key = "field";
+object[key];
+function run() {}
+unknown.run();
+"#;
+    let batch = candidate("src/widget.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
+
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Widget.run"))
+        .expect("method declaration");
+    let field = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Widget.field"))
+        .expect("field declaration");
+
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "field"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(field.id.as_str())
+    }));
+    assert_eq!(
+        batch
+            .candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.relation == compass_languages::CandidateRelation::AccessesMember
+                    && candidate.target_spelling == "field"
+                    && candidate.constraints.exact_target_declaration_id.as_deref()
+                        == Some(field.id.as_str())
+            })
+            .count(),
+        3,
+        "this, dot, and literal computed members resolve to the same field"
+    );
+    // `unknown.run()` is dynamic and must not be attributed to the unrelated
+    // top-level `run` declaration.
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.qualified_name.as_deref() == Some("run")
+    }));
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "key"
+    }));
+
+    let imported = candidate(
+        "src/imported.ts",
+        b"import * as api from \"./api\";\napi.run();\n",
+    );
+    let imported_call = imported
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+        })
+        .expect("namespace member call candidate");
+    assert_eq!(
+        imported_call.constraints.qualified_name.as_deref(),
+        Some("./api::run")
+    );
+    assert!(imported_call.binding_id.is_some());
+
+    let overloads = candidate(
+        "src/overloads.ts",
+        b"function run() {}\nfunction run(value: string) {}\nrun();\nrun(\"x\");\n",
+    );
+    let overload_calls = overloads
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(overload_calls.len(), 2);
+    assert!(overload_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(0)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    assert!(overload_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(1)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let typed_overloads = candidate(
+        "src/typed-overloads.ts",
+        b"function parse(value: string) {}\nfunction parse(value: number) {}\nparse(\"text\");\nparse(42);\n",
+    );
+    let parse_declarations = typed_overloads
+        .declarations
+        .iter()
+        .filter(|declaration| declaration.name == "parse")
+        .collect::<Vec<_>>();
+    assert_eq!(parse_declarations.len(), 2);
+    let parse_calls = typed_overloads
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "parse"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(parse_calls.len(), 2);
+    assert!(parse_calls.iter().all(|candidate| {
+        candidate.constraints.argument_types.len() == 1
+            && candidate.constraints.argument_types[0].is_some()
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    let string_parse = parse_calls
+        .iter()
+        .find(|candidate| candidate.constraints.argument_types[0].as_deref() == Some("string"))
+        .expect("string overload");
+    let number_parse = parse_calls
+        .iter()
+        .find(|candidate| candidate.constraints.argument_types[0].as_deref() == Some("number"))
+        .expect("number overload");
+    assert_ne!(
+        string_parse.constraints.exact_target_declaration_id,
+        number_parse.constraints.exact_target_declaration_id
+    );
+
+    let constructed = candidate(
+        "src/constructed.ts",
+        b"class Constructed { constructor(value: string) {} }\nnew Constructed(\"ok\");\n",
+    );
+    assert!(constructed.declarations.iter().any(|declaration| {
+        declaration.kind == "constructor" && declaration.name == "constructor"
+    }));
+    assert!(constructed.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Constructs
+            && candidate.target_spelling == "Constructed"
+            && candidate.constraints.argument_count == Some(1)
+            && candidate.constraints.argument_types == [Some("string".to_owned())]
+    }));
+
+    let hierarchy = candidate(
+        "src/hierarchy.ts",
+        b"class Base { run() {} }\nclass Child extends Base { call() { super.run(); } }\n",
+    );
+    let base_run = hierarchy
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Base.run"))
+        .expect("base method declaration");
+    assert!(hierarchy.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "run"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(base_run.id.as_str())
+    }));
+
+    let imported_hierarchy = candidate(
+        "src/imported-hierarchy.ts",
+        b"import * as bases from \"./bases\";\nclass Child extends bases.Base { call() { super.run(); } }\n",
+    );
+    let imported_base = imported_hierarchy
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Extends
+                && candidate.target_spelling == "Base"
+        })
+        .expect("qualified imported base candidate");
+    assert_eq!(
+        imported_base.constraints.qualified_name.as_deref(),
+        Some("./bases::Base")
+    );
+    let imported_super = imported_hierarchy
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+        })
+        .expect("qualified imported super call");
+    assert_eq!(
+        imported_super.constraints.qualified_name.as_deref(),
+        Some("./bases::Base.run")
+    );
+
+    let inherited_constructor = candidate(
+        "src/inherited-constructor.ts",
+        b"class Base { constructor(value: string, count: number) {} }\nclass Child extends Base {}\nnew Child(\"ok\", 1);\nnew Child();\n",
+    );
+    let child_constructions = inherited_constructor
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Constructs
+                && candidate.target_spelling == "Child"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(child_constructions.len(), 2);
+    assert!(child_constructions.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(2)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    assert!(child_constructions.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(0)
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+
+    let arity_negative = candidate(
+        "src/arity.ts",
+        b"function exact(value: string) {}\nexact();\nexact(\"ok\");\nfunction optional(value?: string) {}\noptional(\"ok\");\n",
+    );
+    let exact_calls = arity_negative
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "exact"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        exact_calls.len(),
+        2,
+        "the incompatible call remains unresolved"
+    );
+    assert!(exact_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(1)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    assert!(exact_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(0)
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+    assert!(arity_negative.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "optional"
+            && candidate.constraints.argument_count == Some(1)
+    }));
+
+    let private = candidate(
+        "src/private.ts",
+        b"class Secret { #run() {} call() { this.#run(); } }\nnew Secret().call();\n",
+    );
+    let private_run = private
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "#run")
+        .expect("private method declaration");
+    assert!(private.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "#run"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(private_run.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_candidate_infers_object_literal_members_and_lexical_calls() {
+    let source = br#"const config = {
+    legacyAgreements: { Stytch: "gold" },
+    sponsorsToIgnore: ["axios"],
+};
+const frozen = { active: true } as const;
+function send404(response, body) { response.end(body); }
+class Server {
+    static handle(response) { send404(response); }
+}
+
+config.legacyAgreements;
+config.sponsorsToIgnore;
+frozen.active;
+"#;
+    let batch = candidate("src/server.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
+
+    let agreements = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".config.legacyAgreements")
+        })
+        .expect("object-literal property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "legacyAgreements"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(agreements.id.as_str())
+    }));
+    let ignored = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".config.sponsorsToIgnore")
+        })
+        .expect("array-valued object-literal property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "sponsorsToIgnore"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(ignored.id.as_str())
+    }));
+    let active = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".frozen.active"))
+        .expect("as-const object property declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "active"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(active.id.as_str())
+    }));
+
+    let send404 = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "send404")
+        .expect("function declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "send404"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(send404.id.as_str())
+    }));
+}
+
+#[test]
+fn candidate_emits_curated_external_builtin_evidence_and_respects_shadowing() {
+    let batch = candidate(
+        "src/builtins.ts",
+        br#"Array.from(items);
+console.log("ready");
+new Date();
+new Set().add(1);
+new Map().get(key);
+new Date().getTime();
+Error("broken");
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid builtin evidence");
+
+    let external = |relation, spelling: &str, qualified: &str| {
+        batch.candidates.iter().any(|candidate| {
+            candidate.relation == relation
+                && candidate.target_spelling == spelling
+                && candidate.constraints.allow_external
+                && candidate.constraints.module_or_package.as_deref() == Some("javascript.global")
+                && candidate.constraints.qualified_name.as_deref() == Some(qualified)
+        })
+    };
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "from",
+        "global::Array.from"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "log",
+        "global::console.log"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Constructs,
+        "Date",
+        "global::Date"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "add",
+        "global::Set.add"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "get",
+        "global::Map.get"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "getTime",
+        "global::Date.getTime"
+    ));
+    assert!(external(
+        compass_languages::CandidateRelation::Calls,
+        "Error",
+        "global::Error"
+    ));
+    let invalid_instance_member = candidate(
+        "src/invalid-builtin-member.ts",
+        b"new ArrayBuffer().add(1);\nnew WeakMap().values();\n",
+    );
+    assert!(!invalid_instance_member.candidates.iter().any(|candidate| {
+        candidate.constraints.module_or_package.as_deref() == Some("javascript.global")
+            && (candidate.target_spelling == "add" || candidate.target_spelling == "values")
+    }));
+
+    let shadowed = candidate(
+        "src/shadowed-builtins.ts",
+        b"const Array = { from() {} };\nArray.from(items);\n",
+    );
+    assert!(!shadowed.candidates.iter().any(|candidate| {
+        candidate.constraints.module_or_package.as_deref() == Some("javascript.global")
+    }));
+}
+
+#[test]
+fn candidate_declares_for_of_bindings_with_exact_source_anchors() {
+    let batch = candidate(
+        "src/loops.ts",
+        b"for (const _ of DATA) consume(_);\nfor (const { id } of rows) consume(id);\n",
+    );
+    let loop_bindings = batch
+        .declarations
+        .iter()
+        .filter(|declaration| declaration.kind == "variable")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        loop_bindings
+            .iter()
+            .filter(|declaration| declaration.name == "_")
+            .count(),
+        1
+    );
+    assert!(loop_bindings.iter().any(|declaration| {
+        declaration.name == "id"
+            && declaration.range.start_byte
+                == b"for (const _ of DATA) consume(_);\nfor (const { ".len() as u64
+    }));
+
+    let callbacks = candidate(
+        "src/callbacks.js",
+        b"rows.find((activeSponsor) => activeSponsor.slug === target);\n",
+    );
+    assert!(callbacks.declarations.iter().any(|declaration| {
+        declaration.kind == "parameter" && declaration.name == "activeSponsor"
+    }));
+
+    let unparenthesized = candidate(
+        "src/unparenthesized.js",
+        b"rows.find(activeSponsor => activeSponsor.slug === target);\n",
+    );
+    assert!(unparenthesized.declarations.iter().any(|declaration| {
+        declaration.kind == "parameter" && declaration.name == "activeSponsor"
+    }));
+
+    let caught = candidate(
+        "src/catch.js",
+        b"try { run(); } catch (error) { log(error); }\n",
+    );
+    assert!(
+        caught
+            .declarations
+            .iter()
+            .any(|declaration| { declaration.kind == "variable" && declaration.name == "error" })
+    );
+}
+
+#[test]
+fn candidate_resolves_qualified_and_builtin_type_references_without_fallback_guesses() {
+    let batch = candidate(
+        "src/types.ts",
+        br#"import * as Benchmark from "benchmark";
+type Event = Benchmark.Event;
+type Pending = Promise<string>;
+type Context = ThisType<{ value: string }>;
+type ElementRef = HTMLDivElement;
+type Match = RegExpExecArray;
+type ReactElement = React.ReactElement;
+type NodeBuffer = Buffer;
+type Box<T> = { value: T };
+type Pair<T> = { left: T; right: T };
+type Mapped<T> = { [Key in T]: string };
+type Indexed = { [key: string]: unknown };
+type WithThis = (this: Context, value: string) => void;
+type LastOf<T> = T extends unknown ? infer Last : never;
+type ParseFn = (schema: unknown, _params?: string) => void;
+const typed: (_params?: string) => void = (_value) => {};
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("valid type evidence");
+    let type_refs = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::References
+                && candidate
+                    .occurrence_id
+                    .as_ref()
+                    .is_some_and(|occurrence_id| {
+                        batch.occurrences.iter().any(|occurrence| {
+                            occurrence.id == *occurrence_id
+                                && occurrence.context.as_deref() == Some("type")
+                        })
+                    })
+        })
+        .collect::<Vec<_>>();
+    let qualified = type_refs
+        .iter()
+        .find(|candidate| candidate.target_spelling == "Benchmark.Event")
+        .expect("qualified imported type reference");
+    assert_eq!(
+        qualified.constraints.qualified_name.as_deref(),
+        Some("benchmark::Event")
+    );
+    assert!(qualified.binding_id.is_some());
+    for (spelling, target) in [
+        ("Promise", "global::Promise"),
+        ("ThisType", "typescript.lib::ThisType"),
+        ("HTMLDivElement", "dom.lib::HTMLDivElement"),
+        ("RegExpExecArray", "typescript.lib::RegExpExecArray"),
+        ("React.ReactElement", "@types/react::React.ReactElement"),
+        ("Buffer", "node.global::Buffer"),
+    ] {
+        let builtin = type_refs
+            .iter()
+            .find(|candidate| candidate.target_spelling == spelling)
+            .expect("builtin type reference");
+        assert!(builtin.constraints.allow_external);
+        assert_eq!(builtin.constraints.qualified_name.as_deref(), Some(target));
+    }
+    assert!(type_refs.iter().any(|candidate| {
+        candidate.target_spelling == "T"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+    assert!(
+        batch.declarations.iter().any(|declaration| {
+            declaration.kind == "type_parameter" && declaration.name == "Key"
+        })
+    );
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| { declaration.kind == "parameter" && declaration.name == "key" })
+    );
+    assert!(
+        batch
+            .declarations
+            .iter()
+            .any(|declaration| { declaration.kind == "parameter" && declaration.name == "this" })
+    );
+    assert!(
+        batch.declarations.iter().any(|declaration| {
+            declaration.kind == "type_parameter" && declaration.name == "Last"
+        })
+    );
+    assert!(
+        batch.declarations.iter().any(|declaration| {
+            declaration.kind == "parameter" && declaration.name == "_params"
+        })
+    );
+
+    let shadowed = candidate(
+        "src/shadowed-type.ts",
+        b"type Promise = { then(): void };\ntype Local = Promise;\n",
+    );
+    assert!(!shadowed.candidates.iter().any(|candidate| {
+        candidate
+            .occurrence_id
+            .as_ref()
+            .is_some_and(|occurrence_id| {
+                shadowed.occurrences.iter().any(|occurrence| {
+                    occurrence.id == *occurrence_id && occurrence.context.as_deref() == Some("type")
+                })
+            })
+            && candidate.constraints.module_or_package.as_deref() == Some("javascript.global")
+    }));
+}
+
+#[test]
+fn candidate_preserves_dynamic_calls_and_proven_super_and_type_member_evidence() {
+    let batch = candidate(
+        "src/advanced.ts",
+        br#"import * as schemas from "./schemas";
+interface Coerced extends schemas._ZodString {}
+class Base { constructor(value: string) {} }
+class Child extends Base { constructor(value: string) { super(value); } }
+const encoded = (encoder => encoder.encode)(new TextEncoder());
+const dynamicMember = resolvers[method]();
+const dynamicConstructor = new (factory || Base)();
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("advanced evidence");
+
+    let type_member = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::AccessesMember
+                && candidate.target_spelling == "_ZodString"
+        })
+        .expect("qualified heritage member access");
+    assert_eq!(
+        type_member.constraints.qualified_name.as_deref(),
+        Some("./schemas::_ZodString")
+    );
+    assert!(
+        type_member
+            .occurrence_id
+            .as_ref()
+            .and_then(|id| batch
+                .occurrences
+                .iter()
+                .find(|occurrence| occurrence.id == *id))
+            .is_some_and(|occurrence| occurrence.context.as_deref() == Some("type_member"))
+    );
+
+    let base = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Base" && declaration.kind == "class")
+        .expect("base declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "super"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(base.id.as_str())
+    }));
+
+    for context in ["dynamic_call", "dynamic_member_call", "dynamic_new"] {
+        assert!(
+            batch.candidates.iter().any(|candidate| {
+                (candidate.relation == compass_languages::CandidateRelation::Calls
+                    || candidate.relation == compass_languages::CandidateRelation::Constructs)
+                    && candidate
+                        .occurrence_id
+                        .as_ref()
+                        .and_then(|id| {
+                            batch
+                                .occurrences
+                                .iter()
+                                .find(|occurrence| occurrence.id == *id)
+                        })
+                        .is_some_and(|occurrence| occurrence.context.as_deref() == Some(context))
+            }),
+            "missing dynamic context {context}"
+        );
+    }
+}
+
+#[test]
+fn javascript_candidate_keeps_block_bindings_distinct_and_hoists_var() {
+    let batch = candidate(
+        "src/blocks.js",
+        br#"function run(flag) {
+  if (flag) {
+    const callback = () => 1;
+    callback();
+  } else {
+    const callback = () => 2;
+    callback();
+  }
+  var hoisted = () => 3;
+  if (flag) {
+    hoisted();
+  }
+}
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("block evidence");
+
+    let mut call_target_names = batch
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == compass_languages::CandidateRelation::Calls)
+        .filter_map(|candidate| candidate.constraints.exact_target_declaration_id.as_deref())
+        .filter_map(|id| {
+            batch
+                .declarations
+                .iter()
+                .find(|declaration| declaration.id == id)
+        })
+        .map(|declaration| declaration.name.as_str())
+        .collect::<Vec<_>>();
+    call_target_names.sort_unstable();
+    assert_eq!(call_target_names, ["callback", "callback", "hoisted"]);
+    assert!(batch.scopes.iter().any(|scope| scope.kind == "block"));
+    assert!(batch.scopes.iter().any(|scope| scope.kind == "function"));
+}
+
+#[test]
+fn object_literal_properties_do_not_shadow_unqualified_calls() {
+    let batch = candidate(
+        "src/object-shadow.js",
+        br#"const object = { run: () => 1 };
+run();
+"#,
+    );
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
+fn candidate_tracks_type_alias_enum_and_string_named_members() {
+    let source = br#"type Config = { name: string };
+function makeConfig(): Config { return { name: "ready" }; }
+const config = makeConfig();
+config.name;
+
+enum Status { Ready = "ready", Failed = "failed" }
+Status.Ready;
+
+class Box {
+    "quoted" = 1;
+    read() { this["quoted"]; }
+}
+
+new Box().read();
+"#;
+    let batch = candidate("src/typed-members.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("typed member evidence");
+
+    let config_name = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Config.name"))
+        .expect("type-literal member");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "name"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(config_name.id.as_str())
+    }));
+
+    let ready = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Status.Ready"))
+        .expect("enum member");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "Ready"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(ready.id.as_str())
+    }));
+
+    let quoted = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name.ends_with(".Box.quoted")
+                && declaration.range.start_byte < source.len() as u64
+        })
+        .expect("string-named class member");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::AccessesMember
+            && candidate.target_spelling == "quoted"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(quoted.id.as_str())
+    }));
+}

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1557,6 +1557,31 @@ function use(value: Item) { make(value).inspect(); }
 }
 
 #[test]
+fn typescript_imported_callable_return_preserves_explicit_generic_marker() {
+    let batch = candidate(
+        "src/imported-explicit-call.ts",
+        br#"import { identity } from "./factory";
+class Item { inspect(): void {} }
+function use(value: Item) { identity<Item>(value).inspect(); }
+"#,
+    );
+    let call = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .expect("explicit imported callable return member call");
+    assert!(
+        call.constraints
+            .qualified_name
+            .as_deref()
+            .is_some_and(|qualified| qualified.contains("#call<") && qualified.contains("#types<"))
+    );
+    assert!(!call.constraints.allow_external);
+}
+
+#[test]
 fn typescript_generic_function_array_return_preserves_element_receiver() {
     let batch = candidate(
         "src/generic-return-array.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1478,6 +1478,116 @@ function use(box: Box<Item>) { box.pair[0].inspect(); }
 }
 
 #[test]
+fn typescript_generic_function_return_substitutes_nominal_argument() {
+    let batch = candidate(
+        "src/generic-return.ts",
+        br#"class Item { inspect(): void {} }
+function identity<T>(value: T): T { return value; }
+function fixed<T>(value: T): Item { return new Item(); }
+function use() {
+    identity(new Item()).inspect();
+    identity<Item>(new Item()).inspect();
+    fixed("value").inspect();
+}
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 3);
+    assert!(calls.iter().all(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_function_array_return_preserves_element_receiver() {
+    let batch = candidate(
+        "src/generic-return-array.ts",
+        br#"class Item { inspect(): void {} }
+function collect<T>(value: T): T[] { return [value]; }
+function use() { collect(new Item())[0].inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_function_nominal_container_return_preserves_member_receiver() {
+    let batch = candidate(
+        "src/generic-return-container.ts",
+        br#"class Item { inspect(): void {} }
+interface Box<T> { value: T }
+function box<T>(value: T): Box<T> { return { value }; }
+function use() { box(new Item()).value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_generic_function_return_fails_closed_without_inference() {
+    let batch = candidate(
+        "src/generic-return-unknown.ts",
+        br#"declare function identity<T>(): T;
+function use() { identity().inspect(); }
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
+fn typescript_generic_function_return_fails_closed_on_conflicting_inference() {
+    let batch = candidate(
+        "src/generic-return-conflict.ts",
+        br#"class Item { inspect(): void {} }
+class Other {}
+function choose<T>(first: T, second: T): T { return first; }
+function use() { choose(new Item(), new Other()).inspect(); }
+"#,
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+}
+
+#[test]
 fn typescript_generic_index_signature_values_resolve_member_calls() {
     let batch = candidate(
         "src/generic-index-signature.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -874,6 +874,41 @@ function read(result: Result) {
 }
 
 #[test]
+fn typescript_in_guards_resolve_the_unique_union_member_owner() {
+    let batch = candidate(
+        "src/in-guard.ts",
+        br#"type Ready = { run(): void };
+type Pending = { wait(): void };
+type State = Ready | Pending;
+function use(state: State) {
+    if ("run" in state) state.run();
+    if ("missing" in state) state.run();
+}
+"#,
+    );
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Ready.run"))
+        .expect("Ready.run declaration");
+    let runs = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "run"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(runs.len(), 2);
+    assert!(runs.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(run.id.as_str())
+    }));
+    assert!(
+        runs.iter()
+            .any(|candidate| { candidate.constraints.exact_target_declaration_id.is_none() })
+    );
+}
+
+#[test]
 fn typescript_string_discriminant_guards_resolve_exact_branch_members() {
     let batch = candidate(
         "src/string-discriminated.ts",
@@ -2486,6 +2521,65 @@ fn candidate_declares_for_of_bindings_with_exact_source_anchors() {
             .declarations
             .iter()
             .any(|declaration| { declaration.kind == "variable" && declaration.name == "error" })
+    );
+}
+
+#[test]
+fn javascript_callable_values_are_references_not_indirect_calls() {
+    let source = br#"function onValue(value) {}
+const alias = onValue;
+const alias2 = alias;
+const list = [onValue, alias2];
+const object = { handler: alias };
+consume(onValue);
+consume(alias2);
+consume(list[0]);
+consume(object.handler);
+const nonCallable = 1;
+consume(nonCallable);
+const maybe = Math.random() ? onValue : nonCallable;
+consume(maybe);
+"#;
+    let batch = candidate("src/callback-values.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("callback value evidence");
+
+    let on_value = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "onValue" && declaration.kind == "function")
+        .expect("callable source declaration");
+    let alias2 = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "alias2" && declaration.kind == "variable")
+        .expect("second callable alias");
+    let non_callable = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "nonCallable")
+        .expect("non-callable value");
+
+    let references_to = |target: &str| {
+        batch
+            .candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.relation == CandidateRelation::References
+                    && candidate.constraints.exact_target_declaration_id.as_deref() == Some(target)
+            })
+            .count()
+    };
+    assert!(
+        references_to(&on_value.id) >= 2,
+        "onValue callback references"
+    );
+    assert!(references_to(&alias2.id) >= 2, "alias2 callback references");
+    assert_eq!(references_to(&non_callable.id), 0);
+    assert!(
+        !batch
+            .candidates
+            .iter()
+            .any(|candidate| candidate.relation == CandidateRelation::IndirectCalls)
     );
 }
 

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -260,6 +260,55 @@ export default { ...base, isString: value => true };
 }
 
 #[test]
+fn typescript_candidate_publishes_wildcard_barrel_reexports() {
+    let batch = candidate(
+        "src/index.ts",
+        br#"export * from "./values";
+export * as values from "./values";
+export type * from "./types";
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("wildcard reexport evidence");
+
+    let wildcard = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.kind == compass_languages::BindingKind::Reexport
+                && binding.spelling == "*"
+                && binding.qualified_target == "./values::*"
+        })
+        .expect("wildcard reexport binding");
+    assert_eq!(wildcard.namespace, Some(SymbolNamespace::Namespace));
+    assert!(!wildcard.type_only);
+    let alias = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.kind == compass_languages::BindingKind::Reexport
+                && binding.spelling == "values"
+                && binding.qualified_target == "./values::*"
+        })
+        .expect("namespace reexport alias");
+    assert_eq!(alias.namespace, Some(SymbolNamespace::Namespace));
+    assert!(!alias.type_only);
+    assert!(batch.occurrences.iter().any(|occurrence| {
+        occurrence.spelling == "*" && occurrence.context.as_deref() == Some("wildcard")
+    }));
+
+    let type_only = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.kind == compass_languages::BindingKind::Reexport
+                && binding.spelling == "*"
+                && binding.qualified_target == "./types::*"
+        })
+        .expect("type-only wildcard reexport binding");
+    assert!(type_only.type_only);
+}
+
+#[test]
 fn javascript_commonjs_require_preserves_namespace_and_export_keys() {
     let source = br#"const api = require("./api");
 const {

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -214,6 +214,115 @@ export function render() { return <UI.Button />; }
 }
 
 #[test]
+fn typescript_candidate_emits_call_and_member_decorator_evidence() {
+    let source = br#"import { Injectable, Controller as C } from "@nestjs/common";
+import * as decorators from "./decorators";
+function Local(value: string) {}
+@Local("service")
+@C
+@Injectable()
+@decorators.Controller({ path: "/users" })
+class Service {}
+@unknownFactory(makePath())
+class Dynamic {}
+"#;
+    let batch = candidate("src/service.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("decorator evidence");
+    let decorators = batch
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Decorates)
+        .collect::<Vec<_>>();
+    assert_eq!(decorators.len(), 5);
+    let local = decorators
+        .iter()
+        .find(|candidate| candidate.target_spelling == "Local")
+        .expect("local decorator factory");
+    assert_eq!(local.constraints.argument_count, Some(1));
+    assert_eq!(
+        local.constraints.argument_types,
+        [Some("string".to_owned())]
+    );
+    assert!(local.constraints.exact_target_declaration_id.is_some());
+    assert_eq!(
+        local
+            .occurrence_id
+            .as_ref()
+            .and_then(|id| batch
+                .occurrences
+                .iter()
+                .find(|occurrence| occurrence.id == *id))
+            .and_then(|occurrence| occurrence.context.as_deref()),
+        Some("decorator")
+    );
+    let namespace = decorators
+        .iter()
+        .find(|candidate| candidate.target_spelling == "Controller")
+        .expect("namespace decorator factory");
+    assert_eq!(
+        namespace.constraints.qualified_name.as_deref(),
+        Some("./decorators::Controller")
+    );
+    assert_eq!(
+        namespace
+            .occurrence_id
+            .as_ref()
+            .and_then(|id| batch
+                .occurrences
+                .iter()
+                .find(|occurrence| occurrence.id == *id))
+            .and_then(|occurrence| occurrence.context.as_deref()),
+        Some("decorator_member")
+    );
+    let dynamic = decorators
+        .iter()
+        .find(|candidate| candidate.target_spelling == "unknownFactory")
+        .expect("dynamic decorator factory");
+    assert_eq!(dynamic.constraints.exact_target_declaration_id, None);
+    assert_eq!(dynamic.constraints.argument_count, Some(1));
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "makePath"
+    }));
+    assert!(!batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "Injectable"
+    }));
+}
+
+#[test]
+fn typescript_candidate_keeps_recovered_computed_decorator_unresolved() {
+    let batch = candidate(
+        "src/recovered-decorator.ts",
+        br#"@decorators[factoryKey]()
+class Computed {}
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("recovered decorator evidence");
+    let decorator = batch
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Decorates)
+        .expect("recovered decorator candidate");
+    assert_eq!(decorator.constraints.exact_target_declaration_id, None);
+    assert_eq!(
+        decorator
+            .occurrence_id
+            .as_ref()
+            .and_then(|id| batch
+                .occurrences
+                .iter()
+                .find(|occurrence| occurrence.id == *id))
+            .and_then(|occurrence| occurrence.context.as_deref()),
+        Some("decorator_recovery")
+    );
+    assert!(
+        batch
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "partial_parser_recovery")
+    );
+}
+
+#[test]
 fn javascript_candidate_publishes_spread_free_default_object_members() {
     let batch = candidate(
         "src/utils.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -29,7 +29,7 @@ new App();
     let batch = candidate("src/app.ts", source);
     validate_evidence(&batch, EvidenceLimits::default()).expect("valid evidence");
     assert_eq!(batch.adapter.language, "typescript");
-    assert_eq!(batch.adapter.version, 3);
+    assert_eq!(batch.adapter.version, 4);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("ts"));
     assert!(
         batch
@@ -120,7 +120,7 @@ export async function load() { return import("./lazy.js"); }
 "#;
     let batch = candidate("src/render.jsx", source);
     assert_eq!(batch.adapter.language, "javascript");
-    assert_eq!(batch.adapter.version, 3);
+    assert_eq!(batch.adapter.version, 4);
     assert_eq!(batch.adapter.dialect.as_deref(), Some("jsx"));
     assert!(
         batch
@@ -248,13 +248,42 @@ export default { ...base, isString: value => true };
 "#,
     );
     validate_evidence(&spread, EvidenceLimits::default()).expect("spread default evidence");
+    let spread_default = spread
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "spread-default.default")
+        .expect("proven spread default owner");
+    assert!(
+        spread
+            .declarations
+            .iter()
+            .any(|declaration| declaration.qualified_name == "spread-default.default.isString")
+    );
     assert!(
         !spread
             .declarations
             .iter()
-            .any(|declaration| declaration.qualified_name == "spread-default.default")
+            .any(|declaration| declaration.qualified_name == "spread-default.default.isNumber")
     );
-    assert!(!spread.bindings.iter().any(|binding| {
+    assert!(spread.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport
+            && binding.spelling == "default"
+            && binding.target_declaration_id.as_deref() == Some(spread_default.id.as_str())
+    }));
+
+    let unknown = candidate(
+        "src/unknown-spread-default.js",
+        br#"const base = getBase();
+export default { ...base, isString: value => true };
+"#,
+    );
+    assert!(
+        !unknown
+            .declarations
+            .iter()
+            .any(|declaration| declaration.qualified_name == "unknown-spread-default.default")
+    );
+    assert!(!unknown.bindings.iter().any(|binding| {
         binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "default"
     }));
 }
@@ -1813,6 +1842,87 @@ later();
 "#,
     );
     assert!(!spread.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let proven_spread = candidate(
+        "src/const-structural-proven-spread.js",
+        br#"const base = { inspect() {} };
+const config = { ...base };
+config.inspect();
+"#,
+    );
+    let base_inspect = proven_spread
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "const-structural-proven-spread.base.inspect"
+        })
+        .expect("proven spread source member");
+    assert!(proven_spread.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(base_inspect.id.as_str())
+    }));
+
+    let overridden = candidate(
+        "src/const-structural-spread-order.js",
+        br#"const base = { inspect() {} };
+const config = { inspect() { return 'local'; }, ...base };
+config.inspect();
+"#,
+    );
+    let base_target = overridden
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "const-structural-spread-order.base.inspect"
+        })
+        .expect("spread override source member");
+    let config_target = overridden
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "const-structural-spread-order.config.inspect"
+        })
+        .expect("spread override destination member");
+    assert!(overridden.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(base_target.id.as_str())
+    }));
+    assert!(!overridden.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(config_target.id.as_str())
+    }));
+
+    let unknown = candidate(
+        "src/const-structural-unknown-spread.js",
+        br#"const base = getBase();
+const config = { ...base };
+config.inspect();
+"#,
+    );
+    assert!(!unknown.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let ambiguous = candidate(
+        "src/const-structural-ambiguous-spread.js",
+        br#"const base = { inspect() {}, inspect(value) {} };
+const config = { ...base };
+config.inspect();
+"#,
+    );
+    assert!(!ambiguous.candidates.iter().any(|candidate| {
         candidate.relation == CandidateRelation::Calls
             && candidate.target_spelling == "inspect"
             && candidate.constraints.exact_target_declaration_id.is_some()
@@ -3411,6 +3521,28 @@ fn javascript_flow_assignment_object_literal_selects_exact_members() {
             && candidate.target_spelling == "username"
             && candidate.constraints.exact_target_declaration_id.as_deref()
                 == Some(username.id.as_str())
+    }));
+
+    let spread = candidate(
+        "src/object-spread-reassignment.js",
+        br#"const base = { username: 'user' };
+let auth;
+auth = { ...base };
+auth.username;
+"#,
+    );
+    let base_username = spread
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "object-spread-reassignment.base.username"
+        })
+        .expect("spread assignment member declaration");
+    assert!(spread.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "username"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(base_username.id.as_str())
     }));
 }
 

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -309,6 +309,53 @@ export type * from "./types";
 }
 
 #[test]
+fn typescript_candidate_publishes_export_assignment_default() {
+    let batch = candidate(
+        "src/api.ts",
+        br#"export function run() {}
+export = run;
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("export assignment evidence");
+    let run = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run" && declaration.kind == "function")
+        .expect("export assignment target declaration");
+    let binding = batch
+        .bindings
+        .iter()
+        .find(|binding| {
+            binding.kind == compass_languages::BindingKind::Reexport
+                && binding.spelling == "default"
+        })
+        .expect("export assignment default binding");
+    assert_eq!(binding.qualified_target, "api.run");
+    assert_eq!(
+        binding.target_declaration_id.as_deref(),
+        Some(run.id.as_str())
+    );
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == compass_languages::CandidateRelation::Reexports
+            && candidate.target_spelling == "default"
+    }));
+
+    let object = candidate(
+        "src/object-api.ts",
+        br#"export = { run: (value: number) => value };
+"#,
+    );
+    validate_evidence(&object, EvidenceLimits::default())
+        .expect("object export assignment evidence");
+    assert!(object.declarations.iter().any(|declaration| {
+        declaration.qualified_name == "object-api.default" && declaration.kind == "variable"
+    }));
+    assert!(object.declarations.iter().any(|declaration| {
+        declaration.qualified_name == "object-api.default.run" && declaration.kind == "property"
+    }));
+}
+
+#[test]
 fn javascript_commonjs_require_preserves_namespace_and_export_keys() {
     let source = br#"const api = require("./api");
 const {

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -3333,6 +3333,65 @@ api.remove();
 }
 
 #[test]
+fn javascript_object_flow_member_reads_and_literal_writes_resolve_exact_targets() {
+    let batch = candidate(
+        "src/object-flow-debug.js",
+        br#"const response = { request: requestValue, data: null };
+const later = () => {
+    response.data = responseValue;
+    return response.request;
+};
+later();
+
+const key = Symbol('internals');
+class Stream {
+    constructor() {
+        const internals = (this[key] = { isCaptured: false });
+        this.on('newListener', () => {
+            if (!internals.isCaptured) {
+                internals.isCaptured = true;
+            }
+        });
+    }
+}
+new Stream();
+"#,
+    );
+    let request = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "object-flow-debug.response.request")
+        .expect("response.request declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "request"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(request.id.as_str())
+    }));
+    let is_captured = batch
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name
+                == "object-flow-debug.Stream.constructor.internals.isCaptured"
+        })
+        .expect("internals.isCaptured declaration");
+    assert_eq!(
+        batch
+            .candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.relation == CandidateRelation::AccessesMember
+                    && candidate.target_spelling == "isCaptured"
+                    && candidate.constraints.exact_target_declaration_id.as_deref()
+                        == Some(is_captured.id.as_str())
+            })
+            .count(),
+        2
+    );
+}
+
+#[test]
 fn candidate_emits_curated_external_builtin_evidence_and_respects_shadowing() {
     let batch = candidate(
         "src/builtins.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -603,6 +603,54 @@ module.exports = { ...esm, ...cjs };
 }
 
 #[test]
+fn javascript_commonjs_object_assign_publishes_bounded_owner_aliases() {
+    let source = br#"const base = { inherited() {} };
+module.exports = Object.assign({}, base, { direct() {} });
+"#;
+    let batch = candidate("src/object-assign-export.js", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("Object.assign evidence");
+
+    assert!(batch.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "default"
+    }));
+    assert!(batch.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Member
+            && binding.spelling == "*"
+            && binding.qualified_target == "object-assign-export.base"
+    }));
+    assert!(batch.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "direct"
+    }));
+
+    let mutation = candidate(
+        "src/object-assign-mutation.js",
+        br#"const base = { inherited() {} };
+Object.assign(exports, base);
+"#,
+    );
+    validate_evidence(&mutation, EvidenceLimits::default())
+        .expect("Object.assign mutation evidence");
+    assert!(mutation.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Member
+            && binding.spelling == "*"
+            && binding.qualified_target == "object-assign-mutation.base"
+    }));
+
+    let unknown = candidate(
+        "src/object-assign-unknown.js",
+        br#"const base = getBase();
+module.exports = Object.assign({}, base, { direct() {} });
+"#,
+    );
+    assert!(!unknown.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Member && binding.spelling == "*"
+    }));
+    assert!(!unknown.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "direct"
+    }));
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1701,6 +1701,176 @@ new Service();
 }
 
 #[test]
+fn javascript_nominal_member_writes_keep_exact_source_targets() {
+    let source = br#"class Service {
+    constructor() {
+        this.kind = 'initial';
+    }
+}
+const service = new Service();
+service.kind = 'updated';
+"#;
+    let batch = candidate("src/nominal-member-write.js", source);
+    let write_start = source
+        .windows(b"service.kind".len())
+        .rposition(|window| window == b"service.kind")
+        .expect("service.kind write")
+        .saturating_add(b"service.".len());
+    let write_has_exact_target = batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "kind"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|occurrence_id| {
+                    batch
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                })
+                .is_some_and(|occurrence| occurrence.range.start_byte == write_start as u64)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    });
+    assert!(
+        write_has_exact_target,
+        "nominal assignment write lost its exact target: {:#?}",
+        batch.candidates
+    );
+
+    let compound_source = br#"class Service {
+    constructor() {
+        this.kind = 1;
+    }
+}
+const service = new Service();
+service.kind += 1;
+"#;
+    let compound = candidate("src/nominal-member-compound.js", compound_source);
+    let compound_start = compound_source
+        .windows(b"service.kind".len())
+        .rposition(|window| window == b"service.kind")
+        .expect("compound service.kind write")
+        .saturating_add(b"service.".len());
+    assert!(!compound.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "kind"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|occurrence_id| {
+                    compound
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                })
+                .is_some_and(|occurrence| occurrence.range.start_byte == compound_start as u64)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let static_source = br#"class Service {
+    static from() {
+        const service = new Service();
+        service.kind = 'updated';
+        return service;
+    }
+    constructor() {
+        this.kind = 'initial';
+    }
+}
+Service.from();
+"#;
+    let static_batch = candidate("src/nominal-static-write.js", static_source);
+    let static_start = static_source
+        .windows(b"service.kind".len())
+        .rposition(|window| window == b"service.kind")
+        .expect("static service.kind write")
+        .saturating_add(b"service.".len());
+    assert!(static_batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "kind"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|occurrence_id| {
+                    static_batch
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                })
+                .is_some_and(|occurrence| occurrence.range.start_byte == static_start as u64)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let escaped_source = br#"class Service {
+    constructor() {
+        this.kind = 'initial';
+    }
+}
+function consume(value) {
+    return value;
+}
+const service = new Service();
+consume(service);
+service.kind;
+"#;
+    let escaped = candidate("src/nominal-escape-read.js", escaped_source);
+    let escaped_start = escaped_source
+        .windows(b"service.kind".len())
+        .rposition(|window| window == b"service.kind")
+        .expect("escaped service.kind read")
+        .saturating_add(b"service.".len());
+    assert!(escaped.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "kind"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|occurrence_id| {
+                    escaped
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                })
+                .is_some_and(|occurrence| occurrence.range.start_byte == escaped_start as u64)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let nested_source = br#"class Service {
+    constructor() {
+        this.kind = 'initial';
+    }
+}
+function consume(value) {
+    return value;
+}
+const service = new Service();
+consume(service);
+service.nested.kind = 'unknown';
+"#;
+    let nested = candidate("src/nominal-nested-escape-write.js", nested_source);
+    let nested_start = nested_source
+        .windows(b"service.nested.kind".len())
+        .rposition(|window| window == b"service.nested.kind")
+        .expect("nested escaped service.kind write")
+        .saturating_add(b"service.nested.".len());
+    assert!(!nested.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "kind"
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|occurrence_id| {
+                    nested
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *occurrence_id)
+                })
+                .is_some_and(|occurrence| occurrence.range.start_byte == nested_start as u64)
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+}
+
+#[test]
 fn typescript_homomorphic_mapped_alias_preserves_nominal_member_targets() {
     let batch = candidate(
         "src/mapped-alias.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1930,3 +1930,37 @@ new Box().read();
                 == Some(quoted.id.as_str())
     }));
 }
+
+#[test]
+fn typescript_candidate_preserves_imported_type_receiver_for_member_evidence() {
+    let batch = candidate(
+        "src/consumer.ts",
+        br#"import type { Config } from "./types";
+export function use(config: Config) { config.inspect(); }
+"#,
+    );
+    validate_evidence(&batch, EvidenceLimits::default()).expect("imported member evidence");
+    let binding = batch
+        .bindings
+        .iter()
+        .find(|binding| binding.spelling == "Config")
+        .expect("imported type binding");
+    let candidates = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            matches!(
+                candidate.relation,
+                CandidateRelation::Calls | CandidateRelation::AccessesMember
+            ) && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(candidates.len(), 2);
+    for candidate in candidates {
+        assert_eq!(candidate.binding_id.as_deref(), Some(binding.id.as_str()));
+        assert_eq!(
+            candidate.constraints.qualified_name.as_deref(),
+            Some("./types::Config.inspect")
+        );
+    }
+}

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -580,6 +580,29 @@ module.exports = { ...base, direct() {} };
 }
 
 #[test]
+fn javascript_namespace_and_require_spreads_publish_module_owner_aliases() {
+    let source = br#"import * as esm from "./esm";
+const cjs = require("./cjs");
+module.exports = { ...esm, ...cjs };
+"#;
+    let batch = candidate("src/namespace-spread.cjs", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("namespace spread evidence");
+
+    let aliases = batch
+        .bindings
+        .iter()
+        .filter(|binding| {
+            binding.kind == compass_languages::BindingKind::Member && binding.spelling == "*"
+        })
+        .map(|binding| binding.qualified_target.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        aliases,
+        std::collections::BTreeSet::from(["./cjs::*", "./esm::*"])
+    );
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1582,6 +1582,67 @@ function use(value: Item) { identity<Item>(value).inspect(); }
 }
 
 #[test]
+fn typescript_imported_callable_properties_publish_bounded_markers() {
+    let api_batch = candidate(
+        "src/api.ts",
+        br#"import type { Item } from "./item";
+interface TypedApi { make: (value: Item) => Item }
+export declare const typed: TypedApi;
+export const api = {
+    make: (value: Item): Item => value,
+    identity: <T>(value: T): T => value,
+};
+"#,
+    );
+    let make = api_batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".api.make"))
+        .expect("callable object property declaration");
+    assert_eq!(make.signature.as_deref(), Some("|params:Item|return:Item"));
+    let typed = api_batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".typed"))
+        .expect("typed object declaration");
+    assert_eq!(typed.signature.as_deref(), Some("|type:TypedApi"));
+    let batch = candidate(
+        "src/imported-properties.ts",
+        br#"import { api, typed } from "./api";
+import type { Item } from "./item";
+export function use(value: Item) {
+    api.make(value).inspect();
+    api.identity<Item>(value).inspect();
+    typed.make(value).inspect();
+}
+"#,
+    );
+    let inspect_calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(inspect_calls.len(), 3);
+    assert!(inspect_calls.iter().all(|candidate| {
+        candidate
+            .constraints
+            .qualified_name
+            .as_deref()
+            .is_some_and(|qualified| qualified.contains("#call<"))
+            && !candidate.constraints.allow_external
+    }));
+    assert!(inspect_calls.iter().any(|candidate| {
+        candidate
+            .constraints
+            .qualified_name
+            .as_deref()
+            .is_some_and(|qualified| qualified.contains("#types<"))
+    }));
+}
+
+#[test]
 fn typescript_generic_function_array_return_preserves_element_receiver() {
     let batch = candidate(
         "src/generic-return-array.ts",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -3335,7 +3335,7 @@ api.remove();
 #[test]
 fn javascript_object_flow_member_reads_and_literal_writes_resolve_exact_targets() {
     let batch = candidate(
-        "src/object-flow-debug.js",
+        "src/object-flow.js",
         br#"const response = { request: requestValue, data: null };
 const later = () => {
     response.data = responseValue;
@@ -3360,7 +3360,7 @@ new Stream();
     let request = batch
         .declarations
         .iter()
-        .find(|declaration| declaration.qualified_name == "object-flow-debug.response.request")
+        .find(|declaration| declaration.qualified_name == "object-flow.response.request")
         .expect("response.request declaration");
     assert!(batch.candidates.iter().any(|candidate| {
         candidate.relation == CandidateRelation::AccessesMember
@@ -3372,8 +3372,7 @@ new Stream();
         .declarations
         .iter()
         .find(|declaration| {
-            declaration.qualified_name
-                == "object-flow-debug.Stream.constructor.internals.isCaptured"
+            declaration.qualified_name == "object-flow.Stream.constructor.internals.isCaptured"
         })
         .expect("internals.isCaptured declaration");
     assert_eq!(
@@ -3389,6 +3388,87 @@ new Stream();
             .count(),
         2
     );
+
+    let nested = candidate(
+        "src/object-flow-nested.js",
+        br#"function register(transport, data) {
+    transport.request({}, function handleResponse(res) {
+        const response = {
+            status: res.status,
+            headers: new Headers(res.headers),
+            request: res.request,
+        };
+        response.data = data;
+        if (streaming) {
+            settle(resolve, reject, response);
+        } else {
+            function handleStreamEnd() {
+                try {
+                    return consume(response.request, response);
+                } catch (err) {
+                    return err;
+                }
+            }
+            handleStreamEnd();
+        }
+    });
+}
+"#,
+    );
+    let nested_request = nested
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "object-flow-nested.register.response.request"
+        })
+        .expect("nested response.request declaration");
+    assert!(nested.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "request"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(nested_request.id.as_str())
+    }));
+
+    let escaped = candidate(
+        "src/object-flow-escape.js",
+        br#"const response = { request: requestValue };
+consume(response);
+response.request;
+"#,
+    );
+    let escaped_request = escaped
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "object-flow-escape.response.request")
+        .expect("escaped response.request declaration");
+    assert!(!escaped.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "request"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(escaped_request.id.as_str())
+    }));
+
+    let nested_escape = candidate(
+        "src/object-flow-nested-escape.js",
+        br#"const response = { request: requestValue };
+const later = () => consume(response);
+later();
+response.request;
+"#,
+    );
+    let nested_escape_request = nested_escape
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.qualified_name == "object-flow-nested-escape.response.request"
+        })
+        .expect("nested escaped response.request declaration");
+    assert!(!nested_escape.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::AccessesMember
+            && candidate.target_spelling == "request"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(nested_escape_request.id.as_str())
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1473,6 +1473,7 @@ fn javascript_const_this_alias_survives_a_closure_capture() {
         br#"class CancelToken {
     constructor() {
         const token = this;
+        token._listeners = null;
         const later = () => token.subscribe();
         later();
     }
@@ -1495,6 +1496,58 @@ new CancelToken();
             && candidate.target_spelling == "subscribe"
             && candidate.constraints.exact_target_declaration_id.as_deref()
                 == Some(subscribe.id.as_str())
+    }));
+}
+
+#[test]
+fn javascript_const_structural_alias_uses_property_scoped_mutation_barriers() {
+    let batch = candidate(
+        "src/const-structural-closure.js",
+        br#"const config = {
+    inspect() {}
+};
+config.other = 1;
+const later = () => config.inspect();
+later();
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "inspect")
+        .expect("config.inspect declaration");
+    assert!(batch.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inspect.id.as_str())
+    }));
+
+    let overwritten = candidate(
+        "src/const-structural-overwrite.js",
+        br#"const config = { inspect() {} };
+config.inspect = replacement;
+config.inspect();
+"#,
+    );
+    assert!(!overwritten.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let spread = candidate(
+        "src/const-structural-spread.js",
+        br#"const base = { inspect() {} };
+const config = { ...base };
+const later = () => config.inspect();
+later();
+"#,
+    );
+    assert!(!spread.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
     }));
 }
 

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -1549,6 +1549,105 @@ later();
             && candidate.target_spelling == "inspect"
             && candidate.constraints.exact_target_declaration_id.is_some()
     }));
+
+    let inline = candidate(
+        "src/inline-structural-closure.js",
+        br#"const key = Symbol('state');
+class Service {
+    constructor() {
+        const state = (this[key] = { inspect() {}, other: 0 });
+        state.other = 1;
+        const later = () => state.inspect();
+        later();
+    }
+}
+new Service();
+"#,
+    );
+    let inline_inspect = inline
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration.name == "inspect"
+                && declaration
+                    .qualified_name
+                    .ends_with(".Service.constructor.state.inspect")
+        })
+        .expect("inline state.inspect declaration");
+    assert!(inline.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.as_deref()
+                == Some(inline_inspect.id.as_str())
+    }));
+
+    let inline_overwritten = candidate(
+        "src/inline-structural-overwrite.js",
+        br#"const key = Symbol('state');
+class Service {
+    constructor() {
+        const state = (this[key] = { inspect() {} });
+        state.inspect = replacement;
+        state.inspect();
+    }
+}
+new Service();
+"#,
+    );
+    assert!(!inline_overwritten.candidates.iter().any(|candidate| {
+        candidate.relation == CandidateRelation::Calls
+            && candidate.target_spelling == "inspect"
+            && candidate.constraints.exact_target_declaration_id.is_some()
+    }));
+
+    let separate = candidate(
+        "src/inline-structural-separate.js",
+        br#"const firstKey = Symbol('first');
+const secondKey = Symbol('second');
+class Service {
+    constructor() {
+        const first = (this[firstKey] = { inspect() { return 1; } });
+        const second = (this[secondKey] = { inspect() { return 2; } });
+        first.inspect();
+        second.inspect();
+    }
+}
+new Service();
+"#,
+    );
+    let first_inspect = separate
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Service.constructor.first.inspect")
+        })
+        .expect("first inline inspect declaration");
+    let second_inspect = separate
+        .declarations
+        .iter()
+        .find(|declaration| {
+            declaration
+                .qualified_name
+                .ends_with(".Service.constructor.second.inspect")
+        })
+        .expect("second inline inspect declaration");
+    let separate_calls = separate
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert!(separate_calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref()
+            == Some(first_inspect.id.as_str())
+    }));
+    assert!(separate_calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref()
+            == Some(second_inspect.id.as_str())
+    }));
 }
 
 #[test]

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -737,6 +737,85 @@ __exportStar(require("./wrong-target"), other);
 }
 
 #[test]
+fn typescript_tagged_templates_emit_exact_tag_call_shape() {
+    let source = br#"function tag(strings: TemplateStringsArray, value: any) {}
+const name = "x";
+tag`hello ${42}`;
+tag`hello ${"x"} ${'y'}`;
+getTag()`dynamic ${name}`;
+"#;
+    let batch = candidate("src/tagged.ts", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("tagged template evidence");
+    let tag = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "tag")
+        .expect("tag declaration");
+    let tag_calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate.target_spelling == "tag"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(tag_calls.len(), 2);
+    assert!(tag_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(2)
+            && candidate.constraints.argument_types == [None, Some("number".to_owned())]
+            && candidate.constraints.exact_target_declaration_id.as_deref() == Some(tag.id.as_str())
+            && candidate
+                .occurrence_id
+                .as_ref()
+                .and_then(|id| {
+                    batch
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *id)
+                })
+                .and_then(|occurrence| occurrence.context.as_deref())
+                == Some("tagged_template")
+    }));
+    assert!(tag_calls.iter().any(|candidate| {
+        candidate.constraints.argument_count == Some(3)
+            && candidate.constraints.argument_types
+                == [None, Some("string".to_owned()), Some("string".to_owned())]
+            && candidate.constraints.exact_target_declaration_id.is_none()
+    }));
+    let dynamic_call = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == compass_languages::CandidateRelation::Calls
+                && candidate
+                    .occurrence_id
+                    .as_ref()
+                    .and_then(|id| {
+                        batch
+                            .occurrences
+                            .iter()
+                            .find(|occurrence| occurrence.id == *id)
+                    })
+                    .and_then(|occurrence| occurrence.context.as_deref())
+                    == Some("tagged_template")
+                && candidate.constraints.exact_target_declaration_id.is_none()
+        })
+        .expect("dynamic tagged call");
+    assert_eq!(dynamic_call.constraints.exact_target_declaration_id, None);
+    assert_eq!(
+        dynamic_call
+            .occurrence_id
+            .as_ref()
+            .and_then(|id| batch
+                .occurrences
+                .iter()
+                .find(|occurrence| occurrence.id == *id))
+            .and_then(|occurrence| occurrence.context.as_deref()),
+        Some("tagged_template")
+    );
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -651,6 +651,56 @@ module.exports = Object.assign({}, base, { direct() {} });
 }
 
 #[test]
+fn javascript_commonjs_define_property_publishes_source_proven_exports() {
+    let source = br#"import { imported } from './values.js';
+function run() {}
+Object.defineProperty(exports, 'run', { enumerable: true, value: run });
+Object.defineProperty(exports, 'imported', {
+    enumerable: true,
+    get: function () { return imported; },
+});
+Object.defineProperty(exports, '__esModule', { value: true });
+Object.defineProperty(exports, dynamic, { value: run });
+"#;
+    let batch = candidate("src/define-property.cjs", source);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("defineProperty export evidence");
+
+    let reexports = batch
+        .bindings
+        .iter()
+        .filter(|binding| binding.kind == compass_languages::BindingKind::Reexport)
+        .map(|binding| binding.spelling.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(reexports.contains("run"));
+    assert!(reexports.contains("imported"));
+    assert!(!reexports.contains("__esModule"));
+    assert!(!reexports.contains("dynamic"));
+
+    let shadowed = candidate(
+        "src/define-property-shadowed.cjs",
+        br#"function Object() {}
+function run() {}
+Object.defineProperty(exports, 'run', { value: run });
+"#,
+    );
+    assert!(!shadowed.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport && binding.spelling == "run"
+    }));
+
+    let dynamic = candidate(
+        "src/define-property-dynamic.cjs",
+        br#"function run() {}
+Object.defineProperty(exports, 'run', { value: getRun() });
+Object.defineProperty(exports, 'getter', { get: () => getRun() });
+"#,
+    );
+    assert!(!dynamic.bindings.iter().any(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport
+            && matches!(binding.spelling.as_str(), "run" | "getter")
+    }));
+}
+
+#[test]
 fn javascript_static_this_factory_tracks_new_instance_members() {
     let batch = candidate(
         "src/factory.js",

--- a/crates/compass-languages/tests/typescript_universal_candidate.rs
+++ b/crates/compass-languages/tests/typescript_universal_candidate.rs
@@ -2011,6 +2011,84 @@ function ambiguous(value: Exclude<Item | Other, undefined>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_conditional_receivers_select_unique_nominal_branch() {
+    let batch = candidate(
+        "src/conditional-receivers.ts",
+        br#"class Item { inspect(): void {} }
+class Other { other(): void {} }
+type Choose<T> = T extends Item ? Item : Other;
+type ChooseObject<T> = T extends object ? T : never;
+function selected(value: Choose<Item>) { value.inspect(); }
+function rejected(value: Choose<Other>) { value.inspect(); }
+function union(value: Choose<Item | Other>) { value.inspect(); }
+function direct(value: Item extends Item ? Item : Other) { value.inspect(); }
+function object(value: ChooseObject<Item>) { value.inspect(); }
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 5);
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.constraints.exact_target_declaration_id.is_some())
+            .count(),
+        3
+    );
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|candidate| candidate.constraints.exact_target_declaration_id.is_none())
+            .count(),
+        2
+    );
+    assert!(calls.iter().any(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
+fn typescript_mapped_modifier_aliases_preserve_nominal_member_targets() {
+    let batch = candidate(
+        "src/mapped-modifiers.ts",
+        br#"class Item { inspect(): void {} }
+type MutableRequired<T> = { -readonly [K in keyof T]-?: T[K] };
+type ReadonlyOptional<T> = { +readonly [K in keyof T]+?: T[K] };
+function use(mutable: MutableRequired<Item>, readonlyValue: ReadonlyOptional<Item>) {
+    mutable.inspect();
+    readonlyValue.inspect();
+}
+"#,
+    );
+    let inspect = batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name.ends_with(".Item.inspect"))
+        .expect("Item.inspect declaration");
+    let calls = batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "inspect"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|candidate| {
+        candidate.constraints.exact_target_declaration_id.as_deref() == Some(inspect.id.as_str())
+    }));
+}
+
+#[test]
 fn typescript_non_nullable_multi_nominal_union_fails_closed() {
     let batch = candidate(
         "src/non-nullable-ambiguous.ts",

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -57,6 +57,7 @@ fn valid_batch() -> SemanticEvidenceBatch {
             signature_hash: None,
             implementation_hash: None,
             source_hash: None,
+            definition_start_byte: None,
             range: range(0, 6),
         }],
         scopes: vec![ScopeFact {
@@ -470,7 +471,7 @@ fn universal_adapter_profiles_are_unique_sorted_and_truthful() {
             .iter()
             .map(|profile| profile.language)
             .collect::<Vec<_>>(),
-        ["go", "java", "python", "rust"]
+        ["go", "java", "javascript", "python", "rust", "typescript"]
     );
     assert!(
         profiles
@@ -509,6 +510,16 @@ fn universal_adapter_profiles_are_unique_sorted_and_truthful() {
         AdapterRegistry::universal_profile("rust").map(|profile| profile.version),
         Some(15)
     );
+    assert_eq!(
+        AdapterRegistry::universal_profile("javascript")
+            .map(|profile| (profile.version, profile.profile)),
+        Some((5, UniversalAdapterProfile::UniversalCandidate))
+    );
+    assert_eq!(
+        AdapterRegistry::universal_profile("typescript")
+            .map(|profile| (profile.version, profile.profile)),
+        Some((5, UniversalAdapterProfile::UniversalCandidate))
+    );
 }
 
 #[test]
@@ -516,12 +527,17 @@ fn empty_hard_cut_sources_emit_zero_width_file_inventory_evidence() {
     for (path, source_file, language) in [
         ("/repo/pkg/__init__.py", "pkg/__init__.py", "python"),
         ("/repo/pkg/empty.go", "pkg/empty.go", "go"),
+        ("/repo/pkg/empty.java", "pkg/empty.java", "java"),
         ("/repo/pkg/empty.rs", "pkg/empty.rs", "rust"),
+        ("/repo/pkg/empty.js", "pkg/empty.js", "javascript"),
+        ("/repo/pkg/empty.ts", "pkg/empty.ts", "typescript"),
+        ("/repo/pkg/empty.tsx", "pkg/empty.tsx", "typescript"),
     ] {
         let mut engine = Engine::default();
-        let evidence = engine
+        let extraction = engine
             .extract_source_combined(std::path::Path::new(path), source_file, b"")
-            .expect("extract empty hard-cut source")
+            .expect("extract empty hard-cut source");
+        let evidence = extraction
             .graph
             .semantic_evidence
             .expect("empty source evidence");
@@ -536,6 +552,58 @@ fn empty_hard_cut_sources_emit_zero_width_file_inventory_evidence() {
         assert_eq!(evidence.scopes.len(), 1);
         assert_eq!(evidence.scopes[0].kind, "module");
         assert_eq!(evidence.scopes[0].range, evidence.declarations[0].range);
+    }
+}
+
+#[test]
+fn typescript_javascript_candidate_is_wired_into_production_extraction() {
+    for (path, source_file, language, dialect, source) in [
+        (
+            "/repo/src/app.ts",
+            "src/app.ts",
+            "typescript",
+            "ts",
+            b"export const value: string = 'ok';\n".as_slice(),
+        ),
+        (
+            "/repo/src/view.tsx",
+            "src/view.tsx",
+            "typescript",
+            "tsx",
+            b"export const View = () => <span>ok</span>;\n".as_slice(),
+        ),
+        (
+            "/repo/src/app.js",
+            "src/app.js",
+            "javascript",
+            "js",
+            b"export function run(value) { return value; }\n".as_slice(),
+        ),
+    ] {
+        let mut engine = Engine::default();
+        let extraction = engine
+            .extract_source_combined(std::path::Path::new(path), source_file, source)
+            .expect("extract ECMAScript universal source");
+        assert!(
+            extraction.graph.raw_calls.is_none(),
+            "production universal extraction must replace raw calls for {path}"
+        );
+        assert!(
+            extraction.graph.nodes.is_empty() && extraction.graph.edges.is_empty(),
+            "production universal extraction must not publish the replaced generic graph for {path}"
+        );
+        let evidence = extraction
+            .graph
+            .semantic_evidence
+            .expect("production universal evidence");
+        validate_evidence(&evidence, EvidenceLimits::default()).expect("valid ECMAScript evidence");
+        assert_eq!(evidence.adapter.language, language);
+        assert_eq!(evidence.adapter.dialect.as_deref(), Some(dialect));
+        assert_eq!(
+            evidence.adapter.profile,
+            UniversalAdapterProfile::UniversalCandidate
+        );
+        assert_eq!(evidence.adapter.id, format!("compass.{language}.candidate"));
     }
 }
 

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -25,6 +25,7 @@ fn valid_batch() -> SemanticEvidenceBatch {
         adapter: AdapterIdentity {
             id: "compass.python".to_owned(),
             language: "python".to_owned(),
+            dialect: None,
             version: 1,
             evidence_schema: UNIVERSAL_EVIDENCE_SCHEMA.to_owned(),
             profile: UniversalAdapterProfile::UniversalCandidate,
@@ -45,6 +46,7 @@ fn valid_batch() -> SemanticEvidenceBatch {
             kind: "function".to_owned(),
             name: "caller".to_owned(),
             qualified_name: "example.caller".to_owned(),
+            namespace: None,
             module_or_package: Some("example".to_owned()),
             scope_id: None,
             signature: None,
@@ -71,6 +73,8 @@ fn valid_batch() -> SemanticEvidenceBatch {
             kind: BindingKind::ImportAlias,
             spelling: "helper".to_owned(),
             qualified_target: "tools.execute".to_owned(),
+            namespace: None,
+            type_only: false,
             target_declaration_id: None,
             scope_id: Some("scope:caller".to_owned()),
             output_index: None,
@@ -158,6 +162,25 @@ fn unknown_fields_are_rejected_at_nested_boundaries() {
     let error =
         serde_json::from_value::<SemanticEvidenceBatch>(encoded).expect_err("unknown field");
     assert!(error.to_string().contains("unknown field"));
+}
+
+#[test]
+fn type_only_bindings_require_type_or_namespace_identity() {
+    let mut batch = valid_batch();
+    batch.bindings[0].type_only = true;
+    batch.bindings[0].namespace = Some(compass_languages::SymbolNamespace::Value);
+    assert_code(&batch, EvidenceErrorCode::InvalidFact);
+
+    batch.bindings[0].namespace = Some(compass_languages::SymbolNamespace::Type);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("typed import identity");
+}
+
+#[test]
+fn legacy_bindings_without_symbol_identity_remain_valid() {
+    let batch = valid_batch();
+    assert!(batch.bindings[0].namespace.is_none());
+    assert!(!batch.bindings[0].type_only);
+    validate_evidence(&batch, EvidenceLimits::default()).expect("legacy evidence remains valid");
 }
 
 #[test]

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -140,7 +140,9 @@ struct TypeScriptMemberContext<'a> {
 type DeclarationSlot = u32;
 type TypeScriptModuleIndex = AHashMap<(String, String, String), Vec<DeclarationSlot>>;
 type TypeScriptReexportIndex = AHashMap<(String, String, String), Vec<TypeScriptReexportTarget>>;
-type TypeScriptProjectModuleIndex = AHashMap<(String, String), Vec<String>>;
+type TypeScriptProjectModuleIndex = AHashMap<(String, String, String), Vec<String>>;
+type TypeScriptProjectMetadataIndex =
+    AHashMap<(String, String, String, String), BTreeMap<String, String>>;
 
 struct TypeScriptExportWalk<'a> {
     candidate: &'a RelationshipCandidate,
@@ -213,6 +215,7 @@ pub struct UniversalResolutionIndex {
     /// specifier. Values are normalized source-module keys and are retained
     /// only when the existing bounded project resolver admitted a target.
     typescript_project_modules: TypeScriptProjectModuleIndex,
+    typescript_project_metadata: TypeScriptProjectMetadataIndex,
     root: std::path::PathBuf,
     direct_bases: AHashMap<(String, String), DirectBaseSet>,
     direct_subtypes: AHashMap<(String, String), DirectSubtypeSet>,
@@ -404,13 +407,14 @@ impl UniversalResolutionIndex {
             return Err("universal declaration slot count exceeds u32".to_owned());
         }
         let definition_ranges = unique_definition_ranges(&declarations, &scopes);
-        let typescript_project_modules = typescript_project_module_index(
-            project_edges,
-            inventory_nodes,
-            root,
-            limits.candidates,
-            limits.candidates_per_lookup,
-        )?;
+        let (typescript_project_modules, typescript_project_metadata) =
+            typescript_project_module_index(
+                project_edges,
+                inventory_nodes,
+                root,
+                limits.candidates,
+                limits.candidates_per_lookup,
+            )?;
         let (typescript_modules, typescript_export_aliases, typescript_reexport_targets) =
             typescript_module_indices(
                 &declarations,
@@ -1070,6 +1074,7 @@ impl UniversalResolutionIndex {
             typescript_export_aliases,
             typescript_reexport_targets,
             typescript_project_modules,
+            typescript_project_metadata,
             root: root.to_path_buf(),
             direct_bases,
             direct_subtypes,
@@ -1414,12 +1419,18 @@ impl UniversalResolutionIndex {
             return None;
         };
         let (keys, project_resolved) = self
-            .typescript_project_modules
-            .get(&(
-                typescript_project_importer_key(&occurrence.range.source_file, &self.root)?,
-                module.clone(),
-            ))
-            .cloned()
+            .typescript_project_module_keys(
+                &occurrence.range.source_file,
+                &module,
+                if matches!(
+                    candidate.relation,
+                    CandidateRelation::Imports | CandidateRelation::Reexports
+                ) {
+                    occurrence.context.as_deref()
+                } else {
+                    None
+                },
+            )
             .map_or_else(
                 || {
                     (
@@ -1868,7 +1879,7 @@ impl UniversalResolutionIndex {
                 return None;
             }
             let mut modules = self
-                .typescript_project_module_keys(&owner.range.source_file, module)
+                .typescript_project_module_keys(&owner.range.source_file, module, None)
                 .unwrap_or_else(|| {
                     typescript_import_module_keys(&owner.range.source_file, module, &self.root)
                 });
@@ -1890,13 +1901,64 @@ impl UniversalResolutionIndex {
         Some(source_slots)
     }
 
-    fn typescript_project_module_keys(&self, importer: &str, module: &str) -> Option<Vec<String>> {
+    fn typescript_project_module_keys(
+        &self,
+        importer: &str,
+        module: &str,
+        context: Option<&str>,
+    ) -> Option<Vec<String>> {
         typescript_project_module_keys(
             &self.typescript_project_modules,
             importer,
             module,
             &self.root,
+            context,
         )
+    }
+
+    fn typescript_project_metadata(
+        &self,
+        candidate: &RelationshipCandidate,
+        target_source_file: Option<&str>,
+    ) -> Option<BTreeMap<String, String>> {
+        if !matches!(candidate.language.as_str(), "typescript" | "javascript") {
+            return None;
+        }
+        let occurrence = self.occurrence(candidate)?;
+        let module = candidate
+            .constraints
+            .module_or_package
+            .clone()
+            .or_else(|| {
+                candidate
+                    .binding_id
+                    .as_deref()
+                    .and_then(|binding_id| self.bindings.get(binding_id))
+                    .and_then(|binding| binding.qualified_target.rsplit_once("::"))
+                    .map(|(module, _)| module.to_owned())
+            })?;
+        let importer = typescript_project_importer_key(&occurrence.range.source_file, &self.root)?;
+        let target_keys = target_source_file
+            .map(|source| typescript_source_module_keys(source, &self.root))
+            .unwrap_or_else(|| vec![String::new()]);
+        if target_keys.is_empty() {
+            return None;
+        }
+        let mut matches = Vec::new();
+        for ((candidate_importer, candidate_module, _candidate_context, target_key), value) in
+            &self.typescript_project_metadata
+        {
+            if candidate_importer != &importer
+                || candidate_module != &module
+                || !target_keys.contains(target_key)
+            {
+                continue;
+            }
+            matches.push(value.clone());
+        }
+        matches.sort();
+        matches.dedup();
+        (matches.len() == 1).then(|| matches.pop()).flatten()
     }
 
     /// Resolve a bounded TypeScript member-value chain such as
@@ -3576,10 +3638,33 @@ impl UniversalResolutionIndex {
             .filter_map(
                 |(candidate_id, target, resolution_rule, target_kind, target_site)| {
                     let candidate = &self.candidates[candidate_id];
-                    let source = self
+                    let owner_source = self
                         .declarations
                         .get(&candidate.source_declaration_id)
                         .map(|declaration| graph_ids[&declaration.id].clone())?;
+                    let annotation_source = (candidate.relation == CandidateRelation::Decorates)
+                        .then(|| {
+                            let occurrence = self.occurrence(candidate)?;
+                            self.declarations
+                                .values()
+                                .filter(|declaration| {
+                                    declaration.kind == "annotation"
+                                        && declaration.name == occurrence.spelling
+                                        && declaration.range.source_file
+                                            == occurrence.range.source_file
+                                        && declaration.range.start_byte
+                                            <= occurrence.range.start_byte
+                                        && declaration.range.end_byte >= occurrence.range.end_byte
+                                })
+                                .min_by_key(|declaration| {
+                                    (declaration.range.start_byte, declaration.id.as_str())
+                                })
+                                .map(|declaration| graph_ids[&declaration.id].clone())
+                        })
+                        .flatten();
+                    let source = annotation_source
+                        .clone()
+                        .unwrap_or_else(|| owner_source.clone());
                     let (source, target) = if candidate.relation == CandidateRelation::Contains {
                         (source, target)
                     } else if self.occurrence(candidate).is_some_and(|occurrence| {
@@ -3594,7 +3679,11 @@ impl UniversalResolutionIndex {
                         .exact_target_declaration_id
                         .as_deref()
                         .and_then(|id| self.declarations.get(id));
-                    let relation = if self.occurrence(candidate).is_some_and(|occurrence| {
+                    let relation = if candidate.relation == CandidateRelation::Decorates
+                        && annotation_source.is_some()
+                    {
+                        "decorates"
+                    } else if self.occurrence(candidate).is_some_and(|occurrence| {
                         occurrence.role == compass_languages::SemanticRole::Receiver
                     }) {
                         "method"
@@ -3632,24 +3721,89 @@ impl UniversalResolutionIndex {
                     if source == target && relation != "calls" {
                         return None;
                     }
-                    Some(materialized_edge(
+                    let target_source_file = target_site.map(|range| range.source_file.as_str());
+                    let project_metadata =
+                        self.typescript_project_metadata(candidate, target_source_file);
+                    let binding = candidate
+                        .binding_id
+                        .as_deref()
+                        .and_then(|binding_id| self.bindings.get(binding_id));
+                    let occurrence = self.occurrence(candidate);
+                    let edge = materialized_edge(
                         source,
                         target,
                         relation,
                         candidate,
-                        self.occurrence(candidate),
-                        candidate
-                            .binding_id
-                            .as_deref()
-                            .and_then(|binding_id| self.bindings.get(binding_id)),
+                        occurrence,
+                        binding,
                         target_kind.as_deref(),
-                        target_site.map(|range| range.source_file.as_str()),
+                        target_source_file,
                         site,
                         resolution_rule,
                         &candidate.language,
-                    ))
+                        project_metadata.as_ref(),
+                    );
+                    let mut materialized = vec![edge.clone()];
+                    if candidate.relation == CandidateRelation::Reexports
+                        && binding.is_some_and(|binding| {
+                            let target_name = binding
+                                .qualified_target
+                                .rsplit([':', '.'])
+                                .find(|name| !name.is_empty())
+                                .unwrap_or_default();
+                            binding.spelling != target_name
+                                || occurrence
+                                    .and_then(|occurrence| occurrence.qualifier.as_deref())
+                                    .is_some_and(|qualifier| qualifier != binding.spelling)
+                        })
+                    {
+                        let export_name = binding.map(|binding| binding.spelling.as_str());
+                        let alias_source = export_name.and_then(|export_name| {
+                            occurrence.and_then(|occurrence| {
+                                self.declarations
+                                    .values()
+                                    .filter(|declaration| {
+                                        declaration.kind == "export"
+                                            && declaration.name == export_name
+                                            && declaration.range.source_file
+                                                == occurrence.range.source_file
+                                            && declaration.range.start_byte
+                                                <= occurrence.range.start_byte
+                                            && declaration.range.end_byte
+                                                >= occurrence.range.end_byte
+                                    })
+                                    .min_by_key(|declaration| {
+                                        (declaration.range.start_byte, declaration.id.as_str())
+                                    })
+                                    .map(|declaration| graph_ids[&declaration.id].clone())
+                            })
+                        });
+                        if let Some(alias_source) = alias_source {
+                            let mut attributes = edge.attributes.clone();
+                            attributes
+                                .insert("relation".to_owned(), Value::String("aliases".to_owned()));
+                            attributes.insert(
+                                "context".to_owned(),
+                                Value::String("export_alias".to_owned()),
+                            );
+                            attributes.insert(
+                                "rule".to_owned(),
+                                Value::String(format!(
+                                    "universal-reexport-alias-{}",
+                                    resolution_rule_name(resolution_rule)
+                                )),
+                            );
+                            materialized.push(EdgeRecord {
+                                source: alias_source,
+                                target: edge.target.clone(),
+                                attributes,
+                            });
+                        }
+                    }
+                    Some(materialized)
                 },
             )
+            .flatten()
             .collect::<Vec<_>>();
         edges.extend(materialized);
         profile_internal("universal edge materialization", &mut profile_started);
@@ -6824,12 +6978,25 @@ fn typescript_project_module_keys(
     importer: &str,
     module: &str,
     root: &Path,
+    context: Option<&str>,
 ) -> Option<Vec<String>> {
     let importer = typescript_project_importer_key(importer, root)?;
-    project_modules
-        .get(&(importer, module.to_owned()))
-        .filter(|keys| !keys.is_empty())
-        .cloned()
+    if let Some(context) = context.filter(|context| !context.is_empty()) {
+        return project_modules
+            .get(&(importer, module.to_owned(), context.to_owned()))
+            .filter(|keys| !keys.is_empty())
+            .cloned();
+    }
+    let mut keys = project_modules
+        .iter()
+        .filter(|((candidate_importer, candidate_module, _), _)| {
+            candidate_importer == &importer && candidate_module == module
+        })
+        .flat_map(|(_, keys)| keys.iter().cloned())
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    keys.dedup();
+    (!keys.is_empty()).then_some(keys)
 }
 
 fn typescript_project_module_index(
@@ -6838,22 +7005,30 @@ fn typescript_project_module_index(
     root: &Path,
     entry_limit: usize,
     candidates_per_lookup: usize,
-) -> Result<TypeScriptProjectModuleIndex, String> {
+) -> Result<(TypeScriptProjectModuleIndex, TypeScriptProjectMetadataIndex), String> {
     if edges.is_empty() {
-        return Ok(TypeScriptProjectModuleIndex::new());
+        return Ok((
+            TypeScriptProjectModuleIndex::new(),
+            TypeScriptProjectMetadataIndex::new(),
+        ));
     }
     let mut source_by_node = BTreeMap::<String, BTreeSet<String>>::new();
     for node in inventory_nodes {
         let source = node.string("source_file");
         if !source.is_empty() {
-            source_by_node
-                .entry(node.id.clone())
-                .or_default()
-                .insert(source);
+            source_by_node.entry(node.id.clone()).or_default().insert(
+                node.attributes
+                    .get("universal_evidence_source_file")
+                    .and_then(Value::as_str)
+                    .filter(|source| !source.is_empty())
+                    .unwrap_or(&source)
+                    .to_owned(),
+            );
         }
     }
     let max_targets = candidate_storage_limit(candidates_per_lookup);
-    let mut targets = BTreeMap::<(String, String), BTreeSet<String>>::new();
+    let mut targets = BTreeMap::<(String, String, String), BTreeSet<String>>::new();
+    let mut metadata = TypeScriptProjectMetadataIndex::new();
     for edge in edges {
         if edge.attributes.get("relation").and_then(Value::as_str) != Some("imports_from") {
             continue;
@@ -6863,7 +7038,13 @@ fn typescript_project_module_index(
             continue;
         }
         let importer = {
-            let source = edge.string("source_file");
+            let source = edge
+                .attributes
+                .get("universal_evidence_source_file")
+                .and_then(Value::as_str)
+                .filter(|source| !source.is_empty())
+                .map(str::to_owned)
+                .unwrap_or_else(|| edge.string("source_file"));
             if source.is_empty() {
                 unique_inventory_source(&source_by_node, &edge.source)
                     .unwrap_or_default()
@@ -6875,41 +7056,95 @@ fn typescript_project_module_index(
         let Some(importer) = typescript_project_importer_key(&importer, root) else {
             continue;
         };
-        let target_source = {
-            let source = edge.string("target_file");
-            if source.is_empty() {
-                unique_inventory_source(&source_by_node, &edge.target)
-                    .unwrap_or_default()
-                    .to_owned()
-            } else {
-                source
+        let target_source = unique_inventory_source(&source_by_node, &edge.target)
+            .map(str::to_owned)
+            .filter(|source| !source.is_empty())
+            .unwrap_or_else(|| edge.string("target_file"));
+        let normalized_target_source = if target_source.is_empty() {
+            target_source.clone()
+        } else {
+            std::fs::canonicalize(&target_source)
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| target_source.clone())
+        };
+        let edge_target_keys = if normalized_target_source.is_empty() {
+            vec![String::new()]
+        } else {
+            let keys = typescript_source_module_keys(&normalized_target_source, root);
+            if keys.is_empty() {
+                continue;
             }
+            keys
         };
-        let Some(target_keys) = (!target_source.is_empty())
-            .then(|| typescript_source_module_keys(&target_source, root))
-            .filter(|keys| !keys.is_empty())
-        else {
-            continue;
-        };
-        let key = (importer, module);
+        let context = edge.string("context");
+        let key = (importer.clone(), module.clone(), context.clone());
         if !targets.contains_key(&key) && targets.len() >= entry_limit {
             return Err(format!(
                 "TypeScript project module entry count exceeds limit {entry_limit}"
             ));
         }
         let values = targets.entry(key).or_default();
-        for target_key in target_keys {
-            if values.contains(&target_key) || values.len() < max_targets {
-                values.insert(target_key);
+        for target_key in &edge_target_keys {
+            if !target_key.is_empty() && (values.contains(target_key) || values.len() < max_targets)
+            {
+                values.insert(target_key.clone());
+            }
+        }
+        let mut edge_metadata = edge
+            .attributes
+            .iter()
+            .filter_map(|(name, value)| {
+                matches!(
+                    name.as_str(),
+                    "resolution_rule"
+                        | "package_condition"
+                        | "resolution_config"
+                        | "module_resolution"
+                        | "module_kind"
+                        | "resolution_project_references"
+                )
+                .then(|| {
+                    value
+                        .as_str()
+                        .map(|value| (name.clone(), value.to_owned()))
+                        .or_else(|| {
+                            (name == "resolution_project_references")
+                                .then(|| (name.clone(), value.to_string()))
+                        })
+                })
+                .flatten()
+            })
+            .collect::<BTreeMap<_, _>>();
+        edge_metadata.insert("project_module".to_owned(), module.clone());
+        for target_key in edge_target_keys {
+            let metadata_key = (
+                importer.clone(),
+                module.clone(),
+                context.clone(),
+                target_key,
+            );
+            match metadata.entry(metadata_key) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(edge_metadata.clone());
+                }
+                std::collections::hash_map::Entry::Occupied(entry)
+                    if entry.get() != &edge_metadata =>
+                {
+                    entry.remove();
+                }
+                std::collections::hash_map::Entry::Occupied(_) => {}
             }
         }
     }
-    Ok(targets
-        .into_iter()
-        .filter_map(|(key, values)| {
-            (!values.is_empty()).then_some((key, values.into_iter().collect()))
-        })
-        .collect())
+    Ok((
+        targets
+            .into_iter()
+            .filter_map(|(key, values)| {
+                (!values.is_empty()).then_some((key, values.into_iter().collect()))
+            })
+            .collect(),
+        metadata,
+    ))
 }
 
 fn unique_inventory_source<'a>(
@@ -7019,6 +7254,7 @@ fn typescript_module_indices(
             &owner.range.source_file,
             target_module,
             root,
+            None,
         )
         .unwrap_or_else(|| {
             typescript_import_module_keys(&owner.range.source_file, target_module, root)
@@ -7430,6 +7666,13 @@ fn declaration_node(
         _ => declaration.name.clone(),
     };
     let callable = matches!(declaration.kind.as_str(), "function" | "method");
+    // The universal evidence model keeps TypeScript's type-parameter kind
+    // explicit for resolution, while the public graph v1 contract represents
+    // all generic parameters as `parameter` nodes.
+    let graph_kind = match declaration.kind.as_str() {
+        "type_parameter" | "lifetime_parameter" | "const_parameter" => "parameter",
+        kind => kind,
+    };
     let mut attributes = Map::from_iter([
         ("label".to_owned(), Value::String(label)),
         (
@@ -7438,7 +7681,7 @@ fn declaration_node(
         ),
         (
             "symbol_kind".to_owned(),
-            Value::String(declaration.kind.clone()),
+            Value::String(graph_kind.to_owned()),
         ),
         ("file_type".to_owned(), Value::String("code".to_owned())),
         (
@@ -7494,6 +7737,12 @@ fn declaration_node(
             Value::String(declaration.id.clone()),
         ),
     ]);
+    if let Some(legacy_qualified_name) = legacy_callable_qualified_name(declaration) {
+        attributes.insert(
+            "legacy_qualified_name".to_owned(),
+            Value::String(legacy_qualified_name),
+        );
+    }
     if callable {
         attributes.insert("_callable".to_owned(), Value::Bool(true));
     }
@@ -7529,6 +7778,36 @@ fn declaration_node(
     NodeRecord {
         id: graph_node_id.to_owned(),
         attributes,
+    }
+}
+
+/// Preserve the public callable spelling emitted by the pre-universal
+/// TypeScript/JavaScript extractor. Universal evidence keeps its richer module
+/// qualified name for resolution, while framework route contracts continue to
+/// identify source callables as `name()@offset` (or `Owner::name()@offset`).
+fn legacy_callable_qualified_name(declaration: &DeclarationFact) -> Option<String> {
+    let start = declaration
+        .definition_start_byte
+        .unwrap_or(declaration.range.start_byte);
+    match declaration.kind.as_str() {
+        "function" => {
+            if declaration.name == "default" {
+                Some("default".to_owned())
+            } else {
+                Some(format!("{}()@{start}", declaration.name))
+            }
+        }
+        "method" => {
+            let mut parts = declaration.qualified_name.split('.');
+            let _module = parts.next()?;
+            let owner_parts = parts.collect::<Vec<_>>();
+            if owner_parts.len() < 2 {
+                return Some(format!("{}()@{start}", declaration.name));
+            }
+            let (method, owner) = owner_parts.split_last()?;
+            Some(format!("{}::{}()@{start}", owner.join("::"), method))
+        }
+        _ => None,
     }
 }
 
@@ -7779,6 +8058,7 @@ fn materialized_edge(
     range: &compass_languages::EvidenceRange,
     resolution_rule: ResolutionRule,
     language: &str,
+    project_metadata: Option<&BTreeMap<String, String>>,
 ) -> EdgeRecord {
     let context = match (relation, resolution_rule) {
         ("calls", ResolutionRule::QualifiedExternal) => "external_call",
@@ -7788,6 +8068,7 @@ fn materialized_edge(
             .and_then(|occurrence| occurrence.context.as_deref())
             .unwrap_or("reference"),
         ("references", _) if candidate.relation == CandidateRelation::Decorates => "decorator",
+        ("decorates", _) => "decorator",
         ("references", _)
             if occurrence.is_some_and(|occurrence| {
                 occurrence.role == compass_languages::SemanticRole::CallableReference
@@ -7802,7 +8083,9 @@ fn materialized_edge(
         {
             "submodule_import"
         }
-        ("imports_from", _) => "import",
+        ("imports_from", _) => occurrence
+            .and_then(|occurrence| occurrence.context.as_deref())
+            .unwrap_or("import"),
         ("re_exports", _) => "export",
         ("inherits", _) => "base_type",
         ("references", _) => "type_reference",
@@ -7892,28 +8175,47 @@ fn materialized_edge(
     if matches!(
         candidate.relation,
         CandidateRelation::Imports | CandidateRelation::Reexports
-    ) && let Some(binding) = binding
-    {
-        attributes.insert(
-            "local_name".to_owned(),
-            Value::String(binding.spelling.clone()),
-        );
-        attributes.insert(
-            "imported_name".to_owned(),
-            Value::String(candidate.target_spelling.clone()),
-        );
-        attributes.insert(
-            "qualified_target".to_owned(),
-            Value::String(binding.qualified_target.clone()),
-        );
-        attributes.insert(
-            "binding_kind".to_owned(),
-            Value::String(binding_kind_name(binding.kind).to_owned()),
-        );
-        if let Some(module) = candidate.constraints.module_or_package.as_ref() {
+    ) {
+        if let Some(binding) = binding {
+            attributes.insert(
+                "local_name".to_owned(),
+                Value::String(binding.spelling.clone()),
+            );
+            attributes.insert(
+                "imported_name".to_owned(),
+                Value::String(candidate.target_spelling.clone()),
+            );
+            attributes.insert(
+                "qualified_target".to_owned(),
+                Value::String(binding.qualified_target.clone()),
+            );
+            attributes.insert(
+                "binding_kind".to_owned(),
+                Value::String(binding_kind_name(binding.kind).to_owned()),
+            );
+        }
+        let module = candidate
+            .constraints
+            .module_or_package
+            .clone()
+            .or_else(|| {
+                binding
+                    .and_then(|binding| binding.qualified_target.rsplit_once("::"))
+                    .map(|(module, _)| module.to_owned())
+            })
+            .or_else(|| {
+                project_metadata
+                    .and_then(|metadata| metadata.get("project_module"))
+                    .cloned()
+            });
+        if let Some(module) = module {
             attributes.insert(
                 "module".to_owned(),
-                Value::String(import_module_for_edge(language, &range.source_file, module)),
+                Value::String(import_module_for_edge(
+                    language,
+                    &range.source_file,
+                    &module,
+                )),
             );
         }
     }
@@ -7925,6 +8227,29 @@ fn materialized_edge(
             "target_file".to_owned(),
             Value::String(target_source_file.to_owned()),
         );
+    }
+    if let Some(project_metadata) = project_metadata {
+        for (name, value) in project_metadata {
+            if name == "project_module" {
+                continue;
+            }
+            let metadata_value = if name == "resolution_project_references" {
+                serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.clone()))
+            } else {
+                Value::String(value.clone())
+            };
+            attributes.insert(format!("project_{name}"), metadata_value.clone());
+            if matches!(
+                name.as_str(),
+                "package_condition"
+                    | "resolution_config"
+                    | "module_resolution"
+                    | "module_kind"
+                    | "resolution_project_references"
+            ) {
+                attributes.insert(name.clone(), metadata_value);
+            }
+        }
     }
     if let Some(binding) = binding {
         attributes.extend([

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -114,6 +114,17 @@ struct TypeScriptMemberPath {
     members: Vec<String>,
 }
 
+/// A source-proven object spread emitted by the TypeScript/JavaScript
+/// candidate adapter. The `*` member spelling is an owner alias marker, not a
+/// wildcard export: the destination object inherits only members that the
+/// resolver can prove on this source owner.
+#[derive(Clone, Debug)]
+struct TypeScriptMemberAlias {
+    source: String,
+    source_slot: Option<DeclarationSlot>,
+    start_byte: u64,
+}
+
 struct TypeScriptMemberContext<'a> {
     owner_signature: Option<&'a str>,
     type_arguments: &'a [String],
@@ -216,6 +227,7 @@ pub struct UniversalResolutionIndex {
     wildcard_bindings_by_module: AHashMap<(String, String), WildcardModuleSet>,
     wildcard_reexports_by_module: AHashMap<(String, String), WildcardModuleSet>,
     members: AHashMap<(String, String, String), Vec<String>>,
+    typescript_member_aliases: AHashMap<(String, String), Vec<TypeScriptMemberAlias>>,
     return_candidates_by_callable: AHashMap<(String, String), Vec<String>>,
     outer_return_candidates_by_callable: AHashMap<(String, String), Vec<String>>,
     go_module_path: Option<String>,
@@ -934,6 +946,50 @@ impl UniversalResolutionIndex {
             targets.sort_unstable();
             targets.dedup();
         }
+        let mut typescript_member_aliases =
+            AHashMap::<(String, String), Vec<TypeScriptMemberAlias>>::new();
+        for binding in bindings.values().filter(|binding| {
+            binding.kind == compass_languages::BindingKind::Member
+                && binding.spelling == "*"
+                && matches!(binding.language.as_str(), "typescript" | "javascript")
+        }) {
+            let Some(owner) = binding
+                .scope_id
+                .as_deref()
+                .and_then(|id| scopes.get(id))
+                .and_then(|scope| scope.owner_declaration_id.as_deref())
+                .and_then(|id| declarations.get(id))
+            else {
+                continue;
+            };
+            typescript_member_aliases
+                .entry((binding.language.clone(), owner.qualified_name.clone()))
+                .or_default()
+                .push(TypeScriptMemberAlias {
+                    source: binding.qualified_target.clone(),
+                    source_slot: binding
+                        .target_declaration_id
+                        .as_deref()
+                        .and_then(|id| declaration_slot(&declaration_ids, id)),
+                    start_byte: binding.range.start_byte,
+                });
+        }
+        for aliases in typescript_member_aliases.values_mut() {
+            aliases.sort_unstable_by(|left, right| {
+                left.start_byte
+                    .cmp(&right.start_byte)
+                    .then_with(|| left.source.cmp(&right.source))
+                    .then_with(|| left.source_slot.cmp(&right.source_slot))
+            });
+            aliases.dedup_by(|left, right| {
+                left.source == right.source
+                    && left.source_slot == right.source_slot
+                    && left.start_byte == right.start_byte
+            });
+            if aliases.len() > limits.candidates_per_lookup {
+                aliases.truncate(candidate_storage_limit(limits.candidates_per_lookup));
+            }
+        }
         let mut return_entries = AHashMap::<_, Vec<_>>::new();
         let mut outer_return_entries = AHashMap::<_, Vec<_>>::new();
         for candidate in candidates
@@ -1028,6 +1084,7 @@ impl UniversalResolutionIndex {
             wildcard_bindings_by_module,
             wildcard_reexports_by_module,
             members,
+            typescript_member_aliases,
             return_candidates_by_callable,
             outer_return_candidates_by_callable,
             go_module_path,
@@ -1426,6 +1483,7 @@ impl UniversalResolutionIndex {
             && namespace_member_export.is_none();
         let is_member_candidate = member_path.is_some() || namespace_member_export.is_some();
         let mut source_member_target_seen = false;
+        let mut structural_alias_seen = false;
         let mut targets = BTreeSet::new();
         for key in keys {
             let expand_member_chain = member_path.as_ref().is_some_and(|path| {
@@ -1518,6 +1576,20 @@ impl UniversalResolutionIndex {
                                 .copied(),
                         );
                     }
+                    if self
+                        .typescript_member_aliases
+                        .contains_key(&(owner.language.clone(), owner.qualified_name.clone()))
+                    {
+                        structural_alias_seen = true;
+                        if let Ok(Some(alias_members)) = self.typescript_structural_member_slots(
+                            *owner_slot,
+                            &candidate.target_spelling,
+                            candidate,
+                            &mut BTreeSet::new(),
+                        ) {
+                            targets.extend(alias_members);
+                        }
+                    }
                 }
                 // A value import can be declared with a nominal object type
                 // (`declare const api: Api`).  Its callable members live on
@@ -1563,6 +1635,9 @@ impl UniversalResolutionIndex {
             }
         }
         let targets = targets.into_iter().collect::<Vec<_>>();
+        if is_member_candidate && structural_alias_seen && targets.is_empty() {
+            return Some(ResolutionDecision::Unresolved);
+        }
         if is_member_candidate
             && candidate.relation == CandidateRelation::Calls
             && targets.is_empty()
@@ -1580,6 +1655,156 @@ impl UniversalResolutionIndex {
             } else {
                 ResolutionRule::ExplicitBinding
             },
+        )
+    }
+
+    /// Resolve one member through a source-proven object-owner alias. Direct
+    /// members always win; inherited aliases are followed only when the
+    /// source owner is itself a bounded object owner. Multiple distinct
+    /// source declarations remain ambiguous instead of relying on hash or
+    /// traversal order.
+    fn typescript_structural_member_slots(
+        &self,
+        owner_slot: DeclarationSlot,
+        property: &str,
+        candidate: &RelationshipCandidate,
+        visiting: &mut BTreeSet<DeclarationSlot>,
+    ) -> Result<Option<BTreeSet<DeclarationSlot>>, ()> {
+        if !visiting.insert(owner_slot) {
+            return Err(());
+        }
+        let Some(owner) = self.declaration(owner_slot) else {
+            visiting.remove(&owner_slot);
+            return Err(());
+        };
+        let owner_language = owner.language.as_str();
+        let direct_key = (
+            owner_language.to_owned(),
+            owner.qualified_name.clone(),
+            property.to_owned(),
+        );
+        if let Some(members) = self.members_by_owner.get(&direct_key) {
+            let direct = members
+                .iter()
+                .filter(|slot| self.typescript_declaration_allowed_slot(**slot, candidate))
+                .copied()
+                .collect::<BTreeSet<_>>();
+            if !direct.is_empty() {
+                visiting.remove(&owner_slot);
+                return Ok(Some(direct));
+            }
+        }
+        let alias_key = (owner_language.to_owned(), owner.qualified_name.clone());
+        let Some(aliases) = self.typescript_member_aliases.get(&alias_key) else {
+            visiting.remove(&owner_slot);
+            return Ok(None);
+        };
+        if !self.typescript_structural_object_owner(owner_slot) {
+            visiting.remove(&owner_slot);
+            return Err(());
+        }
+        let mut inherited = BTreeSet::new();
+        let mut unresolved = false;
+        for alias in aliases {
+            let source_slots =
+                self.typescript_member_alias_source_slots(owner_language, owner, alias, candidate);
+            let Some(source_slots) = source_slots else {
+                unresolved = true;
+                continue;
+            };
+            if source_slots.is_empty() {
+                unresolved = true;
+                continue;
+            }
+            for source_slot in source_slots {
+                match self.typescript_structural_member_slots(
+                    source_slot,
+                    property,
+                    candidate,
+                    visiting,
+                ) {
+                    Ok(Some(members)) => inherited.extend(members),
+                    Ok(None) => {}
+                    Err(()) => unresolved = true,
+                }
+            }
+        }
+        visiting.remove(&owner_slot);
+        if unresolved {
+            return Err(());
+        }
+        Ok(Some(inherited))
+    }
+
+    fn typescript_structural_object_owner(&self, slot: DeclarationSlot) -> bool {
+        let Some(owner) = self.declaration(slot) else {
+            return false;
+        };
+        if owner.kind != "variable"
+            || !matches!(owner.language.as_str(), "typescript" | "javascript")
+        {
+            return false;
+        }
+        if owner
+            .scope_id
+            .as_deref()
+            .and_then(|scope_id| self.scopes.get(scope_id))
+            .is_some_and(|scope| scope.kind == "object")
+        {
+            return true;
+        }
+        self.members_by_owner
+            .keys()
+            .any(|(language, qualified, _)| {
+                language == &owner.language && qualified == &owner.qualified_name
+            })
+    }
+
+    fn typescript_member_alias_source_slots(
+        &self,
+        language: &str,
+        owner: &DeclarationFact,
+        alias: &TypeScriptMemberAlias,
+        candidate: &RelationshipCandidate,
+    ) -> Option<BTreeSet<DeclarationSlot>> {
+        let mut source_slots = BTreeSet::new();
+        if let Some(slot) = alias.source_slot {
+            source_slots.insert(slot);
+            return Some(source_slots);
+        }
+        if let Some((module, exported)) = alias.source.rsplit_once("::") {
+            if module.is_empty() || exported.is_empty() {
+                return None;
+            }
+            let mut modules = self
+                .typescript_project_module_keys(&owner.range.source_file, module)
+                .unwrap_or_else(|| {
+                    typescript_import_module_keys(&owner.range.source_file, module, &self.root)
+                });
+            modules.sort_unstable();
+            modules.dedup();
+            for module in modules {
+                source_slots.extend(
+                    self.typescript_export_slots(language, &module, exported, candidate, true),
+                );
+            }
+            return Some(source_slots);
+        }
+        if let Some(slots) = self
+            .by_qualified
+            .get(&(language.to_owned(), alias.source.clone()))
+        {
+            source_slots.extend(slots.iter().copied());
+        }
+        Some(source_slots)
+    }
+
+    fn typescript_project_module_keys(&self, importer: &str, module: &str) -> Option<Vec<String>> {
+        typescript_project_module_keys(
+            &self.typescript_project_modules,
+            importer,
+            module,
+            &self.root,
         )
     }
 

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -42,6 +42,7 @@ pub enum ResolutionRule {
     ExactSourceDeclaration,
     ExactLexicalDeclaration,
     ExplicitBinding,
+    ProjectModuleBinding,
     MemberBinding,
     DeferredReceiver,
     WildcardBinding,
@@ -110,6 +111,7 @@ struct TypeScriptReexportTarget {
 type DeclarationSlot = u32;
 type TypeScriptModuleIndex = AHashMap<(String, String, String), Vec<DeclarationSlot>>;
 type TypeScriptReexportIndex = AHashMap<(String, String, String), Vec<TypeScriptReexportTarget>>;
+type TypeScriptProjectModuleIndex = AHashMap<(String, String), Vec<String>>;
 
 struct TypeScriptExportWalk<'a> {
     candidate: &'a RelationshipCandidate,
@@ -173,6 +175,10 @@ pub struct UniversalResolutionIndex {
     /// spelling. Resolution follows this bounded table rather than selecting
     /// a terminal name from an unrelated source file.
     typescript_reexport_targets: TypeScriptReexportIndex,
+    /// Project/module resolver decisions keyed by importer and raw module
+    /// specifier. Values are normalized source-module keys and are retained
+    /// only when the existing bounded project resolver admitted a target.
+    typescript_project_modules: TypeScriptProjectModuleIndex,
     root: std::path::PathBuf,
     direct_bases: AHashMap<(String, String), DirectBaseSet>,
     direct_subtypes: AHashMap<(String, String), DirectSubtypeSet>,
@@ -226,21 +232,47 @@ impl UniversalResolutionIndex {
         root: &Path,
         limits: UniversalResolutionLimits,
     ) -> Result<Self, String> {
-        Self::new_with_inventory_owned_impl(batches, inventory_nodes, root, limits, true)
+        Self::new_with_inventory_owned_impl(batches, inventory_nodes, &[], root, limits, true)
     }
 
-    pub(crate) fn new_with_prevalidated_inventory_owned(
+    pub(crate) fn new_with_project_inventory_owned(
         batches: Vec<SemanticEvidenceBatch>,
         inventory_nodes: &[NodeRecord],
+        project_edges: &[EdgeRecord],
         root: &Path,
         limits: UniversalResolutionLimits,
     ) -> Result<Self, String> {
-        Self::new_with_inventory_owned_impl(batches, inventory_nodes, root, limits, false)
+        Self::new_with_inventory_owned_impl(
+            batches,
+            inventory_nodes,
+            project_edges,
+            root,
+            limits,
+            true,
+        )
+    }
+
+    pub(crate) fn new_with_prevalidated_project_inventory_owned(
+        batches: Vec<SemanticEvidenceBatch>,
+        inventory_nodes: &[NodeRecord],
+        project_edges: &[EdgeRecord],
+        root: &Path,
+        limits: UniversalResolutionLimits,
+    ) -> Result<Self, String> {
+        Self::new_with_inventory_owned_impl(
+            batches,
+            inventory_nodes,
+            project_edges,
+            root,
+            limits,
+            false,
+        )
     }
 
     fn new_with_inventory_owned_impl(
         batches: Vec<SemanticEvidenceBatch>,
         inventory_nodes: &[NodeRecord],
+        project_edges: &[EdgeRecord],
         root: &Path,
         limits: UniversalResolutionLimits,
         validate_batches: bool,
@@ -337,8 +369,22 @@ impl UniversalResolutionIndex {
             return Err("universal declaration slot count exceeds u32".to_owned());
         }
         let definition_ranges = unique_definition_ranges(&declarations, &scopes);
+        let typescript_project_modules = typescript_project_module_index(
+            project_edges,
+            inventory_nodes,
+            root,
+            limits.candidates,
+            limits.candidates_per_lookup,
+        )?;
         let (typescript_modules, typescript_export_aliases, typescript_reexport_targets) =
-            typescript_module_indices(&declarations, &declaration_ids, &bindings, &scopes, root);
+            typescript_module_indices(
+                &declarations,
+                &declaration_ids,
+                &bindings,
+                &scopes,
+                root,
+                &typescript_project_modules,
+            );
         for (name, count, limit) in [
             ("declarations", declarations.len(), limits.declarations),
             ("bindings", bindings.len(), limits.bindings),
@@ -876,6 +922,7 @@ impl UniversalResolutionIndex {
             typescript_modules,
             typescript_export_aliases,
             typescript_reexport_targets,
+            typescript_project_modules,
             root: root.to_path_buf(),
             direct_bases,
             direct_subtypes,
@@ -1218,8 +1265,26 @@ impl UniversalResolutionIndex {
         } else {
             return None;
         };
-        let keys =
-            typescript_import_module_keys(&occurrence.range.source_file, &module, &self.root);
+        let (keys, project_resolved) = self
+            .typescript_project_modules
+            .get(&(
+                typescript_project_importer_key(&occurrence.range.source_file, &self.root)?,
+                module.clone(),
+            ))
+            .cloned()
+            .map_or_else(
+                || {
+                    (
+                        typescript_import_module_keys(
+                            &occurrence.range.source_file,
+                            &module,
+                            &self.root,
+                        ),
+                        false,
+                    )
+                },
+                |keys| (keys, true),
+            );
         if keys.is_empty() {
             return None;
         }
@@ -1281,6 +1346,8 @@ impl UniversalResolutionIndex {
             candidate,
             if member_owner_export.is_some() {
                 ResolutionRule::MemberBinding
+            } else if project_resolved {
+                ResolutionRule::ProjectModuleBinding
             } else {
                 ResolutionRule::ExplicitBinding
             },
@@ -4419,12 +4486,122 @@ fn source_directory(source_file: &str, root: &Path) -> Option<String> {
     (!directory.is_empty()).then_some(directory)
 }
 
+fn typescript_project_importer_key(source_file: &str, root: &Path) -> Option<String> {
+    let relative = typescript_relative_path(source_file, root)?;
+    let key = relative.to_str()?.to_owned();
+    (!key.is_empty() && key.len() <= 4_096).then_some(key)
+}
+
+fn typescript_project_module_keys(
+    project_modules: &TypeScriptProjectModuleIndex,
+    importer: &str,
+    module: &str,
+    root: &Path,
+) -> Option<Vec<String>> {
+    let importer = typescript_project_importer_key(importer, root)?;
+    project_modules
+        .get(&(importer, module.to_owned()))
+        .filter(|keys| !keys.is_empty())
+        .cloned()
+}
+
+fn typescript_project_module_index(
+    edges: &[EdgeRecord],
+    inventory_nodes: &[NodeRecord],
+    root: &Path,
+    entry_limit: usize,
+    candidates_per_lookup: usize,
+) -> Result<TypeScriptProjectModuleIndex, String> {
+    if edges.is_empty() {
+        return Ok(TypeScriptProjectModuleIndex::new());
+    }
+    let mut source_by_node = BTreeMap::<String, BTreeSet<String>>::new();
+    for node in inventory_nodes {
+        let source = node.string("source_file");
+        if !source.is_empty() {
+            source_by_node
+                .entry(node.id.clone())
+                .or_default()
+                .insert(source);
+        }
+    }
+    let max_targets = candidate_storage_limit(candidates_per_lookup);
+    let mut targets = BTreeMap::<(String, String), BTreeSet<String>>::new();
+    for edge in edges {
+        if edge.attributes.get("relation").and_then(Value::as_str) != Some("imports_from") {
+            continue;
+        }
+        let module = edge.string("module");
+        if module.is_empty() || module.len() > 4_096 || module.contains(['\\', '\0']) {
+            continue;
+        }
+        let importer = {
+            let source = edge.string("source_file");
+            if source.is_empty() {
+                unique_inventory_source(&source_by_node, &edge.source)
+                    .unwrap_or_default()
+                    .to_owned()
+            } else {
+                source
+            }
+        };
+        let Some(importer) = typescript_project_importer_key(&importer, root) else {
+            continue;
+        };
+        let target_source = {
+            let source = edge.string("target_file");
+            if source.is_empty() {
+                unique_inventory_source(&source_by_node, &edge.target)
+                    .unwrap_or_default()
+                    .to_owned()
+            } else {
+                source
+            }
+        };
+        let Some(target_keys) = (!target_source.is_empty())
+            .then(|| typescript_source_module_keys(&target_source, root))
+            .filter(|keys| !keys.is_empty())
+        else {
+            continue;
+        };
+        let key = (importer, module);
+        if !targets.contains_key(&key) && targets.len() >= entry_limit {
+            return Err(format!(
+                "TypeScript project module entry count exceeds limit {entry_limit}"
+            ));
+        }
+        let values = targets.entry(key).or_default();
+        for target_key in target_keys {
+            if values.contains(&target_key) || values.len() < max_targets {
+                values.insert(target_key);
+            }
+        }
+    }
+    Ok(targets
+        .into_iter()
+        .filter_map(|(key, values)| {
+            (!values.is_empty()).then_some((key, values.into_iter().collect()))
+        })
+        .collect())
+}
+
+fn unique_inventory_source<'a>(
+    source_by_node: &'a BTreeMap<String, BTreeSet<String>>,
+    node_id: &str,
+) -> Option<&'a str> {
+    let sources = source_by_node.get(node_id)?;
+    let mut values = sources.iter();
+    let source = values.next()?;
+    values.next().is_none().then_some(source.as_str())
+}
+
 fn typescript_module_indices(
     declarations: &AHashMap<String, DeclarationFact>,
     declaration_ids: &[String],
     bindings: &AHashMap<String, BindingFact>,
     scopes: &AHashMap<String, compass_languages::ScopeFact>,
     root: &Path,
+    project_modules: &TypeScriptProjectModuleIndex,
 ) -> (
     TypeScriptModuleIndex,
     TypeScriptModuleIndex,
@@ -4510,8 +4687,15 @@ fn typescript_module_indices(
         if !matches!(owner.language.as_str(), "typescript" | "javascript") {
             continue;
         }
-        let target_modules =
-            typescript_import_module_keys(&owner.range.source_file, target_module, root);
+        let target_modules = typescript_project_module_keys(
+            project_modules,
+            &owner.range.source_file,
+            target_module,
+            root,
+        )
+        .unwrap_or_else(|| {
+            typescript_import_module_keys(&owner.range.source_file, target_module, root)
+        });
         if target_modules.is_empty() {
             continue;
         }
@@ -5505,6 +5689,7 @@ const fn resolution_rule_name(rule: ResolutionRule) -> &'static str {
         ResolutionRule::ExactSourceDeclaration => "exact-source-declaration",
         ResolutionRule::ExactLexicalDeclaration => "exact-lexical-declaration",
         ResolutionRule::ExplicitBinding => "explicit-binding",
+        ResolutionRule::ProjectModuleBinding => "project-module-binding",
         ResolutionRule::MemberBinding => "member-binding",
         ResolutionRule::DeferredReceiver => "deferred-receiver",
         ResolutionRule::WildcardBinding => "wildcard-binding",

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1387,6 +1387,7 @@ impl UniversalResolutionIndex {
             .filter(|path| path.members.len() == 1)
             .map(|path| path.root_export.clone());
         let is_member_candidate = member_path.is_some();
+        let mut source_member_target_seen = false;
         let mut targets = BTreeSet::new();
         for key in keys {
             if let Some(path) = member_path.as_ref()
@@ -1395,6 +1396,9 @@ impl UniversalResolutionIndex {
                     || path.members.len() > 1
                     || !path.type_arguments.is_empty())
             {
+                source_member_target_seen |= !self
+                    .typescript_export_slots(language, &key, &path.root_export, candidate, true)
+                    .is_empty();
                 targets.extend(self.typescript_member_chain_slots(language, &key, path, candidate));
                 continue;
             }
@@ -1415,6 +1419,7 @@ impl UniversalResolutionIndex {
                 candidate,
                 member_owner_export.is_some(),
             );
+            source_member_target_seen |= !owner_targets.is_empty();
             if member_owner_export.is_some() {
                 for owner_slot in &owner_targets {
                     let Some(owner) = self.declaration(*owner_slot) else {
@@ -1425,6 +1430,13 @@ impl UniversalResolutionIndex {
                         owner.qualified_name.clone(),
                         candidate.target_spelling.clone(),
                     )) {
+                        let members = members.iter().copied().collect::<BTreeSet<_>>();
+                        let members = if candidate.relation == CandidateRelation::Calls {
+                            let argument_types = typescript_candidate_argument_types(candidate);
+                            self.typescript_callable_overload_slots(&members, &argument_types, &[])
+                        } else {
+                            members
+                        };
                         targets.extend(
                             members
                                 .iter()
@@ -1479,6 +1491,13 @@ impl UniversalResolutionIndex {
             }
         }
         let targets = targets.into_iter().collect::<Vec<_>>();
+        if is_member_candidate
+            && candidate.relation == CandidateRelation::Calls
+            && targets.is_empty()
+            && source_member_target_seen
+        {
+            return Some(ResolutionDecision::Unresolved);
+        }
         self.unique_typescript_decision(
             Some(&targets),
             candidate,
@@ -1510,6 +1529,15 @@ impl UniversalResolutionIndex {
         }
         let root_targets =
             self.typescript_export_slots(language, module, &path.root_export, candidate, true);
+        let root_targets = if path.call_result && path.call_member_index.is_none() {
+            self.typescript_callable_overload_slots(
+                &root_targets,
+                &path.call_argument_types,
+                &path.call_type_arguments,
+            )
+        } else {
+            root_targets
+        };
         if path.call_member_index.is_some() && root_targets.len() != 1 {
             return BTreeSet::new();
         }
@@ -1763,15 +1791,22 @@ impl UniversalResolutionIndex {
         candidate: &RelationshipCandidate,
     ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
         let mut contexts = BTreeSet::new();
-        let callable_members = members
+        let member_slots = members
             .iter()
-            .filter_map(|slot| {
+            .copied()
+            .filter(|slot| {
                 self.declaration(*slot)
                     .and_then(|declaration| declaration.signature.as_deref())
                     .and_then(typescript_callable_return_type)
-                    .map(|_| *slot)
+                    .is_some()
             })
-            .collect::<Vec<_>>();
+            .take(self.limits.candidates_per_lookup.saturating_add(1))
+            .collect::<BTreeSet<_>>();
+        let callable_members = self.typescript_callable_overload_slots(
+            &member_slots,
+            call_argument_types,
+            call_type_arguments,
+        );
         if callable_members.len() != 1 {
             return BTreeSet::new();
         }
@@ -1789,6 +1824,182 @@ impl UniversalResolutionIndex {
             }
         }
         contexts
+    }
+
+    /// Select one source-proven callable overload when the call carries a
+    /// complete, exact argument shape.  TypeScript overload assignability is
+    /// intentionally not modeled here: unsupported unions, contextual
+    /// inference, optional/rest parameters, and competing exact matches stay
+    /// unresolved instead of being collapsed to a convenient declaration.
+    fn typescript_callable_overload_slots(
+        &self,
+        slots: &BTreeSet<DeclarationSlot>,
+        call_argument_types: &[String],
+        call_type_arguments: &[String],
+    ) -> BTreeSet<DeclarationSlot> {
+        let callable_slots = slots
+            .iter()
+            .filter(|slot| {
+                self.declaration(**slot)
+                    .and_then(|declaration| declaration.signature.as_deref())
+                    .is_some_and(|signature| {
+                        typescript_callable_return_type(signature).is_some()
+                            || typescript_callable_parameter_types(signature).is_some()
+                    })
+            })
+            .take(self.limits.candidates_per_lookup.saturating_add(1))
+            .copied()
+            .collect::<Vec<_>>();
+        if callable_slots.len() > self.limits.candidates_per_lookup {
+            return BTreeSet::new();
+        }
+        if callable_slots.len() <= 1 {
+            return slots.clone();
+        }
+        let matching = callable_slots
+            .iter()
+            .copied()
+            .filter(|slot| {
+                self.declaration(*slot).is_some_and(|declaration| {
+                    let normalized_argument_types = call_argument_types
+                        .iter()
+                        .map(|argument| {
+                            self.typescript_normalize_overload_type(
+                                &declaration.range.source_file,
+                                argument,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    let normalized_type_arguments = call_type_arguments
+                        .iter()
+                        .map(|argument| {
+                            self.typescript_normalize_overload_type(
+                                &declaration.range.source_file,
+                                argument,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    typescript_callable_overload_matches(
+                        declaration,
+                        &normalized_argument_types,
+                        &normalized_type_arguments,
+                        &self.typescript_callable_parameter_aliases(declaration),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        match matching.as_slice() {
+            [only] => BTreeSet::from([*only]),
+            _ => BTreeSet::new(),
+        }
+    }
+
+    fn typescript_callable_parameter_aliases(
+        &self,
+        declaration: &DeclarationFact,
+    ) -> AHashMap<String, String> {
+        let mut aliases = AHashMap::<String, Vec<String>>::new();
+        let mut scope = declaration.scope_id.clone();
+        let mut visited = BTreeSet::new();
+        let mut resolved_spellings = BTreeSet::new();
+        while let Some(scope_id) = scope.filter(|scope_id| visited.insert(scope_id.clone())) {
+            let mut scope_spellings = BTreeSet::new();
+            for binding in self.bindings.values().filter(|binding| {
+                binding.language == declaration.language
+                    && binding.scope_id.as_deref() == Some(scope_id.as_str())
+                    && matches!(
+                        binding.kind,
+                        compass_languages::BindingKind::Import
+                            | compass_languages::BindingKind::ImportAlias
+                            | compass_languages::BindingKind::Reexport
+                    )
+                    && binding.namespace.is_none_or(|namespace| {
+                        matches!(
+                            namespace,
+                            compass_languages::SymbolNamespace::Type
+                                | compass_languages::SymbolNamespace::ValueAndType
+                                | compass_languages::SymbolNamespace::Namespace
+                        )
+                    })
+            }) {
+                if resolved_spellings.contains(&binding.spelling)
+                    && !scope_spellings.contains(&binding.spelling)
+                {
+                    continue;
+                }
+                if !scope_spellings.insert(binding.spelling.clone()) {
+                    let targets = aliases.entry(binding.spelling.clone()).or_default();
+                    if targets.len() < 2 {
+                        targets.push(self.typescript_normalize_overload_type(
+                            &declaration.range.source_file,
+                            &binding.qualified_target,
+                        ));
+                    }
+                    continue;
+                }
+                aliases.insert(
+                    binding.spelling.clone(),
+                    vec![self.typescript_normalize_overload_type(
+                        &declaration.range.source_file,
+                        &binding.qualified_target,
+                    )],
+                );
+            }
+            resolved_spellings.extend(scope_spellings);
+            scope = self
+                .scopes
+                .get(&scope_id)
+                .and_then(|scope| scope.parent_scope_id.clone());
+        }
+        aliases
+            .into_iter()
+            .filter_map(|(spelling, targets)| {
+                let [target] = targets.as_slice() else {
+                    return None;
+                };
+                Some((spelling, target.clone()))
+            })
+            .collect()
+    }
+
+    fn typescript_normalize_overload_type(&self, source_file: &str, value: &str) -> String {
+        self.typescript_normalize_overload_type_at_depth(source_file, value, 0)
+    }
+
+    fn typescript_normalize_overload_type_at_depth(
+        &self,
+        source_file: &str,
+        value: &str,
+        depth: usize,
+    ) -> String {
+        let value = value.trim();
+        if depth > 32 || value.is_empty() || value == "__unknown" || value.len() > 1024 {
+            return value.to_owned();
+        }
+        if let Some((base, arguments)) = typescript_generic_type_parts(value) {
+            let arguments = arguments
+                .iter()
+                .map(|argument| {
+                    self.typescript_normalize_overload_type_at_depth(
+                        source_file,
+                        argument,
+                        depth.saturating_add(1),
+                    )
+                })
+                .collect::<Vec<_>>();
+            return format!("{base}<{}>", arguments.join(","));
+        }
+        let (module, exported) = split_typescript_module_qualified(value);
+        let Some(module) = module else {
+            return value.to_owned();
+        };
+        let Some(key) = typescript_import_module_keys(source_file, module, &self.root)
+            .into_iter()
+            .next()
+        else {
+            return value.to_owned();
+        };
+        format!("{key}::{exported}")
     }
 
     fn typescript_index_value_contexts(
@@ -5418,6 +5629,156 @@ fn typescript_callable_parameter_types(signature: &str) -> Option<Vec<String>> {
     }
     let wrapped = format!("Parameters<{parameters}>");
     typescript_generic_type_parts(&wrapped).map(|(_, arguments)| arguments)
+}
+
+fn typescript_candidate_argument_types(candidate: &RelationshipCandidate) -> Vec<String> {
+    candidate
+        .constraints
+        .argument_types
+        .iter()
+        .map(|argument| argument.clone().unwrap_or_else(|| "__unknown".to_owned()))
+        .collect()
+}
+
+fn typescript_callable_overload_matches(
+    declaration: &DeclarationFact,
+    call_argument_types: &[String],
+    call_type_arguments: &[String],
+    parameter_aliases: &AHashMap<String, String>,
+) -> bool {
+    let Some(signature) = declaration.signature.as_deref() else {
+        return false;
+    };
+    let generic_parameters = typescript_generic_parameter_names(signature);
+    if !call_type_arguments.is_empty() && call_type_arguments.len() != generic_parameters.len() {
+        return false;
+    }
+    let mut inferred_arguments = if call_type_arguments.is_empty() {
+        generic_parameters.clone()
+    } else {
+        call_type_arguments.to_vec()
+    };
+    if let Some(parameter_types) = typescript_callable_parameter_types(signature) {
+        if parameter_types.len() != call_argument_types.len() {
+            return false;
+        }
+        for (parameter, argument) in parameter_types.iter().zip(call_argument_types) {
+            if argument == "__unknown" {
+                if call_type_arguments.is_empty()
+                    || generic_parameters.iter().all(|name| {
+                        !typescript_type_mentions_parameter(parameter, std::slice::from_ref(name))
+                    })
+                {
+                    return false;
+                }
+                continue;
+            }
+            if !typescript_callable_parameter_matches(
+                parameter,
+                argument,
+                &generic_parameters,
+                &mut inferred_arguments,
+                parameter_aliases,
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+    declaration
+        .parameter_count
+        .and_then(|count| usize::try_from(count).ok())
+        .is_some_and(|count| {
+            count == call_argument_types.len()
+                && call_argument_types
+                    .iter()
+                    .all(|argument| argument != "__unknown")
+        })
+}
+
+fn typescript_callable_parameter_matches(
+    parameter: &str,
+    argument: &str,
+    generic_parameters: &[String],
+    inferred_arguments: &mut [String],
+    parameter_aliases: &AHashMap<String, String>,
+) -> bool {
+    typescript_callable_parameter_matches_at_depth(
+        parameter,
+        argument,
+        generic_parameters,
+        inferred_arguments,
+        parameter_aliases,
+        0,
+    )
+}
+
+fn typescript_callable_parameter_matches_at_depth(
+    parameter: &str,
+    argument: &str,
+    generic_parameters: &[String],
+    inferred_arguments: &mut [String],
+    parameter_aliases: &AHashMap<String, String>,
+    depth: usize,
+) -> bool {
+    if depth > 32 {
+        return false;
+    }
+    let parameter = parameter.trim();
+    let argument = argument.trim();
+    if parameter.is_empty() || argument.is_empty() {
+        return false;
+    }
+    if let Some(index) = generic_parameters.iter().position(|name| name == parameter) {
+        let Some(inferred) = inferred_arguments.get_mut(index) else {
+            return false;
+        };
+        if inferred == parameter {
+            inferred.clone_from(&argument.to_owned());
+            return true;
+        }
+        return inferred == argument;
+    }
+    if let Some(alias) = parameter_aliases.get(parameter) {
+        return alias == argument;
+    }
+    if parameter == argument {
+        return true;
+    }
+    if let (Some(parameter_element), Some(argument_element)) =
+        (parameter.strip_suffix("[]"), argument.strip_suffix("[]"))
+    {
+        return typescript_callable_parameter_matches_at_depth(
+            parameter_element,
+            argument_element,
+            generic_parameters,
+            inferred_arguments,
+            parameter_aliases,
+            depth.saturating_add(1),
+        );
+    }
+    let Some((parameter_base, parameter_arguments)) = typescript_generic_type_parts(parameter)
+    else {
+        return false;
+    };
+    let Some((argument_base, argument_arguments)) = typescript_generic_type_parts(argument) else {
+        return false;
+    };
+    parameter_base == argument_base
+        && parameter_arguments.len() == argument_arguments.len()
+        && parameter_arguments
+            .iter()
+            .zip(argument_arguments.iter())
+            .all(|(parameter_argument, argument_argument)| {
+                typescript_callable_parameter_matches_at_depth(
+                    parameter_argument,
+                    argument_argument,
+                    generic_parameters,
+                    inferred_arguments,
+                    parameter_aliases,
+                    depth.saturating_add(1),
+                )
+            })
 }
 
 fn typescript_infer_type_arguments(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -110,6 +110,12 @@ struct TypeScriptMemberPath {
     members: Vec<String>,
 }
 
+struct TypeScriptMemberContext<'a> {
+    owner_signature: Option<&'a str>,
+    type_arguments: &'a [String],
+    index_selector: Option<&'a str>,
+}
+
 /// Compact slot into the declaration table used by secondary indexes.
 ///
 /// Declaration IDs are long, repeated strings on corpus-scale Java and
@@ -1399,7 +1405,12 @@ impl UniversalResolutionIndex {
             self.typescript_export_slots(language, module, &path.root_export, candidate, true);
         let mut targets = BTreeSet::new();
         for root_slot in root_targets {
-            let mut owners = if path.indexed {
+            let has_index_signature = self
+                .declaration(root_slot)
+                .and_then(|declaration| declaration.signature.as_deref())
+                .and_then(typescript_index_value_type)
+                .is_some();
+            let mut owners = if path.indexed && has_index_signature {
                 self.typescript_index_value_contexts(
                     language,
                     module,
@@ -1416,7 +1427,13 @@ impl UniversalResolutionIndex {
                     candidate,
                 )
             };
-            for (index, member_name) in path.members.iter().enumerate() {
+            for (index, raw_member_name) in path.members.iter().enumerate() {
+                let Some((member_name, index_selector)) =
+                    typescript_indexed_member_segment(raw_member_name)
+                else {
+                    owners.clear();
+                    break;
+                };
                 let final_member = index.saturating_add(1) == path.members.len();
                 let mut next_owners = BTreeSet::new();
                 for (owner_slot, owner_type_arguments) in owners.clone() {
@@ -1461,8 +1478,11 @@ impl UniversalResolutionIndex {
                                 language,
                                 module,
                                 type_name,
-                                owner.signature.as_deref(),
-                                &owner_type_arguments,
+                                TypeScriptMemberContext {
+                                    owner_signature: owner.signature.as_deref(),
+                                    type_arguments: &owner_type_arguments,
+                                    index_selector: index_selector.as_deref(),
+                                },
                                 candidate,
                             ));
                         }
@@ -1503,8 +1523,11 @@ impl UniversalResolutionIndex {
             language,
             module,
             type_name,
-            Some(signature),
-            type_arguments,
+            TypeScriptMemberContext {
+                owner_signature: Some(signature),
+                type_arguments,
+                index_selector: None,
+            },
             candidate,
         )
     }
@@ -1552,8 +1575,11 @@ impl UniversalResolutionIndex {
                     language,
                     &alias_module,
                     &substituted,
-                    Some(signature),
-                    &arguments,
+                    TypeScriptMemberContext {
+                        owner_signature: Some(signature),
+                        type_arguments: &arguments,
+                        index_selector: substituted.strip_suffix("[]").map(|_| ""),
+                    },
                     candidate,
                 );
                 if contexts.is_empty() {
@@ -1575,19 +1601,39 @@ impl UniversalResolutionIndex {
         language: &str,
         module: &str,
         type_name: &str,
-        owner_signature: Option<&str>,
-        type_arguments: &[String],
+        context: TypeScriptMemberContext<'_>,
         candidate: &RelationshipCandidate,
     ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
         let type_name = type_name.trim();
         if type_name.is_empty() || type_name.len() > 1024 {
             return BTreeSet::new();
         }
-        let generic_parameters = owner_signature
+        let generic_parameters = context
+            .owner_signature
             .map(typescript_generic_parameter_names)
             .unwrap_or_default();
-        let substituted =
-            typescript_substitute_type_parameters(type_name, &generic_parameters, type_arguments);
+        let substituted = typescript_substitute_type_parameters(
+            type_name,
+            &generic_parameters,
+            context.type_arguments,
+        );
+        let substituted = match context.index_selector {
+            Some("") => match typescript_array_element_type(&substituted) {
+                Some(element) => element.to_owned(),
+                None => return BTreeSet::new(),
+            },
+            Some(index) => {
+                if let Some(element) = typescript_array_element_type(&substituted) {
+                    element
+                } else {
+                    match typescript_tuple_element_type(&substituted, index) {
+                        Some(element) => element,
+                        None => return BTreeSet::new(),
+                    }
+                }
+            }
+            None => substituted,
+        };
         let (base, nested_type_arguments) = typescript_generic_type_parts(&substituted)
             .unwrap_or((substituted.as_str(), Vec::new()));
         let (qualified_module, exported) = split_typescript_module_qualified(base);
@@ -4783,6 +4829,91 @@ fn typescript_generic_type_parts(value: &str) -> Option<(&str, Vec<String>)> {
     (parts.len() <= 64).then_some((base, parts))
 }
 
+fn typescript_array_element_type(value: &str) -> Option<String> {
+    let value = value.trim();
+    if let Some(element) = value.strip_suffix("[]") {
+        let element = element.trim();
+        return (!element.is_empty() && element.len() <= 1024).then(|| element.to_owned());
+    }
+    let (base, arguments) = typescript_generic_type_parts(value)?;
+    if !matches!(base, "Array" | "ReadonlyArray") || arguments.len() != 1 {
+        return None;
+    }
+    arguments.first().cloned()
+}
+
+fn typescript_tuple_elements(value: &str) -> Option<Vec<&str>> {
+    let value = value.trim();
+    if !value.starts_with('[') || !value.ends_with(']') {
+        return None;
+    }
+    let inner = value.get(1..value.len().saturating_sub(1))?.trim();
+    if inner.is_empty() || inner.len() > 1024 {
+        return None;
+    }
+    let mut elements = Vec::new();
+    let mut start = 0_usize;
+    let mut depth = 0_u32;
+    for (index, character) in inner.char_indices() {
+        match character {
+            '<' | '[' | '(' | '{' => depth = depth.saturating_add(1),
+            '>' | ']' | ')' | '}' => depth = depth.checked_sub(1)?,
+            ',' if depth == 0 => {
+                let element = inner.get(start..index)?.trim();
+                if element.is_empty() || element.len() > 1024 {
+                    return None;
+                }
+                elements.push(element);
+                start = index.saturating_add(1);
+            }
+            _ => {}
+        }
+        if elements.len() >= 64 {
+            return None;
+        }
+    }
+    if depth != 0 {
+        return None;
+    }
+    let element = inner.get(start..)?.trim();
+    if element.is_empty() || element.len() > 1024 {
+        return None;
+    }
+    elements.push(element);
+    Some(elements)
+}
+
+fn typescript_tuple_element_type(value: &str, index: &str) -> Option<String> {
+    let index = index.parse::<usize>().ok()?;
+    let element = typescript_tuple_elements(value)?.get(index)?.trim();
+    if element.is_empty() || element.starts_with("...") || element.ends_with('?') {
+        return None;
+    }
+    Some(element.to_owned())
+}
+
+fn typescript_indexed_member_segment(value: &str) -> Option<(String, Option<String>)> {
+    let value = value.trim();
+    if let Some(base) = value.strip_suffix("[]") {
+        let base = base.trim();
+        return (!base.is_empty()).then(|| (base.to_owned(), Some(String::new())));
+    }
+    if let Some(open) = value.rfind('[')
+        && value.ends_with(']')
+    {
+        let base = value.get(..open)?.trim();
+        let index = value.get(open.saturating_add(1)..value.len().saturating_sub(1))?;
+        if base.is_empty()
+            || index.is_empty()
+            || !index.chars().all(|character| character.is_ascii_digit())
+        {
+            return None;
+        }
+        return Some((base.to_owned(), Some(index.to_owned())));
+    }
+    (!value.is_empty()).then(|| (value.to_owned(), None))
+}
+
 fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
     let signature = signature
         .trim()
@@ -4813,6 +4944,15 @@ fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
 }
 
 fn typescript_type_alias_target(signature: &str) -> Option<&str> {
+    let alias_separator = signature.find('=');
+    if let Some(index_separator) = signature.find("|index=")
+        && alias_separator.is_none_or(|separator| separator >= index_separator)
+    {
+        // `index=` is declaration-shape metadata, not an alias target. A
+        // generic interface such as `<T>|index=T` must not be expanded as if
+        // its whole receiver were the indexed value.
+        return None;
+    }
     let (parameters, target) = signature.trim().split_once('=')?;
     let parameters = parameters.trim();
     let target = target
@@ -4852,6 +4992,27 @@ fn typescript_substitute_type_parameters(
         && let Some(argument) = arguments.get(index)
     {
         return argument.clone();
+    }
+    if let Some(element) = type_name.strip_suffix("[]") {
+        let substituted = typescript_substitute_type_parameters(element, parameters, arguments);
+        let substituted = format!("{substituted}[]");
+        return if substituted.len() <= 1024 {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some(elements) = typescript_tuple_elements(type_name) {
+        let substituted = elements
+            .iter()
+            .map(|element| typescript_substitute_type_parameters(element, parameters, arguments))
+            .collect::<Vec<_>>();
+        let substituted = format!("[{}]", substituted.join(","));
+        return if substituted.len() <= 1024 {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
     }
     let Some((base, nested)) = typescript_generic_type_parts(type_name) else {
         return type_name.to_owned();

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1617,6 +1617,7 @@ impl UniversalResolutionIndex {
             &generic_parameters,
             context.type_arguments,
         );
+        let substituted = typescript_utility_receiver_type(&substituted).unwrap_or(substituted);
         let substituted = match context.index_selector {
             Some("") => match typescript_array_element_type(&substituted) {
                 Some(element) => element.to_owned(),
@@ -4842,6 +4843,100 @@ fn typescript_array_element_type(value: &str) -> Option<String> {
     arguments.first().cloned()
 }
 
+fn typescript_utility_receiver_type(value: &str) -> Option<String> {
+    typescript_utility_receiver_type_at_depth(value, 0)
+}
+
+fn typescript_utility_receiver_type_at_depth(value: &str, depth: u32) -> Option<String> {
+    if depth > 32 {
+        return None;
+    }
+    let (base, arguments) = typescript_generic_type_parts(value)?;
+    if arguments.len() != 1 {
+        return None;
+    }
+    let argument = arguments[0].trim();
+    match base {
+        "NonNullable" => {
+            let members = typescript_split_top_level_union(argument)?;
+            let nominal = members
+                .into_iter()
+                .map(str::trim)
+                .filter(|member| !typescript_non_nominal_union_member(member))
+                .collect::<Vec<_>>();
+            let [nominal] = nominal.as_slice() else {
+                return None;
+            };
+            Some((*nominal).to_owned())
+        }
+        "Awaited" => {
+            if let Some((promise, nested)) = typescript_generic_type_parts(argument)
+                && matches!(promise, "Promise" | "PromiseLike")
+                && nested.len() == 1
+            {
+                return typescript_utility_receiver_type_at_depth(
+                    &format!("Awaited<{}>", nested[0]),
+                    depth.saturating_add(1),
+                )
+                .or_else(|| Some(nested[0].clone()));
+            }
+            Some(argument.to_owned())
+        }
+        "Partial" | "Required" | "Readonly" => Some(argument.to_owned()),
+        _ => None,
+    }
+}
+
+fn typescript_non_nominal_union_member(value: &str) -> bool {
+    matches!(
+        value,
+        "any"
+            | "unknown"
+            | "never"
+            | "void"
+            | "undefined"
+            | "null"
+            | "string"
+            | "number"
+            | "boolean"
+            | "bigint"
+            | "symbol"
+            | "object"
+            | "true"
+            | "false"
+    )
+}
+
+fn typescript_split_top_level_union(value: &str) -> Option<Vec<&str>> {
+    let mut members = Vec::new();
+    let mut start = 0_usize;
+    let mut depth = 0_u32;
+    for (index, character) in value.char_indices() {
+        match character {
+            '<' | '{' | '(' | '[' => depth = depth.checked_add(1)?,
+            '>' | '}' | ')' | ']' => depth = depth.checked_sub(1)?,
+            '|' if depth == 0 => {
+                let member = value.get(start..index)?.trim();
+                if member.is_empty() {
+                    return None;
+                }
+                members.push(member);
+                start = index.saturating_add(character.len_utf8());
+            }
+            _ => {}
+        }
+        if members.len() >= 64 {
+            return None;
+        }
+    }
+    let member = value.get(start..)?.trim();
+    if member.is_empty() {
+        return None;
+    }
+    members.push(member);
+    Some(members)
+}
+
 fn typescript_tuple_elements(value: &str) -> Option<Vec<&str>> {
     let value = value.trim();
     if !value.starts_with('[') || !value.ends_with(']') {
@@ -5008,6 +5103,20 @@ fn typescript_substitute_type_parameters(
             .map(|element| typescript_substitute_type_parameters(element, parameters, arguments))
             .collect::<Vec<_>>();
         let substituted = format!("[{}]", substituted.join(","));
+        return if substituted.len() <= 1024 {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some(members) = typescript_split_top_level_union(type_name)
+        && members.len() > 1
+    {
+        let substituted = members
+            .iter()
+            .map(|member| typescript_substitute_type_parameters(member, parameters, arguments))
+            .collect::<Vec<_>>()
+            .join("|");
         return if substituted.len() <= 1024 {
             substituted
         } else {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -2192,6 +2192,33 @@ impl UniversalResolutionIndex {
             }
             return indexed_contexts;
         }
+        if let Some((utility, arguments)) = typescript_generic_type_parts(&substituted)
+            && matches!(utility, "Pick" | "Omit")
+            && arguments.len() == 2
+        {
+            let base = arguments[0].trim();
+            let keys = arguments[1].trim();
+            if typescript_keyof_type_base(keys) == Some(base) {
+                if utility == "Omit" {
+                    return BTreeSet::new();
+                }
+                // `Pick<Base, keyof Base>` is an identity projection. Keep
+                // this resolver branch deliberately narrow: literal Pick or
+                // Omit sets need member-level projection metadata, while a
+                // broad structural key expression must not widen a receiver.
+                return self.typescript_member_type_contexts(
+                    language,
+                    module,
+                    base,
+                    TypeScriptMemberContext {
+                        owner_signature: None,
+                        type_arguments: &[],
+                        index_selector: None,
+                    },
+                    candidate,
+                );
+            }
+        }
         let substituted = match context.index_selector {
             Some("") => match typescript_array_element_type(&substituted) {
                 Some(element) => element.to_owned(),
@@ -5676,6 +5703,15 @@ fn typescript_literal_indexed_type(value: &str) -> Option<(&str, String)> {
     Some((base, property.to_owned()))
 }
 
+fn typescript_keyof_type_base(value: &str) -> Option<&str> {
+    let rest = value.trim().strip_prefix("keyof")?;
+    rest.chars()
+        .next()
+        .filter(|character| character.is_whitespace())?;
+    let base = rest.trim();
+    (!base.is_empty()).then_some(base)
+}
+
 fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
     let signature = signature
         .trim()
@@ -5998,6 +6034,15 @@ fn typescript_substitute_type_parameters(
         && let Some(argument) = arguments.get(index)
     {
         return argument.clone();
+    }
+    if let Some(key_base) = typescript_keyof_type_base(type_name) {
+        let substituted = typescript_substitute_type_parameters(key_base, parameters, arguments);
+        let substituted = format!("keyof {substituted}");
+        return if substituted.len() <= 1024 {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
     }
     if let Some(element) = type_name.strip_suffix("[]") {
         let substituted = typescript_substitute_type_parameters(element, parameters, arguments);

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -106,6 +106,7 @@ struct TypeScriptReexportTarget {
 struct TypeScriptMemberPath {
     root_export: String,
     type_arguments: Vec<String>,
+    indexed: bool,
     members: Vec<String>,
 }
 
@@ -1318,7 +1319,7 @@ impl UniversalResolutionIndex {
         let mut targets = BTreeSet::new();
         for key in keys {
             if let Some(path) = member_path.as_ref()
-                && (path.members.len() > 1 || !path.type_arguments.is_empty())
+                && (path.indexed || path.members.len() > 1 || !path.type_arguments.is_empty())
             {
                 targets.extend(self.typescript_member_chain_slots(language, &key, path, candidate));
                 continue;
@@ -1398,48 +1399,73 @@ impl UniversalResolutionIndex {
             self.typescript_export_slots(language, module, &path.root_export, candidate, true);
         let mut targets = BTreeSet::new();
         for root_slot in root_targets {
-            let mut owners = BTreeSet::from([(root_slot, path.type_arguments.clone())]);
+            let mut owners = if path.indexed {
+                self.typescript_index_value_contexts(
+                    language,
+                    module,
+                    root_slot,
+                    &path.type_arguments,
+                    candidate,
+                )
+            } else {
+                self.typescript_expand_type_alias_contexts(
+                    language,
+                    module,
+                    root_slot,
+                    path.type_arguments.clone(),
+                    candidate,
+                )
+            };
             for (index, member_name) in path.members.iter().enumerate() {
                 let final_member = index.saturating_add(1) == path.members.len();
                 let mut next_owners = BTreeSet::new();
-                for (owner_slot, owner_type_arguments) in owners.iter() {
-                    let Some(owner) = self.declaration(*owner_slot) else {
-                        continue;
-                    };
-                    let Some(members) = self.members_by_owner.get(&(
-                        owner.language.clone(),
-                        owner.qualified_name.clone(),
-                        member_name.clone(),
-                    )) else {
-                        continue;
-                    };
-                    if final_member {
-                        next_owners.extend(
-                            members
-                                .iter()
-                                .filter(|slot| {
-                                    self.typescript_declaration_allowed_slot(**slot, candidate)
-                                })
-                                .map(|slot| (*slot, Vec::new())),
-                        );
-                    } else {
-                        let typed_members = members
-                            .iter()
-                            .filter_map(|slot| self.declaration(*slot))
-                            .filter(|member| member.kind == "property")
-                            .filter_map(|member| member.signature.as_deref())
-                            .collect::<Vec<_>>();
-                        let [type_name] = typed_members.as_slice() else {
+                for (owner_slot, owner_type_arguments) in owners.clone() {
+                    let expanded_owners = self.typescript_expand_type_alias_contexts(
+                        language,
+                        module,
+                        owner_slot,
+                        owner_type_arguments,
+                        candidate,
+                    );
+                    for (owner_slot, owner_type_arguments) in expanded_owners {
+                        let Some(owner) = self.declaration(owner_slot) else {
                             continue;
                         };
-                        next_owners.extend(self.typescript_member_type_contexts(
-                            language,
-                            module,
-                            type_name,
-                            owner.signature.as_deref(),
-                            owner_type_arguments,
-                            candidate,
-                        ));
+                        let Some(members) = self.members_by_owner.get(&(
+                            owner.language.clone(),
+                            owner.qualified_name.clone(),
+                            member_name.clone(),
+                        )) else {
+                            continue;
+                        };
+                        if final_member {
+                            next_owners.extend(
+                                members
+                                    .iter()
+                                    .filter(|slot| {
+                                        self.typescript_declaration_allowed_slot(**slot, candidate)
+                                    })
+                                    .map(|slot| (*slot, Vec::new())),
+                            );
+                        } else {
+                            let typed_members = members
+                                .iter()
+                                .filter_map(|slot| self.declaration(*slot))
+                                .filter(|member| member.kind == "property")
+                                .filter_map(|member| member.signature.as_deref())
+                                .collect::<Vec<_>>();
+                            let [type_name] = typed_members.as_slice() else {
+                                continue;
+                            };
+                            next_owners.extend(self.typescript_member_type_contexts(
+                                language,
+                                module,
+                                type_name,
+                                owner.signature.as_deref(),
+                                &owner_type_arguments,
+                                candidate,
+                            ));
+                        }
                     }
                 }
                 if next_owners.is_empty() {
@@ -1454,6 +1480,94 @@ impl UniversalResolutionIndex {
             }
         }
         targets
+    }
+
+    fn typescript_index_value_contexts(
+        &self,
+        language: &str,
+        module: &str,
+        owner_slot: DeclarationSlot,
+        type_arguments: &[String],
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
+        let Some(owner) = self.declaration(owner_slot) else {
+            return BTreeSet::new();
+        };
+        let Some(signature) = owner.signature.as_deref() else {
+            return BTreeSet::new();
+        };
+        let Some(type_name) = typescript_index_value_type(signature) else {
+            return BTreeSet::new();
+        };
+        self.typescript_member_type_contexts(
+            language,
+            module,
+            type_name,
+            Some(signature),
+            type_arguments,
+            candidate,
+        )
+    }
+
+    fn typescript_expand_type_alias_contexts(
+        &self,
+        language: &str,
+        module: &str,
+        owner_slot: DeclarationSlot,
+        type_arguments: Vec<String>,
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
+        const MAX_ALIAS_DEPTH: usize = 16;
+        let mut current = BTreeSet::from([(owner_slot, type_arguments)]);
+        let mut seen = BTreeSet::new();
+        for _ in 0..=MAX_ALIAS_DEPTH {
+            let mut next = BTreeSet::new();
+            let mut expanded = false;
+            for (slot, arguments) in current {
+                if !seen.insert((slot, arguments.clone())) {
+                    continue;
+                }
+                let Some(owner) = self.declaration(slot) else {
+                    continue;
+                };
+                let Some(signature) = owner.signature.as_deref() else {
+                    next.insert((slot, arguments));
+                    continue;
+                };
+                let Some(alias_target) = typescript_type_alias_target(signature) else {
+                    next.insert((slot, arguments));
+                    continue;
+                };
+                let alias_module =
+                    typescript_source_module_keys(&owner.range.source_file, &self.root)
+                        .into_iter()
+                        .next()
+                        .unwrap_or_else(|| module.to_owned());
+                let substituted = typescript_substitute_type_parameters(
+                    alias_target,
+                    &typescript_generic_parameter_names(signature),
+                    &arguments,
+                );
+                let contexts = self.typescript_member_type_contexts(
+                    language,
+                    &alias_module,
+                    &substituted,
+                    Some(signature),
+                    &arguments,
+                    candidate,
+                );
+                if contexts.is_empty() {
+                    continue;
+                }
+                expanded = true;
+                next.extend(contexts);
+            }
+            if !expanded {
+                return next;
+            }
+            current = next;
+        }
+        BTreeSet::new()
     }
 
     fn typescript_member_type_contexts(
@@ -1472,11 +1586,8 @@ impl UniversalResolutionIndex {
         let generic_parameters = owner_signature
             .map(typescript_generic_parameter_names)
             .unwrap_or_default();
-        let substituted = generic_parameters
-            .iter()
-            .position(|parameter| parameter == type_name)
-            .and_then(|index| type_arguments.get(index))
-            .map_or_else(|| type_name.to_owned(), |argument| argument.clone());
+        let substituted =
+            typescript_substitute_type_parameters(type_name, &generic_parameters, type_arguments);
         let (base, nested_type_arguments) = typescript_generic_type_parts(&substituted)
             .unwrap_or((substituted.as_str(), Vec::new()));
         let (qualified_module, exported) = split_typescript_module_qualified(base);
@@ -1497,12 +1608,97 @@ impl UniversalResolutionIndex {
         modules.sort_unstable();
         modules.dedup();
         let mut contexts = BTreeSet::new();
+        let exported_name = exported
+            .rsplit_once('.')
+            .map_or(exported, |(_, name)| name)
+            .to_owned();
         for module in modules {
-            for slot in self.typescript_export_slots(language, &module, exported, candidate, true) {
+            for slot in
+                self.typescript_export_slots(language, &module, &exported_name, candidate, true)
+            {
+                if exported.contains('.')
+                    && self
+                        .declaration(slot)
+                        .is_none_or(|declaration| declaration.qualified_name != exported)
+                {
+                    continue;
+                }
                 contexts.insert((slot, nested_type_arguments.clone()));
             }
             if contexts.len() > self.limits.candidates_per_lookup {
                 break;
+            }
+        }
+        if qualified_module.is_none() && !exported.contains('.') {
+            let mut imported_contexts = BTreeSet::new();
+            for binding in self.bindings.values().filter(|binding| {
+                binding.language == language
+                    && binding.spelling == exported
+                    && matches!(
+                        binding.kind,
+                        compass_languages::BindingKind::Import
+                            | compass_languages::BindingKind::ImportAlias
+                            | compass_languages::BindingKind::Reexport
+                    )
+                    && binding.namespace.is_none_or(|namespace| {
+                        matches!(
+                            namespace,
+                            compass_languages::SymbolNamespace::Type
+                                | compass_languages::SymbolNamespace::ValueAndType
+                                | compass_languages::SymbolNamespace::Namespace
+                        )
+                    })
+            }) {
+                let Some(owner) = binding
+                    .scope_id
+                    .as_deref()
+                    .and_then(|scope_id| self.scopes.get(scope_id))
+                    .and_then(|scope| scope.owner_declaration_id.as_deref())
+                    .and_then(|declaration_id| self.declarations.get(declaration_id))
+                else {
+                    continue;
+                };
+                let owner_modules =
+                    typescript_source_module_keys(&owner.range.source_file, &self.root);
+                let mut module_candidates = vec![module.to_owned()];
+                module_candidates.extend(typescript_import_module_keys(
+                    &owner.range.source_file,
+                    module,
+                    &self.root,
+                ));
+                if !module_candidates
+                    .iter()
+                    .any(|candidate_module| owner_modules.contains(candidate_module))
+                {
+                    continue;
+                }
+                let Some((target_module, target_export)) =
+                    binding.qualified_target.rsplit_once("::")
+                else {
+                    continue;
+                };
+                let mut target_modules = vec![target_module.to_owned()];
+                target_modules.extend(typescript_import_module_keys(
+                    &owner.range.source_file,
+                    target_module,
+                    &self.root,
+                ));
+                target_modules.sort_unstable();
+                target_modules.dedup();
+                for target_module in target_modules {
+                    for slot in self.typescript_export_slots(
+                        language,
+                        &target_module,
+                        target_export,
+                        candidate,
+                        true,
+                    ) {
+                        imported_contexts.insert((slot, nested_type_arguments.clone()));
+                    }
+                }
+            }
+            if !imported_contexts.is_empty() {
+                contexts = imported_contexts;
             }
         }
         contexts
@@ -4470,8 +4666,13 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
         return None;
     }
     let root_segment = segments.first()?;
+    let indexed = root_segment.ends_with("[]");
+    let root_segment = root_segment
+        .strip_suffix("[]")
+        .unwrap_or(root_segment)
+        .trim();
     let (root_export, type_arguments) = typescript_generic_type_parts(root_segment).map_or_else(
-        || (root_segment.clone(), Vec::new()),
+        || (root_segment.to_owned(), Vec::new()),
         |(base, arguments)| (base.to_owned(), arguments),
     );
     if root_export.is_empty() {
@@ -4480,6 +4681,7 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
     Some(TypeScriptMemberPath {
         root_export,
         type_arguments,
+        indexed,
         members: segments.into_iter().skip(1).collect(),
     })
 }
@@ -4582,7 +4784,12 @@ fn typescript_generic_type_parts(value: &str) -> Option<(&str, Vec<String>)> {
 }
 
 fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
-    let signature = signature.trim();
+    let signature = signature
+        .trim()
+        .split(['=', '|'])
+        .next()
+        .unwrap_or_default()
+        .trim();
     if !signature.starts_with('<') || !signature.ends_with('>') {
         return Vec::new();
     }
@@ -4603,6 +4810,62 @@ fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
         }
     }
     names
+}
+
+fn typescript_type_alias_target(signature: &str) -> Option<&str> {
+    let (parameters, target) = signature.trim().split_once('=')?;
+    let parameters = parameters.trim();
+    let target = target
+        .split_once("|index=")
+        .map_or(target, |(target, _)| target);
+    if parameters.contains("|index=")
+        || (!parameters.is_empty() && !parameters.starts_with('<'))
+        || target.trim().is_empty()
+        || target.len() > 1024
+    {
+        return None;
+    }
+    Some(target.trim())
+}
+
+fn typescript_index_value_type(signature: &str) -> Option<&str> {
+    let value = signature
+        .trim()
+        .split_once("|index=")
+        .map(|(_, value)| value)
+        .or_else(|| signature.trim().strip_prefix("index="))?;
+    (!value.is_empty() && value.len() <= 1024).then_some(value.trim())
+}
+
+fn typescript_substitute_type_parameters(
+    type_name: &str,
+    parameters: &[String],
+    arguments: &[String],
+) -> String {
+    let type_name = type_name.trim();
+    if type_name.is_empty() || type_name.len() > 1024 {
+        return type_name.to_owned();
+    }
+    if let Some(index) = parameters
+        .iter()
+        .position(|parameter| parameter == type_name)
+        && let Some(argument) = arguments.get(index)
+    {
+        return argument.clone();
+    }
+    let Some((base, nested)) = typescript_generic_type_parts(type_name) else {
+        return type_name.to_owned();
+    };
+    let nested = nested
+        .iter()
+        .map(|argument| typescript_substitute_type_parameters(argument, parameters, arguments))
+        .collect::<Vec<_>>();
+    let substituted = format!("{base}<{}>", nested.join(","));
+    if substituted.len() <= 1024 {
+        substituted
+    } else {
+        type_name.to_owned()
+    }
 }
 
 fn typescript_declaration_basic_allowed(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -108,6 +108,8 @@ struct TypeScriptMemberPath {
     type_arguments: Vec<String>,
     call_result: bool,
     call_argument_types: Vec<String>,
+    call_type_arguments: Vec<String>,
+    call_member_index: Option<usize>,
     indexed: bool,
     members: Vec<String>,
 }
@@ -1408,6 +1410,9 @@ impl UniversalResolutionIndex {
         }
         let root_targets =
             self.typescript_export_slots(language, module, &path.root_export, candidate, true);
+        if path.call_member_index.is_some() && root_targets.len() != 1 {
+            return BTreeSet::new();
+        }
         let mut targets = BTreeSet::new();
         for root_slot in root_targets {
             let has_index_signature = self
@@ -1415,12 +1420,13 @@ impl UniversalResolutionIndex {
                 .and_then(|declaration| declaration.signature.as_deref())
                 .and_then(typescript_index_value_type)
                 .is_some();
-            let mut owners = if path.call_result {
+            let mut owners = if path.call_result && path.call_member_index.is_none() {
                 self.typescript_callable_return_contexts(
                     language,
                     module,
                     root_slot,
                     &path.call_argument_types,
+                    &path.call_type_arguments,
                     candidate,
                 )
             } else if path.indexed && has_index_signature {
@@ -1468,6 +1474,22 @@ impl UniversalResolutionIndex {
                         )) else {
                             continue;
                         };
+                        if path.call_result && path.call_member_index == Some(index) {
+                            let owner_module =
+                                typescript_source_module_keys(&owner.range.source_file, &self.root)
+                                    .into_iter()
+                                    .next()
+                                    .unwrap_or_else(|| module.to_owned());
+                            next_owners.extend(self.typescript_member_callable_return_contexts(
+                                language,
+                                &owner_module,
+                                members,
+                                &path.call_argument_types,
+                                &path.call_type_arguments,
+                                candidate,
+                            ));
+                            continue;
+                        }
                         if final_member {
                             next_owners.extend(
                                 members
@@ -1525,6 +1547,7 @@ impl UniversalResolutionIndex {
         module: &str,
         callable_slot: DeclarationSlot,
         call_argument_types: &[String],
+        call_type_arguments: &[String],
         candidate: &RelationshipCandidate,
     ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
         let Some(callable) = self.declaration(callable_slot) else {
@@ -1537,7 +1560,13 @@ impl UniversalResolutionIndex {
             return BTreeSet::new();
         };
         let parameters = typescript_generic_parameter_names(signature);
-        let mut type_arguments = parameters.clone();
+        let mut type_arguments = if call_type_arguments.is_empty() {
+            parameters.clone()
+        } else if call_type_arguments.len() == parameters.len() {
+            call_type_arguments.to_vec()
+        } else {
+            return BTreeSet::new();
+        };
         if let Some(parameter_types) = typescript_callable_parameter_types(signature) {
             if parameter_types.len() != call_argument_types.len() {
                 return BTreeSet::new();
@@ -1545,6 +1574,9 @@ impl UniversalResolutionIndex {
             for (parameter_type, argument_type) in
                 parameter_types.iter().zip(call_argument_types.iter())
             {
+                if argument_type == "__unknown" {
+                    continue;
+                }
                 if !typescript_infer_type_arguments(
                     parameter_type,
                     argument_type,
@@ -1554,7 +1586,8 @@ impl UniversalResolutionIndex {
                     return BTreeSet::new();
                 }
             }
-        } else if !parameters.is_empty()
+        } else if call_type_arguments.is_empty()
+            && !parameters.is_empty()
             && typescript_type_mentions_parameter(return_type, &parameters)
         {
             return BTreeSet::new();
@@ -1576,6 +1609,44 @@ impl UniversalResolutionIndex {
             },
             candidate,
         )
+    }
+
+    fn typescript_member_callable_return_contexts(
+        &self,
+        language: &str,
+        module: &str,
+        members: &[DeclarationSlot],
+        call_argument_types: &[String],
+        call_type_arguments: &[String],
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
+        let mut contexts = BTreeSet::new();
+        let callable_members = members
+            .iter()
+            .filter_map(|slot| {
+                self.declaration(*slot)
+                    .and_then(|declaration| declaration.signature.as_deref())
+                    .and_then(typescript_callable_return_type)
+                    .map(|_| *slot)
+            })
+            .collect::<Vec<_>>();
+        if callable_members.len() != 1 {
+            return BTreeSet::new();
+        }
+        for slot in callable_members {
+            contexts.extend(self.typescript_callable_return_contexts(
+                language,
+                module,
+                slot,
+                call_argument_types,
+                call_type_arguments,
+                candidate,
+            ));
+            if contexts.len() > self.limits.candidates_per_lookup {
+                break;
+            }
+        }
+        contexts
     }
 
     fn typescript_index_value_contexts(
@@ -4789,42 +4860,38 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
         return None;
     }
     let root_segment = segments.first()?;
-    let mut indexed = root_segment.ends_with("[]");
-    let mut root_segment = root_segment
+    let indexed = root_segment.ends_with("[]");
+    let root_segment = root_segment
         .strip_suffix("[]")
         .unwrap_or(root_segment)
         .trim();
-    let (call_result, call_argument_types) = if let Some(marker) = root_segment.find("#call<") {
-        let base = root_segment.get(..marker)?.trim();
-        let marker_payload = root_segment.get(marker.saturating_add("#call<".len())..)?;
-        let marker_payload = marker_payload.strip_suffix('>')?;
-        if base.is_empty() || marker_payload.is_empty() {
-            return None;
-        }
-        let marker_arguments = if marker_payload == "__none" {
-            Vec::new()
+    let (root_base, mut call_result, mut call_argument_types, mut call_type_arguments) =
+        if let Some((base, arguments, type_arguments)) = typescript_call_result_marker(root_segment)
+        {
+            (base, true, arguments, type_arguments)
         } else {
-            let wrapped = format!("Call<{marker_payload}>");
-            let (_, arguments) = typescript_generic_type_parts(&wrapped)?;
-            arguments
+            (root_segment.to_owned(), false, Vec::new(), Vec::new())
         };
-        let marker_end = marker.saturating_add("#call<".len()) + marker_payload.len() + 1;
-        let suffix = root_segment.get(marker_end..).unwrap_or_default();
-        if !suffix.is_empty() {
-            if suffix != "[]" {
-                return None;
-            }
-            indexed = true;
-        }
-        root_segment = base;
-        (true, marker_arguments)
-    } else {
-        (false, Vec::new())
-    };
-    let (root_export, type_arguments) = typescript_generic_type_parts(root_segment).map_or_else(
-        || (root_segment.to_owned(), Vec::new()),
+    let (root_export, type_arguments) = typescript_generic_type_parts(&root_base).map_or_else(
+        || (root_base.clone(), Vec::new()),
         |(base, arguments)| (base.to_owned(), arguments),
     );
+    let mut members = segments.into_iter().skip(1).collect::<Vec<_>>();
+    let member_count = members.len();
+    let mut call_member_index = None;
+    for (index, member) in members.iter_mut().enumerate() {
+        let Some((base, arguments, type_arguments)) = typescript_call_result_marker(member) else {
+            continue;
+        };
+        if call_result || index.saturating_add(1) >= member_count {
+            return None;
+        }
+        *member = base;
+        call_result = true;
+        call_argument_types = arguments;
+        call_type_arguments = type_arguments;
+        call_member_index = Some(index);
+    }
     if root_export.is_empty() {
         return None;
     }
@@ -4833,9 +4900,53 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
         type_arguments,
         call_result,
         call_argument_types,
+        call_type_arguments,
+        call_member_index,
         indexed,
-        members: segments.into_iter().skip(1).collect(),
+        members,
     })
+}
+
+fn typescript_call_result_marker(value: &str) -> Option<(String, Vec<String>, Vec<String>)> {
+    let value = value.trim();
+    let mut call_value = value;
+    let type_arguments = if let Some(marker) = call_value.find("#types<") {
+        let payload_start = marker.saturating_add("#types<".len());
+        let payload = call_value.get(payload_start..)?.strip_suffix('>')?;
+        let marker_end = payload_start
+            .saturating_add(payload.len())
+            .saturating_add(1);
+        if marker_end != call_value.len() || payload.is_empty() {
+            return None;
+        }
+        call_value = call_value.get(..marker)?.trim();
+        let wrapped = format!("Types<{payload}>");
+        let (_, arguments) = typescript_generic_type_parts(&wrapped)?;
+        arguments
+    } else {
+        Vec::new()
+    };
+    let marker = call_value.find("#call<")?;
+    let payload_start = marker.saturating_add("#call<".len());
+    let payload = call_value.get(payload_start..)?.strip_suffix('>')?;
+    let marker_end = payload_start
+        .saturating_add(payload.len())
+        .saturating_add(1);
+    if marker_end != call_value.len() || payload.is_empty() {
+        return None;
+    }
+    let base = call_value.get(..marker)?.trim();
+    if base.is_empty() {
+        return None;
+    }
+    let arguments = if payload == "__none" {
+        Vec::new()
+    } else {
+        let wrapped = format!("Call<{payload}>");
+        let (_, arguments) = typescript_generic_type_parts(&wrapped)?;
+        arguments
+    };
+    Some((base.to_owned(), arguments, type_arguments))
 }
 
 fn split_typescript_module_qualified(value: &str) -> (Option<&str>, &str) {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1540,6 +1540,21 @@ impl UniversalResolutionIndex {
                         member_owner_export.is_some(),
                     )
                 });
+            // A CommonJS namespace can inherit a member through a proven
+            // object spread without publishing that inherited name as a
+            // direct reexport. If the direct export lookup is empty, recover
+            // the module owner itself so the bounded `Member("*")` alias can
+            // project the source member. Direct named reexports still win
+            // because this fallback only runs for an empty owner set.
+            let mut structural_namespace_owner = false;
+            if owner_targets.is_empty() && namespace_member_export.is_some() {
+                let module_targets =
+                    self.typescript_export_slots(language, &key, "*", candidate, true);
+                if !module_targets.is_empty() {
+                    owner_targets = module_targets;
+                    structural_namespace_owner = true;
+                }
+            }
             if owner_targets.is_empty() && commonjs_namespace_call {
                 // A direct CommonJS require can return a callable
                 // `module.exports = fn`.  The namespace binding is retained
@@ -1550,16 +1565,18 @@ impl UniversalResolutionIndex {
                     self.typescript_export_slots(language, &key, "default", candidate, true);
             }
             source_member_target_seen |= !owner_targets.is_empty();
-            if member_owner_export.is_some() {
+            if member_owner_export.is_some() || structural_namespace_owner {
                 for owner_slot in &owner_targets {
                     let Some(owner) = self.declaration(*owner_slot) else {
                         continue;
                     };
-                    if let Some(members) = self.members_by_owner.get(&(
-                        owner.language.clone(),
-                        owner.qualified_name.clone(),
-                        candidate.target_spelling.clone(),
-                    )) {
+                    if member_owner_export.is_some()
+                        && let Some(members) = self.members_by_owner.get(&(
+                            owner.language.clone(),
+                            owner.qualified_name.clone(),
+                            candidate.target_spelling.clone(),
+                        ))
+                    {
                         let members = members.iter().copied().collect::<BTreeSet<_>>();
                         let members = if candidate.relation == CandidateRelation::Calls {
                             let argument_types = typescript_candidate_argument_types(candidate);
@@ -1740,9 +1757,17 @@ impl UniversalResolutionIndex {
         let Some(owner) = self.declaration(slot) else {
             return false;
         };
-        if owner.kind != "variable"
-            || !matches!(owner.language.as_str(), "typescript" | "javascript")
-        {
+        if !matches!(owner.language.as_str(), "typescript" | "javascript") {
+            return false;
+        }
+        // CommonJS object exports retain the file module as their owner. A
+        // `Member("*")` alias is emitted for that owner only after the
+        // adapter proves every spread source, so treating a module owner as a
+        // structural object here does not widen arbitrary module lookups.
+        if owner.kind == "module" {
+            return true;
+        }
+        if owner.kind != "variable" {
             return false;
         }
         if owner

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1390,12 +1390,23 @@ impl UniversalResolutionIndex {
         let mut source_member_target_seen = false;
         let mut targets = BTreeSet::new();
         for key in keys {
-            if let Some(path) = member_path.as_ref()
-                && (path.call_result
+            let expand_member_chain = member_path.as_ref().is_some_and(|path| {
+                path.call_result
                     || path.indexed
                     || path.members.len() > 1
-                    || !path.type_arguments.is_empty())
-            {
+                    || !path.type_arguments.is_empty()
+                    || self
+                        .typescript_export_slots(language, &key, &path.root_export, candidate, true)
+                        .iter()
+                        .any(|slot| {
+                            self.declaration(*slot)
+                                .is_some_and(|declaration| declaration.kind == "type_alias")
+                        })
+            });
+            if expand_member_chain {
+                let Some(path) = member_path.as_ref() else {
+                    continue;
+                };
                 source_member_target_seen |= !self
                     .typescript_export_slots(language, &key, &path.root_export, candidate, true)
                     .is_empty();
@@ -2206,6 +2217,29 @@ impl UniversalResolutionIndex {
                 // this resolver branch deliberately narrow: literal Pick or
                 // Omit sets need member-level projection metadata, while a
                 // broad structural key expression must not widen a receiver.
+                return self.typescript_member_type_contexts(
+                    language,
+                    module,
+                    base,
+                    TypeScriptMemberContext {
+                        owner_signature: None,
+                        type_arguments: &[],
+                        index_selector: None,
+                    },
+                    candidate,
+                );
+            }
+            if let Some(key_names) = typescript_literal_key_names(keys) {
+                let selected = key_names.contains(candidate.target_spelling.as_str());
+                if (utility == "Pick" && !selected) || (utility == "Omit" && selected) {
+                    return BTreeSet::new();
+                }
+                // A literal projection is safe to resolve through its nominal
+                // base: the current member candidate is the only downstream
+                // property being adjudicated, and the key-set check above
+                // prevents a projected-away member from inheriting the base.
+                // This works across imported aliases while remaining bounded;
+                // dynamic and structural key spaces still fail closed.
                 return self.typescript_member_type_contexts(
                     language,
                     module,
@@ -5710,6 +5744,28 @@ fn typescript_keyof_type_base(value: &str) -> Option<&str> {
         .filter(|character| character.is_whitespace())?;
     let base = rest.trim();
     (!base.is_empty()).then_some(base)
+}
+
+fn typescript_literal_key_names(value: &str) -> Option<BTreeSet<String>> {
+    let mut names = BTreeSet::new();
+    for key in value.split('|').map(str::trim) {
+        let key = key
+            .strip_prefix('"')
+            .and_then(|key| key.strip_suffix('"'))
+            .or_else(|| {
+                key.strip_prefix('\'')
+                    .and_then(|key| key.strip_suffix('\''))
+            })
+            .or_else(|| key.strip_prefix('`').and_then(|key| key.strip_suffix('`')))?;
+        if key.is_empty() || key.len() > 1024 {
+            return None;
+        }
+        names.insert(key.to_owned());
+        if names.len() > 256 {
+            return None;
+        }
+    }
+    (!names.is_empty()).then_some(names)
 }
 
 fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -731,6 +731,67 @@ impl UniversalResolutionIndex {
                 .or_default()
                 .push(slot);
         }
+        // Object-literal members are deliberately collected in their lexical
+        // binding scope by the TypeScript adapter: unlike a class/interface,
+        // an object value has no syntax-level scope owner.  Recover the
+        // source-qualified object variable as an additional owner so imported
+        // chains such as `api.make(value).inspect()` can traverse the
+        // callable property without widening ordinary lexical members.
+        let mut structural_object_owners =
+            AHashMap::<(String, String), Vec<DeclarationSlot>>::new();
+        for declaration in declarations.values().filter(|declaration| {
+            declaration.kind == "variable"
+                && matches!(declaration.language.as_str(), "typescript" | "javascript")
+        }) {
+            let Some(slot) = declaration_slot(&declaration_ids, &declaration.id) else {
+                continue;
+            };
+            structural_object_owners
+                .entry((
+                    declaration.language.clone(),
+                    declaration.qualified_name.clone(),
+                ))
+                .or_default()
+                .push(slot);
+        }
+        for declaration in declarations.values().filter(|declaration| {
+            matches!(declaration.language.as_str(), "typescript" | "javascript")
+                && matches!(
+                    declaration.kind.as_str(),
+                    "property" | "method" | "field" | "constructor"
+                )
+        }) {
+            let Some((owner_name, _)) = declaration.qualified_name.rsplit_once('.') else {
+                continue;
+            };
+            let Some(owner_slots) = structural_object_owners
+                .get(&(declaration.language.clone(), owner_name.to_owned()))
+            else {
+                continue;
+            };
+            let Some(slot) = declaration_slot(&declaration_ids, &declaration.id) else {
+                continue;
+            };
+            for owner_slot in owner_slots {
+                let Some(owner_id) = declaration_ids.get(*owner_slot as usize) else {
+                    continue;
+                };
+                let Some(owner) = declarations.get(owner_id) else {
+                    continue;
+                };
+                if owner.scope_id != declaration.scope_id {
+                    continue;
+                }
+                members_by_owner
+                    .entry((
+                        declaration.language.clone(),
+                        owner_name.to_owned(),
+                        declaration.name.clone(),
+                    ))
+                    .or_default()
+                    .push(slot);
+            }
+        }
         for members in members_by_owner.values_mut() {
             members.sort_unstable_by(|left, right| {
                 declaration_ids[*left as usize].cmp(&declaration_ids[*right as usize])
@@ -1355,8 +1416,8 @@ impl UniversalResolutionIndex {
                 member_owner_export.is_some(),
             );
             if member_owner_export.is_some() {
-                for owner in owner_targets {
-                    let Some(owner) = self.declaration(owner) else {
+                for owner_slot in &owner_targets {
+                    let Some(owner) = self.declaration(*owner_slot) else {
                         continue;
                     };
                     if let Some(members) = self.members_by_owner.get(&(
@@ -1372,6 +1433,45 @@ impl UniversalResolutionIndex {
                                 })
                                 .copied(),
                         );
+                    }
+                }
+                // A value import can be declared with a nominal object type
+                // (`declare const api: Api`).  Its callable members live on
+                // the interface/type declaration rather than on the value
+                // declaration itself; expand that direct type evidence before
+                // falling back to an external target.
+                if targets.is_empty()
+                    && let Some(path) = member_path.as_ref()
+                    && path.members.len() == 1
+                {
+                    for owner_slot in &owner_targets {
+                        for (typed_owner, _) in self.typescript_value_type_contexts(
+                            language,
+                            &key,
+                            *owner_slot,
+                            &path.type_arguments,
+                            candidate,
+                        ) {
+                            let Some(typed_owner) = self.declaration(typed_owner) else {
+                                continue;
+                            };
+                            if let Some(members) = self.members_by_owner.get(&(
+                                language.to_owned(),
+                                typed_owner.qualified_name.clone(),
+                                candidate.target_spelling.clone(),
+                            )) {
+                                targets.extend(
+                                    members
+                                        .iter()
+                                        .filter(|slot| {
+                                            self.typescript_declaration_allowed_slot(
+                                                **slot, candidate,
+                                            )
+                                        })
+                                        .copied(),
+                                );
+                            }
+                        }
                     }
                 }
             } else {
@@ -1427,6 +1527,18 @@ impl UniversalResolutionIndex {
                     root_slot,
                     &path.call_argument_types,
                     &path.call_type_arguments,
+                    candidate,
+                )
+            } else if let Some(signature) = self
+                .declaration(root_slot)
+                .and_then(|declaration| declaration.signature.as_deref())
+                && typescript_value_type(signature).is_some()
+            {
+                self.typescript_value_type_contexts(
+                    language,
+                    module,
+                    root_slot,
+                    &path.type_arguments,
                     candidate,
                 )
             } else if path.indexed && has_index_signature {
@@ -1535,6 +1647,36 @@ impl UniversalResolutionIndex {
             }
         }
         targets
+    }
+
+    fn typescript_value_type_contexts(
+        &self,
+        language: &str,
+        module: &str,
+        owner_slot: DeclarationSlot,
+        type_arguments: &[String],
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
+        let Some(owner) = self.declaration(owner_slot) else {
+            return BTreeSet::new();
+        };
+        let Some(signature) = owner.signature.as_deref() else {
+            return BTreeSet::new();
+        };
+        let Some(type_name) = typescript_value_type(signature) else {
+            return BTreeSet::new();
+        };
+        self.typescript_member_type_contexts(
+            language,
+            module,
+            type_name,
+            TypeScriptMemberContext {
+                owner_signature: None,
+                type_arguments,
+                index_selector: None,
+            },
+            candidate,
+        )
     }
 
     /// Resolve the nominal receiver produced by an imported callable result.
@@ -5258,6 +5400,11 @@ fn typescript_callable_return_type(signature: &str) -> Option<&str> {
     let (_, return_type) = signature.rsplit_once("|return:")?;
     let return_type = return_type.trim();
     (!return_type.is_empty() && return_type.len() <= 1024).then_some(return_type)
+}
+
+fn typescript_value_type(signature: &str) -> Option<&str> {
+    let type_name = signature.trim().strip_prefix("|type:")?.trim();
+    (!type_name.is_empty() && type_name.len() <= 1024).then_some(type_name)
 }
 
 fn typescript_callable_parameter_types(signature: &str) -> Option<Vec<String>> {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -106,6 +106,8 @@ struct TypeScriptReexportTarget {
 struct TypeScriptMemberPath {
     root_export: String,
     type_arguments: Vec<String>,
+    call_result: bool,
+    call_argument_types: Vec<String>,
     indexed: bool,
     members: Vec<String>,
 }
@@ -1325,7 +1327,10 @@ impl UniversalResolutionIndex {
         let mut targets = BTreeSet::new();
         for key in keys {
             if let Some(path) = member_path.as_ref()
-                && (path.indexed || path.members.len() > 1 || !path.type_arguments.is_empty())
+                && (path.call_result
+                    || path.indexed
+                    || path.members.len() > 1
+                    || !path.type_arguments.is_empty())
             {
                 targets.extend(self.typescript_member_chain_slots(language, &key, path, candidate));
                 continue;
@@ -1410,7 +1415,15 @@ impl UniversalResolutionIndex {
                 .and_then(|declaration| declaration.signature.as_deref())
                 .and_then(typescript_index_value_type)
                 .is_some();
-            let mut owners = if path.indexed && has_index_signature {
+            let mut owners = if path.call_result {
+                self.typescript_callable_return_contexts(
+                    language,
+                    module,
+                    root_slot,
+                    &path.call_argument_types,
+                    candidate,
+                )
+            } else if path.indexed && has_index_signature {
                 self.typescript_index_value_contexts(
                     language,
                     module,
@@ -1500,6 +1513,69 @@ impl UniversalResolutionIndex {
             }
         }
         targets
+    }
+
+    /// Resolve the nominal receiver produced by an imported callable result.
+    /// Only source-published fixed parameters and direct/container generic
+    /// inference are accepted; overloads, contextual inference, and
+    /// structural assignability remain unresolved.
+    fn typescript_callable_return_contexts(
+        &self,
+        language: &str,
+        module: &str,
+        callable_slot: DeclarationSlot,
+        call_argument_types: &[String],
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
+        let Some(callable) = self.declaration(callable_slot) else {
+            return BTreeSet::new();
+        };
+        let Some(signature) = callable.signature.as_deref() else {
+            return BTreeSet::new();
+        };
+        let Some(return_type) = typescript_callable_return_type(signature) else {
+            return BTreeSet::new();
+        };
+        let parameters = typescript_generic_parameter_names(signature);
+        let mut type_arguments = parameters.clone();
+        if let Some(parameter_types) = typescript_callable_parameter_types(signature) {
+            if parameter_types.len() != call_argument_types.len() {
+                return BTreeSet::new();
+            }
+            for (parameter_type, argument_type) in
+                parameter_types.iter().zip(call_argument_types.iter())
+            {
+                if !typescript_infer_type_arguments(
+                    parameter_type,
+                    argument_type,
+                    &parameters,
+                    &mut type_arguments,
+                ) {
+                    return BTreeSet::new();
+                }
+            }
+        } else if !parameters.is_empty()
+            && typescript_type_mentions_parameter(return_type, &parameters)
+        {
+            return BTreeSet::new();
+        }
+        if !parameters.is_empty()
+            && typescript_type_mentions_parameter(return_type, &parameters)
+            && type_arguments == parameters
+        {
+            return BTreeSet::new();
+        }
+        self.typescript_member_type_contexts(
+            language,
+            module,
+            return_type,
+            TypeScriptMemberContext {
+                owner_signature: Some(signature),
+                type_arguments: &type_arguments,
+                index_selector: None,
+            },
+            candidate,
+        )
     }
 
     fn typescript_index_value_contexts(
@@ -4713,11 +4789,38 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
         return None;
     }
     let root_segment = segments.first()?;
-    let indexed = root_segment.ends_with("[]");
-    let root_segment = root_segment
+    let mut indexed = root_segment.ends_with("[]");
+    let mut root_segment = root_segment
         .strip_suffix("[]")
         .unwrap_or(root_segment)
         .trim();
+    let (call_result, call_argument_types) = if let Some(marker) = root_segment.find("#call<") {
+        let base = root_segment.get(..marker)?.trim();
+        let marker_payload = root_segment.get(marker.saturating_add("#call<".len())..)?;
+        let marker_payload = marker_payload.strip_suffix('>')?;
+        if base.is_empty() || marker_payload.is_empty() {
+            return None;
+        }
+        let marker_arguments = if marker_payload == "__none" {
+            Vec::new()
+        } else {
+            let wrapped = format!("Call<{marker_payload}>");
+            let (_, arguments) = typescript_generic_type_parts(&wrapped)?;
+            arguments
+        };
+        let marker_end = marker.saturating_add("#call<".len()) + marker_payload.len() + 1;
+        let suffix = root_segment.get(marker_end..).unwrap_or_default();
+        if !suffix.is_empty() {
+            if suffix != "[]" {
+                return None;
+            }
+            indexed = true;
+        }
+        root_segment = base;
+        (true, marker_arguments)
+    } else {
+        (false, Vec::new())
+    };
     let (root_export, type_arguments) = typescript_generic_type_parts(root_segment).map_or_else(
         || (root_segment.to_owned(), Vec::new()),
         |(base, arguments)| (base.to_owned(), arguments),
@@ -4728,6 +4831,8 @@ fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<Type
     Some(TypeScriptMemberPath {
         root_export,
         type_arguments,
+        call_result,
+        call_argument_types,
         indexed,
         members: segments.into_iter().skip(1).collect(),
     })
@@ -5036,6 +5141,95 @@ fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
         }
     }
     names
+}
+
+fn typescript_callable_return_type(signature: &str) -> Option<&str> {
+    let (_, return_type) = signature.rsplit_once("|return:")?;
+    let return_type = return_type.trim();
+    (!return_type.is_empty() && return_type.len() <= 1024).then_some(return_type)
+}
+
+fn typescript_callable_parameter_types(signature: &str) -> Option<Vec<String>> {
+    let (_, parameters) = signature.split_once("|params:")?;
+    let parameters = parameters
+        .split_once("|return:")
+        .map_or(parameters, |(parameters, _)| parameters)
+        .trim();
+    if parameters.is_empty() {
+        return Some(Vec::new());
+    }
+    let wrapped = format!("Parameters<{parameters}>");
+    typescript_generic_type_parts(&wrapped).map(|(_, arguments)| arguments)
+}
+
+fn typescript_infer_type_arguments(
+    parameter: &str,
+    argument: &str,
+    parameters: &[String],
+    arguments: &mut [String],
+) -> bool {
+    let parameter = parameter.trim();
+    let argument = argument.trim();
+    if parameter.is_empty() || argument.is_empty() {
+        return true;
+    }
+    if let Some(index) = parameters.iter().position(|name| name == parameter) {
+        let Some(slot) = arguments.get_mut(index) else {
+            return true;
+        };
+        if slot
+            == parameters
+                .get(index)
+                .map(String::as_str)
+                .unwrap_or_default()
+        {
+            slot.clone_from(&argument.to_owned());
+            return true;
+        }
+        return slot == argument;
+    }
+    if let (Some(parameter_element), Some(argument_element)) =
+        (parameter.strip_suffix("[]"), argument.strip_suffix("[]"))
+    {
+        return typescript_infer_type_arguments(
+            parameter_element,
+            argument_element,
+            parameters,
+            arguments,
+        );
+    }
+    let Some((parameter_base, parameter_arguments)) = typescript_generic_type_parts(parameter)
+    else {
+        return true;
+    };
+    let Some((argument_base, argument_arguments)) = typescript_generic_type_parts(argument) else {
+        return true;
+    };
+    if parameter_base != argument_base || parameter_arguments.len() != argument_arguments.len() {
+        return true;
+    }
+    for (parameter_argument, argument_argument) in
+        parameter_arguments.iter().zip(argument_arguments.iter())
+    {
+        if !typescript_infer_type_arguments(
+            parameter_argument,
+            argument_argument,
+            parameters,
+            arguments,
+        ) {
+            return false;
+        }
+    }
+    true
+}
+
+fn typescript_type_mentions_parameter(type_name: &str, parameters: &[String]) -> bool {
+    type_name
+        .split(|character: char| {
+            !(character == '_' || character == '$' || character.is_ascii_alphanumeric())
+        })
+        .filter(|token| !token.is_empty())
+        .any(|token| parameters.iter().any(|parameter| parameter == token))
 }
 
 fn typescript_type_alias_target(signature: &str) -> Option<&str> {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -185,6 +185,10 @@ pub struct UniversalResolutionIndex {
     /// relative imports project-aware without allowing terminal-name lookup
     /// to select a same-spelled declaration from another directory.
     typescript_modules: TypeScriptModuleIndex,
+    /// Declaration slots with an explicit source export binding. The module
+    /// index also retains private declarations for internal type expansion,
+    /// but ordinary value/module imports may select only this admitted set.
+    typescript_exported_declarations: AHashSet<DeclarationSlot>,
     /// Export aliases such as `export default Foo` and `export { Foo as Bar }`
     /// retain the exact source declaration selected by the adapter. Re-export
     /// chains without a local declaration remain unresolved until a later
@@ -404,6 +408,12 @@ impl UniversalResolutionIndex {
                 root,
                 &typescript_project_modules,
             );
+        let typescript_exported_declarations = bindings
+            .values()
+            .filter(|binding| binding.kind == compass_languages::BindingKind::Reexport)
+            .filter_map(|binding| binding.target_declaration_id.as_deref())
+            .filter_map(|id| declaration_slot(&declaration_ids, id))
+            .collect::<AHashSet<_>>();
         for (name, count, limit) in [
             ("declarations", declarations.len(), limits.declarations),
             ("bindings", bindings.len(), limits.bindings),
@@ -1000,6 +1010,7 @@ impl UniversalResolutionIndex {
             by_scope_name,
             by_source_directory_name,
             typescript_modules,
+            typescript_exported_declarations,
             typescript_export_aliases,
             typescript_reexport_targets,
             typescript_project_modules,
@@ -2513,7 +2524,10 @@ impl UniversalResolutionIndex {
         }
         for target_language in typescript_language_family(language) {
             let target_language = *target_language;
-            for index in [&self.typescript_modules, &self.typescript_export_aliases] {
+            for (direct_module_index, index) in [
+                (true, &self.typescript_modules),
+                (false, &self.typescript_export_aliases),
+            ] {
                 if let Some(values) = index.get(&(
                     target_language.to_owned(),
                     module.to_owned(),
@@ -2526,6 +2540,15 @@ impl UniversalResolutionIndex {
                             values
                                 .iter()
                                 .filter(|slot| {
+                                    if direct_module_index
+                                        && !walk.allow_type_owner
+                                        && !self.typescript_exported_declarations.contains(slot)
+                                        && self
+                                            .declaration(**slot)
+                                            .is_none_or(|declaration| declaration.kind != "module")
+                                    {
+                                        return false;
+                                    }
                                     if walk.allow_type_owner {
                                         self.typescript_declaration_allowed_owner_slot(
                                             **slot,

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1386,7 +1386,34 @@ impl UniversalResolutionIndex {
             .as_ref()
             .filter(|path| path.members.len() == 1)
             .map(|path| path.root_export.clone());
-        let is_member_candidate = member_path.is_some();
+        // A namespace import (`import * as api` or `const api =
+        // require("./api")`) carries the module target as `module::*`, while
+        // the source-grounded member occurrence is represented as
+        // `module::member`.  It is a direct export lookup, not a nominal
+        // owner/member lookup; preserve that distinction so an exact provider
+        // re-export can resolve without manufacturing a qualified external.
+        let namespace_member_export = (exported == "*")
+            .then(|| {
+                candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .and_then(|qualified| {
+                        let (qualified_module, path) = split_typescript_module_qualified(qualified);
+                        let segments = split_typescript_member_segments(path);
+                        let [member] = segments.as_slice() else {
+                            return None;
+                        };
+                        (qualified_module == Some(module.as_str())
+                            && member == &candidate.target_spelling)
+                            .then(|| member.clone())
+                    })
+            })
+            .flatten();
+        let commonjs_namespace_call = exported == "*"
+            && candidate.relation == CandidateRelation::Calls
+            && namespace_member_export.is_none();
+        let is_member_candidate = member_path.is_some() || namespace_member_export.is_some();
         let mut source_member_target_seen = false;
         let mut targets = BTreeSet::new();
         for key in keys {
@@ -1413,8 +1440,9 @@ impl UniversalResolutionIndex {
                 targets.extend(self.typescript_member_chain_slots(language, &key, path, candidate));
                 continue;
             }
-            let owner_export = member_owner_export
+            let owner_export = namespace_member_export
                 .as_deref()
+                .or(member_owner_export.as_deref())
                 .unwrap_or(&exported)
                 .to_owned();
             // A member candidate constrains the final target to
@@ -1423,13 +1451,35 @@ impl UniversalResolutionIndex {
             // internal owner lookup; member filtering below still uses the
             // original candidate, so an interface itself is never published
             // as the callable/access target.
-            let owner_targets = self.typescript_export_slots(
-                language,
-                &key,
-                &owner_export,
-                candidate,
-                member_owner_export.is_some(),
-            );
+            let namespace_alias_targets = namespace_member_export.as_ref().map(|_| {
+                self.typescript_export_alias_slots(
+                    language,
+                    &key,
+                    &owner_export,
+                    candidate,
+                    member_owner_export.is_some(),
+                )
+            });
+            let mut owner_targets = namespace_alias_targets
+                .filter(|targets| !targets.is_empty())
+                .unwrap_or_else(|| {
+                    self.typescript_export_slots(
+                        language,
+                        &key,
+                        &owner_export,
+                        candidate,
+                        member_owner_export.is_some(),
+                    )
+                });
+            if owner_targets.is_empty() && commonjs_namespace_call {
+                // A direct CommonJS require can return a callable
+                // `module.exports = fn`.  The namespace binding is retained
+                // for member access, but a direct call may resolve through the
+                // provider's source-grounded default export. Object-valued
+                // defaults remain filtered by the candidate's callable kinds.
+                owner_targets =
+                    self.typescript_export_slots(language, &key, "default", candidate, true);
+            }
             source_member_target_seen |= !owner_targets.is_empty();
             if member_owner_export.is_some() {
                 for owner_slot in &owner_targets {
@@ -2410,6 +2460,38 @@ impl UniversalResolutionIndex {
             &mut walk,
         );
         walk.slots
+    }
+
+    fn typescript_export_alias_slots(
+        &self,
+        language: &str,
+        module: &str,
+        exported: &str,
+        candidate: &RelationshipCandidate,
+        allow_type_owner: bool,
+    ) -> BTreeSet<DeclarationSlot> {
+        let mut slots = BTreeSet::new();
+        for target_language in typescript_language_family(language) {
+            if let Some(values) = self.typescript_export_aliases.get(&(
+                (*target_language).to_owned(),
+                module.to_owned(),
+                exported.to_owned(),
+            )) {
+                slots.extend(
+                    values
+                        .iter()
+                        .filter(|slot| {
+                            if allow_type_owner {
+                                self.typescript_declaration_allowed_owner_slot(**slot, candidate)
+                            } else {
+                                self.typescript_declaration_allowed_slot(**slot, candidate)
+                            }
+                        })
+                        .copied(),
+                );
+            }
+        }
+        slots
     }
 
     fn collect_typescript_export_slots(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1398,20 +1398,12 @@ impl UniversalResolutionIndex {
             self.typescript_export_slots(language, module, &path.root_export, candidate, true);
         let mut targets = BTreeSet::new();
         for root_slot in root_targets {
-            let Some(root) = self.declaration(root_slot) else {
-                continue;
-            };
-            let generic_parameters = root
-                .signature
-                .as_deref()
-                .map(typescript_generic_parameter_names)
-                .unwrap_or_default();
-            let mut owners = BTreeSet::from([root_slot]);
+            let mut owners = BTreeSet::from([(root_slot, path.type_arguments.clone())]);
             for (index, member_name) in path.members.iter().enumerate() {
                 let final_member = index.saturating_add(1) == path.members.len();
                 let mut next_owners = BTreeSet::new();
-                for owner_slot in owners.iter().copied() {
-                    let Some(owner) = self.declaration(owner_slot) else {
+                for (owner_slot, owner_type_arguments) in owners.iter() {
+                    let Some(owner) = self.declaration(*owner_slot) else {
                         continue;
                     };
                     let Some(members) = self.members_by_owner.get(&(
@@ -1428,7 +1420,7 @@ impl UniversalResolutionIndex {
                                 .filter(|slot| {
                                     self.typescript_declaration_allowed_slot(**slot, candidate)
                                 })
-                                .copied(),
+                                .map(|slot| (*slot, Vec::new())),
                         );
                     } else {
                         let typed_members = members
@@ -1440,12 +1432,12 @@ impl UniversalResolutionIndex {
                         let [type_name] = typed_members.as_slice() else {
                             continue;
                         };
-                        next_owners.extend(self.typescript_member_type_slots(
+                        next_owners.extend(self.typescript_member_type_contexts(
                             language,
                             module,
                             type_name,
-                            &generic_parameters,
-                            &path.type_arguments,
+                            owner.signature.as_deref(),
+                            owner_type_arguments,
                             candidate,
                         ));
                     }
@@ -1456,7 +1448,7 @@ impl UniversalResolutionIndex {
                 }
                 owners = next_owners;
             }
-            targets.extend(owners);
+            targets.extend(owners.into_iter().map(|(slot, _)| slot));
             if targets.len() > self.limits.candidates_per_lookup {
                 break;
             }
@@ -1464,25 +1456,28 @@ impl UniversalResolutionIndex {
         targets
     }
 
-    fn typescript_member_type_slots(
+    fn typescript_member_type_contexts(
         &self,
         language: &str,
         module: &str,
         type_name: &str,
-        generic_parameters: &[String],
+        owner_signature: Option<&str>,
         type_arguments: &[String],
         candidate: &RelationshipCandidate,
-    ) -> BTreeSet<DeclarationSlot> {
+    ) -> BTreeSet<(DeclarationSlot, Vec<String>)> {
         let type_name = type_name.trim();
         if type_name.is_empty() || type_name.len() > 1024 {
             return BTreeSet::new();
         }
+        let generic_parameters = owner_signature
+            .map(typescript_generic_parameter_names)
+            .unwrap_or_default();
         let substituted = generic_parameters
             .iter()
             .position(|parameter| parameter == type_name)
             .and_then(|index| type_arguments.get(index))
             .map_or_else(|| type_name.to_owned(), |argument| argument.clone());
-        let (base, _) = typescript_generic_type_parts(&substituted)
+        let (base, nested_type_arguments) = typescript_generic_type_parts(&substituted)
             .unwrap_or((substituted.as_str(), Vec::new()));
         let (qualified_module, exported) = split_typescript_module_qualified(base);
         if exported.is_empty() {
@@ -1501,15 +1496,16 @@ impl UniversalResolutionIndex {
         }
         modules.sort_unstable();
         modules.dedup();
-        let mut slots = BTreeSet::new();
+        let mut contexts = BTreeSet::new();
         for module in modules {
-            slots
-                .extend(self.typescript_export_slots(language, &module, exported, candidate, true));
-            if slots.len() > self.limits.candidates_per_lookup {
+            for slot in self.typescript_export_slots(language, &module, exported, candidate, true) {
+                contexts.insert((slot, nested_type_arguments.clone()));
+            }
+            if contexts.len() > self.limits.candidates_per_lookup {
                 break;
             }
         }
-        slots
+        contexts
     }
 
     fn typescript_export_slots(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -102,6 +102,13 @@ struct TypeScriptReexportTarget {
     exported: String,
 }
 
+#[derive(Clone, Debug)]
+struct TypeScriptMemberPath {
+    root_export: String,
+    type_arguments: Vec<String>,
+    members: Vec<String>,
+}
+
 /// Compact slot into the declaration table used by secondary indexes.
 ///
 /// Declaration IDs are long, repeated strings on corpus-scale Java and
@@ -1289,7 +1296,7 @@ impl UniversalResolutionIndex {
         if keys.is_empty() {
             return None;
         }
-        let member_owner_export = if matches!(
+        let member_path = if matches!(
             candidate.relation,
             CandidateRelation::Calls
                 | CandidateRelation::IndirectCalls
@@ -1299,18 +1306,23 @@ impl UniversalResolutionIndex {
                 .constraints
                 .qualified_name
                 .as_deref()
-                .and_then(|qualified| qualified.rsplit_once("::"))
-                .and_then(|(_, path)| {
-                    let (owner, member) =
-                        path.rsplit_once('.').or_else(|| path.rsplit_once("::"))?;
-                    (member == candidate.target_spelling && !owner.is_empty())
-                        .then_some(owner.to_owned())
-                })
+                .and_then(|qualified| typescript_member_path(qualified, &candidate.target_spelling))
         } else {
             None
         };
+        let member_owner_export = member_path
+            .as_ref()
+            .filter(|path| path.members.len() == 1)
+            .map(|path| path.root_export.clone());
+        let is_member_candidate = member_path.is_some();
         let mut targets = BTreeSet::new();
         for key in keys {
+            if let Some(path) = member_path.as_ref()
+                && (path.members.len() > 1 || !path.type_arguments.is_empty())
+            {
+                targets.extend(self.typescript_member_chain_slots(language, &key, path, candidate));
+                continue;
+            }
             let owner_export = member_owner_export
                 .as_deref()
                 .unwrap_or(&exported)
@@ -1356,7 +1368,7 @@ impl UniversalResolutionIndex {
         self.unique_typescript_decision(
             Some(&targets),
             candidate,
-            if member_owner_export.is_some() {
+            if is_member_candidate {
                 ResolutionRule::MemberBinding
             } else if project_resolved {
                 ResolutionRule::ProjectModuleBinding
@@ -1364,6 +1376,140 @@ impl UniversalResolutionIndex {
                 ResolutionRule::ExplicitBinding
             },
         )
+    }
+
+    /// Resolve a bounded TypeScript member-value chain such as
+    /// `Box<Item>.item.inspect`. The root export and generic arguments come
+    /// from the import binding; each intermediate member must publish a
+    /// direct type signature, and every hop must resolve uniquely. Missing,
+    /// structural, or competing type evidence remains unresolved.
+    fn typescript_member_chain_slots(
+        &self,
+        language: &str,
+        module: &str,
+        path: &TypeScriptMemberPath,
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<DeclarationSlot> {
+        const MAX_MEMBER_CHAIN_DEPTH: usize = 16;
+        if path.members.is_empty() || path.members.len() > MAX_MEMBER_CHAIN_DEPTH {
+            return BTreeSet::new();
+        }
+        let root_targets =
+            self.typescript_export_slots(language, module, &path.root_export, candidate, true);
+        let mut targets = BTreeSet::new();
+        for root_slot in root_targets {
+            let Some(root) = self.declaration(root_slot) else {
+                continue;
+            };
+            let generic_parameters = root
+                .signature
+                .as_deref()
+                .map(typescript_generic_parameter_names)
+                .unwrap_or_default();
+            let mut owners = BTreeSet::from([root_slot]);
+            for (index, member_name) in path.members.iter().enumerate() {
+                let final_member = index.saturating_add(1) == path.members.len();
+                let mut next_owners = BTreeSet::new();
+                for owner_slot in owners.iter().copied() {
+                    let Some(owner) = self.declaration(owner_slot) else {
+                        continue;
+                    };
+                    let Some(members) = self.members_by_owner.get(&(
+                        owner.language.clone(),
+                        owner.qualified_name.clone(),
+                        member_name.clone(),
+                    )) else {
+                        continue;
+                    };
+                    if final_member {
+                        next_owners.extend(
+                            members
+                                .iter()
+                                .filter(|slot| {
+                                    self.typescript_declaration_allowed_slot(**slot, candidate)
+                                })
+                                .copied(),
+                        );
+                    } else {
+                        let typed_members = members
+                            .iter()
+                            .filter_map(|slot| self.declaration(*slot))
+                            .filter(|member| member.kind == "property")
+                            .filter_map(|member| member.signature.as_deref())
+                            .collect::<Vec<_>>();
+                        let [type_name] = typed_members.as_slice() else {
+                            continue;
+                        };
+                        next_owners.extend(self.typescript_member_type_slots(
+                            language,
+                            module,
+                            type_name,
+                            &generic_parameters,
+                            &path.type_arguments,
+                            candidate,
+                        ));
+                    }
+                }
+                if next_owners.is_empty() {
+                    owners.clear();
+                    break;
+                }
+                owners = next_owners;
+            }
+            targets.extend(owners);
+            if targets.len() > self.limits.candidates_per_lookup {
+                break;
+            }
+        }
+        targets
+    }
+
+    fn typescript_member_type_slots(
+        &self,
+        language: &str,
+        module: &str,
+        type_name: &str,
+        generic_parameters: &[String],
+        type_arguments: &[String],
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<DeclarationSlot> {
+        let type_name = type_name.trim();
+        if type_name.is_empty() || type_name.len() > 1024 {
+            return BTreeSet::new();
+        }
+        let substituted = generic_parameters
+            .iter()
+            .position(|parameter| parameter == type_name)
+            .and_then(|index| type_arguments.get(index))
+            .map_or_else(|| type_name.to_owned(), |argument| argument.clone());
+        let (base, _) = typescript_generic_type_parts(&substituted)
+            .unwrap_or((substituted.as_str(), Vec::new()));
+        let (qualified_module, exported) = split_typescript_module_qualified(base);
+        if exported.is_empty() {
+            return BTreeSet::new();
+        }
+        let mut modules = Vec::new();
+        if let Some(qualified_module) = qualified_module {
+            modules.push(qualified_module.to_owned());
+            modules.extend(typescript_import_module_keys(
+                module,
+                qualified_module,
+                &self.root,
+            ));
+        } else {
+            modules.push(module.to_owned());
+        }
+        modules.sort_unstable();
+        modules.dedup();
+        let mut slots = BTreeSet::new();
+        for module in modules {
+            slots
+                .extend(self.typescript_export_slots(language, &module, exported, candidate, true));
+            if slots.len() > self.limits.candidates_per_lookup {
+                break;
+            }
+        }
+        slots
     }
 
     fn typescript_export_slots(
@@ -4319,6 +4465,148 @@ fn typescript_language_family(language: &str) -> &'static [&'static str] {
         "javascript" => &["javascript", "typescript"],
         _ => &[],
     }
+}
+
+fn typescript_member_path(qualified: &str, target_spelling: &str) -> Option<TypeScriptMemberPath> {
+    let (_, path) = split_typescript_module_qualified(qualified);
+    let segments = split_typescript_member_segments(path);
+    if segments.len() < 2 || segments.last()?.as_str() != target_spelling {
+        return None;
+    }
+    let root_segment = segments.first()?;
+    let (root_export, type_arguments) = typescript_generic_type_parts(root_segment).map_or_else(
+        || (root_segment.clone(), Vec::new()),
+        |(base, arguments)| (base.to_owned(), arguments),
+    );
+    if root_export.is_empty() {
+        return None;
+    }
+    Some(TypeScriptMemberPath {
+        root_export,
+        type_arguments,
+        members: segments.into_iter().skip(1).collect(),
+    })
+}
+
+fn split_typescript_module_qualified(value: &str) -> (Option<&str>, &str) {
+    let bytes = value.as_bytes();
+    let mut angle_depth = 0_u32;
+    let mut split = None;
+    for index in 0..bytes.len().saturating_sub(1) {
+        match bytes[index] {
+            b'<' => angle_depth = angle_depth.saturating_add(1),
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
+            b':' if bytes[index + 1] == b':' && angle_depth == 0 => split = Some(index),
+            _ => {}
+        }
+    }
+    split.map_or((None, value), |index| {
+        (
+            value.get(..index).filter(|module| !module.is_empty()),
+            value.get(index.saturating_add(2)..).unwrap_or_default(),
+        )
+    })
+}
+
+fn split_typescript_member_segments(value: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut start = 0_usize;
+    let mut angle_depth = 0_u32;
+    let bytes = value.as_bytes();
+    let mut index = 0_usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'<' => angle_depth = angle_depth.saturating_add(1),
+            b'>' => angle_depth = angle_depth.saturating_sub(1),
+            b'.' if angle_depth == 0 => {
+                if let Some(segment) = value.get(start..index).map(str::trim)
+                    && !segment.is_empty()
+                {
+                    segments.push(segment.to_owned());
+                }
+                start = index.saturating_add(1);
+            }
+            b':' if angle_depth == 0 && bytes.get(index.saturating_add(1)) == Some(&b':') => {
+                if let Some(segment) = value.get(start..index).map(str::trim)
+                    && !segment.is_empty()
+                {
+                    segments.push(segment.to_owned());
+                }
+                start = index.saturating_add(2);
+                index = index.saturating_add(1);
+            }
+            _ => {}
+        }
+        index = index.saturating_add(1);
+    }
+    if let Some(segment) = value.get(start..).map(str::trim)
+        && !segment.is_empty()
+    {
+        segments.push(segment.to_owned());
+    }
+    segments
+}
+
+fn typescript_generic_type_parts(value: &str) -> Option<(&str, Vec<String>)> {
+    let value = value.trim();
+    let bytes = value.as_bytes();
+    let open = bytes.iter().position(|byte| *byte == b'<')?;
+    if open == 0 || !value.ends_with('>') {
+        return None;
+    }
+    let base = value.get(..open)?.trim();
+    let arguments = value.get(open.saturating_add(1)..value.len().saturating_sub(1))?;
+    if base.is_empty() || arguments.is_empty() || arguments.len() > 1024 {
+        return None;
+    }
+    let mut parts = Vec::new();
+    let mut start = 0_usize;
+    let mut depth = 0_u32;
+    for (index, character) in arguments.char_indices() {
+        match character {
+            '<' | '[' | '(' | '{' => depth = depth.saturating_add(1),
+            '>' | ']' | ')' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let part = arguments.get(start..index)?.trim();
+                if part.is_empty() || part.len() > 1024 {
+                    return None;
+                }
+                parts.push(part.to_owned());
+                start = index.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+    let part = arguments.get(start..)?.trim();
+    if part.is_empty() || part.len() > 1024 {
+        return None;
+    }
+    parts.push(part.to_owned());
+    (parts.len() <= 64).then_some((base, parts))
+}
+
+fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
+    let signature = signature.trim();
+    if !signature.starts_with('<') || !signature.ends_with('>') {
+        return Vec::new();
+    }
+    let body = &signature[1..signature.len().saturating_sub(1)];
+    let mut names = Vec::new();
+    for name in body.split(',').map(str::trim) {
+        if name.is_empty()
+            || name.len() > 128
+            || !name.chars().all(|character| {
+                character == '_' || character == '$' || character.is_ascii_alphanumeric()
+            })
+        {
+            return Vec::new();
+        }
+        names.push(name.to_owned());
+        if names.len() > 64 {
+            return Vec::new();
+        }
+    }
+    names
 }
 
 fn typescript_declaration_basic_allowed(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -115,6 +115,7 @@ type TypeScriptProjectModuleIndex = AHashMap<(String, String), Vec<String>>;
 
 struct TypeScriptExportWalk<'a> {
     candidate: &'a RelationshipCandidate,
+    allow_type_owner: bool,
     visiting: BTreeSet<(String, String, String)>,
     slots: BTreeSet<DeclarationSlot>,
 }
@@ -1314,8 +1315,19 @@ impl UniversalResolutionIndex {
                 .as_deref()
                 .unwrap_or(&exported)
                 .to_owned();
-            let owner_targets =
-                self.typescript_export_slots(language, &key, &owner_export, candidate);
+            // A member candidate constrains the final target to
+            // callable/value kinds, but the exported owner can be a
+            // type-only declaration such as an interface. Widen only this
+            // internal owner lookup; member filtering below still uses the
+            // original candidate, so an interface itself is never published
+            // as the callable/access target.
+            let owner_targets = self.typescript_export_slots(
+                language,
+                &key,
+                &owner_export,
+                candidate,
+                member_owner_export.is_some(),
+            );
             if member_owner_export.is_some() {
                 for owner in owner_targets {
                     let Some(owner) = self.declaration(owner) else {
@@ -1360,10 +1372,12 @@ impl UniversalResolutionIndex {
         module: &str,
         exported: &str,
         candidate: &RelationshipCandidate,
+        allow_type_owner: bool,
     ) -> BTreeSet<DeclarationSlot> {
         const MAX_TYPESCRIPT_REEXPORT_DEPTH: usize = 64;
         let mut walk = TypeScriptExportWalk {
             candidate,
+            allow_type_owner,
             visiting: BTreeSet::new(),
             slots: BTreeSet::new(),
         };
@@ -1410,7 +1424,17 @@ impl UniversalResolutionIndex {
                             values
                                 .iter()
                                 .filter(|slot| {
-                                    self.typescript_declaration_allowed_slot(**slot, walk.candidate)
+                                    if walk.allow_type_owner {
+                                        self.typescript_declaration_allowed_owner_slot(
+                                            **slot,
+                                            walk.candidate,
+                                        )
+                                    } else {
+                                        self.typescript_declaration_allowed_slot(
+                                            **slot,
+                                            walk.candidate,
+                                        )
+                                    }
                                 })
                                 .take(remaining)
                                 .copied(),
@@ -3174,6 +3198,17 @@ impl UniversalResolutionIndex {
         typescript_declaration_basic_allowed(target, candidate)
     }
 
+    fn typescript_declaration_allowed_owner_slot(
+        &self,
+        slot: DeclarationSlot,
+        candidate: &RelationshipCandidate,
+    ) -> bool {
+        let Some(target) = self.declaration(slot) else {
+            return false;
+        };
+        typescript_declaration_basic_allowed_with_type_owner(target, candidate)
+    }
+
     fn unique_typescript_decision(
         &self,
         ids: Option<&Vec<DeclarationSlot>>,
@@ -4290,6 +4325,21 @@ fn typescript_declaration_basic_allowed(
     target: &DeclarationFact,
     candidate: &RelationshipCandidate,
 ) -> bool {
+    typescript_declaration_basic_allowed_for(target, candidate, false)
+}
+
+fn typescript_declaration_basic_allowed_with_type_owner(
+    target: &DeclarationFact,
+    candidate: &RelationshipCandidate,
+) -> bool {
+    typescript_declaration_basic_allowed_for(target, candidate, true)
+}
+
+fn typescript_declaration_basic_allowed_for(
+    target: &DeclarationFact,
+    candidate: &RelationshipCandidate,
+    allow_type_owner: bool,
+) -> bool {
     typescript_language_family(&candidate.language).contains(&target.language.as_str())
         && candidate
             .constraints
@@ -4304,7 +4354,12 @@ fn typescript_declaration_basic_allowed(
             || candidate
                 .constraints
                 .allowed_target_kinds
-                .contains(&target.kind))
+                .contains(&target.kind)
+            || (allow_type_owner
+                && matches!(
+                    target.kind.as_str(),
+                    "class" | "enum" | "interface" | "namespace" | "type_alias"
+                )))
 }
 
 fn declaration_overloads<'a>(

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -2524,6 +2524,12 @@ impl UniversalResolutionIndex {
         }
         for target_language in typescript_language_family(language) {
             let target_language = *target_language;
+            // An export-star namespace alias carries a reexport target whose
+            // exported spelling is a wildcard. Treat that spelling as the
+            // provider module owner so \`ns.member\` can use the same exact
+            // member index as a namespace import. Ordinary wildcard barrel
+            // traversal still requests the concrete exported name below.
+            let direct_export = if exported == "*" { "module" } else { exported };
             for (direct_module_index, index) in [
                 (true, &self.typescript_modules),
                 (false, &self.typescript_export_aliases),
@@ -2531,7 +2537,7 @@ impl UniversalResolutionIndex {
                 if let Some(values) = index.get(&(
                     target_language.to_owned(),
                     module.to_owned(),
-                    exported.to_owned(),
+                    direct_export.to_owned(),
                 )) {
                     let remaining = candidate_storage_limit(self.limits.candidates_per_lookup)
                         .saturating_sub(walk.slots.len());
@@ -2550,10 +2556,14 @@ impl UniversalResolutionIndex {
                                         return false;
                                     }
                                     if walk.allow_type_owner {
-                                        self.typescript_declaration_allowed_owner_slot(
-                                            **slot,
-                                            walk.candidate,
-                                        )
+                                        (exported == "*"
+                                            && self.declaration(**slot).is_some_and(
+                                                |declaration| declaration.kind == "module",
+                                            ))
+                                            || self.typescript_declaration_allowed_owner_slot(
+                                                **slot,
+                                                walk.candidate,
+                                            )
                                     } else {
                                         self.typescript_declaration_allowed_slot(
                                             **slot,

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -2118,6 +2118,80 @@ impl UniversalResolutionIndex {
             context.type_arguments,
         );
         let substituted = typescript_utility_receiver_type(&substituted).unwrap_or(substituted);
+        if let Some((base, property)) = typescript_literal_indexed_type(&substituted) {
+            let base_contexts = self.typescript_member_type_contexts(
+                language,
+                module,
+                base,
+                TypeScriptMemberContext {
+                    owner_signature: None,
+                    type_arguments: &[],
+                    index_selector: None,
+                },
+                candidate,
+            );
+            let mut indexed_contexts = BTreeSet::new();
+            for (owner_slot, owner_type_arguments) in base_contexts {
+                let Some(owner) = self.declaration(owner_slot) else {
+                    continue;
+                };
+                let Some(members) = self.members_by_owner.get(&(
+                    owner.language.clone(),
+                    owner.qualified_name.clone(),
+                    property.clone(),
+                )) else {
+                    continue;
+                };
+                if members.len() != 1 {
+                    continue;
+                }
+                let Some(&member_slot) = members.first() else {
+                    continue;
+                };
+                let Some(member) = self.declaration(member_slot) else {
+                    continue;
+                };
+                let Some(signature) = member.signature.as_deref() else {
+                    continue;
+                };
+                let direct_property_type = (member.kind == "property"
+                    && !signature.contains("|params:")
+                    && !signature.contains("|return:"))
+                .then_some(signature.trim());
+                if let Some(value_type) = typescript_value_type(signature).or(direct_property_type)
+                {
+                    let owner_parameters = typescript_generic_parameter_names(
+                        owner.signature.as_deref().unwrap_or_default(),
+                    );
+                    let value_type = typescript_substitute_type_parameters(
+                        value_type,
+                        &owner_parameters,
+                        &owner_type_arguments,
+                    );
+                    let member_module =
+                        typescript_source_module_keys(&member.range.source_file, &self.root)
+                            .into_iter()
+                            .next()
+                            .unwrap_or_else(|| module.to_owned());
+                    indexed_contexts.extend(self.typescript_member_type_contexts(
+                        language,
+                        &member_module,
+                        &value_type,
+                        TypeScriptMemberContext {
+                            owner_signature: Some(signature),
+                            type_arguments: &[],
+                            index_selector: None,
+                        },
+                        candidate,
+                    ));
+                } else if typescript_callable_parameter_types(signature).is_some()
+                    || typescript_callable_return_type(signature).is_some()
+                {
+                    indexed_contexts.insert((member_slot, Vec::new()));
+                }
+            }
+            return indexed_contexts;
+        }
         let substituted = match context.index_selector {
             Some("") => match typescript_array_element_type(&substituted) {
                 Some(element) => element.to_owned(),
@@ -5578,6 +5652,30 @@ fn typescript_indexed_member_segment(value: &str) -> Option<(String, Option<Stri
     (!value.is_empty()).then(|| (value.to_owned(), None))
 }
 
+fn typescript_literal_indexed_type(value: &str) -> Option<(&str, String)> {
+    let value = value.trim();
+    if !value.ends_with(']') {
+        return None;
+    }
+    let open = value.rfind('[')?;
+    let base = value.get(..open)?.trim();
+    let raw_property = value
+        .get(open.saturating_add(1)..value.len().saturating_sub(1))?
+        .trim();
+    let property = raw_property
+        .strip_prefix('"')
+        .and_then(|property| property.strip_suffix('"'))
+        .or_else(|| {
+            raw_property
+                .strip_prefix('\'')
+                .and_then(|property| property.strip_suffix('\''))
+        })?;
+    if base.is_empty() || property.is_empty() || property.len() > 1024 {
+        return None;
+    }
+    Some((base, property.to_owned()))
+}
+
 fn typescript_generic_parameter_names(signature: &str) -> Vec<String> {
     let signature = signature
         .trim()
@@ -5904,6 +6002,18 @@ fn typescript_substitute_type_parameters(
     if let Some(element) = type_name.strip_suffix("[]") {
         let substituted = typescript_substitute_type_parameters(element, parameters, arguments);
         let substituted = format!("{substituted}[]");
+        return if substituted.len() <= 1024 {
+            substituted
+        } else {
+            type_name.to_owned()
+        };
+    }
+    if let Some((base, _)) = typescript_literal_indexed_type(type_name)
+        && let Some(open) = type_name.rfind('[')
+    {
+        let substituted_base = typescript_substitute_type_parameters(base, parameters, arguments);
+        let suffix = type_name.get(open..).unwrap_or_default();
+        let substituted = format!("{substituted_base}{suffix}");
         return if substituted.len() <= 1024 {
             substituted
         } else {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1564,6 +1564,35 @@ impl UniversalResolutionIndex {
                 owner_targets =
                     self.typescript_export_slots(language, &key, "default", candidate, true);
             }
+            if owner_targets.is_empty()
+                && !is_member_candidate
+                && exported != "*"
+                && exported != "default"
+            {
+                // Project a named import through a bounded CommonJS barrel
+                // owner alias when no direct export slot exists.
+                let module_targets =
+                    self.typescript_export_slots(language, &key, "*", candidate, true);
+                for owner_slot in module_targets {
+                    let Some(owner) = self.declaration(owner_slot) else {
+                        continue;
+                    };
+                    if self
+                        .typescript_member_aliases
+                        .contains_key(&(owner.language.clone(), owner.qualified_name.clone()))
+                    {
+                        structural_alias_seen = true;
+                        if let Ok(Some(alias_members)) = self.typescript_structural_member_slots(
+                            owner_slot,
+                            &exported,
+                            candidate,
+                            &mut BTreeSet::new(),
+                        ) {
+                            targets.extend(alias_members);
+                        }
+                    }
+                }
+            }
             source_member_target_seen |= !owner_targets.is_empty();
             if member_owner_export.is_some() || structural_namespace_owner {
                 for owner_slot in &owner_targets {
@@ -1653,6 +1682,9 @@ impl UniversalResolutionIndex {
         }
         let targets = targets.into_iter().collect::<Vec<_>>();
         if is_member_candidate && structural_alias_seen && targets.is_empty() {
+            return Some(ResolutionDecision::Unresolved);
+        }
+        if !is_member_candidate && structural_alias_seen && targets.is_empty() {
             return Some(ResolutionDecision::Unresolved);
         }
         if is_member_candidate

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -95,6 +95,12 @@ struct RustImplTraitSet {
     complete: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TypeScriptReexportTarget {
+    module: String,
+    exported: String,
+}
+
 /// Compact slot into the declaration table used by secondary indexes.
 ///
 /// Declaration IDs are long, repeated strings on corpus-scale Java and
@@ -102,6 +108,14 @@ struct RustImplTraitSet {
 /// the universal resolver's transient memory, while the declaration table
 /// already provides the canonical ID for each slot.
 type DeclarationSlot = u32;
+type TypeScriptModuleIndex = AHashMap<(String, String, String), Vec<DeclarationSlot>>;
+type TypeScriptReexportIndex = AHashMap<(String, String, String), Vec<TypeScriptReexportTarget>>;
+
+struct TypeScriptExportWalk<'a> {
+    candidate: &'a RelationshipCandidate,
+    visiting: BTreeSet<(String, String, String)>,
+    slots: BTreeSet<DeclarationSlot>,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolutionEvidence {
@@ -145,6 +159,21 @@ pub struct UniversalResolutionIndex {
     by_module_name: AHashMap<(String, String, String), Vec<DeclarationSlot>>,
     by_scope_name: AHashMap<(String, String, String), Vec<DeclarationSlot>>,
     by_source_directory_name: AHashMap<(String, String, String), Vec<DeclarationSlot>>,
+    /// TypeScript/JavaScript source modules are indexed by the normalized
+    /// repository-relative module path rather than by a basename. This keeps
+    /// relative imports project-aware without allowing terminal-name lookup
+    /// to select a same-spelled declaration from another directory.
+    typescript_modules: TypeScriptModuleIndex,
+    /// Export aliases such as `export default Foo` and `export { Foo as Bar }`
+    /// retain the exact source declaration selected by the adapter. Re-export
+    /// chains without a local declaration remain unresolved until a later
+    /// module hop can prove one target.
+    typescript_export_aliases: TypeScriptModuleIndex,
+    /// Cross-file re-exports retain their normalized target module and export
+    /// spelling. Resolution follows this bounded table rather than selecting
+    /// a terminal name from an unrelated source file.
+    typescript_reexport_targets: TypeScriptReexportIndex,
+    root: std::path::PathBuf,
     direct_bases: AHashMap<(String, String), DirectBaseSet>,
     direct_subtypes: AHashMap<(String, String), DirectSubtypeSet>,
     members_by_owner: AHashMap<(String, String, String), Vec<DeclarationSlot>>,
@@ -308,6 +337,8 @@ impl UniversalResolutionIndex {
             return Err("universal declaration slot count exceeds u32".to_owned());
         }
         let definition_ranges = unique_definition_ranges(&declarations, &scopes);
+        let (typescript_modules, typescript_export_aliases, typescript_reexport_targets) =
+            typescript_module_indices(&declarations, &declaration_ids, &bindings, &scopes, root);
         for (name, count, limit) in [
             ("declarations", declarations.len(), limits.declarations),
             ("bindings", bindings.len(), limits.bindings),
@@ -842,6 +873,10 @@ impl UniversalResolutionIndex {
             by_module_name,
             by_scope_name,
             by_source_directory_name,
+            typescript_modules,
+            typescript_export_aliases,
+            typescript_reexport_targets,
+            root: root.to_path_buf(),
             direct_bases,
             direct_subtypes,
             members_by_owner,
@@ -969,6 +1004,9 @@ impl UniversalResolutionIndex {
                 trait_qualified_name,
                 candidate,
             );
+        }
+        if let Some(decision) = self.resolve_typescript_import_candidate(language, candidate) {
+            return decision;
         }
         if let Some(decision) = self.resolve_explicit_binding(language, candidate) {
             return decision;
@@ -1126,6 +1164,230 @@ impl UniversalResolutionIndex {
             };
         }
         ResolutionDecision::Unresolved
+    }
+
+    fn resolve_typescript_import_candidate(
+        &self,
+        language: &str,
+        candidate: &RelationshipCandidate,
+    ) -> Option<ResolutionDecision> {
+        if !matches!(language, "typescript" | "javascript") {
+            return None;
+        }
+        let occurrence = self.occurrence(candidate)?;
+        let mut module_and_export = None;
+        if let Some(binding) = candidate
+            .binding_id
+            .as_deref()
+            .and_then(|binding_id| self.bindings.get(binding_id))
+            && matches!(
+                binding.kind,
+                compass_languages::BindingKind::Import
+                    | compass_languages::BindingKind::ImportAlias
+                    | compass_languages::BindingKind::Reexport
+            )
+            && let Some((module, exported)) = binding.qualified_target.rsplit_once("::")
+            && !module.is_empty()
+            && !exported.is_empty()
+        {
+            module_and_export = Some((module.to_owned(), exported.to_owned()));
+        } else if matches!(
+            candidate.relation,
+            CandidateRelation::Imports | CandidateRelation::Reexports
+        ) && let Some(qualified) = candidate.constraints.qualified_name.as_deref()
+            && let Some((module, exported)) = qualified.rsplit_once("::")
+            && !module.is_empty()
+            && !exported.is_empty()
+        {
+            module_and_export = Some((module.to_owned(), exported.to_owned()));
+        }
+
+        let (module, exported) = if let Some(module_and_export) = module_and_export {
+            module_and_export
+        } else if matches!(
+            candidate.relation,
+            CandidateRelation::Imports | CandidateRelation::Reexports
+        ) {
+            let module = candidate
+                .constraints
+                .module_or_package
+                .as_deref()
+                .filter(|module| !module.is_empty())?
+                .to_owned();
+            (module, "module".to_owned())
+        } else {
+            return None;
+        };
+        let keys =
+            typescript_import_module_keys(&occurrence.range.source_file, &module, &self.root);
+        if keys.is_empty() {
+            return None;
+        }
+        let member_owner_export = if matches!(
+            candidate.relation,
+            CandidateRelation::Calls
+                | CandidateRelation::IndirectCalls
+                | CandidateRelation::AccessesMember
+        ) {
+            candidate
+                .constraints
+                .qualified_name
+                .as_deref()
+                .and_then(|qualified| qualified.rsplit_once("::"))
+                .and_then(|(_, path)| {
+                    let (owner, member) =
+                        path.rsplit_once('.').or_else(|| path.rsplit_once("::"))?;
+                    (member == candidate.target_spelling && !owner.is_empty())
+                        .then_some(owner.to_owned())
+                })
+        } else {
+            None
+        };
+        let mut targets = BTreeSet::new();
+        for key in keys {
+            let owner_export = member_owner_export
+                .as_deref()
+                .unwrap_or(&exported)
+                .to_owned();
+            let owner_targets =
+                self.typescript_export_slots(language, &key, &owner_export, candidate);
+            if member_owner_export.is_some() {
+                for owner in owner_targets {
+                    let Some(owner) = self.declaration(owner) else {
+                        continue;
+                    };
+                    if let Some(members) = self.members_by_owner.get(&(
+                        owner.language.clone(),
+                        owner.qualified_name.clone(),
+                        candidate.target_spelling.clone(),
+                    )) {
+                        targets.extend(
+                            members
+                                .iter()
+                                .filter(|slot| {
+                                    self.typescript_declaration_allowed_slot(**slot, candidate)
+                                })
+                                .copied(),
+                        );
+                    }
+                }
+            } else {
+                targets.extend(owner_targets);
+            }
+        }
+        let targets = targets.into_iter().collect::<Vec<_>>();
+        self.unique_typescript_decision(
+            Some(&targets),
+            candidate,
+            if member_owner_export.is_some() {
+                ResolutionRule::MemberBinding
+            } else {
+                ResolutionRule::ExplicitBinding
+            },
+        )
+    }
+
+    fn typescript_export_slots(
+        &self,
+        language: &str,
+        module: &str,
+        exported: &str,
+        candidate: &RelationshipCandidate,
+    ) -> BTreeSet<DeclarationSlot> {
+        const MAX_TYPESCRIPT_REEXPORT_DEPTH: usize = 64;
+        let mut walk = TypeScriptExportWalk {
+            candidate,
+            visiting: BTreeSet::new(),
+            slots: BTreeSet::new(),
+        };
+        self.collect_typescript_export_slots(
+            language,
+            module,
+            exported,
+            0,
+            MAX_TYPESCRIPT_REEXPORT_DEPTH,
+            &mut walk,
+        );
+        walk.slots
+    }
+
+    fn collect_typescript_export_slots(
+        &self,
+        language: &str,
+        module: &str,
+        exported: &str,
+        depth: usize,
+        max_depth: usize,
+        walk: &mut TypeScriptExportWalk<'_>,
+    ) {
+        if depth >= max_depth
+            || walk.slots.len() > self.limits.candidates_per_lookup
+            || !walk
+                .visiting
+                .insert((language.to_owned(), module.to_owned(), exported.to_owned()))
+        {
+            return;
+        }
+        for target_language in typescript_language_family(language) {
+            let target_language = *target_language;
+            for index in [&self.typescript_modules, &self.typescript_export_aliases] {
+                if let Some(values) = index.get(&(
+                    target_language.to_owned(),
+                    module.to_owned(),
+                    exported.to_owned(),
+                )) {
+                    let remaining = candidate_storage_limit(self.limits.candidates_per_lookup)
+                        .saturating_sub(walk.slots.len());
+                    if remaining > 0 {
+                        walk.slots.extend(
+                            values
+                                .iter()
+                                .filter(|slot| {
+                                    self.typescript_declaration_allowed_slot(**slot, walk.candidate)
+                                })
+                                .take(remaining)
+                                .copied(),
+                        );
+                    }
+                }
+            }
+            if exported != "default"
+                && let Some(values) = self.typescript_reexport_targets.get(&(
+                    target_language.to_owned(),
+                    module.to_owned(),
+                    "*".to_owned(),
+                ))
+            {
+                for target in values {
+                    self.collect_typescript_export_slots(
+                        target_language,
+                        &target.module,
+                        exported,
+                        depth.saturating_add(1),
+                        max_depth,
+                        walk,
+                    );
+                }
+            }
+            if let Some(values) = self.typescript_reexport_targets.get(&(
+                target_language.to_owned(),
+                module.to_owned(),
+                exported.to_owned(),
+            )) {
+                for target in values {
+                    self.collect_typescript_export_slots(
+                        target_language,
+                        &target.module,
+                        &target.exported,
+                        depth.saturating_add(1),
+                        max_depth,
+                        walk,
+                    );
+                }
+            }
+        }
+        walk.visiting
+            .remove(&(language.to_owned(), module.to_owned(), exported.to_owned()));
     }
 
     fn resolve_wildcard_binding(
@@ -2834,6 +3096,45 @@ impl UniversalResolutionIndex {
         }
     }
 
+    fn typescript_declaration_allowed_slot(
+        &self,
+        slot: DeclarationSlot,
+        candidate: &RelationshipCandidate,
+    ) -> bool {
+        let Some(target) = self.declaration(slot) else {
+            return false;
+        };
+        typescript_declaration_basic_allowed(target, candidate)
+    }
+
+    fn unique_typescript_decision(
+        &self,
+        ids: Option<&Vec<DeclarationSlot>>,
+        candidate: &RelationshipCandidate,
+        rule: ResolutionRule,
+    ) -> Option<ResolutionDecision> {
+        let ids = ids?;
+        let eligible = ids
+            .iter()
+            .filter(|slot| self.typescript_declaration_allowed_slot(**slot, candidate))
+            .take(self.limits.candidates_per_lookup.saturating_add(1))
+            .copied()
+            .collect::<Vec<_>>();
+        match eligible.as_slice() {
+            [only] => Some(ResolutionDecision::Resolved {
+                declaration_id: self.declaration_id(*only)?.to_owned(),
+                evidence: ResolutionEvidence {
+                    rule,
+                    candidate_count: 1,
+                },
+            }),
+            [] => None,
+            many => Some(ResolutionDecision::Ambiguous {
+                candidate_count: many.len(),
+            }),
+        }
+    }
+
     fn inventory_decision(
         &self,
         language: &str,
@@ -3910,6 +4211,35 @@ fn declaration_basic_allowed(target: &DeclarationFact, candidate: &RelationshipC
                 .contains(&target.kind))
 }
 
+fn typescript_language_family(language: &str) -> &'static [&'static str] {
+    match language {
+        "typescript" => &["typescript", "javascript"],
+        "javascript" => &["javascript", "typescript"],
+        _ => &[],
+    }
+}
+
+fn typescript_declaration_basic_allowed(
+    target: &DeclarationFact,
+    candidate: &RelationshipCandidate,
+) -> bool {
+    typescript_language_family(&candidate.language).contains(&target.language.as_str())
+        && candidate
+            .constraints
+            .argument_count
+            .is_none_or(|arguments| {
+                target.parameter_count.is_none_or(|parameters| {
+                    arguments == parameters
+                        || (target.variadic && arguments >= parameters.saturating_sub(1))
+                })
+            })
+        && (candidate.constraints.allowed_target_kinds.is_empty()
+            || candidate
+                .constraints
+                .allowed_target_kinds
+                .contains(&target.kind))
+}
+
 fn declaration_overloads<'a>(
     declarations: impl Iterator<Item = &'a DeclarationFact>,
 ) -> AHashMap<String, String> {
@@ -4087,6 +4417,244 @@ fn source_directory(source_file: &str, root: &Path) -> Option<String> {
         .trim_matches('/')
         .to_owned();
     (!directory.is_empty()).then_some(directory)
+}
+
+fn typescript_module_indices(
+    declarations: &AHashMap<String, DeclarationFact>,
+    declaration_ids: &[String],
+    bindings: &AHashMap<String, BindingFact>,
+    scopes: &AHashMap<String, compass_languages::ScopeFact>,
+    root: &Path,
+) -> (
+    TypeScriptModuleIndex,
+    TypeScriptModuleIndex,
+    TypeScriptReexportIndex,
+) {
+    let mut modules = TypeScriptModuleIndex::new();
+    for declaration in declarations
+        .values()
+        .filter(|declaration| matches!(declaration.language.as_str(), "typescript" | "javascript"))
+    {
+        let Some(slot) = declaration_slot(declaration_ids, &declaration.id) else {
+            continue;
+        };
+        for module in typescript_source_module_keys(&declaration.range.source_file, root) {
+            modules
+                .entry((
+                    declaration.language.clone(),
+                    module.clone(),
+                    declaration.name.clone(),
+                ))
+                .or_default()
+                .push(slot);
+            if declaration.kind == "module" {
+                modules
+                    .entry((declaration.language.clone(), module, "module".to_owned()))
+                    .or_default()
+                    .push(slot);
+            }
+        }
+    }
+
+    let mut export_aliases = TypeScriptModuleIndex::new();
+    for binding in bindings.values().filter(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport
+            && binding.target_declaration_id.is_some()
+    }) {
+        let Some(target) = binding.target_declaration_id.as_deref() else {
+            continue;
+        };
+        let Some(slot) = declaration_slot(declaration_ids, target) else {
+            continue;
+        };
+        let Some(owner) = binding
+            .scope_id
+            .as_deref()
+            .and_then(|scope_id| scopes.get(scope_id))
+            .and_then(|scope| scope.owner_declaration_id.as_deref())
+            .and_then(|declaration_id| declarations.get(declaration_id))
+        else {
+            continue;
+        };
+        if !matches!(owner.language.as_str(), "typescript" | "javascript") {
+            continue;
+        }
+        for module in typescript_source_module_keys(&owner.range.source_file, root) {
+            export_aliases
+                .entry((owner.language.clone(), module, binding.spelling.clone()))
+                .or_default()
+                .push(slot);
+        }
+    }
+    let mut reexport_targets = TypeScriptReexportIndex::new();
+    for binding in bindings.values().filter(|binding| {
+        binding.kind == compass_languages::BindingKind::Reexport
+            && binding.target_declaration_id.is_none()
+    }) {
+        let Some((target_module, target_export)) = binding.qualified_target.rsplit_once("::")
+        else {
+            continue;
+        };
+        if target_module.is_empty() || target_export.is_empty() {
+            continue;
+        }
+        let Some(owner) = binding
+            .scope_id
+            .as_deref()
+            .and_then(|scope_id| scopes.get(scope_id))
+            .and_then(|scope| scope.owner_declaration_id.as_deref())
+            .and_then(|declaration_id| declarations.get(declaration_id))
+        else {
+            continue;
+        };
+        if !matches!(owner.language.as_str(), "typescript" | "javascript") {
+            continue;
+        }
+        let target_modules =
+            typescript_import_module_keys(&owner.range.source_file, target_module, root);
+        if target_modules.is_empty() {
+            continue;
+        }
+        for owner_module in typescript_source_module_keys(&owner.range.source_file, root) {
+            let targets = reexport_targets
+                .entry((
+                    owner.language.clone(),
+                    owner_module,
+                    binding.spelling.clone(),
+                ))
+                .or_default();
+            for target_module in &target_modules {
+                targets.push(TypeScriptReexportTarget {
+                    module: target_module.clone(),
+                    exported: target_export.to_owned(),
+                });
+            }
+        }
+    }
+    for targets in reexport_targets.values_mut() {
+        targets.sort_unstable_by(|left, right| {
+            left.module
+                .cmp(&right.module)
+                .then_with(|| left.exported.cmp(&right.exported))
+        });
+        targets.dedup();
+    }
+    for index in [&mut modules, &mut export_aliases] {
+        sort_declaration_index(index, declaration_ids, usize::MAX);
+    }
+    (modules, export_aliases, reexport_targets)
+}
+
+fn typescript_source_module_keys(source_file: &str, root: &Path) -> Vec<String> {
+    let Some(relative) = typescript_relative_path(source_file, root) else {
+        return Vec::new();
+    };
+    let Some(module) = typescript_module_stem(&relative) else {
+        return Vec::new();
+    };
+    let mut keys = vec![module.clone()];
+    if relative
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("index"))
+        && let Some(parent) = module.rsplit_once('/').map(|(parent, _)| parent)
+    {
+        if !parent.is_empty() {
+            keys.push(parent.to_owned());
+        }
+    } else if relative
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("index"))
+    {
+        keys.push(String::new());
+    }
+    keys.sort();
+    keys.dedup();
+    keys.retain(|key| !key.is_empty());
+    keys
+}
+
+fn typescript_import_module_keys(importer: &str, module: &str, root: &Path) -> Vec<String> {
+    let mut keys = Vec::new();
+    if module.starts_with('.') {
+        if let Some(importer_path) = typescript_relative_path(importer, root) {
+            let base = importer_path.parent().unwrap_or_else(|| Path::new(""));
+            if let Some(joined) = normalize_relative_module_path(&base.join(module))
+                && let Some(key) = typescript_module_stem(&joined)
+            {
+                keys.push(key);
+                if joined
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|name| name.eq_ignore_ascii_case("index"))
+                    && let Some(parent) = keys[0].rsplit_once('/').map(|(parent, _)| parent)
+                    && !parent.is_empty()
+                {
+                    keys.push(parent.to_owned());
+                }
+            }
+        }
+    } else if !module.is_empty() && !module.starts_with('#') {
+        let path = Path::new(module);
+        if let Some(key) = typescript_module_stem(path) {
+            keys.push(key);
+        }
+    }
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+fn typescript_relative_path(source_file: &str, root: &Path) -> Option<std::path::PathBuf> {
+    let path = Path::new(source_file);
+    let relative = if path.is_absolute() {
+        path.strip_prefix(root).ok()?.to_path_buf()
+    } else {
+        path.to_path_buf()
+    };
+    normalize_relative_module_path(&relative)
+}
+
+fn normalize_relative_module_path(path: &Path) -> Option<std::path::PathBuf> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                components.pop()?;
+            }
+            std::path::Component::Normal(value) => components.push(value.to_owned()),
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+    let mut normalized = std::path::PathBuf::new();
+    for component in components {
+        normalized.push(component);
+    }
+    Some(normalized)
+}
+
+fn typescript_module_stem(path: &Path) -> Option<String> {
+    let mut value = path.to_string_lossy().replace('\\', "/");
+    value = value.trim_start_matches("./").to_owned();
+    for extension in [
+        ".d.mts", ".d.cts", ".d.ts", ".mts", ".cts", ".tsx", ".jsx", ".mjs", ".cjs", ".ts", ".js",
+    ] {
+        if let Some(stem) = value.strip_suffix(extension) {
+            value = stem.to_owned();
+            break;
+        }
+    }
+    while value.ends_with('/') {
+        value.pop();
+    }
+    (!value.is_empty()
+        && !value.starts_with('/')
+        && !value
+            .split('/')
+            .any(|component| component.is_empty() || component == ".."))
+    .then_some(value)
 }
 
 fn read_go_module_path(root: &Path) -> Option<String> {

--- a/crates/compass-resolve/src/evidence.rs
+++ b/crates/compass-resolve/src/evidence.rs
@@ -1695,12 +1695,46 @@ impl UniversalResolutionIndex {
             return Err(());
         };
         let owner_language = owner.language.as_str();
+        if owner.kind == "module" {
+            // Module-owner aliases represent a namespace object (including a
+            // CommonJS `module.exports` object). Resolve direct members only
+            // through the provider's published export slots; the lexical
+            // module scope also contains private declarations that must not be
+            // exposed merely because their names match the requested member.
+            let mut exported = BTreeSet::new();
+            let source_modules =
+                typescript_source_module_keys(&owner.range.source_file, &self.root);
+            for module in source_modules {
+                exported.extend(self.typescript_export_slots(
+                    owner_language,
+                    &module,
+                    property,
+                    candidate,
+                    false,
+                ));
+            }
+            if exported.is_empty() {
+                exported.extend(self.typescript_export_slots(
+                    owner_language,
+                    &owner.qualified_name,
+                    property,
+                    candidate,
+                    false,
+                ));
+            }
+            if !exported.is_empty() {
+                visiting.remove(&owner_slot);
+                return Ok(Some(exported));
+            }
+        }
         let direct_key = (
             owner_language.to_owned(),
             owner.qualified_name.clone(),
             property.to_owned(),
         );
-        if let Some(members) = self.members_by_owner.get(&direct_key) {
+        if owner.kind != "module"
+            && let Some(members) = self.members_by_owner.get(&direct_key)
+        {
             let direct = members
                 .iter()
                 .filter(|slot| self.typescript_declaration_allowed_slot(**slot, candidate))

--- a/crates/compass-resolve/src/frameworks/domain.rs
+++ b/crates/compass-resolve/src/frameworks/domain.rs
@@ -22,8 +22,9 @@ pub fn resolve_domains(
     extraction: &Extraction,
     limits: FrameworkLimits,
 ) -> Result<Vec<ResolvedDomainFact>, FrameworkResolutionError> {
-    let targets = FrameworkTargetIndex::new(extraction);
-    resolve_domains_with_targets(extraction, limits, &targets)
+    let target_extraction = super::materialize_universal_framework_targets(extraction);
+    let targets = FrameworkTargetIndex::new(&target_extraction);
+    resolve_domains_with_targets(&target_extraction, limits, &targets)
 }
 
 pub(super) fn resolve_domains_with_targets(

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -10,7 +10,9 @@ mod spring;
 mod target_index;
 mod typescript;
 
+use compass_languages::{RawNodeRecord, make_id};
 use rayon::join;
+use serde_json::{Map, Value};
 
 type UniversalFrameworkExpansion =
     fn(&mut compass_languages::Extraction) -> Result<(), FrameworkResolutionError>;
@@ -68,11 +70,121 @@ pub(crate) fn resolve_framework_facts(
     if extraction.framework_facts.is_empty() {
         return (Ok(Vec::new()), Ok(Vec::new()));
     }
-    let targets = target_index::FrameworkTargetIndex::new_with_root(extraction, Some(root));
+    let target_extraction = materialize_universal_framework_targets(extraction);
+    let targets = target_index::FrameworkTargetIndex::new_with_root(&target_extraction, Some(root));
     join(
-        || routes::resolve_routes_with_targets(extraction, limits, &targets, Some(root)),
-        || domain::resolve_domains_with_targets(extraction, limits, &targets),
+        || routes::resolve_routes_with_targets(&target_extraction, limits, &targets, Some(root)),
+        || domain::resolve_domains_with_targets(&target_extraction, limits, &targets),
     )
+}
+
+/// Universal TypeScript/JavaScript extraction publishes declaration evidence
+/// first and lets the project resolver materialize graph nodes. Framework
+/// route/domain resolution can also be invoked directly on a single-file
+/// extraction, so provide the target index with source-backed declaration
+/// identities at this boundary without changing the universal evidence batch.
+pub(super) fn materialize_universal_framework_targets(
+    extraction: &compass_languages::Extraction,
+) -> compass_languages::Extraction {
+    let Some(batches) = extraction
+        .semantic_evidence
+        .as_ref()
+        .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
+    else {
+        return extraction.clone();
+    };
+    let mut enriched = extraction.clone();
+    let existing = enriched
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    let mut graph_id_counts = std::collections::BTreeMap::<&str, usize>::new();
+    for declaration in &batches.declarations {
+        *graph_id_counts
+            .entry(declaration.graph_node_id.as_str())
+            .or_default() += 1;
+    }
+    for declaration in &batches.declarations {
+        let id = if graph_id_counts
+            .get(declaration.graph_node_id.as_str())
+            .copied()
+            == Some(1)
+        {
+            declaration.graph_node_id.clone()
+        } else {
+            make_id(&[&declaration.graph_node_id, &declaration.id])
+        };
+        if existing.contains(&id) {
+            continue;
+        }
+        let mut attributes = Map::from_iter([
+            ("label".to_owned(), Value::String(declaration.name.clone())),
+            ("name".to_owned(), Value::String(declaration.name.clone())),
+            (
+                "qualified_name".to_owned(),
+                Value::String(declaration.qualified_name.clone()),
+            ),
+            (
+                "symbol_kind".to_owned(),
+                Value::String(declaration.kind.clone()),
+            ),
+            (
+                "source_file".to_owned(),
+                Value::String(declaration.range.source_file.clone()),
+            ),
+            (
+                "source_location".to_owned(),
+                Value::String(format!("L{}", declaration.range.start_line)),
+            ),
+            (
+                "start_byte".to_owned(),
+                Value::from(declaration.range.start_byte),
+            ),
+            (
+                "end_byte".to_owned(),
+                Value::from(declaration.range.end_byte),
+            ),
+            (
+                "line_start".to_owned(),
+                Value::from(declaration.range.start_line),
+            ),
+            (
+                "line_end".to_owned(),
+                Value::from(declaration.range.end_line),
+            ),
+            (
+                "column_start".to_owned(),
+                Value::from(declaration.range.start_column),
+            ),
+            (
+                "column_end".to_owned(),
+                Value::from(declaration.range.end_column),
+            ),
+            (
+                "language".to_owned(),
+                Value::String(declaration.language.clone()),
+            ),
+            (
+                "extractor".to_owned(),
+                Value::String(format!(
+                    "compass.languages.{}.universal",
+                    declaration.language
+                )),
+            ),
+            ("file_type".to_owned(), Value::String("code".to_owned())),
+            (
+                "confidence".to_owned(),
+                Value::String("EXTRACTED".to_owned()),
+            ),
+            ("_origin".to_owned(), Value::String("ast".to_owned())),
+        ]);
+        if let Some(signature) = declaration.signature.as_ref() {
+            attributes.insert("signature".to_owned(), Value::String(signature.clone()));
+        }
+        enriched.nodes.push(RawNodeRecord { id, attributes });
+    }
+    enriched
 }
 
 #[cfg(test)]

--- a/crates/compass-resolve/src/frameworks/qualification.rs
+++ b/crates/compass-resolve/src/frameworks/qualification.rs
@@ -1,7 +1,10 @@
 use compass_languages::{Extraction, FrameworkLimits};
 use compass_model::provenance::ResolutionState;
 
-use super::{FrameworkResolutionError, ResolvedRoute, resolve_routes};
+use super::{
+    FrameworkResolutionError, ResolvedRoute, materialize_universal_framework_targets,
+    resolve_routes,
+};
 
 /// A route assertion reusable by framework fixtures and external qualification
 /// harnesses. The handler is optional when a convention only promises the
@@ -115,7 +118,13 @@ pub fn qualify_framework_case(
     limits: FrameworkLimits,
     case: &FrameworkQualificationCase,
 ) -> Result<FrameworkQualificationReport, FrameworkQualificationError> {
-    let resolved_routes = resolve_routes(extraction, limits)?;
+    // A universal candidate intentionally keeps the per-file extraction
+    // evidence-only: declaration nodes are projected by the collection
+    // resolver. Qualification fixtures also exercise a single extracted file,
+    // so provide the target index with the same source-backed declaration
+    // identities without publishing a second graph route.
+    let target_extraction = materialize_universal_framework_targets(extraction);
+    let resolved_routes = resolve_routes(&target_extraction, limits)?;
     let mut matched_routes = 0_usize;
     for expected in &case.expectations {
         let candidates = resolved_routes

--- a/crates/compass-resolve/src/frameworks/routes.rs
+++ b/crates/compass-resolve/src/frameworks/routes.rs
@@ -59,8 +59,9 @@ pub fn resolve_routes(
     extraction: &Extraction,
     limits: FrameworkLimits,
 ) -> Result<Vec<ResolvedRoute>, FrameworkResolutionError> {
-    let targets = FrameworkTargetIndex::new(extraction);
-    resolve_routes_with_targets(extraction, limits, &targets, None)
+    let target_extraction = super::materialize_universal_framework_targets(extraction);
+    let targets = FrameworkTargetIndex::new(&target_extraction);
+    resolve_routes_with_targets(&target_extraction, limits, &targets, None)
 }
 
 pub(super) fn resolve_routes_with_targets(
@@ -112,8 +113,10 @@ pub fn resolve_and_publish_framework_routes(
     extraction: &mut Extraction,
     limits: FrameworkLimits,
 ) -> Result<Vec<ResolvedRoute>, FrameworkResolutionError> {
-    let resolved = resolve_routes(extraction, limits)?;
-    publish_resolved_routes(extraction, &resolved)?;
+    let mut target_extraction = super::materialize_universal_framework_targets(extraction);
+    let resolved = resolve_routes(&target_extraction, limits)?;
+    publish_resolved_routes(&mut target_extraction, &resolved)?;
+    *extraction = target_extraction;
     Ok(resolved)
 }
 
@@ -800,6 +803,23 @@ fn source_anchor(anchor: &RawFrameworkAnchor) -> SourceAnchor {
     }
 }
 
+fn evidence_origin(origin: RawFrameworkOrigin) -> EvidenceOrigin {
+    match origin {
+        RawFrameworkOrigin::Ast => EvidenceOrigin::Ast,
+        RawFrameworkOrigin::Config => EvidenceOrigin::Config,
+        RawFrameworkOrigin::Convention => EvidenceOrigin::Convention,
+        RawFrameworkOrigin::Heuristic => EvidenceOrigin::Heuristic,
+    }
+}
+
+fn resolution_name(state: ResolutionState) -> &'static str {
+    match state {
+        ResolutionState::Exact => "exact",
+        ResolutionState::Ambiguous => "ambiguous",
+        ResolutionState::Unresolved => "unresolved",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -925,22 +945,5 @@ mod tests {
         assert!(resolved[0].stages[0].target.is_none());
         assert!(resolved[0].candidates.is_empty());
         Ok(())
-    }
-}
-
-fn evidence_origin(origin: RawFrameworkOrigin) -> EvidenceOrigin {
-    match origin {
-        RawFrameworkOrigin::Ast => EvidenceOrigin::Ast,
-        RawFrameworkOrigin::Config => EvidenceOrigin::Config,
-        RawFrameworkOrigin::Convention => EvidenceOrigin::Convention,
-        RawFrameworkOrigin::Heuristic => EvidenceOrigin::Heuristic,
-    }
-}
-
-fn resolution_name(state: ResolutionState) -> &'static str {
-    match state {
-        ResolutionState::Exact => "exact",
-        ResolutionState::Ambiguous => "ambiguous",
-        ResolutionState::Unresolved => "unresolved",
     }
 }

--- a/crates/compass-resolve/src/frameworks/target_index.rs
+++ b/crates/compass-resolve/src/frameworks/target_index.rs
@@ -239,11 +239,33 @@ impl<'a> FrameworkTargetIndex<'a> {
         limit: usize,
     ) -> (Vec<usize>, bool) {
         let source = source_key(source, self.root);
-        bounded_union(
+        let direct = bounded_union(
             families.iter().filter_map(|family| {
                 self.by_source_terminal
                     .get(&(*family, source.clone(), terminal.to_owned()))
                     .map(Vec::as_slice)
+            }),
+            limit,
+        );
+        if !direct.0.is_empty() || direct.1 {
+            return direct;
+        }
+        // Universal TypeScript/JavaScript evidence deliberately carries a
+        // portable source suffix when a caller has no project root. Framework
+        // facts, however, may still retain the absolute path used for route
+        // convention detection. Treat an exact path suffix as the same source
+        // only for this source-scoped lookup; if several suffixes match, the
+        // normal candidate-state logic reports ambiguity instead of guessing.
+        bounded_union(
+            families.iter().flat_map(|family| {
+                self.by_source_terminal.iter().filter_map(
+                    |((indexed_family, indexed_source, indexed_terminal), values)| {
+                        (*indexed_family == *family
+                            && indexed_terminal == terminal
+                            && source_suffix_matches(indexed_source, &source))
+                        .then_some(values.as_slice())
+                    },
+                )
             }),
             limit,
         )
@@ -289,6 +311,20 @@ impl<'a> FrameworkTargetIndex<'a> {
             limit,
         )
     }
+}
+
+fn source_suffix_matches(left: &str, right: &str) -> bool {
+    let left = left.trim_start_matches("./");
+    let right = right.trim_start_matches("./");
+    left == right
+        || left
+            .strip_prefix('/')
+            .is_some_and(|left| left == right || left.ends_with(&format!("/{right}")))
+        || right
+            .strip_prefix('/')
+            .is_some_and(|right| right == left || right.ends_with(&format!("/{left}")))
+        || left.ends_with(&format!("/{right}"))
+        || right.ends_with(&format!("/{left}"))
 }
 
 pub(super) fn source_key(source: &str, root: Option<&Path>) -> String {

--- a/crates/compass-resolve/src/frameworks/typescript.rs
+++ b/crates/compass-resolve/src/frameworks/typescript.rs
@@ -77,13 +77,32 @@ pub(super) fn import_alias_map(
         .map(|node| (node.id.as_str(), node))
         .collect::<HashMap<_, _>>();
     for edge in &extraction.edges {
-        if edge.attributes.get("language").and_then(Value::as_str) != Some("python") {
+        let language = edge.attributes.get("language").and_then(Value::as_str);
+        if !matches!(language, Some("python" | "javascript" | "typescript")) {
             continue;
         }
-        if !matches!(
-            edge.attributes.get("relation").and_then(Value::as_str),
-            Some("imports" | "imports_from" | "re_exports")
-        ) {
+        let relation = edge.attributes.get("relation").and_then(Value::as_str);
+        // Universal project resolution keeps module imports as one bounded
+        // `imports_from` edge. The exact local binding is carried by the
+        // source-backed reference/call edge (for example
+        // `AccountAlias -> ./AccountPage::AccountPage`), so retain those
+        // explicit binding facts for framework route targets too.
+        let accepted_relation = match language {
+            Some("python") => matches!(relation, Some("imports" | "imports_from" | "re_exports")),
+            Some("javascript" | "typescript") => matches!(
+                relation,
+                Some(
+                    "imports"
+                        | "imports_from"
+                        | "re_exports"
+                        | "references"
+                        | "calls"
+                        | "constructs"
+                )
+            ),
+            _ => false,
+        };
+        if !accepted_relation {
             continue;
         }
         let Some(source_file) = edge
@@ -97,6 +116,11 @@ pub(super) fn import_alias_map(
         let Some(local) = edge
             .attributes
             .get("binding_name")
+            .or_else(|| {
+                matches!(language, Some("javascript" | "typescript"))
+                    .then(|| edge.attributes.get("local_name"))
+                    .flatten()
+            })
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
         else {
@@ -119,10 +143,32 @@ pub(super) fn import_alias_map(
         let target_id = target
             .filter(|node| node.string("symbol_kind") != "file")
             .map(|node| node.id.clone());
-        let (module, imported) = qualified_target.rsplit_once('.').map_or_else(
-            || (qualified_target.replace('.', "/"), "*".to_owned()),
-            |(module, imported)| (module.replace('.', "/"), imported.to_owned()),
-        );
+        let (module, imported) = if matches!(language, Some("javascript" | "typescript")) {
+            let module = edge
+                .attributes
+                .get("module")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .unwrap_or(qualified_target);
+            let imported = edge
+                .attributes
+                .get("imported_name")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .or_else(|| {
+                    edge.attributes
+                        .get("binding_qualified_target")
+                        .and_then(Value::as_str)
+                        .and_then(|value| value.rsplit_once("::").map(|(_, name)| name))
+                })
+                .unwrap_or("*");
+            (module.to_owned(), imported.to_owned())
+        } else {
+            qualified_target.rsplit_once('.').map_or_else(
+                || (qualified_target.replace('.', "/"), "*".to_owned()),
+                |(module, imported)| (module.replace('.', "/"), imported.to_owned()),
+            )
+        };
         let symbol_namespace = target_id.as_ref().and_then(|_| {
             module
                 .rsplit('/')

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -16,8 +16,9 @@ use std::time::Instant;
 
 use ahash::{AHashMap, AHashSet};
 use compass_languages::{
-    Extraction, RawCall, RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord,
-    SemanticEvidenceBatch, file_stem, is_language_builtin_global, make_id, parse_jsonc,
+    CandidateRelation, Extraction, RawCall, RawEdgeRecord as EdgeRecord,
+    RawNodeRecord as NodeRecord, SemanticEvidenceBatch, SemanticRole, file_stem,
+    is_language_builtin_global, make_id, parse_jsonc,
 };
 use compass_model::provenance::{
     EndpointRewriteEvidence, EndpointRewriteRule, append_endpoint_rewrite_evidence,
@@ -366,6 +367,13 @@ fn resolve_owned_with_root_impl(
                 .collect::<HashSet<_>>();
             allowed.extend(
                 extraction
+                    .nodes
+                    .iter()
+                    .filter(|node| is_framework_owned_node(node))
+                    .map(|node| node.id.clone()),
+            );
+            allowed.extend(
+                extraction
                     .edges
                     .iter()
                     .filter(|edge| !evidence::is_replaced_relation(relation(edge)))
@@ -423,11 +431,473 @@ fn universal_allowed_node_ids(extraction: &Extraction) -> HashSet<String> {
             .filter(|edge| !evidence::is_replaced_relation(relation(edge)))
             .flat_map(|edge| [edge.source.clone(), edge.target.clone()]),
     );
+    allowed.extend(
+        extraction
+            .nodes
+            .iter()
+            .filter(|node| is_framework_owned_node(node))
+            .map(|node| node.id.clone()),
+    );
     allowed
+}
+
+fn is_framework_owned_node(node: &NodeRecord) -> bool {
+    node.string("_origin") == "convention"
+        || node.string("extractor").starts_with("compass.frameworks.")
 }
 
 fn is_source_inventory_node(node: &NodeRecord) -> bool {
     node.string("symbol_kind") == "file" && !node.string("source_file").is_empty()
+}
+
+/// Universal JavaScript/TypeScript extraction deliberately publishes only
+/// semantic evidence at the language boundary. Project-level package and
+/// `tsconfig` resolution still needs a bounded source inventory and an
+/// importer/module edge before the evidence index materializes final graph
+/// edges. Build those transient resolver facts here so the language layer does
+/// not regress to a second raw AST graph.
+fn augment_universal_project_inventory(
+    merged: &mut Extraction,
+    evidence_batches: &[SemanticEvidenceBatch],
+    sources: &HashMap<String, String>,
+    root: &Path,
+    project_edges: &mut Vec<EdgeRecord>,
+) {
+    let mut source_languages = BTreeMap::<String, String>::new();
+    let mut source_evidence_lengths = BTreeMap::<String, usize>::new();
+    for batch in evidence_batches
+        .iter()
+        .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
+    {
+        for declaration in &batch.declarations {
+            if !declaration.range.source_file.is_empty() {
+                source_languages
+                    .entry(declaration.range.source_file.clone())
+                    .or_insert_with(|| batch.adapter.language.clone());
+                let length = source_evidence_lengths
+                    .entry(declaration.range.source_file.clone())
+                    .or_insert(0);
+                *length = (*length).max(declaration.range.end_byte as usize);
+            }
+        }
+    }
+    if source_languages.is_empty() {
+        return;
+    }
+
+    let mut source_ids = BTreeMap::<String, String>::new();
+    for node in &merged.nodes {
+        let source = node.string("source_file");
+        if !source.is_empty() && is_file_node(node, &source) {
+            source_ids
+                .entry(source_key(&source, root))
+                .or_insert_with(|| node.id.clone());
+        }
+    }
+    for (source, language) in &source_languages {
+        let key = source_key(source, root);
+        if !is_safe_relative_source(&key) {
+            continue;
+        }
+        let display_source =
+            source_inventory_display(source, &key, sources, root).unwrap_or_else(|| source.clone());
+        let file_id = source_ids.entry(key.clone()).or_insert_with(|| {
+            let id = make_id(&[&display_source]);
+            let label = Path::new(&display_source)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(&display_source)
+                .to_owned();
+            let byte_len = source_inventory_byte_len(&display_source, sources, root).max(
+                source_evidence_lengths
+                    .iter()
+                    .filter(|(source, _)| source_key(source, root) == key)
+                    .map(|(_, length)| *length)
+                    .max()
+                    .unwrap_or(0),
+            );
+            let mut attributes = Map::from_iter([
+                ("label".to_owned(), Value::String(label)),
+                ("symbol_kind".to_owned(), Value::String("file".to_owned())),
+                ("file_type".to_owned(), Value::String("code".to_owned())),
+                (
+                    "source_file".to_owned(),
+                    Value::String(display_source.clone()),
+                ),
+                ("source_location".to_owned(), Value::String("L1".to_owned())),
+                ("start_byte".to_owned(), Value::from(0_u64)),
+                ("end_byte".to_owned(), Value::from(byte_len as u64)),
+                ("line_start".to_owned(), Value::from(1_u64)),
+                ("line_end".to_owned(), Value::from(1_u64)),
+                ("column_start".to_owned(), Value::from(0_u64)),
+                ("column_end".to_owned(), Value::from(0_u64)),
+                ("language".to_owned(), Value::String(language.clone())),
+                (
+                    "extractor".to_owned(),
+                    Value::String(format!("compass.languages.{language}.universal")),
+                ),
+                (
+                    "universal_evidence_source_file".to_owned(),
+                    Value::String(source.clone()),
+                ),
+                (
+                    "confidence".to_owned(),
+                    Value::String("EXTRACTED".to_owned()),
+                ),
+                ("_origin".to_owned(), Value::String("ast".to_owned())),
+            ]);
+            // Keep the inventory node distinguishable from a semantic module
+            // declaration while retaining the stable source identity used by
+            // the existing package/path resolvers.
+            attributes.insert("universal_inventory".to_owned(), Value::Bool(true));
+            merged.nodes.push(NodeRecord {
+                id: id.clone(),
+                attributes,
+            });
+            id
+        });
+        let _ = file_id;
+    }
+
+    let declaration_ids = evidence_batches
+        .iter()
+        .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
+        .flat_map(|batch| {
+            batch
+                .declarations
+                .iter()
+                .map(|declaration| (declaration.id.as_str(), declaration))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut existing = project_edges
+        .iter()
+        .filter(|edge| edge.attributes.get("_universal_project_edge") == Some(&Value::Bool(true)))
+        .map(|edge| {
+            edge.attributes
+                .get("evidence_candidate_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect::<HashSet<_>>();
+    for batch in evidence_batches
+        .iter()
+        .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
+    {
+        for candidate in batch.candidates.iter().filter(|candidate| {
+            matches!(
+                candidate.relation,
+                CandidateRelation::Imports | CandidateRelation::Reexports
+            )
+        }) {
+            if !existing.insert(candidate.id.clone()) {
+                continue;
+            }
+            let Some(occurrence) = candidate.occurrence_id.as_deref().and_then(|id| {
+                batch
+                    .occurrences
+                    .iter()
+                    .find(|occurrence| occurrence.id == id)
+            }) else {
+                continue;
+            };
+            if !matches!(
+                occurrence.role,
+                SemanticRole::Import | SemanticRole::Reexport
+            ) {
+                continue;
+            }
+            let Some(owner) = declaration_ids.get(candidate.source_declaration_id.as_str()) else {
+                continue;
+            };
+            let module = candidate
+                .binding_id
+                .as_deref()
+                .and_then(|binding_id| {
+                    batch
+                        .bindings
+                        .iter()
+                        .find(|binding| binding.id == binding_id)
+                        .and_then(|binding| binding.qualified_target.rsplit_once("::"))
+                        .map(|(module, _)| module.to_owned())
+                })
+                .or_else(|| {
+                    candidate
+                        .constraints
+                        .qualified_name
+                        .as_deref()
+                        .and_then(|qualified| qualified.rsplit_once("::"))
+                        .map(|(module, _)| module.to_owned())
+                })
+                .or_else(|| candidate.constraints.module_or_package.clone())
+                .filter(|module| !module.is_empty())
+                .unwrap_or_default();
+            let context = occurrence
+                .context
+                .as_deref()
+                .filter(|context| !context.is_empty())
+                .map(str::to_owned)
+                .unwrap_or_else(|| {
+                    if candidate.relation == CandidateRelation::Reexports {
+                        "re-export".to_owned()
+                    } else {
+                        "import".to_owned()
+                    }
+                });
+            if module.is_empty() {
+                continue;
+            }
+            let source_key_value = source_key(&occurrence.range.source_file, root);
+            let Some(source_id) = source_ids.get(&source_key_value) else {
+                continue;
+            };
+            let project_source_file = merged
+                .nodes
+                .iter()
+                .find(|node| node.id == *source_id)
+                .map(|node| node.string("source_file"))
+                .filter(|source| !source.is_empty())
+                .unwrap_or_else(|| occurrence.range.source_file.clone());
+            let attributes = Map::from_iter([
+                (
+                    "relation".to_owned(),
+                    Value::String("imports_from".to_owned()),
+                ),
+                ("module".to_owned(), Value::String(module)),
+                ("source_file".to_owned(), Value::String(project_source_file)),
+                (
+                    "universal_evidence_source_file".to_owned(),
+                    Value::String(occurrence.range.source_file.clone()),
+                ),
+                (
+                    "source_location".to_owned(),
+                    Value::String(format!("L{}", occurrence.range.start_line)),
+                ),
+                (
+                    "start_byte".to_owned(),
+                    Value::from(occurrence.range.start_byte),
+                ),
+                (
+                    "end_byte".to_owned(),
+                    Value::from(occurrence.range.end_byte),
+                ),
+                (
+                    "line_start".to_owned(),
+                    Value::from(occurrence.range.start_line),
+                ),
+                (
+                    "line_end".to_owned(),
+                    Value::from(occurrence.range.end_line),
+                ),
+                (
+                    "column_start".to_owned(),
+                    Value::from(occurrence.range.start_column),
+                ),
+                (
+                    "column_end".to_owned(),
+                    Value::from(occurrence.range.end_column),
+                ),
+                (
+                    "language".to_owned(),
+                    Value::String(candidate.language.clone()),
+                ),
+                (
+                    "extractor".to_owned(),
+                    Value::String(format!(
+                        "compass.languages.{}.universal",
+                        candidate.language
+                    )),
+                ),
+                (
+                    "confidence".to_owned(),
+                    Value::String("EXTRACTED".to_owned()),
+                ),
+                ("_origin".to_owned(), Value::String("ast".to_owned())),
+                ("context".to_owned(), Value::String(context)),
+                (
+                    "evidence_candidate_id".to_owned(),
+                    Value::String(candidate.id.clone()),
+                ),
+                (
+                    "evidence_occurrence_id".to_owned(),
+                    Value::String(occurrence.id.clone()),
+                ),
+                ("_universal_project_edge".to_owned(), Value::Bool(true)),
+            ]);
+            let placeholder = make_id(&[
+                "universal-project-import",
+                candidate.language.as_str(),
+                occurrence.range.source_file.as_str(),
+                candidate.id.as_str(),
+            ]);
+            project_edges.push(EdgeRecord {
+                source: source_id.clone(),
+                target: placeholder,
+                attributes,
+            });
+            // `owner` is intentionally looked up above to guarantee that the
+            // candidate is source-backed; the transient project edge is keyed
+            // by its file inventory node so path resolution remains importer-
+            // aware and cannot infer a declaration owner from spelling alone.
+            let _ = owner;
+        }
+    }
+}
+
+/// Framework routes historically exposed callable identities using the
+/// source-oriented `name()@offset` spelling. Universal evidence keeps a
+/// module-qualified name for cross-file resolution, so restore the legacy
+/// display identity only on files that actually publish framework facts. This
+/// preserves existing route/publication identities without weakening the
+/// universal declaration index used by ordinary TypeScript/JavaScript code.
+fn restore_framework_callable_names(
+    extraction: &mut Extraction,
+    sources: &HashMap<String, String>,
+    root: &Path,
+) {
+    let mut framework_sources = BTreeSet::new();
+    for fact in &extraction.framework_facts {
+        match fact {
+            compass_languages::RawFrameworkFact::Route(route) => {
+                framework_sources.insert(route.anchor.source_file.clone());
+                if let Some(handler_source) = route
+                    .detail
+                    .get("handler_source")
+                    .and_then(Value::as_str)
+                    .filter(|source| !source.is_empty())
+                {
+                    // Convention/framework routes may target a callable in
+                    // another TS/JS file. Restore the historical callable
+                    // identity on that source as well as on the route file.
+                    framework_sources.insert(handler_source.to_owned());
+                }
+            }
+            compass_languages::RawFrameworkFact::Domain(domain) => {
+                framework_sources.insert(domain.anchor.source_file.clone());
+            }
+            compass_languages::RawFrameworkFact::Annotation(annotation) => {
+                framework_sources.insert(annotation.anchor.source_file.clone());
+            }
+        }
+    }
+    let nodes_by_id = extraction
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    let framework_source_keys = framework_sources
+        .iter()
+        .map(|source| source_key(source, root))
+        .collect::<BTreeSet<_>>();
+    for edge in &extraction.edges {
+        if !matches!(
+            edge.attributes.get("relation").and_then(Value::as_str),
+            Some("references" | "calls" | "constructs" | "imports" | "imports_from")
+        ) {
+            continue;
+        }
+        let Some(edge_source) = edge
+            .attributes
+            .get("source_file")
+            .and_then(Value::as_str)
+            .filter(|source| !source.is_empty())
+        else {
+            continue;
+        };
+        if !framework_source_keys.contains(&source_key(edge_source, root)) {
+            continue;
+        }
+        let Some(target_source) = nodes_by_id
+            .get(edge.target.as_str())
+            .and_then(|node| node.attributes.get("source_file"))
+            .and_then(Value::as_str)
+            .filter(|source| !source.is_empty())
+        else {
+            continue;
+        };
+        // Universal binding/reference evidence is the source-backed bridge
+        // for framework handlers that live in another TS/JS file.
+        framework_sources.insert(target_source.to_owned());
+    }
+    if framework_sources.is_empty() {
+        return;
+    }
+    for node in &mut extraction.nodes {
+        let source = string_attribute(node, "source_file");
+        if !framework_sources.contains(&source)
+            || !matches!(
+                string_attribute(node, "language").as_str(),
+                "typescript" | "javascript" | "tsx" | "jsx"
+            )
+        {
+            continue;
+        }
+        let Some(legacy) = node
+            .attributes
+            .get("legacy_qualified_name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+        else {
+            continue;
+        };
+        let mut legacy = legacy.to_owned();
+        if string_attribute(node, "symbol_kind") == "function"
+            && let Some(contents) = sources.iter().find_map(|(candidate, contents)| {
+                (source_key(candidate, root) == source).then_some(contents)
+            })
+            && let Some(start) = framework_function_start(contents, node)
+            && let Some(separator) = legacy.rfind('@')
+        {
+            legacy.truncate(separator + 1);
+            legacy.push_str(&start.to_string());
+        }
+        node.attributes
+            .insert("qualified_name".to_owned(), Value::String(legacy));
+        if matches!(
+            string_attribute(node, "symbol_kind").as_str(),
+            "function" | "method" | "class" | "component"
+        ) && let Some(dialect) = framework_source_dialect(&source)
+        {
+            node.attributes
+                .insert("language".to_owned(), Value::String(dialect.to_owned()));
+        }
+    }
+}
+
+fn framework_source_dialect(source: &str) -> Option<&'static str> {
+    match Path::new(source)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("tsx") => Some("tsx"),
+        Some("jsx") => Some("jsx"),
+        _ => None,
+    }
+}
+
+fn framework_function_start(source: &str, node: &NodeRecord) -> Option<usize> {
+    let start = node.attributes.get("start_byte").and_then(Value::as_u64)? as usize;
+    if start > source.len() {
+        return None;
+    }
+    let line_start = source[..start].rfind('\n').map_or(0, |index| index + 1);
+    let line = &source[line_start..];
+    let indent = line.len() - line.trim_start_matches(char::is_whitespace).len();
+    let mut declaration_start = line_start + indent;
+    let remainder = &source[declaration_start..];
+    if let Some(after_export) = remainder.strip_prefix("export") {
+        let consumed = remainder.len() - after_export.len();
+        declaration_start += consumed;
+        declaration_start += after_export.len() - after_export.trim_start().len();
+        if source[declaration_start..].starts_with("default") {
+            declaration_start += "default".len();
+            declaration_start +=
+                source[declaration_start..].len() - source[declaration_start..].trim_start().len();
+        }
+    }
+    Some(declaration_start)
 }
 
 fn finish_resolution(
@@ -441,6 +911,14 @@ fn finish_resolution(
 ) -> Extraction {
     let mut profile_started = Instant::now();
     let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut project_edges = project_edges;
+    augment_universal_project_inventory(
+        &mut merged,
+        &evidence_batches,
+        sources,
+        &canonical_root,
+        &mut project_edges,
+    );
     let has_javascript = sources.keys().any(|source| {
         let extension = extension(source);
         matches!(
@@ -548,6 +1026,7 @@ fn finish_resolution(
         }
     }
     profile_internal("resolver universal evidence", &mut profile_started);
+    restore_framework_callable_names(&mut merged, sources, &canonical_root);
     canonicalize_file_targets(&mut merged, root);
     profile_internal(
         "resolver file-target canonicalization",
@@ -1597,9 +2076,6 @@ fn resolve_javascript_typescript_paths(
     sources: &HashMap<String, String>,
 ) -> Result<(), String> {
     let (configs, referenced_configs) = collect_typescript_configs(extraction, root, sources)?;
-    if configs.is_empty() {
-        return Ok(());
-    }
 
     let mut file_by_source = BTreeMap::<String, (String, String)>::new();
     let mut source_by_file = HashMap::<String, String>::new();
@@ -4008,6 +4484,66 @@ fn source_key(source: &str, root: &Path) -> String {
         return relative.to_string_lossy().replace('\\', "/");
     }
     path.to_string_lossy().replace('\\', "/")
+}
+
+/// Recover the source-inventory spelling for a portable universal-evidence
+/// path. The language adapter intentionally shortens absolute temporary paths
+/// to a stable `parent/file` spelling; a project resolver must map that
+/// spelling back to the admitted source only when the suffix is unique.
+fn source_inventory_display(
+    _evidence_source: &str,
+    key: &str,
+    sources: &HashMap<String, String>,
+    root: &Path,
+) -> Option<String> {
+    if key.is_empty() {
+        return None;
+    }
+    let suffix = format!("/{key}");
+    let mut matches = sources
+        .keys()
+        .filter(|candidate| {
+            source_key(candidate, root) == key || {
+                let candidate = candidate.replace('\\', "/");
+                candidate == key || candidate.ends_with(&suffix)
+            }
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches.dedup();
+    if matches.len() != 1 {
+        return None;
+    }
+    matches
+        .pop()
+        .map(|candidate| source_key(&candidate, root))
+        .filter(|display| is_safe_relative_source(display))
+}
+
+fn source_inventory_byte_len(
+    display: &str,
+    sources: &HashMap<String, String>,
+    root: &Path,
+) -> usize {
+    let display_key = source_key(display, root);
+    let suffix = format!("/{display_key}");
+    let mut matches = sources
+        .iter()
+        .filter(|(candidate, _)| {
+            source_key(candidate, root) == display_key
+                || candidate.replace('\\', "/") == display_key
+                || candidate.replace('\\', "/").ends_with(&suffix)
+        })
+        .map(|(candidate, contents)| (candidate.to_owned(), contents.len()))
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| left.0.cmp(&right.0));
+    matches.dedup_by(|left, right| left.0 == right.0);
+    if matches.len() == 1 {
+        matches.pop().map_or(0, |(_, length)| length)
+    } else {
+        0
+    }
 }
 
 /// Resolve non-member raw calls using unique definitions and import evidence.

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use ahash::{AHashMap, AHashSet};
 use compass_languages::{
     Extraction, RawCall, RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord,
-    SemanticEvidenceBatch, file_stem, is_language_builtin_global, make_id,
+    SemanticEvidenceBatch, file_stem, is_language_builtin_global, make_id, parse_jsonc,
 };
 use compass_model::provenance::{
     EndpointRewriteEvidence, EndpointRewriteRule, append_endpoint_rewrite_evidence,
@@ -434,10 +434,24 @@ fn finish_resolution(
         .any(|source| matches!(extension(source).as_str(), "cs" | "razor" | "cshtml"));
     let has_php = sources.keys().any(|source| extension(source) == "php");
     if has_javascript {
+        if let Err(error) =
+            resolve_javascript_package_conditions(&mut merged, &canonical_root, sources)
+        {
+            merged.error.get_or_insert_with(|| {
+                format!("JavaScript package-condition resolution failed: {error}")
+            });
+        }
         if let Err(error) = resolve_javascript_workspace_modules(&mut merged, &canonical_root) {
             merged
                 .error
                 .get_or_insert_with(|| format!("JavaScript workspace resolution failed: {error}"));
+        }
+        if let Err(error) =
+            resolve_javascript_typescript_paths(&mut merged, &canonical_root, sources)
+        {
+            merged.error.get_or_insert_with(|| {
+                format!("TypeScript/JavaScript path resolution failed: {error}")
+            });
         }
         resolve_javascript_reexports(&mut merged);
     }
@@ -691,6 +705,15 @@ fn resolve_javascript_workspace_modules(
         if relation(edge) != "imports_from" {
             continue;
         }
+        // The importer-aware pass runs first and stamps every package edge it
+        // owns (including explicit Classic/Node10 misses). Do not let this
+        // legacy flattened workspace fallback overwrite a mode-specific
+        // decision or reintroduce a conditional branch.
+        if edge.attributes.contains_key("resolution_rule")
+            || edge.attributes.contains_key("module_resolution")
+        {
+            continue;
+        }
         let module = edge.string("module");
         let Some(candidates) = targets.get(&module) else {
             continue;
@@ -714,6 +737,2082 @@ fn resolve_javascript_workspace_modules(
         }
     }
     Ok(())
+}
+
+#[derive(Clone, Debug)]
+struct JavascriptPackageManifest {
+    source: String,
+    name: String,
+    directory: PathBuf,
+    exports: Option<Value>,
+    imports: Option<Value>,
+    types_versions: Option<Value>,
+    types: Option<String>,
+    module: Option<String>,
+    main: Option<String>,
+}
+
+/// Resolve package exports with an importer-aware condition order.
+///
+/// The previous workspace pass intentionally kept only a unique flattened
+/// target. That is safe for simple packages, but it loses the distinction
+/// between import, require, types, and default branches. This pass evaluates
+/// the documented branch order without unioning mutually exclusive conditions
+/// and only publishes an admitted source target.
+fn resolve_javascript_package_conditions(
+    extraction: &mut Extraction,
+    root: &Path,
+    sources: &HashMap<String, String>,
+) -> Result<(), String> {
+    let (typescript_configs, referenced_configs) =
+        collect_typescript_configs(extraction, root, sources)?;
+    let mut file_by_source = BTreeMap::<String, (String, String)>::new();
+    let mut manifest_sources = BTreeSet::new();
+    for node in &extraction.nodes {
+        let source = string_attribute(node, "source_file");
+        if source.is_empty() {
+            continue;
+        }
+        if is_file_node(node, &source) {
+            file_by_source
+                .entry(source_key(&source, root))
+                .or_insert_with(|| (node.id.clone(), source.clone()));
+        }
+        if Path::new(&source)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some("package.json")
+        {
+            manifest_sources.insert(source);
+        }
+    }
+    if manifest_sources.len() > MAX_JAVASCRIPT_PACKAGE_MANIFESTS {
+        return Err(format!(
+            "package manifest count {} exceeds limit {MAX_JAVASCRIPT_PACKAGE_MANIFESTS}",
+            manifest_sources.len()
+        ));
+    }
+    let mut manifests = Vec::new();
+    for source in manifest_sources {
+        let manifest_path = rooted_source_path(root, &source)?;
+        let Ok(contents) =
+            compass_files::read_source_lossy(&manifest_path, MAX_JAVASCRIPT_PACKAGE_BYTES)
+        else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&contents) else {
+            continue;
+        };
+        let Some(name) = value.get("name").and_then(Value::as_str).filter(|name| {
+            !name.is_empty()
+                && name.len() <= 4_096
+                && !name.contains(['\\', '\0'])
+                && !name
+                    .split('/')
+                    .any(|part| part.is_empty() || matches!(part, "." | ".."))
+        }) else {
+            continue;
+        };
+        let Some(directory) = manifest_path.parent().map(Path::to_path_buf) else {
+            continue;
+        };
+        manifests.push(JavascriptPackageManifest {
+            source,
+            name: name.to_owned(),
+            directory,
+            exports: value.get("exports").cloned(),
+            imports: value.get("imports").cloned(),
+            types_versions: value.get("typesVersions").cloned(),
+            types: value
+                .get("types")
+                .or_else(|| value.get("typings"))
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            module: value
+                .get("module")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            main: value.get("main").and_then(Value::as_str).map(str::to_owned),
+        });
+    }
+    manifests.sort_by(|left, right| left.source.cmp(&right.source));
+
+    let mut export_count = 0_usize;
+    for edge in &mut extraction.edges {
+        if relation(edge) != "imports_from" {
+            continue;
+        }
+        let module = edge.string("module");
+        if module.starts_with('#') {
+            let importer_path = root.join(source_key(&edge.string("source_file"), root));
+            let candidates = manifests
+                .iter()
+                .filter(|manifest| importer_path.starts_with(&manifest.directory))
+                .collect::<Vec<_>>();
+            let deepest = candidates
+                .iter()
+                .map(|manifest| manifest.directory.components().count())
+                .max();
+            let nearest = deepest.and_then(|depth| {
+                let mut nearest = candidates
+                    .into_iter()
+                    .filter(|manifest| manifest.directory.components().count() == depth)
+                    .collect::<Vec<_>>();
+                (nearest.len() == 1).then(|| nearest.pop()).flatten()
+            });
+            let Some(manifest) = nearest else {
+                continue;
+            };
+            let Some(imports) = manifest.imports.as_ref() else {
+                continue;
+            };
+            let importer = edge.string("source_file");
+            let config = select_typescript_path_config(
+                &typescript_configs,
+                &referenced_configs,
+                root,
+                &importer,
+            );
+            let resolution_mode = javascript_module_resolution_mode(config);
+            if let Some(module_resolution) =
+                config.and_then(|config| config.module_resolution.as_ref())
+            {
+                edge.attributes.insert(
+                    "module_resolution".to_owned(),
+                    Value::String(module_resolution.clone()),
+                );
+            }
+            if !resolution_mode.supports_conditional_exports() {
+                // Classic and Node10 resolution do not search package
+                // `imports` maps.
+                // Leave the raw import unresolved rather than applying a
+                // Node-style package rule to a compiler invocation that did
+                // not opt into it.
+                edge.attributes.insert(
+                    "resolution_rule".to_owned(),
+                    Value::String("package-imports-unsupported".to_owned()),
+                );
+                continue;
+            }
+            let conditions = javascript_package_condition_order(
+                edge.string("context").as_str(),
+                config.map_or(&[] as &[String], |config| {
+                    config.custom_conditions.as_slice()
+                }),
+            );
+            let condition_refs = conditions.iter().map(String::as_str).collect::<Vec<_>>();
+            let candidates =
+                resolve_javascript_package_export(imports, &module, &condition_refs, 0, None);
+            let Some((_, condition, target_source)) =
+                candidates.into_iter().find_map(|(target, condition)| {
+                    let target_path =
+                        javascript_package_target(&manifest.directory, root, &target)?;
+                    let importer_is_typescript = is_typescript_source(&edge.string("source_file"));
+                    let candidates = if importer_is_typescript {
+                        typescript_target_candidates(&target_path, &[])
+                    } else {
+                        vec![target_path]
+                    };
+                    candidates.into_iter().find_map(|candidate| {
+                        let key = source_key(&candidate.to_string_lossy(), root);
+                        file_by_source.contains_key(&key).then_some((
+                            target.clone(),
+                            condition.clone(),
+                            key,
+                        ))
+                    })
+                })
+            else {
+                continue;
+            };
+            export_count = export_count.saturating_add(1);
+            if export_count > MAX_JAVASCRIPT_PACKAGE_EXPORTS {
+                return Err(format!(
+                    "package condition resolution count exceeds {MAX_JAVASCRIPT_PACKAGE_EXPORTS}"
+                ));
+            }
+            let Some((target_id, original_source)) = file_by_source.get(&target_source) else {
+                continue;
+            };
+            if edge.target != *target_id {
+                edge.target.clone_from(target_id);
+                stamp_endpoint_rewrite(edge, EndpointRewriteRule::CanonicalImportTarget, 1.0);
+            }
+            edge.attributes.insert(
+                "target_file".to_owned(),
+                Value::String(original_source.clone()),
+            );
+            edge.attributes.insert(
+                "resolution_rule".to_owned(),
+                Value::String("package-imports".to_owned()),
+            );
+            edge.attributes
+                .insert("package_condition".to_owned(), Value::String(condition));
+            edge.attributes.insert(
+                "resolution_config".to_owned(),
+                Value::String(manifest.source.clone()),
+            );
+            continue;
+        }
+        let Some((package_name, subpath)) = javascript_package_specifier(&module) else {
+            continue;
+        };
+        let matching = manifests
+            .iter()
+            .filter(|manifest| manifest.name == package_name)
+            .collect::<Vec<_>>();
+        if matching.len() != 1 {
+            continue;
+        }
+        let manifest = matching[0];
+        let importer = edge.string("source_file");
+        let config = select_typescript_path_config(
+            &typescript_configs,
+            &referenced_configs,
+            root,
+            &importer,
+        );
+        let resolution_mode = javascript_module_resolution_mode(config);
+        if let Some(module_resolution) = config.and_then(|config| config.module_resolution.as_ref())
+        {
+            edge.attributes.insert(
+                "module_resolution".to_owned(),
+                Value::String(module_resolution.clone()),
+            );
+        }
+        if resolution_mode == JavascriptModuleResolution::Classic {
+            // Classic resolution has no package-name lookup. A project alias
+            // may still resolve this edge in the dedicated paths pass.
+            edge.attributes.insert(
+                "resolution_rule".to_owned(),
+                Value::String("package-classic-unresolved".to_owned()),
+            );
+            continue;
+        }
+        let conditions = javascript_package_condition_order(
+            edge.string("context").as_str(),
+            config.map_or(&[] as &[String], |config| {
+                config.custom_conditions.as_slice()
+            }),
+        );
+        let condition_refs = conditions.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut selected = if resolution_mode.supports_conditional_exports() {
+            manifest
+                .exports
+                .as_ref()
+                .and_then(|exports| {
+                    let candidates = resolve_javascript_package_export(
+                        exports,
+                        &subpath,
+                        &condition_refs,
+                        0,
+                        None,
+                    );
+                    (!candidates.is_empty()).then_some(candidates)
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let mut resolution_rule = "package-exports";
+        if selected.is_empty() && is_typescript_source(&edge.string("source_file")) {
+            selected =
+                javascript_types_versions_targets(manifest.types_versions.as_ref(), &subpath)
+                    .into_iter()
+                    .map(|target| (target, "typesVersions".to_owned()))
+                    .collect();
+            if !selected.is_empty() {
+                resolution_rule = "typesVersions";
+            }
+        }
+        if selected.is_empty() {
+            selected = javascript_package_legacy_target(manifest, &subpath, &conditions);
+            if !selected.is_empty() {
+                resolution_rule = "package-legacy";
+            }
+        }
+        let Some((_, condition, target_source)) =
+            selected.into_iter().find_map(|(target, condition)| {
+                let target_path = javascript_package_target(&manifest.directory, root, &target)?;
+                let importer_is_typescript = is_typescript_source(&edge.string("source_file"));
+                let candidates = if importer_is_typescript {
+                    typescript_target_candidates(&target_path, &[])
+                } else {
+                    vec![target_path]
+                };
+                candidates.into_iter().find_map(|candidate| {
+                    let key = source_key(&candidate.to_string_lossy(), root);
+                    file_by_source.contains_key(&key).then_some((
+                        target.clone(),
+                        condition.clone(),
+                        key,
+                    ))
+                })
+            })
+        else {
+            // A manifest was present and the compiler-mode decision was
+            // evaluated, but no admitted target survived. Preserve the
+            // unresolved result so the older flattened workspace pass cannot
+            // resurrect a different conditional branch later in the pipeline.
+            edge.attributes.insert(
+                "resolution_rule".to_owned(),
+                Value::String("package-unresolved".to_owned()),
+            );
+            continue;
+        };
+        export_count = export_count.saturating_add(1);
+        if export_count > MAX_JAVASCRIPT_PACKAGE_EXPORTS {
+            return Err(format!(
+                "package condition resolution count exceeds {MAX_JAVASCRIPT_PACKAGE_EXPORTS}"
+            ));
+        }
+        let Some((target_id, original_source)) = file_by_source.get(&target_source) else {
+            continue;
+        };
+        if edge.target != *target_id {
+            edge.target.clone_from(target_id);
+            stamp_endpoint_rewrite(edge, EndpointRewriteRule::CanonicalImportTarget, 1.0);
+        }
+        edge.attributes.insert(
+            "target_file".to_owned(),
+            Value::String(original_source.clone()),
+        );
+        edge.attributes.insert(
+            "resolution_rule".to_owned(),
+            Value::String(resolution_rule.to_owned()),
+        );
+        edge.attributes
+            .insert("package_condition".to_owned(), Value::String(condition));
+        edge.attributes.insert(
+            "resolution_config".to_owned(),
+            Value::String(manifest.source.clone()),
+        );
+    }
+    Ok(())
+}
+
+fn javascript_package_specifier(module: &str) -> Option<(String, String)> {
+    if module.is_empty() || module.len() > 4_096 || module.contains(['\\', '\0']) {
+        return None;
+    }
+    let parts = module.split('/').collect::<Vec<_>>();
+    let package_len = if parts.first()?.starts_with('@') {
+        if parts.len() < 2 {
+            return None;
+        }
+        2
+    } else {
+        1
+    };
+    if parts
+        .iter()
+        .any(|part| part.is_empty() || matches!(*part, "." | ".."))
+    {
+        return None;
+    }
+    let package = parts[..package_len].join("/");
+    let subpath = if parts.len() == package_len {
+        ".".to_owned()
+    } else {
+        format!("./{}", parts[package_len..].join("/"))
+    };
+    Some((package, subpath))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum JavascriptModuleResolution {
+    /// TypeScript's pre-Node package lookup. Non-relative package names are
+    /// not resolved through `node_modules` or package `imports`/`exports`.
+    Classic,
+    /// The Node10 resolver. Legacy `types`/`main`/`module` fields remain
+    /// available, but conditional package maps are not part of this mode.
+    Node10,
+    Node16,
+    NodeNext,
+    Bundler,
+    /// No explicit mode was found in the admitted project. Preserve the
+    /// historical Compass behavior while recording no invented config value.
+    Inferred,
+}
+
+impl JavascriptModuleResolution {
+    const fn supports_conditional_exports(self) -> bool {
+        matches!(
+            self,
+            Self::Node16 | Self::NodeNext | Self::Bundler | Self::Inferred
+        )
+    }
+}
+
+fn javascript_module_resolution_mode(
+    config: Option<&TypeScriptPathConfig>,
+) -> JavascriptModuleResolution {
+    let Some(config) = config else {
+        return JavascriptModuleResolution::Inferred;
+    };
+    match config.module_resolution.as_deref() {
+        Some("classic") => JavascriptModuleResolution::Classic,
+        Some("node") | Some("node10") => JavascriptModuleResolution::Node10,
+        Some("node16") => JavascriptModuleResolution::Node16,
+        Some("nodenext") => JavascriptModuleResolution::NodeNext,
+        Some("bundler") => JavascriptModuleResolution::Bundler,
+        // Unknown or omitted values are not silently reinterpreted as a
+        // different compiler mode. Omitted/unknown config keeps the existing
+        // conservative package behavior until an explicit mode is available.
+        _ => JavascriptModuleResolution::Inferred,
+    }
+}
+
+fn javascript_package_condition_order(context: &str, custom: &[String]) -> Vec<String> {
+    let mut conditions = vec!["types".to_owned()];
+    for condition in custom {
+        if !conditions.iter().any(|candidate| candidate == condition) {
+            conditions.push(condition.clone());
+        }
+    }
+    conditions.push(if context == "require" {
+        "require".to_owned()
+    } else {
+        "import".to_owned()
+    });
+    conditions.push("node".to_owned());
+    conditions.push("default".to_owned());
+    conditions
+}
+
+fn resolve_javascript_package_export(
+    value: &Value,
+    subpath: &str,
+    conditions: &[&str],
+    depth: usize,
+    wildcard: Option<&str>,
+) -> Vec<(String, String)> {
+    if depth > 32 {
+        return Vec::new();
+    }
+    match value {
+        Value::String(target) => vec![(
+            wildcard.map_or_else(|| target.clone(), |wildcard| target.replace('*', wildcard)),
+            "default".to_owned(),
+        )],
+        Value::Array(values) => values
+            .iter()
+            .flat_map(|value| {
+                resolve_javascript_package_export(value, subpath, conditions, depth + 1, wildcard)
+            })
+            .collect(),
+        Value::Object(entries) => {
+            let has_subpaths = entries
+                .keys()
+                .any(|key| key == "." || key.starts_with("./") || key.starts_with('#'));
+            if has_subpaths {
+                if let Some(value) = entries.get(subpath) {
+                    return resolve_javascript_package_export(
+                        value,
+                        subpath,
+                        conditions,
+                        depth + 1,
+                        wildcard,
+                    );
+                }
+                let mut patterns = entries
+                    .iter()
+                    .filter_map(|(pattern, value)| {
+                        let (prefix, suffix) = pattern.split_once('*')?;
+                        if !(pattern.starts_with("./") || pattern.starts_with('#'))
+                            || !subpath.starts_with(prefix)
+                            || !subpath.ends_with(suffix)
+                        {
+                            return None;
+                        }
+                        let end = subpath.len().saturating_sub(suffix.len());
+                        (end >= prefix.len()).then_some((
+                            prefix.len(),
+                            pattern,
+                            value,
+                            &subpath[prefix.len()..end],
+                        ))
+                    })
+                    .collect::<Vec<_>>();
+                patterns
+                    .sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(right.1)));
+                let Some((_, _, value, wildcard)) = patterns.first() else {
+                    return Vec::new();
+                };
+                return resolve_javascript_package_export(
+                    value,
+                    subpath,
+                    conditions,
+                    depth + 1,
+                    Some(wildcard),
+                );
+            }
+            // Conditional export objects are ordered by the package author;
+            // Node/TypeScript select the first active key in that source
+            // order, not the first condition in Compass' condition set. A
+            // condition set only says whether a key is active.
+            for (condition, value) in entries {
+                if !conditions.iter().any(|active| *active == condition) {
+                    continue;
+                }
+                let candidates = resolve_javascript_package_export(
+                    value,
+                    subpath,
+                    conditions,
+                    depth + 1,
+                    wildcard,
+                );
+                if !candidates.is_empty() {
+                    return candidates
+                        .into_iter()
+                        .map(|(target, _)| (target, condition.clone()))
+                        .collect();
+                }
+            }
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn javascript_package_legacy_target(
+    manifest: &JavascriptPackageManifest,
+    subpath: &str,
+    conditions: &[String],
+) -> Vec<(String, String)> {
+    if subpath != "." {
+        // Node10 resolves a package subpath as a path under the package root
+        // when no conditional `exports` map applies. Keep the target relative
+        // and let the admitted-inventory probe perform extension/index
+        // substitution; never search outside the package directory.
+        return subpath
+            .strip_prefix("./")
+            .filter(|path| !path.is_empty())
+            .map(|path| (format!("./{path}"), "package-subpath".to_owned()))
+            .into_iter()
+            .collect();
+    }
+    let candidates = if conditions.iter().any(|condition| condition == "require") {
+        [
+            manifest.main.as_deref(),
+            manifest.module.as_deref(),
+            manifest.types.as_deref(),
+        ]
+    } else {
+        [
+            manifest.types.as_deref(),
+            manifest.module.as_deref(),
+            manifest.main.as_deref(),
+        ]
+    };
+    candidates
+        .into_iter()
+        .flatten()
+        .map(|target| {
+            let condition = if manifest.types.as_deref() == Some(target) {
+                "types"
+            } else if manifest.module.as_deref() == Some(target) {
+                "module"
+            } else {
+                "main"
+            };
+            (target.to_owned(), condition.to_owned())
+        })
+        .collect()
+}
+
+fn javascript_types_versions_targets(types_versions: Option<&Value>, subpath: &str) -> Vec<String> {
+    let Some(types_versions) = types_versions.and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    // A semver-aware selector would need the compiler's complete version
+    // range semantics. Support the deterministic catch-all form and a single
+    // explicitly supplied range; multiple unknown ranges remain unresolved.
+    let version_map = if let Some(value) = types_versions.get("*") {
+        value.as_object()
+    } else if types_versions.len() == 1 {
+        types_versions.values().next().and_then(Value::as_object)
+    } else {
+        None
+    };
+    let Some(version_map) = version_map else {
+        return Vec::new();
+    };
+    let request = subpath.strip_prefix("./").unwrap_or(subpath);
+    let request = if request == "." { "" } else { request };
+    let mut matching = version_map
+        .iter()
+        .filter_map(|(pattern, value)| {
+            let wildcard = if let Some((prefix, suffix)) = pattern.split_once('*') {
+                if !request.starts_with(prefix) || !request.ends_with(suffix) {
+                    return None;
+                }
+                let end = request.len().saturating_sub(suffix.len());
+                (end >= prefix.len()).then(|| request[prefix.len()..end].to_owned())
+            } else {
+                (pattern == request).then(String::new)
+            }?;
+            Some((pattern.len(), pattern, value, wildcard))
+        })
+        .collect::<Vec<_>>();
+    matching.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(right.1)));
+    if matching
+        .get(1)
+        .is_some_and(|candidate| candidate.0 == matching[0].0)
+    {
+        return Vec::new();
+    }
+    let Some((_, _, value, wildcard)) = matching.first() else {
+        return Vec::new();
+    };
+    let targets = match value {
+        Value::String(value) => vec![value.clone()],
+        Value::Array(values) => values
+            .iter()
+            .take(256)
+            .filter_map(Value::as_str)
+            .map(str::to_owned)
+            .collect(),
+        _ => Vec::new(),
+    };
+    targets
+        .into_iter()
+        .filter(|target| {
+            !target.is_empty()
+                && target.len() <= 4_096
+                && !target.contains(['\\', '\0'])
+                && !Path::new(target).is_absolute()
+        })
+        .map(|target| {
+            let target = target.replace('*', wildcard);
+            if target.starts_with("./") {
+                target
+            } else {
+                format!("./{target}")
+            }
+        })
+        .collect()
+}
+
+fn is_typescript_source(source: &str) -> bool {
+    matches!(extension(source).as_str(), "ts" | "tsx" | "mts" | "cts")
+}
+
+const MAX_TYPESCRIPT_CONFIGS: usize = 256;
+const MAX_TYPESCRIPT_CONFIG_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_TYPESCRIPT_PATH_RULES: usize = 4_096;
+const MAX_TYPESCRIPT_PATH_TARGETS: usize = 4_096;
+const MAX_TYPESCRIPT_CONFIG_EXTENDS_DEPTH: usize = 32;
+const MAX_TYPESCRIPT_CONFIG_EXTENDS: usize = 64;
+const MAX_TYPESCRIPT_CONFIG_REFERENCES: usize = 1_024;
+const MAX_TYPESCRIPT_FILE_PATTERNS: usize = 4_096;
+const MAX_TYPESCRIPT_TYPE_ROOTS: usize = 256;
+const MAX_TYPESCRIPT_CUSTOM_CONDITIONS: usize = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TypeScriptConfigKind {
+    TypeScript,
+    JavaScript,
+}
+
+#[derive(Clone, Debug)]
+struct TypeScriptPathRule {
+    pattern: String,
+    prefix: String,
+    suffix: String,
+    targets: Vec<TypeScriptPathTarget>,
+}
+
+#[derive(Clone, Debug)]
+struct TypeScriptPathTarget {
+    value: String,
+    base: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct TypeScriptFilePattern {
+    value: String,
+    base: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct TypeScriptPathConfig {
+    source: String,
+    directory: PathBuf,
+    base_url: Option<PathBuf>,
+    rules: Vec<TypeScriptPathRule>,
+    root_dirs: Vec<PathBuf>,
+    module: Option<String>,
+    module_resolution: Option<String>,
+    module_suffixes: Vec<String>,
+    kind: TypeScriptConfigKind,
+    allow_js: bool,
+    check_js: bool,
+    resolve_json_module: bool,
+    references: Vec<PathBuf>,
+    extends_sources: Vec<String>,
+    files: Option<Vec<TypeScriptFilePattern>>,
+    include: Option<Vec<TypeScriptFilePattern>>,
+    exclude: Option<Vec<TypeScriptFilePattern>>,
+    type_roots: Vec<PathBuf>,
+    custom_conditions: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TypeScriptConfigValues {
+    base_url: Option<PathBuf>,
+    paths: Option<Vec<TypeScriptPathRule>>,
+    root_dirs: Option<Vec<PathBuf>>,
+    module: Option<String>,
+    module_resolution: Option<String>,
+    module_suffixes: Option<Vec<String>>,
+    allow_js: Option<bool>,
+    check_js: Option<bool>,
+    resolve_json_module: Option<bool>,
+    references: Vec<PathBuf>,
+    extends_sources: Vec<String>,
+    files: Option<Vec<TypeScriptFilePattern>>,
+    include: Option<Vec<TypeScriptFilePattern>>,
+    exclude: Option<Vec<TypeScriptFilePattern>>,
+    type_roots: Option<Vec<PathBuf>>,
+    custom_conditions: Option<Vec<String>>,
+}
+
+impl TypeScriptConfigValues {
+    fn overlay(&mut self, child: Self) {
+        if child.base_url.is_some() {
+            self.base_url = child.base_url;
+        }
+        if child.paths.is_some() {
+            self.paths = child.paths;
+        }
+        if child.root_dirs.is_some() {
+            self.root_dirs = child.root_dirs;
+        }
+        if child.module.is_some() {
+            self.module = child.module;
+        }
+        if child.module_resolution.is_some() {
+            self.module_resolution = child.module_resolution;
+        }
+        if child.module_suffixes.is_some() {
+            self.module_suffixes = child.module_suffixes;
+        }
+        if child.allow_js.is_some() {
+            self.allow_js = child.allow_js;
+        }
+        if child.check_js.is_some() {
+            self.check_js = child.check_js;
+        }
+        if child.resolve_json_module.is_some() {
+            self.resolve_json_module = child.resolve_json_module;
+        }
+        if child.files.is_some() {
+            self.files = child.files;
+        }
+        if child.include.is_some() {
+            self.include = child.include;
+        }
+        if child.exclude.is_some() {
+            self.exclude = child.exclude;
+        }
+        if child.type_roots.is_some() {
+            self.type_roots = child.type_roots;
+        }
+        if child.custom_conditions.is_some() {
+            self.custom_conditions = child.custom_conditions;
+        }
+        self.references.extend(child.references);
+        self.extends_sources.extend(child.extends_sources);
+    }
+}
+
+/// Resolve TypeScript `compilerOptions.paths` and `baseUrl` using the source
+/// inventory already admitted by Compass. This is intentionally separate from
+/// package exports: a project alias is a compiler mapping and takes precedence
+/// over a same-spelled npm package, while unresolved or ambiguous mappings are
+/// left as the extractor emitted them.
+fn resolve_javascript_typescript_paths(
+    extraction: &mut Extraction,
+    root: &Path,
+    sources: &HashMap<String, String>,
+) -> Result<(), String> {
+    let (configs, referenced_configs) = collect_typescript_configs(extraction, root, sources)?;
+    if configs.is_empty() {
+        return Ok(());
+    }
+
+    let mut file_by_source = BTreeMap::<String, (String, String)>::new();
+    let mut source_by_file = HashMap::<String, String>::new();
+    for node in &extraction.nodes {
+        let source = string_attribute(node, "source_file");
+        if !is_file_node(node, &source) {
+            continue;
+        }
+        let key = source_key(&source, root);
+        if !is_safe_relative_source(&key) {
+            continue;
+        }
+        file_by_source
+            .entry(key)
+            .or_insert_with(|| (node.id.clone(), source.clone()));
+        source_by_file.entry(node.id.clone()).or_insert(source);
+    }
+
+    for edge in &mut extraction.edges {
+        if relation(edge) != "imports_from" {
+            continue;
+        }
+        let module = edge.string("module");
+        if module.is_empty() || module.len() > 4_096 {
+            continue;
+        }
+        let importer = {
+            let source = edge.string("source_file");
+            if source.is_empty() {
+                source_by_file
+                    .get(&edge.source)
+                    .cloned()
+                    .unwrap_or_default()
+            } else {
+                source
+            }
+        };
+        let config = select_typescript_path_config(&configs, &referenced_configs, root, &importer);
+        let resolved = if module.starts_with('.') {
+            resolve_typescript_relative_module(config, &importer, &module, &file_by_source, root)
+        } else {
+            let Some(config) = config else {
+                continue;
+            };
+            resolve_typescript_module(config, &module, &file_by_source, root)
+        };
+        let Some((target, rule)) = resolved else {
+            continue;
+        };
+        let Some((target_id, target_source)) = file_by_source.get(&target) else {
+            continue;
+        };
+        if edge.target != *target_id {
+            edge.target.clone_from(target_id);
+            stamp_endpoint_rewrite(edge, EndpointRewriteRule::CanonicalImportTarget, 1.0);
+        }
+        edge.attributes.insert(
+            "target_file".to_owned(),
+            Value::String(target_source.clone()),
+        );
+        edge.attributes
+            .insert("resolution_rule".to_owned(), Value::String(rule.to_owned()));
+        if let Some(config) = config {
+            edge.attributes.insert(
+                "resolution_config".to_owned(),
+                Value::String(config.source.clone()),
+            );
+            if let Some(module_resolution) = &config.module_resolution {
+                edge.attributes.insert(
+                    "module_resolution".to_owned(),
+                    Value::String(module_resolution.clone()),
+                );
+            }
+            if let Some(module) = &config.module {
+                edge.attributes
+                    .insert("module_kind".to_owned(), Value::String(module.clone()));
+            }
+            if !config.references.is_empty() {
+                let references = config
+                    .references
+                    .iter()
+                    .map(|reference| Value::String(source_key(&reference.to_string_lossy(), root)))
+                    .collect::<Vec<_>>();
+                edge.attributes.insert(
+                    "resolution_project_references".to_owned(),
+                    Value::Array(references),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_typescript_configs(
+    extraction: &Extraction,
+    root: &Path,
+    sources: &HashMap<String, String>,
+) -> Result<(Vec<TypeScriptPathConfig>, BTreeSet<String>), String> {
+    let mut config_sources = BTreeSet::new();
+    for source in sources.keys() {
+        let key = source_key(source, root);
+        if is_typescript_config_source(&key) && is_safe_relative_source(&key) {
+            config_sources.insert(key);
+        }
+    }
+    for node in &extraction.nodes {
+        let source = string_attribute(node, "source_file");
+        let key = source_key(&source, root);
+        if is_typescript_config_source(&key) && is_safe_relative_source(&key) {
+            config_sources.insert(key);
+        }
+    }
+    if config_sources.len() > MAX_TYPESCRIPT_CONFIGS {
+        return Err(format!(
+            "TypeScript project configuration count {} exceeds limit {MAX_TYPESCRIPT_CONFIGS}",
+            config_sources.len()
+        ));
+    }
+
+    let mut configs = Vec::new();
+    let mut config_cache = HashMap::<String, Option<TypeScriptConfigValues>>::new();
+    for source in config_sources {
+        let Some(contents) = read_typescript_config_source(root, &source, sources)? else {
+            continue;
+        };
+        if let Some(config) =
+            parse_typescript_path_config(root, &source, &contents, sources, &mut config_cache)?
+        {
+            configs.push(config);
+        }
+    }
+    configs.sort_by(|left, right| left.source.cmp(&right.source));
+    let referenced_configs = configs
+        .iter()
+        .flat_map(|config| config.extends_sources.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    Ok((configs, referenced_configs))
+}
+
+fn is_typescript_config_source(source: &str) -> bool {
+    let Some(name) = Path::new(source)
+        .file_name()
+        .and_then(|value| value.to_str())
+    else {
+        return false;
+    };
+    let lower = name.to_ascii_lowercase();
+    (lower == "tsconfig.json" || (lower.starts_with("tsconfig.") && lower.ends_with(".json")))
+        || (lower == "jsconfig.json"
+            || (lower.starts_with("jsconfig.") && lower.ends_with(".json")))
+}
+
+fn is_safe_relative_source(source: &str) -> bool {
+    let path = Path::new(source);
+    !path.is_absolute()
+        && !path
+            .components()
+            .any(|component| component == std::path::Component::ParentDir)
+}
+
+fn read_typescript_config_source(
+    root: &Path,
+    source: &str,
+    sources: &HashMap<String, String>,
+) -> Result<Option<String>, String> {
+    let mut in_memory = sources
+        .iter()
+        .filter(|(candidate, _)| source_key(candidate, root) == source)
+        .collect::<Vec<_>>();
+    in_memory.sort_by_key(|(candidate, _)| *candidate);
+    if let Some((_, contents)) = in_memory.first() {
+        if in_memory
+            .iter()
+            .skip(1)
+            .any(|(_, candidate)| *candidate != *contents)
+        {
+            return Err(format!(
+                "multiple in-memory contents disagree for TypeScript config {source:?}"
+            ));
+        }
+        if contents.is_empty() {
+            return Ok(None);
+        }
+        if contents.len() as u64 <= MAX_TYPESCRIPT_CONFIG_BYTES {
+            return Ok(Some((*contents).clone()));
+        }
+        return Err(format!(
+            "TypeScript config {source:?} exceeds {MAX_TYPESCRIPT_CONFIG_BYTES} bytes"
+        ));
+    }
+    let path = root.join(source);
+    let canonical = match std::fs::canonicalize(&path) {
+        Ok(path) => path,
+        Err(_) => return Ok(None),
+    };
+    if !canonical.starts_with(root) {
+        return Ok(None);
+    }
+    match compass_files::read_source_lossy(&canonical, MAX_TYPESCRIPT_CONFIG_BYTES) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn parse_typescript_path_config(
+    root: &Path,
+    source: &str,
+    contents: &str,
+    sources: &HashMap<String, String>,
+    cache: &mut HashMap<String, Option<TypeScriptConfigValues>>,
+) -> Result<Option<TypeScriptPathConfig>, String> {
+    let mut stack = Vec::new();
+    let Some(values) =
+        load_typescript_config_values(root, source, contents, sources, cache, &mut stack, 0)?
+    else {
+        return Ok(None);
+    };
+    let config_path = root.join(source);
+    let Some(directory) = config_path.parent() else {
+        return Ok(None);
+    };
+    let kind = Path::new(source)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map_or(TypeScriptConfigKind::TypeScript, |name| {
+            if name.to_ascii_lowercase().starts_with("jsconfig.") {
+                TypeScriptConfigKind::JavaScript
+            } else {
+                TypeScriptConfigKind::TypeScript
+            }
+        });
+    let has_project_metadata = values.base_url.is_some()
+        || values.paths.as_ref().is_some_and(|paths| !paths.is_empty())
+        || values
+            .root_dirs
+            .as_ref()
+            .is_some_and(|roots| !roots.is_empty())
+        || values.module.is_some()
+        || values.module_resolution.is_some()
+        || values.module_suffixes.is_some()
+        || values.allow_js.is_some()
+        || values.check_js.is_some()
+        || values.resolve_json_module.is_some()
+        || !values.references.is_empty()
+        || values.files.as_ref().is_some_and(|files| !files.is_empty())
+        || values
+            .include
+            .as_ref()
+            .is_some_and(|include| !include.is_empty())
+        || values
+            .exclude
+            .as_ref()
+            .is_some_and(|exclude| !exclude.is_empty())
+        || values
+            .type_roots
+            .as_ref()
+            .is_some_and(|roots| !roots.is_empty())
+        || values
+            .custom_conditions
+            .as_ref()
+            .is_some_and(|conditions| !conditions.is_empty());
+    if !has_project_metadata {
+        return Ok(None);
+    }
+    let mut references = values.references;
+    references.sort();
+    references.dedup();
+    let mut extends_sources = values.extends_sources;
+    extends_sources.sort();
+    extends_sources.dedup();
+    let mut type_roots = values.type_roots.unwrap_or_default();
+    type_roots.sort();
+    type_roots.dedup();
+    let custom_conditions = values
+        .custom_conditions
+        .unwrap_or_default()
+        .into_iter()
+        .fold(Vec::new(), |mut conditions, condition| {
+            if !conditions.contains(&condition) {
+                conditions.push(condition);
+            }
+            conditions
+        });
+    Ok(Some(TypeScriptPathConfig {
+        source: source.to_owned(),
+        directory: directory.to_path_buf(),
+        base_url: values.base_url,
+        rules: values.paths.unwrap_or_default(),
+        root_dirs: values.root_dirs.unwrap_or_default(),
+        module: values.module,
+        module_resolution: values.module_resolution,
+        module_suffixes: values.module_suffixes.unwrap_or_default(),
+        kind,
+        allow_js: values.allow_js.unwrap_or(false),
+        check_js: values.check_js.unwrap_or(false),
+        resolve_json_module: values.resolve_json_module.unwrap_or(false),
+        references,
+        extends_sources,
+        files: values.files,
+        include: values.include,
+        exclude: values.exclude,
+        type_roots,
+        custom_conditions,
+    }))
+}
+
+fn load_typescript_config_values(
+    root: &Path,
+    source: &str,
+    contents: &str,
+    sources: &HashMap<String, String>,
+    cache: &mut HashMap<String, Option<TypeScriptConfigValues>>,
+    stack: &mut Vec<String>,
+    depth: usize,
+) -> Result<Option<TypeScriptConfigValues>, String> {
+    if depth > MAX_TYPESCRIPT_CONFIG_EXTENDS_DEPTH {
+        return Err(format!(
+            "TypeScript config extends depth exceeds {MAX_TYPESCRIPT_CONFIG_EXTENDS_DEPTH}"
+        ));
+    }
+    if let Some(cached) = cache.get(source) {
+        return Ok(cached.clone());
+    }
+    if stack.iter().any(|candidate| candidate == source) {
+        return Err(format!(
+            "TypeScript config extends cycle includes {source:?}"
+        ));
+    }
+    let Some(value) = parse_jsonc(contents) else {
+        cache.insert(source.to_owned(), None);
+        return Ok(None);
+    };
+    let Some(object) = value.as_object() else {
+        cache.insert(source.to_owned(), None);
+        return Ok(None);
+    };
+    stack.push(source.to_owned());
+    let extends = typescript_config_extends(object)?;
+    let mut values = TypeScriptConfigValues::default();
+    for base in extends {
+        let base_source = resolve_typescript_extends_source(root, source, &base, sources)?
+            .ok_or_else(|| {
+                format!("TypeScript config {source:?} extends missing config {base:?}")
+            })?;
+        let base_contents = read_typescript_config_source(root, &base_source, sources)?
+            .ok_or_else(|| {
+                format!("TypeScript config {source:?} extends unreadable config {base_source:?}")
+            })?;
+        let base_values = load_typescript_config_values(
+            root,
+            &base_source,
+            &base_contents,
+            sources,
+            cache,
+            stack,
+            depth.saturating_add(1),
+        )?
+        .ok_or_else(|| {
+            format!("TypeScript config {source:?} extends invalid config {base_source:?}")
+        })?;
+        values.overlay(base_values);
+        values.extends_sources.push(base_source);
+    }
+    let local = parse_typescript_config_values(root, source, object, values.base_url.as_ref())?;
+    values.overlay(local);
+    stack.pop();
+    cache.insert(source.to_owned(), Some(values.clone()));
+    Ok(Some(values))
+}
+
+fn typescript_config_extends(
+    object: &serde_json::Map<String, Value>,
+) -> Result<Vec<String>, String> {
+    let Some(value) = object.get("extends") else {
+        return Ok(Vec::new());
+    };
+    let values = match value {
+        Value::String(value) => vec![Some(value.clone())],
+        Value::Array(values) => values
+            .iter()
+            .map(|value| value.as_str().map(str::to_owned))
+            .collect::<Vec<_>>(),
+        _ => return Err("TypeScript config extends must be a string or array".to_owned()),
+    };
+    if values.len() > MAX_TYPESCRIPT_CONFIG_EXTENDS {
+        return Err(format!(
+            "TypeScript config extends count exceeds {MAX_TYPESCRIPT_CONFIG_EXTENDS}"
+        ));
+    }
+    values
+        .into_iter()
+        .map(|value| {
+            let Some(value) = value.filter(|value| !value.is_empty()) else {
+                return Err(
+                    "TypeScript config extends entries must be non-empty strings".to_owned(),
+                );
+            };
+            if value.len() > 4_096 || value.contains('\0') {
+                return Err(
+                    "TypeScript config extends entry is too long or contains NUL".to_owned(),
+                );
+            }
+            Ok(value.to_owned())
+        })
+        .collect()
+}
+
+fn resolve_typescript_extends_source(
+    root: &Path,
+    source: &str,
+    extends: &str,
+    sources: &HashMap<String, String>,
+) -> Result<Option<String>, String> {
+    let source_directory = root
+        .join(source)
+        .parent()
+        .map_or_else(|| root.to_path_buf(), Path::to_path_buf);
+    let mut candidates = Vec::new();
+    let mut push_candidate = |candidate: PathBuf| {
+        let candidate = lexical_path(&candidate);
+        if !candidate.starts_with(root) {
+            return;
+        }
+        let key = source_key(&candidate.to_string_lossy(), root);
+        if is_safe_relative_source(&key) && !candidates.contains(&key) {
+            candidates.push(key);
+        }
+    };
+    if extends.starts_with('.') || extends.starts_with('/') {
+        let Some(path) = safe_typescript_config_path(&source_directory, root, extends) else {
+            return Ok(None);
+        };
+        push_candidate(path.clone());
+        if path.extension().is_none() {
+            push_candidate(path.with_extension("json"));
+        }
+    } else {
+        let mut directory = source_directory;
+        for _ in 0..MAX_TYPESCRIPT_CONFIG_EXTENDS_DEPTH {
+            let package = directory.join("node_modules").join(extends);
+            push_candidate(package.clone());
+            if package.extension().is_none() {
+                push_candidate(package.with_extension("json"));
+            }
+            push_candidate(package.join("tsconfig.json"));
+            if directory == root {
+                break;
+            }
+            let Some(parent) = directory.parent() else {
+                break;
+            };
+            if !parent.starts_with(root) {
+                break;
+            }
+            directory = parent.to_path_buf();
+        }
+    }
+    for candidate in candidates {
+        if read_typescript_config_source(root, &candidate, sources)?.is_some() {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_typescript_config_values(
+    root: &Path,
+    source: &str,
+    object: &serde_json::Map<String, Value>,
+    inherited_base_url: Option<&PathBuf>,
+) -> Result<TypeScriptConfigValues, String> {
+    let config_path = root.join(source);
+    let Some(directory) = config_path.parent() else {
+        return Ok(TypeScriptConfigValues::default());
+    };
+    let options = object.get("compilerOptions").and_then(Value::as_object);
+    let local_base_url = options
+        .and_then(|options| options.get("baseUrl"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty() && value.len() <= 4_096)
+        .and_then(|value| safe_typescript_config_path(directory, root, value));
+    let effective_path_base = local_base_url
+        .clone()
+        .or_else(|| inherited_base_url.cloned())
+        .unwrap_or_else(|| directory.to_path_buf());
+    let mut values = TypeScriptConfigValues {
+        base_url: local_base_url,
+        ..TypeScriptConfigValues::default()
+    };
+    values.files = parse_typescript_file_patterns(object.get("files"), "files", directory)?;
+    values.include = parse_typescript_file_patterns(object.get("include"), "include", directory)?;
+    values.exclude = parse_typescript_file_patterns(object.get("exclude"), "exclude", directory)?;
+    if let Some(options) = options {
+        if let Some(paths) = options.get("paths") {
+            let Some(paths) = paths.as_object() else {
+                return Err("TypeScript compilerOptions.paths must be an object".to_owned());
+            };
+            if paths.len() > MAX_TYPESCRIPT_PATH_RULES {
+                return Err(format!(
+                    "TypeScript path rule count {} exceeds limit {MAX_TYPESCRIPT_PATH_RULES}",
+                    paths.len()
+                ));
+            }
+            let mut rules = Vec::new();
+            let mut target_count = 0_usize;
+            for (pattern, targets) in paths {
+                if pattern.is_empty() || pattern.len() > 4_096 || pattern.matches('*').count() > 1 {
+                    continue;
+                }
+                let target_values = match targets {
+                    Value::Array(values) => values.iter().collect::<Vec<_>>(),
+                    Value::String(_) => vec![targets],
+                    _ => Vec::new(),
+                };
+                let mut normalized_targets = Vec::new();
+                for target in target_values {
+                    let Some(target) = target.as_str() else {
+                        continue;
+                    };
+                    if target.is_empty()
+                        || target.len() > 4_096
+                        || target.matches('*').count() > 1
+                        || safe_typescript_config_path(&effective_path_base, root, target).is_none()
+                    {
+                        continue;
+                    }
+                    normalized_targets.push(TypeScriptPathTarget {
+                        value: target.to_owned(),
+                        base: effective_path_base.clone(),
+                    });
+                    target_count = target_count.saturating_add(1);
+                    if target_count > MAX_TYPESCRIPT_PATH_TARGETS {
+                        return Err(format!(
+                            "TypeScript path target count exceeds limit {MAX_TYPESCRIPT_PATH_TARGETS}"
+                        ));
+                    }
+                }
+                if normalized_targets.is_empty() {
+                    continue;
+                }
+                let (prefix, suffix) = pattern.split_once('*').map_or_else(
+                    || (pattern.as_str(), ""),
+                    |(prefix, suffix)| (prefix, suffix),
+                );
+                rules.push(TypeScriptPathRule {
+                    pattern: pattern.clone(),
+                    prefix: prefix.to_owned(),
+                    suffix: suffix.to_owned(),
+                    targets: normalized_targets,
+                });
+            }
+            rules.sort_by(|left, right| {
+                right
+                    .prefix
+                    .len()
+                    .cmp(&left.prefix.len())
+                    .then_with(|| left.pattern.cmp(&right.pattern))
+            });
+            values.paths = Some(rules);
+        }
+        values.root_dirs = options.get("rootDirs").map(|value| {
+            value
+                .as_array()
+                .map(|roots| {
+                    roots
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter_map(|root_dir| {
+                            safe_typescript_config_path(directory, root, root_dir)
+                        })
+                        .take(256)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        });
+        values.module = options
+            .get("module")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty() && value.len() <= 128)
+            .map(str::to_ascii_lowercase);
+        values.module_resolution = options
+            .get("moduleResolution")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty() && value.len() <= 128)
+            .map(str::to_ascii_lowercase);
+        values.module_suffixes = options.get("moduleSuffixes").map(|value| {
+            value
+                .as_array()
+                .map(|suffixes| {
+                    suffixes
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|suffix| suffix.len() <= 128)
+                        .map(str::to_owned)
+                        .take(256)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        });
+        values.allow_js = options.get("allowJs").and_then(Value::as_bool);
+        values.check_js = options.get("checkJs").and_then(Value::as_bool);
+        values.resolve_json_module = options.get("resolveJsonModule").and_then(Value::as_bool);
+        values.type_roots = parse_typescript_path_array(
+            options.get("typeRoots"),
+            "compilerOptions.typeRoots",
+            directory,
+            root,
+            MAX_TYPESCRIPT_TYPE_ROOTS,
+        )?;
+        values.custom_conditions = parse_typescript_string_array(
+            options.get("customConditions"),
+            "compilerOptions.customConditions",
+            MAX_TYPESCRIPT_CUSTOM_CONDITIONS,
+        )?;
+    }
+    if let Some(references) = object.get("references") {
+        let Some(references) = references.as_array() else {
+            return Err("TypeScript config references must be an array".to_owned());
+        };
+        if references.len() > MAX_TYPESCRIPT_CONFIG_REFERENCES {
+            return Err(format!(
+                "TypeScript project reference count exceeds {MAX_TYPESCRIPT_CONFIG_REFERENCES}"
+            ));
+        }
+        for reference in references {
+            let Some(path) = reference
+                .as_object()
+                .and_then(|reference| reference.get("path"))
+                .and_then(Value::as_str)
+                .filter(|path| !path.is_empty() && path.len() <= 4_096)
+            else {
+                continue;
+            };
+            if let Some(path) = safe_typescript_config_path(directory, root, path) {
+                values.references.push(path);
+            }
+        }
+    }
+    Ok(values)
+}
+
+fn parse_typescript_file_patterns(
+    value: Option<&Value>,
+    key: &str,
+    base: &Path,
+) -> Result<Option<Vec<TypeScriptFilePattern>>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(format!("TypeScript config {key} must be an array"));
+    };
+    if values.len() > MAX_TYPESCRIPT_FILE_PATTERNS {
+        return Err(format!(
+            "TypeScript config {key} count exceeds {MAX_TYPESCRIPT_FILE_PATTERNS}"
+        ));
+    }
+    let mut patterns = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value.as_str() else {
+            return Err(format!("TypeScript config {key} entries must be strings"));
+        };
+        let normalized = value.replace('\\', "/");
+        if normalized.is_empty()
+            || normalized.len() > 4_096
+            || normalized.contains('\0')
+            || Path::new(&normalized).is_absolute()
+        {
+            return Err(format!(
+                "TypeScript config {key} contains an invalid pattern"
+            ));
+        }
+        patterns.push(TypeScriptFilePattern {
+            value: normalized,
+            base: base.to_path_buf(),
+        });
+    }
+    Ok(Some(patterns))
+}
+
+fn parse_typescript_path_array(
+    value: Option<&Value>,
+    key: &str,
+    base: &Path,
+    root: &Path,
+    limit: usize,
+) -> Result<Option<Vec<PathBuf>>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(format!("TypeScript config {key} must be an array"));
+    };
+    if values.len() > limit {
+        return Err(format!("TypeScript config {key} count exceeds {limit}"));
+    }
+    let mut paths = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value.as_str().filter(|value| !value.is_empty()) else {
+            return Err(format!("TypeScript config {key} entries must be strings"));
+        };
+        if value.len() > 4_096 || value.contains('\0') {
+            return Err(format!("TypeScript config {key} contains an invalid path"));
+        }
+        let Some(path) = safe_typescript_config_path(base, root, value) else {
+            return Err(format!(
+                "TypeScript config {key} path escapes the workspace"
+            ));
+        };
+        paths.push(path);
+    }
+    Ok(Some(paths))
+}
+
+fn parse_typescript_string_array(
+    value: Option<&Value>,
+    key: &str,
+    limit: usize,
+) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(format!("TypeScript config {key} must be an array"));
+    };
+    if values.len() > limit {
+        return Err(format!("TypeScript config {key} count exceeds {limit}"));
+    }
+    let mut output = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value.as_str().filter(|value| !value.is_empty()) else {
+            return Err(format!("TypeScript config {key} entries must be strings"));
+        };
+        if value.len() > 256 || value.contains(['\\', '\0']) {
+            return Err(format!(
+                "TypeScript config {key} contains an invalid condition"
+            ));
+        }
+        output.push(value.to_owned());
+    }
+    Ok(Some(output))
+}
+
+fn safe_typescript_config_path(base: &Path, root: &Path, value: &str) -> Option<PathBuf> {
+    if value.contains('\0') {
+        return None;
+    }
+    // TypeScript project files commonly use Windows separators even when the
+    // graph is qualified on another host. Normalize only the configuration
+    // spelling; source inventory paths remain platform-native and bounded.
+    let normalized = value.replace('\\', "/");
+    let path = Path::new(&normalized);
+    let candidate = if path.is_absolute() {
+        lexical_path(path)
+    } else {
+        lexical_path(&base.join(path))
+    };
+    candidate.starts_with(root).then_some(candidate)
+}
+
+fn select_typescript_path_config<'a>(
+    configs: &'a [TypeScriptPathConfig],
+    referenced_configs: &BTreeSet<String>,
+    root: &Path,
+    importer: &str,
+) -> Option<&'a TypeScriptPathConfig> {
+    let importer_key = source_key(importer, root);
+    if !is_safe_relative_source(&importer_key) {
+        return None;
+    }
+    let importer_path = root.join(&importer_key);
+    let importer_extension = extension(importer);
+    let mut candidates = configs
+        .iter()
+        .filter(|config| {
+            !referenced_configs.contains(&config.source)
+                && importer_path.starts_with(&config.directory)
+                && typescript_config_applies(config, &importer_extension)
+                && typescript_config_owns_source(config, &importer_key, root, false)
+        })
+        .collect::<Vec<_>>();
+    let deepest = candidates
+        .iter()
+        .map(|config| config.directory.components().count())
+        .max()?;
+    candidates.retain(|config| config.directory.components().count() == deepest);
+    if candidates.len() == 1 {
+        return candidates.pop();
+    }
+    // Two configs at the same project depth are not interchangeable. A
+    // compiler invocation selects one explicitly; Compass has no such command
+    // context, so it preserves the import rather than guessing.
+    None
+}
+
+fn typescript_config_applies(config: &TypeScriptPathConfig, extension: &str) -> bool {
+    let javascript = matches!(extension, "js" | "jsx" | "mjs" | "cjs");
+    match config.kind {
+        TypeScriptConfigKind::JavaScript => javascript,
+        TypeScriptConfigKind::TypeScript => !javascript || config.allow_js || config.check_js,
+    }
+}
+
+fn typescript_config_owns_source(
+    config: &TypeScriptPathConfig,
+    source: &str,
+    root: &Path,
+    allow_missing_extension: bool,
+) -> bool {
+    let source_key = source_key(source, root);
+    if !is_safe_relative_source(&source_key) {
+        return false;
+    }
+    let source_path = root.join(&source_key);
+    let extension = extension(&source_key);
+    if !allow_missing_extension
+        && !typescript_config_applies(config, &extension)
+        && !extension.is_empty()
+    {
+        return false;
+    }
+
+    let explicitly_included = config.files.as_ref().map_or_else(
+        || {
+            config.include.as_ref().is_none_or(|patterns| {
+                patterns
+                    .iter()
+                    .any(|pattern| typescript_pattern_matches(pattern, &source_path, false))
+            })
+        },
+        |patterns| {
+            patterns
+                .iter()
+                .any(|pattern| typescript_pattern_matches(pattern, &source_path, true))
+        },
+    );
+    if !explicitly_included {
+        return false;
+    }
+
+    if config.exclude.as_ref().is_some_and(|patterns| {
+        patterns
+            .iter()
+            .any(|pattern| typescript_pattern_matches(pattern, &source_path, false))
+    }) {
+        return false;
+    }
+
+    // TypeScript's default exclude keeps dependency trees out of a project
+    // when the config did not supply an explicit exclude list. Preserve this
+    // boundary even when the source inventory contains vendored files.
+    if config.exclude.is_none()
+        && source_path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::Normal(value)
+                    if matches!(
+                        value.to_str(),
+                        Some("node_modules") | Some("bower_components") | Some("jspm_packages")
+                    )
+            )
+        })
+    {
+        return false;
+    }
+    true
+}
+
+fn typescript_pattern_matches(
+    pattern: &TypeScriptFilePattern,
+    source: &Path,
+    exact_file: bool,
+) -> bool {
+    let Ok(relative) = source.strip_prefix(&pattern.base) else {
+        return false;
+    };
+    let relative = relative
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("./")
+        .to_owned();
+    let pattern_value = pattern.value.trim_start_matches("./");
+    if !exact_file
+        && !pattern_value.contains(['*', '?'])
+        && (relative == pattern_value || relative.starts_with(&format!("{pattern_value}/")))
+    {
+        return true;
+    }
+    glob_path_matches(pattern_value, &relative)
+}
+
+fn glob_path_matches(pattern: &str, path: &str) -> bool {
+    let pattern_parts = pattern
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    let path_parts = path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    fn matches_segment(pattern: &str, value: &str) -> bool {
+        let pattern = pattern.as_bytes();
+        let value = value.as_bytes();
+        let mut table = vec![vec![false; value.len() + 1]; pattern.len() + 1];
+        table[0][0] = true;
+        for index in 0..pattern.len() {
+            for value_index in 0..=value.len() {
+                if !table[index][value_index] {
+                    continue;
+                }
+                match pattern[index] {
+                    b'*' => {
+                        table[index + 1][value_index] = true;
+                        if value_index < value.len() {
+                            table[index][value_index + 1] = true;
+                        }
+                    }
+                    b'?' if value_index < value.len() => {
+                        table[index + 1][value_index + 1] = true;
+                    }
+                    byte if value_index < value.len() && byte == value[value_index] => {
+                        table[index + 1][value_index + 1] = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        table[pattern.len()][value.len()]
+    }
+    fn matches_parts(pattern: &[&str], path: &[&str]) -> bool {
+        if pattern.is_empty() {
+            return path.is_empty();
+        }
+        if pattern[0] == "**" {
+            return matches_parts(&pattern[1..], path)
+                || (!path.is_empty() && matches_parts(pattern, &path[1..]));
+        }
+        !path.is_empty()
+            && matches_segment(pattern[0], path[0])
+            && matches_parts(&pattern[1..], &path[1..])
+    }
+    matches_parts(&pattern_parts, &path_parts)
+}
+
+fn resolve_typescript_module(
+    config: &TypeScriptPathConfig,
+    module: &str,
+    file_by_source: &BTreeMap<String, (String, String)>,
+    root: &Path,
+) -> Option<(String, &'static str)> {
+    let mut matching = config
+        .rules
+        .iter()
+        .filter_map(|rule| {
+            let wildcard = if rule.pattern.contains('*') {
+                if !module.starts_with(&rule.prefix) || !module.ends_with(&rule.suffix) {
+                    return None;
+                }
+                let end = module.len().saturating_sub(rule.suffix.len());
+                (end >= rule.prefix.len()).then(|| module[rule.prefix.len()..end].to_owned())
+            } else {
+                (rule.pattern == module).then(String::new)
+            }?;
+            Some((rule, wildcard))
+        })
+        .collect::<Vec<_>>();
+    if let Some(longest_prefix) = matching.iter().map(|(rule, _)| rule.prefix.len()).max() {
+        matching.retain(|(rule, _)| rule.prefix.len() == longest_prefix);
+    }
+    if !matching.is_empty() {
+        if matching.len() != 1 {
+            return None;
+        }
+        let (rule, wildcard) = matching.pop()?;
+        for target in &rule.targets {
+            let substituted = if rule.pattern.contains('*') {
+                target.value.replace('*', &wildcard)
+            } else {
+                target.value.clone()
+            };
+            if let Some(source) = resolve_typescript_target(
+                &target.base,
+                &substituted,
+                file_by_source,
+                root,
+                config.resolve_json_module,
+                &config.module_suffixes,
+            ) && typescript_config_owns_source(config, &source, root, true)
+            {
+                return Some((source, "typescript-paths"));
+            }
+        }
+        return None;
+    }
+    if let Some(base_url) = config.base_url.as_ref()
+        && let Some(source) = resolve_typescript_target(
+            base_url,
+            module,
+            file_by_source,
+            root,
+            config.resolve_json_module,
+            &config.module_suffixes,
+        )
+        && typescript_config_owns_source(config, &source, root, true)
+    {
+        return Some((source, "typescript-base-url"));
+    }
+    resolve_typescript_type_root_module(config, module, file_by_source, root)
+}
+
+fn resolve_typescript_type_root_module(
+    config: &TypeScriptPathConfig,
+    module: &str,
+    file_by_source: &BTreeMap<String, (String, String)>,
+    root: &Path,
+) -> Option<(String, &'static str)> {
+    if config.type_roots.is_empty() || module.is_empty() || module.starts_with('#') {
+        return None;
+    }
+    let mut package_names = vec![module.to_owned()];
+    if let Some((scope, package)) = module
+        .strip_prefix('@')
+        .and_then(|module| module.split_once('/'))
+        && !scope.is_empty()
+        && !package.is_empty()
+    {
+        package_names.push(format!("{scope}__{package}"));
+    }
+    for type_root in &config.type_roots {
+        for package_name in &package_names {
+            if let Some(source) = resolve_typescript_target(
+                type_root,
+                package_name,
+                file_by_source,
+                root,
+                config.resolve_json_module,
+                &config.module_suffixes,
+            ) && typescript_config_owns_source(config, &source, root, true)
+            {
+                return Some((source, "typescript-type-roots"));
+            }
+            // A typeRoots entry is commonly the parent of an `@types`
+            // directory, while some projects point directly at that folder.
+            // Try the explicit package path only when it differs from the
+            // direct candidate to preserve deterministic target order.
+            if !type_root.ends_with("@types") {
+                let at_types = format!("@types/{package_name}");
+                if let Some(source) = resolve_typescript_target(
+                    type_root,
+                    &at_types,
+                    file_by_source,
+                    root,
+                    config.resolve_json_module,
+                    &config.module_suffixes,
+                ) && typescript_config_owns_source(config, &source, root, true)
+                {
+                    return Some((source, "typescript-type-roots"));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn resolve_typescript_relative_module(
+    config: Option<&TypeScriptPathConfig>,
+    importer: &str,
+    module: &str,
+    file_by_source: &BTreeMap<String, (String, String)>,
+    root: &Path,
+) -> Option<(String, &'static str)> {
+    let importer_key = source_key(importer, root);
+    if !is_safe_relative_source(&importer_key) {
+        return None;
+    }
+    let importer_path = root.join(&importer_key);
+    let importer_directory = importer_path.parent().unwrap_or(root);
+    let raw_module = module.replace('\\', "/");
+    let direct = lexical_path(&importer_directory.join(&raw_module));
+    if !direct.starts_with(root) {
+        return None;
+    }
+    let mut bases = vec![(direct, "typescript-relative")];
+    if let Some(config) = config
+        && !config.root_dirs.is_empty()
+    {
+        let mut virtual_relative = None;
+        let mut importer_root = None;
+        for root_dir in &config.root_dirs {
+            if let Ok(relative) = importer_path.strip_prefix(root_dir) {
+                virtual_relative = Some(relative.to_path_buf());
+                importer_root = Some(root_dir);
+                break;
+            }
+        }
+        if let (Some(relative), Some(importer_root)) = (virtual_relative, importer_root) {
+            let virtual_parent = relative.parent().unwrap_or_else(|| Path::new(""));
+            for root_dir in &config.root_dirs {
+                if root_dir == importer_root {
+                    continue;
+                }
+                let candidate = lexical_path(&root_dir.join(virtual_parent).join(&raw_module));
+                if candidate.starts_with(root) {
+                    bases.push((candidate, "typescript-root-dirs"));
+                }
+            }
+        }
+    }
+    let module_suffixes =
+        config.map_or(&[] as &[String], |config| config.module_suffixes.as_slice());
+    for (base, rule) in bases {
+        let candidates = typescript_target_candidates(&base, module_suffixes);
+        for candidate in candidates {
+            if config.is_some_and(|config| {
+                !config.resolve_json_module
+                    && candidate
+                        .extension()
+                        .and_then(|value| value.to_str())
+                        .is_some_and(|value| value.eq_ignore_ascii_case("json"))
+            }) {
+                continue;
+            }
+            let key = source_key(&candidate.to_string_lossy(), root);
+            if file_by_source.contains_key(&key)
+                && config
+                    .is_none_or(|config| typescript_config_owns_source(config, &key, root, true))
+            {
+                return Some((key, rule));
+            }
+        }
+    }
+    None
+}
+
+fn resolve_typescript_target(
+    base: &Path,
+    target: &str,
+    file_by_source: &BTreeMap<String, (String, String)>,
+    root: &Path,
+    resolve_json_module: bool,
+    module_suffixes: &[String],
+) -> Option<String> {
+    let target = safe_typescript_config_path(base, root, target)?;
+    let candidates = typescript_target_candidates(&target, module_suffixes);
+    for candidate in candidates {
+        if !resolve_json_module
+            && candidate
+                .extension()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.eq_ignore_ascii_case("json"))
+        {
+            continue;
+        }
+        let key = source_key(&candidate.to_string_lossy(), root);
+        if file_by_source.contains_key(&key) {
+            return Some(key);
+        }
+    }
+    None
+}
+
+fn typescript_target_candidates(path: &Path, module_suffixes: &[String]) -> Vec<PathBuf> {
+    let mut base_candidates = Vec::new();
+    let mut push = |candidate: PathBuf| {
+        if !base_candidates.contains(&candidate) {
+            base_candidates.push(candidate);
+        }
+    };
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "js" => {
+            push(path.with_extension("ts"));
+            push(path.with_extension("tsx"));
+            push(path.with_extension("d.ts"));
+            push(path.to_path_buf());
+            push(path.with_extension("jsx"));
+        }
+        "jsx" => {
+            push(path.with_extension("tsx"));
+            push(path.with_extension("d.ts"));
+            push(path.to_path_buf());
+        }
+        "mjs" => {
+            push(path.with_extension("mts"));
+            push(path.with_extension("d.mts"));
+            push(path.to_path_buf());
+        }
+        "cjs" => {
+            push(path.with_extension("cts"));
+            push(path.with_extension("d.cts"));
+            push(path.to_path_buf());
+        }
+        _ if !extension.is_empty() => push(path.to_path_buf()),
+        _ => {
+            push(path.to_path_buf());
+            for extension in [
+                "ts", "tsx", "d.ts", "mts", "d.mts", "cts", "d.cts", "js", "jsx", "mjs", "cjs",
+            ] {
+                push(path.with_file_name(format!(
+                    "{}.{extension}",
+                    path.file_name()
+                        .and_then(|value| value.to_str())
+                        .unwrap_or_default()
+                )));
+            }
+        }
+    }
+    for index in [
+        "index.ts",
+        "index.tsx",
+        "index.d.ts",
+        "index.mts",
+        "index.d.mts",
+        "index.cts",
+        "index.d.cts",
+        "index.js",
+        "index.jsx",
+        "index.mjs",
+        "index.cjs",
+    ] {
+        push(path.join(index));
+    }
+    let suffixes = if module_suffixes.is_empty() {
+        vec![String::new()]
+    } else {
+        module_suffixes.to_vec()
+    };
+    let mut candidates = Vec::new();
+    for suffix in suffixes {
+        for candidate in &base_candidates {
+            let candidate = add_typescript_module_suffix(candidate, &suffix);
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates
+}
+
+fn add_typescript_module_suffix(path: &Path, suffix: &str) -> PathBuf {
+    if suffix.is_empty() {
+        return path.to_path_buf();
+    }
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return path.to_path_buf();
+    };
+    let (stem, extension) = [".d.mts", ".d.cts", ".d.ts"]
+        .into_iter()
+        .find_map(|extension| {
+            file_name
+                .strip_suffix(extension)
+                .map(|stem| (stem, extension))
+        })
+        .or_else(|| {
+            file_name.rsplit_once('.').map(|(stem, extension)| {
+                (
+                    stem,
+                    &file_name[file_name.len().saturating_sub(extension.len() + 1)..],
+                )
+            })
+        })
+        .unwrap_or((file_name, ""));
+    let replacement = if extension.is_empty() {
+        format!("{stem}{suffix}")
+    } else {
+        format!("{stem}{suffix}{extension}")
+    };
+    path.with_file_name(replacement)
 }
 
 fn rooted_source_path(root: &Path, source: &str) -> Result<PathBuf, String> {
@@ -835,14 +2934,15 @@ fn resolve_javascript_workspace_symbols(extraction: &mut Extraction) {
     let mut package_roots = HashMap::<(String, String), Vec<String>>::new();
     let mut reexports = HashMap::<String, Vec<String>>::new();
     for edge in &extraction.edges {
-        if relation(edge) == "imports_from" && file_ids.contains(&edge.target) {
+        if relation(edge) == "imports_from"
+            && file_ids.contains(&edge.target)
+            && !edge.string("module").is_empty()
+        {
             let module = edge.string("module");
-            if !module.starts_with('.') && !module.is_empty() {
-                package_roots
-                    .entry((edge.source.clone(), module))
-                    .or_default()
-                    .push(edge.target.clone());
-            }
+            package_roots
+                .entry((edge.source.clone(), module))
+                .or_default()
+                .push(edge.target.clone());
         }
         if relation(edge) == "re_exports"
             && file_ids.contains(&edge.source)
@@ -893,7 +2993,7 @@ fn resolve_javascript_workspace_symbols(extraction: &mut Extraction) {
         }
         let module = edge.string("module");
         let imported_name = edge.string("imported_name");
-        if module.starts_with('.') || module.is_empty() || imported_name.is_empty() {
+        if module.is_empty() || imported_name.is_empty() {
             continue;
         }
         let Some(roots) = package_roots.get(&(edge.source.clone(), module)) else {

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -250,9 +250,17 @@ pub fn resolve_with_root(
         .iter()
         .filter_map(|extraction| extraction.semantic_evidence.clone())
         .collect::<Vec<_>>();
+    let mut project_edges = Vec::new();
     let mut merged = Extraction::default();
     for extraction in extractions {
         if extraction.semantic_evidence.is_some() {
+            project_edges.extend(
+                extraction
+                    .edges
+                    .iter()
+                    .filter(|edge| relation(edge) == "imports_from")
+                    .cloned(),
+            );
             let allowed = universal_allowed_node_ids(extraction);
             merged.nodes.extend(
                 extraction
@@ -296,6 +304,7 @@ pub fn resolve_with_root(
         evidence_batches,
         sources,
         root,
+        project_edges,
         false,
     )
 }
@@ -337,10 +346,18 @@ fn resolve_owned_with_root_impl(
     let language_facts = members::collect_language_call_facts_owned(extractions);
     profile_internal("resolver language fact collection", &mut profile_started);
     let mut evidence_batches = Vec::new();
+    let mut project_edges = Vec::new();
     let mut merged = Extraction::default();
     for extraction in extractions.iter_mut() {
         let universal = extraction.semantic_evidence.take();
         if universal.is_some() {
+            project_edges.extend(
+                extraction
+                    .edges
+                    .iter()
+                    .filter(|edge| relation(edge) == "imports_from")
+                    .cloned(),
+            );
             let mut allowed = universal
                 .as_ref()
                 .into_iter()
@@ -386,6 +403,7 @@ fn resolve_owned_with_root_impl(
         evidence_batches,
         sources,
         root,
+        project_edges,
         evidence_prevalidated,
     )
 }
@@ -418,6 +436,7 @@ fn finish_resolution(
     evidence_batches: Vec<SemanticEvidenceBatch>,
     sources: &HashMap<String, String>,
     root: &Path,
+    project_edges: Vec<EdgeRecord>,
     evidence_prevalidated: bool,
 ) -> Extraction {
     let mut profile_started = Instant::now();
@@ -433,6 +452,19 @@ fn finish_resolution(
         .keys()
         .any(|source| matches!(extension(source).as_str(), "cs" | "razor" | "cshtml"));
     let has_php = sources.keys().any(|source| extension(source) == "php");
+    let mut project_resolution = (!project_edges.is_empty()).then(|| Extraction {
+        nodes: merged
+            .nodes
+            .iter()
+            .filter(|node| {
+                let source = string_attribute(node, "source_file");
+                is_file_node(node, &source)
+            })
+            .cloned()
+            .collect(),
+        edges: project_edges,
+        ..Extraction::default()
+    });
     if has_javascript {
         if let Err(error) =
             resolve_javascript_package_conditions(&mut merged, &canonical_root, sources)
@@ -454,6 +486,28 @@ fn finish_resolution(
             });
         }
         resolve_javascript_reexports(&mut merged);
+        if let Some(project) = project_resolution.as_mut() {
+            if let Err(error) =
+                resolve_javascript_package_conditions(project, &canonical_root, sources)
+            {
+                merged.error.get_or_insert_with(|| {
+                    format!("JavaScript project package-condition resolution failed: {error}")
+                });
+            }
+            if let Err(error) = resolve_javascript_workspace_modules(project, &canonical_root) {
+                merged.error.get_or_insert_with(|| {
+                    format!("JavaScript project workspace resolution failed: {error}")
+                });
+            }
+            if let Err(error) =
+                resolve_javascript_typescript_paths(project, &canonical_root, sources)
+            {
+                merged.error.get_or_insert_with(|| {
+                    format!("JavaScript project path resolution failed: {error}")
+                });
+            }
+            resolve_javascript_reexports(project);
+        }
     }
     profile_internal(
         "resolver JavaScript workspace modules",
@@ -461,17 +515,22 @@ fn finish_resolution(
     );
     profile_internal("resolver JavaScript re-exports", &mut profile_started);
     if !evidence_batches.is_empty() {
+        let project_edges = project_resolution
+            .as_ref()
+            .map_or(&[][..], |project| project.edges.as_slice());
         let index = if evidence_prevalidated {
-            evidence::UniversalResolutionIndex::new_with_prevalidated_inventory_owned(
+            evidence::UniversalResolutionIndex::new_with_prevalidated_project_inventory_owned(
                 evidence_batches,
                 &merged.nodes,
+                project_edges,
                 &canonical_root,
                 evidence::UniversalResolutionLimits::default(),
             )
         } else {
-            evidence::UniversalResolutionIndex::new_with_inventory_owned(
+            evidence::UniversalResolutionIndex::new_with_project_inventory_owned(
                 evidence_batches,
                 &merged.nodes,
+                project_edges,
                 &canonical_root,
                 evidence::UniversalResolutionLimits::default(),
             )

--- a/crates/compass-resolve/tests/semantic_producers.rs
+++ b/crates/compass-resolve/tests/semantic_producers.rs
@@ -41,6 +41,9 @@ fn assert_public_containment(
         .rsplit("::")
         .next()
         .unwrap_or(target_prefix)
+        .rsplit('.')
+        .next()
+        .unwrap_or(target_prefix)
         .split('@')
         .next()
         .unwrap_or(target_prefix);
@@ -412,11 +415,31 @@ namespace Two {
             "crate::rust_ownership::two::Shared",
             Some("crate::rust_ownership::two"),
         ),
-        ("ts_ownership.ts", "Shared@", None),
-        ("ts_ownership.ts", "One::Item@", Some("One")),
-        ("ts_ownership.ts", "One::Nested::Leaf@", Some("One::Nested")),
-        ("ts_ownership.ts", "Two::Item@", Some("Two")),
-        ("ts_ownership.ts", "Two::Shared@", Some("Two")),
+        (
+            "ts_ownership.ts",
+            "ts_ownership.Shared",
+            Some("ts_ownership"),
+        ),
+        (
+            "ts_ownership.ts",
+            "ts_ownership.One.Item",
+            Some("ts_ownership.One"),
+        ),
+        (
+            "ts_ownership.ts",
+            "ts_ownership.One.Nested.Leaf",
+            Some("ts_ownership.One.Nested"),
+        ),
+        (
+            "ts_ownership.ts",
+            "ts_ownership.Two.Item",
+            Some("ts_ownership.Two"),
+        ),
+        (
+            "ts_ownership.ts",
+            "ts_ownership.Two.Shared",
+            Some("ts_ownership.Two"),
+        ),
         ("CsharpOwnership.cs", "Shared@", None),
         ("CsharpOwnership.cs", "One::Item@", Some("One")),
         ("CsharpOwnership.cs", "One::Outer@", Some("One")),

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -9,6 +9,7 @@ use compass_languages::{
 };
 use compass_model::provenance::ResolutionState;
 use compass_resolve::frameworks::{RouteStageRole, resolve_and_publish_framework_routes};
+use compass_resolve::resolve;
 use tempfile::tempdir;
 
 fn fixture(name: &str) -> PathBuf {
@@ -324,6 +325,53 @@ const unrelated = { path: "/not-a-router", component: UserPage };
 }
 
 #[test]
+fn project_react_router_named_imports_resolve_to_source_callables()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut engine = Engine::default();
+    let mut files = Vec::new();
+    let mut sources = HashMap::new();
+    for (path, fixture_name) in [
+        ("src/routes.tsx", "react-router.tsx"),
+        ("src/AccountPage.tsx", "AccountPage.tsx"),
+        ("src/UserPage.tsx", "UserPage.tsx"),
+    ] {
+        let source = fs::read(fixture(fixture_name))?;
+        files.push(engine.extract_source(Path::new(path), &source)?);
+        sources.insert(path.to_owned(), String::from_utf8(source)?);
+    }
+    let mut extraction = resolve(&files, &sources);
+    let resolved =
+        resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+
+    for (path, expected_source) in [
+        ("/accounts/{accountId}", "src/AccountPage.tsx"),
+        ("/account-settings", "src/AccountPage.tsx"),
+        ("/users/{userId}", "src/UserPage.tsx"),
+    ] {
+        let route = resolved
+            .iter()
+            .find(|route| route.route.normalized_path == path)
+            .ok_or("missing React Router route")?;
+        assert_eq!(route.state, ResolutionState::Exact, "{path}");
+        let target = route
+            .stages
+            .last()
+            .and_then(|stage| stage.target.as_deref())
+            .ok_or("missing React Router handler target")?;
+        assert_eq!(
+            extraction
+                .nodes
+                .iter()
+                .find(|node| node.id == target)
+                .map(|node| node.string("source_file")),
+            Some(expected_source.to_owned()),
+            "{path}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn import_alias_metadata_and_near_matches_remain_conservative()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut react = source_extract(Path::new("src/routes.tsx"), "react-router.tsx")?;
@@ -390,7 +438,8 @@ fn import_alias_metadata_and_near_matches_remain_conservative()
 fn default_import_aliases_are_scoped_by_declaring_module_and_follow_default_exports()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut engine = Engine::default();
-    let mut extraction = Extraction::default();
+    let mut files = Vec::new();
+    let mut sources = HashMap::new();
     for (path, source) in [
         (
             "src/admin/routes.tsx",
@@ -415,13 +464,10 @@ export const router = createBrowserRouter([{ path: "/public", Component: Screen 
             "export default function PublicPage() { return null; }\n",
         ),
     ] {
-        let mut source = engine.extract_source(Path::new(path), source.as_bytes())?;
-        extraction.nodes.append(&mut source.nodes);
-        extraction.edges.append(&mut source.edges);
-        extraction
-            .framework_facts
-            .append(&mut source.framework_facts);
+        files.push(engine.extract_source(Path::new(path), source.as_bytes())?);
+        sources.insert(path.to_owned(), source.to_owned());
     }
+    let mut extraction = resolve(&files, &sources);
 
     let resolved =
         resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
@@ -598,7 +644,8 @@ fn file_routes_emit_convention_components_and_exact_bindings()
 fn file_endpoint_reexports_bind_to_the_exported_handler_module()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut engine = Engine::default();
-    let mut extraction = Extraction::default();
+    let mut files = Vec::new();
+    let mut sources = HashMap::new();
     for (path, source) in [
         (
             "src/pages/api/users.ts",
@@ -610,13 +657,10 @@ fn file_endpoint_reexports_bind_to_the_exported_handler_module()
             "export async function GET() { return new Response(); }\n",
         ),
     ] {
-        let mut source = engine.extract_source(Path::new(path), source.as_bytes())?;
-        extraction.nodes.append(&mut source.nodes);
-        extraction.edges.append(&mut source.edges);
-        extraction
-            .framework_facts
-            .append(&mut source.framework_facts);
+        files.push(engine.extract_source(Path::new(path), source.as_bytes())?);
+        sources.insert(path.to_owned(), source.to_owned());
     }
+    let mut extraction = resolve(&files, &sources);
 
     let route = routes(&extraction)
         .find(|route| route.framework == "astro" && route.normalized_path == "/api/users")

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7116,3 +7116,95 @@ new Widget();
     ));
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_consumes_project_path_targets_in_shared_resolution()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "tsconfig.json",
+            br#"{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  }
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "src/api.ts",
+            br#"export class Widget { run() {} }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Widget } from "@/api";
+new Widget().run();
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        if relative.ends_with(".ts") {
+            extraction.semantic_evidence = Some(
+                Engine::default().extract_source_universal_candidate_evidence(
+                    Path::new(relative),
+                    relative,
+                    source,
+                )?,
+            );
+        }
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    let owned = compass_resolve::resolve_owned_with_root(extractions, &sources, root);
+    for resolved in [&resolved, &owned] {
+        assert!(
+            resolved.error.is_none(),
+            "resolver error: {:?}",
+            resolved.error
+        );
+        let calls = resolved
+            .edges
+            .iter()
+            .filter(|edge| {
+                edge.string("source_file") == "app/consumer.ts"
+                    && edge.string("relation") == "calls"
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            calls.iter().any(|edge| {
+                edge.string("resolution_rule") == "project-module-binding"
+                    && resolved.nodes.iter().any(|node| {
+                        node.id == edge.target
+                            && node.string("source_file") == "src/api.ts"
+                            && node.label() == "Widget"
+                    })
+            }),
+            "project construction target missing: {calls:#?}"
+        );
+        assert!(
+            calls.iter().any(|edge| {
+                edge.string("resolution_rule") == "member-binding"
+                    && resolved.nodes.iter().any(|node| {
+                        node.id == edge.target
+                            && node.string("source_file") == "src/api.ts"
+                            && node.label() == ".run()"
+                    })
+            }),
+            "project member target missing: {calls:#?}"
+        );
+    }
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7779,6 +7779,54 @@ export function use(value: Copy<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_candidate_publishes_local_conditional_branch_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = br#"class Item { inspect(): void {} }
+class Other { other(): void {} }
+type Choose<T> = T extends Item ? Item : Other;
+type ChooseObject<T> = T extends object ? T : never;
+function selected(value: Choose<Item>) { value.inspect(); }
+function rejected(value: Choose<Other>) { value.inspect(); }
+function union(value: Choose<Item | Other>) { value.inspect(); }
+function direct(value: Item extends Item ? Item : Other) { value.inspect(); }
+function object(value: ChooseObject<Item>) { value.inspect(); }
+"#;
+    let mut extraction = extract("src/conditional.ts", source);
+    extraction.semantic_evidence = Some(
+        Engine::default().extract_source_universal_candidate_evidence(
+            Path::new("src/conditional.ts"),
+            "src/conditional.ts",
+            source,
+        )?,
+    );
+    let resolved = compass_resolve::resolve(
+        &[extraction],
+        &HashMap::from([(
+            "src/conditional.ts".to_owned(),
+            String::from_utf8(source.to_vec())?,
+        )]),
+    );
+    assert!(resolved.error.is_none(), "resolver error: {:?}", resolved.error);
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "src/conditional.ts" && node.label() == ".inspect()"
+        })
+        .ok_or("missing conditional Item.inspect member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "calls" && edge.target == inspect.id)
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 3);
+    assert!(calls.iter().all(|edge| {
+        edge.string("source_file") == "src/conditional.ts"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_array_and_tuple_member_chains()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6974,6 +6974,157 @@ spread.isString('value');
 }
 
 #[test]
+fn typescript_wildcard_barrels_resolve_transitively_and_fail_closed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/values.js",
+            br#"export function run(value) { return value; }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/middle.js",
+            br#"export * from "./values.js";
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/outer.js",
+            br#"export * from "./middle.js";
+export * as values from "./values.js";
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/left.js",
+            br#"export function same() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/right.js",
+            br#"export function same() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/ambiguous.js",
+            br#"export * from "./left.js";
+export * from "./right.js";
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/cycle-a.js",
+            br#"export * from "./cycle-b.js";
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/cycle-b.js",
+            br#"export * from "./cycle-a.js";
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"import { run } from '../lib/outer.js';
+import { values } from '../lib/outer.js';
+import { same } from '../lib/ambiguous.js';
+import { cycleValue } from '../lib/cycle-a.js';
+run(1);
+values.run(2);
+same();
+cycleValue();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run" && declaration.kind == "function")
+        .ok_or("missing wildcard provider declaration")?;
+    let calls = batches[8]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let run_call = calls
+        .iter()
+        .find(|candidate| {
+            candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| !qualified.contains("values"))
+        })
+        .ok_or("missing transitive wildcard call")?;
+    let namespace_call = calls
+        .iter()
+        .find(|candidate| {
+            candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("values"))
+        })
+        .ok_or("missing namespace reexport member call")?;
+    let same_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "same")
+        .ok_or("missing ambiguous wildcard call")?;
+    let cycle_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "cycleValue")
+        .ok_or("missing cyclic wildcard call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&run_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    assert!(matches!(
+        index.resolve(&namespace_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    assert!(!matches!(
+        index.resolve(&same_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    assert!(!matches!(
+        index.resolve(&cycle_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_object_exports_resolve_named_require_bindings()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7958,14 +7958,14 @@ fn typescript_candidate_resolves_imported_keyof_identity_alias_members()
         (
             "lib/item.ts",
             br#"export interface Item { inspect(): void }
-"
+"#
             .as_slice(),
         ),
         (
             "lib/types.ts",
             br#"export type Copy<T> = Pick<T, keyof T>;
 export type Empty<T> = Omit<T, keyof T>;
-"
+"#
             .as_slice(),
         ),
         (
@@ -7974,7 +7974,7 @@ export type Empty<T> = Omit<T, keyof T>;
 import type { Item } from "../lib/item";
 export function use(value: Copy<Item>) { value.inspect(); }
 export function rejected(value: Empty<Item>) { value.inspect(); }
-"
+"#
             .as_slice(),
         ),
     ];
@@ -8016,6 +8016,98 @@ export function rejected(value: Empty<Item>) { value.inspect(); }
         })
         .collect::<Vec<_>>();
     assert_eq!(calls.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_imported_literal_utility_projection_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item {
+    enabled(): void;
+    debug(): void;
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"import type { Item } from "./item";
+export type Picked = Pick<Item, "enabled">;
+export type Omitted = Omit<Item, "debug">;
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Picked, Omitted } from "../lib/types";
+export function use(picked: Picked, omitted: Omitted) {
+    picked.enabled();
+    picked.debug();
+    omitted.enabled();
+    omitted.debug();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let enabled = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".enabled()")
+        .ok_or("missing imported Pick enabled member")?;
+    let debug = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".debug()")
+        .ok_or("missing imported Omit debug member")?;
+    let enabled_calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == enabled.id
+        })
+        .collect::<Vec<_>>();
+    let debug_calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == debug.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(enabled_calls.len(), 2);
+    assert!(debug_calls.is_empty());
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7806,7 +7806,11 @@ function object(value: ChooseObject<Item>) { value.inspect(); }
             String::from_utf8(source.to_vec())?,
         )]),
     );
-    assert!(resolved.error.is_none(), "resolver error: {:?}", resolved.error);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
     let inspect = resolved
         .nodes
         .iter()
@@ -7820,9 +7824,11 @@ function object(value: ChooseObject<Item>) { value.inspect(); }
         .filter(|edge| edge.string("relation") == "calls" && edge.target == inspect.id)
         .collect::<Vec<_>>();
     assert_eq!(calls.len(), 3);
-    assert!(calls.iter().all(|edge| {
-        edge.string("source_file") == "src/conditional.ts"
-    }));
+    assert!(
+        calls
+            .iter()
+            .all(|edge| { edge.string("source_file") == "src/conditional.ts" })
+    );
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7833,6 +7833,123 @@ function object(value: ChooseObject<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_candidate_publishes_literal_indexed_alias_member_calls()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = br#"interface Nested { inspect(): void }
+interface Item { nested: Nested }
+type NestedAlias = Item["nested"];
+export function use(value: NestedAlias) { value.inspect(); }
+"#;
+    let relative = "src/indexed-alias.ts";
+    let mut extraction = extract(relative, source);
+    extraction.semantic_evidence = Some(
+        Engine::default().extract_source_universal_candidate_evidence(
+            Path::new(relative),
+            relative,
+            source,
+        )?,
+    );
+    let resolved = compass_resolve::resolve(
+        &[extraction],
+        &HashMap::from([(relative.to_owned(), String::from_utf8(source.to_vec())?)]),
+    );
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == relative && node.label() == ".inspect()")
+        .ok_or("missing indexed alias Nested.inspect member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == relative
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].string("resolution_rule"),
+        "exact-source-declaration"
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_imported_generic_indexed_alias_member_calls()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Nested { inspect(): void }
+export interface Item { nested: Nested }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export type NestedOf<T> = T["nested"];
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { NestedOf } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(value: NestedOf<Item>) { value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported indexed alias Nested.inspect member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 1);
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_array_and_tuple_member_chains()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7723,6 +7723,112 @@ nonObject.missing();
 }
 
 #[test]
+fn javascript_namespace_and_require_spreads_follow_published_exports_only()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/esm.ts",
+            br#"export function esmPublished() {}
+function esmPrivate() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/cjs.cjs",
+            br#"function cjsPublished() {}
+function cjsPrivate() {}
+module.exports = { cjsPublished };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/derived.js",
+            br#"import * as esm from "./esm";
+const cjs = require("./cjs");
+module.exports = { ...esm, ...cjs };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const api = require("../lib/derived");
+api.esmPublished();
+api.cjsPublished();
+api.esmPrivate();
+api.cjsPrivate();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let esm_published = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "esmPublished")
+        .ok_or("missing published ESM function")?;
+    let cjs_published = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "cjsPublished")
+        .ok_or("missing published CommonJS function")?;
+    let calls = batches[3]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let find_call = |name: &str| {
+        calls
+            .iter()
+            .find(|candidate| candidate.target_spelling == name)
+            .ok_or_else(|| format!("missing call {name}"))
+    };
+    let esm_call = find_call("esmPublished")?;
+    let cjs_call = find_call("cjsPublished")?;
+    let esm_private_call = find_call("esmPrivate")?;
+    let cjs_private_call = find_call("cjsPrivate")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&esm_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &esm_published.id
+    ));
+    assert!(matches!(
+        index.resolve(&cjs_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &cjs_published.id
+    ));
+    assert!(matches!(
+        index.resolve(&esm_private_call.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    assert!(matches!(
+        index.resolve(&cjs_private_call.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7208,3 +7208,116 @@ new Widget().run();
     }
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_merges_imported_interface_members_across_declarations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/types.ts",
+            br#"export interface Config { run(): void }
+export interface Config { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Config } from "../lib/types";
+export function use(config: Config) { config.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    let owned = compass_resolve::resolve_owned_with_root(extractions, &sources, root);
+    for resolved in [&resolved, &owned] {
+        assert!(
+            resolved.error.is_none(),
+            "resolver error: {:?}",
+            resolved.error
+        );
+        let inspect = resolved
+            .nodes
+            .iter()
+            .find(|node| {
+                node.string("source_file") == "lib/types.ts" && node.label() == ".inspect()"
+            })
+            .ok_or("missing merged interface member")?;
+        assert!(resolved.edges.iter().any(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+                && edge.string("resolution_rule") == "member-binding"
+        }));
+    }
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_leaves_duplicate_merged_interface_members_ambiguous()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/types.ts",
+            br#"export interface Config { inspect(): void }
+export interface Config { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Config } from "../lib/types";
+export function use(config: Config) { config.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls" && edge.string("source_file") == "app/consumer.ts"
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7951,3 +7951,69 @@ export function use(shape: Shape, key: string) { shape[key].inspect(); }
     }));
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_resolves_straight_line_reassignment_to_latest_member()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let relative = "src/reassignment.ts";
+    let source = br#"class First { run() {} }
+class Second { run() {} }
+export function use() {
+    let current = new First();
+    current = new Second();
+    current.run();
+}
+"#;
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    fs::write(&path, source)?;
+    let mut sources = HashMap::new();
+    sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+    let mut extraction = extract(relative, source);
+    extraction.semantic_evidence = Some(
+        Engine::default().extract_source_universal_candidate_evidence(
+            Path::new(relative),
+            relative,
+            source,
+        )?,
+    );
+    let resolved = compass_resolve::resolve_with_root(&[extraction], &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let first_run = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == relative
+                && node.label() == ".run()"
+                && node.string("qualified_name").ends_with("First.run")
+        })
+        .ok_or("missing First.run member")?;
+    let second_run = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == relative
+                && node.label() == ".run()"
+                && node.string("qualified_name").ends_with("Second.run")
+        })
+        .ok_or("missing Second.run member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == relative
+            && edge.target == second_run.id
+            && edge.string("resolution_rule") == "exact-source-declaration"
+    }));
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == relative
+            && edge.target == first_run.id
+            && edge.string("resolution_rule") == "exact-source-declaration"
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8063,6 +8063,152 @@ export function use(value: Item) { make(value).inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_callable_member_returns_and_explicit_generics()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+export class Factory {
+    static make(value: Item): Item { return value; }
+    static identity<T>(value: T): T { return value; }
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Factory } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) {
+    Factory.make(value).inspect();
+    Factory.identity(value).inspect();
+    Factory.identity<Item>(value).inspect();
+    Factory.identity<Item>(unknownValue).inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported callable member return")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 4);
+    assert!(
+        calls
+            .iter()
+            .all(|edge| edge.string("resolution_rule") == "member-binding")
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_ambiguous_imported_callable_member_returns_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+export class Factory {
+    static make(value: Item): Item { return value; }
+}
+export class Factory {
+    static make(value: Item): Item { return value; }
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Factory } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) { Factory.make(value).inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7385,3 +7385,196 @@ export function use(box: Box<Item>) { box.item.inspect(); }
     }));
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_resolves_nested_imported_generic_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export interface Wrapper<U> { value: U }
+export interface Box<T> { item: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Box, Wrapper } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(box: Box<Wrapper<Item>>) { box.item.value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing nested imported generic member")?;
+    let consumer_evidence = extractions
+        .iter()
+        .filter_map(|extraction| extraction.semantic_evidence.as_ref())
+        .find(|evidence| {
+            evidence
+                .declarations
+                .iter()
+                .any(|declaration| declaration.range.source_file == "app/consumer.ts")
+        })
+        .ok_or("missing nested consumer evidence")?;
+    let nested_call = consumer_evidence
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Calls)
+        .ok_or("missing nested generic call candidate")?;
+    assert_eq!(
+        nested_call.constraints.qualified_name.as_deref(),
+        Some("../lib/types::Box<../lib/types::Wrapper<../lib/item::Item>>.item.value.inspect")
+    );
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_nested_generic_member_ambiguity_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export interface Wrapper<U> { value: U }
+export interface Box<T> { item: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Box, Wrapper } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(box: Box<Wrapper<Item>>) { box.item.value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls" && edge.string("source_file") == "app/consumer.ts"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_does_not_invent_nested_generic_primitive_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/types.ts",
+            br#"export interface Box<T> { item: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Box } from "../lib/types";
+export function use(box: Box<string>) { box.item.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8209,6 +8209,164 @@ export function use(value: Item) { Factory.make(value).inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_callable_properties_and_typed_objects()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/api.ts",
+            br#"import type { Item } from "./item";
+interface TypedApi { make: (value: Item) => Item }
+export declare const typed: TypedApi;
+export const api = {
+    make: (value: Item): Item => value,
+    identity: <T>(value: T): T => value,
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { api, typed } from "../lib/api";
+import type { Item } from "../lib/item";
+export function use(value: Item) {
+    api.make(value).inspect();
+    api.identity<Item>(value).inspect();
+    typed.make(value).inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported callable property return")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 3);
+    assert!(
+        calls
+            .iter()
+            .all(|edge| edge.string("resolution_rule") == "member-binding")
+    );
+    let consumer_calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls" && edge.string("source_file") == "app/consumer.ts"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(consumer_calls.len(), 6);
+    assert!(
+        consumer_calls
+            .iter()
+            .all(|edge| edge.string("resolution_rule") == "member-binding")
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_duplicate_imported_callable_properties_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/api.ts",
+            br#"import type { Item } from "./item";
+export const api = {
+    make: (value: Item): Item => value,
+    make: (value: Item): Item => value,
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { api } from "../lib/api";
+import type { Item } from "../lib/item";
+export function use(value: Item) { api.make(value).inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::Path;
 
 use compass_graph::build_from_extraction;
-use compass_languages::{Engine, RawCall};
+use compass_languages::{CandidateRelation, Engine, RawCall};
 use compass_resolve::evidence::{UniversalResolutionIndex, UniversalResolutionLimits};
 use serde_json::Map;
 
@@ -5160,6 +5160,1433 @@ export const wrappedDate = consume(ZonedDate);
 }
 
 #[test]
+fn javascript_package_exports_choose_import_and_require_conditions()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let package = directory.path().join("packages/conditional/package.json");
+    let import_target = directory.path().join("packages/conditional/src/import.ts");
+    let require_target = directory
+        .path()
+        .join("packages/conditional/src/require.cjs");
+    let wildcard_target = directory
+        .path()
+        .join("packages/conditional/src/features/button.ts");
+    let typescript_consumer = directory.path().join("app/consumer.ts");
+    let javascript_consumer = directory.path().join("app/consumer.cjs");
+    let package_source = br##"{
+        "name": "@example/conditional",
+        "exports": {
+            ".": {
+                "import": "./src/import.ts",
+                "require": "./src/require.cjs",
+                "default": "./src/fallback.js"
+            },
+            "./features/*": {
+                "import": "./src/features/*.ts"
+            },
+            "./fallback": ["./src/features/missing.ts", "./src/features/button.ts"]
+        }
+    }"##;
+    let import_source = br#"export const imported = true;"#;
+    let require_source = br#"module.exports = { required: true };"#;
+    let wildcard_source = br#"export const button = true;"#;
+    let typescript_source = br#"import { imported } from "@example/conditional";
+import { button } from "@example/conditional/features/button";
+import { button as fallback } from "@example/conditional/fallback";
+export const value = imported && button && fallback;
+"#;
+    let javascript_source = br#"const { required } = require("@example/conditional");
+module.exports = required;
+"#;
+    for (path, source) in [
+        (&package, package_source.as_slice()),
+        (&import_target, import_source.as_slice()),
+        (&require_target, require_source.as_slice()),
+        (&wildcard_target, wildcard_source.as_slice()),
+        (&typescript_consumer, typescript_source.as_slice()),
+        (&javascript_consumer, javascript_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            import_target.to_str().ok_or("non-UTF-8 fixture path")?,
+            import_source,
+        ),
+        extract(
+            require_target.to_str().ok_or("non-UTF-8 fixture path")?,
+            require_source,
+        ),
+        extract(
+            wildcard_target.to_str().ok_or("non-UTF-8 fixture path")?,
+            wildcard_source,
+        ),
+        extract(
+            typescript_consumer
+                .to_str()
+                .ok_or("non-UTF-8 fixture path")?,
+            typescript_source,
+        ),
+        extract(
+            javascript_consumer
+                .to_str()
+                .ok_or("non-UTF-8 fixture path")?,
+            javascript_source,
+        ),
+    ];
+    let sources = [
+        (&package, package_source.as_slice()),
+        (&import_target, import_source.as_slice()),
+        (&require_target, require_source.as_slice()),
+        (&wildcard_target, wildcard_source.as_slice()),
+        (&typescript_consumer, typescript_source.as_slice()),
+        (&javascript_consumer, javascript_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, directory.path());
+    assert_eq!(resolved.error, None);
+    let import_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == import_target.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing import condition target")?;
+    let require_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == require_target.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing require condition target")?;
+    let wildcard_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == wildcard_target.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing wildcard target")?;
+    let module_edges = resolved
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "imports_from")
+        .collect::<Vec<_>>();
+    assert!(module_edges.iter().any(|edge| {
+        edge.string("source_file") == typescript_consumer.to_string_lossy()
+            && edge.target == import_id
+            && edge.string("package_condition") == "import"
+            && edge.string("resolution_rule") == "package-exports"
+    }));
+    assert!(module_edges.iter().any(|edge| {
+        edge.string("source_file") == typescript_consumer.to_string_lossy()
+            && edge.target == wildcard_id
+            && edge.string("package_condition") == "import"
+    }));
+    assert!(module_edges.iter().any(|edge| {
+        edge.string("source_file") == typescript_consumer.to_string_lossy()
+            && edge.string("module") == "@example/conditional/fallback"
+            && edge.target == wildcard_id
+            && edge.string("package_condition") == "default"
+    }));
+    assert!(
+        module_edges.iter().any(|edge| {
+            edge.string("source_file") == javascript_consumer.to_string_lossy()
+                && edge.target == require_id
+                && edge.string("context") == "require"
+                && edge.string("package_condition") == "require"
+        }),
+        "module_edges={module_edges:#?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_paths_aliases_resolve_extension_substitution_and_named_symbols()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let implementation = root.join("src/api.ts");
+    let consumer = root.join("app/consumer.ts");
+    for path in [&config, &implementation, &consumer] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    }
+    let config_source = br#"{
+        // JSONC is accepted by TypeScript project configuration.
+        "compilerOptions": {
+            "baseUrl": ".",
+            "paths": { "@/*": ["./src/*",], },
+        },
+    }"#;
+    let implementation_source = br#"export class Widget { run() {} }"#;
+    let consumer_source = br#"import { Widget } from "@/api.js";
+export function make() { return new Widget(); }
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            implementation.to_str().ok_or("non-UTF-8 fixture path")?,
+            implementation_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let implementation_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == implementation.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing implementation file")?;
+    let declaration_id = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "Widget"
+                && node.string("source_file") == implementation.to_string_lossy()
+        })
+        .map(|node| node.id.clone())
+        .ok_or("missing Widget declaration")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports_from"
+            && edge.string("module") == "@/api.js"
+            && edge.target == implementation_id
+            && edge.string("resolution_rule") == "typescript-paths"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports"
+            && edge.target == declaration_id
+            && edge.string("local_name") == "Widget"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == declaration_id
+            && edge.string("source_file") == consumer.to_string_lossy()
+    }));
+    Ok(())
+}
+
+#[test]
+fn javascript_jsconfig_base_url_resolves_bare_module() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("jsconfig.json");
+    let implementation = root.join("src/api.js");
+    let consumer = root.join("app/consumer.js");
+    for path in [&config, &implementation, &consumer] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    }
+    let config_source = br#"{"compilerOptions":{"baseUrl":"."}}"#;
+    let implementation_source = br#"export function api() { return true; }"#;
+    let consumer_source = br#"import { api } from "src/api";
+export const value = api();
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            implementation.to_str().ok_or("non-UTF-8 fixture path")?,
+            implementation_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let implementation_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == implementation.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing JavaScript implementation file")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports_from"
+            && edge.string("module") == "src/api"
+            && edge.target == implementation_id
+            && edge.string("resolution_rule") == "typescript-base-url"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_paths_choose_nearest_config_and_ordered_fallbacks()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let root_config = root.join("tsconfig.json");
+    let nested_config = root.join("app/tsconfig.json");
+    let first = root.join("app/src/first.ts");
+    let second = root.join("app/src/second.ts");
+    let consumer = root.join("app/consumer.ts");
+    for path in [&root_config, &nested_config, &first, &second, &consumer] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    }
+    let root_config_source = br#"{
+        "compilerOptions": { "paths": { "@/*": ["./wrong/*"] } }
+    }"#;
+    let nested_config_source = br#"{
+        "compilerOptions": {
+            "baseUrl": ".",
+            "paths": { "@/*": ["./missing/*", "./src/*"] }
+        }
+    }"#;
+    let first_source = br#"export const first = true;"#;
+    let second_source = br#"export const second = true;"#;
+    let consumer_source = br#"import { second } from "@/second.js";
+export const value = second;
+"#;
+    for (path, source) in [
+        (&root_config, root_config_source.as_slice()),
+        (&nested_config, nested_config_source.as_slice()),
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            first.to_str().ok_or("non-UTF-8 fixture path")?,
+            first_source,
+        ),
+        extract(
+            second.to_str().ok_or("non-UTF-8 fixture path")?,
+            second_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&root_config, root_config_source.as_slice()),
+        (&nested_config, nested_config_source.as_slice()),
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let second_file_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == second.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing second file")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports_from"
+            && edge.string("module") == "@/second.js"
+            && edge.target == second_file_id
+            && edge.string("resolution_config") == "app/tsconfig.json"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_paths_leave_same_depth_config_ambiguity_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let first_config = root.join("app/tsconfig.json");
+    let second_config = root.join("app/tsconfig.alt.json");
+    let first = root.join("app/one.ts");
+    let second = root.join("app/two.ts");
+    let consumer = root.join("app/consumer.ts");
+    for path in [&first_config, &second_config, &first, &second, &consumer] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    }
+    let first_config_source = br#"{"compilerOptions":{"paths":{"@/shared":["./one.ts"]}}}"#;
+    let second_config_source = br#"{"compilerOptions":{"paths":{"@/shared":["./two.ts"]}}}"#;
+    let first_source = br#"export const one = true;"#;
+    let second_source = br#"export const two = true;"#;
+    let consumer_source = br#"import { one } from "@/shared";
+export const value = one;
+"#;
+    for (path, source) in [
+        (&first_config, first_config_source.as_slice()),
+        (&second_config, second_config_source.as_slice()),
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            first.to_str().ok_or("non-UTF-8 fixture path")?,
+            first_source,
+        ),
+        extract(
+            second.to_str().ok_or("non-UTF-8 fixture path")?,
+            second_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&first_config, first_config_source.as_slice()),
+        (&second_config, second_config_source.as_slice()),
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let file_ids = resolved
+        .nodes
+        .iter()
+        .filter(|node| {
+            [first.to_string_lossy(), second.to_string_lossy()]
+                .iter()
+                .any(|source| node.string("source_file") == *source)
+        })
+        .map(|node| node.id.as_str())
+        .collect::<HashSet<_>>();
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from" && edge.string("module") == "@/shared"
+        })
+        .ok_or("missing ambiguous import")?;
+    assert!(!file_ids.contains(import.target.as_str()));
+    assert!(import.string("resolution_rule").is_empty());
+    Ok(())
+}
+
+#[test]
+fn typescript_config_extends_inherits_paths_and_project_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let base = root.join("tsconfig.base.json");
+    let config = root.join("tsconfig.json");
+    let implementation = root.join("src/api.ts");
+    let consumer = root.join("app/consumer.ts");
+    for path in [&base, &config, &implementation, &consumer] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    }
+    let base_source = br#"{
+        "compilerOptions": {
+            "baseUrl": "..",
+            "paths": { "@/*": ["src/*"] },
+            "module": "NodeNext",
+            "moduleResolution": "NodeNext"
+        }
+    }"#;
+    let config_source = br#"{
+        "extends": "./tsconfig.base.json",
+        "compilerOptions": { "allowJs": true },
+        "references": [{ "path": "./src" }]
+    }"#;
+    let implementation_source = br#"export class Widget {}"#;
+    let consumer_source = br#"import { Widget } from "@/api.js";
+export const value = new Widget();
+"#;
+    for (path, source) in [
+        (&base, base_source.as_slice()),
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            implementation.to_str().ok_or("non-UTF-8 fixture path")?,
+            implementation_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&base, base_source.as_slice()),
+        (&config, config_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let implementation_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == implementation.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing inherited implementation")?;
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("source_file") == consumer.to_string_lossy()
+        })
+        .ok_or("missing inherited alias import")?;
+    assert_eq!(import.target, implementation_id);
+    assert_eq!(import.string("resolution_rule"), "typescript-paths");
+    assert_eq!(import.string("resolution_config"), "tsconfig.json");
+    assert_eq!(import.string("module_resolution"), "nodenext");
+    assert_eq!(import.string("module_kind"), "nodenext");
+    assert_eq!(
+        import.attributes.get("resolution_project_references"),
+        Some(&serde_json::json!(["src"]))
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_relative_imports_use_module_suffixes_and_root_dirs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let consumer = root.join("src/app/consumer.ts");
+    let suffixed = root.join("src/app/feature.ios.ts");
+    let generated = root.join("generated/app/runtime.ts");
+    let config_source = br#"{
+        "compilerOptions": {
+            "module": "ESNext",
+            "moduleResolution": "Bundler",
+            "moduleSuffixes": [".ios", ""],
+            "rootDirs": ["src", "generated"]
+        }
+    }"#;
+    let consumer_source = br#"import { feature } from "./feature.js";
+import { runtime } from "./runtime.js";
+export const value = feature + runtime;
+"#;
+    let suffixed_source = br#"export const feature = 1;"#;
+    let generated_source = br#"export const runtime = 2;"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+        (&suffixed, suffixed_source.as_slice()),
+        (&generated, generated_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            suffixed.to_str().ok_or("non-UTF-8 fixture path")?,
+            suffixed_source,
+        ),
+        extract(
+            generated.to_str().ok_or("non-UTF-8 fixture path")?,
+            generated_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+        (&suffixed, suffixed_source.as_slice()),
+        (&generated, generated_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let suffixed_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == suffixed.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing suffixed target")?;
+    let generated_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == generated.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing rootDirs target")?;
+    let imports = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("source_file") == consumer.to_string_lossy()
+        })
+        .collect::<Vec<_>>();
+    assert!(imports.iter().any(|edge| {
+        edge.target == suffixed_id && edge.string("resolution_rule") == "typescript-relative"
+    }));
+    assert!(imports.iter().any(|edge| {
+        edge.target == generated_id && edge.string("resolution_rule") == "typescript-root-dirs"
+    }));
+    assert!(imports.iter().all(|edge| {
+        edge.string("module_resolution") == "bundler"
+            && edge.string("module_kind") == "esnext"
+            && edge.string("resolution_config") == "tsconfig.json"
+    }));
+    Ok(())
+}
+
+#[test]
+fn javascript_relative_named_imports_repoint_to_the_unique_export()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let target = root.join("src/target.ts");
+    let consumer = root.join("src/consumer.ts");
+    let target_source = br#"export function greet() { return "hello"; }"#;
+    let consumer_source = br#"import { greet } from "./target.js";
+export function run() { return greet(); }
+"#;
+    for (path, source) in [
+        (&target, target_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            target.to_str().ok_or("non-UTF-8 fixture path")?,
+            target_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&target, target_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let greet = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "greet()" && node.string("source_file") == target.to_string_lossy()
+        })
+        .ok_or("missing greet declaration")?;
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports"
+                && edge.string("module") == "./target.js"
+                && edge.string("local_name") == "greet"
+        })
+        .ok_or("missing relative named import")?;
+    assert_eq!(import.target, greet.id);
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.target == greet.id
+            && edge.string("source_file") == consumer.to_string_lossy()
+    }));
+    Ok(())
+}
+
+#[test]
+fn javascript_package_imports_use_the_nearest_package_and_type_condition()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let package = root.join("packages/toolkit/package.json");
+    let implementation = root.join("packages/toolkit/src/internal/tool.ts");
+    let consumer = root.join("packages/toolkit/src/consumer.ts");
+    let package_source = br##"{
+  "name": "@example/toolkit",
+  "imports": {
+    "#internal/*": {
+      "types": "./src/internal/*.ts",
+      "default": "./src/internal/*.js"
+    }
+  }
+}"##;
+    let implementation_source = br#"export function tool() { return 1; }"#;
+    let consumer_source = br##"import { tool } from "#internal/tool";
+export const value = tool();
+"##;
+    for (path, source) in [
+        (&package, package_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            implementation.to_str().ok_or("non-UTF-8 fixture path")?,
+            implementation_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&package, package_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let implementation_id = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "tool()"
+                && node.string("source_file") == implementation.to_string_lossy()
+        })
+        .map(|node| node.id.clone())
+        .ok_or("missing package-import target")?;
+    let module_import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from" && edge.string("module") == "#internal/tool"
+        })
+        .ok_or("missing package imports edge")?;
+    assert_eq!(module_import.string("resolution_rule"), "package-imports");
+    assert_eq!(module_import.string("package_condition"), "types");
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports"
+                && edge.string("module") == "#internal/tool"
+                && edge.string("local_name") == "tool"
+        })
+        .ok_or("missing named package import")?;
+    assert_eq!(import.target, implementation_id);
+    Ok(())
+}
+
+#[test]
+fn typescript_package_types_versions_selects_the_admitted_declaration_target()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let package = root.join("packages/typed/package.json");
+    let declaration = root.join("packages/typed/types/index.ts");
+    let consumer = root.join("app/consumer.ts");
+    let package_source = br#"{
+  "name": "@example/typed",
+  "types": "./src/index.d.ts",
+  "typesVersions": { "*": { "*": ["types/*"] } }
+}"#;
+    let declaration_source = br#"export function helper(): string { return "ok"; }"#;
+    let consumer_source = br#"import { helper } from "@example/typed";
+export const value = helper();
+"#;
+    for (path, source) in [
+        (&package, package_source.as_slice()),
+        (&declaration, declaration_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            declaration.to_str().ok_or("non-UTF-8 fixture path")?,
+            declaration_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&package, package_source.as_slice()),
+        (&declaration, declaration_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let module_import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from" && edge.string("module") == "@example/typed"
+        })
+        .ok_or("missing package import")?;
+    assert_eq!(module_import.string("resolution_rule"), "typesVersions");
+    let helper = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            matches!(node.label(), "helper()" | "helper")
+                && node.string("source_file") == declaration.to_string_lossy()
+        })
+        .ok_or("missing typesVersions declaration")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports"
+            && edge.target == helper.id
+            && edge.string("local_name") == "helper"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_include_exclude_ownership_blocks_out_of_project_alias_targets()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let allowed = root.join("src/allowed.ts");
+    let excluded = root.join("src/excluded.ts");
+    let consumer = root.join("src/consumer.ts");
+    let config_source = br#"{
+  "compilerOptions": { "baseUrl": ".", "paths": { "@/*": ["src/*"] } },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/excluded.ts"]
+}"#;
+    let allowed_source = br#"export const allowed = true;"#;
+    let excluded_source = br#"export const excluded = true;"#;
+    let consumer_source = br#"import { allowed } from "@/allowed";
+import { excluded } from "@/excluded";
+export const value = allowed && excluded;
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&allowed, allowed_source.as_slice()),
+        (&excluded, excluded_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            allowed.to_str().ok_or("non-UTF-8 fixture path")?,
+            allowed_source,
+        ),
+        extract(
+            excluded.to_str().ok_or("non-UTF-8 fixture path")?,
+            excluded_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&allowed, allowed_source.as_slice()),
+        (&excluded, excluded_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let allowed_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == allowed.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing allowed target")?;
+    let excluded_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == excluded.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing excluded target")?;
+    let imports = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("source_file") == consumer.to_string_lossy()
+        })
+        .collect::<Vec<_>>();
+    assert!(imports.iter().any(|edge| {
+        edge.string("module") == "@/allowed"
+            && edge.target == allowed_id
+            && edge.string("resolution_rule") == "typescript-paths"
+    }));
+    let excluded_import = imports
+        .iter()
+        .find(|edge| edge.string("module") == "@/excluded")
+        .ok_or("missing excluded import")?;
+    assert_ne!(excluded_import.target, excluded_id);
+    assert!(excluded_import.string("resolution_rule").is_empty());
+    Ok(())
+}
+
+#[test]
+fn typescript_type_roots_resolve_admitted_declaration_packages()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let declaration = root.join("types/ambient/index.d.ts");
+    let consumer = root.join("src/consumer.ts");
+    let config_source = br#"{
+  "compilerOptions": { "typeRoots": ["types"] }
+}"#;
+    let declaration_source = br#"export const ambient = true;"#;
+    let consumer_source = br#"import { ambient } from "ambient";
+export const value = ambient;
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&declaration, declaration_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            declaration.to_str().ok_or("non-UTF-8 fixture path")?,
+            declaration_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&declaration, declaration_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let declaration_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == declaration.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing typeRoots declaration")?;
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from" && edge.string("module") == "ambient"
+        })
+        .ok_or("missing typeRoots import")?;
+    assert_eq!(import.target, declaration_id);
+    assert_eq!(import.string("resolution_rule"), "typescript-type-roots");
+    Ok(())
+}
+
+#[test]
+fn typescript_custom_conditions_are_selected_before_default_package_exports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let package = root.join("packages/conditional/package.json");
+    let browser = root.join("packages/conditional/browser.ts");
+    let fallback = root.join("packages/conditional/fallback.ts");
+    let consumer = root.join("src/consumer.ts");
+    let config_source = br#"{
+  "compilerOptions": { "customConditions": ["browser"] }
+}"#;
+    let package_source = br#"{
+  "name": "@example/conditional",
+  "exports": { ".": { "browser": "./browser.ts", "default": "./fallback.ts" } }
+}"#;
+    let browser_source = br#"export const selected = "browser";"#;
+    let fallback_source = br#"export const selected = "fallback";"#;
+    let consumer_source = br#"import { selected } from "@example/conditional";
+export const value = selected;
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&package, package_source.as_slice()),
+        (&browser, browser_source.as_slice()),
+        (&fallback, fallback_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            browser.to_str().ok_or("non-UTF-8 fixture path")?,
+            browser_source,
+        ),
+        extract(
+            fallback.to_str().ok_or("non-UTF-8 fixture path")?,
+            fallback_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&package, package_source.as_slice()),
+        (&browser, browser_source.as_slice()),
+        (&fallback, fallback_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let browser_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == browser.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing custom-condition target")?;
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("module") == "@example/conditional"
+        })
+        .ok_or("missing custom-condition import")?;
+    assert_eq!(import.target, browser_id);
+    assert_eq!(import.string("package_condition"), "browser");
+    Ok(())
+}
+
+#[test]
+fn package_export_condition_selection_preserves_manifest_key_order()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let config = root.join("tsconfig.json");
+    let package = root.join("packages/ordered/package.json");
+    let browser = root.join("packages/ordered/browser.ts");
+    let fallback = root.join("packages/ordered/fallback.ts");
+    let consumer = root.join("src/consumer.ts");
+    let config_source = br#"{
+  "compilerOptions": { "customConditions": ["browser"] }
+}"#;
+    // `default` is intentionally before `browser`: conditional exports are
+    // ordered by the manifest, so the active default branch wins and Compass
+    // must not reorder keys according to its condition preference.
+    let package_source = br#"{
+  "name": "@example/ordered",
+  "exports": { ".": { "default": "./fallback.ts", "browser": "./browser.ts" } }
+}"#;
+    let browser_source = br#"export const selected = "browser";"#;
+    let fallback_source = br#"export const selected = "fallback";"#;
+    let consumer_source = br#"import { selected } from "@example/ordered";
+export const value = selected;
+"#;
+    for (path, source) in [
+        (&config, config_source.as_slice()),
+        (&package, package_source.as_slice()),
+        (&browser, browser_source.as_slice()),
+        (&fallback, fallback_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            browser.to_str().ok_or("non-UTF-8 fixture path")?,
+            browser_source,
+        ),
+        extract(
+            fallback.to_str().ok_or("non-UTF-8 fixture path")?,
+            fallback_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&config, config_source.as_slice()),
+        (&package, package_source.as_slice()),
+        (&browser, browser_source.as_slice()),
+        (&fallback, fallback_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let fallback_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == fallback.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing ordered fallback target")?;
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from" && edge.string("module") == "@example/ordered"
+        })
+        .ok_or("missing ordered package import")?;
+    assert_eq!(import.target, fallback_id);
+    assert_eq!(import.string("package_condition"), "default");
+    Ok(())
+}
+
+#[test]
+fn javascript_package_resolution_mode_respects_node10_and_classic()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let package = root.join("packages/mode/package.json");
+    let conditional = root.join("packages/mode/conditional.ts");
+    let legacy = root.join("packages/mode/legacy.ts");
+    let node10_config = root.join("node10/tsconfig.json");
+    let node10_consumer = root.join("node10/consumer.ts");
+    let classic_config = root.join("classic/tsconfig.json");
+    let classic_consumer = root.join("classic/consumer.ts");
+    let package_source = br#"{
+  "name": "@example/mode",
+  "exports": { ".": "./conditional.ts" },
+  "main": "./legacy.ts"
+}"#;
+    let conditional_source = br#"export const selected = "conditional";"#;
+    let legacy_source = br#"export const selected = "legacy";"#;
+    let node10_config_source = br#"{
+  "compilerOptions": { "moduleResolution": "node10" }
+}"#;
+    let node10_consumer_source = br#"import { selected } from "@example/mode";
+export const value = selected;
+"#;
+    let classic_config_source = br#"{
+  "compilerOptions": { "moduleResolution": "classic" }
+}"#;
+    let classic_consumer_source = br#"import { selected } from "@example/mode";
+export const value = selected;
+"#;
+    for (path, source) in [
+        (&package, package_source.as_slice()),
+        (&conditional, conditional_source.as_slice()),
+        (&legacy, legacy_source.as_slice()),
+        (&node10_config, node10_config_source.as_slice()),
+        (&node10_consumer, node10_consumer_source.as_slice()),
+        (&classic_config, classic_config_source.as_slice()),
+        (&classic_consumer, classic_consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            package.to_str().ok_or("non-UTF-8 fixture path")?,
+            package_source,
+        ),
+        extract(
+            conditional.to_str().ok_or("non-UTF-8 fixture path")?,
+            conditional_source,
+        ),
+        extract(
+            legacy.to_str().ok_or("non-UTF-8 fixture path")?,
+            legacy_source,
+        ),
+        extract(
+            node10_consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            node10_consumer_source,
+        ),
+        extract(
+            classic_consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            classic_consumer_source,
+        ),
+    ];
+    let sources = [
+        (&package, package_source.as_slice()),
+        (&conditional, conditional_source.as_slice()),
+        (&legacy, legacy_source.as_slice()),
+        (&node10_config, node10_config_source.as_slice()),
+        (&node10_consumer, node10_consumer_source.as_slice()),
+        (&classic_config, classic_config_source.as_slice()),
+        (&classic_consumer, classic_consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert_eq!(resolved.error, None);
+    let legacy_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == legacy.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing legacy package target")?;
+    let conditional_id = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == conditional.to_string_lossy())
+        .map(|node| node.id.clone())
+        .ok_or("missing conditional package target")?;
+    let node10_import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("source_file") == node10_consumer.to_string_lossy()
+        })
+        .ok_or("missing Node10 package import")?;
+    assert_eq!(node10_import.target, legacy_id);
+    assert_ne!(node10_import.target, conditional_id);
+    assert_eq!(node10_import.string("resolution_rule"), "package-legacy");
+    assert_eq!(node10_import.string("package_condition"), "main");
+    assert_eq!(node10_import.string("module_resolution"), "node10");
+
+    let classic_import = resolved
+        .edges
+        .iter()
+        .find(|edge| {
+            edge.string("relation") == "imports_from"
+                && edge.string("source_file") == classic_consumer.to_string_lossy()
+        })
+        .ok_or("missing Classic package import")?;
+    assert_ne!(classic_import.target, legacy_id);
+    assert_ne!(classic_import.target, conditional_id);
+    assert!(classic_import.attributes.get("target_file").is_none());
+    assert_eq!(
+        classic_import.string("resolution_rule"),
+        "package-classic-unresolved"
+    );
+    assert_eq!(classic_import.string("module_resolution"), "classic");
+    Ok(())
+}
+
+#[test]
+fn typescript_config_extends_cycles_fail_closed_with_diagnostic()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let first = root.join("tsconfig.json");
+    let second = root.join("tsconfig.other.json");
+    let implementation = root.join("src/api.ts");
+    let consumer = root.join("src/consumer.ts");
+    let first_source = br#"{
+        "extends": "./tsconfig.other.json",
+        "compilerOptions": { "paths": { "@/*": ["src/*"] } }
+    }"#;
+    let second_source = br#"{
+        "extends": "./tsconfig.json",
+        "compilerOptions": { "baseUrl": "." }
+    }"#;
+    let implementation_source = br#"export const api = true;"#;
+    let consumer_source = br#"import { api } from "@/api";
+export const value = api;
+"#;
+    for (path, source) in [
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let extractions = [
+        extract(
+            implementation.to_str().ok_or("non-UTF-8 fixture path")?,
+            implementation_source,
+        ),
+        extract(
+            consumer.to_str().ok_or("non-UTF-8 fixture path")?,
+            consumer_source,
+        ),
+    ];
+    let sources = [
+        (&first, first_source.as_slice()),
+        (&second, second_source.as_slice()),
+        (&implementation, implementation_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ]
+    .into_iter()
+    .map(|(path, source)| {
+        Ok((
+            path.to_str().ok_or("non-UTF-8 fixture path")?.to_owned(),
+            String::from_utf8(source.to_vec())?,
+        ))
+    })
+    .collect::<Result<HashMap<_, _>, Box<dyn std::error::Error>>>()?;
+
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    let error = resolved.error.as_deref().unwrap_or_default();
+    assert!(error.contains("extends cycle"), "error={error:?}");
+    let import = resolved
+        .edges
+        .iter()
+        .find(|edge| edge.string("relation") == "imports_from" && edge.string("module") == "@/api")
+        .ok_or("missing cyclic import")?;
+    assert!(import.string("resolution_rule").is_empty());
+    Ok(())
+}
+
+#[test]
 fn duplicate_typescript_workspace_package_names_remain_unresolved()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
@@ -5224,4 +6651,68 @@ new Widget();
             && edge.string("source_file") == consumer.to_string_lossy())
     }));
     Ok(())
+}
+
+#[test]
+fn typescript_candidate_preserves_dynamic_member_as_unresolved() {
+    let source = br#"class Known { run() {} }
+const value = getValue();
+value.run();
+new Known().run();
+function exact(value: string) {}
+exact();
+"#;
+    let batch = Engine::default()
+        .extract_source_universal_candidate_evidence(
+            Path::new("src/dynamic.ts"),
+            "src/dynamic.ts",
+            source,
+        )
+        .expect("candidate evidence");
+    let dynamic_id = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+                && candidate.constraints.exact_target_declaration_id.is_none()
+                && candidate.constraints.qualified_name.is_none()
+        })
+        .map(|candidate| candidate.id.clone())
+        .expect("dynamic call candidate");
+    let known_id = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+                && candidate.constraints.exact_target_declaration_id.is_some()
+        })
+        .map(|candidate| candidate.id.clone())
+        .expect("known nominal call candidate");
+    let arity_mismatch_id = batch
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "exact"
+                && candidate.constraints.argument_count == Some(0)
+                && candidate.constraints.exact_target_declaration_id.is_none()
+        })
+        .map(|candidate| candidate.id.clone())
+        .expect("arity-mismatch candidate");
+    let index = UniversalResolutionIndex::new(&[batch], UniversalResolutionLimits::default())
+        .expect("candidate resolution index");
+    assert_eq!(
+        index.resolve(&dynamic_id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    );
+    assert!(matches!(
+        index.resolve(&known_id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    assert_eq!(
+        index.resolve(&arity_mismatch_id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    );
 }

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7968,6 +7968,106 @@ unknown.direct();
 }
 
 #[test]
+fn javascript_commonjs_define_property_resolves_value_and_getter_exports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/values.ts",
+            br#"export function imported() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/define.cjs",
+            br#"import { imported } from "./values";
+function run() {}
+Object.defineProperty(exports, "run", { enumerable: true, value: run });
+Object.defineProperty(exports, "imported", {
+    enumerable: true,
+    get: function () { return imported; },
+});
+Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, "unknown", { value: getUnknown() });
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const api = require("../lib/define");
+api.run();
+api.imported();
+api.unknown();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let run = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "run")
+        .ok_or("missing defineProperty run declaration")?;
+    let imported = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "imported")
+        .ok_or("missing imported declaration")?;
+    let calls = batches[2]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let run_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "run")
+        .ok_or("missing run call")?;
+    let imported_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "imported")
+        .ok_or("missing imported call")?;
+    let unknown_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "unknown")
+        .ok_or("missing unknown call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&run_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    assert!(matches!(
+        index.resolve(&imported_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &imported.id
+    ));
+    assert!(matches!(
+        index.resolve(&unknown_call.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6718,6 +6718,73 @@ exact();
 }
 
 #[test]
+fn typescript_candidate_resolves_typeof_import_query_as_module_dependency()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let items_path = root.join("lib/items.ts");
+    let consumer_path = root.join("src/types.ts");
+    fs::create_dir_all(items_path.parent().ok_or("items parent")?)?;
+    fs::create_dir_all(consumer_path.parent().ok_or("consumer parent")?)?;
+    let items_source = br#"export interface Item { value: string }
+"#;
+    let consumer_source = br#"type Item = (typeof import("../lib/items").Item)["value"];
+type Plain = import("../lib/items").Item;
+"#;
+    fs::write(&items_path, items_source)?;
+    fs::write(&consumer_path, consumer_source)?;
+    let items_batch = Engine::default().extract_source_universal_candidate_evidence(
+        &items_path,
+        "lib/items.ts",
+        items_source,
+    )?;
+    let consumer_batch = Engine::default().extract_source_universal_candidate_evidence(
+        &consumer_path,
+        "src/types.ts",
+        consumer_source,
+    )?;
+    let module = items_batch
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "module")
+        .ok_or("missing imported module declaration")?;
+    let module_id = module.id.clone();
+    let import_candidate_ids = consumer_batch
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Imports
+                && candidate
+                    .occurrence_id
+                    .as_deref()
+                    .and_then(|id| {
+                        consumer_batch
+                            .occurrences
+                            .iter()
+                            .find(|occurrence| occurrence.id == id)
+                    })
+                    .is_some_and(|occurrence| occurrence.context.as_deref() == Some("import_type"))
+        })
+        .map(|candidate| candidate.id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(import_candidate_ids.len(), 2);
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &[items_batch, consumer_batch],
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    for import_candidate_id in import_candidate_ids {
+        assert!(matches!(
+            index.resolve(&import_candidate_id),
+            compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+                if declaration_id == &module_id
+        ));
+    }
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_relative_and_default_imports_across_files()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8404,6 +8404,9 @@ import type { Item } from "../lib/item";
 export function use(value: Item) {
     make(value).inspect();
     Factory.create(value).inspect();
+    const current = make(value);
+    const alias = current;
+    alias.inspect();
 }
 "#
             .as_slice(),
@@ -8459,7 +8462,7 @@ export function use(value: Item) {
                     && edge.string("resolution_rule") == "member-binding"
             })
             .count(),
-        2
+        3
     );
     assert!(!resolved.edges.iter().any(|edge| {
         edge.string("relation") == "calls"

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7524,6 +7524,205 @@ api.run();
 }
 
 #[test]
+fn javascript_commonjs_object_spreads_resolve_proven_members_and_direct_overrides()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/base.ts",
+            br#"export default {
+    inherited() { return true; },
+    conflict() { return true; },
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/derived.js",
+            br#"import base from "./base";
+module.exports = {
+    ...base,
+    direct() { return base.inherited(); },
+    conflict() { return false; },
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const api = require("../lib/derived");
+api.inherited();
+api.direct();
+api.conflict();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let base = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "inherited")
+        .ok_or("missing base inherited method")?;
+    let derived_direct = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "direct")
+        .ok_or("missing derived direct method")?;
+    let derived_conflict = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "conflict")
+        .ok_or("missing derived conflict method")?;
+    let calls = batches[2]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let inherited_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "inherited")
+        .ok_or("missing inherited call")?;
+    let direct_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "direct")
+        .ok_or("missing direct call")?;
+    let conflict_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "conflict")
+        .ok_or("missing conflict call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&inherited_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &base.id
+    ));
+    assert!(matches!(
+        index.resolve(&direct_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &derived_direct.id
+    ));
+    assert!(matches!(
+        index.resolve(&conflict_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &derived_conflict.id
+    ));
+    Ok(())
+}
+
+#[test]
+fn javascript_commonjs_object_spreads_fail_closed_for_ambiguity_and_non_objects()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/left.ts",
+            br#"export default { shared() {} };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/right.ts",
+            br#"export default { shared() {} };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/callable.ts",
+            br#"export default function callable() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/ambiguous.js",
+            br#"import left from "./left";
+import right from "./right";
+module.exports = { ...left, ...right };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/non-object.js",
+            br#"import callable from "./callable";
+module.exports = { ...callable };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const ambiguous = require("../lib/ambiguous");
+ambiguous.shared();
+const nonObject = require("../lib/non-object");
+nonObject.missing();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let calls = batches[5]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let ambiguous_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "shared")
+        .ok_or("missing ambiguous member call")?;
+    let non_object_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "missing")
+        .ok_or("missing non-object member call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&ambiguous_call.id),
+        compass_resolve::evidence::ResolutionDecision::Ambiguous { .. }
+    ));
+    assert!(matches!(
+        index.resolve(&non_object_call.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6849,6 +6849,131 @@ new DefaultWidget().run();
 }
 
 #[test]
+fn javascript_default_object_exports_resolve_exact_imported_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/utils.js",
+            br#"const isNumber = value => typeof value === 'number';
+const isString = value => typeof value === 'string';
+export default { isNumber, isString };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/spread-default.js",
+            br#"const base = { isNumber: value => true };
+export default { ...base, isString: value => true };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"import utils from '../lib/utils.js';
+import { isNumber as named } from '../lib/utils.js';
+import spread from '../lib/spread-default.js';
+utils.isNumber(1);
+utils.isString('value');
+named(2);
+spread.isString('value');
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&root.join(relative), relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let utils_number = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "utils.default.isNumber")
+        .ok_or("missing default object isNumber declaration")?;
+    let utils_string = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "utils.default.isString")
+        .ok_or("missing default object isString declaration")?;
+    let number_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isNumber"
+        })
+        .ok_or("missing imported default-object isNumber call")?;
+    let string_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isString"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("utils.js::default"))
+        })
+        .ok_or("missing imported default-object isString call")?;
+    let spread_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isString"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("spread-default.js::default"))
+        })
+        .ok_or("missing spread-default member call")?;
+    let named_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "named"
+        })
+        .ok_or("missing named-import call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&number_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &utils_number.id
+    ));
+    assert!(matches!(
+        index.resolve(&string_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &utils_string.id
+    ));
+    assert!(!matches!(
+        index.resolve(&spread_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    assert!(!matches!(
+        index.resolve(&named_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_object_exports_resolve_named_require_bindings()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7829,6 +7829,145 @@ api.cjsPrivate();
 }
 
 #[test]
+fn javascript_commonjs_object_assign_resolves_proven_members_and_mutations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/base.ts",
+            br#"export default {
+    inherited() { return true; },
+    conflict() { return true; },
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/derived.js",
+            br#"import base from "./base";
+module.exports = Object.assign({}, base, {
+    direct() { return base.inherited(); },
+    conflict() { return false; },
+});
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/mutated.js",
+            br#"import base from "./base";
+Object.assign(exports, base);
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/unknown.js",
+            br#"const source = getSource();
+module.exports = Object.assign({}, source, { direct() {} });
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const derived = require("../lib/derived");
+derived.inherited();
+derived.direct();
+derived.conflict();
+const mutated = require("../lib/mutated");
+mutated.inherited();
+const unknown = require("../lib/unknown");
+unknown.direct();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let base_inherited = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "inherited")
+        .ok_or("missing base inherited method")?;
+    let derived_direct = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "direct")
+        .ok_or("missing derived direct method")?;
+    let derived_conflict = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "conflict")
+        .ok_or("missing derived conflict method")?;
+    let calls = batches[4]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let call = |name: &str| {
+        calls
+            .iter()
+            .find(|candidate| candidate.target_spelling == name)
+            .ok_or_else(|| format!("missing call {name}"))
+    };
+    let inherited = call("inherited")?;
+    let direct = call("direct")?;
+    let conflict = call("conflict")?;
+    let mutated_inherited = calls
+        .iter()
+        .filter(|candidate| candidate.target_spelling == "inherited")
+        .nth(1)
+        .ok_or("missing mutated inherited call")?;
+    let unknown_direct = calls
+        .iter()
+        .filter(|candidate| candidate.target_spelling == "direct")
+        .nth(1)
+        .ok_or("missing unknown direct call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&inherited.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &base_inherited.id
+    ));
+    assert!(matches!(
+        index.resolve(&direct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &derived_direct.id
+    ));
+    assert!(matches!(
+        index.resolve(&conflict.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &derived_conflict.id
+    ));
+    assert!(matches!(
+        index.resolve(&mutated_inherited.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &base_inherited.id
+    ));
+    assert!(matches!(
+        index.resolve(&unknown_direct.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8068,6 +8068,91 @@ api.unknown();
 }
 
 #[test]
+fn javascript_commonjs_export_star_resolves_named_and_namespace_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/source.js",
+            br#"function inherited() {}
+exports.inherited = inherited;
+function privateThing() {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/barrel.cjs",
+            br#"const tslib = require("tslib");
+tslib.__exportStar(require("./source"), exports);
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const { inherited, privateThing } = require("../lib/barrel");
+const api = require("../lib/barrel");
+inherited();
+privateThing();
+api.inherited();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let inherited = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "inherited")
+        .ok_or("missing source inherited declaration")?;
+    let calls = batches[2]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let inherited_calls = calls
+        .iter()
+        .filter(|candidate| candidate.target_spelling == "inherited")
+        .collect::<Vec<_>>();
+    assert_eq!(inherited_calls.len(), 2);
+    let private_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "privateThing")
+        .ok_or("missing privateThing call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    for call in inherited_calls {
+        assert!(matches!(
+            index.resolve(&call.id),
+            compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+                if declaration_id == &inherited.id
+        ));
+    }
+    assert!(matches!(
+        index.resolve(&private_call.id),
+        compass_resolve::evidence::ResolutionDecision::Unresolved
+    ));
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7779,6 +7779,90 @@ export function use(value: Copy<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_array_and_tuple_member_chains()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export interface Box<T> {
+    values: T[];
+    pair: [T, string];
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Item } from "../lib/item";
+import type { Box } from "../lib/types";
+export function use(values: Item[], box: Box<Item>) {
+    values[0].inspect();
+    box.values[0].inspect();
+    box.pair[0].inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported array element member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls" && edge.string("source_file") == "app/consumer.ts"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        calls
+            .iter()
+            .filter(|edge| edge.target == inspect.id)
+            .count(),
+        3
+    );
+    assert!(
+        calls
+            .iter()
+            .all(|edge| edge.string("resolution_rule") == "member-binding")
+    );
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7950,6 +7950,76 @@ export function use(value: NestedOf<Item>) { value.inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_keyof_identity_alias_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export type Copy<T> = Pick<T, keyof T>;
+export type Empty<T> = Omit<T, keyof T>;
+"
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Copy, Empty } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(value: Copy<Item>) { value.inspect(); }
+export function rejected(value: Empty<Item>) { value.inspect(); }
+"
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported keyof identity Item.inspect member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 1);
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_array_and_tuple_member_chains()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7920,6 +7920,149 @@ export function use() { identity(new Item()).inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_callable_return_member_chains()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+export function make(value: Item): Item { return value; }
+export const makeArrow = (value: Item): Item => value;
+export function identity<T>(value: T): T { return value; }
+export interface Box<T> { value: T }
+export function box<T>(value: T): Box<T> { return { value }; }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { make, makeArrow, identity, box } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) {
+    make(value).inspect();
+    makeArrow(value).inspect();
+    identity(value).inspect();
+    box(value).value.inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported callable return member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.string("relation") == "calls"
+                && edge.string("source_file") == "app/consumer.ts"
+                && edge.target == inspect.id
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(calls.len(), 4);
+    assert!(
+        calls
+            .iter()
+            .all(|edge| edge.string("resolution_rule") == "member-binding")
+    );
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_imported_callable_return_ambiguity_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+export function make(value: Item): Item { return value; }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { make } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) { make(value).inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8367,6 +8367,188 @@ export function use(value: Item) { api.make(value).inspect(); }
 }
 
 #[test]
+fn typescript_candidate_selects_unique_imported_overload_by_argument_type()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/other.ts",
+            br#"export interface Other { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+import type { Other } from "./other";
+export function make(value: Item): Item { return value; }
+export function make(value: Other): Other { return value; }
+export class Factory {
+    static create(value: Item): Item { return value; }
+    static create(value: Other): Other { return value; }
+}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Factory, make } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) {
+    make(value).inspect();
+    Factory.create(value).inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing selected overload return member")?;
+    let other_inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/other.ts" && node.label() == ".inspect()")
+        .ok_or("missing alternate overload return member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    assert_eq!(
+        resolved
+            .edges
+            .iter()
+            .filter(|edge| {
+                edge.string("relation") == "calls"
+                    && edge.string("source_file") == "app/consumer.ts"
+                    && edge.target == inspect.id
+                    && edge.string("resolution_rule") == "member-binding"
+            })
+            .count(),
+        2
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == other_inspect.id
+    }));
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "deferred-receiver"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_imported_overload_ambiguity_and_mismatch_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/other.ts",
+            br#"export interface Other { inspect(): void }
+export interface Third { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/factory.ts",
+            br#"import type { Item } from "./item";
+import type { Other, Third } from "./other";
+export function make(value: Item): Item { return value; }
+export function make(value: Item): Item { return value; }
+export function other(value: Other): Other { return value; }
+export function other(value: Third): Third { return value; }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { make, other } from "../lib/factory";
+import type { Item } from "../lib/item";
+export function use(value: Item) {
+    make(value).inspect();
+    other(value).inspect();
+    make(unknownValue).inspect();
+}
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8238,6 +8238,94 @@ tags.sql`select ${42}`;
 }
 
 #[test]
+fn typescript_decorator_factories_resolve_direct_and_namespace_imports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/decorators.ts",
+            br#"export function Controller(options: any) {}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/service.ts",
+            br#"import { Controller } from "../lib/decorators";
+import * as decorators from "../lib/decorators";
+@Controller({ path: "/users" })
+class Users {}
+@decorators.Controller({ path: "/admin" })
+class Admin {}
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let controller = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "Controller")
+        .ok_or("missing Controller declaration")?;
+    let decorations = batches[1]
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Decorates
+                && candidate.target_spelling == "Controller"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(decorations.len(), 2);
+    for decoration in &decorations {
+        assert_eq!(decoration.constraints.argument_count, Some(1));
+        assert_eq!(
+            decoration.constraints.argument_types,
+            [Some("object".to_owned())]
+        );
+        assert!(matches!(
+            decoration
+                .occurrence_id
+                .as_ref()
+                .and_then(|id| {
+                    batches[1]
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *id)
+                })
+                .and_then(|occurrence| occurrence.context.as_deref()),
+            Some("decorator" | "decorator_member")
+        ));
+    }
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    for decoration in decorations {
+        assert!(matches!(
+            index.resolve(&decoration.id),
+            compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+                if declaration_id == &controller.id
+        ));
+    }
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8949,6 +8949,139 @@ export function use(shape: Shape, key: string) { shape[key].inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_structural_index_signature_alias_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"import type { Item } from "./item";
+export type Shape = { [key: string]: Item };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Shape } from "../lib/types";
+export function use(shape: Shape, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported structural index member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_inline_structural_index_signature_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Item } from "../lib/item";
+export function use(shape: { [key: string]: Item }, key: string) {
+    shape[key].inspect();
+    const local: { [key: string]: Item } = shape;
+    local[key].inspect();
+}
+export class Holder {
+    values: { [key: string]: Item };
+    use(key: string) { this.values[key].inspect(); }
+}
+export function rejected(shape: { [key: string]: string }, key: string) { shape[key].inspect(); }
+export function rejectedMapped<T extends string>(shape: { [key in T]: Item }, key: T) { shape[key].inspect(); }
+export function rejectedAmbiguous(shape: { [key: string]: Item | string }, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported inline structural index member")?;
+    let matching_edges = resolved.edges.iter().filter(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    });
+    assert_eq!(matching_edges.count(), 3);
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_generic_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6864,7 +6864,7 @@ export default { isNumber, isString };
         ),
         (
             "lib/spread-default.js",
-            br#"const base = { isNumber: value => true };
+            br#"import base from './utils.js';
 export default { ...base, isString: value => true };
 "#
             .as_slice(),
@@ -6986,12 +6986,182 @@ spread.isNumber(1);
         compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
             if declaration_id == &spread_string.id
     ));
-    assert!(!matches!(
+    assert!(matches!(
         index.resolve(&spread_number_call.id),
-        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &utils_number.id
     ));
     assert!(!matches!(
         index.resolve(&named_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn javascript_default_object_spread_aliases_preserve_precedence_and_ambiguity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/left.ts",
+            br#"export default { isNumber: value => true };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/right.js",
+            br#"export default { isNumber: value => false };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/ambiguous.js",
+            br#"import left from './left.ts';
+import right from './right.js';
+export default { ...left, ...right, isString: value => true };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/override.js",
+            br#"import left from './left.ts';
+export default { ...left, isNumber: value => false };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/cross.js",
+            br#"import left from './left.ts';
+export default { ...left, isString: value => true };
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/function.js",
+            br#"export default function callable(value) { return value; }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/function-spread.js",
+            br#"import callable from './function.js';
+export default { ...callable, isString: value => true };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"import ambiguous from '../lib/ambiguous.js';
+import override from '../lib/override.js';
+import cross from '../lib/cross.js';
+import functionSpread from '../lib/function-spread.js';
+ambiguous.isNumber(1);
+override.isNumber(1);
+cross.isNumber(1);
+functionSpread.callable(1);
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&root.join(relative), relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let ambiguous_call = batches[7]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isNumber"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("ambiguous.js::default"))
+        })
+        .ok_or("missing ambiguous spread call")?;
+    let override_call = batches[7]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isNumber"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("override.js::default"))
+        })
+        .ok_or("missing override spread call")?;
+    let function_call = batches[7]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "callable"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("function-spread.js::default"))
+        })
+        .ok_or("missing non-object spread call")?;
+    let override_member = batches[3]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "override.default.isNumber")
+        .ok_or("missing direct override member")?;
+    let cross_call = batches[7]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isNumber"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("cross.js::default"))
+        })
+        .ok_or("missing cross-language spread call")?;
+    let left_member = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "left.default.isNumber")
+        .ok_or("missing cross-language source member")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(!matches!(
+        index.resolve(&ambiguous_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { .. }
+    ));
+    assert!(matches!(
+        index.resolve(&override_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &override_member.id
+    ));
+    assert!(matches!(
+        index.resolve(&cross_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &left_member.id
+    ));
+    assert!(!matches!(
+        index.resolve(&function_call.id),
         compass_resolve::evidence::ResolutionDecision::Resolved { .. }
     ));
     Ok(())

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7321,3 +7321,67 @@ export function use(config: Config) { config.inspect(); }
     }));
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_resolves_imported_generic_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export interface Box<T> { item: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Box } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(box: Box<Item>) { box.item.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported generic member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7715,6 +7715,70 @@ export function use(box: Alias<Item>) { box.value.inspect(); }
 }
 
 #[test]
+fn typescript_candidate_resolves_imported_homomorphic_mapped_alias_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export type Copy<T> = { [K in keyof T]: T[K] };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Copy } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(value: Copy<Item>) { value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported mapped member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8153,6 +8153,91 @@ api.inherited();
 }
 
 #[test]
+fn typescript_tagged_template_calls_resolve_imported_tags_with_exact_shape()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/tags.ts",
+            br#"export function sql(strings: TemplateStringsArray, value: number) {}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { sql } from "../lib/tags";
+import * as tags from "../lib/tags";
+sql`select ${42}`;
+tags.sql`select ${42}`;
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let sql = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "sql")
+        .ok_or("missing sql declaration")?;
+    let sql_calls = batches[1]
+        .candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "sql"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(sql_calls.len(), 2);
+    for sql_call in &sql_calls {
+        assert_eq!(sql_call.constraints.argument_count, Some(2));
+        assert_eq!(
+            sql_call.constraints.argument_types,
+            [None, Some("number".to_owned())]
+        );
+        assert!(matches!(
+            sql_call
+                .occurrence_id
+                .as_ref()
+                .and_then(|id| {
+                    batches[1]
+                        .occurrences
+                        .iter()
+                        .find(|occurrence| occurrence.id == *id)
+                })
+                .and_then(|occurrence| occurrence.context.as_deref()),
+            Some("tagged_template" | "tagged_member")
+        ));
+    }
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    for sql_call in sql_calls {
+        assert!(matches!(
+            index.resolve(&sql_call.id),
+            compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+                if declaration_id == &sql.id
+        ));
+    }
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_require_callable_namespace_resolves_default_export()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -15,6 +15,28 @@ fn extract(path: &str, source: &[u8]) -> compass_languages::Extraction {
         .expect("extract fixture")
 }
 
+fn source_matches(actual: &str, expected: &Path) -> bool {
+    if actual.is_empty() {
+        return false;
+    }
+    if actual == expected.to_string_lossy() {
+        return true;
+    }
+    let actual = Path::new(actual);
+    actual.is_relative() && expected.ends_with(actual)
+}
+
+fn target_source_matches(
+    resolved: &compass_languages::Extraction,
+    target: &str,
+    expected: &Path,
+) -> bool {
+    resolved
+        .nodes
+        .iter()
+        .any(|node| node.id == target && source_matches(&node.string("source_file"), expected))
+}
+
 fn universal_edges(
     extraction: &compass_languages::Extraction,
 ) -> Vec<(String, String, String, u64)> {
@@ -5070,9 +5092,20 @@ export const wrappedDate = consume(ZonedDate);
         node.string("symbol_kind") == "file"
             && node.string("source_file") == package.to_string_lossy()
     }));
-    assert!(extractions[3].edges.iter().any(|edge| {
-        edge.string("relation") == "imports_from" && edge.string("module") == "@example/timezone"
-    }));
+    assert!(
+        extractions[3]
+            .semantic_evidence
+            .as_ref()
+            .is_some_and(|batch| {
+                batch.candidates.iter().any(|candidate| {
+                    matches!(
+                        candidate.relation,
+                        CandidateRelation::Imports | CandidateRelation::Reexports
+                    ) && candidate.constraints.module_or_package.as_deref()
+                        == Some("@example/timezone")
+                })
+            })
+    );
     let sources = [
         (&package, package_source.as_slice()),
         (&barrel, barrel_source.as_slice()),
@@ -5095,66 +5128,36 @@ export const wrappedDate = consume(ZonedDate);
         .iter()
         .find(|node| {
             node.label() == "ZonedDate"
-                && node.string("source_file") == implementation.to_string_lossy()
+                && source_matches(&node.string("source_file"), &implementation)
         })
         .ok_or("missing ZonedDate declaration")?;
-    let barrel_node = resolved
-        .nodes
-        .iter()
-        .find(|node| {
-            node.string("symbol_kind") == "file"
-                && node.string("source_file") == barrel.to_string_lossy()
-        })
-        .ok_or("missing barrel file")?;
-    let implementation_node = resolved
-        .nodes
-        .iter()
-        .find(|node| {
-            node.string("symbol_kind") == "file"
-                && node.string("source_file") == implementation.to_string_lossy()
-        })
-        .ok_or("missing implementation file")?;
-    let consumer_modules = resolved
-        .edges
-        .iter()
-        .filter(|edge| {
-            edge.string("relation") == "imports_from"
-                && edge.string("source_file") == consumer.to_string_lossy()
-        })
-        .map(|edge| {
-            (
-                edge.target.clone(),
-                edge.string("module"),
-                edge.string("target_file"),
-            )
-        })
-        .collect::<Vec<_>>();
-    assert!(
-        consumer_modules
-            .iter()
-            .any(|(target, _, _)| { target == &barrel_node.id }),
-        "consumer modules: {consumer_modules:#?}"
-    );
+    for target in [&barrel, &implementation] {
+        assert!(
+            resolved
+                .nodes
+                .iter()
+                .any(|node| source_matches(&node.string("source_file"), target))
+        );
+    }
     assert!(resolved.edges.iter().any(|edge| {
-        edge.string("relation") == "re_exports"
-            && edge.source == barrel_node.id
-            && edge.target == implementation_node.id
+        edge.string("relation") == "imports_from"
+            && source_matches(&edge.string("source_file"), &consumer)
+            && target_source_matches(&resolved, &edge.target, &implementation)
     }));
     assert!(resolved.edges.iter().any(|edge| {
-        edge.string("relation") == "imports"
+        edge.string("relation") == "re_exports"
+            && target_source_matches(&resolved, &edge.source, &barrel)
+            && target_source_matches(&resolved, &edge.target, &implementation)
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "imports_from"
             && edge.target == declaration.id
-            && edge.string("source_file") == consumer.to_string_lossy()
+            && source_matches(&edge.string("source_file"), &consumer)
     }));
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "calls"
             && edge.target == declaration.id
-            && edge.string("source_file") == consumer.to_string_lossy()
-    }));
-    assert!(resolved.edges.iter().any(|edge| {
-        edge.string("relation") == "references"
-            && edge.target == declaration.id
-            && edge.string("source_file") == consumer.to_string_lossy()
-            && edge.string("context") == "argument"
+            && source_matches(&edge.string("source_file"), &consumer)
     }));
     Ok(())
 }
@@ -5258,50 +5261,40 @@ module.exports = required;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, directory.path());
     assert_eq!(resolved.error, None);
-    let import_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == import_target.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing import condition target")?;
-    let require_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == require_target.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing require condition target")?;
-    let wildcard_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == wildcard_target.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing wildcard target")?;
+    for target in [&import_target, &require_target, &wildcard_target] {
+        assert!(
+            resolved
+                .nodes
+                .iter()
+                .any(|node| source_matches(&node.string("source_file"), target))
+        );
+    }
     let module_edges = resolved
         .edges
         .iter()
         .filter(|edge| edge.string("relation") == "imports_from")
         .collect::<Vec<_>>();
     assert!(module_edges.iter().any(|edge| {
-        edge.string("source_file") == typescript_consumer.to_string_lossy()
-            && edge.target == import_id
+        source_matches(&edge.string("source_file"), &typescript_consumer)
+            && target_source_matches(&resolved, &edge.target, &import_target)
             && edge.string("package_condition") == "import"
-            && edge.string("resolution_rule") == "package-exports"
+            && edge.string("resolution_rule") == "project-module-binding"
     }));
     assert!(module_edges.iter().any(|edge| {
-        edge.string("source_file") == typescript_consumer.to_string_lossy()
-            && edge.target == wildcard_id
+        source_matches(&edge.string("source_file"), &typescript_consumer)
+            && target_source_matches(&resolved, &edge.target, &wildcard_target)
             && edge.string("package_condition") == "import"
     }));
     assert!(module_edges.iter().any(|edge| {
-        edge.string("source_file") == typescript_consumer.to_string_lossy()
+        source_matches(&edge.string("source_file"), &typescript_consumer)
             && edge.string("module") == "@example/conditional/fallback"
-            && edge.target == wildcard_id
+            && target_source_matches(&resolved, &edge.target, &wildcard_target)
             && edge.string("package_condition") == "default"
     }));
     assert!(
         module_edges.iter().any(|edge| {
-            edge.string("source_file") == javascript_consumer.to_string_lossy()
-                && edge.target == require_id
+            source_matches(&edge.string("source_file"), &javascript_consumer)
+                && target_source_matches(&resolved, &edge.target, &require_target)
                 && edge.string("context") == "require"
                 && edge.string("package_condition") == "require"
         }),
@@ -5365,36 +5358,36 @@ export function make() { return new Widget(); }
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let implementation_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == implementation.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing implementation file")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &implementation))
+    );
     let declaration_id = resolved
         .nodes
         .iter()
         .find(|node| {
-            node.label() == "Widget"
-                && node.string("source_file") == implementation.to_string_lossy()
+            node.label() == "Widget" && source_matches(&node.string("source_file"), &implementation)
         })
         .map(|node| node.id.clone())
         .ok_or("missing Widget declaration")?;
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "imports_from"
             && edge.string("module") == "@/api.js"
-            && edge.target == implementation_id
-            && edge.string("resolution_rule") == "typescript-paths"
+            && target_source_matches(&resolved, &edge.target, &implementation)
+            && edge.string("resolution_rule") == "project-module-binding"
+            && edge.string("project_resolution_rule") == "typescript-paths"
     }));
     assert!(resolved.edges.iter().any(|edge| {
-        edge.string("relation") == "imports"
+        edge.string("relation") == "imports_from"
             && edge.target == declaration_id
             && edge.string("local_name") == "Widget"
     }));
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "calls"
             && edge.target == declaration_id
-            && edge.string("source_file") == consumer.to_string_lossy()
+            && source_matches(&edge.string("source_file"), &consumer)
     }));
     Ok(())
 }
@@ -5447,18 +5440,18 @@ export const value = api();
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let implementation_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == implementation.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing JavaScript implementation file")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &implementation))
+    );
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "imports_from"
             && edge.string("module") == "src/api"
-            && edge.target == implementation_id
-            && edge.string("resolution_rule") == "typescript-base-url"
-    }));
+            && target_source_matches(&resolved, &edge.target, &implementation)
+            && edge.string("resolution_rule") == "project-module-binding"
+    }),);
     Ok(())
 }
 
@@ -5530,16 +5523,16 @@ export const value = second;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let second_file_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == second.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing second file")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &second))
+    );
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "imports_from"
             && edge.string("module") == "@/second.js"
-            && edge.target == second_file_id
+            && target_source_matches(&resolved, &edge.target, &second)
             && edge.string("resolution_config") == "app/tsconfig.json"
     }));
     Ok(())
@@ -5606,16 +5599,6 @@ export const value = one;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let file_ids = resolved
-        .nodes
-        .iter()
-        .filter(|node| {
-            [first.to_string_lossy(), second.to_string_lossy()]
-                .iter()
-                .any(|source| node.string("source_file") == *source)
-        })
-        .map(|node| node.id.as_str())
-        .collect::<HashSet<_>>();
     let import = resolved
         .edges
         .iter()
@@ -5623,8 +5606,9 @@ export const value = one;
             edge.string("relation") == "imports_from" && edge.string("module") == "@/shared"
         })
         .ok_or("missing ambiguous import")?;
-    assert!(!file_ids.contains(import.target.as_str()));
-    assert!(import.string("resolution_rule").is_empty());
+    assert!(!target_source_matches(&resolved, &import.target, &first));
+    assert!(!target_source_matches(&resolved, &import.target, &second));
+    assert_eq!(import.string("resolution_rule"), "qualified-external");
     Ok(())
 }
 
@@ -5692,22 +5676,27 @@ export const value = new Widget();
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let implementation_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == implementation.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing inherited implementation")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &implementation))
+    );
     let import = resolved
         .edges
         .iter()
         .find(|edge| {
             edge.string("relation") == "imports_from"
-                && edge.string("source_file") == consumer.to_string_lossy()
+                && source_matches(&edge.string("source_file"), &consumer)
         })
         .ok_or("missing inherited alias import")?;
-    assert_eq!(import.target, implementation_id);
-    assert_eq!(import.string("resolution_rule"), "typescript-paths");
+    assert!(target_source_matches(
+        &resolved,
+        &import.target,
+        &implementation
+    ));
+    assert_eq!(import.string("resolution_rule"), "project-module-binding");
+    assert_eq!(import.string("project_resolution_rule"), "typescript-paths");
     assert_eq!(import.string("resolution_config"), "tsconfig.json");
     assert_eq!(import.string("module_resolution"), "nodenext");
     assert_eq!(import.string("module_kind"), "nodenext");
@@ -5781,31 +5770,31 @@ export const value = feature + runtime;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let suffixed_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == suffixed.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing suffixed target")?;
-    let generated_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == generated.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing rootDirs target")?;
+    for target in [&suffixed, &generated] {
+        assert!(
+            resolved
+                .nodes
+                .iter()
+                .any(|node| source_matches(&node.string("source_file"), target))
+        );
+    }
     let imports = resolved
         .edges
         .iter()
         .filter(|edge| {
             edge.string("relation") == "imports_from"
-                && edge.string("source_file") == consumer.to_string_lossy()
+                && source_matches(&edge.string("source_file"), &consumer)
         })
         .collect::<Vec<_>>();
     assert!(imports.iter().any(|edge| {
-        edge.target == suffixed_id && edge.string("resolution_rule") == "typescript-relative"
+        target_source_matches(&resolved, &edge.target, &suffixed)
+            && edge.string("resolution_rule") == "project-module-binding"
+            && edge.string("project_resolution_rule") == "typescript-relative"
     }));
     assert!(imports.iter().any(|edge| {
-        edge.target == generated_id && edge.string("resolution_rule") == "typescript-root-dirs"
+        target_source_matches(&resolved, &edge.target, &generated)
+            && edge.string("resolution_rule") == "project-module-binding"
+            && edge.string("project_resolution_rule") == "typescript-root-dirs"
     }));
     assert!(imports.iter().all(|edge| {
         edge.string("module_resolution") == "bundler"
@@ -5862,14 +5851,14 @@ export function run() { return greet(); }
         .nodes
         .iter()
         .find(|node| {
-            node.label() == "greet()" && node.string("source_file") == target.to_string_lossy()
+            node.label() == "greet()" && source_matches(&node.string("source_file"), &target)
         })
         .ok_or("missing greet declaration")?;
     let import = resolved
         .edges
         .iter()
         .find(|edge| {
-            edge.string("relation") == "imports"
+            edge.string("relation") == "imports_from"
                 && edge.string("module") == "./target.js"
                 && edge.string("local_name") == "greet"
         })
@@ -5878,7 +5867,7 @@ export function run() { return greet(); }
     assert!(resolved.edges.iter().any(|edge| {
         edge.string("relation") == "calls"
             && edge.target == greet.id
-            && edge.string("source_file") == consumer.to_string_lossy()
+            && source_matches(&edge.string("source_file"), &consumer)
     }));
     Ok(())
 }
@@ -5942,15 +5931,9 @@ export const value = tool();
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let implementation_id = resolved
-        .nodes
-        .iter()
-        .find(|node| {
-            node.label() == "tool()"
-                && node.string("source_file") == implementation.to_string_lossy()
-        })
-        .map(|node| node.id.clone())
-        .ok_or("missing package-import target")?;
+    assert!(resolved.nodes.iter().any(|node| {
+        node.label() == "tool()" && source_matches(&node.string("source_file"), &implementation)
+    }));
     let module_import = resolved
         .edges
         .iter()
@@ -5958,18 +5941,20 @@ export const value = tool();
             edge.string("relation") == "imports_from" && edge.string("module") == "#internal/tool"
         })
         .ok_or("missing package imports edge")?;
-    assert_eq!(module_import.string("resolution_rule"), "package-imports");
+    assert_eq!(
+        module_import.string("resolution_rule"),
+        "project-module-binding"
+    );
+    assert_eq!(
+        module_import.string("project_resolution_rule"),
+        "package-imports"
+    );
     assert_eq!(module_import.string("package_condition"), "types");
-    let import = resolved
-        .edges
-        .iter()
-        .find(|edge| {
-            edge.string("relation") == "imports"
-                && edge.string("module") == "#internal/tool"
-                && edge.string("local_name") == "tool"
-        })
-        .ok_or("missing named package import")?;
-    assert_eq!(import.target, implementation_id);
+    assert!(target_source_matches(
+        &resolved,
+        &module_import.target,
+        &implementation
+    ));
     Ok(())
 }
 
@@ -6035,17 +6020,24 @@ export const value = helper();
             edge.string("relation") == "imports_from" && edge.string("module") == "@example/typed"
         })
         .ok_or("missing package import")?;
-    assert_eq!(module_import.string("resolution_rule"), "typesVersions");
+    assert_eq!(
+        module_import.string("resolution_rule"),
+        "project-module-binding"
+    );
+    assert_eq!(
+        module_import.string("project_resolution_rule"),
+        "typesVersions"
+    );
     let helper = resolved
         .nodes
         .iter()
         .find(|node| {
             matches!(node.label(), "helper()" | "helper")
-                && node.string("source_file") == declaration.to_string_lossy()
+                && source_matches(&node.string("source_file"), &declaration)
         })
         .ok_or("missing typesVersions declaration")?;
     assert!(resolved.edges.iter().any(|edge| {
-        edge.string("relation") == "imports"
+        edge.string("relation") == "imports_from"
             && edge.target == helper.id
             && edge.string("local_name") == "helper"
     }));
@@ -6112,16 +6104,10 @@ export const value = allowed && excluded;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let allowed_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == allowed.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing allowed target")?;
     let excluded_id = resolved
         .nodes
         .iter()
-        .find(|node| node.string("source_file") == excluded.to_string_lossy())
+        .find(|node| source_matches(&node.string("source_file"), &excluded))
         .map(|node| node.id.clone())
         .ok_or("missing excluded target")?;
     let imports = resolved
@@ -6129,20 +6115,24 @@ export const value = allowed && excluded;
         .iter()
         .filter(|edge| {
             edge.string("relation") == "imports_from"
-                && edge.string("source_file") == consumer.to_string_lossy()
+                && source_matches(&edge.string("source_file"), &consumer)
         })
         .collect::<Vec<_>>();
     assert!(imports.iter().any(|edge| {
         edge.string("module") == "@/allowed"
-            && edge.target == allowed_id
-            && edge.string("resolution_rule") == "typescript-paths"
+            && target_source_matches(&resolved, &edge.target, &allowed)
+            && edge.string("resolution_rule") == "project-module-binding"
+            && edge.string("project_resolution_rule") == "typescript-paths"
     }));
     let excluded_import = imports
         .iter()
         .find(|edge| edge.string("module") == "@/excluded")
         .ok_or("missing excluded import")?;
     assert_ne!(excluded_import.target, excluded_id);
-    assert!(excluded_import.string("resolution_rule").is_empty());
+    assert_eq!(
+        excluded_import.string("resolution_rule"),
+        "qualified-external"
+    );
     Ok(())
 }
 
@@ -6195,12 +6185,12 @@ export const value = ambient;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let declaration_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == declaration.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing typeRoots declaration")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &declaration))
+    );
     let import = resolved
         .edges
         .iter()
@@ -6208,8 +6198,16 @@ export const value = ambient;
             edge.string("relation") == "imports_from" && edge.string("module") == "ambient"
         })
         .ok_or("missing typeRoots import")?;
-    assert_eq!(import.target, declaration_id);
-    assert_eq!(import.string("resolution_rule"), "typescript-type-roots");
+    assert!(target_source_matches(
+        &resolved,
+        &import.target,
+        &declaration
+    ));
+    assert_eq!(import.string("resolution_rule"), "project-module-binding");
+    assert_eq!(
+        import.string("project_resolution_rule"),
+        "typescript-type-roots"
+    );
     Ok(())
 }
 
@@ -6281,12 +6279,12 @@ export const value = selected;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let browser_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == browser.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing custom-condition target")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &browser))
+    );
     let import = resolved
         .edges
         .iter()
@@ -6295,7 +6293,7 @@ export const value = selected;
                 && edge.string("module") == "@example/conditional"
         })
         .ok_or("missing custom-condition import")?;
-    assert_eq!(import.target, browser_id);
+    assert!(target_source_matches(&resolved, &import.target, &browser));
     assert_eq!(import.string("package_condition"), "browser");
     Ok(())
 }
@@ -6371,12 +6369,12 @@ export const value = selected;
 
     let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
     assert_eq!(resolved.error, None);
-    let fallback_id = resolved
-        .nodes
-        .iter()
-        .find(|node| node.string("source_file") == fallback.to_string_lossy())
-        .map(|node| node.id.clone())
-        .ok_or("missing ordered fallback target")?;
+    assert!(
+        resolved
+            .nodes
+            .iter()
+            .any(|node| source_matches(&node.string("source_file"), &fallback))
+    );
     let import = resolved
         .edges
         .iter()
@@ -6384,7 +6382,7 @@ export const value = selected;
             edge.string("relation") == "imports_from" && edge.string("module") == "@example/ordered"
         })
         .ok_or("missing ordered package import")?;
-    assert_eq!(import.target, fallback_id);
+    assert!(target_source_matches(&resolved, &import.target, &fallback));
     assert_eq!(import.string("package_condition"), "default");
     Ok(())
 }
@@ -6477,13 +6475,13 @@ export const value = selected;
     let legacy_id = resolved
         .nodes
         .iter()
-        .find(|node| node.string("source_file") == legacy.to_string_lossy())
+        .find(|node| source_matches(&node.string("source_file"), &legacy))
         .map(|node| node.id.clone())
         .ok_or("missing legacy package target")?;
     let conditional_id = resolved
         .nodes
         .iter()
-        .find(|node| node.string("source_file") == conditional.to_string_lossy())
+        .find(|node| source_matches(&node.string("source_file"), &conditional))
         .map(|node| node.id.clone())
         .ok_or("missing conditional package target")?;
     let node10_import = resolved
@@ -6491,12 +6489,27 @@ export const value = selected;
         .iter()
         .find(|edge| {
             edge.string("relation") == "imports_from"
-                && edge.string("source_file") == node10_consumer.to_string_lossy()
+                && source_matches(&edge.string("source_file"), &node10_consumer)
         })
         .ok_or("missing Node10 package import")?;
-    assert_eq!(node10_import.target, legacy_id);
-    assert_ne!(node10_import.target, conditional_id);
-    assert_eq!(node10_import.string("resolution_rule"), "package-legacy");
+    assert!(target_source_matches(
+        &resolved,
+        &node10_import.target,
+        &legacy
+    ));
+    assert!(!target_source_matches(
+        &resolved,
+        &node10_import.target,
+        &conditional
+    ));
+    assert_eq!(
+        node10_import.string("resolution_rule"),
+        "project-module-binding"
+    );
+    assert_eq!(
+        node10_import.string("project_resolution_rule"),
+        "package-legacy"
+    );
     assert_eq!(node10_import.string("package_condition"), "main");
     assert_eq!(node10_import.string("module_resolution"), "node10");
 
@@ -6505,7 +6518,7 @@ export const value = selected;
         .iter()
         .find(|edge| {
             edge.string("relation") == "imports_from"
-                && edge.string("source_file") == classic_consumer.to_string_lossy()
+                && source_matches(&edge.string("source_file"), &classic_consumer)
         })
         .ok_or("missing Classic package import")?;
     assert_ne!(classic_import.target, legacy_id);
@@ -6513,6 +6526,10 @@ export const value = selected;
     assert!(classic_import.attributes.get("target_file").is_none());
     assert_eq!(
         classic_import.string("resolution_rule"),
+        "qualified-external"
+    );
+    assert_eq!(
+        classic_import.string("project_resolution_rule"),
         "package-classic-unresolved"
     );
     assert_eq!(classic_import.string("module_resolution"), "classic");
@@ -6582,7 +6599,7 @@ export const value = api;
         .iter()
         .find(|edge| edge.string("relation") == "imports_from" && edge.string("module") == "@/api")
         .ok_or("missing cyclic import")?;
-    assert!(import.string("resolution_rule").is_empty());
+    assert_eq!(import.string("resolution_rule"), "qualified-external");
     Ok(())
 }
 
@@ -6832,12 +6849,12 @@ new DefaultWidget().run();
     let widget = batches[0]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "Widget")
+        .find(|declaration| declaration.name == "Widget" && declaration.kind == "class")
         .ok_or("missing Widget declaration")?;
     let default_widget = batches[1]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "DefaultWidget")
+        .find(|declaration| declaration.name == "DefaultWidget" && declaration.kind == "class")
         .ok_or("missing default declaration")?;
     let widget_construct = batches[2]
         .candidates
@@ -8489,12 +8506,12 @@ new Widget();
     let app_widget = batches[0]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "Widget")
+        .find(|declaration| declaration.name == "Widget" && declaration.kind == "class")
         .ok_or("missing app Widget")?;
     let lib_widget = batches[1]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "Widget")
+        .find(|declaration| declaration.name == "Widget" && declaration.kind == "class")
         .ok_or("missing lib Widget")?;
     let construct = batches[2]
         .candidates
@@ -8549,7 +8566,7 @@ new Runtime().run();
     let runtime = batches[0]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "Runtime")
+        .find(|declaration| declaration.name == "Runtime" && declaration.kind == "class")
         .ok_or("missing JavaScript Runtime declaration")?;
     assert_eq!(runtime.language, "javascript");
     let run = batches[0]
@@ -8627,7 +8644,7 @@ new PublicWidget().run();
     let widget = batches[0]
         .declarations
         .iter()
-        .find(|declaration| declaration.name == "Widget")
+        .find(|declaration| declaration.name == "Widget" && declaration.kind == "class")
         .ok_or("missing re-exported Widget declaration")?;
     let run = batches[0]
         .declarations

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6716,3 +6716,403 @@ exact();
         compass_resolve::evidence::ResolutionDecision::Unresolved
     );
 }
+
+#[test]
+fn typescript_candidate_resolves_relative_and_default_imports_across_files()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/api.ts",
+            br#"export class Widget { run() {} }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/default.ts",
+            br#"class DefaultWidget { run() {} }
+export default DefaultWidget;
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Widget } from "../lib/api.js";
+import DefaultWidget from "../lib/default";
+new Widget();
+new Widget().run();
+new DefaultWidget();
+new DefaultWidget().run();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let widget = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Widget")
+        .ok_or("missing Widget declaration")?;
+    let default_widget = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "DefaultWidget")
+        .ok_or("missing default declaration")?;
+    let widget_construct = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Constructs
+                && candidate.target_spelling == "Widget"
+        })
+        .ok_or("missing Widget construction candidate")?;
+    let default_construct = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Constructs
+                && candidate.target_spelling == "DefaultWidget"
+        })
+        .ok_or("missing default construction candidate")?;
+    let widget_member_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "run"
+        })
+        .ok_or("missing imported member call candidate")?;
+    let default_member_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("default"))
+        })
+        .ok_or("missing default imported member call candidate")?;
+    let widget_run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run")
+        .ok_or("missing Widget.run declaration")?;
+    let default_run = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run")
+        .ok_or("missing DefaultWidget.run declaration")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&widget_construct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &widget.id
+    ));
+    assert!(matches!(
+        index.resolve(&default_construct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &default_widget.id
+    ));
+    let widget_member_decision = index.resolve(&widget_member_call.id);
+    assert!(matches!(
+        widget_member_decision,
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &widget_run.id
+    ));
+    assert!(matches!(
+        index.resolve(&default_member_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &default_run.id
+    ));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_does_not_use_terminal_name_for_relative_imports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "app/api.ts",
+            br#"export class Widget {}
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/api.ts",
+            br#"export class Widget {}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Widget } from "./api";
+new Widget();
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut batches = Vec::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        batches.push(
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)?,
+        );
+    }
+    let app_widget = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Widget")
+        .ok_or("missing app Widget")?;
+    let lib_widget = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Widget")
+        .ok_or("missing lib Widget")?;
+    let construct = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Constructs)
+        .ok_or("missing construction candidate")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&construct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &app_widget.id
+    ));
+    assert_ne!(app_widget.id, lib_widget.id);
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_exact_javascript_interop() -> Result<(), Box<dyn std::error::Error>>
+{
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/runtime.js",
+            br#"export class Runtime { run() {} }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Runtime } from "../lib/runtime.js";
+new Runtime().run();
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut batches = Vec::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        batches.push(
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)?,
+        );
+    }
+    let runtime = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Runtime")
+        .ok_or("missing JavaScript Runtime declaration")?;
+    assert_eq!(runtime.language, "javascript");
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run")
+        .ok_or("missing JavaScript Runtime.run declaration")?;
+    let construct = batches[1]
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Constructs)
+        .ok_or("missing interop construction candidate")?;
+    let call = batches[1]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "run"
+        })
+        .ok_or("missing interop member call candidate")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&construct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &runtime.id
+    ));
+    assert!(matches!(
+        index.resolve(&call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_follows_cross_file_reexport_aliases()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/api.ts",
+            br#"export class Widget { run() {} }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/barrel.ts",
+            br#"export { Widget as PublicWidget } from "./api";
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { PublicWidget } from "../lib/barrel";
+new PublicWidget().run();
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut batches = Vec::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        batches.push(
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)?,
+        );
+    }
+    let widget = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "Widget")
+        .ok_or("missing re-exported Widget declaration")?;
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run")
+        .ok_or("missing re-exported Widget.run declaration")?;
+    let construct = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Constructs)
+        .ok_or("missing re-exported construction candidate")?;
+    let call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "run"
+        })
+        .ok_or("missing re-exported member call candidate")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&construct.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &widget.id
+    ));
+    assert!(matches!(
+        index.resolve(&call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_duplicate_module_realizations_ambiguous()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "app/api.ts",
+            br#"export class Widget {}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/api.js",
+            br#"export class Widget {}
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import { Widget } from "./api";
+new Widget();
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut batches = Vec::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        batches.push(
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)?,
+        );
+    }
+    let construct = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| candidate.relation == CandidateRelation::Constructs)
+        .ok_or("missing construction candidate")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&construct.id),
+        compass_resolve::evidence::ResolutionDecision::Ambiguous { candidate_count } if candidate_count == 2
+    ));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7795,6 +7795,9 @@ fn typescript_candidate_resolves_imported_array_and_tuple_member_chains()
             br#"export interface Box<T> {
     values: T[];
     pair: [T, string];
+    nullable: NonNullable<T | undefined>;
+    awaited: Awaited<Promise<T>>;
+    readonlyValue: Readonly<T>;
 }
 "#
             .as_slice(),
@@ -7807,6 +7810,9 @@ export function use(values: Item[], box: Box<Item>) {
     values[0].inspect();
     box.values[0].inspect();
     box.pair[0].inspect();
+    box.nullable.inspect();
+    box.awaited.inspect();
+    box.readonlyValue.inspect();
 }
 "#
             .as_slice(),
@@ -7852,7 +7858,7 @@ export function use(values: Item[], box: Box<Item>) {
             .iter()
             .filter(|edge| edge.target == inspect.id)
             .count(),
-        3
+        6
     );
     assert!(
         calls

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -8854,3 +8854,72 @@ export function use() {
     }));
     Ok(())
 }
+
+#[test]
+fn typescript_callable_values_materialize_as_references_not_indirect_calls()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let relative = "src/callback-values.ts";
+    let source = br#"function onValue(value: string) {}
+const alias = onValue;
+const alias2 = alias;
+const handlers = [onValue, alias2];
+consume(onValue);
+consume(alias2);
+consume(handlers[0]);
+"#;
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    fs::write(&path, source)?;
+    let mut sources = HashMap::new();
+    sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+    let mut extraction = extract(relative, source);
+    extraction.semantic_evidence = Some(
+        Engine::default().extract_source_universal_candidate_evidence(
+            Path::new(relative),
+            relative,
+            source,
+        )?,
+    );
+    let resolved = compass_resolve::resolve_with_root(&[extraction], &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let on_value = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == relative
+                && node.string("qualified_name").ends_with(".onValue")
+                && node.string("symbol_kind") == "function"
+        })
+        .ok_or("missing callable declaration")?;
+    let alias2 = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == relative
+                && node.string("qualified_name").ends_with(".alias2")
+                && node.string("symbol_kind") == "variable"
+        })
+        .ok_or("missing callable alias declaration")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "references"
+            && edge.string("source_file") == relative
+            && edge.target == on_value.id
+            && edge.string("resolution_rule") == "exact-source-declaration"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "references"
+            && edge.string("source_file") == relative
+            && edge.target == alias2.id
+            && edge.string("resolution_rule") == "exact-source-declaration"
+    }));
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "indirect_call" && edge.string("source_file") == relative
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7578,3 +7578,376 @@ export function use(box: Box<string>) { box.item.inspect(); }
     }));
     Ok(())
 }
+
+#[test]
+fn typescript_candidate_resolves_imported_generic_object_type_alias_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export type Boxed<T> = { value: T };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Boxed } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(box: Boxed<Item>) { box.value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported alias member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_imported_nominal_generic_type_alias_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"import type { Box } from "./box";
+export type Alias<T> = Box<T>;
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/box.ts",
+            br#"export interface Box<T> { value: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Alias } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(box: Alias<Item>) { box.value.inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing nominal alias member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_imported_index_signature_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"import type { Item } from "./item";
+export interface Shape { [key: string]: Item }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Shape } from "../lib/types";
+export function use(shape: Shape, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported index member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_resolves_imported_generic_index_signature_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"export interface Shape<T> { [key: string]: T }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Shape } from "../lib/types";
+import type { Item } from "../lib/item";
+export function use(shape: Shape<Item>, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == "lib/item.ts" && node.label() == ".inspect()")
+        .ok_or("missing imported generic index member")?;
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.target == inspect.id
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_keeps_imported_index_signature_ambiguity_unresolved()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/item.ts",
+            br#"export interface Item { inspect(): void }
+export interface Item { inspect(): void }
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/types.ts",
+            br#"import type { Item } from "./item";
+export interface Shape { [key: string]: Item }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Shape } from "../lib/types";
+export function use(shape: Shape, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_candidate_does_not_invent_imported_index_signature_primitive_members()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/types.ts",
+            br#"export interface Shape { [key: string]: string }
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import type { Shape } from "../lib/types";
+export function use(shape: Shape, key: string) { shape[key].inspect(); }
+"#
+            .as_slice(),
+        ),
+    ];
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(&path, source)?;
+        sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+        let mut extraction = extract(relative, source);
+        extraction.semantic_evidence = Some(
+            Engine::default().extract_source_universal_candidate_evidence(
+                Path::new(relative),
+                relative,
+                source,
+            )?,
+        );
+        extractions.push(extraction);
+    }
+    let resolved = compass_resolve::resolve_with_root(&extractions, &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    assert!(!resolved.edges.iter().any(|edge| {
+        edge.string("relation") == "calls"
+            && edge.string("source_file") == "app/consumer.ts"
+            && edge.string("resolution_rule") == "member-binding"
+    }));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6849,6 +6849,87 @@ new DefaultWidget().run();
 }
 
 #[test]
+fn javascript_commonjs_object_exports_resolve_named_require_bindings()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/cjs.js",
+            br#"function run() {}
+module.exports = {
+    run,
+    method() { return run(); },
+};
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.js",
+            br#"const { run, method } = require("../lib/cjs");
+run();
+method();
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "run")
+        .ok_or("missing CommonJS run declaration")?;
+    let method = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "method" && declaration.name == "method")
+        .ok_or("missing CommonJS method declaration")?;
+    let calls = batches[1]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let run_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "run")
+        .ok_or("missing required run call")?;
+    let method_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "method")
+        .ok_or("missing required method call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&run_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    assert!(matches!(
+        index.resolve(&method_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &method.id
+    ));
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_does_not_use_terminal_name_for_relative_imports()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6866,9 +6866,11 @@ module.exports = {
         ),
         (
             "app/consumer.js",
-            br#"const { run, method } = require("../lib/cjs");
-run();
-method();
+            br#"const { run: execute, method: invoke } = require("../lib/cjs");
+execute();
+invoke();
+const api = require("../lib/cjs");
+api.run();
 "#
             .as_slice(),
         ),
@@ -6904,12 +6906,23 @@ method();
         .collect::<Vec<_>>();
     let run_call = calls
         .iter()
-        .find(|candidate| candidate.target_spelling == "run")
-        .ok_or("missing required run call")?;
+        .find(|candidate| candidate.target_spelling == "execute")
+        .ok_or("missing aliased required run call")?;
     let method_call = calls
         .iter()
-        .find(|candidate| candidate.target_spelling == "method")
-        .ok_or("missing required method call")?;
+        .find(|candidate| candidate.target_spelling == "invoke")
+        .ok_or("missing aliased required method call")?;
+    let api_run_call = calls
+        .iter()
+        .find(|candidate| {
+            candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.ends_with("::run"))
+        })
+        .ok_or("missing namespace require member call")?;
     let index = UniversalResolutionIndex::new_with_inventory(
         &batches,
         &[],
@@ -6925,6 +6938,69 @@ method();
         index.resolve(&method_call.id),
         compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
             if declaration_id == &method.id
+    ));
+    assert!(matches!(
+        index.resolve(&api_run_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
+    ));
+    Ok(())
+}
+
+#[test]
+fn javascript_commonjs_require_callable_namespace_resolves_default_export()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let provider = root.join("lib/callable.cjs");
+    let consumer = root.join("app/consumer.js");
+    let provider_source = br#"function run() {}
+module.exports = run;
+"#;
+    let consumer_source = br#"const fn = require("../lib/callable");
+fn();
+"#;
+    for (path, source) in [
+        (&provider, provider_source.as_slice()),
+        (&consumer, consumer_source.as_slice()),
+    ] {
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = [
+        Engine::default().extract_source_universal_candidate_evidence(
+            &provider,
+            "lib/callable.cjs",
+            provider_source,
+        )?,
+        Engine::default().extract_source_universal_candidate_evidence(
+            &consumer,
+            "app/consumer.js",
+            consumer_source,
+        )?,
+    ];
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.kind == "function" && declaration.name == "run")
+        .ok_or("missing CommonJS callable declaration")?;
+    let call = batches[1]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "fn"
+        })
+        .ok_or("missing direct CommonJS callable call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    assert!(matches!(
+        index.resolve(&call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &run.id
     ));
     Ok(())
 }

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -6878,6 +6878,7 @@ utils.isNumber(1);
 utils.isString('value');
 named(2);
 spread.isString('value');
+spread.isNumber(1);
 "#
             .as_slice(),
         ),
@@ -6905,6 +6906,11 @@ spread.isString('value');
         .iter()
         .find(|declaration| declaration.qualified_name == "utils.default.isString")
         .ok_or("missing default object isString declaration")?;
+    let spread_string = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "spread-default.default.isString")
+        .ok_or("missing spread-default direct member declaration")?;
     let number_call = batches[2]
         .candidates
         .iter()
@@ -6939,6 +6945,19 @@ spread.isString('value');
                     .is_some_and(|qualified| qualified.contains("spread-default.js::default"))
         })
         .ok_or("missing spread-default member call")?;
+    let spread_number_call = batches[2]
+        .candidates
+        .iter()
+        .find(|candidate| {
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "isNumber"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("spread-default.js::default"))
+        })
+        .ok_or("missing spread-default inherited member call")?;
     let named_call = batches[2]
         .candidates
         .iter()
@@ -6962,8 +6981,13 @@ spread.isString('value');
         compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
             if declaration_id == &utils_string.id
     ));
-    assert!(!matches!(
+    assert!(matches!(
         index.resolve(&spread_call.id),
+        compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+            if declaration_id == &spread_string.id
+    ));
+    assert!(!matches!(
+        index.resolve(&spread_number_call.id),
         compass_resolve::evidence::ResolutionDecision::Resolved { .. }
     ));
     assert!(!matches!(

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7863,6 +7863,57 @@ export function use(values: Item[], box: Box<Item>) {
 }
 
 #[test]
+fn typescript_candidate_resolves_generic_callable_return_member_chain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let relative = "src/generic-return.ts";
+    let source = br#"class Item { inspect(): void {} }
+function identity<T>(value: T): T { return value; }
+export function use() { identity(new Item()).inspect(); }
+"#;
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+    fs::write(&path, source)?;
+    let mut extraction = extract(relative, source);
+    extraction.semantic_evidence = Some(
+        Engine::default().extract_source_universal_candidate_evidence(
+            Path::new(relative),
+            relative,
+            source,
+        )?,
+    );
+    let mut sources = HashMap::new();
+    sources.insert(relative.to_owned(), String::from_utf8(source.to_vec())?);
+    let resolved = compass_resolve::resolve_with_root(&[extraction], &sources, root);
+    assert!(
+        resolved.error.is_none(),
+        "resolver error: {:?}",
+        resolved.error
+    );
+    let inspect = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("source_file") == relative && node.label() == ".inspect()")
+        .ok_or("missing generic return member")?;
+    let calls = resolved
+        .edges
+        .iter()
+        .filter(|edge| edge.string("relation") == "calls" && edge.string("source_file") == relative)
+        .collect::<Vec<_>>();
+    let inspect_calls = calls
+        .iter()
+        .filter(|edge| edge.target == inspect.id)
+        .collect::<Vec<_>>();
+    assert_eq!(inspect_calls.len(), 1);
+    assert_eq!(
+        inspect_calls[0].string("resolution_rule"),
+        "exact-source-declaration"
+    );
+    Ok(())
+}
+
+#[test]
 fn typescript_candidate_resolves_imported_index_signature_member_chain()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/crates/compass-resolve/tests/universal_resolution.rs
+++ b/crates/compass-resolve/tests/universal_resolution.rs
@@ -7125,6 +7125,112 @@ cycleValue();
 }
 
 #[test]
+fn typescript_export_assignment_resolves_import_equals_and_default_imports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let files = [
+        (
+            "lib/api.ts",
+            br#"export function run(value: number) { return value; }
+export = run;
+"#
+            .as_slice(),
+        ),
+        (
+            "lib/object-api.ts",
+            br#"export = { run: (value: number) => value };
+"#
+            .as_slice(),
+        ),
+        (
+            "app/consumer.ts",
+            br#"import api = require("../lib/api");
+import run from "../lib/api";
+import object = require("../lib/object-api");
+api(1);
+run(2);
+object.run(3);
+"#
+            .as_slice(),
+        ),
+    ];
+    for (relative, source) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().ok_or("fixture path has no parent")?)?;
+        fs::write(path, source)?;
+    }
+    let batches = files
+        .iter()
+        .map(|(relative, source)| {
+            let path = root.join(relative);
+            Engine::default()
+                .extract_source_universal_candidate_evidence(&path, relative, source)
+                .map_err(|error| format!("candidate extraction failed for {relative}: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let run = batches[0]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.name == "run" && declaration.kind == "function")
+        .ok_or("missing export-assignment declaration")?;
+    let object_run = batches[1]
+        .declarations
+        .iter()
+        .find(|declaration| declaration.qualified_name == "object-api.default.run")
+        .ok_or("missing object export-assignment member")?;
+    let calls = batches[2]
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.relation == CandidateRelation::Calls)
+        .collect::<Vec<_>>();
+    let import_equals_call = calls
+        .iter()
+        .find(|candidate| candidate.target_spelling == "api")
+        .ok_or("missing import-equals call")?;
+    let default_import_call = calls
+        .iter()
+        .find(|candidate| {
+            candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("../lib/api"))
+        })
+        .ok_or("missing default-import call")?;
+    let object_member_call = calls
+        .iter()
+        .find(|candidate| {
+            candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.contains("../lib/object-api"))
+        })
+        .ok_or("missing object import-equals member call")?;
+    let index = UniversalResolutionIndex::new_with_inventory(
+        &batches,
+        &[],
+        root,
+        UniversalResolutionLimits::default(),
+    )?;
+    for (call, declaration) in [
+        (import_equals_call, &run.id),
+        (default_import_call, &run.id),
+        (object_member_call, &object_run.id),
+    ] {
+        assert!(matches!(
+            index.resolve(&call.id),
+            compass_resolve::evidence::ResolutionDecision::Resolved { ref declaration_id, .. }
+                if declaration_id == declaration
+        ));
+    }
+    Ok(())
+}
+
+#[test]
 fn javascript_commonjs_object_exports_resolve_named_require_bindings()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;

--- a/docs/design/language-architecture.md
+++ b/docs/design/language-architecture.md
@@ -30,8 +30,9 @@ This architecture is transitioning one language at a time. The status labels bel
 | --- | --- |
 | Available now | The vendored package supplies 37 pinned static Tree-sitter grammars |
 | Available now | Python and Go are registered hard-cut adapters: they emit semantic evidence and use shared resolution and projection |
-| Available now | Rust is a quality-gated, hard-cut version-13 `UniversalCandidate`; version 13 resolves bounded multi-stage method-result chains across files while preserving a source-proven fallback when project-wide result evidence is absent, version 12 resolves the next member on a same-file method's exact outer nominal result type, version 11 resolves calls chained from source-proven associated-function results and publishes concrete impl `Self` returns, version 10 prevents ambiguous local `self` method sets from becoming fabricated external or deferred calls, version 9 preserves source-valid calls through mutually exclusive Unix/Windows reexports, version 8 publishes blanket trait implementations from the exact impl-scoped generic parameter declaration, version 7 publishes source-anchored references from an implementer declaration proven in the current source evidence to non-primitive nested type arguments in its trait implementation, version 6 resolves inherited associated types through complete source-proven supertrait hierarchies and exact receiver declarations, version 5 preserves impl-scoped associated types and exact lexical `Self::Type` returns, version 4 publishes scoped type, lifetime, and const generic parameters, and version 3 preserves nested function declarations and lexical calls; replaced publisher and collection resolution branches remain removed |
+| Available now | Rust is a quality-gated, hard-cut version-15 `UniversalCandidate`; version 15 preserves bounded multi-stage method-result chains across files while retaining source-proven fallbacks when project-wide result evidence is absent, alongside the earlier associated-type, generic-parameter, re-export, and lexical-call safeguards; replaced publisher and collection resolution branches remain removed |
 | Available now | Java is a hard-cut version-3 `UniversalCandidate`; its replaced publisher and Java member resolver are removed, and post-cutover pinned-corpus qualification is complete |
+| Available now | TypeScript and JavaScript are hard-cut `UniversalCandidate` adapters; TSX uses the TypeScript identity, both share the bounded ECMAScript evidence emitter, and their replaced generic publisher is removed |
 | Available now | The remaining production languages keep their established extraction and resolution paths |
 | Planned | Later languages transition independently after language-specific qualification |
 
@@ -191,6 +192,8 @@ Examples include:
 - Java packages, overload signatures, annotations, and interfaces
 - Python modules, aliases, decorators, and dynamic member occurrences
 - Go packages, receiver ownership, imports, and interfaces
+- TypeScript/JavaScript namespaces, import/re-export bindings, JSX values,
+  CommonJS/ESM module candidates, prototypes, and source-anchored type edges
 
 The current graph contract has a known Rust representation boundary. An
 implementation owner can be published exactly when the implementer is a
@@ -207,7 +210,11 @@ being assigned a convenient but false identity.
 
 An AST-backed adapter receives borrowed source bytes and one prepared tree. It does not parse the source again or call the language pack's generic intelligence pipeline.
 
-After a language completes its universal transition, its adapter emits evidence only. The shared projector creates graph nodes and edges for both single-file and collection builds.
+After a language enters its universal transition, its adapter emits evidence
+only. The shared projector creates graph nodes and edges for both single-file
+and collection builds. `UniversalCandidate` means this route is active while
+qualification continues; it is not permission to retain the replaced direct
+publisher.
 
 ## Universal evidence
 
@@ -336,7 +343,10 @@ supported languages.
 
 ## Language-by-language transitions
 
-Each language keeps its established direct implementation until its universal candidate proves the transition is safe.
+An established language keeps its direct implementation until its universal
+candidate proves the transition is safe. TypeScript and JavaScript have
+completed the route switch and remain candidates while their completion gates
+run.
 
 ```text
 established adapter baseline

--- a/docs/design/managed-language-analyzers.md
+++ b/docs/design/managed-language-analyzers.md
@@ -75,16 +75,18 @@ Candidate or hard-cut status does not mean compiler-grade completeness. It
 states which publication architecture is active and which qualification has
 been completed.
 
-### Established TypeScript and JavaScript paths
+### TypeScript and JavaScript universal candidates
 
-TypeScript, TSX, JavaScript, and JSX still use established extraction and
-language-specific collection resolution. They are not entries in the
-hard-cut universal adapter registry.
+TypeScript, TSX, JavaScript, and JSX now use the registered universal candidate
+route. TypeScript and JavaScript retain distinct adapter identities while
+sharing one bounded source-grounded ECMAScript emitter; TSX is the TypeScript
+parser dialect. Their replaced direct graph publisher is not a fallback.
+Candidate status means the universal route is active while the complete
+qualification matrix and any compiler-backed enrichment remain future work.
 
-Compiler enrichment must not create a permanent third route beside their
-established and future universal paths. TypeScript and JavaScript must first
-complete an independently qualified universal hard cut, or compiler facts
-must remain Program-only until that cutover occurs.
+Compiler enrichment must not create a permanent third graph route beside the
+candidate path. Until a compiler provider is independently bounded and
+qualified, compiler facts remain Program-only.
 
 ### Program and SCIP support
 
@@ -591,9 +593,10 @@ under the same process and network bounds as the Go toolchain.
 
 ### TypeScript
 
-TypeScript and TSX must first hard-cut to version-1 universal evidence and
-remove replaced publication/resolution branches. Until then, analyzer facts
-remain Program-only.
+TypeScript and TSX use version-1 universal candidate evidence and have their
+replaced publication/resolution branches removed. Promotion to a complete
+adapter still requires the conformance and corpus gates below; analyzer facts
+remain Program-only until a separate provider is qualified.
 
 Use verified `scip-typescript` first. Build a pinned TypeScript Compiler API
 bridge for controlled batch analysis and BuilderProgram incrementality.
@@ -622,8 +625,10 @@ callbacks, properties, JSX, and external declarations.
 
 ### JavaScript
 
-JavaScript/JSX/MJS/CJS need a version-1 universal profile or documented shared
-ECMAScript profile and qualified hard cut before analyzer graph projection.
+JavaScript/JSX/MJS/CJS use the version-1 JavaScript universal candidate and
+share the TypeScript emitter with distinct language policy and identity.
+Analyzer graph projection remains disabled until a provider is separately
+qualified.
 
 Share the TypeScript tool/runtime but retain distinct JavaScript policy for
 `allowJs`, `checkJs`, JSDoc, declarations, CJS/ESM, and package resolution.
@@ -779,14 +784,16 @@ unrealizable. Published realizations remain immutable.
 - No non-Java graph relationship changes.
 - Pre-generated offline SCIP remains supported.
 
-### Phase 3: TypeScript and JavaScript universal hard cut
+### Phase 3: TypeScript and JavaScript universal completion
 
 **Direction**
 
-- Add honest version-1 TypeScript/TSX/JavaScript/JSX profiles.
-- Emit complete structural universal evidence.
-- Qualify against established fixtures and production corpora.
-- Remove replaced direct/member/module/re-export paths atomically.
+- Complete the version-1 TypeScript/TSX/JavaScript/JSX candidate conformance
+  matrix and corpus qualification.
+- Extend structural evidence only when each new relation has direct source
+  anchors, resolver coverage, and negative fixtures.
+- Remove any remaining candidate-era compatibility branch atomically when its
+  replacement is fully qualified.
 
 **Acceptance criteria**
 
@@ -933,8 +940,8 @@ unrealizable. Published realizations remain immutable.
 
 | Milestone | Python | Rust | Go | TypeScript | JavaScript | Java |
 | --- | --- | --- | --- | --- | --- | --- |
-| Native structural path | Available | Available | Available | Established | Established | Available |
-| Universal hard cut | Available | Available | Available | Required | Required | Available |
+| Native structural path | Available | Available | Available | Universal candidate | Universal candidate | Available |
+| Universal hard cut | Available | Available | Available | Candidate route; qualification ongoing | Candidate route; qualification ongoing | Available |
 | Offline SCIP ingestion | Generic | Generic | Generic | Generic | Generic | Calls projected |
 | Managed artifact runner | Planned | Planned | Not selected | Planned | Planned | Planned |
 | Native batch analyzer | Optional | Optional | Go types | Compiler API | Compiler API | JDT Core |
@@ -976,7 +983,8 @@ The integration is complete only when:
   remain visible;
 - meaning-affecting inputs participate in cache/history identity;
 - current, watch, and history workflows publish coherent artifacts;
-- TypeScript/JavaScript hard-cut before analyzer facts alter production graphs;
+- TypeScript/JavaScript completion before analyzer facts alter production
+  graphs;
 - cross-platform correctness, determinism, security, packaging, history, and
   performance gates pass per advertised profile; and
 - current behavior and planned phases remain distinguished across all public

--- a/docs/implementation/code-graph-parity-qualification.md
+++ b/docs/implementation/code-graph-parity-qualification.md
@@ -4,6 +4,11 @@ This report records the 2026-08-01 Compass-versus-Graphify qualification for
 Python, Rust, Go, Java, TypeScript, and JavaScript. It is an implementation
 checkpoint, not a claim that Graphify defines the upper bound for Compass.
 
+The TypeScript/JavaScript figures below predate the universal-candidate route
+switch wired in the current branch. Treat them as the established-path
+baseline; rerun the qualification suite before making a post-cutover quality
+or performance claim.
+
 ## Pinned repository matrix
 
 | Language | Repository | Revision | Source size |

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -135,10 +135,25 @@ Version-1 descriptors contain:
 
 - adapter ID
 - source language
+- optional parser dialect provenance (for example `ts` or `tsx`)
 - adapter version
 - evidence schema
 - publication profile
 - capability claims
+
+The shared fact model also has additive optional identity metadata for
+TypeScript/JavaScript qualification: declarations and bindings may carry a
+value/type/namespace symbol-space tag, and import/re-export bindings may mark
+`typeOnly`. Legacy producers omit these fields; their stable IDs do not gain an
+identity component until a producer explicitly emits one. A type-only binding
+must use the type or namespace space and is rejected otherwise.
+
+The TypeScript/JavaScript candidate also records exact module-specifier and
+binding anchors for imports, resolves JSX member tags through proven namespace
+receivers, treats `this` and private member identifiers as nominal source
+evidence, and accepts only literal computed members. Dynamic member keys and
+unproven `super` receivers remain unresolved; these semantics are qualification
+evidence until the production hard cut is approved.
 
 The architectural profile names are `Direct`, `UniversalCandidate`, and
 `UniversalComplete`. A historical compatibility evidence type still serializes

--- a/docs/implementation/universal-evidence.md
+++ b/docs/implementation/universal-evidence.md
@@ -30,10 +30,10 @@ future work.
 | Status | Implementation |
 | --- | --- |
 | Available now | `compass-languages` owns the source registry, parsers, established adapters, and semantic evidence version 1 |
-| Available now | Python, Go, Rust, and Java are entries in the hard-cut `AdapterRegistry`; Go and Java are at adapter version 3, Python is at version 11, and Rust is at version 15 |
-| Available now | `EvidenceBuilder` emits bounded `SemanticEvidenceBatch` values for all four hard-cut languages |
+| Available now | Python, Go, Rust, Java, TypeScript, and JavaScript are entries in the hard-cut `AdapterRegistry`; Go and Java are at adapter version 3, Python is at version 11, Rust is at version 15, and the ECMAScript candidates are at version 5 |
+| Available now | `EvidenceBuilder` emits bounded `SemanticEvidenceBatch` values for all registered universal languages; TypeScript and JavaScript share a source-grounded emitter and retain distinct adapter identities |
 | Available now | `UniversalResolutionIndex` resolves and projects hard-cut evidence without a language-name branch |
-| Available now | Rust has passed Phase 2 qualification; Java remains `UniversalCandidate` after completing post-cutover pinned-corpus qualification |
+| Available now | Rust has passed Phase 2 qualification; Java, TypeScript, and JavaScript remain `UniversalCandidate` while their respective completion gates run |
 | Planned | `GrammarProvider`, grammar provenance, and producer-registry validation |
 | Planned | Independently qualified hard cuts for the remaining registered languages |
 
@@ -152,8 +152,8 @@ The TypeScript/JavaScript candidate also records exact module-specifier and
 binding anchors for imports, resolves JSX member tags through proven namespace
 receivers, treats `this` and private member identifiers as nominal source
 evidence, and accepts only literal computed members. Dynamic member keys and
-unproven `super` receivers remain unresolved; these semantics are qualification
-evidence until the production hard cut is approved.
+unproven `super` receivers remain unresolved; these semantics are production
+candidate evidence and remain subject to the completion qualification gates.
 
 The architectural profile names are `Direct`, `UniversalCandidate`, and
 `UniversalComplete`. A historical compatibility evidence type still serializes
@@ -387,11 +387,14 @@ This table describes the current branch.
 | --- | --- | --- |
 | Python | Hard-cut universal | `SemanticEvidenceBatch` plus shared resolution and projection; no replaced collection resolver |
 | Go | Hard-cut universal | `SemanticEvidenceBatch` plus shared resolution and projection; no replaced Go collection resolver |
-| Rust | Hard-cut `UniversalCandidate` | Version-5 adapter evidence plus shared resolution and projection; impl-scoped associated types, exact `Self::Type` returns, scoped generic parameters, and nested lexical calls are preserved, Phase 2 is qualified, and replaced Rust paths are removed |
+| Rust | Hard-cut `UniversalCandidate` | Version-15 adapter evidence plus shared resolution and projection; bounded method-result chains, impl-scoped associated types, exact `Self::Type` returns, scoped generic parameters, and nested lexical calls are preserved, Phase 2 is qualified, and replaced Rust paths are removed |
 | Java | Hard-cut `UniversalCandidate` | Version-3 evidence plus shared resolution and projection; exact callable ownership, proven conversions, replaced Java paths removed, and post-cutover corpus qualification complete |
+| TypeScript | Hard-cut `UniversalCandidate` | Version-5 evidence plus shared resolution and projection; TSX aliases this identity and the replaced generic publisher is removed |
+| JavaScript | Hard-cut `UniversalCandidate` | Version-5 evidence plus shared resolution and projection; CJS/ESM and package decisions retain source and provenance bounds |
 | Remaining registered languages | Established direct adapters | Current language-specific or generic extraction paths |
 
-Python, Go, Rust, and Java are hard-cut on this branch. Each later language
+Python, Go, Rust, Java, TypeScript, and JavaScript are hard-cut on this branch.
+Each later language
 reuses the same hard-cut registry, evidence model, resolver, and projector
 without adding language cases to the central publisher. A language's
 transition does not alter the publication route of any other language.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -88,6 +88,13 @@ the adapter actually emits. The batch contains six bounded collections:
   proven. Tagged-template arity and known substitution types therefore
   participate in the same fail-closed overload and cross-file resolution rules
   as ordinary calls.
+  Decorator factories use `Decorates` candidates rather than generic call
+  edges. Direct decorators carry `decorator` context; member decorators carry
+  `decorator_member` context and resolve through the nominal member/index
+  path. A decorator invocation's bounded argument count and known literal
+  types participate in overload selection. Dynamic or computed decorator
+  expressions retain a targetless occurrence, while calls nested inside
+  decorator arguments remain independent call evidence.
 - `EvidenceDiagnostic` records a bounded extraction problem without creating
   a graph fact.
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -78,6 +78,16 @@ the adapter actually emits. The batch contains six bounded collections:
   conversions, but only when one applicable vector is more specific than all
   other applicable vectors. Unknown hierarchy or a competing conversion
   remains unresolved.
+  The qualification-only TypeScript/JavaScript adapter represents a tagged
+  template (``tag`text ${value}``) as a call with occurrence context
+  `tagged_template` (or `tagged_member` for a member tag). Its bounded argument
+  vector starts with an explicit unknown slot for the runtime
+  `TemplateStringsArray`, followed by one slot per substitution expression. The
+  synthetic slot is intentionally not typed as a general array, and dynamic tag
+  expressions remain targetless unless a declaration is independently source
+  proven. Tagged-template arity and known substitution types therefore
+  participate in the same fail-closed overload and cross-file resolution rules
+  as ordinary calls.
 - `EvidenceDiagnostic` records a bounded extraction problem without creating
   a graph fact.
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -24,7 +24,7 @@ the adapter actually emits. The batch contains six bounded collections:
 - `ScopeFact` identifies a lexical scope, optional owning declaration, parent
   scope, and exact range.
 - `BindingFact` records an import, import alias, re-export, local alias,
-  call-result, or package binding. Its target is qualified; a proven local
+  call-result, member, or package binding. Its target is qualified; a proven local
   declaration may also be named directly. TypeScript and JavaScript import
   and re-export bindings may additionally carry a `namespace` identity and a
   `typeOnly` marker. A type-only binding must identify the `type` or
@@ -44,6 +44,11 @@ the adapter actually emits. The batch contains six bounded collections:
   resolves to an exact source declaration or an explicitly qualified external
   identity. An unresolved prelude or imported spelling must not be
   reinterpreted as a repository-local type.
+  The qualification-only TypeScript/JavaScript adapter may use a member binding
+  with spelling `*` as a source-range-backed object-owner alias. This is not a
+  wildcard export: the resolver follows it only when the target owner and
+  requested member are independently source-proven, and otherwise preserves
+  an unresolved or ambiguous result.
 - `OccurrenceFact` records one exact use site and its role, owner, spelling,
   optional qualifier, lexical scope, and range. Repeated uses are separate
   occurrences.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -51,11 +51,17 @@ the adapter actually emits. The batch contains six bounded collections:
   source, or bounded `Object.assign` composition. CommonJS
   `Object.defineProperty(exports, "name", { value/get: ... })` reexports are
   likewise admitted only for a static key and source-proven value/getter
-  return; `__esModule`, dynamic descriptors, and shadowed CommonJS globals are
-  not exported. This is not a wildcard export: the resolver follows it only
-  when the target owner and requested member are independently source-proven,
-  direct destination properties retain precedence, and otherwise it preserves
-  an unresolved or ambiguous result.
+ return; `__esModule`, dynamic descriptors, and shadowed CommonJS globals are
+  not exported. The same bounded owner-alias path admits
+  `__exportStar(require("./source"), exports)` and `tslib.__exportStar` only
+  when the helper is source-proven or imported from `tslib`, the require
+  argument is a static string, and the destination is the unshadowed
+  CommonJS export object. Named imports and namespace members may project a
+  requested source-published property through that alias; direct destination
+  properties retain precedence, and unknown, dynamic, lookalike-helper, or
+  ambiguous cases remain unresolved. None of these aliases is a wildcard
+  export: the resolver follows them only when the target owner and requested
+  member are independently source-proven.
 - `OccurrenceFact` records one exact use site and its role, owner, spelling,
   optional qualifier, lexical scope, and range. Repeated uses are separate
   occurrences.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -47,7 +47,8 @@ the adapter actually emits. The batch contains six bounded collections:
   The qualification-only TypeScript/JavaScript adapter may use a member binding
   with spelling `*` as a source-range-backed object-owner alias, including a
   CommonJS file-module owner for a proven `module.exports = { ...source }`
-  shape. This is not a wildcard export: the resolver follows it only when the
+  shape, including a source-anchored namespace import or static `require()`
+  source. This is not a wildcard export: the resolver follows it only when the
   target owner and requested member are independently source-proven, direct
   destination properties retain precedence, and otherwise it preserves an
   unresolved or ambiguous result.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -45,10 +45,12 @@ the adapter actually emits. The batch contains six bounded collections:
   identity. An unresolved prelude or imported spelling must not be
   reinterpreted as a repository-local type.
   The qualification-only TypeScript/JavaScript adapter may use a member binding
-  with spelling `*` as a source-range-backed object-owner alias. This is not a
-  wildcard export: the resolver follows it only when the target owner and
-  requested member are independently source-proven, and otherwise preserves
-  an unresolved or ambiguous result.
+  with spelling `*` as a source-range-backed object-owner alias, including a
+  CommonJS file-module owner for a proven `module.exports = { ...source }`
+  shape. This is not a wildcard export: the resolver follows it only when the
+  target owner and requested member are independently source-proven, direct
+  destination properties retain precedence, and otherwise it preserves an
+  unresolved or ambiguous result.
 - `OccurrenceFact` records one exact use site and its role, owner, spelling,
   optional qualifier, lexical scope, and range. Repeated uses are separate
   occurrences.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -1,9 +1,10 @@
 # Universal semantic evidence
 
 Compass resolves source relationships through a language-neutral evidence
-contract. Python, Go, Rust, and Java use this contract in production. Other
-languages keep their existing extractors until a dedicated change removes the
-old algorithm and adds the universal adapter atomically.
+contract. Python, Go, Rust, and Java use this contract in production, and the
+TypeScript and JavaScript candidate adapters now use the same production route.
+The ECMAScript adapters remain candidates while their complete qualification
+matrix is finished; they do not retain a second direct graph publisher.
 
 This is a hard-cutover interface. It has no raw-fact translation layer, shadow
 mode, terminal-name fallback, or runtime dependency on Graphify.
@@ -44,7 +45,7 @@ the adapter actually emits. The batch contains six bounded collections:
   resolves to an exact source declaration or an explicitly qualified external
   identity. An unresolved prelude or imported spelling must not be
   reinterpreted as a repository-local type.
-  The qualification-only TypeScript/JavaScript adapter may use a member binding
+  The TypeScript/JavaScript candidate adapter may use a member binding
   with spelling `*` as a source-range-backed object-owner alias, including a
   CommonJS file-module owner for a proven `module.exports = { ...source }`
   shape, including a source-anchored namespace import, static `require()`
@@ -78,7 +79,7 @@ the adapter actually emits. The batch contains six bounded collections:
   conversions, but only when one applicable vector is more specific than all
   other applicable vectors. Unknown hierarchy or a competing conversion
   remains unresolved.
-  The qualification-only TypeScript/JavaScript adapter represents a tagged
+  The TypeScript/JavaScript candidate adapter represents a tagged
   template (``tag`text ${value}``) as a call with occurrence context
   `tagged_template` (or `tagged_member` for a member tag). Its bounded argument
   vector starts with an explicit unknown slot for the runtime
@@ -102,8 +103,8 @@ the adapter actually emits. The batch contains six bounded collections:
   identity; contextual or malformed non-statement assignments remain
   unresolved rather than being promoted into declarations.
   JSX attribute values, spread attributes, and child expressions are ordinary
-  value-reference contexts. The qualification-only TypeScript/JavaScript
-  adapter emits exact `jsx_value`, `jsx_spread`, and `jsx_child` occurrences
+  value-reference contexts. The TypeScript/JavaScript candidate adapter emits
+  exact `jsx_value`, `jsx_spread`, and `jsx_child` occurrences
   for local, imported, and unresolved values, while excluding prop names,
   member-property spellings, and call callees. This preserves callback
   arguments and object/receiver values without inventing indirect calls.
@@ -185,7 +186,8 @@ orders return the same first error.
 
 `AdapterRegistry::universal_profile(language)` is the authority for universal
 cutover. A returned `AdapterProfile` means universal evidence is mandatory.
-Python, Go, Rust, and Java are currently registered. An unregistered language
+Python, Go, Rust, Java, TypeScript, and JavaScript are currently registered;
+TSX resolves to the canonical TypeScript profile. An unregistered language
 does not silently claim universal behavior.
 
 An adapter profile must:
@@ -659,8 +661,11 @@ Python or Go has met the production qualification gates.
 
 ## Current qualification boundary
 
-Python, Go, Rust, and Java are hard-cut universal language adapters. Rust and
-Java remain `UniversalCandidate`; this framework change does not promote Java.
+Python and Go are hard-cut universal language adapters. Rust, Java,
+TypeScript, and JavaScript remain `UniversalCandidate`; the latter two share a
+bounded ECMAScript emitter but retain distinct adapter identities. TSX uses the
+TypeScript candidate profile. Candidate status means the universal route is
+active while complete capability and corpus qualification remain in progress.
 `spring-java` is the first production universal framework pack and advertises
 typed HTTP, bean, injection, messaging, scheduling, persistence, transaction,
 and security capabilities. Kotlin Spring remains on its established detector.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -17,12 +17,19 @@ the adapter actually emits. The batch contains six bounded collections:
 - `DeclarationFact` identifies a source-backed declaration and its existing
   graph node, kind, name, qualified name, optional module/package, lexical
   scope, signature, optional bounded canonical parameter-type vector, optional
-  complete-direct-base marker for Java types, and exact range.
+  complete-direct-base marker for Java types, and exact range. TypeScript and
+  JavaScript candidate evidence may additionally identify the declaration's
+  `namespace` as `value`, `type`, `namespace`, or `value_and_type`; legacy
+  adapters omit this optional field.
 - `ScopeFact` identifies a lexical scope, optional owning declaration, parent
   scope, and exact range.
 - `BindingFact` records an import, import alias, re-export, local alias,
   call-result, or package binding. Its target is qualified; a proven local
-  declaration may also be named directly. A call-result binding names the
+  declaration may also be named directly. TypeScript and JavaScript import
+  and re-export bindings may additionally carry a `namespace` identity and a
+  `typeOnly` marker. A type-only binding must identify the `type` or
+  `namespace` space; this prevents a type import from being resolved as a
+  runtime value. A call-result binding names the
   exact callable that initialized a receiver and may record the zero-based
   output selected by a destructuring assignment. It may preserve an exact
   nominal result type proven in the same file, reference an earlier

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -48,11 +48,14 @@ the adapter actually emits. The batch contains six bounded collections:
   with spelling `*` as a source-range-backed object-owner alias, including a
   CommonJS file-module owner for a proven `module.exports = { ...source }`
   shape, including a source-anchored namespace import, static `require()`
-  source, or bounded `Object.assign` composition. This is not a wildcard
-  export: the resolver follows it only when the target owner and requested
-  member are independently source-proven, direct destination properties
-  retain precedence, and otherwise it preserves an unresolved or ambiguous
-  result.
+  source, or bounded `Object.assign` composition. CommonJS
+  `Object.defineProperty(exports, "name", { value/get: ... })` reexports are
+  likewise admitted only for a static key and source-proven value/getter
+  return; `__esModule`, dynamic descriptors, and shadowed CommonJS globals are
+  not exported. This is not a wildcard export: the resolver follows it only
+  when the target owner and requested member are independently source-proven,
+  direct destination properties retain precedence, and otherwise it preserves
+  an unresolved or ambiguous result.
 - `OccurrenceFact` records one exact use site and its role, owner, spelling,
   optional qualifier, lexical scope, and range. Repeated uses are separate
   occurrences.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -101,6 +101,12 @@ the adapter actually emits. The batch contains six bounded collections:
   initializer calls and subsequent references/members keep the same binding
   identity; contextual or malformed non-statement assignments remain
   unresolved rather than being promoted into declarations.
+  JSX attribute values, spread attributes, and child expressions are ordinary
+  value-reference contexts. The qualification-only TypeScript/JavaScript
+  adapter emits exact `jsx_value`, `jsx_spread`, and `jsx_child` occurrences
+  for local, imported, and unresolved values, while excluding prop names,
+  member-property spellings, and call callees. This preserves callback
+  arguments and object/receiver values without inventing indirect calls.
 - `EvidenceDiagnostic` records a bounded extraction problem without creating
   a graph fact.
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -107,6 +107,12 @@ the adapter actually emits. The batch contains six bounded collections:
   for local, imported, and unresolved values, while excluding prop names,
   member-property spellings, and call callees. This preserves callback
   arguments and object/receiver values without inventing indirect calls.
+  TypeScript `import("...")` and `typeof import("...")` type queries retain
+  the exact module literal as an `imports` candidate with `import_type`
+  context. This remains a type-space dependency rather than a runtime
+  dynamic-import call, including indexed queries that the pinned parser
+  recovers through its byte-preserving mask; bounded comments, strings, and
+  query counts fail closed.
 - `EvidenceDiagnostic` records a bounded extraction problem without creating
   a graph fact.
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -47,11 +47,12 @@ the adapter actually emits. The batch contains six bounded collections:
   The qualification-only TypeScript/JavaScript adapter may use a member binding
   with spelling `*` as a source-range-backed object-owner alias, including a
   CommonJS file-module owner for a proven `module.exports = { ...source }`
-  shape, including a source-anchored namespace import or static `require()`
-  source. This is not a wildcard export: the resolver follows it only when the
-  target owner and requested member are independently source-proven, direct
-  destination properties retain precedence, and otherwise it preserves an
-  unresolved or ambiguous result.
+  shape, including a source-anchored namespace import, static `require()`
+  source, or bounded `Object.assign` composition. This is not a wildcard
+  export: the resolver follows it only when the target owner and requested
+  member are independently source-proven, direct destination properties
+  retain precedence, and otherwise it preserves an unresolved or ambiguous
+  result.
 - `OccurrenceFact` records one exact use site and its role, owner, spelling,
   optional qualifier, lexical scope, and range. Repeated uses are separate
   occurrences.

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -95,6 +95,12 @@ the adapter actually emits. The batch contains six bounded collections:
   types participate in overload selection. Dynamic or computed decorator
   expressions retain a targetless occurrence, while calls nested inside
   decorator arguments remain independent call evidence.
+  TypeScript `using` and `await using` resource bindings are emitted as
+  immutable, source-anchored variable declarations even though the pinned
+  tree-sitter grammar represents them as assignment expressions. Their
+  initializer calls and subsequent references/members keep the same binding
+  identity; contextual or malformed non-statement assignments remain
+  unresolved rather than being promoted into declarations.
 - `EvidenceDiagnostic` records a bounded extraction problem without creating
   a graph fact.
 

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1069,8 +1069,8 @@
       "id": "node-variable",
       "kind": "variable",
       "source": "fixtures/code-graph/routes/typescript/express.ts",
-      "qualifiedName": "app",
-      "producer": "compass.languages.typescript",
+      "qualifiedName": "express.app",
+      "producer": "compass.languages.typescript.universal",
       "origins": [
         "ast"
       ],
@@ -1113,8 +1113,8 @@
       "id": "node-export",
       "kind": "export",
       "source": "fixtures/code-graph/qualification/rich.ts",
-      "qualifiedName": "DefaultStore@271",
-      "producer": "compass.languages.typescript",
+      "qualifiedName": "rich.DefaultStore",
+      "producer": "compass.languages.typescript.universal",
       "origins": [
         "ast"
       ],
@@ -1135,8 +1135,8 @@
       "id": "node-annotation",
       "kind": "annotation",
       "source": "fixtures/code-graph/qualification/rich.ts",
-      "qualifiedName": "sealed@159",
-      "producer": "compass.languages.typescript",
+      "qualifiedName": "rich::sealed",
+      "producer": "compass.languages.typescript.universal",
       "origins": [
         "ast"
       ],
@@ -1479,7 +1479,7 @@
       "kind": "instantiates",
       "source": "fixtures/code-graph/domain/messaging/dynamic-near-matches.ts",
       "qualifiedName": "*",
-      "producer": "compass.languages.typescript",
+      "producer": "compass.resolve.typescript.universal",
       "origins": [
         "ast"
       ],
@@ -1501,7 +1501,7 @@
       "kind": "decorates",
       "source": "fixtures/code-graph/qualification/rich.ts",
       "qualifiedName": "*",
-      "producer": "compass.languages.typescript",
+      "producer": "compass.resolve.typescript.universal",
       "origins": [
         "ast"
       ],
@@ -1545,7 +1545,7 @@
       "kind": "aliases",
       "source": "fixtures/code-graph/qualification/rich.ts",
       "qualifiedName": "*",
-      "producer": "compass.languages.typescript",
+      "producer": "compass.resolve.typescript.universal",
       "origins": [
         "ast"
       ],


### PR DESCRIPTION
## Summary

Route TypeScript and JavaScript production extraction through the registered
universal semantic candidate. Compass now uses one deterministic source-backed
path for normal builds and qualification fixtures, so universal evidence is
available to users instead of being qualification-only.

## What changed

- Registered `compass.typescript.candidate` and `compass.javascript.candidate`
  as the production universal adapters, with TSX canonicalized to TypeScript.
- Emit source-anchored declarations, definitions, imports, re-exports,
  references, calls, constructions, heritage, aliases, members, JSX values,
  decorators, resources, and type-query evidence with explicit provenance.
- Wire project-wide TypeScript/JavaScript inventory and resolution for local
  modules, package conditions, aliases, re-exports, callable values, and
  framework route targets while preserving ambiguity and unresolved states.
- Preserve framework-owned convention nodes and source locations through
  universal merging, including Express/Next/Fastify/Hono/Remix-style routes.
- Keep graph identities, relationship direction, multiplicity, source ranges,
  cache reuse, and deterministic publication stable across clean, warm, rebuilt,
  restored, and alternate-checkout builds.
- Update the universal evidence reference, language architecture, managed
  analyzer guidance, qualification manifest, and changelog.

## Impact

Compass no longer falls back to the legacy JavaScript/TypeScript extractor for
production graph generation. Cross-file and framework-aware graph quality now
comes from the same universal candidate that is independently qualified, with
fail-closed handling for ambiguous or unsupported bindings.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --lib --bins --locked`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test -p compass-languages --test typescript_universal_candidate --locked`
- `cargo test -p compass-resolve --test typescript_routes --locked`
- `sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-6923-inline ./scripts/qualify_code_graph_v1.sh --fixtures-only`

Qualification passed with 57 languages, 1,041 coverage records, 1,773
invariants, 27 exact framework flows, and byte-identical clean/warm/rebuild/
restored/alternate outputs. Graph digest:
`sha256:26a8e78a4c340627ccecc80042d21c9caed54604133c555bb5e4763a891da6c4`.

This remains a draft PR for review of the production hard cut.
