### PR TITLE
Optimize TypeScript code graph performance

### DIFF
--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -80,6 +80,7 @@ use crate::raw_guard::enforce_incomplete_raw_guard;
 pub const DEFAULT_MAX_SOURCE_BYTES: u64 = 16 * 1024 * 1024;
 const SEMANTIC_MARKER_FILE: &str = "semantic-marker.json";
 const PIPELINE_RAYON_WORKER_CAP: usize = 12;
+const PARALLEL_AST_FACT_DIGEST_MIN_FILES: usize = 32;
 const STORE_SNAPSHOT_EXCLUSIONS: [&str; 3] =
     [STORE_FILE_NAME, "store.sqlite3-wal", "store.sqlite3-shm"];
 const ROOT_ARTIFACTS: [&str; 6] = [
@@ -839,7 +840,7 @@ impl<'a> FactDigestEvidenceContext<'a> {
                     continue;
                 };
                 let next = format!("{base}|parent={parent}");
-                if base != &next {
+                if previous.get(scope.id.as_str()) != Some(&next) {
                     changed = true;
                 }
                 scope_keys.insert(scope.id.as_str(), next);
@@ -1374,7 +1375,7 @@ fn ast_fact_digest_entries(
         })?;
         Ok((relative_fact_path(path, root), digest))
     };
-    let entries = if paths.len() < 256 {
+    let entries = if !should_parallel_ast_fact_digest(paths.len()) {
         paths
             .iter()
             .zip(extractions)
@@ -1391,6 +1392,10 @@ fn ast_fact_digest_entries(
     // build the deterministic contract map sequentially so a malformed fact
     // set reports the same first failure regardless of worker scheduling.
     entries.into_iter().collect()
+}
+
+const fn should_parallel_ast_fact_digest(files: usize) -> bool {
+    files >= PARALLEL_AST_FACT_DIGEST_MIN_FILES
 }
 
 fn detected_file_sets_match(manifest: &Manifest, files: &BTreeMap<String, Vec<String>>) -> bool {
@@ -4299,12 +4304,22 @@ fn commit_snapshot(
             .store_write_transactions
             .saturating_add(gc.delete_transactions);
     }
+    let commit_started = Instant::now();
     if presealed_artifacts && !publish_store {
         guard.commit_with_presealed_artifacts(&artifacts)?;
     } else {
         guard.commit_with_artifacts(&artifacts)?;
     }
+    profile_internal_duration(
+        "snapshot seal and pointer publication",
+        commit_started.elapsed(),
+    );
+    let root_projection_started = Instant::now();
     BuildGuard::publish_root_artifacts(output_container, &ROOT_ARTIFACTS, root_artifacts_changed)?;
+    profile_internal_duration(
+        "root artifact projection",
+        root_projection_started.elapsed(),
+    );
     Ok(BuildGuard::resolve_current_snapshot_directory(
         output_container,
     )?)
@@ -7098,6 +7113,17 @@ mod tests {
             Some("src/module_299.py")
         );
         Ok(())
+    }
+
+    #[test]
+    fn ast_fact_digests_parallelize_at_the_cold_extraction_crossover() {
+        assert!(!should_parallel_ast_fact_digest(
+            PARALLEL_AST_FACT_DIGEST_MIN_FILES - 1
+        ));
+        assert!(should_parallel_ast_fact_digest(
+            PARALLEL_AST_FACT_DIGEST_MIN_FILES
+        ));
+        assert!(should_parallel_ast_fact_digest(246));
     }
 
     #[cfg(unix)]

--- a/crates/compass-files/src/atomic.rs
+++ b/crates/compass-files/src/atomic.rs
@@ -1,4 +1,6 @@
 use std::fs::{self, File, OpenOptions};
+#[cfg(target_vendor = "apple")]
+use std::io::Read;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -35,6 +37,23 @@ fn temporary_path(destination: &Path) -> PathBuf {
         .and_then(|value| value.to_str())
         .unwrap_or("compass");
     destination.with_file_name(format!(".{name}.{pid}.{sequence}.tmp"))
+}
+
+#[cfg(target_vendor = "apple")]
+fn unpredictable_temporary_path(destination: &Path) -> Result<PathBuf, FileError> {
+    let mut nonce = [0_u8; 16];
+    File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(&mut nonce))
+        .map_err(|error| io_error(destination, error))?;
+    let pid = std::process::id();
+    let name = destination
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("compass");
+    Ok(destination.with_file_name(format!(
+        ".{name}.{pid}.{:032x}.tmp",
+        u128::from_ne_bytes(nonce)
+    )))
 }
 
 fn atomic_replace<F>(path: &Path, write: F) -> Result<(), FileError>
@@ -80,6 +99,79 @@ where
 
         #[cfg(not(windows))]
         fs::rename(&temporary, &destination).map_err(|source| io_error(&destination, source))?;
+
+        sync_directory(parent)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+/// Atomically copy an existing file using the platform's native copy path.
+///
+/// Native copies can use copy-on-write clones or in-kernel copying while the
+/// temporary-file, sync, and rename sequence preserves the same publication
+/// guarantees as the streaming atomic writers.
+pub(crate) fn copy_file_atomic(source: &Path, path: &Path) -> Result<(), FileError> {
+    let destination = resolved_destination(path);
+    let parent = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|error| io_error(parent, error))?;
+    #[cfg(target_vendor = "apple")]
+    let temporary = {
+        // Keep the destination absent so `fs::copy` can use clonefile on
+        // APFS. An OS-random name prevents another process from predicting
+        // and replacing the path before clonefile creates it.
+        unpredictable_temporary_path(&destination)?
+    };
+    #[cfg(not(target_vendor = "apple"))]
+    let temporary = {
+        let temporary = temporary_path(&destination);
+        OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+            .map_err(|error| io_error(&temporary, error))?;
+        temporary
+    };
+
+    let result = (|| {
+        let expected_bytes = fs::metadata(source)
+            .map_err(|error| io_error(source, error))?
+            .len();
+        let copied_bytes =
+            fs::copy(source, &temporary).map_err(|error| io_error(&temporary, error))?;
+        if copied_bytes != expected_bytes {
+            return Err(io_error(
+                &temporary,
+                std::io::Error::other(format!(
+                    "native copy wrote {copied_bytes} bytes; expected {expected_bytes}"
+                )),
+            ));
+        }
+        if let Ok(metadata) = fs::metadata(&destination) {
+            fs::set_permissions(&temporary, metadata.permissions())
+                .map_err(|error| io_error(&temporary, error))?;
+        }
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&temporary)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| io_error(&temporary, error))?;
+
+        #[cfg(windows)]
+        {
+            replace_atomic_windows(&temporary, &destination)
+                .map_err(|error| io_error(&destination, error))?;
+        }
+
+        #[cfg(not(windows))]
+        fs::rename(&temporary, &destination).map_err(|error| io_error(&destination, error))?;
 
         sync_directory(parent)
     })();

--- a/crates/compass-files/src/build_guard.rs
+++ b/crates/compass-files/src/build_guard.rs
@@ -1,11 +1,10 @@
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufReader};
+use std::fs::{self, OpenOptions};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::atomic::sync_directory;
-use crate::{FileError, io_error, write_atomic_with, write_text_atomic};
+use crate::atomic::{copy_file_atomic, sync_directory};
+use crate::{FileError, io_error, write_text_atomic};
 
 const SNAPSHOTS_DIRECTORY: &str = "snapshots";
 const CURRENT_SNAPSHOT: &str = "current-snapshot";
@@ -221,14 +220,25 @@ impl BuildGuard {
         artifacts: &[&str],
         refresh: bool,
     ) -> Result<(), FileError> {
+        let resolve_started = Instant::now();
         validate_exclusions(artifacts)?;
         let active = Self::resolve_current_snapshot_directory(output_directory)?;
+        profile_internal_duration(
+            "root projection resolve active snapshot",
+            resolve_started.elapsed(),
+        );
 
         let completion_marker = output_directory.join(ROOT_ARTIFACTS_COMPLETE);
         let repair_all = refresh || !completion_marker.is_file();
+        let marker_started = Instant::now();
         remove_file_if_exists(&completion_marker)?;
+        profile_internal_duration(
+            "root projection remove completion marker",
+            marker_started.elapsed(),
+        );
 
         for artifact in artifacts {
+            let artifact_started = Instant::now();
             let source = active.join(artifact);
             let destination = output_directory.join(artifact);
             if source.is_file() {
@@ -238,13 +248,23 @@ impl BuildGuard {
             } else {
                 remove_file_if_exists(&destination)?;
             }
+            profile_internal_duration(
+                &format!("root projection artifact {artifact}"),
+                artifact_started.elapsed(),
+            );
         }
 
         let snapshot = active
             .file_name()
             .ok_or_else(|| FileError::InvalidSnapshotArtifact(active.clone()))?
             .to_string_lossy();
-        write_text_atomic(completion_marker, &snapshot)
+        let completion_started = Instant::now();
+        write_text_atomic(completion_marker, &snapshot)?;
+        profile_internal_duration(
+            "root projection publish completion marker",
+            completion_started.elapsed(),
+        );
+        Ok(())
     }
 
     pub fn commit(self) -> Result<(), FileError> {
@@ -306,14 +326,10 @@ impl BuildGuard {
     }
 }
 
-fn copy_file_atomic(source: &Path, destination: &Path) -> Result<(), FileError> {
-    let file = File::open(source).map_err(|error| io_error(source, error))?;
-    let mut reader = BufReader::new(file);
-    write_atomic_with(destination, |writer| {
-        io::copy(&mut reader, writer)
-            .map(|_| ())
-            .map_err(|error| io_error(source, error))
-    })
+fn profile_internal_duration(label: &str, elapsed: Duration) {
+    if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
+        eprintln!("[compass internal] {label}: {:.3}s", elapsed.as_secs_f64());
+    }
 }
 
 fn remove_file_if_exists(path: &Path) -> Result<(), FileError> {

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -777,6 +777,16 @@ fn build_guard_materializes_and_repairs_root_artifacts() -> Result<(), Box<dyn E
         fs::read_to_string(directory.path().join("graph.json"))?,
         "graph-one"
     );
+    fs::write(directory.path().join("graph.json"), "root-only-change")?;
+    assert_eq!(
+        fs::read_to_string(BuildGuard::resolve_artifact(
+            directory.path(),
+            "graph.json"
+        )?)?,
+        "graph-one",
+        "the conventional root copy must not share mutable storage with its immutable snapshot"
+    );
+    BuildGuard::publish_root_artifacts(directory.path(), &["graph.html", "graph.json"], true)?;
     assert_eq!(
         fs::read_to_string(directory.path().join("graph.html"))?,
         "html-one"

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -5,8 +5,10 @@
 //! both languages here; qualification callers use the same entry point so
 //! there is no shadow implementation to drift from the shipped graph path.
 
+use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
+use std::time::Instant;
 
 use tree_sitter::Node;
 
@@ -191,6 +193,7 @@ struct CandidateState<'source, 'tree> {
     declarations: HashMap<String, DeclarationInfo>,
     definition_start_bytes: HashMap<String, u64>,
     declarations_by_scope: HashMap<String, Vec<String>>,
+    declarations_by_scope_name: HashMap<String, HashMap<String, Vec<String>>>,
     declarations_by_qualified: HashMap<String, Vec<String>>,
     generic_parameters_by_declaration: HashMap<String, HashMap<String, Option<String>>>,
     generic_parameter_order_by_declaration: HashMap<String, Vec<String>>,
@@ -201,7 +204,7 @@ struct CandidateState<'source, 'tree> {
     type_alias_union_targets: HashMap<String, Vec<String>>,
     property_literal_values: HashMap<String, String>,
     index_value_types: HashMap<String, String>,
-    import_bindings: HashMap<(String, String), ImportInfo>,
+    import_bindings: HashMap<String, HashMap<String, ImportInfo>>,
     variable_types: HashMap<String, String>,
     /// Source-order receiver facts for simple local assignments.  A fact is
     /// usable only when it is in the variable's binding scope and precedes
@@ -287,6 +290,8 @@ struct CandidateState<'source, 'tree> {
     base_type_bindings: HashMap<String, HashMap<String, String>>,
     parser_recovered: bool,
     declaration_name_nodes: HashSet<usize>,
+    preorder_nodes: Vec<(Node<'tree>, usize)>,
+    precollected_import_nodes: Vec<Node<'tree>>,
     import_nodes: HashSet<usize>,
     emitted_facts: HashSet<String>,
     builder: EvidenceBuilder,
@@ -361,6 +366,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         declarations: HashMap::new(),
         definition_start_bytes: HashMap::new(),
         declarations_by_scope: HashMap::new(),
+        declarations_by_scope_name: HashMap::new(),
         declarations_by_qualified: HashMap::new(),
         generic_parameters_by_declaration: HashMap::new(),
         generic_parameter_order_by_declaration: HashMap::new(),
@@ -395,25 +401,40 @@ pub(crate) fn extract_candidate_tree_evidence(
         base_type_bindings: HashMap::new(),
         parser_recovered,
         declaration_name_nodes: HashSet::new(),
+        preorder_nodes: Vec::new(),
+        precollected_import_nodes: Vec::new(),
         import_nodes: HashSet::new(),
         emitted_facts: HashSet::new(),
         builder,
         _tree: std::marker::PhantomData,
     };
+    let mut profile_started = Instant::now();
     state.collect_constructor_name_hints(root, 0);
+    profile_candidate_pass(source_file, "constructor hints", &mut profile_started);
     state.collect_declarations(root, root_scope, module_name, 0)?;
+    profile_candidate_pass(source_file, "declarations", &mut profile_started);
     // Imports are lexically hoisted by ECMAScript/TypeScript.  Materialize
     // their bindings before receiver inference so a later declaration such
     // as `const client = new ImportedClient()` can use the imported class
     // without depending on source order.
-    state.precollect_imports(root, 0)?;
+    state.emit_precollected_imports()?;
+    profile_candidate_pass(source_file, "imports", &mut profile_started);
     state.resolve_callable_property_aliases();
+    profile_candidate_pass(source_file, "callable aliases", &mut profile_started);
     state.precollect_base_targets(root, 0);
-    state.infer_variable_types(root, 0);
-    state.collect_flow_assignment_facts(root, 0);
+    profile_candidate_pass(source_file, "base targets", &mut profile_started);
+    let scoped_preorder = state.take_scoped_preorder();
+    profile_candidate_pass(source_file, "scope projection", &mut profile_started);
+    state.infer_variable_types(&scoped_preorder);
+    profile_candidate_pass(source_file, "variable inference", &mut profile_started);
+    state.collect_flow_assignment_facts(&scoped_preorder);
+    profile_candidate_pass(source_file, "flow facts", &mut profile_started);
     state.emit_declaration_ownership_candidates()?;
-    state.emit_nodes(root, 0)?;
+    profile_candidate_pass(source_file, "declaration ownership", &mut profile_started);
+    state.emit_preordered_nodes(&scoped_preorder)?;
+    profile_candidate_pass(source_file, "node emission", &mut profile_started);
     state.emit_import_type_queries(root)?;
+    profile_candidate_pass(source_file, "import type queries", &mut profile_started);
     if parser_recovered {
         state.builder.diagnose(
             "partial_parser_recovery",
@@ -428,6 +449,22 @@ pub(crate) fn extract_candidate_tree_evidence(
         declaration.definition_start_byte = definition_start_bytes.get(&declaration.id).copied();
     }
     Ok(batch)
+}
+
+fn profile_candidate_pass(source_file: &str, pass: &str, started: &mut Instant) {
+    if std::env::var_os("COMPASS_PROFILE_INTERNAL").is_some() {
+        let selected = std::env::var("COMPASS_PROFILE_ECMASCRIPT_FILE").ok();
+        if selected
+            .as_deref()
+            .is_none_or(|selected| source_file.ends_with(selected))
+        {
+            eprintln!(
+                "[compass internal] ECMAScript {source_file} {pass}: {:.6}s",
+                started.elapsed().as_secs_f64()
+            );
+        }
+    }
+    *started = Instant::now();
 }
 
 impl<'source, 'tree> CandidateState<'source, 'tree> {
@@ -466,6 +503,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             if current_depth > MAX_TRAVERSAL_DEPTH {
                 continue;
             }
+            self.preorder_nodes.push((current, current_depth));
             if current.kind() == "new_expression"
                 && let Some(constructor) = current
                     .child_by_field_name("constructor")
@@ -509,12 +547,29 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                     self.constructor_name_hints.insert(spelling.to_owned());
                 }
             }
-            let mut cursor = current.walk();
-            let children = current.named_children(&mut cursor).collect::<Vec<_>>();
-            for child in children.into_iter().rev() {
-                pending.push((child, current_depth.saturating_add(1)));
+            let named_child_count = u32::try_from(current.named_child_count()).unwrap_or(u32::MAX);
+            for index in (0..named_child_count).rev() {
+                if let Some(child) = current.named_child(index) {
+                    pending.push((child, current_depth.saturating_add(1)));
+                }
             }
         }
+    }
+
+    fn take_scoped_preorder(&mut self) -> Vec<(Node<'tree>, usize, String)> {
+        let preorder = std::mem::take(&mut self.preorder_nodes);
+        let mut scope_stack = Vec::<String>::new();
+        let mut scoped = Vec::with_capacity(preorder.len());
+        for (node, depth) in preorder {
+            scope_stack.truncate(depth);
+            let scope = scope_stack.last().map_or_else(
+                || self.scope_for_node(node),
+                |parent| self.scope_for_child(node, parent),
+            );
+            scope_stack.push(scope.clone());
+            scoped.push((node, depth, scope));
+        }
+        scoped
     }
 
     fn collect_declarations(
@@ -532,6 +587,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 "ECMAScript declaration traversal exceeded the bounded depth",
             )?;
             return Ok(());
+        }
+        if node.kind() == "import_statement"
+            || (node.kind() == "export_statement"
+                && first_named_child_kind(node, "string").is_some())
+        {
+            self.precollected_import_nodes.push(node);
         }
         let mut scope_id = self.enter_lexical_scope(node, scope_id)?;
         // Conditional and mapped types introduce their own type-binding
@@ -1470,6 +1531,12 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             .entry(scope_id.to_owned())
             .or_default()
             .push(declaration.id.clone());
+        self.declarations_by_scope_name
+            .entry(scope_id.to_owned())
+            .or_default()
+            .entry(declaration.name.clone())
+            .or_default()
+            .push(declaration.id.clone());
         self.declarations_by_qualified
             .entry(declaration.qualified_name.clone())
             .or_default()
@@ -1567,14 +1634,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let mut current = Some(scope_id.to_owned());
         while let Some(scope) = current {
             let candidates = self
-                .declarations_by_scope
-                .get(&scope)
-                .into_iter()
-                .flat_map(|ids| ids.iter())
+                .declaration_ids_in_scope(&scope, name)
+                .iter()
                 .filter_map(|id| self.declarations.get(id))
                 .filter(|declaration| {
-                    declaration.name == name
-                        && declaration.namespace.accepts(Namespace::Value)
+                    declaration.namespace.accepts(Namespace::Value)
                         && self.lexically_visible_unqualified(&scope, declaration)
                 })
                 .collect::<Vec<_>>();
@@ -1588,21 +1652,15 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         false
     }
 
-    fn precollect_imports(&mut self, node: Node<'tree>, depth: usize) -> Result<(), EvidenceError> {
-        if depth > MAX_TRAVERSAL_DEPTH {
-            return Ok(());
-        }
-        let scope_id = self.scope_for_node(node);
-        match node.kind() {
-            "import_statement" => self.emit_import(node, &scope_id, false)?,
-            "export_statement" if first_named_child_kind(node, "string").is_some() => {
-                self.emit_import(node, &scope_id, true)?;
+    fn emit_precollected_imports(&mut self) -> Result<(), EvidenceError> {
+        let imports = std::mem::take(&mut self.precollected_import_nodes);
+        for node in imports {
+            let scope_id = self.scope_for_node(node);
+            match node.kind() {
+                "import_statement" => self.emit_import(node, &scope_id, false)?,
+                "export_statement" => self.emit_import(node, &scope_id, true)?,
+                _ => {}
             }
-            _ => {}
-        }
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            self.precollect_imports(child, depth + 1)?;
         }
         Ok(())
     }
@@ -1731,31 +1789,25 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
-    fn infer_variable_types(&mut self, node: Node<'tree>, depth: usize) {
-        let mut pending = vec![(node, depth)];
-        while let Some((current, current_depth)) = pending.pop() {
-            if current_depth > MAX_TRAVERSAL_DEPTH {
-                continue;
-            }
+    fn infer_variable_types(&mut self, scoped_preorder: &[(Node<'tree>, usize, String)]) {
+        for &(current, _, ref scope_id) in scoped_preorder {
             if is_parameter_node(current) {
-                let scope_id = self.scope_for_node(current);
-                self.infer_parameter_nominal_type(current, &scope_id);
-                self.infer_inline_object_type_receiver(current, &scope_id);
+                self.infer_parameter_nominal_type(current, scope_id);
+                self.infer_inline_object_type_receiver(current, scope_id);
             }
             if current.kind() == "variable_declarator"
                 && let Some(name_node) = current.child_by_field_name("name")
             {
-                let scope_id = self.scope_for_node(current);
-                self.infer_variable_object_sources(current, &scope_id);
-                self.infer_variable_prototype_source(current, &scope_id);
-                self.infer_inline_object_type_receiver(current, &scope_id);
-                self.infer_destructured_variable_types(current, &scope_id);
-                if let Some(qualified_type) = self.nominal_type_for_variable(current, &scope_id) {
+                self.infer_variable_object_sources(current, scope_id);
+                self.infer_variable_prototype_source(current, scope_id);
+                self.infer_inline_object_type_receiver(current, scope_id);
+                self.infer_destructured_variable_types(current, scope_id);
+                if let Some(qualified_type) = self.nominal_type_for_variable(current, scope_id) {
                     let mut names = Vec::new();
                     collect_pattern_names(name_node, self.source, &mut names);
                     for (name, _) in names {
                         if let Some(Resolution::Local(declaration)) =
-                            self.resolve_name(&scope_id, &name, Namespace::Value)
+                            self.resolve_name(scope_id, &name, Namespace::Value)
                             && declaration.kind == "variable"
                         {
                             self.variable_types
@@ -1768,14 +1820,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 current.kind(),
                 "call_expression" | "optional_call_expression"
             ) {
-                let scope_id = self.scope_for_node(current);
-                self.infer_contextual_callable_parameters(current, &scope_id);
-            }
-            let mut children = Vec::new();
-            let mut cursor = current.walk();
-            children.extend(current.named_children(&mut cursor));
-            for child in children.into_iter().rev() {
-                pending.push((child, current_depth.saturating_add(1)));
+                self.infer_contextual_callable_parameters(current, scope_id);
             }
         }
     }
@@ -1788,151 +1833,138 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     /// an unknown mutation.  This keeps JavaScript reassignment useful while
     /// failing closed on aliasing and control-flow shapes the native
     /// candidate does not model.
-    fn collect_flow_assignment_facts(&mut self, node: Node<'tree>, depth: usize) {
-        let mut pending = vec![(node, depth)];
-        while let Some((current, current_depth)) = pending.pop() {
-            if current_depth > MAX_TRAVERSAL_DEPTH {
-                continue;
-            }
-            let scope_id = self.scope_for_node(current);
-            if matches!(
-                current.kind(),
-                "call_expression" | "optional_call_expression" | "new_expression"
-            ) {
-                self.record_flow_call_argument_escapes(current, &scope_id);
-            }
-            if current.kind() == "with_statement" {
-                self.record_flow_scope_barriers(
-                    &scope_id,
-                    current.start_byte(),
-                    "dynamic with scope",
-                );
-            }
-            if is_callable_node(current) {
-                self.record_flow_closure_captures(current, &scope_id);
-            }
-            if current.kind() == "variable_declarator"
-                && let Some(name_node) = current.child_by_field_name("name")
-                && let Some(value) = current.child_by_field_name("value")
+    fn collect_flow_assignment_facts(&mut self, scoped_preorder: &[(Node<'tree>, usize, String)]) {
+        for &(current, _, ref scope_id) in scoped_preorder {
+            self.collect_flow_assignment_fact(current, scope_id);
+        }
+    }
+
+    fn collect_flow_assignment_fact(&mut self, current: Node<'tree>, scope_id: &str) {
+        if matches!(
+            current.kind(),
+            "call_expression" | "optional_call_expression" | "new_expression"
+        ) {
+            self.record_flow_call_argument_escapes(current, scope_id);
+        }
+        if current.kind() == "with_statement" {
+            self.record_flow_scope_barriers(scope_id, current.start_byte(), "dynamic with scope");
+        }
+        if is_callable_node(current) {
+            self.record_flow_closure_captures(current, scope_id);
+        }
+        if current.kind() == "variable_declarator"
+            && let Some(name_node) = current.child_by_field_name("name")
+            && let Some(value) = current.child_by_field_name("value")
+        {
+            let value = unwrap_expression_node(value);
+            if name_node.kind() == "identifier"
+                && let Some(receiver) = self.flow_receiver_for_value(scope_id, value)
             {
-                let value = unwrap_expression_node(value);
-                if name_node.kind() == "identifier"
-                    && let Some(receiver) = self.flow_receiver_for_value(&scope_id, value)
-                {
-                    let mut names = Vec::new();
-                    collect_pattern_names(name_node, self.source, &mut names);
-                    for (name, _) in names {
-                        let Some(Resolution::Local(variable)) =
-                            self.resolve_name(&scope_id, &name, Namespace::Value)
-                        else {
-                            continue;
-                        };
-                        if variable.kind == "variable"
-                            && self.flow_scope_is_compatible(&variable.scope_id, &scope_id)
-                            && self.flow_assignment_is_straight_line(name_node, &scope_id)
-                        {
-                            self.record_flow_assignment(
-                                &variable.id,
-                                value.start_byte(),
-                                receiver.clone(),
-                            );
-                        }
+                let mut names = Vec::new();
+                collect_pattern_names(name_node, self.source, &mut names);
+                for (name, _) in names {
+                    let Some(Resolution::Local(variable)) =
+                        self.resolve_name(scope_id, &name, Namespace::Value)
+                    else {
+                        continue;
+                    };
+                    if variable.kind == "variable"
+                        && self.flow_scope_is_compatible(&variable.scope_id, scope_id)
+                        && self.flow_assignment_is_straight_line(name_node, scope_id)
+                    {
+                        self.record_flow_assignment(
+                            &variable.id,
+                            value.start_byte(),
+                            receiver.clone(),
+                        );
                     }
                 }
             }
-            if matches!(
-                current.kind(),
-                "assignment_expression" | "augmented_assignment_expression"
-            ) && let Some(left) = current.child_by_field_name("left")
-            {
-                if left.kind() == "identifier" {
-                    let name = node_text(self.source, left);
-                    if let Some(Resolution::Local(variable)) =
-                        self.resolve_name(&scope_id, &name, Namespace::Value)
-                        && variable.kind == "variable"
-                    {
-                        let right = current.child_by_field_name("right");
-                        let operator = right
-                            .and_then(|right| {
-                                self.source
-                                    .get(left.end_byte()..right.start_byte())
-                                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
-                            })
-                            .map(str::trim)
-                            .unwrap_or_default();
-                        let straight_line = self
-                            .flow_scope_is_compatible(&variable.scope_id, &scope_id)
-                            && self.flow_assignment_is_straight_line(left, &scope_id);
-                        let receiver = right.map(unwrap_expression_node).and_then(|right| {
-                            self.flow_receiver_for_value(&scope_id, right).or_else(|| {
-                                (right.kind() == "object")
-                                    .then(|| {
-                                        self.flow_object_assignment_receiver(&scope_id, current)
-                                    })
-                                    .flatten()
-                            })
-                        });
-                        if straight_line && operator == "=" {
-                            if let Some(receiver) = receiver {
-                                self.record_flow_assignment(
-                                    &variable.id,
-                                    current.start_byte(),
-                                    receiver,
-                                );
-                            } else {
-                                self.record_flow_assignment_barrier(
-                                    &variable.id,
-                                    current.start_byte(),
-                                    "unsupported local assignment value",
-                                );
-                            }
+        }
+        if matches!(
+            current.kind(),
+            "assignment_expression" | "augmented_assignment_expression"
+        ) && let Some(left) = current.child_by_field_name("left")
+        {
+            if left.kind() == "identifier" {
+                let name = node_text(self.source, left);
+                if let Some(Resolution::Local(variable)) =
+                    self.resolve_name(scope_id, &name, Namespace::Value)
+                    && variable.kind == "variable"
+                {
+                    let right = current.child_by_field_name("right");
+                    let operator = right
+                        .and_then(|right| {
+                            self.source
+                                .get(left.end_byte()..right.start_byte())
+                                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                        })
+                        .map(str::trim)
+                        .unwrap_or_default();
+                    let straight_line = self.flow_scope_is_compatible(&variable.scope_id, scope_id)
+                        && self.flow_assignment_is_straight_line(left, scope_id);
+                    let receiver = right.map(unwrap_expression_node).and_then(|right| {
+                        self.flow_receiver_for_value(scope_id, right).or_else(|| {
+                            (right.kind() == "object")
+                                .then(|| self.flow_object_assignment_receiver(scope_id, current))
+                                .flatten()
+                        })
+                    });
+                    if straight_line && operator == "=" {
+                        if let Some(receiver) = receiver {
+                            self.record_flow_assignment(
+                                &variable.id,
+                                current.start_byte(),
+                                receiver,
+                            );
                         } else {
                             self.record_flow_assignment_barrier(
                                 &variable.id,
                                 current.start_byte(),
-                                if straight_line {
-                                    "compound local assignment"
-                                } else {
-                                    "conditional or out-of-scope local assignment"
-                                },
+                                "unsupported local assignment value",
                             );
                         }
+                    } else {
+                        self.record_flow_assignment_barrier(
+                            &variable.id,
+                            current.start_byte(),
+                            if straight_line {
+                                "compound local assignment"
+                            } else {
+                                "conditional or out-of-scope local assignment"
+                            },
+                        );
                     }
                 }
-                if matches!(
-                    left.kind(),
-                    "member_expression" | "optional_member_expression" | "subscript_expression"
-                ) && let Some(object) = left.child_by_field_name("object")
-                {
-                    let property = member_property_node(left);
-                    let property_name =
-                        property.and_then(|property| member_property_name(self.source, property));
-                    self.record_flow_member_write(
-                        &scope_id,
-                        object,
-                        current.start_byte(),
-                        property,
-                        property_name.as_deref(),
-                    );
-                }
             }
-            if current.kind() == "return_statement"
-                && let Some(value) = current
-                    .child_by_field_name("argument")
-                    .or_else(|| current.child_by_field_name("value"))
+            if matches!(
+                left.kind(),
+                "member_expression" | "optional_member_expression" | "subscript_expression"
+            ) && let Some(object) = left.child_by_field_name("object")
             {
-                self.record_flow_value_escape(
-                    &scope_id,
-                    unwrap_expression_node(value),
+                let property = member_property_node(left);
+                let property_name =
+                    property.and_then(|property| member_property_name(self.source, property));
+                self.record_flow_member_write(
+                    scope_id,
+                    object,
                     current.start_byte(),
-                    "returned local alias",
+                    property,
+                    property_name.as_deref(),
                 );
             }
-            let mut cursor = current.walk();
-            let children = current.named_children(&mut cursor).collect::<Vec<_>>();
-            for child in children.into_iter().rev() {
-                pending.push((child, current_depth.saturating_add(1)));
-            }
+        }
+        if current.kind() == "return_statement"
+            && let Some(value) = current
+                .child_by_field_name("argument")
+                .or_else(|| current.child_by_field_name("value"))
+        {
+            self.record_flow_value_escape(
+                scope_id,
+                unwrap_expression_node(value),
+                current.start_byte(),
+                "returned local alias",
+            );
         }
     }
 
@@ -3576,90 +3608,91 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
-    fn emit_nodes(&mut self, node: Node<'tree>, depth: usize) -> Result<(), EvidenceError> {
-        if depth > MAX_TRAVERSAL_DEPTH {
-            return Ok(());
-        }
-        let scope_id = self.scope_for_node(node);
-        match node.kind() {
-            "import_statement" => {
-                if !self.import_nodes.contains(&node.start_byte()) {
-                    self.emit_import(node, &scope_id, false)?;
+    fn emit_preordered_nodes(
+        &mut self,
+        scoped_preorder: &[(Node<'tree>, usize, String)],
+    ) -> Result<(), EvidenceError> {
+        let mut skip_descendants_of_depth = None;
+        for &(node, depth, ref scope_id) in scoped_preorder {
+            if let Some(skipped_depth) = skip_descendants_of_depth {
+                if depth > skipped_depth {
+                    continue;
                 }
-                return Ok(());
+                skip_descendants_of_depth = None;
             }
-            "export_statement" => {
-                if first_named_child_kind(node, "string").is_some() {
-                    if !self.import_nodes.contains(&node.start_byte()) {
-                        self.emit_export(node, &scope_id)?;
-                    }
-                    return Ok(());
-                }
-                self.emit_export(node, &scope_id)?;
-                if first_named_child_kind(node, "export_clause").is_some() {
-                    // The clause was consumed as a single source construct;
-                    // still walk a declaration attached to the export.
-                    let mut cursor = node.walk();
-                    for child in node.named_children(&mut cursor) {
-                        if child.kind() != "export_clause" {
-                            self.emit_nodes(child, depth + 1)?;
-                        }
-                    }
-                    return Ok(());
-                }
-            }
-            "call_expression" | "optional_call_expression" => {
-                // A decorator factory invocation is represented by the
-                // Decorates candidate emitted from its enclosing decorator
-                // node. Do not publish a second ordinary Calls edge for the
-                // same syntax; nested calls in decorator arguments still
-                // receive their own traversal pass.
-                if !node
-                    .parent()
-                    .is_some_and(|parent| parent.kind() == "decorator")
-                {
-                    self.emit_call(node, &scope_id, false)?;
-                    self.emit_dynamic_import(node, &scope_id)?;
-                    self.emit_commonjs_object_assign(&scope_id, node, false)?;
-                    self.emit_commonjs_define_property(&scope_id, node)?;
-                    self.emit_commonjs_export_star(&scope_id, node)?;
-                }
-            }
-            "new_expression" => self.emit_call(node, &scope_id, true)?,
-            "member_expression" | "optional_member_expression" | "subscript_expression" => {
-                self.emit_member(node, &scope_id)?;
-            }
-            "jsx_opening_element" | "jsx_self_closing_element" => {
-                self.emit_jsx(node, &scope_id)?;
-            }
-            "jsx_expression" => {
-                self.emit_jsx_value_references(node, &scope_id)?;
-            }
-            "decorator" => self.emit_decorator(node, &scope_id)?,
-            "class_heritage" if self.language == "javascript" => {
-                self.emit_bases(node, &scope_id)?;
-            }
-            "extends_clause" | "extends_type_clause" | "implements_clause" => {
-                self.emit_bases(node, &scope_id)?;
-            }
-            "assignment_expression" => self.emit_commonjs_export(node, &scope_id)?,
-            "variable_declarator" => self.emit_require_declarator(node, &scope_id)?,
-            "type_identifier" | "nested_type_identifier" => {
-                if is_type_reference_node(node) {
-                    self.emit_type_reference(node, &scope_id)?;
-                }
-            }
-            "identifier" => {
-                self.emit_callable_reference(node, &scope_id)?;
-            }
-            _ => {}
-        }
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if self.import_nodes.contains(&child.start_byte()) {
+            if matches!(node.kind(), "import_statement" | "export_statement")
+                && self.import_nodes.contains(&node.start_byte())
+            {
+                skip_descendants_of_depth = Some(depth);
                 continue;
             }
-            self.emit_nodes(child, depth + 1)?;
+            if node.kind() == "export_clause"
+                && node
+                    .parent()
+                    .is_some_and(|parent| parent.kind() == "export_statement")
+            {
+                skip_descendants_of_depth = Some(depth);
+                continue;
+            }
+            match node.kind() {
+                "import_statement" => {
+                    self.emit_import(node, scope_id, false)?;
+                    skip_descendants_of_depth = Some(depth);
+                }
+                "export_statement" => {
+                    if first_named_child_kind(node, "string").is_some() {
+                        self.emit_export(node, scope_id)?;
+                        skip_descendants_of_depth = Some(depth);
+                        continue;
+                    }
+                    self.emit_export(node, scope_id)?;
+                }
+                "call_expression" | "optional_call_expression" => {
+                    // A decorator factory invocation is represented by the
+                    // Decorates candidate emitted from its enclosing decorator
+                    // node. Do not publish a second ordinary Calls edge for the
+                    // same syntax; nested calls in decorator arguments still
+                    // receive their own traversal pass.
+                    if !node
+                        .parent()
+                        .is_some_and(|parent| parent.kind() == "decorator")
+                    {
+                        self.emit_call(node, scope_id, false)?;
+                        self.emit_dynamic_import(node, scope_id)?;
+                        self.emit_commonjs_object_assign(scope_id, node, false)?;
+                        self.emit_commonjs_define_property(scope_id, node)?;
+                        self.emit_commonjs_export_star(scope_id, node)?;
+                    }
+                }
+                "new_expression" => self.emit_call(node, scope_id, true)?,
+                "member_expression" | "optional_member_expression" | "subscript_expression" => {
+                    self.emit_member(node, scope_id)?;
+                }
+                "jsx_opening_element" | "jsx_self_closing_element" => {
+                    self.emit_jsx(node, scope_id)?;
+                }
+                "jsx_expression" => {
+                    self.emit_jsx_value_references(node, scope_id)?;
+                }
+                "decorator" => self.emit_decorator(node, scope_id)?,
+                "class_heritage" if self.language == "javascript" => {
+                    self.emit_bases(node, scope_id)?;
+                }
+                "extends_clause" | "extends_type_clause" | "implements_clause" => {
+                    self.emit_bases(node, scope_id)?;
+                }
+                "assignment_expression" => self.emit_commonjs_export(node, scope_id)?,
+                "variable_declarator" => self.emit_require_declarator(node, scope_id)?,
+                "type_identifier" | "nested_type_identifier" => {
+                    if is_type_reference_node(node) {
+                        self.emit_type_reference(node, scope_id)?;
+                    }
+                }
+                "identifier" => {
+                    self.emit_callable_reference(node, scope_id)?;
+                }
+                _ => {}
+            }
         }
         Ok(())
     }
@@ -3791,6 +3824,13 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             current = candidate.parent();
         }
         self.root_scope.clone()
+    }
+
+    fn scope_for_child(&self, child: Node<'tree>, parent_scope: &str) -> String {
+        self.scope_by_node
+            .get(&child.id())
+            .cloned()
+            .unwrap_or_else(|| parent_scope.to_owned())
     }
 
     fn infer_binding_scope(&self, node: Node<'tree>, fallback: &str) -> String {
@@ -4091,14 +4131,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         while let Some(scope) = current {
             if self
                 .import_bindings
-                .contains_key(&(scope.clone(), name.to_owned()))
-                || self
-                    .declarations_by_scope
-                    .get(&scope)
-                    .into_iter()
-                    .flat_map(|ids| ids.iter())
-                    .filter_map(|id| self.declarations.get(id))
-                    .any(|declaration| declaration.name == name)
+                .get(&scope)
+                .is_some_and(|bindings| bindings.contains_key(name))
+                || !self.declaration_ids_in_scope(&scope, name).is_empty()
             {
                 return false;
             }
@@ -4365,18 +4400,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 )?;
             }
             if !reexport {
-                self.import_bindings.insert(
-                    (scope_id.to_owned(), binding.local_name.clone()),
-                    ImportInfo {
-                        binding_id: binding_id.clone(),
-                        target: target.clone(),
-                        module: module.clone(),
-                        imported_name: binding.imported_name.clone(),
-                        namespace,
-                        type_only: binding.type_only,
-                        callable_namespace: false,
-                    },
-                );
+                self.import_bindings
+                    .entry(scope_id.to_owned())
+                    .or_default()
+                    .insert(
+                        binding.local_name.clone(),
+                        ImportInfo {
+                            binding_id: binding_id.clone(),
+                            target: target.clone(),
+                            module: module.clone(),
+                            imported_name: binding.imported_name.clone(),
+                            namespace,
+                            type_only: binding.type_only,
+                            callable_namespace: false,
+                        },
+                    );
             }
             let owner = self.owner_for_scope(scope_id);
             let occurrence_id = self.builder.occur_with_context(
@@ -4486,18 +4524,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             false,
             range_for_node(self.source_file, local_node),
         )?;
-        self.import_bindings.insert(
-            (scope_id.to_owned(), local_name.clone()),
-            ImportInfo {
-                binding_id: binding_id.clone(),
-                target: target.clone(),
-                module: module.clone(),
-                imported_name: "*".to_owned(),
-                namespace: Namespace::Both,
-                type_only: false,
-                callable_namespace: true,
-            },
-        );
+        self.import_bindings
+            .entry(scope_id.to_owned())
+            .or_default()
+            .insert(
+                local_name.clone(),
+                ImportInfo {
+                    binding_id: binding_id.clone(),
+                    target: target.clone(),
+                    module: module.clone(),
+                    imported_name: "*".to_owned(),
+                    namespace: Namespace::Both,
+                    type_only: false,
+                    callable_namespace: true,
+                },
+            );
         let occurrence_id = self.builder.occur_with_context(
             SemanticRole::Import,
             &owner,
@@ -4619,14 +4660,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let mut current = Some(scope_id.to_owned());
         while let Some(scope) = current {
             let declarations = self
-                .declarations_by_scope
-                .get(&scope)
-                .into_iter()
-                .flat_map(|ids| ids.iter())
+                .declaration_ids_in_scope(&scope, name)
+                .iter()
                 .filter_map(|id| self.declarations.get(id))
                 .filter(|declaration| {
-                    declaration.name == name
-                        && declaration.namespace.accepts(namespace)
+                    declaration.namespace.accepts(namespace)
                         && self.lexically_visible_unqualified(&scope, declaration)
                 })
                 .cloned()
@@ -5188,7 +5226,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 None,
             );
         }
-        let spelling = node_text(self.source, target);
+        let spelling = node_text_ref(self.source, target);
         if target.kind() == "super" {
             if let Some(resolution) = self.resolve_super_target(scope_id) {
                 return self.add_declaration_resolution_with_arguments(
@@ -5777,18 +5815,21 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             type_only,
             range_for_node(self.source_file, anchor),
         )?;
-        self.import_bindings.insert(
-            (scope_id.to_owned(), local_name.to_owned()),
-            ImportInfo {
-                binding_id: binding_id.clone(),
-                target: target.clone(),
-                module: module.to_owned(),
-                imported_name: imported_name.to_owned(),
-                namespace,
-                type_only,
-                callable_namespace: imported_name == "*" && context == "require",
-            },
-        );
+        self.import_bindings
+            .entry(scope_id.to_owned())
+            .or_default()
+            .insert(
+                local_name.to_owned(),
+                ImportInfo {
+                    binding_id: binding_id.clone(),
+                    target: target.clone(),
+                    module: module.to_owned(),
+                    imported_name: imported_name.to_owned(),
+                    namespace,
+                    type_only,
+                    callable_namespace: imported_name == "*" && context == "require",
+                },
+            );
         let owner = self.owner_for_scope(scope_id);
         let occurrence_id = self.builder.occur_with_context(
             SemanticRole::Import,
@@ -6015,7 +6056,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         if self.declaration_name_nodes.contains(&node.start_byte()) {
             return Ok(());
         }
-        let spelling = node_text(self.source, node);
+        let spelling = node_text_ref(self.source, node);
         if spelling.is_empty() {
             return Ok(());
         }
@@ -6416,7 +6457,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }) {
             return Ok(());
         }
-        let spelling = node_text(self.source, node);
+        let spelling = node_text_ref(self.source, node);
         if node.kind() == "nested_type_identifier"
             && let (Some(module), Some(name)) = (
                 node.child_by_field_name("module"),
@@ -6608,7 +6649,7 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         {
             return Ok(());
         }
-        let spelling = node_text(self.source, node);
+        let spelling = node_text_ref(self.source, node);
         let Some(resolution) = self.resolve_name(scope_id, &spelling, Namespace::Value) else {
             return Ok(());
         };
@@ -7267,7 +7308,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     fn resolve_name(&self, scope_id: &str, name: &str, namespace: Namespace) -> Option<Resolution> {
         let mut current = Some(scope_id.to_owned());
         while let Some(scope) = current {
-            if let Some(import) = self.import_bindings.get(&(scope.clone(), name.to_owned())) {
+            if let Some(import) = self
+                .import_bindings
+                .get(&scope)
+                .and_then(|bindings| bindings.get(name))
+            {
                 let accepts = if import.namespace == Namespace::Module {
                     matches!(namespace, Namespace::Type | Namespace::Both)
                         || (namespace == Namespace::Value && !import.type_only)
@@ -7279,14 +7324,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 }
             }
             let candidates = self
-                .declarations_by_scope
-                .get(&scope)
-                .into_iter()
-                .flat_map(|ids| ids.iter())
+                .declaration_ids_in_scope(&scope, name)
+                .iter()
                 .filter_map(|id| self.declarations.get(id))
                 .filter(|declaration| {
-                    declaration.name == name
-                        && declaration.namespace.accepts(namespace)
+                    declaration.namespace.accepts(namespace)
                         && self.lexically_visible_unqualified(&scope, declaration)
                 })
                 .cloned()
@@ -7312,7 +7354,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
     ) -> Option<Resolution> {
         let mut current = Some(scope_id.to_owned());
         while let Some(scope) = current {
-            if let Some(import) = self.import_bindings.get(&(scope.clone(), name.to_owned())) {
+            if let Some(import) = self
+                .import_bindings
+                .get(&scope)
+                .and_then(|bindings| bindings.get(name))
+            {
                 let accepts = if import.namespace == Namespace::Module {
                     matches!(namespace, Namespace::Type | Namespace::Both)
                         || (namespace == Namespace::Value && !import.type_only)
@@ -7324,14 +7370,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 }
             }
             let candidates = self
-                .declarations_by_scope
-                .get(&scope)
-                .into_iter()
-                .flat_map(|ids| ids.iter())
+                .declaration_ids_in_scope(&scope, name)
+                .iter()
                 .filter_map(|id| self.declarations.get(id))
                 .filter(|declaration| {
-                    declaration.name == name
-                        && declaration.namespace.accepts(namespace)
+                    declaration.namespace.accepts(namespace)
                         && self.lexically_visible_unqualified(&scope, declaration)
                 })
                 .cloned()
@@ -8396,14 +8439,11 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         let mut current = Some(scope_id.to_owned());
         while let Some(scope) = current {
             let candidates = self
-                .declarations_by_scope
-                .get(&scope)
-                .into_iter()
-                .flat_map(|ids| ids.iter())
+                .declaration_ids_in_scope(&scope, name)
+                .iter()
                 .filter_map(|id| self.declarations.get(id))
                 .filter(|declaration| {
-                    declaration.name == name
-                        && declaration.namespace.accepts(Namespace::Type)
+                    declaration.namespace.accepts(Namespace::Type)
                         && self.lexically_visible_unqualified(&scope, declaration)
                         && matches!(
                             declaration.kind.as_str(),
@@ -8446,6 +8486,14 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             current = self.scope_parents.get(&scope).cloned().flatten();
         }
         None
+    }
+
+    fn declaration_ids_in_scope(&self, scope_id: &str, name: &str) -> &[String] {
+        self.declarations_by_scope_name
+            .get(scope_id)
+            .and_then(|declarations| declarations.get(name))
+            .map(Vec::as_slice)
+            .unwrap_or_default()
     }
 
     fn resolve_super_target(&self, scope_id: &str) -> Option<Resolution> {
@@ -13264,4 +13312,10 @@ fn node_text(source: &[u8], node: Node<'_>) -> String {
         .map_or_else(String::new, |bytes| {
             String::from_utf8_lossy(bytes).into_owned()
         })
+}
+
+fn node_text_ref<'source>(source: &'source [u8], node: Node<'_>) -> Cow<'source, str> {
+    source
+        .get(node.start_byte()..node.end_byte())
+        .map_or(Cow::Borrowed(""), String::from_utf8_lossy)
 }

--- a/crates/compass-resolve/src/frameworks/domain.rs
+++ b/crates/compass-resolve/src/frameworks/domain.rs
@@ -57,6 +57,9 @@ pub fn resolve_and_publish_framework_domains(
 }
 
 pub fn publish_resolved_domains(extraction: &mut Extraction, resolved: &[ResolvedDomainFact]) {
+    if resolved.is_empty() {
+        return;
+    }
     let mut nodes = extraction
         .nodes
         .iter()

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -70,12 +70,54 @@ pub(crate) fn resolve_framework_facts(
     if extraction.framework_facts.is_empty() {
         return (Ok(Vec::new()), Ok(Vec::new()));
     }
+    if universal_framework_targets_are_materialized(extraction) {
+        let targets = target_index::FrameworkTargetIndex::new_with_root(extraction, Some(root));
+        return join(
+            || routes::resolve_routes_with_targets(extraction, limits, &targets, Some(root)),
+            || domain::resolve_domains_with_targets(extraction, limits, &targets),
+        );
+    }
     let target_extraction = materialize_universal_framework_targets(extraction);
     let targets = target_index::FrameworkTargetIndex::new_with_root(&target_extraction, Some(root));
     join(
         || routes::resolve_routes_with_targets(&target_extraction, limits, &targets, Some(root)),
         || domain::resolve_domains_with_targets(&target_extraction, limits, &targets),
     )
+}
+
+fn universal_framework_targets_are_materialized(
+    extraction: &compass_languages::Extraction,
+) -> bool {
+    let Some(batch) = extraction
+        .semantic_evidence
+        .as_ref()
+        .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
+    else {
+        return true;
+    };
+    let existing = extraction
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let mut graph_id_counts = std::collections::BTreeMap::<&str, usize>::new();
+    for declaration in &batch.declarations {
+        *graph_id_counts
+            .entry(declaration.graph_node_id.as_str())
+            .or_default() += 1;
+    }
+    batch.declarations.iter().all(|declaration| {
+        if graph_id_counts
+            .get(declaration.graph_node_id.as_str())
+            .copied()
+            == Some(1)
+        {
+            existing.contains(declaration.graph_node_id.as_str())
+        } else {
+            let id = make_id(&[&declaration.graph_node_id, &declaration.id]);
+            existing.contains(id.as_str())
+        }
+    })
 }
 
 /// Universal TypeScript/JavaScript extraction publishes declaration evidence

--- a/crates/compass-resolve/src/frameworks/routes.rs
+++ b/crates/compass-resolve/src/frameworks/routes.rs
@@ -124,6 +124,9 @@ pub fn publish_resolved_routes(
     extraction: &mut Extraction,
     routes: &[ResolvedRoute],
 ) -> Result<(), FrameworkResolutionError> {
+    if routes.is_empty() {
+        return Ok(());
+    }
     let existing_nodes = extraction
         .nodes
         .iter()

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -474,8 +474,9 @@ fn augment_universal_project_inventory(
                 source_languages
                     .entry(declaration.range.source_file.clone())
                     .or_insert_with(|| batch.adapter.language.clone());
+                let normalized_source = source_key(&declaration.range.source_file, root);
                 let length = source_evidence_lengths
-                    .entry(declaration.range.source_file.clone())
+                    .entry(normalized_source)
                     .or_insert(0);
                 *length = (*length).max(declaration.range.end_byte as usize);
             }
@@ -484,14 +485,15 @@ fn augment_universal_project_inventory(
     if source_languages.is_empty() {
         return;
     }
+    let source_inventory = source_inventory_index(sources, root);
 
-    let mut source_ids = BTreeMap::<String, String>::new();
+    let mut source_files = BTreeMap::<String, (String, String)>::new();
     for node in &merged.nodes {
         let source = node.string("source_file");
         if !source.is_empty() && is_file_node(node, &source) {
-            source_ids
+            source_files
                 .entry(source_key(&source, root))
-                .or_insert_with(|| node.id.clone());
+                .or_insert_with(|| (node.id.clone(), source));
         }
     }
     for (source, language) in &source_languages {
@@ -499,23 +501,19 @@ fn augment_universal_project_inventory(
         if !is_safe_relative_source(&key) {
             continue;
         }
-        let display_source =
-            source_inventory_display(source, &key, sources, root).unwrap_or_else(|| source.clone());
-        let file_id = source_ids.entry(key.clone()).or_insert_with(|| {
+        let (display_source, inventory_byte_len) = source_inventory
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| (source.clone(), 0));
+        source_files.entry(key.clone()).or_insert_with(|| {
             let id = make_id(&[&display_source]);
             let label = Path::new(&display_source)
                 .file_name()
                 .and_then(|name| name.to_str())
                 .unwrap_or(&display_source)
                 .to_owned();
-            let byte_len = source_inventory_byte_len(&display_source, sources, root).max(
-                source_evidence_lengths
-                    .iter()
-                    .filter(|(source, _)| source_key(source, root) == key)
-                    .map(|(_, length)| *length)
-                    .max()
-                    .unwrap_or(0),
-            );
+            let byte_len =
+                inventory_byte_len.max(source_evidence_lengths.get(&key).copied().unwrap_or(0));
             let mut attributes = Map::from_iter([
                 ("label".to_owned(), Value::String(label)),
                 ("symbol_kind".to_owned(), Value::String("file".to_owned())),
@@ -554,9 +552,8 @@ fn augment_universal_project_inventory(
                 id: id.clone(),
                 attributes,
             });
-            id
+            (id, display_source)
         });
-        let _ = file_id;
     }
 
     let declaration_ids = evidence_batches
@@ -584,6 +581,16 @@ fn augment_universal_project_inventory(
         .iter()
         .filter(|batch| matches!(batch.adapter.language.as_str(), "javascript" | "typescript"))
     {
+        let occurrences_by_id = batch
+            .occurrences
+            .iter()
+            .map(|occurrence| (occurrence.id.as_str(), occurrence))
+            .collect::<HashMap<_, _>>();
+        let bindings_by_id = batch
+            .bindings
+            .iter()
+            .map(|binding| (binding.id.as_str(), binding))
+            .collect::<HashMap<_, _>>();
         for candidate in batch.candidates.iter().filter(|candidate| {
             matches!(
                 candidate.relation,
@@ -593,12 +600,11 @@ fn augment_universal_project_inventory(
             if !existing.insert(candidate.id.clone()) {
                 continue;
             }
-            let Some(occurrence) = candidate.occurrence_id.as_deref().and_then(|id| {
-                batch
-                    .occurrences
-                    .iter()
-                    .find(|occurrence| occurrence.id == id)
-            }) else {
+            let Some(occurrence) = candidate
+                .occurrence_id
+                .as_deref()
+                .and_then(|id| occurrences_by_id.get(id).copied())
+            else {
                 continue;
             };
             if !matches!(
@@ -614,10 +620,9 @@ fn augment_universal_project_inventory(
                 .binding_id
                 .as_deref()
                 .and_then(|binding_id| {
-                    batch
-                        .bindings
-                        .iter()
-                        .find(|binding| binding.id == binding_id)
+                    bindings_by_id
+                        .get(binding_id)
+                        .copied()
                         .and_then(|binding| binding.qualified_target.rsplit_once("::"))
                         .map(|(module, _)| module.to_owned())
                 })
@@ -648,23 +653,19 @@ fn augment_universal_project_inventory(
                 continue;
             }
             let source_key_value = source_key(&occurrence.range.source_file, root);
-            let Some(source_id) = source_ids.get(&source_key_value) else {
+            let Some((source_id, project_source_file)) = source_files.get(&source_key_value) else {
                 continue;
             };
-            let project_source_file = merged
-                .nodes
-                .iter()
-                .find(|node| node.id == *source_id)
-                .map(|node| node.string("source_file"))
-                .filter(|source| !source.is_empty())
-                .unwrap_or_else(|| occurrence.range.source_file.clone());
             let attributes = Map::from_iter([
                 (
                     "relation".to_owned(),
                     Value::String("imports_from".to_owned()),
                 ),
                 ("module".to_owned(), Value::String(module)),
-                ("source_file".to_owned(), Value::String(project_source_file)),
+                (
+                    "source_file".to_owned(),
+                    Value::String(project_source_file.clone()),
+                ),
                 (
                     "universal_evidence_source_file".to_owned(),
                     Value::String(occurrence.range.source_file.clone()),
@@ -944,6 +945,7 @@ fn finish_resolution(
         ..Extraction::default()
     });
     if has_javascript {
+        let mut javascript_profile_started = Instant::now();
         if let Err(error) =
             resolve_javascript_package_conditions(&mut merged, &canonical_root, sources)
         {
@@ -951,11 +953,19 @@ fn finish_resolution(
                 format!("JavaScript package-condition resolution failed: {error}")
             });
         }
+        profile_internal(
+            "resolver JavaScript package conditions (merged)",
+            &mut javascript_profile_started,
+        );
         if let Err(error) = resolve_javascript_workspace_modules(&mut merged, &canonical_root) {
             merged
                 .error
                 .get_or_insert_with(|| format!("JavaScript workspace resolution failed: {error}"));
         }
+        profile_internal(
+            "resolver JavaScript workspace exports (merged)",
+            &mut javascript_profile_started,
+        );
         if let Err(error) =
             resolve_javascript_typescript_paths(&mut merged, &canonical_root, sources)
         {
@@ -963,6 +973,10 @@ fn finish_resolution(
                 format!("TypeScript/JavaScript path resolution failed: {error}")
             });
         }
+        profile_internal(
+            "resolver TypeScript paths (merged)",
+            &mut javascript_profile_started,
+        );
         resolve_javascript_reexports(&mut merged);
         if let Some(project) = project_resolution.as_mut() {
             if let Err(error) =
@@ -972,11 +986,19 @@ fn finish_resolution(
                     format!("JavaScript project package-condition resolution failed: {error}")
                 });
             }
+            profile_internal(
+                "resolver JavaScript package conditions (project)",
+                &mut javascript_profile_started,
+            );
             if let Err(error) = resolve_javascript_workspace_modules(project, &canonical_root) {
                 merged.error.get_or_insert_with(|| {
                     format!("JavaScript project workspace resolution failed: {error}")
                 });
             }
+            profile_internal(
+                "resolver JavaScript workspace exports (project)",
+                &mut javascript_profile_started,
+            );
             if let Err(error) =
                 resolve_javascript_typescript_paths(project, &canonical_root, sources)
             {
@@ -984,6 +1006,10 @@ fn finish_resolution(
                     format!("JavaScript project path resolution failed: {error}")
                 });
             }
+            profile_internal(
+                "resolver TypeScript paths (project)",
+                &mut javascript_profile_started,
+            );
             resolve_javascript_reexports(project);
         }
     }
@@ -1147,6 +1173,9 @@ fn resolve_javascript_workspace_modules(
     extraction: &mut Extraction,
     root: &Path,
 ) -> Result<(), String> {
+    if !has_javascript_import_edges(extraction) {
+        return Ok(());
+    }
     let mut file_by_source = BTreeMap::<String, (String, String)>::new();
     let mut manifests = BTreeSet::new();
     for node in &extraction.nodes {
@@ -1302,6 +1331,9 @@ fn resolve_javascript_package_conditions(
     root: &Path,
     sources: &HashMap<String, String>,
 ) -> Result<(), String> {
+    if !has_javascript_import_edges(extraction) {
+        return Ok(());
+    }
     let (typescript_configs, referenced_configs) =
         collect_typescript_configs(extraction, root, sources)?;
     let mut file_by_source = BTreeMap::<String, (String, String)>::new();
@@ -2075,6 +2107,9 @@ fn resolve_javascript_typescript_paths(
     root: &Path,
     sources: &HashMap<String, String>,
 ) -> Result<(), String> {
+    if !has_javascript_import_edges(extraction) {
+        return Ok(());
+    }
     let (configs, referenced_configs) = collect_typescript_configs(extraction, root, sources)?;
 
     let mut file_by_source = BTreeMap::<String, (String, String)>::new();
@@ -2167,6 +2202,13 @@ fn resolve_javascript_typescript_paths(
         }
     }
     Ok(())
+}
+
+fn has_javascript_import_edges(extraction: &Extraction) -> bool {
+    extraction
+        .edges
+        .iter()
+        .any(|edge| relation(edge) == "imports_from")
 }
 
 fn collect_typescript_configs(
@@ -4486,64 +4528,42 @@ fn source_key(source: &str, root: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-/// Recover the source-inventory spelling for a portable universal-evidence
-/// path. The language adapter intentionally shortens absolute temporary paths
-/// to a stable `parent/file` spelling; a project resolver must map that
-/// spelling back to the admitted source only when the suffix is unique.
-fn source_inventory_display(
-    _evidence_source: &str,
-    key: &str,
+/// Index exact and suffix spellings for portable universal-evidence paths.
+/// The language adapter can shorten an absolute temporary path to a stable
+/// `parent/file` spelling; that spelling maps back to an admitted source only
+/// when the suffix is unique.
+fn source_inventory_index(
     sources: &HashMap<String, String>,
     root: &Path,
-) -> Option<String> {
-    if key.is_empty() {
-        return None;
-    }
-    let suffix = format!("/{key}");
-    let mut matches = sources
-        .keys()
-        .filter(|candidate| {
-            source_key(candidate, root) == key || {
-                let candidate = candidate.replace('\\', "/");
-                candidate == key || candidate.ends_with(&suffix)
-            }
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    matches.sort();
-    matches.dedup();
-    if matches.len() != 1 {
-        return None;
+) -> BTreeMap<String, (String, usize)> {
+    let mut matches = BTreeMap::<String, BTreeMap<String, (String, usize)>>::new();
+    for (candidate, contents) in sources {
+        let normalized_candidate = candidate.replace('\\', "/");
+        let display = source_key(candidate, root);
+        let mut spellings = BTreeSet::from([display.clone(), normalized_candidate.clone()]);
+        spellings.extend(
+            normalized_candidate
+                .match_indices('/')
+                .map(|(index, _)| normalized_candidate[index + 1..].to_owned())
+                .filter(|suffix| !suffix.is_empty()),
+        );
+        for spelling in spellings {
+            matches
+                .entry(spelling)
+                .or_default()
+                .insert(candidate.clone(), (display.clone(), contents.len()));
+        }
     }
     matches
-        .pop()
-        .map(|candidate| source_key(&candidate, root))
-        .filter(|display| is_safe_relative_source(display))
-}
-
-fn source_inventory_byte_len(
-    display: &str,
-    sources: &HashMap<String, String>,
-    root: &Path,
-) -> usize {
-    let display_key = source_key(display, root);
-    let suffix = format!("/{display_key}");
-    let mut matches = sources
-        .iter()
-        .filter(|(candidate, _)| {
-            source_key(candidate, root) == display_key
-                || candidate.replace('\\', "/") == display_key
-                || candidate.replace('\\', "/").ends_with(&suffix)
+        .into_iter()
+        .filter_map(|(spelling, mut candidates)| {
+            if candidates.len() != 1 {
+                return None;
+            }
+            let (_, (display, byte_len)) = candidates.pop_first()?;
+            is_safe_relative_source(&display).then_some((spelling, (display, byte_len)))
         })
-        .map(|(candidate, contents)| (candidate.to_owned(), contents.len()))
-        .collect::<Vec<_>>();
-    matches.sort_by(|left, right| left.0.cmp(&right.0));
-    matches.dedup_by(|left, right| left.0 == right.0);
-    if matches.len() == 1 {
-        matches.pop().map_or(0, |(_, length)| length)
-    } else {
-        0
-    }
+        .collect()
 }
 
 /// Resolve non-member raw calls using unique definitions and import evidence.
@@ -5240,6 +5260,22 @@ mod tests {
             target: target.to_owned(),
             attributes,
         }
+    }
+
+    #[test]
+    fn javascript_resolution_indices_require_import_edges() {
+        let mut extraction = Extraction::default();
+        assert!(!has_javascript_import_edges(&extraction));
+
+        extraction
+            .edges
+            .push(edge("module", "member", "contains", "module.ts"));
+        assert!(!has_javascript_import_edges(&extraction));
+
+        extraction
+            .edges
+            .push(edge("module", "target", "imports_from", "module.ts"));
+        assert!(has_javascript_import_edges(&extraction));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Reuse a scoped preorder traversal and lexical indexes across TypeScript/JavaScript evidence passes.
- Avoid repeated resolver scans and skip JavaScript/framework resolution work when no relevant evidence exists.
- Fix AST fact-digest convergence and parallelize digest generation at the measured crossover.
- Use native atomic file copies for root artifact projection while preserving immutable snapshots.
- Add focused regression coverage and opt-in internal profiling boundaries.

## Why

TypeScript/JavaScript code-graph builds spent substantial time repeating whole-tree traversals, linearly scanning evidence collections, and streaming immutable artifacts back to the root output. The fact-digest fixed-point loop also compared the wrong values, causing unnecessary work for nested scopes.

## Impact

Published graph semantics and hashes remain unchanged for the qualified Axios and date-fns projects. Representative local runs improved, but the strict 2× performance target was not reached; this PR intentionally preserves exact graph output rather than changing the output contract.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `sh scripts/check_product_boundary.sh`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-42e2-performance cargo test -p compass-languages --test typescript_universal_candidate --locked` — 113 passed
- Earlier focused resolver, framework, file-publication, digest, and Clippy checks passed.
- Axios and date-fns graph hashes matched their pre-change baselines exactly.
