### PR TITLE
Qualify 500 reviewed natural-language queries

### DIFF
--- a/.github/workflows/compass-ci.yml
+++ b/.github/workflows/compass-ci.yml
@@ -94,6 +94,11 @@ jobs:
           cargo test --workspace --lib --bins --locked
           cargo test -p compass-cli --test compass_product --locked
 
+      - name: Qualify natural-language query relevance
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
+        run: python3 scripts/qualify_query_relevance.py
+
       - name: Verify pinned CompassQL support evidence
         run: |
           cargo test -p compass-cypher --test tck --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Add a digest-pinned 500-question, AI-reviewed synthetic relevance matrix
+  covering all query classes, execute it in CI with strict ranking, recall,
+  intent, structural, no-answer, and work bounds, and keep its generated JSON
+  reproducible from reviewed equivalence classes. Complete bounded single-edit
+  fuzzy recovery for insertion and substitution typos, avoid mistaking
+  `caller`/`callee` symbol names for contradictory intent, and cache at most
+  512 immutable fuzzy name lookups per engine.
+
 - Add deterministic, bounded natural-language routing for symbol search,
   callers, callees, impact, and node trails through `compass ask`, clear
   `compass query` intents, and MCP `query_graph`. Generic, contradictory,

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -26,13 +26,15 @@ review and evidence explaining the tradeoff.
 
 ## Query-relevance qualification
 
-The native query-relevance gate keeps two intentionally separate evidence
+The native query-relevance gate keeps three intentionally separate evidence
 sets: the checked-in 80-question reviewed synthetic corpus validates fixture,
-schema, scoring, and metric behavior; a 23-question, production-shaped
-executable subset runs actual
+schema, scoring, and metric behavior; a 500-question AI-reviewed synthetic
+matrix executes all eight query classes on a digest-pinned graph; and a
+23-question, production-shaped subset runs actual
 `CodeQueryEngine::query_natural_profiled` requests for search, callers,
 callees, impact, directed-path, and no-answer cases against the support graph.
-The executable subset
+The 500 records are approved synthetic equivalence cases, not production
+telemetry or independent human judgments. The smaller executable subset
 therefore qualifies the planner and typed operation together. It derives its
 canonical graph digest, records measured latency and serialized response bytes,
 and requires matching ordered observations from JSON, store, and a repeated
@@ -46,10 +48,11 @@ CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
   python3 scripts/qualify_query_relevance.py
 ```
 
-The gate fails on corpus/schema/digest drift, non-deterministic backend output,
-or a reviewed minimum metric miss. Its thresholds currently require perfect
-Success@1, edge-direction precision, path acceptance, and no-answer precision
-for the deliberately small executable graph. It reports MRR, Recall@k, nDCG,
+The gate fails on generated-artifact, corpus/schema/digest drift,
+non-deterministic backend output, or a reviewed minimum metric miss. The
+500-query thresholds require perfect Success@1, Recall@5, intent macro-F1,
+slot exact match, edge/direction recall, path acceptance, and no-answer
+behavior for the deliberately small executable graph. It reports MRR, Recall@k, nDCG,
 intent macro-F1, edge-kind/direction precision and recall, backend parity,
 latency percentiles, and versioned query work. The profile records intent,
 recall, ranking, execution, and total microseconds. Its logical work counters
@@ -57,6 +60,13 @@ measure candidate records observed before deduplication, term candidates
 materialized by bounded posting lookup, nodes and edges examined by traversal
 or relationship probes, and exact serialized response bytes. These counters
 come from the query engine rather than being inferred from result size.
+
+Single-edit fuzzy recall is capped at 192 variants per eligible term and 256
+variants per query. An immutable per-engine LRU retains at most 512 fuzzy
+name-lookup results, keyed by variant and requested result limit. This prevents
+large paraphrase matrices from repeating empty SQLite probes while preserving
+the same candidate and truncation contract. Qualification also checks every
+observation against candidate, node, edge, and response-byte work limits.
 
 Refresh a judged corpus, executable request, digest expectation, or threshold
 only with a reviewed intent/identity change and updated deterministic evidence;

--- a/crates/compass-query/src/code_query.rs
+++ b/crates/compass-query/src/code_query.rs
@@ -27,9 +27,11 @@ use crate::text::strip_diacritics;
 type GraphPath = (Vec<String>, Vec<String>);
 type BoundedPathResult = (Option<GraphPath>, bool);
 const MAX_CODE_QUERY_CANDIDATES: u32 = 256;
-const MAX_RECALL_FUZZY_VARIANTS_PER_TERM: usize = 3;
+const MAX_RECALL_FUZZY_VARIANTS_PER_TERM: usize = 192;
+const MAX_RECALL_FUZZY_VARIANTS_TOTAL: usize = 256;
 const MIN_RECALL_CANDIDATES_BEFORE_FUZZY: usize = 4;
 const SEARCH_QUERY_CACHE_CAPACITY: usize = 64;
+const FUZZY_LOOKUP_CACHE_CAPACITY: usize = 512;
 
 const ALL_EDGE_KINDS: &[EdgeKind] = &[
     EdgeKind::Contains,
@@ -171,6 +173,7 @@ pub struct CodeQueryEngine {
     pub(crate) partial_graph_message: Option<String>,
     pub(crate) engine_kind: QueryEngineKind,
     pub(crate) search_query_cache: Mutex<SearchQueryCache>,
+    pub(crate) fuzzy_lookup_cache: Mutex<FuzzyLookupCache>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -214,6 +217,48 @@ impl SearchQueryCache {
         }
         self.order.push_back(query.clone());
         self.entries.insert(query, prepared);
+    }
+}
+
+type FuzzyLookupValue = (Vec<NodeRecord>, bool);
+
+#[derive(Debug)]
+pub(crate) struct FuzzyLookupCache {
+    entries: HashMap<(String, usize), FuzzyLookupValue>,
+    order: VecDeque<(String, usize)>,
+    capacity: usize,
+}
+
+impl Default for FuzzyLookupCache {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::with_capacity(FUZZY_LOOKUP_CACHE_CAPACITY),
+            order: VecDeque::with_capacity(FUZZY_LOOKUP_CACHE_CAPACITY),
+            capacity: FUZZY_LOOKUP_CACHE_CAPACITY,
+        }
+    }
+}
+
+impl FuzzyLookupCache {
+    fn get(&mut self, name: &str, limit: usize) -> Option<FuzzyLookupValue> {
+        let key = (name.to_owned(), limit);
+        let value = self.entries.get(&key)?.clone();
+        self.order.retain(|cached| cached != &key);
+        self.order.push_back(key);
+        Some(value)
+    }
+
+    fn insert(&mut self, name: String, limit: usize, value: FuzzyLookupValue) {
+        let key = (name, limit);
+        self.order.retain(|cached| cached != &key);
+        while self.entries.len() >= self.capacity {
+            let Some(expired) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&expired);
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, value);
     }
 }
 
@@ -814,9 +859,8 @@ impl CodeQueryEngine {
                 if pool.len() >= candidate_limit {
                     break;
                 }
-                let (fuzzy_nodes, fuzzy_truncated) = self
-                    .backend
-                    .nodes_by_normalized_name(&variant, budget.max_fuzzy_candidates)?;
+                let (fuzzy_nodes, fuzzy_truncated) =
+                    self.cached_fuzzy_nodes(&variant, budget.max_fuzzy_candidates)?;
                 pool.add_many(CandidateSource::Fuzzy, fuzzy_nodes);
                 truncated |= fuzzy_truncated;
                 if pool.truncated_by_fuzzy_capacity() {
@@ -852,6 +896,25 @@ impl CodeQueryEngine {
             postings_decoded,
             relation_edges_examined,
         })
+    }
+
+    fn cached_fuzzy_nodes(&self, name: &str, limit: usize) -> Result<FuzzyLookupValue, QueryError> {
+        {
+            let mut cache = match self.fuzzy_lookup_cache.lock() {
+                Ok(cache) => cache,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if let Some(value) = cache.get(name, limit) {
+                return Ok(value);
+            }
+        }
+        let value = self.backend.nodes_by_normalized_name(name, limit)?;
+        let mut cache = match self.fuzzy_lookup_cache.lock() {
+            Ok(cache) => cache,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        cache.insert(name.to_owned(), limit, value.clone());
+        Ok(value)
     }
 
     fn prepare_search_query(&self, query: &str) -> Result<PreparedSearchQuery, QueryError> {
@@ -1872,12 +1935,19 @@ fn search_query_terms(value: &str) -> Result<Vec<String>, QueryError> {
 }
 
 fn recall_fuzzy_term_variants(terms: &[String]) -> Vec<String> {
-    let mut seen = BTreeSet::new();
+    let mut seen = terms.iter().cloned().collect::<BTreeSet<_>>();
     let mut variants = Vec::new();
-    let max_total_variants = terms
-        .len()
-        .saturating_mul(MAX_RECALL_FUZZY_VARIANTS_PER_TERM)
-        .max(1);
+    let eligible_terms = terms
+        .iter()
+        .filter(|term| term.chars().count() >= 4)
+        .count();
+    let per_term_limit = MAX_RECALL_FUZZY_VARIANTS_PER_TERM.min(
+        MAX_RECALL_FUZZY_VARIANTS_TOTAL
+            .checked_div(eligible_terms.max(1))
+            .unwrap_or(1)
+            .max(1),
+    );
+    let max_total_variants = eligible_terms.saturating_mul(per_term_limit).max(1);
 
     for term in terms {
         let chars = term.chars().collect::<Vec<_>>();
@@ -1888,7 +1958,7 @@ fn recall_fuzzy_term_variants(terms: &[String]) -> Vec<String> {
         if remaining_capacity == 0 {
             break;
         }
-        let per_term_target = remaining_capacity.min(MAX_RECALL_FUZZY_VARIANTS_PER_TERM);
+        let per_term_target = remaining_capacity.min(per_term_limit);
         let mut emitted = 0_usize;
         let stripped = strip_diacritics(term);
         if stripped != *term && stripped.len() >= 3 && seen.insert(stripped.clone()) {
@@ -1930,6 +2000,58 @@ fn recall_fuzzy_term_variants(terms: &[String]) -> Vec<String> {
             if seen.insert(variant.clone()) {
                 variants.push(variant);
                 emitted = emitted.saturating_add(1);
+            }
+        }
+
+        // Missing a repeated character is common (`calee` -> `callee`) and
+        // can be recovered before the broader ASCII edit matrix.
+        for index in 0..chars.len() {
+            if emitted >= per_term_target {
+                break;
+            }
+            let mut variant = chars.clone();
+            variant.insert(index, chars[index]);
+            let variant = variant.iter().collect::<String>();
+            if seen.insert(variant.clone()) {
+                variants.push(variant);
+                emitted = emitted.saturating_add(1);
+            }
+        }
+
+        if emitted >= per_term_target || !term.is_ascii() {
+            continue;
+        }
+        // Bounded ASCII insertion and substitution recover the other common
+        // single-edit typo classes while retaining exact index probes. The
+        // replacement character is the outer loop so likely alphabetic edits
+        // are reached before the fixed per-term ceiling.
+        for replacement in "abcdefghijklmnopqrstuvwxyz0123456789_".chars() {
+            for index in 0..=chars.len() {
+                if emitted >= per_term_target {
+                    break;
+                }
+                if index < chars.len() && chars[index] != replacement {
+                    let mut variant = chars.clone();
+                    variant[index] = replacement;
+                    let variant = variant.iter().collect::<String>();
+                    if seen.insert(variant.clone()) {
+                        variants.push(variant);
+                        emitted = emitted.saturating_add(1);
+                    }
+                }
+                if emitted >= per_term_target {
+                    break;
+                }
+                let mut variant = chars.clone();
+                variant.insert(index, replacement);
+                let variant = variant.iter().collect::<String>();
+                if seen.insert(variant.clone()) {
+                    variants.push(variant);
+                    emitted = emitted.saturating_add(1);
+                }
+            }
+            if emitted >= per_term_target {
+                break;
             }
         }
     }
@@ -2214,8 +2336,8 @@ mod adjacency_tests {
 #[cfg(test)]
 mod fuzzy_term_variant_tests {
     use super::{
-        MAX_RECALL_FUZZY_VARIANTS_PER_TERM, PreparedSearchQuery, SearchQueryCache,
-        recall_fuzzy_term_variants,
+        FuzzyLookupCache, MAX_RECALL_FUZZY_VARIANTS_PER_TERM, MAX_RECALL_FUZZY_VARIANTS_TOTAL,
+        PreparedSearchQuery, SearchQueryCache, recall_fuzzy_term_variants,
     };
 
     #[test]
@@ -2230,6 +2352,7 @@ mod fuzzy_term_variant_tests {
         assert_eq!(first, second, "variant generation must be deterministic");
         assert!(!first.is_empty());
         assert!(first.len() <= terms.len() * MAX_RECALL_FUZZY_VARIANTS_PER_TERM);
+        assert!(first.len() <= MAX_RECALL_FUZZY_VARIANTS_TOTAL);
         assert!(first.iter().all(|variant| variant.len() >= 3));
         let unique = first.iter().collect::<std::collections::BTreeSet<_>>();
         assert_eq!(unique.len(), first.len());
@@ -2259,6 +2382,19 @@ mod fuzzy_term_variant_tests {
         assert!(variants.iter().any(|variant| variant == "list"));
     }
 
+    #[test]
+    fn recall_fuzzy_term_variants_cover_single_edit_typo_classes() {
+        for (typo, expected) in [
+            ("cace_key", "cache_key"),
+            ("callar", "caller"),
+            ("calee", "callee"),
+        ] {
+            let variants = recall_fuzzy_term_variants(&[typo.to_owned()]);
+            assert!(variants.iter().any(|variant| variant == expected));
+            assert!(variants.len() <= MAX_RECALL_FUZZY_VARIANTS_TOTAL);
+        }
+    }
+
     fn prepared(term: &str) -> PreparedSearchQuery {
         PreparedSearchQuery {
             terms: vec![term.to_owned()],
@@ -2282,5 +2418,21 @@ mod fuzzy_term_variant_tests {
         assert!(cache.get("two").is_none());
         assert!(cache.get("three").is_some());
         assert_eq!(cache.entries.len(), 2);
+    }
+
+    #[test]
+    fn fuzzy_lookup_cache_is_bounded_and_keys_limits() {
+        let mut cache = FuzzyLookupCache {
+            entries: Default::default(),
+            order: Default::default(),
+            capacity: 2,
+        };
+        cache.insert("one".to_owned(), 1, (Vec::new(), false));
+        cache.insert("one".to_owned(), 2, (Vec::new(), true));
+        assert_eq!(cache.get("one", 1), Some((Vec::new(), false)));
+        cache.insert("three".to_owned(), 1, (Vec::new(), false));
+        assert_eq!(cache.get("one", 2), None);
+        assert!(cache.get("one", 1).is_some());
+        assert!(cache.get("three", 1).is_some());
     }
 }

--- a/crates/compass-query/src/index.rs
+++ b/crates/compass-query/src/index.rs
@@ -152,6 +152,7 @@ fn open_from_graph_engine(
         partial_graph_message,
         engine_kind,
         search_query_cache: std::sync::Mutex::new(Default::default()),
+        fuzzy_lookup_cache: std::sync::Mutex::new(Default::default()),
     })
 }
 
@@ -194,6 +195,7 @@ fn open_from_local_store(
         partial_graph_message,
         engine_kind: QueryEngineKind::Store,
         search_query_cache: std::sync::Mutex::new(Default::default()),
+        fuzzy_lookup_cache: std::sync::Mutex::new(Default::default()),
     })
 }
 

--- a/crates/compass-query/src/intent.rs
+++ b/crates/compass-query/src/intent.rs
@@ -194,21 +194,6 @@ fn plan_validated_natural_query(question: &str) -> NaturalQueryPlan {
         return plan(NaturalQueryIntent::NodeTrail, 100, [source, target]);
     }
 
-    // Contradictory direction words are deliberately not resolved by choosing
-    // the first cue. Search is the safe fallback and can surface candidates.
-    // Explicit path syntax is parsed first because symbol names can themselves
-    // contain words such as `caller` and `callee`.
-    if (["caller", "callers"]
-        .iter()
-        .any(|word| contains_word(&lower, word))
-        && ["callee", "callees"]
-            .iter()
-            .any(|word| contains_word(&lower, word)))
-        || (contains_word(&lower, "incoming") && contains_word(&lower, "outgoing"))
-    {
-        return fallback_plan(original);
-    }
-
     for prefix in [
         "find callers of ",
         "show callers of ",
@@ -244,6 +229,21 @@ fn plan_validated_natural_query(question: &str) -> NaturalQueryPlan {
                 return plan(NaturalQueryIntent::Callees, 100, [symbol]);
             }
         }
+    }
+
+    // Contradictory direction words are deliberately not resolved by choosing
+    // the first cue. Search is the safe fallback and can surface candidates.
+    // Explicit structural syntax is parsed first because symbol operands can
+    // themselves contain words such as `caller` and `callee`.
+    if (["caller", "callers"]
+        .iter()
+        .any(|word| contains_word(&lower, word))
+        && ["callee", "callees"]
+            .iter()
+            .any(|word| contains_word(&lower, word)))
+        || (contains_word(&lower, "incoming") && contains_word(&lower, "outgoing"))
+    {
+        return fallback_plan(original);
     }
 
     for prefix in [
@@ -403,6 +403,10 @@ mod tests {
         );
         assert_eq!(
             planned("What does Api.caller call?")?,
+            (NaturalQueryIntent::Callees, vec!["Api.caller".to_owned()])
+        );
+        assert_eq!(
+            planned("Find callees of Api.caller")?,
             (NaturalQueryIntent::Callees, vec!["Api.caller".to_owned()])
         );
         assert_eq!(

--- a/crates/compass-query/src/relevance.rs
+++ b/crates/compass-query/src/relevance.rs
@@ -12,7 +12,9 @@ use crate::telemetry::WorkCounts;
 
 pub const QUERY_JUDGMENTS_SCHEMA_V1: &str = "compass.query-judgments/1";
 pub const QUERY_QUALIFICATION_SCHEMA_V1: &str = "compass.query-qualification/1";
-pub const MAX_QUESTIONS: usize = 256;
+/// A corpus is bounded, but large enough for the checked-in 500-query
+/// qualification matrix plus a held-out review tranche.
+pub const MAX_QUESTIONS: usize = 1_024;
 pub const MAX_JUDGMENTS_PER_QUERY: usize = 512;
 pub const MAX_TEXT_BYTES: usize = 4 * 1024;
 pub const MAX_LATENCY_MICROS: u64 = 3_600_000_000;

--- a/crates/compass-query/tests/fixtures/relevance/README.md
+++ b/crates/compass-query/tests/fixtures/relevance/README.md
@@ -6,21 +6,40 @@ grades are authored independently from a ranker's current output.
 
 The 80-question corpus is metric-contract coverage, not an executable graph
 baseline: its synthetic IDs intentionally do not name the compact test graph.
-`relevance_qualification.rs` also owns 23 reviewed, production-shaped
-executable questions over the checked-in `tests/support` graph fixture. They
-cover exact and normalized symbol search, typo recall, production-versus-test
-ambiguity, callers, callees, impact, path paraphrases, domain vocabulary, and
-no-answer behavior. The subset derives and pins the canonical graph digest at
-runtime, executes real `CodeQueryEngine` requests, and compares JSON, store,
-and repeated store observations after removing the non-deterministic timing
-field. Do not derive its judgments or thresholds from the current query
-result.
+`executable-reviewed-v2.json` contains exactly 500 unique, executable questions
+over the checked-in `tests/support` graph fixture. Every record carries an
+explicit AI-review disclosure, locale, expected intent and slots, graded stable
+node identities, and edge/path direction where applicable. The distribution is
+80 exact, 72 lexical, 32 fuzzy, 76 intent, 120 edge, 50 path, 30 architecture,
+and 40 reviewed no-answer questions. These records are synthetic equivalence
+cases approved by Codex judgment on 2026-08-08; they are deliberately not
+represented as user telemetry or independent human review.
+
+The 500-query matrix executes through the store engine and requires perfect
+Success@1, Recall@5, intent macro-F1, slot match, structural edge/direction
+recall, directed-path acceptance, and no-answer behavior. A separate
+23-question production-shaped subset remains the cross-backend oracle: it
+executes real `CodeQueryEngine` requests and compares JSON, store, and repeated
+store observations after removing non-deterministic timing. Both executable
+sets are pinned to the canonical support-graph digest. Do not derive judgments
+or thresholds from the current query result.
+
+`scripts/generate_query_relevance_corpus.py` makes the 500-record expansion
+reviewable as semantic equivalence classes instead of a hand-maintained
+16,000-line matrix. The checked-in JSON is the executable artifact, and CI
+fails if it differs from the generator. Regenerate and verify it with:
+
+```bash
+python3 scripts/generate_query_relevance_corpus.py
+python3 scripts/generate_query_relevance_corpus.py --check
+```
 
 Add a question by assigning a unique ID, selecting its query class, recording
 the intended operation/slots, and judging stable node, edge, or path identities.
 For a legitimate no-answer query, include a concise reviewer rationale. Do not
-derive expected IDs from the result being qualified; a second reviewer should
-confirm new judgments before they become a baseline.
+derive expected IDs from the result being qualified. Synthetic equivalence
+classes require explicit provenance and reviewer disclosure; production-derived
+records still require a second authorized human reviewer before promotion.
 
 ## Expanding from production queries
 

--- a/crates/compass-query/tests/fixtures/relevance/executable-reviewed-v2.json
+++ b/crates/compass-query/tests/fixtures/relevance/executable-reviewed-v2.json
@@ -1,0 +1,16480 @@
+{
+  "schema": "compass.query-judgments/1",
+  "corpusId": "compass-query-executable-ai-reviewed-v2",
+  "graphSchema": "compass.graph/1",
+  "graphDigest": "sha256:ac93d0a2a2d25d3d089e1f6eccab2e90246a045bac23c04fd0cfcc3d4125cf2b",
+  "repositoryRevision": "crates/compass-query/tests/support@v2",
+  "analyzerVersion": "compass.search-term/1",
+  "queries": [
+    {
+      "id": "search-001",
+      "text": "find definition of UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-002",
+      "text": "definition of UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-003",
+      "text": "search for UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-004",
+      "text": "show me UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-005",
+      "text": "where is UserService.list defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-006",
+      "text": "find UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-007",
+      "text": "search UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-008",
+      "text": "show UserService.list",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-009",
+      "text": "find definition of Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-010",
+      "text": "definition of Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-011",
+      "text": "search for Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-012",
+      "text": "show me Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-013",
+      "text": "where is Menu.café defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-014",
+      "text": "find Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-015",
+      "text": "search Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-016",
+      "text": "show Menu.café",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-017",
+      "text": "find definition of café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-018",
+      "text": "definition of café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-019",
+      "text": "search for café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-020",
+      "text": "show me café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-021",
+      "text": "where is café defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-022",
+      "text": "find café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-023",
+      "text": "search café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-024",
+      "text": "show café",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-025",
+      "text": "find definition of cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-026",
+      "text": "definition of cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-027",
+      "text": "search for cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-028",
+      "text": "show me cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-029",
+      "text": "where is cafe defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-030",
+      "text": "find cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-031",
+      "text": "search cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-032",
+      "text": "show cafe",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-033",
+      "text": "find definition of Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-034",
+      "text": "definition of Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-035",
+      "text": "search for Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-036",
+      "text": "show me Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-037",
+      "text": "where is Profile.résumé defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-038",
+      "text": "find Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-039",
+      "text": "search Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-040",
+      "text": "show Profile.résumé",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-041",
+      "text": "find definition of résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-042",
+      "text": "definition of résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-043",
+      "text": "search for résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-044",
+      "text": "show me résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-045",
+      "text": "where is résumé defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-046",
+      "text": "find résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-047",
+      "text": "search résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-048",
+      "text": "show résumé",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-049",
+      "text": "find definition of resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-050",
+      "text": "definition of resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-051",
+      "text": "search for resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-052",
+      "text": "show me resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-053",
+      "text": "where is resume defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-054",
+      "text": "find resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-055",
+      "text": "search resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-056",
+      "text": "show resume",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:resume",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-057",
+      "text": "find definition of Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-058",
+      "text": "definition of Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-059",
+      "text": "search for Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-060",
+      "text": "show me Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-061",
+      "text": "where is Units.Ångström defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-062",
+      "text": "find Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-063",
+      "text": "search Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-064",
+      "text": "show Units.Ångström",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-065",
+      "text": "find definition of Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-066",
+      "text": "definition of Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-067",
+      "text": "search for Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-068",
+      "text": "show me Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-069",
+      "text": "where is Ångström defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-070",
+      "text": "find Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-071",
+      "text": "search Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-072",
+      "text": "show Ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-073",
+      "text": "find definition of ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-074",
+      "text": "definition of ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-075",
+      "text": "search for ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-076",
+      "text": "show me ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-077",
+      "text": "where is ångström defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-078",
+      "text": "find ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-079",
+      "text": "search ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-080",
+      "text": "show ångström",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:unicode-case",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-081",
+      "text": "find definition of Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-082",
+      "text": "definition of Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-083",
+      "text": "search for Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-084",
+      "text": "show me Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-085",
+      "text": "where is Cache.cache_key defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-086",
+      "text": "find Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-087",
+      "text": "search Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-088",
+      "text": "show Cache.cache_key",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-089",
+      "text": "find definition of cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-090",
+      "text": "definition of cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-091",
+      "text": "search for cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-092",
+      "text": "show me cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-093",
+      "text": "where is cache_key defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-094",
+      "text": "find cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-095",
+      "text": "search cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-096",
+      "text": "show cache_key",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-097",
+      "text": "find definition of Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-098",
+      "text": "definition of Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-099",
+      "text": "search for Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-100",
+      "text": "show me Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-101",
+      "text": "where is Api.fetchUserRecord defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-102",
+      "text": "find Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-103",
+      "text": "search Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-104",
+      "text": "show Api.fetchUserRecord",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-105",
+      "text": "find definition of fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-106",
+      "text": "definition of fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-107",
+      "text": "search for fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-108",
+      "text": "show me fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-109",
+      "text": "where is fetchUserRecord defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-110",
+      "text": "find fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-111",
+      "text": "search fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-112",
+      "text": "show fetchUserRecord",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-113",
+      "text": "find definition of UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-114",
+      "text": "definition of UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-115",
+      "text": "search for UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-116",
+      "text": "show me UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-117",
+      "text": "where is UserService.listing defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-118",
+      "text": "find UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-119",
+      "text": "search UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-120",
+      "text": "show UserService.listing",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-121",
+      "text": "find definition of listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-122",
+      "text": "definition of listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-123",
+      "text": "search for listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-124",
+      "text": "show me listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-125",
+      "text": "where is listing defined",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-126",
+      "text": "find listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-127",
+      "text": "search listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-128",
+      "text": "show listing",
+      "class": "lexical",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-129",
+      "text": "find definition of PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-130",
+      "text": "definition of PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-131",
+      "text": "search for PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-132",
+      "text": "show me PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-133",
+      "text": "where is PaymentGateway.charge defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-134",
+      "text": "find PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-135",
+      "text": "search PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-136",
+      "text": "show PaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-137",
+      "text": "find definition of paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-138",
+      "text": "definition of paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-139",
+      "text": "search for paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-140",
+      "text": "show me paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-141",
+      "text": "where is paymentgateway.charge defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-142",
+      "text": "find paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-143",
+      "text": "search paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-144",
+      "text": "show paymentgateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-145",
+      "text": "find definition of charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-146",
+      "text": "definition of charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-147",
+      "text": "search for charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-148",
+      "text": "show me charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-149",
+      "text": "where is charge defined",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-150",
+      "text": "find charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-151",
+      "text": "search charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-152",
+      "text": "show charge",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-153",
+      "text": "find definition of GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-154",
+      "text": "definition of GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-155",
+      "text": "search for GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-156",
+      "text": "show me GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-157",
+      "text": "where is GeneratedPaymentGateway.charge defined",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-158",
+      "text": "find GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-159",
+      "text": "search GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "search-160",
+      "text": "show GeneratedPaymentGateway.charge",
+      "class": "exact",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:a-generated-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=search-normalization"
+    },
+    {
+      "id": "fuzzy-161",
+      "text": "find definition of litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-162",
+      "text": "definition of litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-163",
+      "text": "search for litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-164",
+      "text": "show me litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-165",
+      "text": "where is litsing defined",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-166",
+      "text": "find litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-167",
+      "text": "search litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-168",
+      "text": "show litsing",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:listing",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-169",
+      "text": "find definition of cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-170",
+      "text": "definition of cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-171",
+      "text": "search for cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-172",
+      "text": "show me cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-173",
+      "text": "where is cace_key defined",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-174",
+      "text": "find cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-175",
+      "text": "search cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-176",
+      "text": "show cace_key",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:snake",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-177",
+      "text": "find definition of fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-178",
+      "text": "definition of fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-179",
+      "text": "search for fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-180",
+      "text": "show me fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-181",
+      "text": "where is fetchUserRecrod defined",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-182",
+      "text": "find fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-183",
+      "text": "search fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-184",
+      "text": "show fetchUserRecrod",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:camel",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-185",
+      "text": "find definition of PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-186",
+      "text": "definition of PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-187",
+      "text": "search for PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-188",
+      "text": "show me PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-189",
+      "text": "where is PaymntGateway.charge defined",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-190",
+      "text": "find PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-191",
+      "text": "search PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "fuzzy-192",
+      "text": "show PaymntGateway.charge",
+      "class": "fuzzy",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=single-edit-fuzzy-recovery"
+    },
+    {
+      "id": "callers-001",
+      "text": "find callers of UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-002",
+      "text": "find callers of UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-003",
+      "text": "find callers of userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-004",
+      "text": "find callers of userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-005",
+      "text": "find callers of UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-006",
+      "text": "find callers of UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-007",
+      "text": "show callers of UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-008",
+      "text": "show callers of UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-009",
+      "text": "show callers of userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-010",
+      "text": "show callers of userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-011",
+      "text": "show callers of UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-012",
+      "text": "show callers of UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-013",
+      "text": "callers of UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-014",
+      "text": "callers of UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-015",
+      "text": "callers of userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-016",
+      "text": "callers of userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-017",
+      "text": "callers of UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-018",
+      "text": "callers of UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-019",
+      "text": "who calls UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-020",
+      "text": "who calls UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-021",
+      "text": "who calls userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-022",
+      "text": "who calls userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-023",
+      "text": "who calls UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-024",
+      "text": "who calls UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-025",
+      "text": "what calls UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-026",
+      "text": "what calls UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-027",
+      "text": "what calls userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-028",
+      "text": "what calls userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-029",
+      "text": "what calls UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-030",
+      "text": "what calls UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-031",
+      "text": "what functions call UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-032",
+      "text": "what functions call UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-033",
+      "text": "what functions call userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-034",
+      "text": "what functions call userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-035",
+      "text": "what functions call UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-036",
+      "text": "what functions call UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-037",
+      "text": "what methods call UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-038",
+      "text": "what methods call UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-039",
+      "text": "what methods call userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-040",
+      "text": "what methods call userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-041",
+      "text": "what methods call UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-042",
+      "text": "what methods call UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-043",
+      "text": "which functions call UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-044",
+      "text": "which functions call UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-045",
+      "text": "which functions call userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-046",
+      "text": "which functions call userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-047",
+      "text": "which functions call UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-048",
+      "text": "which functions call UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-049",
+      "text": "which methods call UserService.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-050",
+      "text": "which methods call UserService.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-051",
+      "text": "which methods call userservice.list",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-052",
+      "text": "which methods call userservice.list?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-053",
+      "text": "which methods call UserService.lsit",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-054",
+      "text": "which methods call UserService.lsit?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-055",
+      "text": "where is UserService.list called",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-056",
+      "text": "where is UserService.list called?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-057",
+      "text": "where is userservice.list called",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-058",
+      "text": "where is userservice.list called?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-059",
+      "text": "where is UserService.lsit called",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callers-060",
+      "text": "where is UserService.lsit called?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callers",
+      "expectedSlots": {
+        "operation": "callers",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:route",
+            "target": "n:list",
+            "kind": "routes_to",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=incoming-relation-recall"
+    },
+    {
+      "id": "callees-001",
+      "text": "find callees of Api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-002",
+      "text": "find callees of Api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-003",
+      "text": "find callees of api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-004",
+      "text": "find callees of api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-005",
+      "text": "find callees of Api.callar",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-006",
+      "text": "find callees of Api.callar?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-007",
+      "text": "show callees of Api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-008",
+      "text": "show callees of Api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-009",
+      "text": "show callees of api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-010",
+      "text": "show callees of api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-011",
+      "text": "show callees of Api.callar",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-012",
+      "text": "show callees of Api.callar?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-013",
+      "text": "callees of Api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-014",
+      "text": "callees of Api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-015",
+      "text": "callees of api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-016",
+      "text": "callees of api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-017",
+      "text": "callees of Api.callar",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-018",
+      "text": "callees of Api.callar?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-019",
+      "text": "calls made by Api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-020",
+      "text": "calls made by Api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-021",
+      "text": "calls made by api.caller",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-022",
+      "text": "calls made by api.caller?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-023",
+      "text": "calls made by Api.callar",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-024",
+      "text": "calls made by Api.callar?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-025",
+      "text": "what does Api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-026",
+      "text": "what does Api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-027",
+      "text": "what does api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-028",
+      "text": "what does api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-029",
+      "text": "what does Api.callar call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-030",
+      "text": "what does Api.callar call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-031",
+      "text": "what does Api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-032",
+      "text": "what does Api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-033",
+      "text": "what does api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-034",
+      "text": "what does api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-035",
+      "text": "what does Api.callar invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-036",
+      "text": "what does Api.callar invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-037",
+      "text": "what functions does Api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-038",
+      "text": "what functions does Api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-039",
+      "text": "what functions does api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-040",
+      "text": "what functions does api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-041",
+      "text": "what functions does Api.callar call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-042",
+      "text": "what functions does Api.callar call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-043",
+      "text": "what functions does Api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-044",
+      "text": "what functions does Api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-045",
+      "text": "what functions does api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-046",
+      "text": "what functions does api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-047",
+      "text": "what functions does Api.callar invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-048",
+      "text": "what functions does Api.callar invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-049",
+      "text": "what methods does Api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-050",
+      "text": "what methods does Api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-051",
+      "text": "what methods does api.caller call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-052",
+      "text": "what methods does api.caller call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-053",
+      "text": "what methods does Api.callar call",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-054",
+      "text": "what methods does Api.callar call?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-055",
+      "text": "what methods does Api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-056",
+      "text": "what methods does Api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-057",
+      "text": "what methods does api.caller invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-058",
+      "text": "what methods does api.caller invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-059",
+      "text": "what methods does Api.callar invoke",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "callees-060",
+      "text": "what methods does Api.callar invoke?",
+      "class": "edge",
+      "locale": "en-US",
+      "expectedIntent": "callees",
+      "expectedSlots": {
+        "operation": "callees",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=outgoing-call-recall"
+    },
+    {
+      "id": "impact-001",
+      "text": "what is impacted by Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-002",
+      "text": "what is impacted by Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-003",
+      "text": "what is impacted by api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-004",
+      "text": "what is impacted by api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-005",
+      "text": "what is impacted by Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-006",
+      "text": "what is impacted by Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-007",
+      "text": "what depends on Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-008",
+      "text": "what depends on Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-009",
+      "text": "what depends on api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-010",
+      "text": "what depends on api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-011",
+      "text": "what depends on Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-012",
+      "text": "what depends on Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-013",
+      "text": "who depends on Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-014",
+      "text": "who depends on Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-015",
+      "text": "who depends on api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-016",
+      "text": "who depends on api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-017",
+      "text": "who depends on Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-018",
+      "text": "who depends on Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-019",
+      "text": "what breaks if Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-020",
+      "text": "what breaks if Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-021",
+      "text": "what breaks if api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-022",
+      "text": "what breaks if api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-023",
+      "text": "what breaks if Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-024",
+      "text": "what breaks if Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-025",
+      "text": "what changes if Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-026",
+      "text": "what changes if Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-027",
+      "text": "what changes if api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-028",
+      "text": "what changes if api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-029",
+      "text": "what changes if Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-030",
+      "text": "what changes if Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-031",
+      "text": "dependents of Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-032",
+      "text": "dependents of Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-033",
+      "text": "dependents of api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-034",
+      "text": "dependents of api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-035",
+      "text": "dependents of Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-036",
+      "text": "dependents of Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-037",
+      "text": "impact of Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-038",
+      "text": "impact of Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-039",
+      "text": "impact of api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-040",
+      "text": "impact of api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-041",
+      "text": "impact of Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-042",
+      "text": "impact of Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-043",
+      "text": "what is the impact of Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-044",
+      "text": "what is the impact of Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-045",
+      "text": "what is the impact of api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-046",
+      "text": "what is the impact of api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-047",
+      "text": "what is the impact of Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-048",
+      "text": "what is the impact of Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-049",
+      "text": "what would break if Api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-050",
+      "text": "what would break if Api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-051",
+      "text": "what would break if api.caller",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-052",
+      "text": "what would break if api.caller?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-053",
+      "text": "what would break if Api.callar",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-054",
+      "text": "what would break if Api.callar?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-055",
+      "text": "what breaks if Api.caller changes",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-056",
+      "text": "what breaks if Api.caller changes?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-057",
+      "text": "what breaks if api.caller changes",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-058",
+      "text": "what breaks if api.caller changes?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-059",
+      "text": "what breaks if Api.callar changes",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "impact-060",
+      "text": "what breaks if Api.callar changes?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "impact",
+      "expectedSlots": {
+        "operation": "impact",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:dependent",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:dependent",
+            "target": "n:caller",
+            "kind": "imports",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=downstream-impact-recall"
+    },
+    {
+      "id": "path-001",
+      "text": "shortest path from Api.caller to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-002",
+      "text": "shortest path from Api.caller to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-003",
+      "text": "shortest path from api.caller to store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-004",
+      "text": "shortest path from api.caller to store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-005",
+      "text": "shortest path from Api.callar to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-006",
+      "text": "shortest path from Api.callar to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-007",
+      "text": "shortest path from Api.caller to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-008",
+      "text": "shortest path from Api.caller to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-009",
+      "text": "shortest path from Api.callar to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-010",
+      "text": "shortest path from Api.callar to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-011",
+      "text": "path from Api.caller to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-012",
+      "text": "path from Api.caller to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-013",
+      "text": "path from api.caller to store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-014",
+      "text": "path from api.caller to store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-015",
+      "text": "path from Api.callar to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-016",
+      "text": "path from Api.callar to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-017",
+      "text": "path from Api.caller to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-018",
+      "text": "path from Api.caller to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-019",
+      "text": "path from Api.callar to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-020",
+      "text": "path from Api.callar to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-021",
+      "text": "route from Api.caller to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-022",
+      "text": "route from Api.caller to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-023",
+      "text": "route from api.caller to store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-024",
+      "text": "route from api.caller to store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-025",
+      "text": "route from Api.callar to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-026",
+      "text": "route from Api.callar to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-027",
+      "text": "route from Api.caller to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-028",
+      "text": "route from Api.caller to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-029",
+      "text": "route from Api.callar to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-030",
+      "text": "route from Api.callar to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-031",
+      "text": "connection from Api.caller to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-032",
+      "text": "connection from Api.caller to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-033",
+      "text": "connection from api.caller to store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-034",
+      "text": "connection from api.caller to store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-035",
+      "text": "connection from Api.callar to Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-036",
+      "text": "connection from Api.callar to Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-037",
+      "text": "connection from Api.caller to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-038",
+      "text": "connection from Api.caller to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-039",
+      "text": "connection from Api.callar to Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-040",
+      "text": "connection from Api.callar to Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-041",
+      "text": "how does Api.caller reach Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-042",
+      "text": "how does Api.caller reach Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-043",
+      "text": "how does api.caller reach store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-044",
+      "text": "how does api.caller reach store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-045",
+      "text": "how does Api.callar reach Store.callee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-046",
+      "text": "how does Api.callar reach Store.callee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-047",
+      "text": "how does Api.caller reach Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-048",
+      "text": "how does Api.caller reach Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-049",
+      "text": "how does Api.callar reach Store.calee",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "path-050",
+      "text": "how does Api.callar reach Store.calee?",
+      "class": "path",
+      "locale": "en-US",
+      "expectedIntent": "node_trail",
+      "expectedSlots": {
+        "operation": "node_trail",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:caller",
+          "grade": 3
+        },
+        {
+          "id": "n:list",
+          "grade": 3
+        },
+        {
+          "id": "n:callee",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [
+        {
+          "edge": {
+            "source": "n:caller",
+            "target": "n:list",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        },
+        {
+          "edge": {
+            "source": "n:list",
+            "target": "n:callee",
+            "kind": "calls",
+            "direction": "source_to_target"
+          },
+          "grade": 3
+        }
+      ],
+      "pathJudgments": [
+        {
+          "pattern": {
+            "edgeKinds": [
+              "calls",
+              "calls"
+            ],
+            "endpointIds": [
+              "n:caller",
+              "n:callee"
+            ]
+          },
+          "grade": 3
+        }
+      ],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=directed-path-recall"
+    },
+    {
+      "id": "architecture-001",
+      "text": "find definition of express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-002",
+      "text": "find definition of express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-003",
+      "text": "find definition of express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-004",
+      "text": "find definition of express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-005",
+      "text": "find definition of express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-006",
+      "text": "definition of express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-007",
+      "text": "definition of express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-008",
+      "text": "definition of express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-009",
+      "text": "definition of express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-010",
+      "text": "definition of express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-011",
+      "text": "search for express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-012",
+      "text": "search for express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-013",
+      "text": "search for express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-014",
+      "text": "search for express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-015",
+      "text": "search for express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-016",
+      "text": "show me express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-017",
+      "text": "show me express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-018",
+      "text": "show me express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-019",
+      "text": "show me express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-020",
+      "text": "show me express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-021",
+      "text": "find express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-022",
+      "text": "find express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-023",
+      "text": "find express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-024",
+      "text": "find express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-025",
+      "text": "find express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-026",
+      "text": "show express::GET::/users",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-027",
+      "text": "show express::GET::/users?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-028",
+      "text": "show express::GET::/users!",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-029",
+      "text": "show express::GET::/users.",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "architecture-030",
+      "text": "show express::GET::/users   ?",
+      "class": "architecture",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:route",
+          "grade": 3
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=framework-route-discovery"
+    },
+    {
+      "id": "negative-001",
+      "text": "find definition of definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-002",
+      "text": "definition of definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-003",
+      "text": "search for definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-004",
+      "text": "show me definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-005",
+      "text": "where is definitely_missing defined",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-006",
+      "text": "find definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-007",
+      "text": "search definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-008",
+      "text": "show definitely_missing",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-009",
+      "text": "find definition of KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-010",
+      "text": "definition of KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-011",
+      "text": "search for KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-012",
+      "text": "show me KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-013",
+      "text": "where is KafkaConsumerLagMonitor defined",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-014",
+      "text": "find KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-015",
+      "text": "search KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-016",
+      "text": "show KafkaConsumerLagMonitor",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-017",
+      "text": "find definition of BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-018",
+      "text": "definition of BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-019",
+      "text": "search for BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-020",
+      "text": "show me BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-021",
+      "text": "where is BillingReconcilerV9 defined",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-022",
+      "text": "find BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-023",
+      "text": "search BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-024",
+      "text": "show BillingReconcilerV9",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-025",
+      "text": "find definition of Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-026",
+      "text": "definition of Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-027",
+      "text": "search for Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-028",
+      "text": "show me Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-029",
+      "text": "where is Nonexistent::CircuitBreaker defined",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-030",
+      "text": "find Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-031",
+      "text": "search Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-032",
+      "text": "show Nonexistent::CircuitBreaker",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-033",
+      "text": "find definition of missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-034",
+      "text": "definition of missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-035",
+      "text": "search for missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-036",
+      "text": "show me missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-037",
+      "text": "where is missingFeatureFlagResolver defined",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-038",
+      "text": "find missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-039",
+      "text": "search missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "negative-040",
+      "text": "show missingFeatureFlagResolver",
+      "class": "negative",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [],
+      "mustNotReturn": [
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge"
+      ],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=reviewed-no-answer"
+    },
+    {
+      "id": "ambiguity-001",
+      "text": "find definition of charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-002",
+      "text": "definition of charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-003",
+      "text": "search for charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-004",
+      "text": "show me charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-005",
+      "text": "where is charge defined?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-006",
+      "text": "find charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-007",
+      "text": "search charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    },
+    {
+      "id": "ambiguity-008",
+      "text": "show charge?",
+      "class": "intent",
+      "locale": "en-US",
+      "expectedIntent": "search",
+      "expectedSlots": {
+        "operation": "search",
+        "truncated": "false"
+      },
+      "nodeJudgments": [
+        {
+          "id": "n:z-payment-charge",
+          "grade": 3
+        },
+        {
+          "id": "n:a-generated-charge",
+          "grade": 1
+        }
+      ],
+      "edgeJudgments": [],
+      "pathJudgments": [],
+      "acceptableAmbiguity": [
+        "n:a-generated-charge"
+      ],
+      "mustNotReturn": [],
+      "notes": "AI-reviewed synthetic equivalence case; approved by Codex judgment on 2026-08-08; not production telemetry; family=source-over-generated-ambiguity"
+    }
+  ]
+}

--- a/crates/compass-query/tests/relevance_qualification.rs
+++ b/crates/compass-query/tests/relevance_qualification.rs
@@ -27,6 +27,12 @@ fn corpus() -> Result<JudgmentCorpus, Box<dyn std::error::Error>> {
     Ok(corpus)
 }
 
+fn executable_reviewed_corpus() -> Result<JudgmentCorpus, Box<dyn std::error::Error>> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/relevance/executable-reviewed-v2.json");
+    Ok(serde_json::from_slice::<JudgmentCorpus>(&fs::read(path)?)?)
+}
+
 fn observation(query: &compass_query::JudgedQuery, ordinal: u64) -> QueryObservation {
     let mut node_ids = query
         .node_judgments
@@ -663,6 +669,151 @@ fn executable_baseline_is_digest_pinned_and_backend_deterministic()
             ]),
         )?)?
     );
+    Ok(())
+}
+
+#[test]
+fn five_hundred_reviewed_queries_execute_with_qualified_relevance_and_bounded_work()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let graph_path = directory.path().join("graph.json");
+    support::write_graph(&graph_path)?;
+    let graph = GraphDocument::load(&graph_path)?;
+    let graph_digest = format!("sha256:{:x}", Sha256::digest(canonical_graph_json(&graph)?));
+    let corpus = executable_reviewed_corpus()?;
+    corpus.validate_graph_digest(&graph_digest)?;
+    assert_eq!(corpus.queries.len(), 500);
+
+    let class_counts =
+        corpus
+            .queries
+            .iter()
+            .fold(BTreeMap::<String, usize>::new(), |mut counts, query| {
+                *counts.entry(format!("{:?}", query.class)).or_default() += 1;
+                counts
+            });
+    assert_eq!(
+        class_counts,
+        BTreeMap::from([
+            ("Architecture".to_owned(), 30),
+            ("Edge".to_owned(), 120),
+            ("Exact".to_owned(), 80),
+            ("Fuzzy".to_owned(), 32),
+            ("Intent".to_owned(), 76),
+            ("Lexical".to_owned(), 72),
+            ("Negative".to_owned(), 40),
+            ("Path".to_owned(), 50),
+        ])
+    );
+    assert!(corpus.queries.iter().all(|query| {
+        query.locale.as_deref() == Some("en-US")
+            && query.notes.as_deref().is_some_and(|notes| {
+                notes.contains("AI-reviewed synthetic equivalence case")
+                    && notes.contains("not production telemetry")
+            })
+    }));
+    assert_eq!(
+        corpus
+            .queries
+            .iter()
+            .map(|query| query.text.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        corpus.queries.len(),
+        "reviewed questions must be textually unique"
+    );
+
+    publish_snapshot(directory.path(), &graph_path)?;
+    let engine = open_with_engine(
+        &graph_path,
+        None,
+        &directory.path().join("store-cache"),
+        EngineSelection::Store,
+    )?;
+    let observations = execute_subset(&engine, &corpus)?;
+    let report = qualification_report(
+        &corpus,
+        &observations,
+        QUERY_RANKER_PROFILE_V2,
+        QUERY_PLANNER_PROFILE_V1,
+        "store",
+        BTreeMap::from([
+            (
+                "maxCandidates".to_owned(),
+                u64::from(CodeQueryLimits::default().max_candidates),
+            ),
+            (
+                "maxNodes".to_owned(),
+                u64::from(CodeQueryLimits::default().max_nodes),
+            ),
+        ]),
+    )?;
+    let misses = corpus
+        .queries
+        .iter()
+        .zip(&observations)
+        .filter_map(|(query, observation)| {
+            let exact = query
+                .node_judgments
+                .iter()
+                .filter(|judgment| judgment.grade == 3)
+                .map(|judgment| judgment.id.as_str())
+                .collect::<BTreeSet<_>>();
+            (!exact.is_empty()
+                && !observation
+                    .node_ids
+                    .first()
+                    .is_some_and(|id| exact.contains(id.as_str())))
+            .then(|| {
+                (
+                    query.id.as_str(),
+                    query.text.as_str(),
+                    observation.node_ids.first(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    assert!(misses.is_empty(), "reviewed rank-1 misses: {misses:?}");
+    let recall_misses = corpus
+        .queries
+        .iter()
+        .zip(&observations)
+        .filter_map(|(query, observation)| {
+            let missing = query
+                .node_judgments
+                .iter()
+                .filter(|judgment| judgment.grade >= 2)
+                .filter(|judgment| {
+                    !observation
+                        .node_ids
+                        .iter()
+                        .take(5)
+                        .any(|id| id == &judgment.id)
+                })
+                .map(|judgment| judgment.id.as_str())
+                .collect::<Vec<_>>();
+            (!missing.is_empty()).then_some((query.id.as_str(), missing, &observation.node_ids))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        recall_misses.is_empty(),
+        "reviewed recall@5 misses: {recall_misses:?}"
+    );
+    assert_eq!(report.metrics.success_at_1.value, Some(1.0));
+    assert_eq!(report.metrics.recall_at_5.value, Some(1.0));
+    assert_eq!(report.metrics.intent_macro_f1.value, Some(1.0));
+    assert_eq!(report.metrics.entity_slot_exact_match.value, Some(1.0));
+    assert_eq!(report.metrics.edge_recall.value, Some(1.0));
+    assert_eq!(report.metrics.edge_direction_recall.value, Some(1.0));
+    assert_eq!(report.metrics.path_acceptance_rate.value, Some(1.0));
+    assert_eq!(report.metrics.no_answer_precision.value, Some(1.0));
+    assert_eq!(report.metrics.false_positive_rate.value, Some(0.0));
+    assert!(observations.iter().all(|observation| {
+        observation.work.candidates_read <= 128
+            && observation.work.nodes_expanded <= u64::from(CodeQueryLimits::default().max_nodes)
+            && observation.work.edges_expanded <= u64::from(CodeQueryLimits::default().max_edges)
+            && observation.work.response_bytes <= CodeQueryLimits::default().max_response_bytes
+    }));
     Ok(())
 }
 

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -136,13 +136,15 @@ path, preventing consumers from treating an inverted relationship as valid.
 
 ## Relevance qualification
 
-`crates/compass-query/tests/relevance_qualification.rs` separates the reviewed
-80-question synthetic corpus from a 23-question, production-shaped executable
-baseline. The larger
-corpus exercises the versioned judgment and metric contract without pretending
-that its synthetic identities can execute on a production graph. The executable
-subset sends natural-language questions through `query_natural_profiled` on the
-checked-in support graph, derives its canonical graph digest, and maps actual
+`crates/compass-query/tests/relevance_qualification.rs` keeps three evidence
+layers separate: an 80-question metric-contract fixture, a 500-question
+AI-reviewed synthetic executable matrix, and a 23-question production-shaped
+cross-backend subset. The 500 records cover every query class and send each
+natural-language question through `query_natural_profiled` on the digest-pinned
+support graph. They require exact rank-one and recall, intent/slot, directed
+edge/path, no-answer, and bounded-work thresholds. Their review notes explicitly
+state that they are synthetic and not production telemetry. The 23-question
+subset maps actual
 `CodeQueryResponse` values into ordered node IDs, directed edges, paths,
 truncation/no-answer state, measured latency, and serialized response bytes.
 JSON/store parity and repeated store execution must agree once timing is
@@ -159,6 +161,13 @@ responses contain no timing fields and remain byte-deterministic.
 The reviewed executable threshold block lives beside the test so a failure is
 local and deterministic. Updating its expected identities, graph digest, or
 minimums requires an intentional review rather than copying a new result.
+The generated 500-record artifact is checked against
+`scripts/generate_query_relevance_corpus.py --check` before execution. Fuzzy
+recall covers bounded adjacent transposition, deletion, insertion, and
+substitution variants (192 per eligible term and 256 per query), and a
+512-entry per-engine LRU caches immutable name-lookup results. The cache is
+keyed by normalized variant and result limit, so it cannot reuse an unbounded
+or differently truncated result.
 `scripts/prepare_query_relevance_review.py` turns approved local JSONL query
 logs into bounded, redacted, deterministic review candidates. It never sends
 data, invents expected results, or writes directly to the judgment corpus; a

--- a/scripts/generate_query_relevance_corpus.py
+++ b/scripts/generate_query_relevance_corpus.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Generate the reviewed executable Compass query-relevance corpus.
+
+The checked-in artifact is generated from the equivalence classes below so
+reviewers can audit the semantic judgment once per class and still execute a
+large paraphrase matrix. This script never derives an expected answer from
+Compass output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "crates/compass-query/tests/fixtures/relevance/executable-reviewed-v2.json"
+SCHEMA = "compass.query-judgments/1"
+REVIEW = (
+    "AI-reviewed synthetic equivalence case; approved by Codex judgment on "
+    "2026-08-08; not production telemetry"
+)
+
+
+def edge(source: str, target: str, kind: str) -> dict[str, object]:
+    return {
+        "edge": {
+            "source": source,
+            "target": target,
+            "kind": kind,
+            "direction": "source_to_target",
+        },
+        "grade": 3,
+    }
+
+
+def record(
+    identifier: str,
+    text: str,
+    query_class: str,
+    intent: str,
+    *,
+    nodes: tuple[tuple[str, int], ...] = (),
+    edges: tuple[dict[str, object], ...] = (),
+    paths: tuple[dict[str, object], ...] = (),
+    ambiguity: tuple[str, ...] = (),
+    must_not_return: tuple[str, ...] = (),
+    family: str,
+) -> dict[str, object]:
+    return {
+        "id": identifier,
+        "text": text,
+        "class": query_class,
+        "locale": "en-US",
+        "expectedIntent": intent,
+        "expectedSlots": {"operation": intent, "truncated": "false"},
+        "nodeJudgments": [{"id": node, "grade": grade} for node, grade in nodes],
+        "edgeJudgments": list(edges),
+        "pathJudgments": list(paths),
+        "acceptableAmbiguity": list(ambiguity),
+        "mustNotReturn": list(must_not_return),
+        "notes": f"{REVIEW}; family={family}",
+    }
+
+
+def search_records() -> list[dict[str, object]]:
+    templates = (
+        "find definition of {symbol}",
+        "definition of {symbol}",
+        "search for {symbol}",
+        "show me {symbol}",
+        "where is {symbol} defined",
+        "find {symbol}",
+        "search {symbol}",
+        "show {symbol}",
+    )
+    targets = (
+        ("UserService.list", "n:list", "exact"),
+        ("Menu.café", "n:unicode", "exact"),
+        ("café", "n:unicode", "lexical"),
+        ("cafe", "n:unicode", "lexical"),
+        ("Profile.résumé", "n:resume", "exact"),
+        ("résumé", "n:resume", "lexical"),
+        ("resume", "n:resume", "lexical"),
+        ("Units.Ångström", "n:unicode-case", "exact"),
+        ("Ångström", "n:unicode-case", "lexical"),
+        ("ångström", "n:unicode-case", "lexical"),
+        ("Cache.cache_key", "n:snake", "exact"),
+        ("cache_key", "n:snake", "lexical"),
+        ("Api.fetchUserRecord", "n:camel", "exact"),
+        ("fetchUserRecord", "n:camel", "lexical"),
+        ("UserService.listing", "n:listing", "exact"),
+        ("listing", "n:listing", "lexical"),
+        ("PaymentGateway.charge", "n:z-payment-charge", "exact"),
+        ("paymentgateway.charge", "n:z-payment-charge", "exact"),
+        ("charge", "n:z-payment-charge", "intent"),
+        ("GeneratedPaymentGateway.charge", "n:a-generated-charge", "exact"),
+    )
+    result: list[dict[str, object]] = []
+    ordinal = 1
+    for symbol, expected, query_class in targets:
+        for template in templates:
+            nodes = [(expected, 3)]
+            if symbol == "charge":
+                nodes.append(("n:a-generated-charge", 1))
+            result.append(
+                record(
+                    f"search-{ordinal:03d}",
+                    template.format(symbol=symbol),
+                    query_class,
+                    "search",
+                    nodes=tuple(nodes),
+                    family="search-normalization",
+                )
+            )
+            ordinal += 1
+
+    for typo, expected in (
+        ("litsing", "n:listing"),
+        ("cace_key", "n:snake"),
+        ("fetchUserRecrod", "n:camel"),
+        ("PaymntGateway.charge", "n:z-payment-charge"),
+    ):
+        for template in templates:
+            result.append(
+                record(
+                    f"fuzzy-{ordinal:03d}",
+                    template.format(symbol=typo),
+                    "fuzzy",
+                    "search",
+                    nodes=((expected, 3),),
+                    family="single-edit-fuzzy-recovery",
+                )
+            )
+            ordinal += 1
+    return result
+
+
+def callers_records() -> list[dict[str, object]]:
+    templates = (
+        "find callers of {symbol}",
+        "show callers of {symbol}",
+        "callers of {symbol}",
+        "who calls {symbol}",
+        "what calls {symbol}",
+        "what functions call {symbol}",
+        "what methods call {symbol}",
+        "which functions call {symbol}",
+        "which methods call {symbol}",
+        "where is {symbol} called",
+    )
+    nodes = (("n:caller", 3), ("n:list", 3), ("n:route", 3))
+    edges = (
+        edge("n:caller", "n:list", "calls"),
+        edge("n:route", "n:list", "routes_to"),
+    )
+    return [
+        record(
+            f"callers-{index:03d}",
+            template.format(symbol=symbol) + punctuation,
+            "edge",
+            "callers",
+            nodes=nodes,
+            edges=edges,
+            family="incoming-relation-recall",
+        )
+        for index, (template, symbol, punctuation) in enumerate(
+            (
+                (template, symbol, punctuation)
+                for template in templates
+                for symbol in ("UserService.list", "userservice.list", "UserService.lsit")
+                for punctuation in ("", "?")
+            ),
+            start=1,
+        )
+    ]
+
+
+def callees_records() -> list[dict[str, object]]:
+    templates = (
+        "find callees of {symbol}",
+        "show callees of {symbol}",
+        "callees of {symbol}",
+        "calls made by {symbol}",
+        "what does {symbol} call",
+        "what does {symbol} invoke",
+        "what functions does {symbol} call",
+        "what functions does {symbol} invoke",
+        "what methods does {symbol} call",
+        "what methods does {symbol} invoke",
+    )
+    nodes = (("n:caller", 3), ("n:list", 3))
+    edges = (edge("n:caller", "n:list", "calls"),)
+    return [
+        record(
+            f"callees-{index:03d}",
+            template.format(symbol=symbol) + punctuation,
+            "edge",
+            "callees",
+            nodes=nodes,
+            edges=edges,
+            family="outgoing-call-recall",
+        )
+        for index, (template, symbol, punctuation) in enumerate(
+            (
+                (template, symbol, punctuation)
+                for template in templates
+                for symbol in ("Api.caller", "api.caller", "Api.callar")
+                for punctuation in ("", "?")
+            ),
+            start=1,
+        )
+    ]
+
+
+def impact_records() -> list[dict[str, object]]:
+    templates = (
+        "what is impacted by {symbol}",
+        "what depends on {symbol}",
+        "who depends on {symbol}",
+        "what breaks if {symbol}",
+        "what changes if {symbol}",
+        "dependents of {symbol}",
+        "impact of {symbol}",
+        "what is the impact of {symbol}",
+        "what would break if {symbol}",
+        "what breaks if {symbol} changes",
+    )
+    nodes = (("n:caller", 3), ("n:dependent", 3))
+    edges = (edge("n:dependent", "n:caller", "imports"),)
+    return [
+        record(
+            f"impact-{index:03d}",
+            template.format(symbol=symbol) + punctuation,
+            "intent",
+            "impact",
+            nodes=nodes,
+            edges=edges,
+            family="downstream-impact-recall",
+        )
+        for index, (template, symbol, punctuation) in enumerate(
+            (
+                (template, symbol, punctuation)
+                for template in templates
+                for symbol in ("Api.caller", "api.caller", "Api.callar")
+                for punctuation in ("", "?")
+            ),
+            start=1,
+        )
+    ]
+
+
+def path_records() -> list[dict[str, object]]:
+    templates = (
+        "shortest path from {source} to {target}",
+        "path from {source} to {target}",
+        "route from {source} to {target}",
+        "connection from {source} to {target}",
+        "how does {source} reach {target}",
+        "how can {source} reach {target}",
+        "how is {source} connected to {target}",
+    )
+    pairs = (
+        ("Api.caller", "Store.callee"),
+        ("api.caller", "store.callee"),
+        ("Api.callar", "Store.callee"),
+        ("Api.caller", "Store.calee"),
+        ("Api.callar", "Store.calee"),
+    )
+    variants = [
+        (template, source, target, punctuation)
+        for template in templates
+        for source, target in pairs
+        for punctuation in ("", "?")
+    ][:50]
+    return [
+        record(
+            f"path-{index:03d}",
+            template.format(source=source, target=target) + punctuation,
+            "path",
+            "node_trail",
+            nodes=(("n:caller", 3), ("n:list", 3), ("n:callee", 3)),
+            edges=(
+                edge("n:caller", "n:list", "calls"),
+                edge("n:list", "n:callee", "calls"),
+            ),
+            paths=(
+                {
+                    "pattern": {
+                        "edgeKinds": ["calls", "calls"],
+                        "endpointIds": ["n:caller", "n:callee"],
+                    },
+                    "grade": 3,
+                },
+            ),
+            family="directed-path-recall",
+        )
+        for index, (template, source, target, punctuation) in enumerate(variants, start=1)
+    ]
+
+
+def architecture_records() -> list[dict[str, object]]:
+    templates = (
+        "find definition of {symbol}",
+        "definition of {symbol}",
+        "search for {symbol}",
+        "show me {symbol}",
+        "find {symbol}",
+        "show {symbol}",
+    )
+    punctuation = ("", "?", "!", ".", "   ?")
+    return [
+        record(
+            f"architecture-{index:03d}",
+            template.format(symbol="express::GET::/users") + suffix,
+            "architecture",
+            "search",
+            nodes=(("n:route", 3),),
+            family="framework-route-discovery",
+        )
+        for index, (template, suffix) in enumerate(
+            ((template, suffix) for template in templates for suffix in punctuation), start=1
+        )
+    ]
+
+
+def negative_records() -> list[dict[str, object]]:
+    templates = (
+        "find definition of {symbol}",
+        "definition of {symbol}",
+        "search for {symbol}",
+        "show me {symbol}",
+        "where is {symbol} defined",
+        "find {symbol}",
+        "search {symbol}",
+        "show {symbol}",
+    )
+    symbols = (
+        "definitely_missing",
+        "KafkaConsumerLagMonitor",
+        "BillingReconcilerV9",
+        "Nonexistent::CircuitBreaker",
+        "missingFeatureFlagResolver",
+    )
+    forbidden = (
+        "n:list",
+        "n:listing",
+        "n:caller",
+        "n:callee",
+        "n:z-payment-charge",
+    )
+    return [
+        record(
+            f"negative-{index:03d}",
+            template.format(symbol=symbol),
+            "negative",
+            "search",
+            must_not_return=forbidden,
+            family="reviewed-no-answer",
+        )
+        for index, (symbol, template) in enumerate(
+            ((symbol, template) for symbol in symbols for template in templates), start=1
+        )
+    ]
+
+
+def ambiguity_records() -> list[dict[str, object]]:
+    templates = (
+        "find definition of charge?",
+        "definition of charge?",
+        "search for charge?",
+        "show me charge?",
+        "where is charge defined?",
+        "find charge?",
+        "search charge?",
+        "show charge?",
+    )
+    return [
+        record(
+            f"ambiguity-{index:03d}",
+            text,
+            "intent",
+            "search",
+            nodes=(("n:z-payment-charge", 3), ("n:a-generated-charge", 1)),
+            ambiguity=("n:a-generated-charge",),
+            family="source-over-generated-ambiguity",
+        )
+        for index, text in enumerate(templates, start=1)
+    ]
+
+
+def build() -> dict[str, object]:
+    queries = (
+        search_records()
+        + callers_records()
+        + callees_records()
+        + impact_records()
+        + path_records()
+        + architecture_records()
+        + negative_records()
+        + ambiguity_records()
+    )
+    if len(queries) != 500:
+        raise RuntimeError(f"expected 500 generated judgments, got {len(queries)}")
+    ids = [query["id"] for query in queries]
+    texts = [query["text"] for query in queries]
+    if len(ids) != len(set(ids)):
+        raise RuntimeError("generated query ids are not unique")
+    if len(texts) != len(set(texts)):
+        raise RuntimeError("generated query texts are not unique")
+    return {
+        "schema": SCHEMA,
+        "corpusId": "compass-query-executable-ai-reviewed-v2",
+        "graphSchema": "compass.graph/1",
+        "graphDigest": "sha256:ac93d0a2a2d25d3d089e1f6eccab2e90246a045bac23c04fd0cfcc3d4125cf2b",
+        "repositoryRevision": "crates/compass-query/tests/support@v2",
+        "analyzerVersion": "compass.search-term/1",
+        "queries": queries,
+    }
+
+
+def encoded() -> str:
+    return json.dumps(build(), ensure_ascii=False, indent=2, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    expected = encoded()
+    if args.check:
+        if not OUTPUT.exists() or OUTPUT.read_text(encoding="utf-8") != expected:
+            print(f"{OUTPUT.relative_to(ROOT)} is stale; regenerate it with {Path(__file__).name}")
+            return 1
+        return 0
+    OUTPUT.write_text(expected, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_query_relevance.py
+++ b/scripts/qualify_query_relevance.py
@@ -13,6 +13,12 @@ def main() -> int:
     if not target:
         print("CARGO_TARGET_DIR must name this checkout's external target directory", file=sys.stderr)
         return 2
+    corpus_check = subprocess.run(
+        [sys.executable, "scripts/generate_query_relevance_corpus.py", "--check"],
+        check=False,
+    )
+    if corpus_check.returncode != 0:
+        return corpus_check.returncode
     review_self_test = subprocess.run(
         [sys.executable, "scripts/prepare_query_relevance_review.py", "--self-test"],
         check=False,


### PR DESCRIPTION
## Summary

- add a digest-pinned, reproducible 500-question AI-reviewed synthetic relevance corpus covering all eight query classes
- execute strict rank, recall, intent, slot, edge direction, path, no-answer, and work gates in CI
- complete bounded single-edit fuzzy recall, fix caller/callee operand intent parsing, and add a 512-entry immutable lookup cache
- document corpus governance and clearly distinguish synthetic judgments from production telemetry

## Verification

- python3 scripts/qualify_query_relevance.py
- cargo test -p compass-query --locked
- cargo clippy -p compass-query --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked
- cargo test -p compass-cli --test compass_product --locked
- sh scripts/check_product_boundary.sh

## Evidence boundary

The 500 records are executable AI-reviewed synthetic equivalence cases, not production telemetry or independent human review. They provide a strong deterministic regression gate; global production-accuracy claims still require an approved held-out production corpus.