### PR TITLE
Simplify Compass output layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Simplify every Compass-owned current-output path beneath `compass-out/`.
+  Immutable build snapshots now live under `snapshots/`, the selector is
+  `current-snapshot`, the SQLite query index is under
+  `store/`, and snapshot-local sidecars use concise names such as
+  `build-state.json` and `analysis.json`. This is an unconditional hard cut
+  with no old-path detector, compatibility reader, or migrator. History
+  realization schema 1,
+  store format v1, and `compass/v1` realization roots remain unchanged; the
+  output path cutover does not introduce a new serialized schema.
+
 - Let agents size natural `query` and `explain` pages with an explicit token
   budget (2,000 by default) and retrieve every deterministic continuation with
   `--page`. Output now reports exact page/fact ranges and no longer silently

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -62,12 +62,28 @@ A user-visible incompatible change requires:
 Versioned formats use Compass-owned identifiers. Consumers should reject
 unknown major versions instead of attempting legacy fallback behavior.
 
+Current output uses visible Compass-owned paths: `snapshots/`,
+`current-snapshot`, `root-artifacts-complete`, and
+`store/`. Snapshot-local state likewise uses concise names such as
+`build-state.json` and `analysis.json`. This is an unconditional hard cut:
+the runtime has no hidden-layout detector, compatibility reader, path mapping,
+or in-place migrator. Output created by an older layout must be archived or
+removed before rebuilding. Repository configuration under `.compass/` remains
+unchanged because it is not output state.
+
+Versioned history remains on realization schema 1, store-format root
+`compass/store-format/v1`, and the `compass/v1` realization-root namespace.
+The visible output-path cutover does not change those serialized contracts.
+Historical realizations containing former hidden artifact paths are not mapped
+or rewritten; rebuild those revisions when they must be materialized with the
+current visible artifact layout.
+
 The current local build publishes `graph.json` (`compass.graph/1`) directly
 under the selected output root by default. It also materializes
 `GRAPH_REPORT.md`, `manifest.json`, and optional `graph.html` at that stable
-root path. Compass retains an immutable generation behind those conventional
+root path. Compass retains an immutable snapshot behind those conventional
 paths as its coherent internal authority.
-Passing `--store sqlite` also publishes a validated `compass-store.sqlite3`
+Passing `--store sqlite` also publishes a validated `store.sqlite3`
 sidecar and typed `store.ref` selector. Typed code queries use JSON by default;
 `--engine store` explicitly selects and validates the sidecar. The SQLite file
 and reference are internal realizations of the backend-neutral `compass-store`
@@ -112,11 +128,11 @@ command accepts cloud credentials, endpoints, or TLS configuration.
 
 The default published location is `DIR/graph.json` under the selected
 `--out DIR` (default `compass-out/`). A `--store sqlite` build additionally
-publishes `store.ref` beside the active generation's `graph.json` and keeps the
-shared database at `DIR/.compass-store/compass-store.sqlite3`.
+publishes `store.ref` beside the current snapshot's `graph.json` and keeps the
+shared database at `DIR/store/store.sqlite3`.
 `compass store status|validate|backup|restore` are the supported operational
 surface. Backups are digest-bound directories and restores never overwrite an
-existing destination. Local publication retains two complete generations and
+existing destination. Local publication retains two complete snapshots and
 performs bounded reachability GC; remote leases, service quotas, and
 distributed GC remain deferred. The local API enforces bounded values, scans,
 transactions, graph sizes, and request work.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,8 +2,8 @@
 
 Compass uses its own executable, output directory, environment variable, and
 sidecars. Its output root now preserves the familiar flat artifact shape so
-file-based workflows can transition without learning Compass's hidden
-generation or store layout.
+file-based workflows can transition while Compass's snapshot and store
+layout remains visible and clearly owned.
 
 ## Install Compass
 
@@ -42,7 +42,7 @@ Scripts that open, copy, serve, mount, or archive these conventional filenames
 only need the executable and output-directory rename. The JSON schema and
 cache payloads remain Compass contracts: do not copy `graphify-out/cache/` or
 `graphify-out/manifest.json` into `compass-out/`. Compass rebuilds them from
-source while retaining its own internal generation and store protocols.
+source while retaining its own internal snapshot and store protocols.
 
 ## Opt into Program IR generation
 
@@ -65,6 +65,28 @@ graphify://... MCP resources     -> compass://...
 
 Compass does not fall back to the old names.
 
+## Hard cut to visible Compass output state
+
+Current output no longer hides Compass-owned files. The layout now uses
+`snapshots/`, `current-snapshot`, `store/`, and
+visible snapshot-local names such as `build-state.json` and
+`analysis.json`.
+
+Compass contains no compatibility reader, detector, or in-place migrator for
+the former hidden layout. Archive or remove the entire old output directory
+before running this version, then build it again:
+
+```bash
+mv compass-out compass-out-hidden-layout-backup
+compass update .
+```
+
+The history realization schema and SQLite store format remain at v1. Compass
+does not rewrite immutable realizations or map former hidden artifact paths.
+Use `compass history build` to recreate any revision that must materialize with
+the current visible artifact layout; archive the existing history database
+first only when it is needed for audit or rollback.
+
 ## Compass Store sidecar upgrades
 
 The `0.3.x` line supports the logical majors `compass.store/1`,
@@ -74,11 +96,11 @@ or corrupt `store.ref`, and redb or prototype files are rebuildable hard cuts;
 they are not migrated in place.
 
 The optimized immutable graph-index layout is also a hard cut from store files
-created by the pre-release per-generation/chunked-payload implementation. New
+created by the pre-release per-snapshot/chunked-payload implementation. New
 SQLite state lives at
-`compass-out/.compass-store/compass-store.sqlite3`; active generations contain
+`compass-out/store/store.sqlite3`; current snapshots contain
 only canonical `graph.json` and `store.ref`. Do not move an older database into
-that location or copy a newer database into a generation directory. Preserve
+that location or copy a newer database into a snapshot directory. Preserve
 `graph.json` and rebuild from source:
 
 ```bash
@@ -116,7 +138,7 @@ The script preserves existing sidecars in a timestamped rollback directory,
 restores them if `compass update --force` fails, and never replaces the JSON
 artifact. A normal `compass update --force --store sqlite` is also sufficient
 when the old sidecar has already been removed. Builds without `--store sqlite`
-now publish JSON only and remove store files from the new generation. Typed
+now publish JSON only and remove store files from the new snapshot. Typed
 queries use JSON by default; use `--engine store` to select a retained sidecar.
 
 Downgrades must validate the output with the target binary. Do not reuse a

--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ compass-out/
 ├── graph.json        machine-readable graph
 ├── GRAPH_REPORT.md   architecture and community summary
 ├── graph.html        interactive visualization when size permits
-└── manifest.json     incremental build state
+├── manifest.json     incremental build state
+├── snapshots/        coherent retained build snapshots
+├── current-snapshot  selected snapshot identifier
+└── store/            SQLite query index when enabled
 ```
 
 ### 4. Ask useful questions

--- a/benchmarks/performance/analyze.py
+++ b/benchmarks/performance/analyze.py
@@ -130,10 +130,10 @@ def load_corpora(manifest_path: Path) -> list[dict[str, str | Path]]:
 
 def compass_graph(workspace: Path, name: str) -> Path:
     output = workspace / "outputs" / "compass" / name / "compass-out"
-    generation = (output / ".compass-active-generation").read_text(
+    snapshot = (output / "current-snapshot").read_text(
         encoding="utf-8"
     ).strip()
-    graph = output / ".compass-generations" / generation / "graph.json"
+    graph = output / "snapshots" / snapshot / "graph.json"
     if not graph.is_file():
         raise FileNotFoundError(graph)
     return graph

--- a/benchmarks/performance/compass/adapters.py
+++ b/benchmarks/performance/compass/adapters.py
@@ -171,16 +171,16 @@ class CompassAdapter(ToolAdapter):
 
     def graph_path(self, output: Path) -> Path:
         compass_output = output / "compass-out"
-        pointer = compass_output / ".compass-active-generation"
+        pointer = compass_output / "current-snapshot"
         try:
-            generation = pointer.read_text(encoding="utf-8").strip()
+            snapshot = pointer.read_text(encoding="utf-8").strip()
         except OSError as error:
-            raise RuntimeError(f"missing Compass generation pointer: {pointer}") from error
-        if not generation.startswith("generation-") or Path(generation).name != generation:
-            raise RuntimeError(f"invalid Compass generation pointer: {generation!r}")
-        active = compass_output / ".compass-generations" / generation
-        if not active.is_dir() or (active / ".compass-build-incomplete").exists():
-            raise RuntimeError(f"incomplete Compass generation: {active}")
+            raise RuntimeError(f"missing Compass snapshot pointer: {pointer}") from error
+        if not snapshot.startswith("snapshot-") or Path(snapshot).name != snapshot:
+            raise RuntimeError(f"invalid Compass snapshot pointer: {snapshot!r}")
+        active = compass_output / "snapshots" / snapshot
+        if not active.is_dir() or (active / "build-incomplete").exists():
+            raise RuntimeError(f"incomplete Compass snapshot: {active}")
         graph = active / "graph.json"
         if not graph.is_file() or not graph.resolve().is_relative_to(output.resolve()):
             raise RuntimeError(f"invalid Compass graph artifact: {graph}")
@@ -195,11 +195,11 @@ class CompassAdapter(ToolAdapter):
         return evidence
 
     def prune_superseded_artifacts(self, output: Path, active_graph: Path) -> None:
-        generations = output / "compass-out" / ".compass-generations"
+        snapshots = output / "compass-out" / "snapshots"
         active = active_graph.parent.resolve()
-        if not generations.is_dir() or active.parent.resolve() != generations.resolve():
-            raise RuntimeError(f"active Compass generation is outside {generations}")
-        for candidate in generations.iterdir():
+        if not snapshots.is_dir() or active.parent.resolve() != snapshots.resolve():
+            raise RuntimeError(f"active Compass snapshot is outside {snapshots}")
+        for candidate in snapshots.iterdir():
             if candidate.is_dir() and candidate.resolve() != active:
                 guarded_remove(candidate)
 

--- a/benchmarks/performance/tests/test_adapters.py
+++ b/benchmarks/performance/tests/test_adapters.py
@@ -104,28 +104,28 @@ class AdapterTests(unittest.TestCase):
             self.assertFalse((checkout / "graphify-out").exists())
             self.assertEqual(source.read_text(), "pass\n")
 
-    def test_compass_active_generation_is_validated(self) -> None:
+    def test_compass_current_snapshot_is_validated(self) -> None:
         adapter = CompassAdapter(Path("/opt/compass"), revision("compass"))
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory)
             compass_out = output / "compass-out"
-            active = compass_out / ".compass-generations" / "generation-123"
+            active = compass_out / "snapshots" / "snapshot-123"
             active.mkdir(parents=True)
-            (compass_out / ".compass-active-generation").write_text("generation-123\n")
+            (compass_out / "current-snapshot").write_text("snapshot-123\n")
             graph = active / "graph.json"
             graph.write_text("{}")
             self.assertEqual(adapter.graph_path(output), graph)
-            (active / ".compass-build-incomplete").touch()
+            (active / "build-incomplete").touch()
             with self.assertRaisesRegex(RuntimeError, "incomplete"):
                 adapter.graph_path(output)
 
-    def test_generation_pointer_cannot_escape(self) -> None:
+    def test_snapshot_pointer_cannot_escape(self) -> None:
         adapter = CompassAdapter(Path("/opt/compass"), revision("compass"))
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory)
             compass_out = output / "compass-out"
             compass_out.mkdir()
-            (compass_out / ".compass-active-generation").write_text("../outside")
+            (compass_out / "current-snapshot").write_text("../outside")
             with self.assertRaisesRegex(RuntimeError, "invalid"):
                 adapter.graph_path(output)
 
@@ -141,14 +141,14 @@ class AdapterTests(unittest.TestCase):
             {"detect": 1.2, "deterministic_extract": 2.5, "total": 4.0},
         )
 
-    def test_compass_prunes_only_inactive_generations(self) -> None:
+    def test_compass_prunes_only_incurrent_snapshots(self) -> None:
         adapter = CompassAdapter(Path("/opt/compass"), revision("compass"))
         with tempfile.TemporaryDirectory() as directory:
             workspace = QualificationWorkspace.create(Path(directory) / "workspace")
             output = workspace.root / "artifacts" / "fixture"
-            generations = output / "compass-out" / ".compass-generations"
-            active = generations / "generation-active"
-            inactive = generations / "generation-inactive"
+            snapshots = output / "compass-out" / "snapshots"
+            active = snapshots / "snapshot-active"
+            inactive = snapshots / "snapshot-inactive"
             active.mkdir(parents=True)
             inactive.mkdir()
             graph = active / "graph.json"

--- a/benchmarks/performance/tests/test_analyze.py
+++ b/benchmarks/performance/tests/test_analyze.py
@@ -59,12 +59,12 @@ class AnalyzeTests(unittest.TestCase):
             )
 
             compass_out = workspace / "outputs" / "compass" / "sample" / "compass-out"
-            generation = compass_out / ".compass-generations" / "generation-1"
-            generation.mkdir(parents=True)
-            (compass_out / ".compass-active-generation").write_text(
-                "generation-1\n", encoding="utf-8"
+            snapshot = compass_out / "snapshots" / "snapshot-1"
+            snapshot.mkdir(parents=True)
+            (compass_out / "current-snapshot").write_text(
+                "snapshot-1\n", encoding="utf-8"
             )
-            shutil.copyfile(FIXTURES / "compass_graph.json", generation / "graph.json")
+            shutil.copyfile(FIXTURES / "compass_graph.json", snapshot / "graph.json")
 
             graphify_out = (
                 workspace / "outputs" / "graphify" / "sample" / "graphify-out"

--- a/crates/compass-cli/src/code_query_commands.rs
+++ b/crates/compass-cli/src/code_query_commands.rs
@@ -29,8 +29,10 @@ pub(crate) fn command(operation: &str, args: &[String]) -> Outcome {
 
 fn execute(operation: &str, args: &[String]) -> Result<CodeQueryResponse, String> {
     let positional = positional(args);
-    let requested_graph =
-        PathBuf::from(option(args, "--graph").unwrap_or("compass-out/graph.json"));
+    let graph_option = option(args, "--graph");
+    let output =
+        PathBuf::from(std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned()));
+    let requested_graph = graph_option.map_or_else(|| output.join("graph.json"), PathBuf::from);
     let engine = match option(args, "--engine") {
         Some("default") => EngineSelection::Default,
         Some("json") => EngineSelection::Json,
@@ -50,10 +52,15 @@ fn execute(operation: &str, args: &[String]) -> Result<CodeQueryResponse, String
                 .unwrap_or_else(|| std::path::Path::new("."))
                 .join("cache")
         });
-    let graph = resolve_generation_artifact(requested_graph)?;
+    let graph = if graph_option.is_some() {
+        resolve_snapshot_artifact(requested_graph)?
+    } else {
+        compass_files::BuildGuard::resolve_artifact(&output, "graph.json")
+            .map_err(|error| error.to_string())?
+    };
     let program = option(args, "--program")
         .map(PathBuf::from)
-        .map(resolve_generation_artifact)
+        .map(resolve_snapshot_artifact)
         .transpose()?;
     let engine = open_with_engine(&graph, program.as_deref(), &cache, engine)
         .map_err(|error| error.to_string())?;
@@ -95,7 +102,7 @@ fn execute(operation: &str, args: &[String]) -> Result<CodeQueryResponse, String
     .map_err(|error| error.to_string())
 }
 
-fn resolve_generation_artifact(path: PathBuf) -> Result<PathBuf, String> {
+fn resolve_snapshot_artifact(path: PathBuf) -> Result<PathBuf, String> {
     compass_files::BuildGuard::resolve_requested_artifact(&path).map_err(|error| error.to_string())
 }
 

--- a/crates/compass-cli/src/help.rs
+++ b/crates/compass-cli/src/help.rs
@@ -620,7 +620,7 @@ const PAGES: &[Page] = &[
         "diagnose quality",
         "Inspect typed graph evidence and publication quality",
         ["compass diagnose quality [OPTIONS]"],
-        "Options:\n  --graph <PATH>          Typed graph [default: compass-out/graph.json]\n  --json                  Emit compass.graph-quality/1 JSON\n\nChecks:\n  Evidence confidence, source anchors, external placeholders, publication omissions, identity collisions, and consistency with graph-overview.json and .compass_output_stats.json.\n\nExamples:\n  compass diagnose quality\n  compass diagnose quality --graph compass-out/graph.json --json"
+        "Options:\n  --graph <PATH>          Typed graph [default: compass-out/graph.json]\n  --json                  Emit compass.graph-quality/1 JSON\n\nChecks:\n  Evidence confidence, source anchors, external placeholders, publication omissions, identity collisions, and consistency with graph-overview.json and output-stats.json.\n\nExamples:\n  compass diagnose quality\n  compass diagnose quality --graph compass-out/graph.json --json"
     ),
     page!(
         "diagnose multigraph",

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -876,7 +876,8 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
         let Some(output_container) = self.working_tree_seed.as_ref() else {
             return Ok(None);
         };
-        let Ok(output_dir) = compass_files::BuildGuard::resolve_active_directory(output_container)
+        let Ok(output_dir) =
+            compass_files::BuildGuard::resolve_current_snapshot_directory(output_container)
         else {
             return Ok(None);
         };
@@ -984,8 +985,9 @@ impl CompleteGraphBuilder for NativeCompleteGraphBuilder {
         }
 
         let output_container = output_root.join("compass-out");
-        let output_dir = compass_files::BuildGuard::resolve_active_directory(&output_container)
-            .map_err(|error| MaterializeError::Builder(error.to_string()))?;
+        let output_dir =
+            compass_files::BuildGuard::resolve_current_snapshot_directory(&output_container)
+                .map_err(|error| MaterializeError::Builder(error.to_string()))?;
         let detection = detect(
             checkout,
             &DetectOptions {

--- a/crates/compass-cli/src/lib.rs
+++ b/crates/compass-cli/src/lib.rs
@@ -123,8 +123,7 @@ pub struct Outcome {
 }
 
 pub(crate) fn resolve_output_artifact(output: &Path, name: &str) -> Result<PathBuf, String> {
-    compass_files::BuildGuard::resolve_requested_artifact(&output.join(name))
-        .map_err(|error| error.to_string())
+    compass_files::BuildGuard::resolve_artifact(output, name).map_err(|error| error.to_string())
 }
 
 impl Outcome {
@@ -2309,7 +2308,7 @@ fn command_hook_refresh(frontend: Frontend, args: &[String]) -> Outcome {
         .find(|argument| !argument.starts_with('-'))
         .map_or_else(|| PathBuf::from("."), PathBuf::from);
     let output_name = std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned());
-    let marker = launch_root.join(&output_name).join(".compass_root");
+    let marker = launch_root.join(&output_name).join("source-root.txt");
     let recorded_root = hook_commands::read_text_bounded(&marker, 16 * 1024)
         .ok()
         .map(|value| value.trim().to_owned())
@@ -2779,7 +2778,7 @@ fn extract_help() -> String {
 }
 
 fn saved_graph_root() -> Option<PathBuf> {
-    let path = default_graph_path().parent()?.join(".compass_root");
+    let path = default_graph_path().parent()?.join("source-root.txt");
     let root = fs::read_to_string(path).ok()?;
     let root = root.trim();
     (!root.is_empty()).then(|| PathBuf::from(root))
@@ -2810,7 +2809,7 @@ fn command_export(frontend: Frontend, args: &[String]) -> Outcome {
     let mut labels_path = default_graph_path()
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join(".compass_labels.json");
+        .join("labels.json");
     let mut labels_explicit = false;
     let mut report_path = default_graph_path()
         .parent()
@@ -3037,7 +3036,7 @@ fn command_export(frontend: Frontend, args: &[String]) -> Outcome {
     if graph_explicit {
         let output_dir = graph_path.parent().unwrap_or_else(|| Path::new("."));
         if !labels_explicit {
-            labels_path = output_dir.join(".compass_labels.json");
+            labels_path = output_dir.join("labels.json");
         }
         if !report_explicit {
             report_path = output_dir.join("GRAPH_REPORT.md");
@@ -3165,13 +3164,16 @@ fn command_export(frontend: Frontend, args: &[String]) -> Outcome {
     match result {
         Ok(mut output) => {
             if format == "html" {
+                let artifact_directory = graph_path.parent().unwrap_or_else(|| Path::new("."));
                 let output_container =
                     compass_files::BuildGuard::output_container_for_artifact(&graph_path);
-                if let Err(error) = compass_files::BuildGuard::publish_root_artifacts(
-                    &output_container,
-                    &["graph.html"],
-                    true,
-                ) {
+                if output_container != artifact_directory
+                    && let Err(error) = compass_files::BuildGuard::publish_root_artifacts(
+                        &output_container,
+                        &["graph.html"],
+                        true,
+                    )
+                {
                     return Outcome::failure(format!(
                         "error: could not publish graph.html at the output root: {error}"
                     ));
@@ -3459,7 +3461,7 @@ fn export_obsidian_cli(inputs: &ExportInputs, output_dir: &Path) -> Result<Strin
 fn export_wiki_cli(inputs: &ExportInputs, output_dir: &Path) -> Result<String, String> {
     if inputs.communities.is_empty() {
         return Err(
-            ".compass_analysis.json is missing or empty — refusing to export wiki to prevent data loss.\nRun `compass extract .` (or `compass cluster-only .`) to regenerate community data first."
+            "analysis.json is missing or empty — refusing to export wiki to prevent data loss.\nRun `compass extract .` (or `compass cluster-only .`) to regenerate community data first."
                 .to_owned(),
         );
     }
@@ -4201,28 +4203,6 @@ mod mcp_option_tests {
         let options = parse_mcp_options(&args)?
             .ok_or_else(|| "options unexpectedly returned help".to_owned())?;
         assert_eq!(options.graph_path, PathBuf::from("flag.json"));
-        Ok(())
-    }
-
-    #[test]
-    fn shared_cli_artifact_resolution_distinguishes_legacy_from_malformed_pointer()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let directory = tempfile::tempdir()?;
-        let output = directory.path().join("compass-out");
-        fs::create_dir_all(&output)?;
-        fs::write(output.join("graph.json"), "{}")?;
-
-        assert_eq!(
-            resolve_output_artifact(&output, "graph.json")?,
-            output.join("graph.json"),
-            "pointer absence must retain documented legacy compatibility"
-        );
-
-        fs::write(output.join(".compass-active-generation"), "../escape")?;
-        let Err(error) = resolve_output_artifact(&output, "graph.json") else {
-            return Err("a malformed pointer must never fall back to the legacy graph".into());
-        };
-        assert!(error.contains("generation"), "{error}");
         Ok(())
     }
 

--- a/crates/compass-cli/src/result_commands.rs
+++ b/crates/compass-cli/src/result_commands.rs
@@ -156,8 +156,8 @@ pub(super) fn command_reflect(frontend: Frontend, args: &[String]) -> Outcome {
     };
     if let Some(graph_path) = graph.as_deref() {
         let parent = graph_path.parent().unwrap_or_else(|| Path::new("."));
-        analysis.get_or_insert_with(|| parent.join(".compass_analysis.json"));
-        labels.get_or_insert_with(|| parent.join(".compass_labels.json"));
+        analysis.get_or_insert_with(|| parent.join("analysis.json"));
+        labels.get_or_insert_with(|| parent.join("labels.json"));
     }
     if if_stale
         && lessons_fresh(

--- a/crates/compass-cli/src/semantic_commands.rs
+++ b/crates/compass-cli/src/semantic_commands.rs
@@ -119,15 +119,13 @@ pub(super) fn command_cache_check(frontend: Frontend, args: &[String]) -> Outcom
     }
     if (!nodes.is_empty() || !edges.is_empty() || !hyperedges.is_empty())
         && let Err(error) = write_compact_json(
-            &output.join(".compass_cached.json"),
+            &output.join("cached.json"),
             &json!({"nodes":nodes,"edges":edges,"hyperedges":hyperedges}),
         )
     {
         return Outcome::failure(format!("error: {error}"));
     }
-    if let Err(error) =
-        write_text_atomic(output.join(".compass_uncached.txt"), &uncached.join("\n"))
-    {
+    if let Err(error) = write_text_atomic(output.join("uncached.txt"), &uncached.join("\n")) {
         return Outcome::failure(format!("error: {error}"));
     }
     Outcome {

--- a/crates/compass-cli/src/store_commands.rs
+++ b/crates/compass-cli/src/store_commands.rs
@@ -414,15 +414,22 @@ fn output_root(args: &[String]) -> Result<PathBuf, String> {
             .map_err(|error| error.to_string())?;
         return Ok(graph.parent().unwrap_or(Path::new(".")).to_path_buf());
     }
-    if candidate.join("graph.json").is_file() || candidate.join(STORE_FILE_NAME).is_file() {
-        return Ok(candidate);
-    }
     let output_container = if candidate.join("compass-out").is_dir() {
         candidate.join("compass-out")
     } else {
-        candidate
+        candidate.clone()
     };
-    BuildGuard::resolve_active_directory(&output_container).map_err(|error| error.to_string())
+    if output_container.join("current-snapshot").is_file()
+        || output_container.join("snapshots").is_dir()
+    {
+        return BuildGuard::resolve_current_snapshot_directory(&output_container)
+            .map_err(|error| error.to_string());
+    }
+    if candidate.join("graph.json").is_file() || candidate.join(STORE_FILE_NAME).is_file() {
+        return Ok(candidate);
+    }
+    BuildGuard::resolve_current_snapshot_directory(&output_container)
+        .map_err(|error| error.to_string())
 }
 
 fn positional(args: &[String]) -> Vec<String> {

--- a/crates/compass-cli/tests/code_query_cli.rs
+++ b/crates/compass-cli/tests/code_query_cli.rs
@@ -122,7 +122,7 @@ fn typed_query_text_is_a_projection_of_the_same_response() -> Result<(), Box<dyn
 }
 
 #[test]
-fn typed_query_resolves_the_active_generation_from_the_public_path() -> Result<(), Box<dyn Error>> {
+fn typed_query_resolves_the_current_snapshot_from_the_public_path() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let output = directory.path().join("compass-out");
     let guard = BuildGuard::begin(&output)?;
@@ -144,7 +144,7 @@ fn typed_query_resolves_the_active_generation_from_the_public_path() -> Result<(
 }
 
 #[test]
-fn typed_query_prefers_active_generation_over_stale_legacy_graph() -> Result<(), Box<dyn Error>> {
+fn typed_query_prefers_current_snapshot_over_a_stale_root_facade() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let output = directory.path().join("compass-out");
     support::write_typed_graph(&output)?;
@@ -168,11 +168,11 @@ fn typed_query_prefers_active_generation_over_stale_legacy_graph() -> Result<(),
 }
 
 #[test]
-fn typed_query_fails_closed_on_a_malformed_generation_pointer() -> Result<(), Box<dyn Error>> {
+fn typed_query_fails_closed_on_a_malformed_snapshot_pointer() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let output = directory.path().join("compass-out");
     support::write_typed_graph(&output)?;
-    std::fs::write(output.join(".compass-active-generation"), "../escape")?;
+    std::fs::write(output.join("current-snapshot"), "../escape")?;
 
     let outcome = run(
         Frontend::Compass,
@@ -184,18 +184,18 @@ fn typed_query_fails_closed_on_a_malformed_generation_pointer() -> Result<(), Bo
         ],
     );
     assert_ne!(outcome.code, 0);
-    assert!(outcome.stderr.contains("generation"));
+    assert!(outcome.stderr.contains("snapshot"));
     Ok(())
 }
 
 #[test]
-fn natural_query_reads_legacy_only_when_the_generation_pointer_is_absent()
+fn natural_query_accepts_a_standalone_graph_but_rejects_a_malformed_managed_pointer()
 -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let output = directory.path().join("compass-out");
     support::write_typed_graph(&output)?;
 
-    let legacy = run(
+    let standalone = run(
         Frontend::Compass,
         [
             OsString::from("query"),
@@ -204,9 +204,9 @@ fn natural_query_reads_legacy_only_when_the_generation_pointer_is_absent()
             output.join("graph.json").into_os_string(),
         ],
     );
-    assert_eq!(legacy.code, 0, "{}", legacy.stderr);
+    assert_eq!(standalone.code, 0, "{}", standalone.stderr);
 
-    std::fs::write(output.join(".compass-active-generation"), "../escape")?;
+    std::fs::write(output.join("current-snapshot"), "../escape")?;
     let malformed = run(
         Frontend::Compass,
         [
@@ -218,7 +218,7 @@ fn natural_query_reads_legacy_only_when_the_generation_pointer_is_absent()
     );
     assert_ne!(malformed.code, 0);
     assert!(
-        malformed.stderr.contains("generation"),
+        malformed.stderr.contains("snapshot"),
         "{}",
         malformed.stderr
     );

--- a/crates/compass-cli/tests/coverage_paths.rs
+++ b/crates/compass-cli/tests/coverage_paths.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 
 use compass_cli::{Frontend, run, run_mcp, run_watch};
+use compass_files::BuildGuard;
 
 fn invoke(frontend: Frontend, arguments: &[&str]) -> compass_cli::Outcome {
     run(
@@ -76,44 +77,36 @@ fn diagnostic_node_count(graph: &Path) -> Result<usize, Box<dyn Error>> {
 }
 
 #[test]
-fn diagnose_rereads_the_active_generation_for_an_explicit_public_graph()
--> Result<(), Box<dyn Error>> {
+fn diagnose_rereads_the_current_snapshot_for_an_explicit_public_graph() -> Result<(), Box<dyn Error>>
+{
     let directory = tempfile::tempdir()?;
     let output = directory.path();
     let public = output.join("graph.json");
     write_diagnostic_graph(&public, 1)?;
-    let generations = output.join(".compass-generations");
-    let first = generations.join("generation-first");
-    let second = generations.join("generation-second");
+    let snapshots = output.join("snapshots");
+    let first = snapshots.join("snapshot-first");
+    let second = snapshots.join("snapshot-second");
     fs::create_dir_all(&first)?;
     fs::create_dir_all(&second)?;
     write_diagnostic_graph(&first.join("graph.json"), 2)?;
     write_diagnostic_graph(&second.join("graph.json"), 3)?;
 
-    fs::write(
-        output.join(".compass-active-generation"),
-        "generation-first",
-    )?;
+    fs::write(output.join("current-snapshot"), "snapshot-first")?;
     assert_eq!(diagnostic_node_count(&public)?, 2);
-    fs::write(
-        output.join(".compass-active-generation"),
-        "generation-second",
-    )?;
+    fs::write(output.join("current-snapshot"), "snapshot-second")?;
     assert_eq!(diagnostic_node_count(&public)?, 3);
     Ok(())
 }
 
 #[test]
-fn diagnose_uses_legacy_only_when_the_generation_pointer_is_absent() -> Result<(), Box<dyn Error>> {
+fn diagnose_accepts_a_standalone_graph_but_rejects_a_malformed_managed_pointer()
+-> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let public = directory.path().join("graph.json");
     write_diagnostic_graph(&public, 1)?;
     assert_eq!(diagnostic_node_count(&public)?, 1);
 
-    fs::write(
-        directory.path().join(".compass-active-generation"),
-        "../escape",
-    )?;
+    fs::write(directory.path().join("current-snapshot"), "../escape")?;
     let outcome = invoke_owned(
         Frontend::Compass,
         &[
@@ -125,7 +118,7 @@ fn diagnose_uses_legacy_only_when_the_generation_pointer_is_absent() -> Result<(
         ],
     );
     assert_ne!(outcome.code, 0);
-    assert!(outcome.stderr.contains("generation"), "{}", outcome.stderr);
+    assert!(outcome.stderr.contains("snapshot"), "{}", outcome.stderr);
     Ok(())
 }
 
@@ -633,9 +626,9 @@ fn completed_read_query_diagnostic_merge_tree_and_export_commands_run_end_to_end
     fs::create_dir_all(&output)?;
     let graph = output.join("graph.json");
     write_graph_fixture(&graph)?;
-    fs::write(output.join(".compass_labels.json"), r#"{"0":"Core"}"#)?;
+    fs::write(output.join("labels.json"), r#"{"0":"Core"}"#)?;
     fs::write(
-        output.join(".compass_analysis.json"),
+        output.join("analysis.json"),
         r#"{"communities":{"0":["n_transformer","n_attention","n_layernorm","n_concept_attn"]},"cohesion":{"0":0.75}}"#,
     )?;
     fs::write(output.join("GRAPH_REPORT.md"), "# Fixture\n")?;
@@ -797,15 +790,24 @@ fn split_value_read_export_and_cluster_forms_complete_against_a_real_graph()
 -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let output = directory.path().join("compass-out");
-    fs::create_dir_all(&output)?;
-    let graph = output.join("graph.json");
-    write_graph_fixture(&graph)?;
-    fs::write(output.join(".compass_labels.json"), r#"{"0":"Core"}"#)?;
+    let guard = BuildGuard::begin(&output)?;
+    let snapshot = guard.staging_directory().to_path_buf();
+    write_graph_fixture(&snapshot.join("graph.json"))?;
+    fs::write(snapshot.join("labels.json"), r#"{"0":"Core"}"#)?;
     fs::write(
-        output.join(".compass_analysis.json"),
+        snapshot.join("analysis.json"),
         r#"{"communities":{"0":["n_transformer","n_attention"]},"cohesion":{"0":0.5}}"#,
     )?;
-    fs::write(output.join("GRAPH_REPORT.md"), "# Fixture\n")?;
+    fs::write(snapshot.join("GRAPH_REPORT.md"), "# Fixture\n")?;
+    let artifacts = [
+        "graph.json",
+        "labels.json",
+        "analysis.json",
+        "GRAPH_REPORT.md",
+    ];
+    guard.commit_with_artifacts(&artifacts)?;
+    BuildGuard::publish_root_artifacts(&output, &artifacts, true)?;
+    let graph = output.join("graph.json");
     let graph_text = graph.to_string_lossy().into_owned();
 
     for arguments in [

--- a/crates/compass-cli/tests/hook_cli.rs
+++ b/crates/compass-cli/tests/hook_cli.rs
@@ -157,7 +157,7 @@ fn native_hook_refresh_honors_recorded_scan_root() -> Result<(), Box<dyn Error>>
     let output_root = root.join("compass-out");
     std::fs::create_dir_all(&output_root)?;
     std::fs::write(
-        output_root.join(".compass_root"),
+        output_root.join("source-root.txt"),
         source_root.to_string_lossy().as_bytes(),
     )?;
 

--- a/crates/compass-cli/tests/init_cli.rs
+++ b/crates/compass-cli/tests/init_cli.rs
@@ -95,7 +95,7 @@ fn sqlite_store_option_publishes_a_durable_snapshot_alongside_json() -> Result<(
     assert!(timing.contains("bytes_written="));
 
     let output_root = root.path().join("compass-out");
-    let active = BuildGuard::resolve_active_directory(&output_root)?;
+    let active = BuildGuard::resolve_current_snapshot_directory(&output_root)?;
     let graph_path = active.join("graph.json");
     let store_path = local_sqlite_store_path(&graph_path);
     let store = SqliteStore::open_read_only(&store_path)?;
@@ -117,12 +117,12 @@ fn sqlite_store_option_publishes_a_durable_snapshot_alongside_json() -> Result<(
         String::from_utf8_lossy(&update.stdout),
         String::from_utf8_lossy(&update.stderr)
     );
-    let active = BuildGuard::resolve_active_directory(&output_root)?;
+    let active = BuildGuard::resolve_current_snapshot_directory(&output_root)?;
     assert!(active.join("graph.json").is_file());
     assert!(!active.join(STORE_FILE_NAME).exists());
     assert!(store_path.is_file());
     assert!(active.join(STORE_REF_FILE_NAME).is_file());
-    assert!(!active.join(".compass-build-incomplete").exists());
+    assert!(!active.join("build-incomplete").exists());
     Ok(())
 }
 
@@ -141,15 +141,49 @@ fn graph_build_defaults_to_sqlite_query_artifacts() -> Result<(), Box<dyn Error>
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let active = BuildGuard::resolve_active_directory(&root.path().join("compass-out"))?;
+    let output_root = root.path().join("compass-out");
+    let active = BuildGuard::resolve_current_snapshot_directory(&output_root)?;
     assert!(active.join("graph.json").is_file());
     assert!(active.join(STORE_REF_FILE_NAME).is_file());
     assert!(local_sqlite_store_path(&active.join("graph.json")).is_file());
+    assert!(output_root.join("current-snapshot").is_file());
+    assert!(output_root.join("snapshots").is_dir());
+    assert!(output_root.join("store").is_dir());
+    for entry in fs::read_dir(&output_root)? {
+        let name = entry?.file_name();
+        let name = name.to_string_lossy();
+        assert!(
+            !name.starts_with(".compass") && !name.starts_with("compass-"),
+            "prefixed Compass artifact {name} remained at {}",
+            output_root.display()
+        );
+    }
+    for entry in fs::read_dir(&active)? {
+        let name = entry?.file_name();
+        let name = name.to_string_lossy();
+        assert!(
+            !name.starts_with(".compass") && !name.starts_with("compass-"),
+            "prefixed Compass artifact {name} remained at {}",
+            active.display()
+        );
+    }
+    for name in [
+        "ast-fact-digests.json",
+        "build-state.json",
+        "labels.json",
+        "output-stats.json",
+        "source-root.txt",
+    ] {
+        assert!(
+            active.join(name).is_file(),
+            "missing visible artifact {name}"
+        );
+    }
     Ok(())
 }
 
 #[test]
-fn explicit_json_build_replaces_an_opted_in_store_generation() -> Result<(), Box<dyn Error>> {
+fn explicit_json_build_replaces_an_opted_in_store_snapshot() -> Result<(), Box<dyn Error>> {
     let root = tempfile::tempdir()?;
     fs::write(root.path().join("main.rs"), "fn main() {}\n")?;
     let sqlite = Command::new(env!("CARGO_BIN_EXE_compass"))
@@ -159,7 +193,7 @@ fn explicit_json_build_replaces_an_opted_in_store_generation() -> Result<(), Box
         .output()?;
     assert!(sqlite.status.success());
     let output = root.path().join("compass-out");
-    let active = BuildGuard::resolve_active_directory(&output)?;
+    let active = BuildGuard::resolve_current_snapshot_directory(&output)?;
     assert!(!active.join(STORE_FILE_NAME).exists());
     assert!(local_sqlite_store_path(&active.join("graph.json")).is_file());
 
@@ -174,7 +208,7 @@ fn explicit_json_build_replaces_an_opted_in_store_generation() -> Result<(), Box
         String::from_utf8_lossy(&json.stdout),
         String::from_utf8_lossy(&json.stderr)
     );
-    let active = BuildGuard::resolve_active_directory(&output)?;
+    let active = BuildGuard::resolve_current_snapshot_directory(&output)?;
     assert!(active.join("graph.json").is_file());
     assert!(!active.join(STORE_FILE_NAME).exists());
     assert!(!active.join(STORE_REF_FILE_NAME).exists());

--- a/crates/compass-cli/tests/program_cli.rs
+++ b/crates/compass-cli/tests/program_cli.rs
@@ -35,13 +35,6 @@ fn native_update_emits_and_reports_program_analysis() -> Result<(), Box<dyn Erro
         BuildGuard::resolve_artifact(&directory.path().join("compass-out"), "program.json")?
             .is_file()
     );
-    assert!(
-        !directory
-            .path()
-            .join("compass-out/.compass_program.json")
-            .exists()
-    );
-
     let warm = run(Frontend::Compass, args);
     assert_eq!(warm.code, 0, "{}", warm.stderr);
     assert!(warm.stdout.contains(

--- a/crates/compass-cli/tests/prs_cli.rs
+++ b/crates/compass-cli/tests/prs_cli.rs
@@ -58,7 +58,7 @@ exit 1
 }
 
 #[test]
-fn prs_impact_reads_only_the_active_generation_when_public_graph_is_absent()
+fn prs_impact_reads_only_the_current_snapshot_when_public_graph_is_absent()
 -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let bin = directory.path().join("bin");
@@ -78,12 +78,10 @@ exit 1
 "#,
     )?;
     let output = directory.path().join("compass-out");
-    let generation = output
-        .join(".compass-generations")
-        .join("generation-current");
-    std::fs::create_dir_all(&generation)?;
+    let snapshot = output.join("snapshots").join("snapshot-current");
+    std::fs::create_dir_all(&snapshot)?;
     std::fs::write(
-        generation.join("graph.json"),
+        snapshot.join("graph.json"),
         serde_json::to_vec(&serde_json::json!({
             "directed":false,
             "multigraph":false,
@@ -97,10 +95,7 @@ exit 1
             "links":[]
         }))?,
     )?;
-    std::fs::write(
-        output.join(".compass-active-generation"),
-        "generation-current",
-    )?;
+    std::fs::write(output.join("current-snapshot"), "snapshot-current")?;
     let public = output.join("graph.json");
     assert!(!public.exists());
     let public_arg = public.to_string_lossy().into_owned();
@@ -123,10 +118,7 @@ exit 1
         String::from_utf8_lossy(&detail.stdout)
     );
 
-    std::fs::write(
-        output.join(".compass-active-generation"),
-        "../invalid-generation",
-    )?;
+    std::fs::write(output.join("current-snapshot"), "../invalid-snapshot")?;
     let malformed = Command::new(env!("CARGO_BIN_EXE_compass"))
         .current_dir(directory.path())
         .env("PATH", path)

--- a/crates/compass-cli/tests/semantic_extract.rs
+++ b/crates/compass-cli/tests/semantic_extract.rs
@@ -7,6 +7,42 @@ use std::process::Command;
 use serde_json::Value;
 
 #[test]
+fn cache_check_publishes_only_visible_compass_output_names() -> Result<(), Box<dyn Error>> {
+    let corpus = tempfile::tempdir()?;
+    fs::write(corpus.path().join("main.rs"), "fn main() {}\n")?;
+    fs::write(corpus.path().join("files.txt"), "main.rs\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_compass"))
+        .args([
+            "cache-check",
+            "files.txt",
+            "--root",
+            corpus.path().to_str().ok_or("non-UTF-8 corpus path")?,
+        ])
+        .current_dir(corpus.path())
+        .env_remove("COMPASS_OUT")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let compass_output = corpus.path().join("compass-out");
+    assert_eq!(
+        fs::read_to_string(compass_output.join("uncached.txt"))?,
+        "main.rs"
+    );
+    for entry in fs::read_dir(&compass_output)? {
+        let name = entry?.file_name();
+        let name = name.to_string_lossy();
+        assert!(!name.starts_with(".compass") && !name.starts_with("compass-"));
+    }
+    Ok(())
+}
+
+#[test]
 fn native_semantic_extract_uses_provider_then_runs_warm_without_network()
 -> Result<(), Box<dyn Error>> {
     let corpus = tempfile::tempdir()?;
@@ -115,7 +151,7 @@ fn native_semantic_extract_uses_provider_then_runs_warm_without_network()
         .map_err(|error| format!("provider failed: {error}"))?;
 
     let output = corpus.path().join("compass-out");
-    let active = compass_files::BuildGuard::resolve_active_directory(&output)?;
+    let active = compass_files::BuildGuard::resolve_current_snapshot_directory(&output)?;
     let graph: Value = serde_json::from_slice(&fs::read(active.join("graph.json"))?)?;
     assert!(
         graph["nodes"].as_array().is_some_and(|nodes| {
@@ -135,14 +171,12 @@ fn native_semantic_extract_uses_provider_then_runs_warm_without_network()
         }),
         "{graph:#}"
     );
-    let analysis: Value =
-        serde_json::from_slice(&fs::read(active.join(".compass_analysis.json"))?)?;
+    let analysis: Value = serde_json::from_slice(&fs::read(active.join("analysis.json"))?)?;
     assert_eq!(
         analysis["tokens"],
         serde_json::json!({"input":17,"output":9})
     );
-    let marker: Value =
-        serde_json::from_slice(&fs::read(active.join(".compass_semantic_marker"))?)?;
+    let marker: Value = serde_json::from_slice(&fs::read(active.join("semantic-marker.json"))?)?;
     assert_eq!(marker["output_tokens"], 9);
     let manifest: Value = serde_json::from_slice(&fs::read(active.join("manifest.json"))?)?;
     assert!(

--- a/crates/compass-cli/tests/store_cli.rs
+++ b/crates/compass-cli/tests/store_cli.rs
@@ -94,7 +94,7 @@ fn store_status_backup_and_restore_are_end_to_end_validated() -> Result<(), Box<
     assert!(restored_validation.status.success());
     let restored_json: Value = serde_json::from_slice(&restored_validation.stdout)?;
     assert_eq!(restored_json["valid"], true);
-    let active_output = BuildGuard::resolve_active_directory(&output)?;
+    let active_output = BuildGuard::resolve_current_snapshot_directory(&output)?;
     assert_eq!(
         fs::read(active_output.join("graph.json"))?,
         fs::read(restored.join("graph.json"))?
@@ -114,9 +114,9 @@ fn store_validate_rejects_a_corrupt_sidecar_without_touching_graph_json()
         .output()?;
     assert!(init.status.success());
     let output = root.path().join("compass-out");
-    let active_output = BuildGuard::resolve_active_directory(&output)?;
+    let active_output = BuildGuard::resolve_current_snapshot_directory(&output)?;
     let graph = fs::read(active_output.join("graph.json"))?;
-    fs::write(active_output.join("compass-store.sqlite3"), b"corrupt")?;
+    fs::write(output.join("store/store.sqlite3"), b"corrupt")?;
     let result = Command::new(env!("CARGO_BIN_EXE_compass"))
         .args(["store", "validate", output.to_str().ok_or("output path")?])
         .output()?;

--- a/crates/compass-core/src/build_state.rs
+++ b/crates/compass-core/src/build_state.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 
 use crate::CoreError;
 
-pub(crate) const BUILD_STATE_FILE: &str = ".compass_build_state.json";
+pub(crate) const BUILD_STATE_FILE: &str = "build-state.json";
 const BUILD_STATE_SCHEMA: &str = "compass.build-state/1";
 const HASH_BUFFER_BYTES: usize = 1024 * 1024;
 
@@ -94,14 +94,9 @@ pub(crate) struct BuildProfile {
     #[serde(default)]
     pub code_only: bool,
     pub program_analysis: bool,
-    #[serde(default = "legacy_graph_storage")]
     pub graph_storage: String,
     #[serde(default = "default_max_source_bytes")]
     pub max_source_bytes: u64,
-}
-
-fn legacy_graph_storage() -> String {
-    "sqlite".to_owned()
 }
 
 const fn default_max_source_bytes() -> u64 {
@@ -280,7 +275,7 @@ mod tests {
         let manifest = output.join("manifest.json");
         let graph = output.join("graph.json");
         let program = output.join("program.json");
-        let required = output.join(".compass_root");
+        let required = output.join("source-root.txt");
         fs::write(&manifest, b"manifest")?;
         fs::write(&graph, b"graph")?;
         fs::write(&program, b"program")?;

--- a/crates/compass-core/src/cluster_existing.rs
+++ b/crates/compass-core/src/cluster_existing.rs
@@ -158,9 +158,8 @@ where
     let analyze_started = Instant::now();
     let hub_labels = label_communities_by_hub(&document, &communities);
     let signatures = community_member_signatures(&communities);
-    let saved_labels = load_usize_string_map(&options.output_dir.join(".compass_labels.json"));
-    let saved_signatures =
-        load_usize_string_map(&options.output_dir.join(".compass_labels.json.sig"));
+    let saved_labels = load_usize_string_map(&options.output_dir.join("labels.json"));
+    let saved_signatures = load_usize_string_map(&options.output_dir.join("labels.json.sig"));
     let cohesion = score_communities(&document, &communities);
     let gods = god_nodes(&document, 10);
     let surprises = surprising_connections(&document, &communities, 5);
@@ -207,7 +206,7 @@ where
     let export_started = Instant::now();
     let backup = backup_if_protected(&options.output_dir);
     write_json_atomic(
-        options.output_dir.join(".compass_analysis.json"),
+        options.output_dir.join("analysis.json"),
         &json!({
             "communities": communities.iter().map(|(key, value)| (key.to_string(), value)).collect::<BTreeMap<_, _>>(),
             "cohesion": cohesion.iter().map(|(key, value)| (key.to_string(), value)).collect::<BTreeMap<_, _>>(),
@@ -227,11 +226,8 @@ where
             community_labels: Some(&labels),
         },
     )?;
-    write_python_string_map(options.output_dir.join(".compass_labels.json"), &labels)?;
-    write_python_string_map(
-        options.output_dir.join(".compass_labels.json.sig"),
-        &signatures,
-    )?;
+    write_python_string_map(options.output_dir.join("labels.json"), &labels)?;
+    write_python_string_map(options.output_dir.join("labels.json.sig"), &signatures)?;
     write_graph_overview_artifact(&document, &communities, &labels, &options.output_dir)?;
     let html_path = options.output_dir.join("graph.html");
     let html_written = if options.no_viz {

--- a/crates/compass-core/src/diagnostics.rs
+++ b/crates/compass-core/src/diagnostics.rs
@@ -235,7 +235,7 @@ pub fn diagnose_graph_quality(path: &Path) -> Result<Value, CoreError> {
     );
 
     let output_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let output_stats = read_json_object(&output_dir.join(".compass_output_stats.json"));
+    let output_stats = read_json_object(&output_dir.join("output-stats.json"));
     let overview = read_json_object(&output_dir.join("graph-overview.json"));
     let stats_nodes = output_stats
         .as_ref()
@@ -399,11 +399,11 @@ fn diagnose_oversized_graph(path: &Path, size: u64, cap: u64) -> Result<Value, C
         &path
             .parent()
             .unwrap_or_else(|| Path::new("."))
-            .join(".compass_output_stats.json"),
+            .join("output-stats.json"),
     )
     .ok_or_else(|| {
         CoreError::DiagnosticFile(format!(
-            "graph file {} exceeds the {}-byte cap and has no .compass_output_stats.json; set COMPASS_MAX_GRAPH_BYTES to inspect it",
+            "graph file {} exceeds the {}-byte cap and has no output-stats.json; set COMPASS_MAX_GRAPH_BYTES to inspect it",
             path.display(),
             grouped(u128::from(cap)),
         ))

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -719,7 +719,7 @@ fn attach_source_inventory(
     checkout: &Path,
     detected: &BTreeMap<String, Vec<String>>,
 ) -> Result<(), MaterializeError> {
-    const INVENTORY_PATH: &str = ".compass_source_inventory.json";
+    const INVENTORY_PATH: &str = "source-inventory.json";
     if completed
         .artifacts
         .authoritative_sidecars

--- a/crates/compass-core/src/lib.rs
+++ b/crates/compass-core/src/lib.rs
@@ -58,7 +58,7 @@ impl ExportInputs {
     pub fn load(graph_path: &Path) -> Result<Self, GraphError> {
         let document = GraphDocument::load(graph_path)?;
         let output_dir = graph_path.parent().unwrap_or_else(|| Path::new("."));
-        let analysis = read_json_value(&output_dir.join(".compass_analysis.json"));
+        let analysis = read_json_value(&output_dir.join("analysis.json"));
         let mut communities = analysis
             .as_ref()
             .and_then(|value| value.get("communities"))
@@ -91,7 +91,7 @@ impl ExportInputs {
             .cloned()
             .and_then(|value| serde_json::from_value(value).ok())
             .unwrap_or_default();
-        let labels = read_json_value(&output_dir.join(".compass_labels.json"))
+        let labels = read_json_value(&output_dir.join("labels.json"))
             .and_then(|value| value.as_object().map(parse_string_map))
             .unwrap_or_default();
         let report = fs::read_to_string(output_dir.join("GRAPH_REPORT.md")).unwrap_or_default();
@@ -186,16 +186,15 @@ impl LoadedGraph {
 pub fn default_graph_path() -> PathBuf {
     let output =
         PathBuf::from(std::env::var("COMPASS_OUT").unwrap_or_else(|_| "compass-out".to_owned()));
-    let requested = output.join("graph.json");
-    compass_files::BuildGuard::resolve_requested_artifact(&requested)
-        .unwrap_or_else(|_| output.join(".compass-invalid-active-generation"))
+    compass_files::BuildGuard::resolve_artifact(&output, "graph.json")
+        .unwrap_or_else(|_| output.join("invalid-current-snapshot"))
 }
 
 fn load_learning_overlay(graph_path: &Path) -> HashMap<String, Map<String, Value>> {
     let sidecar = graph_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join(".compass_learning.json");
+        .join("learning.json");
     let Ok(bytes) = fs::read(sidecar) else {
         return HashMap::new();
     };
@@ -291,7 +290,7 @@ fn resolve_source_path(source: &str, graph_path: &Path) -> Option<PathBuf> {
         })
         .unwrap_or_else(|| "compass-out".into());
     let mut roots = Vec::new();
-    if let Ok(recorded) = fs::read_to_string(output_dir.join(".compass_root")) {
+    if let Ok(recorded) = fs::read_to_string(output_dir.join("source-root.txt")) {
         let recorded = recorded.trim();
         if !recorded.is_empty() {
             roots.push(PathBuf::from(recorded));

--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -78,13 +78,10 @@ use crate::raw_guard::enforce_incomplete_raw_guard;
 /// size while building records. Callers may raise this bound explicitly for
 /// repositories with intentionally large generated sources.
 pub const DEFAULT_MAX_SOURCE_BYTES: u64 = 16 * 1024 * 1024;
-const SEMANTIC_MARKER_FILE: &str = ".compass_semantic_marker";
+const SEMANTIC_MARKER_FILE: &str = "semantic-marker.json";
 const PIPELINE_RAYON_WORKER_CAP: usize = 12;
-const STORE_GENERATION_EXCLUSIONS: [&str; 3] = [
-    STORE_FILE_NAME,
-    "compass-store.sqlite3-wal",
-    "compass-store.sqlite3-shm",
-];
+const STORE_SNAPSHOT_EXCLUSIONS: [&str; 3] =
+    [STORE_FILE_NAME, "store.sqlite3-wal", "store.sqlite3-shm"];
 const ROOT_ARTIFACTS: [&str; 6] = [
     "GRAPH_REPORT.md",
     "graph-overview.json",
@@ -171,8 +168,8 @@ pub enum BuildPurpose {
     Extract,
 }
 
-const OUTPUT_STATS_FILE: &str = ".compass_output_stats.json";
-const AST_FACT_DIGESTS_FILE: &str = ".compass_ast_fact_digests.json";
+const OUTPUT_STATS_FILE: &str = "output-stats.json";
+const AST_FACT_DIGESTS_FILE: &str = "ast-fact-digests.json";
 const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/3";
 const MAX_AST_FACT_DIGEST_ENTRIES: usize = 100_000;
 const MAX_AST_FACT_DIGEST_FILE_BYTES: usize = 16 * 1024 * 1024;
@@ -1936,7 +1933,7 @@ fn publish_fact_neutral_incremental(
         store_metrics.is_some(),
         timings,
     )?;
-    let published_output_dir = commit_generation(
+    let published_output_dir = commit_snapshot(
         guard,
         output_container,
         options.graph_storage,
@@ -2283,7 +2280,7 @@ fn build_graph_inner_unscoped(
         source,
     })?;
     let prior_build_complete = BuildGuard::ensure_complete(&output_container).is_ok();
-    let guard = BuildGuard::begin_excluding(&output_container, &STORE_GENERATION_EXCLUSIONS)?;
+    let guard = BuildGuard::begin_excluding(&output_container, &STORE_SNAPSHOT_EXCLUSIONS)?;
     let output_dir = guard.staging_directory().to_path_buf();
     if !options.program_analysis {
         remove_if_exists(&output_dir.join("program.json"))?;
@@ -2419,7 +2416,7 @@ fn build_graph_inner_unscoped(
             }
             remove_if_exists(&output_dir.join("needs_update"))?;
             let store_ready = storage_artifacts_complete(options.graph_storage, &output_dir);
-            let published_output_dir = commit_generation(
+            let published_output_dir = commit_snapshot(
                 guard,
                 &output_container,
                 options.graph_storage,
@@ -2504,7 +2501,7 @@ fn build_graph_inner_unscoped(
             storage_artifacts_complete(options.graph_storage, &output_dir),
             &mut timings,
         )?;
-        let published_output_dir = commit_generation(
+        let published_output_dir = commit_snapshot(
             guard,
             &output_container,
             options.graph_storage,
@@ -3321,7 +3318,7 @@ fn build_graph_inner_unscoped(
             storage_artifacts_complete(options.graph_storage, &output_dir),
             &mut timings,
         )?;
-        let published_output_dir = commit_generation(
+        let published_output_dir = commit_snapshot(
             guard,
             &output_container,
             options.graph_storage,
@@ -3462,7 +3459,7 @@ fn build_graph_inner_unscoped(
         write_semantic_marker(&output_dir, semantic)?;
         if options.purpose == BuildPurpose::Update {
             write_text_atomic(
-                output_dir.join(".compass_root"),
+                output_dir.join("source-root.txt"),
                 &options.root.to_string_lossy(),
             )?;
         }
@@ -3503,7 +3500,7 @@ fn build_graph_inner_unscoped(
             no_cluster_state_started.elapsed(),
         );
         let no_cluster_commit_started = Instant::now();
-        let published_output_dir = commit_generation(
+        let published_output_dir = commit_snapshot(
             guard,
             &output_container,
             options.graph_storage,
@@ -3513,7 +3510,7 @@ fn build_graph_inner_unscoped(
             &mut timings,
         )?;
         profile_internal_duration(
-            "no-cluster generation commit",
+            "no-cluster snapshot commit",
             no_cluster_commit_started.elapsed(),
         );
         timings.publish = stage_started.elapsed();
@@ -3575,7 +3572,7 @@ fn build_graph_inner_unscoped(
         BuildPurpose::Update => update_artifacts_complete(options, &output_dir),
         BuildPurpose::Extract => {
             output_dir.join("graph.json").is_file()
-                && output_dir.join(".compass_analysis.json").is_file()
+                && output_dir.join("analysis.json").is_file()
                 && storage_artifacts_complete(options.graph_storage, &output_dir)
         }
     };
@@ -3634,7 +3631,7 @@ fn build_graph_inner_unscoped(
                 true,
                 &mut timings,
             )?;
-            let published_output_dir = commit_generation(
+            let published_output_dir = commit_snapshot(
                 guard,
                 &output_container,
                 options.graph_storage,
@@ -3793,18 +3790,15 @@ fn build_graph_inner_unscoped(
             })
         };
         if options.purpose == BuildPurpose::Extract {
-            write_json_atomic(output_dir.join(".compass_analysis.json"), &analysis, true)?;
+            write_json_atomic(output_dir.join("analysis.json"), &analysis, true)?;
         } else {
             let labels_json = serde_json::to_string_pretty(&labels).map_err(|source| {
                 CoreError::SerializeExtraction {
-                    path: output_dir.join(".compass_labels.json"),
+                    path: output_dir.join("labels.json"),
                     source,
                 }
             })?;
-            write_text_atomic(
-                output_dir.join(".compass_labels.json"),
-                &format!("{labels_json}\n"),
-            )?;
+            write_text_atomic(output_dir.join("labels.json"), &format!("{labels_json}\n"))?;
         }
         let detection_summary = DetectionSummary {
             total_files: detection.total_files,
@@ -3873,7 +3867,7 @@ fn build_graph_inner_unscoped(
         let started = Instant::now();
         let model = if options.purpose == BuildPurpose::Update {
             write_text_atomic(
-                output_dir.join(".compass_root"),
+                output_dir.join("source-root.txt"),
                 &options.root.to_string_lossy(),
             )?;
             graph_overview_model(&document, &communities, &labels, &output_dir)?
@@ -4016,7 +4010,7 @@ fn build_graph_inner_unscoped(
         &mut timings,
     )?;
     profile_internal("Program output and build seals", &mut internal_started);
-    let published_output_dir = commit_generation(
+    let published_output_dir = commit_snapshot(
         guard,
         &output_container,
         options.graph_storage,
@@ -4221,17 +4215,17 @@ fn publish_build_state(
     }
     match options.purpose {
         BuildPurpose::Update => {
-            required.push(output_dir.join(".compass_root"));
+            required.push(output_dir.join("source-root.txt"));
             if !options.no_cluster {
                 required.extend([
                     output_dir.join(GRAPH_OVERVIEW_FILE),
-                    output_dir.join(".compass_labels.json"),
+                    output_dir.join("labels.json"),
                     output_dir.join("GRAPH_REPORT.md"),
                 ]);
             }
         }
         BuildPurpose::Extract if !options.no_cluster => {
-            required.push(output_dir.join(".compass_analysis.json"));
+            required.push(output_dir.join("analysis.json"));
         }
         BuildPurpose::Extract => {}
     }
@@ -4265,7 +4259,7 @@ fn publish_build_state(
     state.save(output_dir)
 }
 
-fn commit_generation(
+fn commit_snapshot(
     guard: BuildGuard,
     output_container: &Path,
     graph_storage: GraphStorage,
@@ -4311,7 +4305,9 @@ fn commit_generation(
         guard.commit_with_artifacts(&artifacts)?;
     }
     BuildGuard::publish_root_artifacts(output_container, &ROOT_ARTIFACTS, root_artifacts_changed)?;
-    Ok(BuildGuard::resolve_active_directory(output_container)?)
+    Ok(BuildGuard::resolve_current_snapshot_directory(
+        output_container,
+    )?)
 }
 
 fn garbage_collect_shared_store(
@@ -4339,7 +4335,7 @@ fn garbage_collect_shared_store(
         &staging_reference_path,
         &staging_reference_bytes,
     )?];
-    if let Ok(active_directory) = BuildGuard::resolve_active_directory(output_container) {
+    if let Ok(active_directory) = BuildGuard::resolve_current_snapshot_directory(output_container) {
         let path = active_directory.join(STORE_REF_FILE_NAME);
         if let Ok(bytes) = fs::read(&path) {
             retained_references.push(parse_reference(&path, &bytes)?);
@@ -4355,7 +4351,7 @@ fn garbage_collect_shared_store(
     });
 
     let mut all_references = retained_references.clone();
-    for directory in BuildGuard::complete_generation_directories(output_container)? {
+    for directory in BuildGuard::complete_snapshot_directories(output_container)? {
         let path = directory.join(STORE_REF_FILE_NAME);
         let Ok(bytes) = fs::read(&path) else {
             continue;
@@ -4395,8 +4391,8 @@ fn garbage_collect_shared_store(
     Ok(stats)
 }
 
-/// Ensure every committed generation has a validated, queryable immutable
-/// snapshot in the output root's shared store. The generation publishes only a
+/// Ensure every committed snapshot has a validated, queryable immutable
+/// snapshot in the output root's shared store. The snapshot publishes only a
 /// digest-bound selector beside the permanent `graph.json` artifact.
 fn ensure_store_snapshot(output_dir: &Path) -> Result<StorePublishMetrics, CoreError> {
     let graph_path = output_dir.join("graph.json");
@@ -6570,8 +6566,8 @@ fn update_artifacts_complete(options: &BuildOptions, output_dir: &Path) -> bool 
     let mut required = vec![
         "graph.json",
         "GRAPH_REPORT.md",
-        ".compass_labels.json",
-        ".compass_root",
+        "labels.json",
+        "source-root.txt",
         GRAPH_OVERVIEW_FILE,
     ];
     if options.graph_storage.publishes_store() {
@@ -6670,7 +6666,7 @@ fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<O
         .and_then(|bytes| serde_json::from_slice::<OutputStats>(&bytes).ok());
     if let Some(stats) = saved.filter(|stats| stats.graph_bytes == graph_bytes) {
         if options.no_cluster == stats.clustered
-            || !output_dir.join(".compass_root").is_file()
+            || !output_dir.join("source-root.txt").is_file()
             || (!options.no_cluster
                 && (options.resolution != 1.0
                     || options.exclude_hubs.is_some()
@@ -6686,7 +6682,7 @@ fn unchanged_output_stats(options: &BuildOptions, output_dir: &Path) -> Option<O
     let header = &bytes[..bytes.len().min(512)];
     let has_key = |key: &[u8]| header.windows(key.len()).any(|window| window == key);
     let is_clustered = has_key(b"\"directed\"") && has_key(b"\"multigraph\"");
-    if options.no_cluster == is_clustered || !output_dir.join(".compass_root").is_file() {
+    if options.no_cluster == is_clustered || !output_dir.join("source-root.txt").is_file() {
         return None;
     }
     let document: GraphDocument = serde_json::from_slice(&bytes).ok()?;
@@ -7883,11 +7879,9 @@ mod tests {
         );
         assert_eq!(overview["model"]["schema"], "compass.viewer.graph/1");
         assert!(cold.output_dir.join("manifest.json").is_file());
-        assert!(!cold.output_dir.join(".compass_incomplete").exists());
         let cold_graph = V1GraphDocument::load(&cold.output_dir.join("graph.json"))?;
-        let output_stats: Value = serde_json::from_slice(&fs::read(
-            cold.output_dir.join(".compass_output_stats.json"),
-        )?)?;
+        let output_stats: Value =
+            serde_json::from_slice(&fs::read(cold.output_dir.join("output-stats.json"))?)?;
         assert_eq!(output_stats["nodes"], cold_graph.nodes.len());
         assert_eq!(output_stats["edges"], cold_graph.links.len());
         assert_eq!(
@@ -8406,7 +8400,7 @@ char* Arena::AllocateAligned(size_t bytes) { return Allocate(bytes); }
         assert!(value.get("links").is_some());
         assert!(value.get("edges").is_none());
         assert!(!result.output_dir.join("GRAPH_REPORT.md").exists());
-        assert!(!result.output_dir.join(".compass_analysis.json").exists());
+        assert!(!result.output_dir.join("analysis.json").exists());
 
         let update_dir = tempfile::tempdir()?;
         fs::write(update_dir.path().join("main.py"), "def main():\n    pass\n")?;
@@ -8420,7 +8414,7 @@ char* Arena::AllocateAligned(size_t bytes) { return Allocate(bytes); }
         assert_eq!(value["multigraph"], true);
         assert!(value.get("links").is_some());
         assert!(value.get("edges").is_none());
-        assert!(result.output_dir.join(".compass_root").is_file());
+        assert!(result.output_dir.join("source-root.txt").is_file());
         Ok(())
     }
 
@@ -8593,7 +8587,7 @@ char* Arena::AllocateAligned(size_t bytes) { return Allocate(bytes); }
                 .is_some_and(|hash| !hash.is_empty())
         );
         let analysis: Value =
-            serde_json::from_slice(&fs::read(first.output_dir.join(".compass_analysis.json"))?)?;
+            serde_json::from_slice(&fs::read(first.output_dir.join("analysis.json"))?)?;
         assert_eq!(analysis["tokens"], json!({"input": 13, "output": 7}));
 
         let second_layer = SemanticLayer {

--- a/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
+++ b/crates/compass-core/tests/code_graph_v1_publication_resilience.rs
@@ -39,9 +39,7 @@ fn invalid_topology_is_quarantined_and_the_valid_graph_is_published() -> Result<
     options.no_viz = true;
     options.built_at_commit = Some("0123456789012345678901234567890123456789".to_owned());
     let _first = build_local_graph(&options)?;
-    let pointer = directory
-        .path()
-        .join("compass-out/.compass-active-generation");
+    let pointer = directory.path().join("compass-out/current-snapshot");
     let active_before = fs::read_to_string(&pointer)?;
 
     options.force = true;
@@ -105,9 +103,8 @@ fn invalid_topology_is_quarantined_and_the_valid_graph_is_published() -> Result<
             && diagnostic.message.contains("0 nodes and 1 edges")
     }));
 
-    let stats: serde_json::Value = serde_json::from_slice(&fs::read(
-        result.output_dir.join(".compass_output_stats.json"),
-    )?)?;
+    let stats: serde_json::Value =
+        serde_json::from_slice(&fs::read(result.output_dir.join("output-stats.json"))?)?;
     assert_eq!(stats["omitted_nodes"], 0);
     assert_eq!(stats["omitted_edges"], 1);
     assert_eq!(stats["identity_collisions"], 0);
@@ -415,7 +412,7 @@ fn sealed_legacy_build_state_cannot_skip_current_publication() -> Result<(), Box
     options.built_at_commit = Some("0123456789012345678901234567890123456789".to_owned());
     let first = build_local_graph(&options)?;
     let graph_path = first.output_dir.join("graph.json");
-    let state_path = first.output_dir.join(".compass_build_state.json");
+    let state_path = first.output_dir.join("build-state.json");
 
     let mut graph: serde_json::Value = serde_json::from_slice(&fs::read(&graph_path)?)?;
     let files = graph["graph"]["files"]

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -157,7 +157,7 @@ fn current_snapshot_is_published_without_invoking_the_exact_builder()
         artifacts
             .artifacts
             .authoritative_sidecars
-            .get(".compass_source_inventory.json")
+            .get("source-inventory.json")
             .ok_or("source inventory was not published")?,
     )?;
     assert_eq!(inventory["schema"], "compass.history.source_inventory/1");

--- a/crates/compass-core/tests/loading_coverage.rs
+++ b/crates/compass-core/tests/loading_coverage.rs
@@ -141,11 +141,11 @@ fn export_inputs_fall_back_to_node_communities_and_tolerate_partial_sidecars()
         r#"{"directed":false,"multigraph":false,"graph":{},"nodes":[{"id":"a","label":"A","community":0},{"id":"b","label":"B","community":"1"},{"id":"c","label":"C","community":"bad"}],"links":[]}"#,
     )?;
     fs::write(
-        output.join(".compass_analysis.json"),
+        output.join("analysis.json"),
         r#"{"communities":{"bad":"not-an-array"},"cohesion":{"0":0.75,"bad":1,"1":"wrong"},"gods":"wrong"}"#,
     )?;
     fs::write(
-        output.join(".compass_labels.json"),
+        output.join("labels.json"),
         r#"{"0":"Core","1":7,"bad":"ignored"}"#,
     )?;
     fs::write(output.join("GRAPH_REPORT.md"), "# Fixture\n")?;
@@ -176,11 +176,11 @@ fn loaded_graph_learning_overlay_marks_current_missing_and_unfingerprinted_sourc
         r#"{"directed":false,"multigraph":false,"graph":{},"nodes":[{"id":"a","label":"A"}],"links":[]}"#,
     )?;
     fs::write(
-        output.join(".compass_root"),
+        output.join("source-root.txt"),
         directory.path().to_string_lossy().as_bytes(),
     )?;
     fs::write(
-        output.join(".compass_learning.json"),
+        output.join("learning.json"),
         serde_json::to_vec(&serde_json::json!({
             "nodes": {
                 "current": {"source_file":"source.rs","code_fingerprint":fingerprint},
@@ -204,9 +204,9 @@ fn loaded_graph_learning_overlay_marks_current_missing_and_unfingerprinted_sourc
 
     let directed = LoadedGraph::load_directed(&graph)?;
     assert_eq!(directed.graph.node_count(), 1);
-    fs::write(output.join(".compass_learning.json"), "not json")?;
+    fs::write(output.join("learning.json"), "not json")?;
     assert!(LoadedGraph::load(&graph)?.overlay.is_empty());
-    fs::remove_file(output.join(".compass_learning.json"))?;
+    fs::remove_file(output.join("learning.json"))?;
     assert!(LoadedGraph::load(&graph)?.overlay.is_empty());
     Ok(())
 }
@@ -404,7 +404,7 @@ fn incremental_mixed_origin_nodes_use_fresh_ast_typed_data() -> Result<(), Box<d
         initial.output_dir.join("graph.json"),
         serde_json::to_vec_pretty(&initial_graph)?,
     )?;
-    fs::write(initial.output_dir.join(".compass_semantic_marker"), b"{}")?;
+    fs::write(initial.output_dir.join("semantic-marker.json"), b"{}")?;
 
     fs::write(
         &source,
@@ -498,7 +498,7 @@ fn incremental_mixed_origin_edges_use_fresh_ast_relationship_sites() -> Result<(
         initial.output_dir.join("graph.json"),
         serde_json::to_vec_pretty(&initial_graph)?,
     )?;
-    fs::write(initial.output_dir.join(".compass_semantic_marker"), b"{}")?;
+    fs::write(initial.output_dir.join("semantic-marker.json"), b"{}")?;
 
     fs::write(
         &source,

--- a/crates/compass-core/tests/program_pipeline.rs
+++ b/crates/compass-core/tests/program_pipeline.rs
@@ -239,7 +239,6 @@ fn program_pipeline_is_deterministic_incremental_and_uses_program_json()
     let cold = build_local_graph(&options)?;
     let cold_output = cold.output_dir.join("program.json");
     assert!(cold_output.is_file());
-    assert!(!cold.output_dir.join(".compass_program.json").exists());
     assert_eq!(cold.program_modules, 1);
     assert!(cold.program_summaries >= 2);
     assert_eq!(cold.program_syntax_analyzed, 1);
@@ -323,7 +322,7 @@ fn program_pipeline_is_opt_in_at_the_core_api() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn disabling_program_analysis_removes_the_previous_generation_program() -> Result<(), Box<dyn Error>>
+fn disabling_program_analysis_removes_the_previous_snapshot_program() -> Result<(), Box<dyn Error>>
 {
     let directory = tempfile::tempdir()?;
     fs::write(directory.path().join("lib.rs"), "pub fn visible() {}\n")?;
@@ -356,9 +355,7 @@ fn invalid_explicit_artifact_does_not_replace_existing_program() -> Result<(), B
     let first = build_local_graph(&options)?;
     let program_path = first.output_dir.join("program.json");
     let before = fs::read(&program_path)?;
-    let pointer = directory
-        .path()
-        .join("compass-out/.compass-active-generation");
+    let pointer = directory.path().join("compass-out/current-snapshot");
     let active_before = fs::read_to_string(&pointer)?;
 
     options
@@ -628,16 +625,14 @@ fn malformed_discovered_scip_and_obstructed_output_fail_closed() -> Result<(), B
     let first = build_local_graph(&options)?;
     let program_path = first.output_dir.join("program.json");
     let before = fs::read(&program_path)?;
-    let pointer = directory
-        .path()
-        .join("compass-out/.compass-active-generation");
+    let pointer = directory.path().join("compass-out/current-snapshot");
     let active_before = fs::read_to_string(&pointer)?;
 
     fs::write(directory.path().join("index.scip"), [0x12, 0x05, 0x01])?;
     assert!(build_local_graph(&options).is_err());
     assert_eq!(fs::read(&program_path)?, before);
     assert_eq!(fs::read_to_string(&pointer)?, active_before);
-    assert!(!first.output_dir.join(".compass-build-incomplete").exists());
+    assert!(!first.output_dir.join("build-incomplete").exists());
 
     fs::remove_file(directory.path().join("index.scip"))?;
     fs::remove_file(&program_path)?;
@@ -645,6 +640,6 @@ fn malformed_discovered_scip_and_obstructed_output_fail_closed() -> Result<(), B
     assert!(build_local_graph(&options).is_err());
     assert!(program_path.is_dir());
     assert_eq!(fs::read_to_string(pointer)?, active_before);
-    assert!(!first.output_dir.join(".compass-build-incomplete").exists());
+    assert!(!first.output_dir.join("build-incomplete").exists());
     Ok(())
 }

--- a/crates/compass-files/src/build_guard.rs
+++ b/crates/compass-files/src/build_guard.rs
@@ -7,19 +7,19 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::atomic::sync_directory;
 use crate::{FileError, io_error, write_atomic_with, write_text_atomic};
 
-const GENERATIONS_DIRECTORY: &str = ".compass-generations";
-const ACTIVE_GENERATION: &str = ".compass-active-generation";
-const INCOMPLETE_MARKER: &str = ".compass-build-incomplete";
-const ROOT_ARTIFACTS_COMPLETE: &str = ".compass-root-artifacts-complete";
-const RETAINED_COMPLETE_GENERATIONS: usize = 2;
-const MAX_GENERATION_DIRECTORY_ENTRIES: usize = 1_024;
-static GENERATION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const SNAPSHOTS_DIRECTORY: &str = "snapshots";
+const CURRENT_SNAPSHOT: &str = "current-snapshot";
+const INCOMPLETE_MARKER: &str = "build-incomplete";
+const ROOT_ARTIFACTS_COMPLETE: &str = "root-artifacts-complete";
+const RETAINED_COMPLETE_SNAPSHOTS: usize = 2;
+const MAX_SNAPSHOT_DIRECTORY_ENTRIES: usize = 1_024;
+static SNAPSHOT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
-/// Owns an unpublished output generation until every authoritative artifact is sealed.
+/// Owns an unpublished output snapshot until every authoritative artifact is sealed.
 #[derive(Debug)]
 pub struct BuildGuard {
     output_directory: PathBuf,
-    generation_directory: PathBuf,
+    snapshot_directory: PathBuf,
     marker: PathBuf,
     committed: bool,
 }
@@ -29,40 +29,40 @@ impl BuildGuard {
         Self::begin_excluding(output_directory, &[])
     }
 
-    /// Return complete published generations in deterministic newest-first
+    /// Return complete published snapshots in deterministic newest-first
     /// order. In-progress directories are deliberately excluded so callers
     /// can make retention decisions without treating partial artifacts as
     /// roots.
-    pub fn complete_generation_directories(
+    pub fn complete_snapshot_directories(
         output_directory: &Path,
     ) -> Result<Vec<PathBuf>, FileError> {
-        let generations = output_directory.join(GENERATIONS_DIRECTORY);
-        if !generations.is_dir() {
+        let snapshots = output_directory.join(SNAPSHOTS_DIRECTORY);
+        if !snapshots.is_dir() {
             return Ok(Vec::new());
         }
-        let mut complete = fs::read_dir(&generations)
-            .map_err(|source| io_error(&generations, source))?
+        let mut complete = fs::read_dir(&snapshots)
+            .map_err(|source| io_error(&snapshots, source))?
             .filter_map(Result::ok)
             .filter(|entry| {
                 entry.file_type().is_ok_and(|kind| kind.is_dir())
                     && !entry.path().join(INCOMPLETE_MARKER).exists()
             })
             .map(|entry| entry.path())
-            .take(MAX_GENERATION_DIRECTORY_ENTRIES.saturating_add(1))
+            .take(MAX_SNAPSHOT_DIRECTORY_ENTRIES.saturating_add(1))
             .collect::<Vec<_>>();
-        if complete.len() > MAX_GENERATION_DIRECTORY_ENTRIES {
-            return Err(FileError::InvalidGenerationArtifact(generations));
+        if complete.len() > MAX_SNAPSHOT_DIRECTORY_ENTRIES {
+            return Err(FileError::InvalidSnapshotArtifact(snapshots));
         }
         complete.sort();
         complete.reverse();
         Ok(complete)
     }
 
-    /// Start a generation without copying selected top-level artifacts from
-    /// the active generation.
+    /// Start a snapshot without copying selected top-level artifacts from
+    /// the current snapshot.
     ///
-    /// Large shared sidecars can live outside immutable generations and be
-    /// addressed by a small generation-local reference. Exclusions are exact
+    /// Large shared sidecars can live outside immutable snapshots and be
+    /// addressed by a small snapshot-local reference. Exclusions are exact
     /// file names rather than patterns so callers cannot accidentally omit an
     /// unrelated artifact family.
     pub fn begin_excluding(
@@ -72,19 +72,27 @@ impl BuildGuard {
         validate_exclusions(excluded_artifacts)?;
         fs::create_dir_all(output_directory)
             .map_err(|source| io_error(output_directory, source))?;
-        let generations = output_directory.join(GENERATIONS_DIRECTORY);
-        fs::create_dir_all(&generations).map_err(|source| io_error(&generations, source))?;
-        let generation_directory = generations.join(generation_name());
-        fs::create_dir(&generation_directory)
-            .map_err(|source| io_error(&generation_directory, source))?;
+        let active = match output_directory.join(CURRENT_SNAPSHOT).try_exists() {
+            Ok(true) => Some(Self::resolve_current_snapshot_directory(output_directory)?),
+            Ok(false) => None,
+            Err(source) => {
+                return Err(io_error(output_directory.join(CURRENT_SNAPSHOT), source));
+            }
+        };
+        let snapshots = output_directory.join(SNAPSHOTS_DIRECTORY);
+        fs::create_dir_all(&snapshots).map_err(|source| io_error(&snapshots, source))?;
+        let snapshot_directory = snapshots.join(snapshot_name());
+        fs::create_dir(&snapshot_directory)
+            .map_err(|source| io_error(&snapshot_directory, source))?;
 
-        let active = Self::resolve_active_directory(output_directory)?;
-        copy_generation(&active, &generation_directory, excluded_artifacts, true)?;
-        let marker = generation_directory.join(INCOMPLETE_MARKER);
+        if let Some(active) = active {
+            copy_snapshot(&active, &snapshot_directory, excluded_artifacts, true)?;
+        }
+        let marker = snapshot_directory.join(INCOMPLETE_MARKER);
         write_text_atomic(&marker, "1")?;
         Ok(Self {
             output_directory: output_directory.to_path_buf(),
-            generation_directory,
+            snapshot_directory,
             marker,
             committed: false,
         })
@@ -92,31 +100,33 @@ impl BuildGuard {
 
     #[must_use]
     pub fn staging_directory(&self) -> &Path {
-        &self.generation_directory
+        &self.snapshot_directory
     }
 
-    /// Return the stable active-generation path, with a legacy-root fallback.
-    pub fn resolve_active_directory(output_directory: &Path) -> Result<PathBuf, FileError> {
-        let pointer = output_directory.join(ACTIVE_GENERATION);
+    /// Return the snapshot selected by the current output layout.
+    pub fn resolve_current_snapshot_directory(
+        output_directory: &Path,
+    ) -> Result<PathBuf, FileError> {
+        let pointer = output_directory.join(CURRENT_SNAPSHOT);
         match fs::read_to_string(&pointer) {
             Ok(value) => {
-                let generation = value.trim();
-                let relative = Path::new(generation);
-                if generation.is_empty()
+                let snapshot = value.trim();
+                let relative = Path::new(snapshot);
+                if snapshot.is_empty()
                     || relative.components().count() != 1
                     || !matches!(relative.components().next(), Some(Component::Normal(_)))
-                    || !generation.starts_with("generation-")
+                    || !snapshot.starts_with("snapshot-")
                 {
-                    return Err(FileError::InvalidGenerationArtifact(pointer));
+                    return Err(FileError::InvalidSnapshotArtifact(pointer));
                 }
-                let active = output_directory.join(GENERATIONS_DIRECTORY).join(relative);
+                let active = output_directory.join(SNAPSHOTS_DIRECTORY).join(relative);
                 if !active.is_dir() || active.join(INCOMPLETE_MARKER).exists() {
                     return Err(FileError::IncompleteBuild(active));
                 }
                 Ok(active)
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                Ok(output_directory.to_path_buf())
+                Err(FileError::InvalidSnapshotArtifact(pointer))
             }
             Err(source) => Err(io_error(pointer, source)),
         }
@@ -136,30 +146,31 @@ impl BuildGuard {
                 )
             })
         {
-            return Err(FileError::InvalidGenerationArtifact(relative.to_path_buf()));
+            return Err(FileError::InvalidSnapshotArtifact(relative.to_path_buf()));
         }
-        Ok(Self::resolve_active_directory(output_directory)?.join(relative))
+        Ok(Self::resolve_current_snapshot_directory(output_directory)?.join(relative))
     }
 
-    /// Resolve a public artifact path while honoring a published generation before
-    /// any stale legacy-root file. Legacy files remain readable only when no active
-    /// generation pointer exists.
+    /// Resolve a managed output artifact through its current snapshot.
+    /// Standalone artifact files outside managed snapshots remain valid inputs.
     pub fn resolve_requested_artifact(path: &Path) -> Result<PathBuf, FileError> {
         let Some(name) = path.file_name() else {
-            return Err(FileError::InvalidGenerationArtifact(path.to_path_buf()));
+            return Err(FileError::InvalidSnapshotArtifact(path.to_path_buf()));
         };
         let output_directory = path.parent().unwrap_or_else(|| Path::new("."));
-        let pointer = output_directory.join(ACTIVE_GENERATION);
+        let pointer = output_directory.join(CURRENT_SNAPSHOT);
         match pointer.try_exists() {
             Ok(true) => Self::resolve_artifact(output_directory, Path::new(name)),
-            Ok(false) if path.is_file() => Ok(path.to_path_buf()),
-            Ok(false) => Self::resolve_artifact(output_directory, Path::new(name)),
+            Ok(false) if output_directory.join(SNAPSHOTS_DIRECTORY).is_dir() => {
+                Err(FileError::InvalidSnapshotArtifact(pointer))
+            }
+            Ok(false) => Ok(path.to_path_buf()),
             Err(source) => Err(io_error(pointer, source)),
         }
     }
 
     pub fn ensure_complete(output_directory: &Path) -> Result<(), FileError> {
-        let active = Self::resolve_active_directory(output_directory)?;
+        let active = Self::resolve_current_snapshot_directory(output_directory)?;
         let marker = active.join(INCOMPLETE_MARKER);
         if marker.exists() {
             Err(FileError::IncompleteBuild(marker))
@@ -170,26 +181,25 @@ impl BuildGuard {
 
     /// Return the stable output container that owns a generated artifact.
     ///
-    /// Paths inside the active immutable generation map back to their public
-    /// output root. Standalone and legacy-root artifacts keep their immediate
-    /// parent directory.
+    /// Paths inside the current immutable snapshot map back to their public
+    /// output root. Standalone artifacts keep their immediate parent directory.
     #[must_use]
     pub fn output_container_for_artifact(path: &Path) -> PathBuf {
         let artifact_directory = path.parent().unwrap_or_else(|| Path::new("."));
-        let Some(generations_directory) = artifact_directory.parent() else {
+        let Some(snapshots_directory) = artifact_directory.parent() else {
             return artifact_directory.to_path_buf();
         };
-        if generations_directory
+        if snapshots_directory
             .file_name()
             .and_then(|name| name.to_str())
-            != Some(GENERATIONS_DIRECTORY)
+            != Some(SNAPSHOTS_DIRECTORY)
         {
             return artifact_directory.to_path_buf();
         }
-        let Some(output_directory) = generations_directory.parent() else {
+        let Some(output_directory) = snapshots_directory.parent() else {
             return artifact_directory.to_path_buf();
         };
-        if Self::resolve_active_directory(output_directory)
+        if Self::resolve_current_snapshot_directory(output_directory)
             .is_ok_and(|active| active == artifact_directory)
         {
             output_directory.to_path_buf()
@@ -198,9 +208,9 @@ impl BuildGuard {
         }
     }
 
-    /// Materialize selected generation files directly under the output root.
+    /// Materialize selected snapshot files directly under the output root.
     ///
-    /// The immutable generation remains authoritative for Compass-aware
+    /// The immutable snapshot remains authoritative for Compass-aware
     /// readers. These independently atomic copies provide stable conventional
     /// paths for browsers, scripts, archives, and other file-based consumers.
     /// Missing optional artifacts remove an older root copy. A failed or
@@ -212,10 +222,7 @@ impl BuildGuard {
         refresh: bool,
     ) -> Result<(), FileError> {
         validate_exclusions(artifacts)?;
-        let active = Self::resolve_active_directory(output_directory)?;
-        if active == output_directory {
-            return Ok(());
-        }
+        let active = Self::resolve_current_snapshot_directory(output_directory)?;
 
         let completion_marker = output_directory.join(ROOT_ARTIFACTS_COMPLETE);
         let repair_all = refresh || !completion_marker.is_file();
@@ -233,11 +240,11 @@ impl BuildGuard {
             }
         }
 
-        let generation = active
+        let snapshot = active
             .file_name()
-            .ok_or_else(|| FileError::InvalidGenerationArtifact(active.clone()))?
+            .ok_or_else(|| FileError::InvalidSnapshotArtifact(active.clone()))?
             .to_string_lossy();
-        write_text_atomic(completion_marker, &generation)
+        write_text_atomic(completion_marker, &snapshot)
     }
 
     pub fn commit(self) -> Result<(), FileError> {
@@ -248,8 +255,8 @@ impl BuildGuard {
         self.commit_with_artifacts_inner(artifacts, true)
     }
 
-    /// Publish a generation whose listed artifacts were already written by an
-    /// atomic writer in this generation. The files are still checked before
+    /// Publish a snapshot whose listed artifacts were already written by an
+    /// atomic writer in this snapshot. The files are still checked before
     /// publication, but are not flushed a second time during the commit.
     pub fn commit_with_presealed_artifacts(self, artifacts: &[&str]) -> Result<(), FileError> {
         self.commit_with_artifacts_inner(artifacts, false)
@@ -261,9 +268,9 @@ impl BuildGuard {
         sync_artifacts: bool,
     ) -> Result<(), FileError> {
         for artifact in artifacts {
-            let path = self.generation_directory.join(artifact);
+            let path = self.snapshot_directory.join(artifact);
             if !path.is_file() {
-                return Err(FileError::InvalidGenerationArtifact(path));
+                return Err(FileError::InvalidSnapshotArtifact(path));
             }
             if sync_artifacts {
                 OpenOptions::new()
@@ -279,20 +286,20 @@ impl BuildGuard {
         // incomplete-marker removal with those durable files, so a second
         // pre-commit directory flush is unnecessary on that path.
         if sync_artifacts {
-            sync_directory(&self.generation_directory)?;
+            sync_directory(&self.snapshot_directory)?;
         }
         fs::remove_file(&self.marker).map_err(|source| io_error(&self.marker, source))?;
-        sync_directory(&self.generation_directory)?;
-        let pointer = self.output_directory.join(ACTIVE_GENERATION);
-        let generation = self
-            .generation_directory
+        sync_directory(&self.snapshot_directory)?;
+        let pointer = self.output_directory.join(CURRENT_SNAPSHOT);
+        let snapshot = self
+            .snapshot_directory
             .file_name()
-            .ok_or_else(|| FileError::InvalidGenerationArtifact(self.generation_directory.clone()))?
+            .ok_or_else(|| FileError::InvalidSnapshotArtifact(self.snapshot_directory.clone()))?
             .to_string_lossy();
-        write_text_atomic(&pointer, &generation)?;
-        prune_complete_generations(
-            &self.output_directory.join(GENERATIONS_DIRECTORY),
-            generation.as_ref(),
+        write_text_atomic(&pointer, &snapshot)?;
+        prune_complete_snapshots(
+            &self.output_directory.join(SNAPSHOTS_DIRECTORY),
+            snapshot.as_ref(),
         )?;
         self.committed = true;
         Ok(())
@@ -317,52 +324,50 @@ fn remove_file_if_exists(path: &Path) -> Result<(), FileError> {
     }
 }
 
-fn prune_complete_generations(generations: &Path, active: &str) -> Result<(), FileError> {
-    let mut complete = fs::read_dir(generations)
-        .map_err(|source| io_error(generations, source))?
+fn prune_complete_snapshots(snapshots: &Path, current: &str) -> Result<(), FileError> {
+    let mut complete = fs::read_dir(snapshots)
+        .map_err(|source| io_error(snapshots, source))?
         .filter_map(Result::ok)
         .filter(|entry| {
             entry.file_type().is_ok_and(|kind| kind.is_dir())
                 && !entry.path().join(INCOMPLETE_MARKER).exists()
         })
-        .take(MAX_GENERATION_DIRECTORY_ENTRIES.saturating_add(1))
+        .take(MAX_SNAPSHOT_DIRECTORY_ENTRIES.saturating_add(1))
         .collect::<Vec<_>>();
-    if complete.len() > MAX_GENERATION_DIRECTORY_ENTRIES {
-        return Err(FileError::InvalidGenerationArtifact(
-            generations.to_path_buf(),
-        ));
+    if complete.len() > MAX_SNAPSHOT_DIRECTORY_ENTRIES {
+        return Err(FileError::InvalidSnapshotArtifact(snapshots.to_path_buf()));
     }
     complete.sort_by_key(|entry| entry.file_name());
     complete.reverse();
     let retained = complete
         .iter()
-        .take(RETAINED_COMPLETE_GENERATIONS)
+        .take(RETAINED_COMPLETE_SNAPSHOTS)
         .map(|entry| entry.file_name())
-        .chain(std::iter::once(std::ffi::OsString::from(active)))
+        .chain(std::iter::once(std::ffi::OsString::from(current)))
         .collect::<std::collections::BTreeSet<_>>();
     for entry in complete {
         if !retained.contains(&entry.file_name()) {
             fs::remove_dir_all(entry.path()).map_err(|source| io_error(entry.path(), source))?;
         }
     }
-    sync_directory(generations)
+    sync_directory(snapshots)
 }
 
 impl Drop for BuildGuard {
     fn drop(&mut self) {
         if !self.committed {
-            let _ = fs::remove_dir_all(&self.generation_directory);
+            let _ = fs::remove_dir_all(&self.snapshot_directory);
         }
     }
 }
 
-fn generation_name() -> String {
+fn snapshot_name() -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let sequence = GENERATION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    format!("generation-{nanos}-{}-{sequence}", std::process::id())
+    let sequence = SNAPSHOT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("snapshot-{nanos}-{}-{sequence}", std::process::id())
 }
 
 fn validate_exclusions(excluded_artifacts: &[&str]) -> Result<(), FileError> {
@@ -372,13 +377,13 @@ fn validate_exclusions(excluded_artifacts: &[&str]) -> Result<(), FileError> {
             || path.components().count() != 1
             || !matches!(path.components().next(), Some(Component::Normal(_)))
         {
-            return Err(FileError::InvalidGenerationArtifact(path.to_path_buf()));
+            return Err(FileError::InvalidSnapshotArtifact(path.to_path_buf()));
         }
     }
     Ok(())
 }
 
-fn copy_generation(
+fn copy_snapshot(
     source: &Path,
     destination: &Path,
     excluded_artifacts: &[&str],
@@ -388,11 +393,11 @@ fn copy_generation(
         let entry = entry.map_err(|error| io_error(source, error))?;
         let name = entry.file_name();
         if name == INCOMPLETE_MARKER
-            || name == GENERATIONS_DIRECTORY
-            || name == ACTIVE_GENERATION
+            || name == SNAPSHOTS_DIRECTORY
+            || name == CURRENT_SNAPSHOT
             || name
                 .to_string_lossy()
-                .starts_with(&format!("{ACTIVE_GENERATION}.tmp-"))
+                .starts_with(&format!("{CURRENT_SNAPSHOT}.tmp-"))
         {
             continue;
         }
@@ -408,7 +413,7 @@ fn copy_generation(
         let file_type = entry.file_type().map_err(|error| io_error(&from, error))?;
         if file_type.is_dir() {
             fs::create_dir(&to).map_err(|error| io_error(&to, error))?;
-            copy_generation(&from, &to, excluded_artifacts, false)?;
+            copy_snapshot(&from, &to, excluded_artifacts, false)?;
         } else if file_type.is_file() {
             fs::copy(&from, &to).map_err(|error| io_error(&to, error))?;
         }

--- a/crates/compass-files/src/lib.rs
+++ b/crates/compass-files/src/lib.rs
@@ -73,8 +73,8 @@ pub enum FileError {
     TooLarge { path: PathBuf, limit: u64 },
     #[error("an interrupted graph build is recorded at {0}")]
     IncompleteBuild(PathBuf),
-    #[error("generation artifact is missing or unsafe: {0}")]
-    InvalidGenerationArtifact(PathBuf),
+    #[error("snapshot artifact is missing or unsafe: {0}")]
+    InvalidSnapshotArtifact(PathBuf),
     #[error("invalid cache kind for operation: {0}")]
     InvalidCacheKind(String),
     #[error("invalid Compass project config at {path}: {source}")]

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -143,7 +143,7 @@ fn detection_ignores_compass_generated_output() -> Result<(), Box<dyn Error>> {
     fs::write(root.join("main.rs"), "fn main() {}\n")?;
     fs::create_dir(root.join("compass-out"))?;
     fs::write(root.join("compass-out/graph.json"), "{}\n")?;
-    fs::write(root.join("compass-out/.compass_labels.json"), "{}\n")?;
+    fs::write(root.join("compass-out/labels.json"), "{}\n")?;
     fs::create_dir(root.join("graphify-out"))?;
     fs::write(
         root.join("graphify-out/generated.rs"),
@@ -664,7 +664,7 @@ fn lossy_source_limit_slicing_and_build_guard() -> Result<(), Box<dyn Error>> {
     assert!(slices.len() >= 2);
 
     let guard = BuildGuard::begin(directory.path())?;
-    BuildGuard::ensure_complete(directory.path())?;
+    assert!(BuildGuard::ensure_complete(directory.path()).is_err());
     guard.commit()?;
     BuildGuard::ensure_complete(directory.path())?;
     let not_a_directory = directory.path().join("not-a-directory");
@@ -672,9 +672,7 @@ fn lossy_source_limit_slicing_and_build_guard() -> Result<(), Box<dyn Error>> {
     assert!(BuildGuard::begin(&not_a_directory.join("output")).is_err());
 
     let broken_guard = BuildGuard::begin(directory.path())?;
-    let marker = broken_guard
-        .staging_directory()
-        .join(".compass-build-incomplete");
+    let marker = broken_guard.staging_directory().join("build-incomplete");
     fs::remove_file(&marker)?;
     fs::create_dir(&marker)?;
     assert!(broken_guard.commit().is_err());
@@ -682,7 +680,7 @@ fn lossy_source_limit_slicing_and_build_guard() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn build_guard_publishes_one_complete_generation_at_a_time() -> Result<(), Box<dyn Error>> {
+fn build_guard_publishes_one_complete_snapshot_at_a_time() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let first = BuildGuard::begin(directory.path())?;
     fs::write(first.staging_directory().join("graph.json"), "graph-one")?;
@@ -825,7 +823,7 @@ fn build_guard_maps_active_artifacts_to_the_output_container() -> Result<(), Box
 }
 
 #[test]
-fn build_guard_can_exclude_a_large_generation_sidecar() -> Result<(), Box<dyn Error>> {
+fn build_guard_can_exclude_a_large_snapshot_sidecar() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let first = BuildGuard::begin(directory.path())?;
     fs::write(first.staging_directory().join("graph.json"), "graph-one")?;
@@ -843,7 +841,19 @@ fn build_guard_can_exclude_a_large_generation_sidecar() -> Result<(), Box<dyn Er
 }
 
 #[test]
-fn build_guard_retains_only_two_complete_generations() -> Result<(), Box<dyn Error>> {
+fn build_guard_never_imports_an_unmanaged_root_snapshot() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root_graph = directory.path().join("graph.json");
+    fs::write(&root_graph, "unmanaged")?;
+
+    let guard = BuildGuard::begin(directory.path())?;
+    assert!(!guard.staging_directory().join("graph.json").exists());
+    assert!(BuildGuard::resolve_requested_artifact(&root_graph).is_err());
+    Ok(())
+}
+
+#[test]
+fn build_guard_retains_only_two_complete_snapshots() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     for version in 0..4 {
         let guard = BuildGuard::begin(directory.path())?;
@@ -853,11 +863,11 @@ fn build_guard_retains_only_two_complete_generations() -> Result<(), Box<dyn Err
         )?;
         guard.commit_with_artifacts(&["graph.json"])?;
     }
-    let generations = fs::read_dir(directory.path().join(".compass-generations"))?
+    let snapshots = fs::read_dir(directory.path().join("snapshots"))?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().is_dir())
         .collect::<Vec<_>>();
-    assert_eq!(generations.len(), 2);
+    assert_eq!(snapshots.len(), 2);
     assert_eq!(
         fs::read_to_string(BuildGuard::resolve_artifact(
             directory.path(),
@@ -1224,7 +1234,7 @@ fn slicing_hashing_atomic_writes_and_stat_index_cover_hostile_boundaries()
     assert!(write_text_atomic(directory.path().join("not-a-directory/child"), "x").is_err());
 
     let guard = BuildGuard::begin(directory.path())?;
-    fs::remove_file(guard.staging_directory().join(".compass-build-incomplete"))?;
+    fs::remove_file(guard.staging_directory().join("build-incomplete"))?;
     assert!(guard.commit().is_err());
     Ok(())
 }

--- a/crates/compass-graph/src/snapshot.rs
+++ b/crates/compass-graph/src/snapshot.rs
@@ -1449,7 +1449,7 @@ pub fn garbage_collect_graph_snapshots<S: Store + ?Sized>(
     })
 }
 
-/// Check whether immutable graph manifests exceed the retained-generation
+/// Check whether immutable graph manifests exceed the retained-snapshot
 /// budget using a key-only bounded projection.
 pub fn graph_snapshot_needs_gc<S: Store + ?Sized>(
     store: &S,

--- a/crates/compass-history/src/artifacts.rs
+++ b/crates/compass-history/src/artifacts.rs
@@ -49,9 +49,9 @@ const EDGE_COMPATIBILITY_FIELDS: [&str; 6] = [
     "confidence_score",
     "_origin",
 ];
-const TRUSTED_GRAPH_CONTENT: &str = ".compass-history/graph.v1.json";
-const PROGRAM_SOURCE_DIGEST_CONTENT: &str = ".compass-history/program.source-digest";
-const SOURCE_INVENTORY_CONTENT: &str = ".compass_source_inventory.json";
+const TRUSTED_GRAPH_CONTENT: &str = "history/graph.v1.json";
+const PROGRAM_SOURCE_DIGEST_CONTENT: &str = "history/program.source-digest";
+const SOURCE_INVENTORY_CONTENT: &str = "source-inventory.json";
 
 /// All authoritative inputs needed to reconstruct a complete Compass output.
 #[derive(Clone, Debug, PartialEq)]
@@ -324,8 +324,8 @@ impl GraphArtifacts {
         let artifacts = Self {
             document,
             program: program.bundle,
-            analysis: read_optional_json(&output_dir.join(".compass_analysis.json"))?,
-            labels: read_optional_json(&output_dir.join(".compass_labels.json"))?,
+            analysis: read_optional_json(&output_dir.join("analysis.json"))?,
+            labels: read_optional_json(&output_dir.join("labels.json"))?,
             manifest: read_optional_json(&output_dir.join("manifest.json"))?,
             authoritative_sidecars,
         };
@@ -699,12 +699,8 @@ impl GraphArtifacts {
             ));
         }
 
-        add_optional_analysis(
-            &mut partitioned,
-            ".compass_analysis.json",
-            self.analysis.take(),
-        )?;
-        add_optional_analysis(&mut partitioned, ".compass_labels.json", self.labels.take())?;
+        add_optional_analysis(&mut partitioned, "analysis.json", self.analysis.take())?;
+        add_optional_analysis(&mut partitioned, "labels.json", self.labels.take())?;
         if let Some(manifest) = self.manifest.take() {
             let manifest = canonical_manifest_owned(manifest);
             partitioned.metadata.push((
@@ -780,8 +776,8 @@ impl GraphArtifacts {
                 [_, _, kind, path] if kind == b"sidecar" => {
                     let value = decode_record(bytes, "compass.analysis.sidecar")?;
                     match path.as_slice() {
-                        b".compass_analysis.json" => analysis = Some(value),
-                        b".compass_labels.json" => labels = Some(value),
+                        b"analysis.json" => analysis = Some(value),
+                        b"labels.json" => labels = Some(value),
                         _ => {
                             return Err(HistoryError::InvalidArtifacts(
                                 "unknown analysis sidecar".to_owned(),
@@ -1039,10 +1035,10 @@ impl GraphArtifacts {
             write_bytes_atomic(output_dir.join("program.json"), &program.canonical_bytes()?)?;
         }
         if let Some(value) = &self.analysis {
-            write_json_atomic(output_dir.join(".compass_analysis.json"), value, false)?;
+            write_json_atomic(output_dir.join("analysis.json"), value, false)?;
         }
         if let Some(value) = &self.labels {
-            write_json_atomic(output_dir.join(".compass_labels.json"), value, false)?;
+            write_json_atomic(output_dir.join("labels.json"), value, false)?;
         }
         if let Some(value) = &self.manifest {
             write_json_atomic(output_dir.join("manifest.json"), value, false)?;
@@ -1059,7 +1055,7 @@ impl GraphArtifacts {
             write_bytes_atomic(destination, bytes)?;
         }
         write_json_atomic(
-            output_dir.join(".compass_semantic_marker"),
+            output_dir.join("semantic-marker.json"),
             &SemanticCompletionMarker::from(completion),
             false,
         )?;
@@ -1297,8 +1293,8 @@ fn artifact_registry_with_graph_bytes(
         ));
     }
     for (path, value) in [
-        (".compass_analysis.json", artifacts.analysis.as_ref()),
-        (".compass_labels.json", artifacts.labels.as_ref()),
+        ("analysis.json", artifacts.analysis.as_ref()),
+        ("labels.json", artifacts.labels.as_ref()),
         ("manifest.json", artifacts.manifest.as_ref()),
     ] {
         if let Some(value) = value {
@@ -1330,7 +1326,7 @@ fn artifact_registry_with_graph_bytes(
         "GRAPH_REPORT.md",
         "graph.html",
         "GRAPH_TREE.html",
-        ".compass_labels.json.sig",
+        "labels.json.sig",
     ] {
         registry.push(ArtifactRegistryEntry {
             registry_version: 1,
@@ -1352,7 +1348,7 @@ fn artifact_registry_with_graph_bytes(
     }
     registry.push(ArtifactRegistryEntry {
         registry_version: 1,
-        relative_path: ".compass_semantic_marker".to_owned(),
+        relative_path: "semantic-marker.json".to_owned(),
         class: ArtifactClass::Operational,
         media_type: "application/json".to_owned(),
         schema_version: None,
@@ -1401,11 +1397,7 @@ fn completion_from_partition(
 fn is_builtin_artifact(path: &str) -> bool {
     matches!(
         path,
-        "graph.json"
-            | "program.json"
-            | ".compass_analysis.json"
-            | ".compass_labels.json"
-            | "manifest.json"
+        "graph.json" | "program.json" | "analysis.json" | "labels.json" | "manifest.json"
     )
 }
 
@@ -1508,12 +1500,12 @@ fn verify_builtin_registry_content(
     {
         let bytes = match entry.relative_path.as_str() {
             "graph.json" => Some(authoritative_graph_bytes(artifacts)?),
-            ".compass_analysis.json" => artifacts
+            "analysis.json" => artifacts
                 .analysis
                 .as_ref()
                 .map(canonical_json_bytes)
                 .transpose()?,
-            ".compass_labels.json" => artifacts
+            "labels.json" => artifacts
                 .labels
                 .as_ref()
                 .map(canonical_json_bytes)
@@ -2189,8 +2181,8 @@ mod tests {
         }
         assert!(validate_relative_path("nested/facts.json").is_ok());
         assert!(is_builtin_artifact("graph.json"));
-        assert!(is_builtin_artifact(".compass_analysis.json"));
-        assert!(is_builtin_artifact(".compass_labels.json"));
+        assert!(is_builtin_artifact("analysis.json"));
+        assert!(is_builtin_artifact("labels.json"));
         assert!(is_builtin_artifact("manifest.json"));
         assert!(!is_builtin_artifact("custom.json"));
 

--- a/crates/compass-history/src/graph_read.rs
+++ b/crates/compass-history/src/graph_read.rs
@@ -74,8 +74,8 @@ impl RealizationReader<'_> {
                     let path = text(path, "analysis sidecar")?;
                     let value = crate::artifacts::decode_typed(&bytes, "compass.analysis.sidecar")?;
                     match path.as_str() {
-                        ".compass_labels.json" => sink.labels(value)?,
-                        ".compass_analysis.json" => {}
+                        "labels.json" => sink.labels(value)?,
+                        "analysis.json" => {}
                         _ => {
                             return Err(HistoryError::InvalidArtifacts(format!(
                                 "unknown analysis sidecar {path}"

--- a/crates/compass-history/tests/roundtrip.rs
+++ b/crates/compass-history/tests/roundtrip.rs
@@ -124,7 +124,7 @@ fn trusted_graph_partition_does_not_duplicate_full_graph_as_metadata()
         !matches!(
             decode_segments(key).as_deref(),
             Ok([_, _, kind, path])
-                if kind == b"sidecar" && path == b".compass-history/graph.v1.json"
+                if kind == b"sidecar" && path == b"history/graph.v1.json"
         )
     }));
     assert!(partition.metadata.iter().all(|(key, _)| {
@@ -147,17 +147,21 @@ fn source_inventory_uses_one_decomposed_canonical_record() -> Result<(), Box<dyn
         "code_files": {"src/lib.rs": {"git_object": "fixture"}}
     }))?;
     let mut artifacts = empty_trusted_artifacts()?;
-    artifacts.authoritative_sidecars.insert(
-        ".compass_source_inventory.json".to_owned(),
-        inventory.clone(),
-    );
+    artifacts
+        .authoritative_sidecars
+        .insert("source-inventory.json".to_owned(), inventory.clone());
 
     let registry = artifacts.artifact_registry()?;
     let entry = registry
         .iter()
-        .find(|entry| entry.relative_path == ".compass_source_inventory.json")
+        .find(|entry| entry.relative_path == "source-inventory.json")
         .ok_or("source inventory registry entry missing")?;
     assert!(entry.storage.is_none());
+    assert!(
+        artifacts
+            .export_sidecars()
+            .contains_key("source-inventory.json")
+    );
 
     let partition = artifacts.partition(&completion())?;
     assert_eq!(GraphArtifacts::reconstruct(&partition)?, artifacts);
@@ -487,7 +491,7 @@ fn completed_seed_writes_normalized_marker_and_opaque_sidecars()
         vec![0, 1, 255]
     );
     let marker: serde_json::Value = serde_json::from_slice(&std::fs::read(
-        directory.path().join(".compass_semantic_marker"),
+        directory.path().join("semantic-marker.json"),
     )?)?;
     assert_eq!(marker["schema"], "compass.history.completion");
     assert_eq!(marker["semantic_files_expected"], 1);
@@ -574,8 +578,8 @@ fn registry_loading_verifies_builtin_opaque_derived_and_operational_artifacts()
     let opaque = vec![0, 1, 255];
     for (path, bytes) in [
         ("graph.json", graph.as_slice()),
-        (".compass_analysis.json", analysis.as_slice()),
-        (".compass_labels.json", labels.as_slice()),
+        ("analysis.json", analysis.as_slice()),
+        ("labels.json", labels.as_slice()),
         ("manifest.json", manifest.as_slice()),
         ("semantic/facts.bin", opaque.as_slice()),
     ] {
@@ -597,8 +601,8 @@ fn registry_loading_verifies_builtin_opaque_derived_and_operational_artifacts()
     };
     let mut registry = vec![
         authoritative("graph.json", &graph),
-        authoritative(".compass_analysis.json", &analysis),
-        authoritative(".compass_labels.json", &labels),
+        authoritative("analysis.json", &analysis),
+        authoritative("labels.json", &labels),
         authoritative("manifest.json", &manifest),
         authoritative("semantic/facts.bin", &opaque),
     ];

--- a/crates/compass-mcp/src/lib.rs
+++ b/crates/compass-mcp/src/lib.rs
@@ -1235,7 +1235,7 @@ fn read_resource_text(uri: &str, context: &GraphContext) -> Result<String, Strin
                 .path
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
-                .join(".compass_labels.json");
+                .join("labels.json");
             let labels = fs::read(&labels_path)
                 .ok()
                 .and_then(|bytes| serde_json::from_slice::<BTreeMap<usize, String>>(&bytes).ok())
@@ -1333,7 +1333,7 @@ mod tests {
     }
 
     #[test]
-    fn project_path_fails_closed_on_a_malformed_generation_pointer()
+    fn project_path_fails_closed_on_a_malformed_snapshot_pointer()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let default = temp.path().join("default.json");
@@ -1341,10 +1341,7 @@ mod tests {
         let project = temp.path().join("project");
         fs::create_dir_all(project.join("compass-out"))?;
         sample(&project.join("compass-out/graph.json"))?;
-        fs::write(
-            project.join("compass-out/.compass-active-generation"),
-            "../escape",
-        )?;
+        fs::write(project.join("compass-out/current-snapshot"), "../escape")?;
         let server = CompassMcp::new(default);
         let mut args = Map::new();
         args.insert(
@@ -1352,13 +1349,13 @@ mod tests {
             Value::String(project.to_string_lossy().into_owned()),
         );
         let result = server.invoke("graph_stats", args);
-        assert!(result.contains("generation"), "{result}");
+        assert!(result.contains("snapshot"), "{result}");
         assert!(!result.contains("Nodes: 2"), "{result}");
         Ok(())
     }
 
     #[test]
-    fn default_public_graph_tracks_generation_changes_and_fails_closed()
+    fn default_public_graph_tracks_snapshot_changes_and_fails_closed()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let output = temp.path().join("compass-out");
@@ -1368,7 +1365,7 @@ mod tests {
         let first = compass_files::BuildGuard::begin(&output)?;
         fs::write(
             first.staging_directory().join("graph.json"),
-            r#"{"directed":true,"nodes":[{"id":"generation-one"}],"links":[]}"#,
+            r#"{"directed":true,"nodes":[{"id":"snapshot-one"}],"links":[]}"#,
         )?;
         first.commit_with_artifacts(&["graph.json"])?;
 
@@ -1391,9 +1388,9 @@ mod tests {
                 .contains("Nodes: 3")
         );
 
-        fs::write(output.join(".compass-active-generation"), "../escape")?;
+        fs::write(output.join("current-snapshot"), "../escape")?;
         let malformed = server.invoke("graph_stats", Map::new());
-        assert!(malformed.contains("generation"), "{malformed}");
+        assert!(malformed.contains("snapshot"), "{malformed}");
         assert!(!malformed.contains("Nodes: 2"), "{malformed}");
         Ok(())
     }
@@ -1452,7 +1449,7 @@ mod tests {
         )?;
         fs::write(temp.path().join("GRAPH_REPORT.md"), "# Report\nBody\n")?;
         fs::write(
-            temp.path().join(".compass_labels.json"),
+            temp.path().join("labels.json"),
             r#"{"0":"Core","1":"Docs"}"#,
         )?;
         let server = CompassMcp::new(&graph);

--- a/crates/compass-mcp/tests/coverage_paths.rs
+++ b/crates/compass-mcp/tests/coverage_paths.rs
@@ -28,7 +28,7 @@ fn write_fixture(root: &std::path::Path) -> Result<std::path::PathBuf, Box<dyn E
     )?;
     fs::write(root.join("GRAPH_REPORT.md"), "# Fixture report\n")?;
     fs::write(
-        root.join(".compass_labels.json"),
+        root.join("labels.json"),
         r#"{"0":"Core","1":"Feature","2":"Boundary"}"#,
     )?;
     Ok(graph)

--- a/crates/compass-model/src/code_graph.rs
+++ b/crates/compass-model/src/code_graph.rs
@@ -1280,7 +1280,7 @@ fn content_cache_path(graph_path: &Path, digest: &str) -> PathBuf {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("cache")
-        .join(format!(".{file_name}.{digest}.compass-v1"))
+        .join(format!("{file_name}.{digest}.content-v1.cache"))
 }
 
 fn load_content_cache(path: &Path, digest: &str) -> Option<GraphDocument> {
@@ -1328,4 +1328,19 @@ fn write_content_cache(
         let _ = fs::remove_file(temporary);
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::content_cache_path;
+
+    #[test]
+    fn content_cache_path_is_visible_and_scoped() {
+        assert_eq!(
+            content_cache_path(Path::new("compass-out/graph.json"), "abc123"),
+            Path::new("compass-out/cache/graph.json.abc123.content-v1.cache")
+        );
+    }
 }

--- a/crates/compass-model/src/document.rs
+++ b/crates/compass-model/src/document.rs
@@ -1398,7 +1398,7 @@ fn query_cache_path(graph_path: &Path) -> PathBuf {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("cache")
-        .join(format!(".{file_name}.compass-cache-v1"))
+        .join(format!("{file_name}.query-v1.cache"))
 }
 
 fn affected_cache_path(graph_path: &Path) -> PathBuf {
@@ -1410,7 +1410,7 @@ fn affected_cache_path(graph_path: &Path) -> PathBuf {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("cache")
-        .join(format!(".{file_name}.compass-affected-v1"))
+        .join(format!("{file_name}.affected-v1.cache"))
 }
 
 fn traversal_cache_path(graph_path: &Path) -> PathBuf {
@@ -1422,7 +1422,7 @@ fn traversal_cache_path(graph_path: &Path) -> PathBuf {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("cache")
-        .join(format!(".{file_name}.compass-traversal-v1"))
+        .join(format!("{file_name}.traversal-v1.cache"))
 }
 
 fn encode_cache_header(magic: &[u8; 8], signature: GraphSignature) -> [u8; QUERY_CACHE_HEADER_LEN] {
@@ -1779,7 +1779,7 @@ mod tests {
     }
 
     #[test]
-    fn query_cache_is_hidden_and_invalidates_when_the_graph_changes() {
+    fn query_cache_is_visible_and_invalidates_when_the_graph_changes() {
         let directory = tempfile::tempdir().unwrap_or_else(|_| std::process::abort());
         let path = directory.path().join("graph.json");
         fs::create_dir(directory.path().join("cache")).unwrap_or_else(|_| std::process::abort());
@@ -1788,6 +1788,10 @@ mod tests {
 
         let first = GraphDocument::load(&path).unwrap_or_else(|_| std::process::abort());
         assert_eq!(first.nodes[0].id, "a");
+        assert_eq!(
+            query_cache_path(&path),
+            directory.path().join("cache/graph.json.query-v1.cache")
+        );
         assert!(query_cache_path(&path).is_file());
 
         fs::write(
@@ -1815,6 +1819,10 @@ mod tests {
         .unwrap_or_else(|_| std::process::abort());
 
         let full = GraphDocument::load(&path).unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            affected_cache_path(&path),
+            directory.path().join("cache/graph.json.affected-v1.cache")
+        );
         assert!(affected_cache_path(&path).is_file());
         let compact =
             GraphDocument::load_for_affected(&path).unwrap_or_else(|_| std::process::abort());
@@ -1849,6 +1857,10 @@ mod tests {
 
         let compact =
             GraphDocument::load_for_traversal(&path).unwrap_or_else(|_| std::process::abort());
+        assert_eq!(
+            traversal_cache_path(&path),
+            directory.path().join("cache/graph.json.traversal-v1.cache")
+        );
         assert!(traversal_cache_path(&path).is_file());
         assert_eq!(compact.nodes[0].label(), "A");
         assert_eq!(compact.nodes[0].string("source_file"), "src/a.py");

--- a/crates/compass-model/tests/code_graph_loading.rs
+++ b/crates/compass-model/tests/code_graph_loading.rs
@@ -172,12 +172,11 @@ fn strict_loading_uses_a_content_addressed_validated_cache()
     let cache_entries =
         fs::read_dir(directory.path().join("cache"))?.collect::<Result<Vec<_>, _>>()?;
     assert_eq!(cache_entries.len(), 1);
-    assert!(
-        cache_entries[0]
-            .file_name()
-            .to_string_lossy()
-            .contains(".graph.json.")
-    );
+    let cache_name = cache_entries[0].file_name();
+    let cache_name = cache_name.to_string_lossy();
+    assert!(cache_name.starts_with("graph.json."));
+    assert!(cache_name.ends_with(".content-v1.cache"));
+    assert!(!cache_name.contains("compass"));
     assert_eq!(GraphDocument::load(&graph_path)?, document());
     Ok(())
 }

--- a/crates/compass-output/src/backup.rs
+++ b/crates/compass-output/src/backup.rs
@@ -8,10 +8,10 @@ const BACKUP_ARTIFACTS: &[&str] = &[
     "graph.json",
     "program.json",
     "GRAPH_REPORT.md",
-    ".compass_labels.json",
-    ".compass_analysis.json",
+    "labels.json",
+    "analysis.json",
     "manifest.json",
-    ".compass_semantic_marker",
+    "semantic-marker.json",
     "cost.json",
 ];
 
@@ -35,8 +35,8 @@ pub fn backup_if_protected(output_dir: &Path) -> BackupResult {
     if !graph_path.is_file() {
         return BackupResult::default();
     }
-    let semantic = output_dir.join(".compass_semantic_marker").exists();
-    let curated = labels_are_curated(&output_dir.join(".compass_labels.json"));
+    let semantic = output_dir.join("semantic-marker.json").exists();
+    let curated = labels_are_curated(&output_dir.join("labels.json"));
     if !semantic && !curated {
         return BackupResult::default();
     }
@@ -113,10 +113,7 @@ mod tests {
         fs::write(directory.path().join("graph.json"), "graph")?;
         fs::write(directory.path().join("program.json"), "program")?;
         fs::write(directory.path().join("GRAPH_REPORT.md"), "report")?;
-        fs::write(
-            directory.path().join(".compass_labels.json"),
-            r#"{"0":"Orders"}"#,
-        )?;
+        fs::write(directory.path().join("labels.json"), r#"{"0":"Orders"}"#)?;
         let first = backup_if_protected(directory.path());
         assert!(
             first

--- a/crates/compass-output/src/history_bundle.rs
+++ b/crates/compass-output/src/history_bundle.rs
@@ -72,16 +72,16 @@ fn build_staging(staging: &Path, input: &HistoryBundleInput<'_>) -> Result<(), O
         write_bytes_atomic(staging.join("program.json"), program)?;
     }
     if let Some(value) = input.analysis {
-        write_json_atomic(staging.join(".compass_analysis.json"), value, false)?;
+        write_json_atomic(staging.join("analysis.json"), value, false)?;
     }
     if let Some(value) = input.labels {
-        write_json_atomic(staging.join(".compass_labels.json"), value, false)?;
+        write_json_atomic(staging.join("labels.json"), value, false)?;
     }
     if let Some(value) = input.manifest {
         write_json_atomic(staging.join("manifest.json"), value, false)?;
     }
     write_json_atomic(
-        staging.join(".compass_semantic_marker"),
+        staging.join("semantic-marker.json"),
         input.semantic_marker,
         false,
     )?;
@@ -168,12 +168,12 @@ fn render_v1(staging: &Path, input: &HistoryBundleInput<'_>) -> Result<(), Outpu
             &TreeOptions::default(),
         )?;
     }
-    if requested.contains(".compass_labels.json.sig") {
+    if requested.contains("labels.json.sig") {
         let signatures = community_member_signatures(&communities)
             .into_iter()
             .map(|(community, signature)| (community.to_string(), signature))
             .collect::<BTreeMap<_, _>>();
-        write_json_atomic(staging.join(".compass_labels.json.sig"), &signatures, false)?;
+        write_json_atomic(staging.join("labels.json.sig"), &signatures, false)?;
     }
     Ok(())
 }
@@ -185,7 +185,7 @@ fn validate_requests(requests: &[DerivedArtifactRequest]) -> Result<(), OutputEr
         if request.regeneration_version != SUPPORTED_HISTORY_RENDERER
             || !matches!(
                 request.relative_path.as_str(),
-                "GRAPH_REPORT.md" | "graph.html" | "GRAPH_TREE.html" | ".compass_labels.json.sig"
+                "GRAPH_REPORT.md" | "graph.html" | "GRAPH_TREE.html" | "labels.json.sig"
             )
         {
             return Err(OutputError::UnsupportedHistoryRenderer {
@@ -286,11 +286,11 @@ fn validate_sidecars(sidecars: &BTreeMap<String, Vec<u8>>) -> Result<(), OutputE
                 | "GRAPH_REPORT.md"
                 | "graph.html"
                 | "GRAPH_TREE.html"
-                | ".compass_analysis.json"
-                | ".compass_labels.json"
-                | ".compass_labels.json.sig"
+                | "analysis.json"
+                | "labels.json"
+                | "labels.json.sig"
                 | "manifest.json"
-                | ".compass_semantic_marker"
+                | "semantic-marker.json"
         ) {
             return Err(OutputError::UnsafeHistoryPath(relative.clone()));
         }
@@ -322,7 +322,7 @@ fn unique_staging(parent: &Path, name: &str) -> Result<PathBuf, OutputError> {
     for _ in 0..100 {
         let nonce = STAGING_NONCE.fetch_add(1, Ordering::Relaxed);
         let path = parent.join(format!(
-            ".{name}.compass-history-{}-{nonce}",
+            "{name}.history-staging-{}-{nonce}",
             std::process::id()
         ));
         match fs::create_dir(&path) {

--- a/crates/compass-output/src/html.rs
+++ b/crates/compass-output/src/html.rs
@@ -1033,7 +1033,7 @@ fn load_learning_overlay(output_path: &Path) -> BTreeMap<String, Value> {
     let path = output_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join(".compass_learning.json");
+        .join("learning.json");
     let raw = fs::read(path)
         .ok()
         .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok());
@@ -1088,7 +1088,7 @@ fn resolve_learning_source(source: &str, output_path: &Path) -> Option<std::path
     }
     let out = output_path.parent().unwrap_or_else(|| Path::new("."));
     let mut roots = Vec::new();
-    if let Ok(recorded) = fs::read_to_string(out.join(".compass_root")) {
+    if let Ok(recorded) = fs::read_to_string(out.join("source-root.txt")) {
         let recorded = recorded.trim();
         if !recorded.is_empty() {
             roots.push(std::path::PathBuf::from(recorded));
@@ -2542,7 +2542,7 @@ mod tests {
             Sha256::digest(fs::read(directory.path().join("source.rs"))?)
         );
         fs::write(
-            out.join(".compass_learning.json"),
+            out.join("learning.json"),
             serde_json::to_vec(&json!({"nodes":{"a":{
                 "status":"preferred","uses":2,"score":1.5,
                 "source_file":"source.rs","code_fingerprint":digest

--- a/crates/compass-output/src/lib.rs
+++ b/crates/compass-output/src/lib.rs
@@ -91,7 +91,7 @@ pub enum OutputError {
     )]
     EmptyWikiCommunities,
     #[error(
-        "all community node IDs are stale — none exist in the graph. Re-run `compass extract .` to regenerate .compass_analysis.json."
+        "all community node IDs are stale — none exist in the graph. Re-run `compass extract .` to regenerate analysis.json."
     )]
     StaleWikiCommunities,
     #[error("unsupported history renderer {version} for {path}")]

--- a/crates/compass-output/src/obsidian.rs
+++ b/crates/compass-output/src/obsidian.rs
@@ -15,7 +15,7 @@ const COMMUNITY_COLORS: [&str; 10] = [
     "#4E79A7", "#F28E2B", "#E15759", "#76B7B2", "#59A14F", "#EDC948", "#B07AA1", "#FF9DA7",
     "#9C755F", "#BAB0AC",
 ];
-const MANIFEST: &str = ".compass_obsidian_manifest.json";
+const MANIFEST: &str = "sync-manifest.json";
 
 #[derive(Clone, Debug, Default)]
 pub struct ObsidianOptions<'a> {

--- a/crates/compass-output/tests/history_bundle.rs
+++ b/crates/compass-output/tests/history_bundle.rs
@@ -36,7 +36,7 @@ fn v1_renderer_publishes_a_valid_complete_bundle_atomically()
         "GRAPH_REPORT.md",
         "graph.html",
         "GRAPH_TREE.html",
-        ".compass_labels.json.sig",
+        "labels.json.sig",
     ]
     .map(|path| DerivedArtifactRequest {
         relative_path: path.to_owned(),
@@ -63,7 +63,7 @@ fn v1_renderer_publishes_a_valid_complete_bundle_atomically()
     assert!(destination.join("GRAPH_REPORT.md").is_file());
     assert!(destination.join("graph.html").is_file());
     assert!(destination.join("GRAPH_TREE.html").is_file());
-    assert!(destination.join(".compass_labels.json.sig").is_file());
+    assert!(destination.join("labels.json.sig").is_file());
     assert!(
         std::fs::read_to_string(destination.join("GRAPH_REPORT.md"))?
             .contains("# Graph Report - fixture")
@@ -75,9 +75,8 @@ fn v1_renderer_publishes_a_valid_complete_bundle_atomically()
         std::fs::read_to_string(destination.join("GRAPH_TREE.html"))?
             .contains("compass tree viewer")
     );
-    let signatures: serde_json::Value = serde_json::from_slice(&std::fs::read(
-        destination.join(".compass_labels.json.sig"),
-    )?)?;
+    let signatures: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(destination.join("labels.json.sig"))?)?;
     assert!(signatures.get("0").is_some());
     assert_eq!(
         std::fs::read(destination.join("semantic/facts.bin"))?,

--- a/crates/compass-prs/src/lib.rs
+++ b/crates/compass-prs/src/lib.rs
@@ -1274,50 +1274,44 @@ mod tests {
     }
 
     #[test]
-    fn graph_impact_rereads_the_active_generation_pointer() {
+    fn graph_impact_rereads_the_current_snapshot_pointer() {
         let directory = tempfile::tempdir().unwrap_or_else(|_| std::process::abort());
         let output = directory.path();
         let public = output.join("graph.json");
-        write_impact_graph(&public, "Legacy", 0);
-        let generations = output.join(".compass-generations");
-        let first = generations.join("generation-first");
-        let second = generations.join("generation-second");
+        write_impact_graph(&public, "Public", 0);
+        let snapshots = output.join("snapshots");
+        let first = snapshots.join("snapshot-first");
+        let second = snapshots.join("snapshot-second");
         std::fs::create_dir_all(&first).unwrap_or_else(|_| std::process::abort());
         std::fs::create_dir_all(&second).unwrap_or_else(|_| std::process::abort());
         write_impact_graph(&first.join("graph.json"), "First", 1);
         write_impact_graph(&second.join("graph.json"), "Second", 2);
 
-        std::fs::write(
-            output.join(".compass-active-generation"),
-            "generation-first",
-        )
-        .unwrap_or_else(|_| std::process::abort());
+        std::fs::write(output.join("current-snapshot"), "snapshot-first")
+            .unwrap_or_else(|_| std::process::abort());
         let first_labels = attach_graph_impact(&StubRunner::default(), &mut [], &public, None);
         assert_eq!(first_labels.get(&1), Some(&vec!["First".to_owned()]));
 
-        std::fs::write(
-            output.join(".compass-active-generation"),
-            "generation-second",
-        )
-        .unwrap_or_else(|_| std::process::abort());
+        std::fs::write(output.join("current-snapshot"), "snapshot-second")
+            .unwrap_or_else(|_| std::process::abort());
         let second_labels = attach_graph_impact(&StubRunner::default(), &mut [], &public, None);
         assert_eq!(second_labels.get(&2), Some(&vec!["Second".to_owned()]));
     }
 
     #[test]
-    fn graph_impact_uses_legacy_only_when_the_pointer_is_absent() {
+    fn graph_impact_accepts_standalone_graphs_but_rejects_malformed_managed_pointers() {
         let directory = tempfile::tempdir().unwrap_or_else(|_| std::process::abort());
         let public = directory.path().join("graph.json");
-        write_impact_graph(&public, "Legacy", 0);
+        write_impact_graph(&public, "Standalone", 0);
 
-        let legacy_labels = attach_graph_impact(&StubRunner::default(), &mut [], &public, None);
-        assert_eq!(legacy_labels.get(&0), Some(&vec!["Legacy".to_owned()]));
+        let standalone_labels = attach_graph_impact(&StubRunner::default(), &mut [], &public, None);
+        assert_eq!(
+            standalone_labels.get(&0),
+            Some(&vec!["Standalone".to_owned()])
+        );
 
-        std::fs::write(
-            directory.path().join(".compass-active-generation"),
-            "../escape",
-        )
-        .unwrap_or_else(|_| std::process::abort());
+        std::fs::write(directory.path().join("current-snapshot"), "../escape")
+            .unwrap_or_else(|_| std::process::abort());
         let malformed_labels = attach_graph_impact(&StubRunner::default(), &mut [], &public, None);
         assert!(malformed_labels.is_empty());
     }

--- a/crates/compass-query/src/code_query.rs
+++ b/crates/compass-query/src/code_query.rs
@@ -1155,7 +1155,7 @@ fn default_repository_root(graph_path: &Path) -> PathBuf {
     if graph_directory
         .parent()
         .and_then(Path::file_name)
-        .is_some_and(|name| name == ".compass-generations")
+        .is_some_and(|name| name == "snapshots")
     {
         return graph_directory
             .ancestors()

--- a/crates/compass-query/tests/code_explore.rs
+++ b/crates/compass-query/tests/code_explore.rs
@@ -36,18 +36,16 @@ fn explore_connects_symbols_and_groups_digest_verified_source()
 }
 
 #[test]
-fn explore_derives_repository_root_from_a_generation_graph()
--> Result<(), Box<dyn std::error::Error>> {
+fn explore_derives_repository_root_from_a_snapshot_graph() -> Result<(), Box<dyn std::error::Error>>
+{
     let directory = tempfile::tempdir()?;
-    let generation = directory
-        .path()
-        .join("compass-out/.compass-generations/generation-test");
-    fs::create_dir_all(&generation)?;
-    let graph_path = generation.join("graph.json");
+    let snapshot = directory.path().join("compass-out/snapshots/snapshot-test");
+    fs::create_dir_all(&snapshot)?;
+    let graph_path = snapshot.join("graph.json");
     support::write_graph(&graph_path)?;
     fs::create_dir_all(directory.path().join("src"))?;
     fs::rename(
-        generation.join("src/lib.rs"),
+        snapshot.join("src/lib.rs"),
         directory.path().join("src/lib.rs"),
     )?;
     let engine = open(&graph_path, None, &directory.path().join("cache"))?;

--- a/crates/compass-reflect/src/lib.rs
+++ b/crates/compass-reflect/src/lib.rs
@@ -61,13 +61,13 @@ pub fn reflect(options: &ReflectOptions) -> Result<ReflectResult, ReflectError> 
             graph
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
-                .join(".compass_analysis.json")
+                .join("analysis.json")
         });
         let labels = options.labels.clone().unwrap_or_else(|| {
             graph
                 .parent()
                 .unwrap_or_else(|| Path::new("."))
-                .join(".compass_labels.json")
+                .join("labels.json")
         });
         aggregate::load_graph_context(graph, &analysis, &labels)
     });

--- a/crates/compass-reflect/src/overlay.rs
+++ b/crates/compass-reflect/src/overlay.rs
@@ -10,7 +10,7 @@ use time::OffsetDateTime;
 
 use crate::{Aggregate, ProvenanceEvent, ReflectError};
 
-pub const LEARNING_SIDECAR_NAME: &str = ".compass_learning.json";
+pub const LEARNING_SIDECAR_NAME: &str = "learning.json";
 const LEARNING_SCHEMA_VERSION: u8 = 1;
 const PROVENANCE_CAP: usize = 5;
 
@@ -174,7 +174,7 @@ fn resolve_source_path(source: &str, graph_path: &Path) -> Option<PathBuf> {
     }
     let output = graph_path.parent().unwrap_or_else(|| Path::new("."));
     let mut candidates = Vec::new();
-    if let Ok(recorded) = fs::read_to_string(output.join(".compass_root")) {
+    if let Ok(recorded) = fs::read_to_string(output.join("source-root.txt")) {
         let recorded = recorded.trim();
         if !recorded.is_empty() {
             candidates.push(PathBuf::from(recorded));

--- a/crates/compass-reflect/tests/reflection_coverage.rs
+++ b/crates/compass-reflect/tests/reflection_coverage.rs
@@ -107,15 +107,15 @@ fn reflection_loads_memory_graph_context_writes_overlay_and_tracks_freshness()
         r#"{"directed":true,"multigraph":false,"graph":{},"nodes":[{"id":"node_a","label":"Alpha","source_file":"source.rs"},{"id":"node_b","label":"Duplicate"},{"id":"node_c","label":"Duplicate"}],"links":[]}"#,
     )?;
     fs::write(
-        output_dir.join(".compass_root"),
+        output_dir.join("source-root.txt"),
         root.to_string_lossy().as_bytes(),
     )?;
-    let analysis = output_dir.join(".compass_analysis.json");
+    let analysis = output_dir.join("analysis.json");
     fs::write(
         &analysis,
         r#"{"communities":{"0":["node_a"],"1":["node_b"],"2":[]}}"#,
     )?;
-    let labels = output_dir.join(".compass_labels.json");
+    let labels = output_dir.join("labels.json");
     fs::write(
         &labels,
         r#"{"0":"Core","1":true,"2":7,"3":{"name":"ignored"}}"#,
@@ -153,7 +153,7 @@ fn reflection_loads_memory_graph_context_writes_overlay_and_tracks_freshness()
     })?;
     assert_eq!(result.aggregate.total, 1);
     assert!(lessons.is_file());
-    assert!(output_dir.join(".compass_learning.json").is_file());
+    assert!(output_dir.join("learning.json").is_file());
     assert!(lessons_fresh(
         &lessons,
         &memory_dir,

--- a/crates/compass-store-qualification/src/main.rs
+++ b/crates/compass-store-qualification/src/main.rs
@@ -275,7 +275,7 @@ fn main() -> Result<(), String> {
 
 fn run_sqlite(nodes: usize) -> Result<ReleaseReport, String> {
     let directory = tempfile::tempdir().map_err(|error| error.to_string())?;
-    let path = directory.path().join("compass-store.sqlite3");
+    let path = directory.path().join("store.sqlite3");
     let store = compass_store::SqliteStore::open(&path).map_err(|error| error.to_string())?;
     run_with_store("sqlite", nodes, directory, path, store)
 }

--- a/crates/compass-store-redb/src/lib.rs
+++ b/crates/compass-store-redb/src/lib.rs
@@ -31,7 +31,7 @@ type RedbValue = &'static [u8];
 const REDB_KV: TableDefinition<RedbKey, RedbValue> = TableDefinition::new("compass.kv.v1");
 
 /// Conventional filename for an explicit redb local backend.
-pub const REDB_FILE_NAME: &str = "compass-store.redb";
+pub const REDB_FILE_NAME: &str = "store.redb";
 
 enum RedbDatabase {
     ReadWrite(Database),

--- a/crates/compass-store/src/lib.rs
+++ b/crates/compass-store/src/lib.rs
@@ -28,9 +28,9 @@ pub const GRAPH_SNAPSHOT_SCHEMA_V1: &str = "compass.store.graph-snapshot/1";
 pub const STORE_REF_SCHEMA_V1: &str = "compass.store.ref/1";
 pub const STORE_RETENTION_SCHEMA_V1: &str = "compass.store.retention/1";
 pub const GRAPH_SCHEMA_V1: &str = "compass.graph/1";
-pub const STORE_FILE_NAME: &str = "compass-store.sqlite3";
+pub const STORE_FILE_NAME: &str = "store.sqlite3";
 pub const STORE_REF_FILE_NAME: &str = "store.ref";
-pub const STORE_DIRECTORY_NAME: &str = ".compass-store";
+pub const STORE_DIRECTORY_NAME: &str = "store";
 pub const KEY_ENCODING_V1: u8 = 1;
 pub const MAX_KEY_SEGMENTS: usize = 32;
 pub const MAX_NAMESPACE_BYTES: usize = 128;
@@ -649,7 +649,7 @@ pub struct SnapshotManifest {
 ///
 /// The reference is an application artifact rather than a SQLite implementation
 /// detail. It lets a reader validate that the selected database and snapshot are
-/// the ones published with the active generation before opening query state.
+/// the ones published with the active snapshot before opening query state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StoreRef {
     pub schema: String,
@@ -725,27 +725,32 @@ impl StoreRef {
 
 /// Resolve the local SQLite realization selected by a graph artifact.
 ///
-/// Current build generations keep the database once under the output root and
+/// Current build snapshots keep the database once under the output root and
 /// publish only a small `store.ref` beside `graph.json`. An adjacent database
-/// remains supported for standalone restored bundles and older generations.
+/// remains supported only for standalone restored bundles.
 #[must_use]
 pub fn local_sqlite_store_path(graph_path: &Path) -> PathBuf {
     let graph_directory = graph_path.parent().unwrap_or_else(|| Path::new("."));
     let adjacent = graph_directory.join(STORE_FILE_NAME);
-    if adjacent.is_file() {
-        return adjacent;
+    let output_store = graph_directory
+        .join(STORE_DIRECTORY_NAME)
+        .join(STORE_FILE_NAME);
+    if graph_directory.join("current-snapshot").is_file()
+        || graph_directory.join("snapshots").is_dir()
+    {
+        return output_store;
     }
-    let Some(generations_directory) = graph_directory.parent() else {
+    let Some(snapshots_directory) = graph_directory.parent() else {
         return adjacent;
     };
-    if generations_directory
+    if snapshots_directory
         .file_name()
         .and_then(|name| name.to_str())
-        != Some(".compass-generations")
+        != Some("snapshots")
     {
         return adjacent;
     }
-    let Some(output_root) = generations_directory.parent() else {
+    let Some(output_root) = snapshots_directory.parent() else {
         return adjacent;
     };
     output_root.join(STORE_DIRECTORY_NAME).join(STORE_FILE_NAME)
@@ -930,7 +935,7 @@ impl SqliteStore {
         self.read_snapshot().map(|(manifest, _)| manifest)
     }
 
-    /// Flush all acknowledged WAL frames before a filesystem generation is
+    /// Flush all acknowledged WAL frames before a filesystem snapshot is
     /// committed.  The main database file is the only authoritative artifact
     /// named by `BuildGuard`; checkpointing makes it self-contained for copy,
     /// backup, and recovery operations.
@@ -1007,7 +1012,7 @@ impl SqliteStore {
     /// Restore a validated SQLite backup into a new path.
     ///
     /// Restores intentionally refuse to overwrite an existing path. A caller
-    /// that needs replacement must move the old generation aside first, which
+    /// that needs replacement must move the old snapshot aside first, which
     /// preserves a recoverable rollback copy.
     pub fn restore_from(
         backup: impl AsRef<Path>,
@@ -2512,9 +2517,34 @@ mod tests {
 
     use super::{
         GRAPH_SCHEMA_V1, ImmutableWrite, Key, KeyRange, MemoryStore, NamespaceId, PartitionKey,
-        ScanLimits, SqliteStore, Store, StoreError, VersionToken, WriteCondition,
-        decode_key_segments, encode_key_segments,
+        STORE_DIRECTORY_NAME, STORE_FILE_NAME, ScanLimits, SqliteStore, Store, StoreError,
+        VersionToken, WriteCondition, decode_key_segments, encode_key_segments,
+        local_sqlite_store_path,
     };
+
+    #[test]
+    fn visible_output_paths_resolve_the_shared_sqlite_store() -> Result<(), Box<dyn Error>> {
+        let directory = tempfile::tempdir()?;
+        let output = directory.path().join("compass-out");
+        let snapshot = output.join("snapshots/snapshot-test");
+        fs::create_dir_all(&snapshot)?;
+        fs::write(output.join("current-snapshot"), "snapshot-test\n")?;
+        fs::write(
+            snapshot.join(STORE_FILE_NAME),
+            b"unmanaged snapshot-local store",
+        )?;
+        let expected = output.join(STORE_DIRECTORY_NAME).join(STORE_FILE_NAME);
+
+        assert_eq!(
+            local_sqlite_store_path(&output.join("graph.json")),
+            expected
+        );
+        assert_eq!(
+            local_sqlite_store_path(&snapshot.join("graph.json")),
+            expected
+        );
+        Ok(())
+    }
 
     #[test]
     fn namespace_partition_and_key_are_isolated_and_ordered() -> Result<(), Box<dyn Error>> {

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -229,7 +229,7 @@ The build pipeline treats output as a set. Invalid individual node and edge
 records are deterministically quarantined and reported before the remaining
 graph passes strict validation. A partial graph is published with an explicit
 warning and exact omission summary. Document-level validation errors or an
-empty usable graph remain failures and cannot replace the active generation.
+empty usable graph remain failures and cannot replace the current snapshot.
 Write paths use temporary or staged artifacts and atomic replacement where the
 contract requires it.
 

--- a/docs/cookbook/ci-and-automation.md
+++ b/docs/cookbook/ci-and-automation.md
@@ -18,7 +18,7 @@ Upload the three artifacts plus:
 
 ```bash
 git rev-parse HEAD > compass-out/source-revision.txt
-compass --version > compass-out/compass-version.txt
+compass --version > compass-out/version.txt
 ```
 
 Treat graph artifacts with source-code confidentiality.
@@ -145,7 +145,7 @@ compass-out/
 ├── GRAPH_REPORT.md
 ├── manifest.json
 ├── source-revision.txt
-├── compass-version.txt
+├── version.txt
 ├── policy-result.json
 └── topology-diff.json
 ```

--- a/docs/design/compass-store.md
+++ b/docs/design/compass-store.md
@@ -8,16 +8,16 @@ implemented. This includes the namespace-first common contract, versioned
 logical envelopes, SQLite backup/restore, explicit rebuild tooling, release
 qualification reports, canonical JSON/typed-query/CompassQL differential
 checks, and packaging boundaries. `graph.json` remains permanent and
-compatible. Local bounded generation retention and reachability collection are
+compatible. Local bounded snapshot retention and reachability collection are
 implemented. PostgreSQL, DynamoDB, hosted credentials/TLS, distributed leases,
 and service quotas remain future work.
 
 New stores contain only the Phase 2 content-addressed projected indexes and
 their manifest; they do not duplicate the complete graph in a legacy chunked
 payload. One stable SQLite database lives below the output root, while each
-BuildGuard generation contains canonical `graph.json` and a small immutable
+BuildGuard snapshot contains canonical `graph.json` and a small immutable
 `store.ref`. The database is prepared and checkpointed before the filesystem
-generation switch publishes that reference. `graph.json` remains a permanent
+snapshot switch publishes that reference. `graph.json` remains a permanent
 compatible engine and is never removed or made dependent on SQLite.
 
 The first support window is `0.3.x`: matching logical majors may be reopened
@@ -674,7 +674,7 @@ digest, schema, index kind, ordering, root selection, and graph validation
 before returning a record. Point reads and scans enforce item, byte, object,
 and depth limits; corruption is never converted into an empty result.
 
-`snapshot_id` is a meaning-oriented identity digest. The build generation ID
+`snapshot_id` is a meaning-oriented identity digest. The build snapshot ID
 is retained in the exported metadata and graph digest but is excluded from
 the identity projection, so operational rebuilds do not create a different
 logical identity. A prepared snapshot writes no active selector. Activation is
@@ -683,11 +683,11 @@ to finish against that immutable realization.
 
 The Phase 3 local adapter maps these same objects and selectors to durable
 SQLite. It validates the active selector and canonical export after reopen,
-publishes a typed `store.ref`, and checkpoints WAL frames before the generation
+publishes a typed `store.ref`, and checkpoints WAL frames before the snapshot
 switch. After publication, bounded mark-and-sweep collection retains objects
-reachable from the active and previous complete generations and deletes other
+reachable from the active and previous complete snapshots and deletes other
 entries in bounded transactions. A malformed or stale store fails the
-unpublished build and leaves the previous generation and its JSON engine
+unpublished build and leaves the previous snapshot and its JSON engine
 readable.
 
 ### Structural sharing and incremental update
@@ -722,24 +722,24 @@ safe to retry and later collect.
 ### Local artifact-set publication
 
 For `compass init` and `compass update`, the existing filesystem build guard
-remains the coordinator for a coherent local output generation. A dual-profile
-generation contains:
+remains the coordinator for a coherent local output snapshot. A dual-profile
+snapshot contains:
 
 ```text
-staged generation/
+staged snapshot/
   graph.json
   reports and viewer artifacts
   store.ref -> immutable snapshot ID + manifest digest + store identity
 ```
 
 The store snapshot is fully prepared but does not independently become
-current. The filesystem generation switch atomically publishes `graph.json`,
-its reports, and `store.ref` together. A reader opening that generation may
+current. The filesystem snapshot switch atomically publishes `graph.json`,
+its reports, and `store.ref` together. A reader opening that snapshot may
 choose either the JSON engine or the referenced store engine and must observe
 the same graph.
 
-A JSON-profile generation follows the existing artifact publication without a
-store reference. A store-profile generation stages `store.ref` plus reports
+A JSON-profile snapshot follows the existing artifact publication without a
+store reference. A store-profile snapshot stages `store.ref` plus reports
 derived from that immutable snapshot and deliberately omits eager JSON
 materialization; its export command can create JSON as a new coherent artifact
 without changing the selected snapshot.
@@ -750,11 +750,11 @@ usable complete engine. No best-effort sequence of “update database, then
 replace JSON” is allowed to expose two different current graphs.
 
 When selected by default or with `--store sqlite`, the Phase 3 local implementation uses the
-stable `DIR/.compass-store/compass-store.sqlite3` database outside staged and
-complete generation directories. SQLite runs in WAL/FULL mode; the writer
-checkpoints before the generation switch, while the staged generation receives
+stable `DIR/store/store.sqlite3` database outside staged and
+complete snapshot directories. SQLite runs in WAL/FULL mode; the writer
+checkpoints before the snapshot switch, while the staged snapshot receives
 only `store.ref` and bounded retention metadata. An ordinary build omits the
-reference and retains the JSON publication. No generation copies the database.
+reference and retains the JSON publication. No snapshot copies the database.
 
 ### Store-native or cloud publication
 
@@ -875,7 +875,7 @@ own format migration policy.
 | Key order | Binary primary-key order | Byte-key table order | Binary `bytea` order | Table sort-key order |
 | Strong read | Read transaction | Read transaction | Primary/qualifying synchronous path | Consistent base-table read |
 | Conditional write | Transaction plus row/version predicate | Write transaction plus version check | Unique constraint/conditional update | Conditional expression |
-| Publication commit | One selector-row CAS or filesystem generation switch | One selector-key CAS or filesystem generation switch | One selector-row CAS | One selector-item CAS |
+| Publication commit | One selector-row CAS or filesystem snapshot switch | One selector-key CAS or filesystem snapshot switch | One selector-row CAS | One selector-item CAS |
 | Optional acceleration | FTS/derived tables | Derived local tables | Derived indexes/text search | Derived items or separately qualified service |
 
 Only the contract column meanings are portable. For example, availability of a
@@ -912,7 +912,7 @@ explicit transactions. Immutable objects are compressed above the adapter and
 inserted with backend-neutral bounded batches; one conflict-checked SQL
 transaction covers each batch without a preceding existence query per object.
 The publication path explicitly checkpoints before `BuildGuard` seals the
-generation. File creation, permissions, symlink handling, corruption recovery,
+snapshot. File creation, permissions, symlink handling, corruption recovery,
 and atomic replacement reuse `compass-files` primitives. Native tests use
 `EXPLAIN QUERY PLAN` to require primary-key point and partition-range plans;
 physical choices remain benchmarked adapter details rather than public schema.
@@ -1048,7 +1048,7 @@ Immutable publication makes orphaned content expected. Garbage collection is
 mark-and-sweep, rooted at:
 
 - active selectors;
-- filesystem `store.ref` records for retained local generations;
+- filesystem `store.ref` records for retained local snapshots;
 - retained historical realization roots;
 - explicit pins; and
 - unexpired reader or build leases.
@@ -1072,10 +1072,10 @@ Recovery is ordered by authority:
 2. validate its manifest and roots;
 3. use a coherent backend backup or an alternate retained snapshot if the
    store is corrupt;
-4. for local artifact generations, open the co-published `graph.json` engine;
+4. for local artifact snapshots, open the co-published `graph.json` engine;
 5. rebuild disposable indexes or the store snapshot from validated JSON or
    source; and
-6. publish a new generation rather than editing an immutable snapshot.
+6. publish a new snapshot rather than editing an immutable snapshot.
 
 A missing object reachable from a committed manifest is corruption or
 incomplete replication, not an empty graph. A dangling prepared manifest is

--- a/docs/guides/compass-store-operations.md
+++ b/docs/guides/compass-store-operations.md
@@ -27,7 +27,7 @@ The first local release declares these logical, machine-readable formats:
 | Graph document | `compass.graph/1` | Canonical `graph.json`, interchange, inspection, and recovery | Permanent compatible engine; unknown majors fail |
 | Store contract | `compass.store/1` | Namespace/partition/key values, limits, conditional writes, scans, and typed errors | Major changes require a new adapter contract |
 | Graph snapshot | `compass.store.graph-snapshot/1` | Immutable manifests, content digests, ordered index roots, and selector state | Same-major patch upgrades only in the first window |
-| Store reference | `compass.store.ref/1` | Binds `graph.json`, store snapshot, adapter, and generation digests | Validate before a store query |
+| Store reference | `compass.store.ref/1` | Binds `graph.json`, store snapshot, adapter, and snapshot digests | Validate before a store query |
 | Backup bundle | `compass.store.backup/1` | `manifest.json`, graph, reference, and a validated adapter copy | Restore only into a new directory |
 
 The SQLite table layout, redb file layout, WAL/SHM files, object-key spelling,
@@ -39,7 +39,7 @@ run the rebuild procedure, and retain the unchanged `graph.json`.
 
 | Backend | Local CLI | Credentials/network | Platforms | Status |
 | --- | --- | --- | --- | --- |
-| SQLite | Default sidecar `compass-store.sqlite3` (use `--store json` to opt out) | None; local file only | macOS, Linux, Windows | Released local adapter |
+| SQLite | Default sidecar `store.sqlite3` (use `--store json` to opt out) | None; local file only | macOS, Linux, Windows | Released local adapter |
 | redb | Explicit Rust adapter `compass-store-redb` | None; local file only | CI-supported native platforms | Library/conformance adapter; not selected by the CLI |
 | PostgreSQL | No released CLI adapter | Would require an explicit endpoint, credentials, TLS, and bounded client | Future service profile | Deferred |
 | DynamoDB | No released CLI adapter | Would require an explicit AWS boundary, credentials, TLS, retries, and quotas | Future service profile | Deferred |
@@ -53,21 +53,21 @@ contract and pass the same conformance and differential suites.
 For an output root `DIR` the published set is:
 
 ```text
-DIR/.compass-active-generation # BuildGuard publication pointer, when used
-DIR/.compass-generations/<generation>/graph.json
-DIR/.compass-generations/<generation>/store.ref  # with default storage or --store sqlite
-DIR/.compass-store/compass-store.sqlite3          # shared by store generations
+DIR/current-snapshot # BuildGuard publication pointer, when used
+DIR/snapshots/<snapshot>/graph.json
+DIR/snapshots/<snapshot>/store.ref  # with default storage or --store sqlite
+DIR/store/store.sqlite3          # shared by store snapshots
 ```
 
 `graph.json` is the portable authority. When SQLite is selected (the default),
 the canonical JSON artifact and a small digest-bound `store.ref` are published
-as one generation. The SQLite database has one stable location outside the
-generation directories; it is never copied into each generation. Immutable
+as one snapshot. The SQLite database has one stable location outside the
+snapshot directories; it is never copied into each snapshot. Immutable
 objects are prepared in bounded transactions, the WAL is checkpointed, and
-only then can the BuildGuard pointer select the generation. Readers validate
+only then can the BuildGuard pointer select the snapshot. Readers validate
 `store.ref`, open its immutable manifest, and remain pinned even if a later
-generation is published. A failed or interrupted update leaves the previous
-coherent generation selected. The JSON query index beneath the requested cache
+snapshot is published. A failed or interrupted update leaves the previous
+coherent snapshot selected. The JSON query index beneath the requested cache
 root is disposable and may be deleted at any time.
 
 New stores contain projected immutable graph indexes and their manifest; they
@@ -166,7 +166,7 @@ Redb backups use the library adapter's read-only reopen rule; they are not
 currently exposed by the CLI.
 
 The local publisher retains the active and immediately previous complete
-BuildGuard generations. After a successful store publication it marks the
+BuildGuard snapshots. After a successful store publication it marks the
 manifests and tree objects selected by those retained references, deletes
 unreachable entries in bounded transactions, performs bounded incremental
 page reclamation, and checkpoints the WAL. Staging and active references are

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -27,13 +27,15 @@ code-only realization and one or more semantic realizations with different
 provider/model configuration.
 
 History graph schema `networkx-node-link/v1` records automatic multigraph
-promotion. This release is a hard cutover for caches and operational state:
-Compass starts the new `cache/v1` namespace empty and never imports or reads
-legacy cache entries. The immutable realization schema itself is unchanged.
+promotion. History realization schema 1, store format v1, and `compass/v1`
+named roots remain unchanged. The visible artifact-name cutover does not add a
+new serialized schema. Compass does not translate dot-prefixed artifact
+registry entries or import legacy cache entries; rebuild an affected revision
+when it must materialize in the current layout.
 
 Before publication, Compass binds every detected code file to its exact Git
 blob ID and requires an AST completion stamp in the extraction manifest. The
-canonical `.compass_source_inventory.json` sidecar records that proof and
+canonical `source-inventory.json` sidecar records that proof and
 distinguishes files that legitimately produced no graph records. A missing
 stamp fails closed instead of publishing an apparently complete graph.
 

--- a/docs/implementation/compass-store-plan.md
+++ b/docs/implementation/compass-store-plan.md
@@ -39,10 +39,10 @@ and is independently mergeable:
   versioned SQLite realization in one package. The contract does not expose
   SQL or require a particular backend, so redb, PostgreSQL, DynamoDB, or a
   service adapter can implement the same trait later.
-- Every committed local generation contains `graph.json`. Builds using the
+- Every committed local snapshot contains `graph.json`. Builds using the
   default SQLite storage (or explicit `--store sqlite`) additionally contain a
   typed `store.ref`; one shared
-  `.compass-store/compass-store.sqlite3` lives outside the generation
+  `store/store.sqlite3` lives outside the snapshot
   directories. The store contains immutable digest-addressed projected trees,
   manifests, and a CAS-protected selector, but no legacy complete-graph
   payload. WAL is checkpointed before the BuildGuard switch; streamed
@@ -64,7 +64,7 @@ Acceptance criteria for this slice are deliberately concrete:
    selection, reference failures, pinned readers, cache identity, and
    JSON-equivalent typed query results.
 3. The core publication regression test proves the shared database and
-   generation reference are present, reopenable, digest-valid, and
+   snapshot reference are present, reopenable, digest-valid, and
    byte-identical to canonical `graph.json` after a local build.
 4. Deleting or corrupting the sidecar never changes the JSON artifact; default
    query opening falls back only when the sidecar is absent, while an active
@@ -94,14 +94,14 @@ and canonical JSON export. Repeated builds are idempotent and report immutable
 object reuse; prepared content never becomes active until the selector CAS.
 The permanent `graph.json` engine remains unchanged. Phase 3 persists these
 same objects in the SQLite sidecar and verifies their canonical export before
-the generation is sealed.
+the snapshot is sealed.
 
 The slice's acceptance evidence is in
 `crates/compass-graph/tests/store_snapshot.rs`: deterministic identity across
-record insertion order and operational generation IDs, immutable object reuse,
+record insertion order and operational snapshot IDs, immutable object reuse,
 selector-before-commit behavior, bounded reads, directional multiplicity, key
 vectors, and fail-closed tamper detection. Persistent SQLite publication and
-CLI generation checks are covered by the Phase 3 tests below; full
+CLI snapshot checks are covered by the Phase 3 tests below; full
 `JsonGraphEngine` versus streaming store-engine differential qualification and
 measured performance claims remain follow-on work.
 
@@ -468,7 +468,7 @@ broader remote-adapter work.
 
 - Phase 0's adapter conformance harness;
 - Phase 2's immutable snapshot builder; and
-- the existing `BuildGuard` generation publication primitive.
+- the existing `BuildGuard` snapshot publication primitive.
 
 ### Owned surfaces
 
@@ -489,14 +489,14 @@ broader remote-adapter work.
 4. Run the complete adapter conformance suite against a newly created and a
    reopened database.
 5. Add reopen/durability, WAL checkpoint, orphan-discovery, stale-format, and
-   generation-publication tests. Fault-injected crash qualification remains a
+   snapshot-publication tests. Fault-injected crash qualification remains a
    release gate for the larger Phase 3 evidence set.
 6. Define a typed, versioned `store.ref` containing store identity, namespace,
    snapshot ID, manifest digest, and graph digest but no machine-specific
    absolute path.
 7. During `init`, `update`, `extract`, or `watch` with default storage (or
    `--store sqlite`), prepare the SQLite snapshot and stage `store.ref` with
-   `graph.json` and other output artifacts. The filesystem generation switch is
+   `graph.json` and other output artifacts. The filesystem snapshot switch is
    the only local commit.
 8. Keep `graph.json` as the permanent compatible engine. The default query
    uses a validated adjacent store reference, while explicit JSON always opens
@@ -504,7 +504,7 @@ broader remote-adapter work.
    before commit.
 9. Make SQLite publication the default dual profile. `--store json` opts out
    of the sidecar; selecting SQLite never removes JSON.
-10. Retain two complete local generations and run bounded root-based object GC
+10. Retain two complete local snapshots and run bounded root-based object GC
     after coherent publication. Distributed lease-aware GC remains Phase 8.
 
 ### Required tests
@@ -513,8 +513,8 @@ broader remote-adapter work.
 - acknowledged writes survive process reopen under the configured durability;
 - copying or recovering SQLite accounts for WAL state;
 - an interrupted database write cannot change the active filesystem
-  generation;
-- an interrupted filesystem switch leaves the prior generation readable;
+  snapshot;
+- an interrupted filesystem switch leaves the prior snapshot readable;
 - published `graph.json` and `store.ref` select equal graph digests;
 - a store database missing or corrupt after publication does not make the
   co-published JSON unreadable;
@@ -531,9 +531,9 @@ broader remote-adapter work.
   separate release gate.
 - `compass init --store sqlite` and `compass update --store sqlite` CLI
   integration tests assert successful exit, `graph.json`, `store.ref`,
-  complete manifest, and no visible partial generation.
+  complete manifest, and no visible partial snapshot.
 - Cross-engine comparison covers the published core fixture and CLI init/update
-  generations and rejects publication on any canonical mismatch.
+  snapshots and rejects publication on any canonical mismatch.
 - The permanent `graph.json` engine remains independently readable when the
   store is missing or corrupt. Default queries use the validated sidecar when
   present and fail closed when a published reference is corrupt; explicit
@@ -544,7 +544,7 @@ broader remote-adapter work.
 ### Exit and rollback
 
 Disable SQLite publication and remove unpublished databases. Existing
-`graph.json` generations remain valid. Do not attempt to repair a partially
+`graph.json` snapshots remain valid. Do not attempt to repair a partially
 published store by rewriting its immutable objects; rebuild a new snapshot.
 
 ## Phase 4: Route local queries to the store engine (implemented local slice)
@@ -561,7 +561,7 @@ default or whenever the caller explicitly selects it.
 
 ### Prerequisite inputs
 
-- Phase 3 has qualification evidence from real local build generations.
+- Phase 3 has qualification evidence from real local build snapshots.
 - Every current query family is already behind the Phase 1 graph read contract.
 
 ### Owned surfaces
@@ -575,7 +575,7 @@ default or whenever the caller explicitly selects it.
 
 1. Define deterministic engine selection:
    - explicit JSON path selects `JsonGraphEngine`;
-   - a validated active generation with a valid `store.ref` selects
+   - a validated active snapshot with a valid `store.ref` selects
      `StoreGraphEngine` by default;
    - an explicit `--engine json|store` diagnostic option may override the
      default where the command surface review approves it.
@@ -587,7 +587,7 @@ default or whenever the caller explicitly selects it.
    only as a disposable, differential-tested accelerator.
 5. Make corruption and unavailability actionable. An automatic switch to JSON
    is permitted only before results are emitted, only when the selected local
-   generation proves digest equivalence, and only with an explicit diagnostic.
+   snapshot proves digest equivalence, and only with an explicit diagnostic.
 6. Remove assumptions that opening a current graph loads every node and edge.
 7. Add engine identity to safe diagnostics and telemetry, not to public result
    meaning.
@@ -596,7 +596,7 @@ default or whenever the caller explicitly selects it.
 9. Define a typed storage/materialization profile at the application boundary:
    `json`, `store`, or `dual`. Preserve the existing output profile by default;
    expose `store` only through a separately reviewed CLI/configuration change.
-   Store-only generations must support bounded deterministic JSON export.
+   Store-only snapshots must support bounded deterministic JSON export.
 
 The shipped local slice implements items 1–8 for typed code queries and the
 dual local profile. It pins opened readers, uses backend-neutral candidate
@@ -622,7 +622,7 @@ separately gated.
   immutable snapshot; and
 - accelerator deletion changes latency only, not ordered results;
 - `json` publishes the existing artifact set without requiring a database;
-- `dual` publishes equal JSON and store snapshots in one generation; and
+- `dual` publishes equal JSON and store snapshots in one snapshot; and
 - `store` avoids full JSON materialization but can export byte-identical
   canonical JSON on demand.
 
@@ -649,7 +649,7 @@ storage profiles remain follow-on gates. Typed projected-query and
 ### Exit and rollback
 
 Engine selection can return to JSON without converting data because each local
-generation still contains it. Keep store databases as disposable/unselected or
+snapshot still contains it. Keep store databases as disposable/unselected or
 rebuild them. A rollback must not remove the graph read abstraction.
 
 ## Phase 5: Add the redb embedded adapter (implemented local slice)
@@ -1038,7 +1038,7 @@ The local release work closes the first support window without claiming cloud
 readiness:
 
 - `compass store status|validate|backup|restore` validates the co-published
-  SQLite generation and writes digest-bound backup bundles;
+  SQLite snapshot and writes digest-bound backup bundles;
 - `scripts/rebuild_compass_store.sh` provides an explicit, rollback-preserving
   hard-cut rebuild path;
 - `compass-store-qualification` and
@@ -1132,7 +1132,7 @@ other way.
 The program is complete only when a reviewer can demonstrate this sequence
 without inspecting backend internals:
 
-1. build one graph and publish a coherent JSON plus store generation;
+1. build one graph and publish a coherent JSON plus store snapshot;
 2. query both engines and obtain equal ordered outputs;
 3. interrupt an update at each publication boundary and retain the old graph;
 4. complete an update and keep an already-open reader on its old snapshot;

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -39,8 +39,8 @@ structural graph by default; pass `--program` when the initial workspace also
 needs Program IR.
 The initial build publishes JSON and a SQLite query snapshot by default. Pass
 `--store json` when only the portable JSON artifact is wanted. The database
-lives below the output root at `.compass-store/compass-store.sqlite3`; the
-generation contains only the small reference beside `graph.json`.
+lives below the output root at `store/store.sqlite3`; the
+snapshot contains only the small reference beside `graph.json`.
 
 ### `update`
 
@@ -483,7 +483,9 @@ compass cache-check FILES_FROM
 ```
 
 Checks whether cached semantic results can be reused for a file list, root,
-mode, and prompt contract.
+mode, and prompt contract. Results are written visibly below the selected
+output root as `cached.json` (when hits exist) and
+`uncached.txt`.
 
 ### `merge-chunks`
 
@@ -702,8 +704,8 @@ compass store restore --from BACKUP_DIR --into OUTPUT [--format text|json]
 
 `status` is read-only and reports graph, shared SQLite store, selector, schema,
 and digest state. `validate` requires a matching
-`.compass-store/compass-store.sqlite3`, active snapshot, and generation
-`store.ref`; a mismatch is an error, never an empty graph.
+`store/store.sqlite3`, the current snapshot, and that snapshot's `store.ref`;
+a mismatch is an error, never an empty graph.
 `backup` creates a new digest-bound directory after checkpointing SQLite.
 `restore` validates that bundle and writes only to a new or empty destination.
 The commands currently operate on the local SQLite adapter. The redb adapter is

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,9 +46,11 @@ Do not point two concurrent writers at one output directory.
 
 Successful builds materialize `graph.json`, `manifest.json`,
 `GRAPH_REPORT.md`, and optional `graph.html` directly under this root. These
-stable paths are the portable integration surface. Hidden generations, store
-references, and the encoding beneath `cache/` remain Compass-owned operational
-state and should be kept opaque.
+stable paths are the portable integration surface. Visible snapshot
+directories, store references, and the encoding beneath `cache/` remain
+Compass-owned operational state. Their visible names disclose what Compass
+created; consumers should still use documented commands and stable root
+artifacts instead of parsing implementation files directly.
 
 ## Compass Store configuration
 
@@ -57,8 +59,8 @@ query storage is enabled by default; passing `--store json` opts out. A SQLite
 build additionally publishes:
 
 ```text
-DIR/.compass-store/compass-store.sqlite3
-DIR/.compass-generations/<active>/store.ref
+DIR/store/store.sqlite3
+DIR/snapshots/<active>/store.ref
 ```
 
 `DIR` is `compass-out/` by default and can be set with `--out DIR` or the
@@ -72,15 +74,15 @@ service adapters, so no endpoint, credential, TLS, or cloud SDK configuration
 is read by local store commands.
 
 SQLite uses one shared local WAL-backed file and checkpoints it before
-publication and backup; complete generations are not database copies. Do not
+publication and backup; complete snapshots are not database copies. Do not
 run two writers against one output root. JSON query indexes beneath the cache
 root are disposable and may be deleted; the output root, including the shared
-database and generation references, must be kept together. Use
+database and snapshot references, must be kept together. Use
 `compass store status|validate` for
 health, `compass store backup` for a digest-bound copy, and `compass store
 restore` into a new directory for recovery. The store API enforces bounded
 namespace, partition, key, value, transaction, scan, and graph sizes. Local
-publication retains and collects two complete generations; distributed leases
+publication retains and collects two complete snapshots; distributed leases
 and hosted quotas are deferred. Local disk availability remains an operational
 limit. See the [operations guide](../guides/operations.md)
 for the support window and rebuild procedure.

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -17,40 +17,59 @@ compass-out/
 ├── program.json                 # only with --program or --program-artifact
 ├── graph-overview.json          # clustered builds
 ├── cache/                       # Compass-owned disposable cache layout
-├── .compass-active-generation
-├── .compass-generations/<active>/
+├── current-snapshot
+├── snapshots/<current>/
 │   ├── graph.json
 │   ├── graph.html, report, manifest, and optional public artifacts
-│   └── store.ref                # with the default SQLite query index
-├── .compass-store/
-│   └── compass-store.sqlite3   # with the default SQLite query index
-└── optional sidecars and exports
+│   ├── store.ref                # with the default SQLite query index
+│   ├── build-state.json
+│   ├── output-stats.json
+│   ├── ast-fact-digests.json
+│   ├── analysis.json and labels.json  # clustered builds
+│   ├── labels.json.sig     # when label signatures are available
+│   ├── semantic-marker.json # semantic builds and history exports
+│   ├── learning.json       # learned reflection overlay, when present
+│   ├── cache/              # operation-specific disposable graph caches
+│   │   ├── graph.json.query-v1.cache
+│   │   ├── graph.json.affected-v1.cache
+│   │   ├── graph.json.traversal-v1.cache
+│   │   └── graph.json.<digest>.content-v1.cache
+│   └── source-root.txt
+├── store/
+│   └── store.sqlite3   # with the default SQLite query index
+├── root-artifacts-complete
+├── cached.json             # cache-check hits, when any
+├── uncached.txt            # cache-check misses
+├── obsidian/sync-manifest.json # when exporting an Obsidian vault
+└── source-inventory.json   # versioned-history export, when requested
 ```
 
 `--out DIR` or compatible `COMPASS_OUT` use can select another root.
 
 The ordinary files at the root are a stable, flat consumer façade. Compass
-publishes its immutable generation first, then materializes each root file by
+publishes its immutable snapshot first, then materializes each root file by
 atomic replacement; a completion marker makes an interrupted façade update
 self-repair on the next build. Compass-aware readers continue to resolve the
-active generation, while browsers, scripts, archive tools, and integrations
+current snapshot, while browsers, scripts, archive tools, and integrations
 can use literal paths such as `compass-out/graph.json` and
 `compass-out/graph.html`. Consumers that need a related set should read it only
 after the producing Compass command returns successfully.
 
-The `cache/` directory is already rooted beside these files for familiar
-incremental-build ergonomics, but its contents and encoding are private to
-Compass. Do not copy another product's cache or manifest into it. Future
-Compass storage and cache revisions can evolve independently without changing
-the flat public artifact paths.
+The output root already establishes Compass ownership, so entries beneath it
+use concise purpose-based names without repeating a `compass-` prefix. The
+`cache/` directory is rooted beside these files for familiar incremental-build
+ergonomics, but its contents and encoding are private to Compass. Do not copy
+another product's cache or manifest into it. Future storage and cache
+revisions can evolve independently without changing the flat public artifact
+paths.
 
 ## Authority table
 
 | Artifact | Authority | Consumer use |
 | --- | --- | --- |
 | `graph.json` | machine-readable graph snapshot | queries, integrations, export |
-| `.compass-store/compass-store.sqlite3` | bounded shared namespace/partition/key query index | default large-graph queries and explicit store-engine queries |
-| active generation `store.ref` | typed selector for the co-published store identity and snapshot | store-engine validation before query execution |
+| `store/store.sqlite3` | bounded shared namespace/partition/key query index | default large-graph queries and explicit store-engine queries |
+| current snapshot `store.ref` | typed selector for the co-published store identity and snapshot | store-engine validation before query execution |
 | `program.json` (optional) | provenance-aware Program IR | program inspection, semantic analysis |
 | `GRAPH_REPORT.md` | derived human orientation | architecture survey |
 | `graph.html` | derived optional visualization | interactive exploration |
@@ -60,11 +79,11 @@ the flat public artifact paths.
 
 Do not reconstruct graph truth from HTML when JSON is available.
 
-`.compass-store/compass-store.sqlite3` is the default local SQLite realization
-shared by retained graph generations. It is addressed through the `compass-store`
+`store/store.sqlite3` is the default local SQLite realization
+shared by retained graph snapshots. It is addressed through the `compass-store`
 namespace/partition/key contract and is not a public SQL schema. The file is
-not copied into a published generation; a new build writes immutable content,
-checkpoints it, and publishes a digest-bound generation reference. `graph.json`
+not copied into a published snapshot; a new build writes immutable content,
+checkpoints it, and publishes a digest-bound snapshot reference. `graph.json`
 remains the complete portable graph engine. Pass `--store json` during a build
 to omit the sidecar; `--engine json` forces the portable reader, while the
 default query engine uses the sidecar when it is present and fails closed if
@@ -161,7 +180,7 @@ The first three provide bounded examples. The summary contains exact omitted
 node, omitted edge, identity-collision, and capped-example counts. At most 100
 examples of each record category are stored.
 
-The private `.compass_output_stats.json` and sealed build state retain the same
+The Compass-owned `output-stats.json` and sealed build state retain the same
 counts so no-op and watch results preserve the partial status. They are
 operational state, not an alternative graph schema. Consumers should use graph
 diagnostics or typed query `incomplete_coverage` diagnostics.
@@ -497,7 +516,7 @@ with the publisher statistics and overview sidecars.
 
 For graphs larger than the default bounded in-memory reader cap, the command
 returns `quality_scope: "publisher-stats-only"`: counts and omission metadata
-come from `.compass_output_stats.json`, while record-level ratios are reported
+come from `output-stats.json`, while record-level ratios are reported
 as unavailable. This is an explicit safety boundary; use a prepared store or a
 bounded investigation with `COMPASS_MAX_GRAPH_BYTES` rather than silently
 allocating an unbounded JSON graph.

--- a/editors/vscode/src/views/graphSnapshot.test.ts
+++ b/editors/vscode/src/views/graphSnapshot.test.ts
@@ -13,21 +13,21 @@ afterEach(async () => {
 });
 
 describe("CurrentGraphSnapshot", () => {
-  it("keeps overview and details on one immutable generation and cleans replacements", async () => {
+  it("keeps overview and details on one immutable snapshot and cleans replacements", async () => {
     const source = await mkdtemp(path.join(tmpdir(), "compass-graph-source-test-"));
     temporaryDirectories.push(source);
     const sourceGraph = path.join(source, "graph.json");
-    await writeFile(sourceGraph, "generation-one");
-    await writeFile(path.join(source, ".compass_analysis.json"), "analysis-one");
+    await writeFile(sourceGraph, "snapshot-one");
+    await writeFile(path.join(source, "analysis.json"), "analysis-one");
 
     const snapshot = new CurrentGraphSnapshot();
     const first = await snapshot.replace(sourceGraph);
-    await writeFile(sourceGraph, "generation-two");
-    expect(await readFile(first, "utf8")).toBe("generation-one");
+    await writeFile(sourceGraph, "snapshot-two");
+    expect(await readFile(first, "utf8")).toBe("snapshot-one");
 
     const second = await snapshot.replace(sourceGraph);
     await expect(access(first)).rejects.toThrow();
-    expect(await readFile(second, "utf8")).toBe("generation-two");
+    expect(await readFile(second, "utf8")).toBe("snapshot-two");
 
     await snapshot.dispose();
     await expect(access(second)).rejects.toThrow();

--- a/editors/vscode/src/views/graphSnapshot.ts
+++ b/editors/vscode/src/views/graphSnapshot.ts
@@ -20,12 +20,12 @@ export class CurrentGraphSnapshot {
       const sourceDirectory = path.dirname(sourceGraphPath);
       await Promise.all([
         this.copyOptional(
-          path.join(sourceDirectory, ".compass_analysis.json"),
-          path.join(directory, ".compass_analysis.json")
+          path.join(sourceDirectory, "analysis.json"),
+          path.join(directory, "analysis.json")
         ),
         this.copyOptional(
-          path.join(sourceDirectory, ".compass_labels.json"),
-          path.join(directory, ".compass_labels.json")
+          path.join(sourceDirectory, "labels.json"),
+          path.join(directory, "labels.json")
         )
       ]);
     } catch (error) {

--- a/editors/vscode/src/workspace/repositorySession.test.ts
+++ b/editors/vscode/src/workspace/repositorySession.test.ts
@@ -13,38 +13,38 @@ afterEach(async () => {
 });
 
 describe("resolvePublishedArtifact", () => {
-  it("falls back to the legacy root when no generation is published", async () => {
+  it("requires a published snapshot", async () => {
     const output = await fixture();
-    expect(resolvePublishedArtifact(output, "graph.json")).toBe(path.join(output, "graph.json"));
+    expect(() => resolvePublishedArtifact(output, "graph.json")).toThrow(/current snapshot/i);
   });
 
-  it("follows the sealed active generation", async () => {
+  it("follows the sealed active snapshot", async () => {
     const output = await fixture();
-    const generation = "generation-123";
-    await mkdir(path.join(output, ".compass-generations", generation), { recursive: true });
-    await writeFile(path.join(output, ".compass-active-generation"), generation);
+    const snapshot = "snapshot-123";
+    await mkdir(path.join(output, "snapshots", snapshot), { recursive: true });
+    await writeFile(path.join(output, "current-snapshot"), snapshot);
 
     expect(resolvePublishedArtifact(output, "graph.json")).toBe(
-      path.join(output, ".compass-generations", generation, "graph.json")
+      path.join(output, "snapshots", snapshot, "graph.json")
     );
   });
 
-  it("rejects malformed and incomplete generation pointers", async () => {
+  it("rejects malformed and incomplete snapshot pointers", async () => {
     const output = await fixture();
-    const generation = "generation-456";
-    const active = path.join(output, ".compass-generations", generation);
+    const snapshot = "snapshot-456";
+    const active = path.join(output, "snapshots", snapshot);
     await mkdir(active, { recursive: true });
-    await writeFile(path.join(active, ".compass-build-incomplete"), "1");
-    await writeFile(path.join(output, ".compass-active-generation"), generation);
+    await writeFile(path.join(active, "build-incomplete"), "1");
+    await writeFile(path.join(output, "current-snapshot"), snapshot);
     expect(() => resolvePublishedArtifact(output, "graph.json")).toThrow(/incomplete/i);
 
-    await writeFile(path.join(output, ".compass-active-generation"), "../escape");
+    await writeFile(path.join(output, "current-snapshot"), "../escape");
     expect(() => resolvePublishedArtifact(output, "graph.json")).toThrow(/invalid/i);
   });
 });
 
 async function fixture(): Promise<string> {
-  const directory = await mkdtemp(path.join(tmpdir(), "compass-vscode-generation-"));
+  const directory = await mkdtemp(path.join(tmpdir(), "compass-vscode-snapshot-"));
   directories.push(directory);
   const output = path.join(directory, "compass-out");
   await mkdir(output);

--- a/editors/vscode/src/workspace/repositorySession.ts
+++ b/editors/vscode/src/workspace/repositorySession.ts
@@ -28,19 +28,20 @@ export class RepositorySession {
 }
 
 export function resolvePublishedArtifact(outputDirectory: string, artifact: string): string {
-  const legacy = path.join(outputDirectory, artifact);
-  const pointer = path.join(outputDirectory, ".compass-active-generation");
-  if (!existsSync(pointer)) return legacy;
-  const generation = readFileSync(pointer, "utf8").trim();
-  if (!/^generation-[^/\\]+$/.test(generation)) {
-    throw new Error(`Invalid Compass active generation pointer: ${pointer}`);
+  const pointer = path.join(outputDirectory, "current-snapshot");
+  if (!existsSync(pointer)) {
+    throw new Error(`Missing Compass current snapshot pointer: ${pointer}`);
   }
-  const active = path.join(outputDirectory, ".compass-generations", generation);
+  const snapshot = readFileSync(pointer, "utf8").trim();
+  if (!/^snapshot-[^/\\]+$/.test(snapshot)) {
+    throw new Error(`Invalid Compass active snapshot pointer: ${pointer}`);
+  }
+  const active = path.join(outputDirectory, "snapshots", snapshot);
   if (!statSync(active).isDirectory()) {
-    throw new Error(`Invalid Compass active generation directory: ${active}`);
+    throw new Error(`Invalid Compass active snapshot directory: ${active}`);
   }
-  if (existsSync(path.join(active, ".compass-build-incomplete"))) {
-    throw new Error(`Incomplete Compass active generation: ${active}`);
+  if (existsSync(path.join(active, "build-incomplete"))) {
+    throw new Error(`Incomplete Compass active snapshot: ${active}`);
   }
   return path.join(active, artifact);
 }

--- a/scripts/qualify_code_graph_v1.sh
+++ b/scripts/qualify_code_graph_v1.sh
@@ -56,13 +56,13 @@ import pathlib
 import sys
 
 output = pathlib.Path(sys.argv[1]) / "compass-out"
-pointer = output / ".compass-active-generation"
-generation = pointer.read_text().strip()
-if not generation.startswith("generation-") or "/" in generation or "\\" in generation:
-    raise SystemExit(f"invalid active generation {generation!r}")
-active = output / ".compass-generations" / generation
-if not active.is_dir() or (active / ".compass-build-incomplete").exists():
-    raise SystemExit(f"incomplete active generation {active}")
+pointer = output / "current-snapshot"
+snapshot = pointer.read_text().strip()
+if not snapshot.startswith("snapshot-") or "/" in snapshot or "\\" in snapshot:
+    raise SystemExit(f"invalid active snapshot {snapshot!r}")
+active = output / "snapshots" / snapshot
+if not active.is_dir() or (active / "build-incomplete").exists():
+    raise SystemExit(f"incomplete active snapshot {active}")
 print(active / "graph.json")
 PY
 }

--- a/scripts/rebuild_compass_store.sh
+++ b/scripts/rebuild_compass_store.sh
@@ -36,22 +36,22 @@ fi
 mkdir -p "$(dirname -- "$output")"
 output=$(CDPATH= cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")
 
-active_generation=
-active_directory=
-if [ -f "$output/.compass-active-generation" ]; then
-    active_generation=$(tr -d '\r\n' < "$output/.compass-active-generation")
-    case "$active_generation" in
+current_snapshot=
+current_directory=
+if [ -f "$output/current-snapshot" ]; then
+    current_snapshot=$(tr -d '\r\n' < "$output/current-snapshot")
+    case "$current_snapshot" in
         ''|.|..|*/*|*\\*)
-            echo "error: invalid active Compass generation: $active_generation" >&2
+            echo "error: invalid active Compass snapshot: $current_snapshot" >&2
             exit 1
             ;;
     esac
-    active_directory="$output/.compass-generations/$active_generation"
+    current_directory="$output/snapshots/$current_snapshot"
 fi
 
 graph_path="$output/graph.json"
-if [ -n "$active_directory" ]; then
-    graph_path="$active_directory/graph.json"
+if [ -n "$current_directory" ]; then
+    graph_path="$current_directory/graph.json"
 fi
 if [ ! -f "$graph_path" ]; then
     echo "error: graph.json is required before rebuilding the store: $graph_path" >&2
@@ -64,18 +64,18 @@ mkdir -p "$backup"
 moved=0
 restore_on_failure() {
     if [ "$moved" -eq 1 ]; then
-        if [ -d "$output/.compass-store" ] && [ ! -e "$backup/failed-.compass-store" ]; then
-            mv "$output/.compass-store" "$backup/failed-.compass-store"
+        if [ -d "$output/store" ] && [ ! -e "$backup/failed-store" ]; then
+            mv "$output/store" "$backup/failed-store"
         fi
-        if [ -d "$backup/.compass-store" ] && [ ! -e "$output/.compass-store" ]; then
-            mv "$backup/.compass-store" "$output/.compass-store"
+        if [ -d "$backup/store" ] && [ ! -e "$output/store" ]; then
+            mv "$backup/store" "$output/store"
         fi
-        if [ -n "$active_directory" ] && [ -f "$backup/active-store.ref" ] \
-            && [ ! -e "$active_directory/store.ref" ]; then
-            mv "$backup/active-store.ref" "$active_directory/store.ref"
+        if [ -n "$current_directory" ] && [ -f "$backup/active-store.ref" ] \
+            && [ ! -e "$current_directory/store.ref" ]; then
+            mv "$backup/active-store.ref" "$current_directory/store.ref"
         fi
-        for name in compass-store.sqlite3 store.ref compass-store.redb \
-            compass-store.sqlite3-wal compass-store.sqlite3-shm
+        for name in store.sqlite3 store.ref store.redb \
+            store.sqlite3-wal store.sqlite3-shm
         do
             if [ -f "$backup/$name" ] && [ ! -e "$output/$name" ]; then
                 mv "$backup/$name" "$output/$name"
@@ -85,20 +85,20 @@ restore_on_failure() {
 }
 trap restore_on_failure EXIT HUP INT TERM
 
-if [ -d "$output/.compass-store" ]; then
-    mv "$output/.compass-store" "$backup/.compass-store"
+if [ -d "$output/store" ]; then
+    mv "$output/store" "$backup/store"
     moved=1
 fi
-if [ -n "$active_directory" ] && [ -f "$active_directory/store.ref" ]; then
-    printf '%s\n' "$active_generation" > "$backup/active-generation.txt"
-    mv "$active_directory/store.ref" "$backup/active-store.ref"
+if [ -n "$current_directory" ] && [ -f "$current_directory/store.ref" ]; then
+    printf '%s\n' "$current_snapshot" > "$backup/active-snapshot.txt"
+    mv "$current_directory/store.ref" "$backup/active-store.ref"
     moved=1
 fi
 
 # Also preserve pre-shared-layout sidecars so this remains a hard-cut tool for
 # development and pre-release stores.
-for name in compass-store.sqlite3 store.ref compass-store.redb \
-    compass-store.sqlite3-wal compass-store.sqlite3-shm
+for name in store.sqlite3 store.ref store.redb \
+    store.sqlite3-wal store.sqlite3-shm
 do
     if [ -e "$output/$name" ]; then
         mv "$output/$name" "$backup/$name"

--- a/scripts/test_release_scripts.sh
+++ b/scripts/test_release_scripts.sh
@@ -92,7 +92,7 @@ do
 done
 
 if tar -tzf "$test_root/dist-aarch64-apple-darwin/compass-aarch64-apple-darwin.tar.gz" \
-    | grep -Eiq '(^|/)(graph\.json|compass-store\.(sqlite3|redb)|store\.ref|\.compass|credentials|\.env)(/|$|\.)'; then
+    | grep -Eiq '(^|/)(graph\.json|store\.(sqlite3|redb)|store\.ref|\.compass|credentials|\.env)(/|$|\.)'; then
     echo "release archive contains local store state or credentials" >&2
     exit 1
 fi

--- a/scripts/tests/test_store_release.sh
+++ b/scripts/tests/test_store_release.sh
@@ -7,13 +7,13 @@ trap 'rm -rf "$test_root"' EXIT HUP INT TERM
 
 project="$test_root/project"
 output="$project/compass-out"
-old_generation=generation-old
-mkdir -p "$output/.compass-generations/$old_generation" "$output/.compass-store"
-printf '%s\n' "$old_generation" > "$output/.compass-active-generation"
+old_snapshot=snapshot-old
+mkdir -p "$output/snapshots/$old_snapshot" "$output/store"
+printf '%s\n' "$old_snapshot" > "$output/current-snapshot"
 printf '%s\n' '{"graph":{"schema":"compass.graph/1"},"nodes":[],"links":[]}' \
-    > "$output/.compass-generations/$old_generation/graph.json"
-printf 'old-sqlite\n' > "$output/.compass-store/compass-store.sqlite3"
-printf 'old-reference\n' > "$output/.compass-generations/$old_generation/store.ref"
+    > "$output/snapshots/$old_snapshot/graph.json"
+printf 'old-sqlite\n' > "$output/store/store.sqlite3"
+printf 'old-reference\n' > "$output/snapshots/$old_snapshot/store.ref"
 
 cat > "$test_root/fake-compass" <<'EOF'
 #!/bin/sh
@@ -32,32 +32,32 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 test "$store" = sqlite
-new_generation=generation-new
-mkdir -p "$output/.compass-store" "$output/.compass-generations/$new_generation"
-printf 'new-sqlite\n' > "$output/.compass-store/compass-store.sqlite3"
+new_snapshot=snapshot-new
+mkdir -p "$output/store" "$output/snapshots/$new_snapshot"
+printf 'new-sqlite\n' > "$output/store/store.sqlite3"
 printf '%s\n' '{"graph":{"schema":"compass.graph/1"},"nodes":[],"links":[]}' \
-    > "$output/.compass-generations/$new_generation/graph.json"
-printf 'new-reference\n' > "$output/.compass-generations/$new_generation/store.ref"
-printf '%s\n' "$new_generation" > "$output/.compass-active-generation"
+    > "$output/snapshots/$new_snapshot/graph.json"
+printf 'new-reference\n' > "$output/snapshots/$new_snapshot/store.ref"
+printf '%s\n' "$new_snapshot" > "$output/current-snapshot"
 EOF
 chmod +x "$test_root/fake-compass"
 
 FAKE_COMPASS_FAIL=0 sh "$repo_root/scripts/rebuild_compass_store.sh" "$project" --compass "$test_root/fake-compass" > "$test_root/success.txt"
 backup=$(sed -n 's/^previous sidecar backup: //p' "$test_root/success.txt")
 test -n "$backup"
-test "$(cat "$output/.compass-store/compass-store.sqlite3")" = new-sqlite
-test "$(cat "$backup/.compass-store/compass-store.sqlite3")" = old-sqlite
+test "$(cat "$output/store/store.sqlite3")" = new-sqlite
+test "$(cat "$backup/store/store.sqlite3")" = old-sqlite
 test "$(cat "$backup/active-store.ref")" = old-reference
 
-printf 'replacement-sqlite\n' > "$output/.compass-store/compass-store.sqlite3"
+printf 'replacement-sqlite\n' > "$output/store/store.sqlite3"
 printf 'replacement-reference\n' \
-    > "$output/.compass-generations/generation-new/store.ref"
+    > "$output/snapshots/snapshot-new/store.ref"
 if FAKE_COMPASS_FAIL=1 sh "$repo_root/scripts/rebuild_compass_store.sh" \
     "$project" --compass "$test_root/fake-compass" > "$test_root/failure.txt" 2>&1; then
     echo "expected failed rebuild" >&2
     exit 1
 fi
-test "$(cat "$output/.compass-store/compass-store.sqlite3")" = replacement-sqlite
-test "$(cat "$output/.compass-generations/generation-new/store.ref")" = replacement-reference
+test "$(cat "$output/store/store.sqlite3")" = replacement-sqlite
+test "$(cat "$output/snapshots/snapshot-new/store.ref")" = replacement-reference
 
 echo "store release script tests passed"


### PR DESCRIPTION
## Summary

- replace hidden and Compass-prefixed files beneath `compass-out/` with a visible, concise layout
- rename generations to immutable snapshots under `snapshots/snapshot-<id>/`, selected by `current-snapshot`
- move the SQLite query accelerator to `store/store.sqlite3` while retaining history schema v1
- remove legacy layout fallbacks and update CLI, core, MCP, query, history, output, VS Code, scripts, tests, and docs for the hard cutover

## Why

The prior output mixed hidden state, repeated `compass-` prefixes, and generation terminology that obscured which files Compass created and what their lifecycle was. The new layout makes every managed artifact discoverable and uses snapshot terminology for immutable published graph realizations.

## Compatibility impact

This is an intentional hard cutover. Existing `compass-out/` directories must be regenerated; no legacy aliases, migration reader, or root-output fallback remains. The history/store machine schema stays at v1 because artifact locations changed without changing the stored graph/history contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- targeted Compass Files, Model, Store, History, Output, CLI, Core, MCP, PRS, Query, and product-contract tests
- `sh scripts/check_product_boundary.sh`
- `sh scripts/tests/test_store_release.sh`
- benchmark adapter/analyzer Python tests
- `npm run typecheck:js`
- affected VS Code tests
- generated a fresh temporary `compass-out/` and verified it contains no hidden or `compass-`-prefixed child paths

One pre-existing unrelated MCP coverage assertion still expects the text `Traversal: DFS`; the affected MCP library tests pass. A transient VS Code discovery mock timeout passed on exact rerun.
