### PR TITLE
Handle VS Code snapshot refresh failures

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Follow the visible `current-snapshot` and `snapshots/` output protocol without
+  breaking activation for fresh or mixed multi-root workspaces. Missing output
+  remains ready for initialization, while invalid or incomplete snapshots are
+  isolated to the affected repository and expose their failure reason.
 - Keep large repository file trees and selected-path lists inside bounded,
   keyboard-focusable scroll panes during Compass initialization.
 - Replace manual path entry in initialization with a bounded repository tree

--- a/editors/vscode/src/views/treeModel.test.ts
+++ b/editors/vscode/src/views/treeModel.test.ts
@@ -21,7 +21,8 @@ const available: SessionTreeSnapshot = {
   id: "repository-1",
   root: "/work/repo",
   graphState: "available",
-  capabilityError: undefined
+  capabilityError: undefined,
+  graphError: undefined
 };
 
 describe("buildWorkspaceTree", () => {
@@ -97,7 +98,8 @@ describe("buildWorkspaceTree", () => {
   it("offers one targeted retry after a failed graph build", () => {
     const nodes = buildWorkspaceTree(discovery, [{
       ...available,
-      graphState: "failed"
+      graphState: "failed",
+      graphError: "Invalid Compass active snapshot pointer"
     }]);
 
     expect(nodes.map((node) => node.label)).toEqual([
@@ -106,6 +108,7 @@ describe("buildWorkspaceTree", () => {
       "Explore"
     ]);
     expect(nodes[0]?.description).toBe("Build failed");
+    expect(nodes[0]?.tooltip).toContain("Invalid Compass active snapshot pointer");
     expect(nodes[1]?.command).toBe("compass.update");
     expect(commands(nodes).filter((command) => command === "compass.update")).toHaveLength(1);
   });

--- a/editors/vscode/src/views/treeModel.ts
+++ b/editors/vscode/src/views/treeModel.ts
@@ -21,6 +21,7 @@ export type SessionTreeSnapshot = {
   root: string;
   graphState: GraphState;
   capabilityError: string | undefined;
+  graphError: string | undefined;
   activeWriter?: unknown;
   watch?: unknown;
 };
@@ -191,7 +192,9 @@ function repositoryStatusNodes(
     repositoryId: session.id,
     label: path.basename(session.root) || session.root,
     description: graphStateLabel(session.graphState),
-    tooltip: session.root,
+    tooltip: session.graphError
+      ? `${session.root}\n${session.graphError}`
+      : session.root,
     icon: graphStateIcon(session.graphState),
     contextValue: repositoryContextValue(session)
   }));

--- a/editors/vscode/src/workspace/repositorySession.test.ts
+++ b/editors/vscode/src/workspace/repositorySession.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolvePublishedArtifact } from "./repositorySession";
+import { findPublishedArtifact, resolvePublishedArtifact } from "./repositorySession";
 
 const directories: string[] = [];
 
@@ -15,6 +15,7 @@ afterEach(async () => {
 describe("resolvePublishedArtifact", () => {
   it("requires a published snapshot", async () => {
     const output = await fixture();
+    expect(findPublishedArtifact(output, "graph.json")).toBeUndefined();
     expect(() => resolvePublishedArtifact(output, "graph.json")).toThrow(/current snapshot/i);
   });
 

--- a/editors/vscode/src/workspace/repositorySession.ts
+++ b/editors/vscode/src/workspace/repositorySession.ts
@@ -8,6 +8,7 @@ export type GraphState = "available" | "not-materialized" | "building" | "failed
 export class RepositorySession {
   capabilities: CapabilityReport | undefined;
   capabilityError: string | undefined;
+  graphError: string | undefined;
   graphState: GraphState = "not-materialized";
   activeWriter: RunningCommand | undefined;
   watch: RunningCommand | undefined;
@@ -19,19 +20,33 @@ export class RepositorySession {
   ) {}
 
   get graphPath(): string {
-    return resolvePublishedArtifact(path.join(this.root, "compass-out"), "graph.json");
+    const outputDirectory = path.join(this.root, "compass-out");
+    return findPublishedArtifact(outputDirectory, "graph.json")
+      ?? missingSnapshotError(outputDirectory);
   }
 
   get programPath(): string {
-    return resolvePublishedArtifact(path.join(this.root, "compass-out"), "program.json");
+    const outputDirectory = path.join(this.root, "compass-out");
+    return findPublishedArtifact(outputDirectory, "program.json")
+      ?? missingSnapshotError(outputDirectory);
+  }
+
+  findGraphPath(): string | undefined {
+    return findPublishedArtifact(path.join(this.root, "compass-out"), "graph.json");
   }
 }
 
 export function resolvePublishedArtifact(outputDirectory: string, artifact: string): string {
+  return findPublishedArtifact(outputDirectory, artifact)
+    ?? missingSnapshotError(outputDirectory);
+}
+
+export function findPublishedArtifact(
+  outputDirectory: string,
+  artifact: string
+): string | undefined {
   const pointer = path.join(outputDirectory, "current-snapshot");
-  if (!existsSync(pointer)) {
-    throw new Error(`Missing Compass current snapshot pointer: ${pointer}`);
-  }
+  if (!existsSync(pointer)) return undefined;
   const snapshot = readFileSync(pointer, "utf8").trim();
   if (!/^snapshot-[^/\\]+$/.test(snapshot)) {
     throw new Error(`Invalid Compass active snapshot pointer: ${pointer}`);
@@ -44,4 +59,10 @@ export function resolvePublishedArtifact(outputDirectory: string, artifact: stri
     throw new Error(`Incomplete Compass active snapshot: ${active}`);
   }
   return path.join(active, artifact);
+}
+
+function missingSnapshotError(outputDirectory: string): never {
+  throw new Error(
+    `Missing Compass current snapshot pointer: ${path.join(outputDirectory, "current-snapshot")}`
+  );
 }

--- a/editors/vscode/src/workspace/sessionRegistry.test.ts
+++ b/editors/vscode/src/workspace/sessionRegistry.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { refreshedGraphState } from "./sessionRegistry";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { WorkspaceFolder } from "vscode";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CompassProcessManager } from "../cli/processManager";
+import { refreshedGraphState, SessionRegistry } from "./sessionRegistry";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
 
 describe("refreshedGraphState", () => {
   it("gives an active writer precedence over filesystem state", () => {
@@ -17,3 +30,76 @@ describe("refreshedGraphState", () => {
     expect(refreshedGraphState("not-materialized", true, false)).toBe("available");
   });
 });
+
+describe("SessionRegistry.refresh", () => {
+  it("keeps a fresh repository available for initialization", async () => {
+    const root = await fixture();
+    const registry = registryFor(root);
+
+    await expect(registry.refresh()).resolves.toBeUndefined();
+    expect(registry.all()[0]).toMatchObject({
+      graphState: "not-materialized",
+      graphError: undefined
+    });
+  });
+
+  it("refreshes valid and fresh repositories independently", async () => {
+    const ready = await fixture();
+    const fresh = await fixture();
+    await publishGraph(ready, "snapshot-ready");
+    const registry = registryFor(ready, fresh);
+
+    await expect(registry.refresh()).resolves.toBeUndefined();
+    expect(registry.all().map((session) => session.graphState)).toEqual([
+      "available",
+      "not-materialized"
+    ]);
+  });
+
+  it("isolates an invalid pointer and recovers after a valid publication", async () => {
+    const root = await fixture();
+    const output = path.join(root, "compass-out");
+    await mkdir(output);
+    await writeFile(path.join(output, "current-snapshot"), "../escape");
+    const registry = registryFor(root);
+
+    await expect(registry.refresh()).resolves.toBeUndefined();
+    expect(registry.all()[0]).toMatchObject({
+      graphState: "failed",
+      graphError: expect.stringMatching(/invalid/i)
+    });
+
+    await publishGraph(root, "snapshot-recovered");
+    await expect(registry.refresh()).resolves.toBeUndefined();
+    expect(registry.all()[0]).toMatchObject({
+      graphState: "available",
+      graphError: undefined
+    });
+  });
+});
+
+async function fixture(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "compass-vscode-registry-"));
+  directories.push(directory);
+  return directory;
+}
+
+async function publishGraph(root: string, snapshot: string): Promise<void> {
+  const output = path.join(root, "compass-out");
+  const active = path.join(output, "snapshots", snapshot);
+  await mkdir(active, { recursive: true });
+  await writeFile(path.join(active, "graph.json"), "{}");
+  await writeFile(path.join(output, "current-snapshot"), snapshot);
+}
+
+function registryFor(...roots: string[]): SessionRegistry {
+  const folders = roots.map((root, index) => ({
+    index,
+    name: path.basename(root),
+    uri: {
+      fsPath: root,
+      toString: () => `file://${root}`
+    }
+  })) as unknown as WorkspaceFolder[];
+  return new SessionRegistry(folders, {} as CompassProcessManager);
+}

--- a/editors/vscode/src/workspace/sessionRegistry.ts
+++ b/editors/vscode/src/workspace/sessionRegistry.ts
@@ -35,9 +35,20 @@ export class SessionRegistry {
 
   async refresh(): Promise<void> {
     await Promise.all(this.all().map(async (session) => {
+      const recoveringFromResolutionError = session.graphError !== undefined;
+      let materialized = false;
+      try {
+        const graphPath = session.findGraphPath();
+        materialized = graphPath !== undefined && await exists(graphPath);
+        session.graphError = undefined;
+      } catch (error) {
+        session.graphError = message(error);
+        session.graphState = session.activeWriter ? "building" : "failed";
+        return;
+      }
       session.graphState = refreshedGraphState(
-        session.graphState,
-        await exists(session.graphPath),
+        recoveringFromResolutionError ? "not-materialized" : session.graphState,
+        materialized,
         session.activeWriter !== undefined
       );
     }));
@@ -60,4 +71,8 @@ async function exists(file: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }


### PR DESCRIPTION
## Summary

- treat an absent `current-snapshot` as a fresh, not-yet-materialized repository instead of failing extension activation
- isolate malformed, missing-directory, and incomplete snapshot failures to the affected repository in multi-root workspaces
- expose strict snapshot-resolution errors in the repository tooltip and recover automatically after a valid snapshot is published
- add fresh-workspace, mixed multi-root, invalid-pointer, and recovery regression coverage

## Root cause

The new snapshot-aware `graphPath` getter correctly rejected a missing `current-snapshot`, but workspace refresh evaluated that getter before entering its asynchronous file-existence error handling. A fresh repository therefore rejected the entire registry refresh, and one invalid repository could prevent every folder in a multi-root workspace from activating.

## Impact

Fresh repositories remain eligible for Compass initialization. Existing valid snapshots continue to resolve strictly through `current-snapshot` and `snapshots/snapshot-*`. Corrupt or incomplete publications are not mistaken for missing output: they enter a visible failed state without crashing the extension, and a subsequent coherent publication restores availability.

## Validation

- focused repository-session, session-registry, and workspace-tree tests: 16 passed
- VS Code extension tests: 120 passed
- viewer tests: 158 passed
- browser tests: 78 passed
- `npm run typecheck:js`
- `npm run build -w editors/vscode`
- `node scripts/check_viewer_assets.mjs`

The VS Code Electron integration harness was attempted during diagnosis but its downloaded macOS Electron executable was absent (`ENOENT`) before the extension could launch. The failed 924 MB download was removed; unit, build, and browser gates are unaffected.
