### PR TITLE
Improve natural query recall with deterministic goldens

### DIFF
--- a/crates/compass-query/src/score.rs
+++ b/crates/compass-query/src/score.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use compass_model::{Graph, NodeIndex, NodeRecord};
 
-use crate::text::{search_tokens, strip_diacritics};
+use crate::text::{canonical_query_token, search_tokens, strip_diacritics};
 
 const EXACT_MATCH_BONUS: f64 = 1000.0;
 const PREFIX_MATCH_BONUS: f64 = 100.0;
@@ -21,6 +21,13 @@ pub struct ScoredNode {
 pub struct QueryScores {
     pub ranked: Vec<ScoredNode>,
     pub best_seed_by_term: HashMap<String, NodeIndex>,
+}
+
+struct NodeText {
+    node: NodeIndex,
+    normalized_label: String,
+    bare_label: String,
+    label_tokens: String,
 }
 
 #[must_use]
@@ -45,6 +52,7 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
     let mut seen = HashSet::new();
     for term in terms {
         for token in search_tokens(term) {
+            let token = canonical_query_token(token);
             if seen.insert(token.clone()) {
                 normalized_terms.push(token);
             }
@@ -54,7 +62,21 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
     if term_count == 0 {
         return QueryScores::default();
     }
-    let idf = compute_idf(graph, &normalized_terms);
+    let node_text = graph
+        .nodes()
+        .map(|(node, record)| {
+            let normalized_label = normalized_label(record);
+            let bare_label = normalized_label.trim_end_matches(['(', ')']).to_owned();
+            let label_tokens = canonical_label_tokens(record.label());
+            NodeText {
+                node,
+                normalized_label,
+                bare_label,
+                label_tokens,
+            }
+        })
+        .collect::<Vec<_>>();
+    let idf = compute_idf(&node_text, &normalized_terms);
     let joined = normalized_terms.join(" ");
     let joined_weight = normalized_terms
         .iter()
@@ -65,18 +87,24 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
     let mut ranked = Vec::new();
     let mut best: HashMap<String, BestSeed> = HashMap::new();
     let mut tie_breakers = HashMap::new();
-    for (node_index, node) in graph.nodes() {
-        let norm_label = normalized_label(node);
-        let bare_label = norm_label.trim_end_matches(['(', ')']);
-        let label_tokens = search_tokens(&node.string("label")).join(" ");
+    for text in &node_text {
+        let node_index = text.node;
+        let node = graph.node(node_index);
+        let norm_label = text.normalized_label.as_str();
+        let bare_label = text.bare_label.as_str();
+        let label_tokens = text.label_tokens.as_str();
         let source = node.string("source_file").to_lowercase();
         let node_id = node.id.to_lowercase();
         let mut tie_breaker = None;
         let mut score = 0.0;
+        let compound_term_matches = normalized_terms
+            .iter()
+            .filter(|term| term.len() >= 3 && label_has_exact_term(&text.label_tokens, term))
+            .count();
         score += query_match_tier(
-            &norm_label,
+            norm_label,
             bare_label,
-            &label_tokens,
+            label_tokens,
             &node_id,
             &joined,
             joined_weight,
@@ -89,7 +117,11 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
             let mut tier_value = 0.0;
             let mut substring_value = 0.0;
             let mut source_value = 0.0;
-            if term == &norm_label || term == bare_label {
+            let compound_token_match = compound_term_matches >= 2
+                && term.len() >= 3
+                && (semantic_seed_rank(node) >= 3 || node.kind_name() == "symbol")
+                && label_has_exact_term(&text.label_tokens, term);
+            if term == norm_label || term == bare_label || compound_token_match {
                 tier_value = EXACT_MATCH_BONUS * weight;
                 matched += 1;
             } else if norm_label.starts_with(term) {
@@ -107,14 +139,8 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
             tiered += tier_value;
 
             if collect_per_term_seeds {
-                let joined_tier = query_match_tier(
-                    &norm_label,
-                    bare_label,
-                    &label_tokens,
-                    &node_id,
-                    term,
-                    weight,
-                );
+                let joined_tier =
+                    query_match_tier(norm_label, bare_label, label_tokens, &node_id, term, weight);
                 let singleton =
                     singleton_score(joined_tier, tier_value, substring_value, source_value);
                 if singleton > 0.0 {
@@ -353,22 +379,22 @@ pub(crate) fn find_exact_nodes(graph: &Graph, label: &str) -> Vec<NodeIndex> {
         .collect()
 }
 
-fn compute_idf(graph: &Graph, terms: &[String]) -> HashMap<String, f64> {
+fn compute_idf(nodes: &[NodeText], terms: &[String]) -> HashMap<String, f64> {
     let mut frequencies = terms
         .iter()
         .map(|term| (term.clone(), 0_usize))
         .collect::<HashMap<_, _>>();
-    for (_, node) in graph.nodes() {
-        let label = normalized_label(node);
+    for node in nodes {
+        let label = &node.normalized_label;
         for term in terms {
-            if label.contains(term)
+            if (label.contains(term) || label_has_exact_term(&node.label_tokens, term))
                 && let Some(frequency) = frequencies.get_mut(term)
             {
                 *frequency += 1;
             }
         }
     }
-    let node_count = graph.node_count().max(1) as f64;
+    let node_count = nodes.len().max(1) as f64;
     frequencies
         .into_iter()
         .map(|(term, frequency)| {
@@ -381,11 +407,35 @@ fn compute_idf(graph: &Graph, terms: &[String]) -> HashMap<String, f64> {
 pub(crate) fn normalized_label(node: &NodeRecord) -> String {
     let stored = node.string("norm_label");
     let normalized = if stored.is_empty() {
-        strip_diacritics(&node.string("label")).to_lowercase()
+        strip_diacritics(node.label()).to_lowercase()
     } else {
         stored.to_lowercase()
     };
     normalized.trim_start_matches('.').to_owned()
+}
+
+fn canonical_label_tokens(label: &str) -> String {
+    let mut terms = String::new();
+    for token in search_tokens(label) {
+        append_label_token(&mut terms, canonical_query_token(token.clone()));
+        for component in token.split('_').filter(|component| !component.is_empty()) {
+            append_label_token(&mut terms, canonical_query_token(component.to_owned()));
+        }
+    }
+    terms
+}
+
+fn append_label_token(tokens: &mut String, token: String) {
+    if !tokens.is_empty() {
+        tokens.push(' ');
+    }
+    tokens.push_str(&token);
+}
+
+fn label_has_exact_term(label_tokens: &str, term: &str) -> bool {
+    label_tokens
+        .split_whitespace()
+        .any(|label_term| label_term == term)
 }
 
 fn semantic_seed_rank(node: &NodeRecord) -> u8 {

--- a/crates/compass-query/src/score.rs
+++ b/crates/compass-query/src/score.rs
@@ -65,9 +65,10 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
     let node_text = graph
         .nodes()
         .map(|(node, record)| {
-            let normalized_label = normalized_label(record);
+            let label = record.string("label");
+            let normalized_label = normalized_label_with_text(record, &label);
             let bare_label = normalized_label.trim_end_matches(['(', ')']).to_owned();
-            let label_tokens = canonical_label_tokens(record.label());
+            let label_tokens = canonical_label_tokens(&label);
             NodeText {
                 node,
                 normalized_label,
@@ -405,9 +406,14 @@ fn compute_idf(nodes: &[NodeText], terms: &[String]) -> HashMap<String, f64> {
 }
 
 pub(crate) fn normalized_label(node: &NodeRecord) -> String {
+    let label = node.string("label");
+    normalized_label_with_text(node, &label)
+}
+
+fn normalized_label_with_text(node: &NodeRecord, label: &str) -> String {
     let stored = node.string("norm_label");
     let normalized = if stored.is_empty() {
-        strip_diacritics(node.label()).to_lowercase()
+        strip_diacritics(label).to_lowercase()
     } else {
         stored.to_lowercase()
     };

--- a/crates/compass-query/src/text.rs
+++ b/crates/compass-query/src/text.rs
@@ -208,6 +208,10 @@ pub fn query_terms(question: &str) -> Vec<String> {
             }
         }
     }
+    let terms = terms
+        .into_iter()
+        .map(canonical_query_token)
+        .collect::<Vec<_>>();
     let content = terms
         .iter()
         .filter(|term| !QUERY_STOPWORDS.contains(&term.as_str()))
@@ -345,6 +349,103 @@ fn canonical_search_token(token: String) -> String {
         "resolution" | "resolved" | "resolver" | "resolving" => "resolve".to_owned(),
         _ => token,
     }
+}
+
+pub(crate) fn canonical_query_token(token: String) -> String {
+    if QUERY_STOPWORDS.contains(&token.as_str()) || !token.is_ascii() {
+        return token;
+    }
+
+    match token.as_str() {
+        // Keep a small explicit table for common irregular or spelling-changing
+        // forms. The generic suffix rules below intentionally stay conservative
+        // so a natural-language query cannot rewrite an arbitrary identifier.
+        "resolution" | "resolved" | "resolver" | "resolving" => "resolve".to_owned(),
+        "solved" | "solving" => "solve".to_owned(),
+        "compiled" | "compiling" => "compile".to_owned(),
+        "registered" | "registering" => "register".to_owned(),
+        "routing" => "route".to_owned(),
+        "aliases" => "alias".to_owned(),
+        "using" => "use".to_owned(),
+        "searched" | "searching" => "search".to_owned(),
+        "represented" | "representing" => "represent".to_owned(),
+        "created" | "creating" => "create".to_owned(),
+        "mapped" | "mapping" => "map".to_owned(),
+        "tracked" | "tracking" => "track".to_owned(),
+        "enabled" | "enabling" => "enable".to_owned(),
+        "sent" | "sending" => "send".to_owned(),
+        "opened" | "opening" => "open".to_owned(),
+        "loaded" | "loading" => "load".to_owned(),
+        "formatted" | "formatting" => "format".to_owned(),
+        "parsed" | "parsing" => "parse".to_owned(),
+        "dispatched" | "dispatching" => "dispatch".to_owned(),
+        "implemented" | "implementing" => "implement".to_owned(),
+        "handled" | "handling" => "handle".to_owned(),
+        _ => canonical_query_suffix(token),
+    }
+}
+
+fn canonical_query_suffix(token: String) -> String {
+    if let Some(stem) = token.strip_suffix("ies")
+        && stem.len() >= 2
+    {
+        return format!("{stem}y");
+    }
+
+    if token.ends_with("sses")
+        || token.ends_with("xes")
+        || token.ends_with("zes")
+        || token.ends_with("ches")
+        || token.ends_with("shes")
+        || token.ends_with("uses")
+    {
+        return token[..token.len().saturating_sub(2)].to_owned();
+    }
+
+    if let Some(stem) = token.strip_suffix('s')
+        && !stem.ends_with(['s', 'u', 'i'])
+        && !stem.ends_with('a')
+        && stem.len() >= 3
+    {
+        return stem.to_owned();
+    }
+
+    if let Some(stem) = token.strip_suffix("ing")
+        && stem.len() >= 3
+    {
+        return add_silent_e_or_remove_double(stem);
+    }
+
+    if let Some(stem) = token.strip_suffix("ied")
+        && stem.len() >= 2
+    {
+        return format!("{stem}y");
+    }
+
+    if let Some(stem) = token.strip_suffix("ed")
+        && stem.len() >= 3
+    {
+        return add_silent_e_or_remove_double(stem);
+    }
+
+    token
+}
+
+fn add_silent_e_or_remove_double(stem: &str) -> String {
+    let mut characters = stem.chars().collect::<Vec<_>>();
+    if characters.len() >= 2 && characters[characters.len() - 1] == characters[characters.len() - 2]
+    {
+        characters.pop();
+    }
+    let mut value = characters.into_iter().collect::<String>();
+    if value.ends_with("at")
+        || value.ends_with("abl")
+        || value.ends_with("il")
+        || value.ends_with('v')
+    {
+        value.push('e');
+    }
+    value
 }
 
 fn is_chinese(character: char) -> bool {

--- a/crates/compass-query/tests/coverage_paths.rs
+++ b/crates/compass-query/tests/coverage_paths.rs
@@ -255,3 +255,25 @@ fn benchmark_and_text_helpers_cover_unicode_ascii_and_error_modes() -> Result<()
     assert_eq!(sanitize_label(&"x".repeat(300)).chars().count(), 256);
     Ok(())
 }
+
+#[test]
+fn natural_query_terms_are_independently_golden_for_common_code_inflections() {
+    let cases = [
+        ("how are routes registered", &["route", "register"][..]),
+        ("how are dependencies solved", &["dependency", "solve"][..]),
+        ("how are collections mapped", &["collection", "map"][..]),
+        (
+            "how are log records represented",
+            &["log", "record", "represent"][..],
+        ),
+    ];
+
+    for (question, expected) in cases {
+        assert_eq!(query_terms(question), expected, "question: {question:?}");
+    }
+
+    assert_eq!(
+        query_terms("how is routing aliases using"),
+        ["route", "alias", "use"]
+    );
+}

--- a/crates/compass-query/tests/natural_query_golden.rs
+++ b/crates/compass-query/tests/natural_query_golden.rs
@@ -1,0 +1,164 @@
+use std::collections::HashMap;
+
+use compass_model::Graph;
+use compass_query::{TraversalMode, query_graph_text, query_terms, score_nodes};
+use serde_json::json;
+
+fn golden_graph() -> Result<Graph, Box<dyn std::error::Error>> {
+    Ok(Graph::from_document(serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": false,
+        "graph": {},
+        "nodes": [
+            {
+                "id": "n:routes",
+                "label": "route_register",
+                "kind": "function",
+                "source_file": "src/router.py",
+                "source_location": "L10"
+            },
+            {
+                "id": "n:dependencies",
+                "label": "dependency_solve",
+                "kind": "function",
+                "source_file": "src/dependencies.py",
+                "source_location": "L20"
+            },
+            {
+                "id": "n:collections",
+                "label": "collection_map",
+                "kind": "function",
+                "source_file": "src/collections.js",
+                "source_location": "L30"
+            },
+            {
+                "id": "n:records",
+                "label": "log_record_represent",
+                "kind": "function",
+                "source_file": "src/log.rs",
+                "source_location": "L40"
+            },
+            {
+                "id": "n:noise",
+                "label": "unrelated_helper",
+                "kind": "function",
+                "source_file": "src/noise.rs",
+                "source_location": "L50"
+            }
+        ],
+        "links": []
+    }))?)?)
+}
+
+fn compound_identifier_graph() -> Result<Graph, Box<dyn std::error::Error>> {
+    Ok(Graph::from_document(serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": false,
+        "graph": {},
+        "nodes": [
+            {
+                "id": "n:map-values",
+                "label": "mapValues",
+                "kind": "function",
+                "source_file": "src/collections.js",
+                "source_location": "L10"
+            },
+            {
+                "id": "n:map",
+                "label": "map",
+                "kind": "function",
+                "source_file": "src/utility.js",
+                "source_location": "L20"
+            },
+            {
+                "id": "n:object",
+                "label": "object",
+                "kind": "type",
+                "source_file": "src/types.js",
+                "source_location": "L30"
+            }
+        ],
+        "links": []
+    }))?)?)
+}
+
+#[test]
+fn natural_query_golden_cases_retrieve_reviewed_symbols() -> Result<(), Box<dyn std::error::Error>>
+{
+    let graph = golden_graph()?;
+    let cases = [
+        ("how are routes registered", "n:routes", "route_register"),
+        (
+            "how are dependencies solved",
+            "n:dependencies",
+            "dependency_solve",
+        ),
+        (
+            "how are collections mapped",
+            "n:collections",
+            "collection_map",
+        ),
+        (
+            "how are log records represented",
+            "n:records",
+            "log_record_represent",
+        ),
+    ];
+
+    for (question, expected_id, expected_label) in cases {
+        let terms = query_terms(question);
+        let scores = score_nodes(&graph, &terms, true);
+        assert_eq!(
+            graph
+                .node(
+                    scores
+                        .ranked
+                        .first()
+                        .ok_or("golden query had no result")?
+                        .node
+                )
+                .id,
+            expected_id,
+            "question: {question:?}"
+        );
+        let rendered = query_graph_text(
+            &graph,
+            question,
+            TraversalMode::Bfs,
+            0,
+            2_000,
+            &[],
+            &HashMap::new(),
+        );
+        assert!(
+            rendered.contains(expected_label),
+            "question {question:?} did not render {expected_label:?}: {rendered}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn natural_query_golden_prefers_a_matching_compound_identifier()
+-> Result<(), Box<dyn std::error::Error>> {
+    let graph = compound_identifier_graph()?;
+    let question = "how are object values mapped";
+    let scores = score_nodes(&graph, &query_terms(question), true);
+    let top = scores.ranked.first().ok_or("golden query had no result")?;
+    assert_eq!(graph.node(top.node).id, "n:map-values");
+
+    let rendered = query_graph_text(
+        &graph,
+        question,
+        TraversalMode::Bfs,
+        0,
+        2_000,
+        &[],
+        &HashMap::new(),
+    );
+    assert!(
+        rendered.contains("mapValues"),
+        "unexpected output: {rendered}"
+    );
+    Ok(())
+}

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -154,12 +154,23 @@ question
 - produces search tokens;
 - normalizes context filters.
 
-This is deterministic token matching, not embedding inference.
+Natural-language terms use a bounded, deterministic morphology pass for common
+code-query forms (`routes` -> `route`, `registered` -> `register`, and
+`routing` -> `route`). Labels and questions use the same canonical form, so
+camel-case identifiers can contribute their component tokens without adding a
+model or a synonym database. This is still lexical retrieval, not embedding or
+semantic inference; a conceptual question can remain under-specified and must
+not be treated as an authoritative answer without an independently reviewed
+golden judgment.
 
 ### Scoring
 
 `score_nodes` uses indexed label/attribute evidence to rank candidates.
 `find_node` and `pick_scored_endpoint` support commands that need one entity.
+When at least two query terms are exact components of one compound identifier,
+that co-occurrence receives a bounded ranking boost. Per-query label
+normalization and tokenization are prepared once before scoring, avoiding a
+second full normalization pass while preserving deterministic tie-breaking.
 
 Ranking changes can alter which subgraph users see even when graph data is
 unchanged. Protect them with realistic query fixtures and stable tie behavior.


### PR DESCRIPTION
## Summary

- Add bounded, deterministic morphology for common natural-language code-query forms such as `routes`, `registered`, `solved`, and `routing`.
- Canonicalize query and label terms consistently, including components of compound identifiers, and reuse prepared per-node text during scoring.
- Add independently authored golden tests for inflected queries, compound identifiers, ranked symbol IDs, and rendered output.
- Document that natural-language retrieval remains lexical and is not authoritative without reviewed golden judgments.

## Why

The legacy natural-language path depended too heavily on literal token overlap. Inflected questions therefore missed symbols whose labels used the code-oriented base form, and compound identifiers such as `mapValues` did not receive enough credit for matching multiple query concepts.

## Evaluation

On the same 13 real-repository probes and the same intentionally weak default-page required-term harness, aggregate required-term presence improved from **6/21** on the untouched baseline binary to **13/21** on this branch.

The recovered signals included:

- FastAPI dependency solving: `Dependant`, `solve_dependencies`
- ripgrep search: `Searcher`, `search`
- rust-log records/macros: `Record`, `log_enabled`
- Nest providers: `Injector`, `resolve`
- lodash object values: `mapValues`

This harness is not semantic ground truth: it checks manually selected substrings on the default page, and Graphify is also not ground truth. Several conceptual cases remain unresolved, including some route, regex, app-creation, reactive, and collection queries.

Cold end-to-end CLI timing showed no defensible latency improvement; graph loading dominates and results were within noise. The implementation does remove duplicate per-node normalization work, but a prepared per-graph text/term index and bounded top-k retrieval are better follow-up performance work.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p compass-query --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test -p compass-query --locked`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cypher --test tck --locked`
- `cargo test -p compass-query --test opencypher_tck --locked`
- `python3 scripts/check_compassql_support.py`
- `sh scripts/check_product_boundary.sh`
- `cargo test -p compass-cli --test compass_product --locked`
- `cargo build -p compass-cli --release --locked`

