### PR TITLE
Release Compass 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.6 - 2026-08-06
+
 - Simplify every Compass-owned current-output path beneath `compass-out/`.
   Immutable build snapshots now live under `snapshots/`, the selector is
   `current-snapshot`, the SQLite query index is under
@@ -27,6 +29,10 @@
 
 - Keep the initialization repository tree and selected-path ledger inside
   bounded, independently scrollable panes so large file lists remain usable.
+
+- Keep VS Code activation resilient across fresh and mixed multi-root
+  workspaces by distinguishing missing current snapshots from
+  invalid/incomplete snapshots and surfacing repository-scoped refresh errors.
 
 ## 0.3.5 - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "regex",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "axum",
  "compass-core",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "base64",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,29 +35,29 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.5" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.5" }
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-program = { path = "../compass-program", version = "0.3.5" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.5" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.5" }
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.5" }
-compass-global = { path = "../compass-global", version = "0.3.5" }
-compass-history = { path = "../compass-history", version = "0.3.5" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.5" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.5" }
-compass-output = { path = "../compass-output", version = "0.3.5" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.5" }
-compass-prs = { path = "../compass-prs", version = "0.3.5" }
-compass-query = { path = "../compass-query", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.5" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.5" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.5" }
+compass-core = { path = "../compass-core", version = "0.3.6" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.6" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-program = { path = "../compass-program", version = "0.3.6" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.6" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.6" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.6" }
+compass-global = { path = "../compass-global", version = "0.3.6" }
+compass-history = { path = "../compass-history", version = "0.3.6" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.6" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.6" }
+compass-output = { path = "../compass-output", version = "0.3.6" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.6" }
+compass-prs = { path = "../compass-prs", version = "0.3.6" }
+compass-query = { path = "../compass-query", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.6" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.6" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.6" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.5" }
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-program = { path = "../compass-program", version = "0.3.5" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.6" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-program = { path = "../compass-program", version = "0.3.6" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,16 +24,16 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.5" }
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-history = { path = "../compass-history", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5" }
-compass-output = { path = "../compass-output", version = "0.3.5" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.5" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.6" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-history = { path = "../compass-history", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
+compass-output = { path = "../compass-output", version = "0.3.6" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.6" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.6" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.5" }
+compass-media = { path = "../compass-media", version = "0.3.6" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.5" }
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.6" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-program = { path = "../compass-program", version = "0.3.5" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-program = { path = "../compass-program", version = "0.3.6" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,12 +19,12 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.5" }
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-prs = { path = "../compass-prs", version = "0.3.5" }
-compass-query = { path = "../compass-query", version = "0.3.5" }
+compass-core = { path = "../compass-core", version = "0.3.6" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-prs = { path = "../compass-prs", version = "0.3.6" }
+compass-query = { path = "../compass-query", version = "0.3.6" }
 
 [dev-dependencies]
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,12 +20,12 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-history = { path = "../compass-history", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-query = { path = "../compass-query", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-history = { path = "../compass-history", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-query = { path = "../compass-query", version = "0.3.6" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -16,8 +16,8 @@ regex.workspace = true
 serde_json.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-files = { path = "../compass-files", version = "0.3.5" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -18,12 +18,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.5" }
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.6" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -31,9 +31,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.5" }
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.5" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.6" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.6" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-program = { path = "../compass-program", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-program = { path = "../compass-program", version = "0.3.6" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.5" }
-compass-history = { path = "../compass-history", version = "0.3.5" }
-compass-ir = { path = "../compass-ir", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.6" }
+compass-history = { path = "../compass-history", version = "0.3.6" }
+compass-ir = { path = "../compass-ir", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.5" }
-compass-program = { path = "../compass-program", version = "0.3.5" }
+compass-languages = { path = "../compass-languages", version = "0.3.6" }
+compass-program = { path = "../compass-program", version = "0.3.6" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.5" }
-compass-media = { path = "../compass-media", version = "0.3.5" }
+compass-files = { path = "../compass-files", version = "0.3.6" }
+compass-media = { path = "../compass-media", version = "0.3.6" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.5" }
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-query = { path = "../compass-query", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.5" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.6" }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-query = { path = "../compass-query", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.6" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.5" }
+compass-store = { path = "../compass-store", version = "0.3.6" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.5" }
-compass-model = { path = "../compass-model", version = "0.3.5" }
-compass-store = { path = "../compass-store", version = "0.3.5", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.6" }
+compass-model = { path = "../compass-model", version = "0.3.6" }
+compass-store = { path = "../compass-store", version = "0.3.6", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.5", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.5", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.6", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.6", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "regex",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "axum",
  "compass-core",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "base64",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-cypher",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.5", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.5", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.5", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.5", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.5", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.5", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.5", path = "../crates/compass-output" }
-compass-query = { version = "0.3.5", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.5", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.5", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.6", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.6", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.6", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.6", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.6", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.6", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.6", path = "../crates/compass-output" }
+compass-query = { version = "0.3.6", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.6", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.6", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1686,7 +1686,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.5"
+    "producerVersion": "compass-languages/0.3.6"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- Bump the Compass Rust workspace and internal package constraints from 0.3.5 to 0.3.6, including both lockfiles and the code-graph qualification producer identity.
- Carry forward the latest origin/main changes for visible snapshot output, paginated query/explain output, selectable graph layouts, scrollable initialization, and resilient VS Code snapshot refresh.
- Record the 0.3.6 release notes and keep the VS Code/package-lock metadata aligned at 0.3.6.

## Validation

- cargo check --workspace --all-targets --locked
- cargo check --manifest-path fuzz/Cargo.toml --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked
- cargo test -p compass-cli --test compass_product --locked
- ./scripts/qualify_code_graph_v1.sh --fixtures-only
- sh scripts/check_product_boundary.sh
- sh scripts/test_release_scripts.sh
- npm run typecheck:js
- node scripts/check_viewer_assets.mjs
- npm run test:js

The release workflow will build and publish macOS, Linux, and Windows archives after the `compass-v0.3.6` tag is created.