### PR TITLE
Add deterministic BM25 shadow retrieval for text queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.19",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -57,6 +57,47 @@ Refresh a judged corpus, executable request, digest expectation, or threshold
 only with a reviewed intent/identity change and updated deterministic evidence;
 never regenerate expected judgments or thresholds from a proposed ranker.
 
+### Shadow text-ranker qualification
+
+The generic text-traversal ranker has an opt-in
+`text-ranker/bm25-v1` qualification profile. It is not selected by the CLI or
+MCP defaults. Run its controlled 100,000-node comparison with:
+
+```bash
+CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
+  scripts/qualify_text_ranker_bm25.sh
+```
+
+The script builds a release-mode qualification executable and runs each
+profile in a separate process so OS-reported peak RSS is comparable. Each run
+checks the exact top node ID, records the first query, then records 31 warm
+samples. The synthetic question has one rare matching symbol; it is useful for
+measuring indexed lookup overhead but does not represent common-term posting
+scans or a real-repository relevance distribution.
+
+One macOS Apple Silicon development run on 2026-08-08 produced:
+
+| Profile | First query | Warm p50 | Warm p95 | Maximum RSS | Top ID |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `text-ranker/legacy-v1` | 158.868 ms | 155.983 ms | 157.671 ms | 281,444,352 B | expected |
+| `text-ranker/bm25-v1` | 366.502 ms | 0.005 ms | 0.010 ms | 322,453,504 B | expected |
+
+The BM25 first query includes lazy construction of 202,008 terms for 100,000
+documents. On this run it was about 131% slower on first use and maximum RSS
+was about 14.6% higher, while warm rare-term lookup was substantially faster.
+The very small warm measurements are timer-sensitive and should not be
+generalized into a universal speedup.
+
+The compact reviewed language goldens currently give both profiles 1.0 for
+Success@1, MRR, Recall@5/20, and nDCG on four answerable Python/Rust/TypeScript/
+Unicode questions, plus 1.0 no-answer precision on one negative question. That
+small equal-score result demonstrates no regression on those cases; it does
+not demonstrate the required 10% relative Recall@5 improvement. Because the
+cold-query and memory observations also exceed the 10% review threshold, this
+evidence does not support making BM25 the default. It remains a shadow profile
+pending real-repository judgments and a decision about amortization or a more
+compact/persistent index.
+
 ## Compass Store release qualification
 
 The local store release harness records the adapter's build/query timings,

--- a/crates/compass-model/Cargo.toml
+++ b/crates/compass-model/Cargo.toml
@@ -18,6 +18,7 @@ rmp-serde.workspace = true
 rayon.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+unicode-normalization.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-model/src/graph.rs
+++ b/crates/compass-model/src/graph.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use serde_json::{Map, Value};
 
-use crate::{EdgeRecord, GraphDocument, GraphError, NodeRecord, QueryIndex, SchemaFingerprint};
+use crate::{
+    EdgeRecord, GraphDocument, GraphError, LexicalIndex, NodeRecord, QueryIndex, SchemaFingerprint,
+};
 
 pub type NodeIndex = usize;
 pub type EdgeIndex = usize;
@@ -262,6 +264,12 @@ impl Graph {
     #[must_use]
     pub fn query_index(&self) -> &QueryIndex {
         &self.query_index
+    }
+
+    /// Return the graph-derived lexical index, building it on first use.
+    #[must_use]
+    pub fn lexical_index(&self) -> &LexicalIndex {
+        self.query_index.lexical_index(&self.nodes)
     }
 
     #[must_use]

--- a/crates/compass-model/src/lexical.rs
+++ b/crates/compass-model/src/lexical.rs
@@ -1,0 +1,187 @@
+use unicode_normalization::UnicodeNormalization;
+use unicode_normalization::char::is_combining_mark;
+
+/// Remove combining marks from a Unicode normalization of `text`.
+#[must_use]
+pub fn strip_diacritics(text: &str) -> String {
+    text.nfkd()
+        .filter(|character| !is_combining_mark(*character))
+        .collect()
+}
+
+/// Split a code-oriented identifier into deterministic lowercase terms.
+///
+/// This handles Unicode words, punctuation, snake case, camel case, and
+/// acronym boundaries. It intentionally does not remove query stop words.
+#[must_use]
+pub fn identifier_tokens(text: &str) -> Vec<String> {
+    unicode_words(&split_identifier_words(&strip_diacritics(text)).to_lowercase())
+}
+
+/// Canonicalize one ASCII code-search term with bounded morphology.
+///
+/// Callers remain responsible for query-specific stop-word policy. Non-ASCII
+/// terms are returned unchanged so language-specific text is not rewritten by
+/// English suffix rules.
+#[must_use]
+pub fn canonical_code_token(token: String) -> String {
+    if !token.is_ascii() {
+        return token;
+    }
+
+    match token.as_str() {
+        "resolution" | "resolved" | "resolver" | "resolving" => "resolve".to_owned(),
+        "solved" | "solving" => "solve".to_owned(),
+        "compiled" | "compiling" => "compile".to_owned(),
+        "registered" | "registering" => "register".to_owned(),
+        "routing" => "route".to_owned(),
+        "aliases" => "alias".to_owned(),
+        "using" => "use".to_owned(),
+        "searched" | "searching" => "search".to_owned(),
+        "represented" | "representing" => "represent".to_owned(),
+        "created" | "creating" => "create".to_owned(),
+        "mapped" | "mapping" => "map".to_owned(),
+        "tracked" | "tracking" => "track".to_owned(),
+        "enabled" | "enabling" => "enable".to_owned(),
+        "sent" | "sending" => "send".to_owned(),
+        "opened" | "opening" => "open".to_owned(),
+        "loaded" | "loading" => "load".to_owned(),
+        "formatted" | "formatting" => "format".to_owned(),
+        "parsed" | "parsing" => "parse".to_owned(),
+        "dispatched" | "dispatching" => "dispatch".to_owned(),
+        "implemented" | "implementing" => "implement".to_owned(),
+        "handled" | "handling" => "handle".to_owned(),
+        _ => canonical_suffix(token),
+    }
+}
+
+fn unicode_words(text: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    for character in text.chars() {
+        if character.is_alphanumeric() || character == '_' {
+            current.push(character);
+        } else if !current.is_empty() {
+            words.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+fn split_identifier_words(text: &str) -> String {
+    let characters = text.chars().collect::<Vec<_>>();
+    let mut words = String::with_capacity(text.len());
+    for (index, &character) in characters.iter().enumerate() {
+        let previous = index.checked_sub(1).and_then(|at| characters.get(at));
+        let next = characters.get(index + 1);
+        let boundary = character.is_uppercase()
+            && previous.is_some_and(|value| {
+                value.is_lowercase()
+                    || value.is_numeric()
+                    || (value.is_uppercase() && next.is_some_and(|next| next.is_lowercase()))
+            });
+        if boundary {
+            words.push(' ');
+        }
+        words.push(character);
+    }
+    words
+}
+
+fn canonical_suffix(token: String) -> String {
+    if let Some(stem) = token.strip_suffix("ies")
+        && stem.len() >= 2
+    {
+        return format!("{stem}y");
+    }
+
+    if token.ends_with("sses")
+        || token.ends_with("xes")
+        || token.ends_with("zes")
+        || token.ends_with("ches")
+        || token.ends_with("shes")
+        || token.ends_with("uses")
+    {
+        return token[..token.len().saturating_sub(2)].to_owned();
+    }
+
+    if let Some(stem) = token.strip_suffix('s')
+        && !stem.ends_with(['s', 'u', 'i'])
+        && !stem.ends_with('a')
+        && stem.len() >= 3
+    {
+        return stem.to_owned();
+    }
+
+    if let Some(stem) = token.strip_suffix("ing")
+        && stem.len() >= 3
+    {
+        return add_silent_e_or_remove_double(stem);
+    }
+
+    if let Some(stem) = token.strip_suffix("ied")
+        && stem.len() >= 2
+    {
+        return format!("{stem}y");
+    }
+
+    if let Some(stem) = token.strip_suffix("ed")
+        && stem.len() >= 3
+    {
+        return add_silent_e_or_remove_double(stem);
+    }
+
+    token
+}
+
+fn add_silent_e_or_remove_double(stem: &str) -> String {
+    let mut characters = stem.chars().collect::<Vec<_>>();
+    if characters.len() >= 2 && characters[characters.len() - 1] == characters[characters.len() - 2]
+    {
+        characters.pop();
+    }
+    let mut value = characters.into_iter().collect::<String>();
+    if value.ends_with("at")
+        || value.ends_with("abl")
+        || value.ends_with("il")
+        || value.ends_with('v')
+    {
+        value.push('e');
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{canonical_code_token, identifier_tokens, strip_diacritics};
+
+    #[test]
+    fn identifier_tokens_preserve_code_boundaries_and_unicode() {
+        assert_eq!(
+            identifier_tokens("HTTPRoute_mapValues crème"),
+            ["http", "route_map", "values", "creme"]
+        );
+        assert_eq!(identifier_tokens("路由/处理"), ["路由", "处理"]);
+        assert_eq!(strip_diacritics("Crème brûlée"), "Creme brulee");
+    }
+
+    #[test]
+    fn code_token_morphology_is_bounded_and_deterministic() {
+        let cases = [
+            ("routes", "route"),
+            ("registered", "register"),
+            ("dependencies", "dependency"),
+            ("mapped", "map"),
+            ("resolution", "resolve"),
+            ("using", "use"),
+            ("analysis", "analysis"),
+            ("路由", "路由"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(canonical_code_token(input.to_owned()), expected);
+        }
+    }
+}

--- a/crates/compass-model/src/lexical_index.rs
+++ b/crates/compass-model/src/lexical_index.rs
@@ -1,0 +1,206 @@
+use std::collections::BTreeMap;
+
+use crate::{NodeIndex, NodeRecord, canonical_code_token, identifier_tokens};
+
+/// Per-field occurrence counts for one term in one graph node document.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LexicalTermFrequency {
+    pub label: u16,
+    pub identifier: u16,
+    pub kind: u16,
+    pub source: u16,
+}
+
+impl LexicalTermFrequency {
+    #[must_use]
+    pub fn total(self) -> u32 {
+        u32::from(self.label)
+            .saturating_add(u32::from(self.identifier))
+            .saturating_add(u32::from(self.kind))
+            .saturating_add(u32::from(self.source))
+    }
+}
+
+/// One deterministic term posting into the graph's node vector.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LexicalPosting {
+    pub node: NodeIndex,
+    pub frequency: LexicalTermFrequency,
+}
+
+/// Lazy, graph-derived lexical statistics used by bounded query retrieval.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LexicalIndex {
+    postings: BTreeMap<String, Vec<LexicalPosting>>,
+    document_lengths: Vec<u32>,
+    average_document_length: f64,
+}
+
+impl LexicalIndex {
+    pub(crate) fn build(nodes: &[NodeRecord]) -> Self {
+        let mut postings = BTreeMap::<String, Vec<LexicalPosting>>::new();
+        let mut document_lengths = Vec::with_capacity(nodes.len());
+        let mut total_document_length = 0_u64;
+
+        for (node_index, node) in nodes.iter().enumerate() {
+            let mut terms = BTreeMap::<String, LexicalTermFrequency>::new();
+            add_field_terms(&mut terms, node.label(), LexicalField::Label);
+            add_field_terms(&mut terms, &node.id, LexicalField::Identifier);
+            if let Some(qualified_name) = node
+                .logical_property("qualified_name")
+                .and_then(|value| value.as_str().map(str::to_owned))
+            {
+                add_field_terms(&mut terms, &qualified_name, LexicalField::Identifier);
+            }
+            add_field_terms(&mut terms, node.kind_name(), LexicalField::Kind);
+            if let Some(source_file) = node.source_file() {
+                add_field_terms(&mut terms, source_file, LexicalField::Source);
+            }
+
+            let document_length = terms
+                .values()
+                .map(|frequency| frequency.total())
+                .fold(0_u32, u32::saturating_add);
+            document_lengths.push(document_length);
+            total_document_length =
+                total_document_length.saturating_add(u64::from(document_length));
+
+            for (term, frequency) in terms {
+                postings.entry(term).or_default().push(LexicalPosting {
+                    node: node_index,
+                    frequency,
+                });
+            }
+        }
+
+        let average_document_length = if nodes.is_empty() {
+            0.0
+        } else {
+            total_document_length as f64 / nodes.len() as f64
+        };
+        Self {
+            postings,
+            document_lengths,
+            average_document_length,
+        }
+    }
+
+    #[must_use]
+    pub fn postings(&self, term: &str) -> &[LexicalPosting] {
+        self.postings.get(term).map_or(&[], Vec::as_slice)
+    }
+
+    #[must_use]
+    pub fn document_length(&self, node: NodeIndex) -> Option<u32> {
+        self.document_lengths.get(node).copied()
+    }
+
+    #[must_use]
+    pub fn document_count(&self) -> usize {
+        self.document_lengths.len()
+    }
+
+    #[must_use]
+    pub fn term_count(&self) -> usize {
+        self.postings.len()
+    }
+
+    #[must_use]
+    pub fn average_document_length(&self) -> f64 {
+        self.average_document_length
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LexicalField {
+    Label,
+    Identifier,
+    Kind,
+    Source,
+}
+
+fn add_field_terms(
+    terms: &mut BTreeMap<String, LexicalTermFrequency>,
+    value: &str,
+    field: LexicalField,
+) {
+    for token in identifier_tokens(value) {
+        add_term(terms, canonical_code_token(token.clone()), field);
+        if token.contains('_') {
+            for component in token.split('_').filter(|component| !component.is_empty()) {
+                add_term(terms, canonical_code_token(component.to_owned()), field);
+            }
+        }
+    }
+}
+
+fn add_term(terms: &mut BTreeMap<String, LexicalTermFrequency>, term: String, field: LexicalField) {
+    if term.is_empty()
+        || (term.chars().all(|character| character.is_ascii_lowercase())
+            && term.chars().count() <= 2)
+    {
+        return;
+    }
+    let frequency = terms.entry(term).or_default();
+    let slot = match field {
+        LexicalField::Label => &mut frequency.label,
+        LexicalField::Identifier => &mut frequency.identifier,
+        LexicalField::Kind => &mut frequency.kind,
+        LexicalField::Source => &mut frequency.source,
+    };
+    *slot = slot.saturating_add(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{Graph, LexicalTermFrequency};
+
+    #[test]
+    fn graph_lexical_index_is_lazy_deterministic_and_field_aware() {
+        let document = serde_json::from_value(json!({
+            "directed": true,
+            "multigraph": false,
+            "graph": {},
+            "nodes": [{
+                "id": "n:route-register",
+                "label": "route_register",
+                "qualifiedName": "api::RouteRegister",
+                "kind": "function",
+                "source_file": "src/routes.py"
+            }, {
+                "id": "n:dependency-solve",
+                "label": "solveDependencies",
+                "kind": "method",
+                "source_file": "src/dependencies.py"
+            }],
+            "links": []
+        }))
+        .unwrap_or_else(|_| std::process::abort());
+        let graph = Graph::from_document(document).unwrap_or_else(|_| std::process::abort());
+        let first = graph.lexical_index();
+        let second = graph.lexical_index();
+
+        assert!(std::ptr::eq(first, second));
+        assert_eq!(first.document_count(), 2);
+        assert!(first.term_count() > 4);
+        assert!(first.average_document_length().is_finite());
+        assert!(first.average_document_length() > 0.0);
+        assert!(first.document_length(0).is_some());
+        assert_eq!(first.document_length(99), None);
+        assert_eq!(
+            first.postings("route")[0].frequency,
+            LexicalTermFrequency {
+                label: 1,
+                identifier: 2,
+                kind: 0,
+                source: 1,
+            }
+        );
+        assert_eq!(first.postings("dependency")[0].node, 1);
+
+        let cloned = graph.clone();
+        assert!(std::ptr::eq(first, cloned.lexical_index()));
+    }
+}

--- a/crates/compass-model/src/lib.rs
+++ b/crates/compass-model/src/lib.rs
@@ -8,6 +8,7 @@ mod document;
 mod error;
 mod graph;
 pub mod identity;
+mod lexical;
 pub mod provenance;
 pub mod query_contract;
 mod query_index;
@@ -16,6 +17,7 @@ mod validation;
 pub use document::{EdgeRecord, GraphDocument, NodeRecord};
 pub use error::GraphError;
 pub use graph::{EdgeIndex, Graph, NodeIndex};
+pub use lexical::{canonical_code_token, identifier_tokens, strip_diacritics};
 pub use query_index::{QueryIndex, SchemaFingerprint, cypher_node_label, cypher_relationship_type};
 pub use validation::{
     CodeGraphValidationError, CodeGraphValidationReport, ExtractionValidationError,

--- a/crates/compass-model/src/lib.rs
+++ b/crates/compass-model/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod graph;
 pub mod identity;
 mod lexical;
+mod lexical_index;
 pub mod provenance;
 pub mod query_contract;
 mod query_index;
@@ -18,6 +19,7 @@ pub use document::{EdgeRecord, GraphDocument, NodeRecord};
 pub use error::GraphError;
 pub use graph::{EdgeIndex, Graph, NodeIndex};
 pub use lexical::{canonical_code_token, identifier_tokens, strip_diacritics};
+pub use lexical_index::{LexicalIndex, LexicalPosting, LexicalTermFrequency};
 pub use query_index::{QueryIndex, SchemaFingerprint, cypher_node_label, cypher_relationship_type};
 pub use validation::{
     CodeGraphValidationError, CodeGraphValidationReport, ExtractionValidationError,

--- a/crates/compass-model/src/query_index.rs
+++ b/crates/compass-model/src/query_index.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::OnceLock;
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::{EdgeIndex, EdgeRecord, NodeIndex, NodeRecord};
+use crate::{EdgeIndex, EdgeRecord, LexicalIndex, NodeIndex, NodeRecord};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SchemaFingerprint([u8; 32]);
@@ -40,6 +41,7 @@ pub struct QueryIndex {
     outgoing_by_type: Vec<BTreeMap<String, Vec<EdgeIndex>>>,
     incoming_by_type: Vec<BTreeMap<String, Vec<EdgeIndex>>>,
     schema_fingerprint: SchemaFingerprint,
+    lexical_index: OnceLock<LexicalIndex>,
 }
 
 impl QueryIndex {
@@ -52,6 +54,7 @@ impl QueryIndex {
             outgoing_by_type: Vec::new(),
             incoming_by_type: Vec::new(),
             schema_fingerprint: SchemaFingerprint::empty(),
+            lexical_index: OnceLock::new(),
         }
     }
 
@@ -111,6 +114,7 @@ impl QueryIndex {
             outgoing_by_type,
             incoming_by_type,
             schema_fingerprint,
+            lexical_index: OnceLock::new(),
         }
     }
 
@@ -157,6 +161,11 @@ impl QueryIndex {
     #[must_use]
     pub const fn schema_fingerprint(&self) -> SchemaFingerprint {
         self.schema_fingerprint
+    }
+
+    pub(crate) fn lexical_index(&self, nodes: &[NodeRecord]) -> &LexicalIndex {
+        self.lexical_index
+            .get_or_init(|| LexicalIndex::build(nodes))
     }
 }
 

--- a/crates/compass-query/examples/text_ranker_profile_qualification.rs
+++ b/crates/compass-query/examples/text_ranker_profile_qualification.rs
@@ -1,0 +1,202 @@
+use std::error::Error;
+use std::io;
+use std::time::{Duration, Instant};
+
+use compass_model::Graph;
+use compass_query::{TextRankProfile, query_terms, score_nodes_with_profile};
+use serde_json::{Value, json};
+
+const SCHEMA_V1: &str = "compass.text-ranker-qualification/1";
+const SCALE_NODES: usize = 100_000;
+const WARM_SAMPLES: usize = 31;
+const QUESTION: &str = "how are dependencies solved";
+const EXPECTED_ID: &str = "n:dependency-solve";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let graph = scale_graph()?;
+    let terms = query_terms(QUESTION);
+    let mode = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "--compare".to_owned());
+    let report = match mode.as_str() {
+        "--legacy" => single_profile_report(&graph, &terms, TextRankProfile::LegacyV1)?,
+        "--bm25" => single_profile_report(&graph, &terms, TextRankProfile::Bm25V1)?,
+        "--compare" => comparison_report(&graph, &terms)?,
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected --legacy, --bm25, or --compare",
+            )
+            .into());
+        }
+    };
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn single_profile_report(
+    graph: &Graph,
+    terms: &[String],
+    profile: TextRankProfile,
+) -> Result<Value, Box<dyn Error>> {
+    let first = measure(graph, terms, profile)?;
+    let warm = warm_samples(graph, terms, profile)?;
+    let lexical_index = if profile == TextRankProfile::Bm25V1 {
+        let index = graph.lexical_index();
+        json!({
+            "documents": index.document_count(),
+            "terms": index.term_count(),
+            "averageDocumentLength": index.average_document_length(),
+        })
+    } else {
+        Value::Null
+    };
+    Ok(json!({
+        "schema": SCHEMA_V1,
+        "mode": "single-profile",
+        "nodes": SCALE_NODES,
+        "warmSamples": WARM_SAMPLES,
+        "question": QUESTION,
+        "expectedId": EXPECTED_ID,
+        "result": profile_report(first, &warm),
+        "lexicalIndex": lexical_index,
+        "interpretation": interpretation()
+    }))
+}
+
+fn comparison_report(graph: &Graph, terms: &[String]) -> Result<Value, Box<dyn Error>> {
+    let legacy_first = measure(graph, terms, TextRankProfile::LegacyV1)?;
+    let legacy_warm = warm_samples(graph, terms, TextRankProfile::LegacyV1)?;
+    let bm25_first = measure(graph, terms, TextRankProfile::Bm25V1)?;
+    let bm25_warm = warm_samples(graph, terms, TextRankProfile::Bm25V1)?;
+    let index = graph.lexical_index();
+    Ok(json!({
+        "schema": SCHEMA_V1,
+        "mode": "comparison",
+        "nodes": SCALE_NODES,
+        "warmSamples": WARM_SAMPLES,
+        "question": QUESTION,
+        "expectedId": EXPECTED_ID,
+        "legacy": profile_report(legacy_first, &legacy_warm),
+        "bm25": profile_report(bm25_first, &bm25_warm),
+        "lexicalIndex": {
+            "documents": index.document_count(),
+            "terms": index.term_count(),
+            "averageDocumentLength": index.average_document_length(),
+        },
+        "interpretation": interpretation()
+    }))
+}
+
+fn interpretation() -> Value {
+    json!({
+        "legacyFirstIncludes": "full graph scan",
+        "bm25FirstIncludes": "lazy lexical index construction and query",
+        "warmSamplesExclude": "graph loading and first-use index construction",
+        "peakMemory": "measure each single-profile run with the repository qualification script"
+    })
+}
+
+fn scale_graph() -> Result<Graph, Box<dyn Error>> {
+    let mut nodes = (0..SCALE_NODES.saturating_sub(1))
+        .map(|index| {
+            json!({
+                "id": format!("n:scale:{index:05}"),
+                "label": format!("symbol_{index:05}"),
+                "kind": if index % 5 == 0 { "method" } else { "function" },
+                "source_file": format!("src/module_{:03}.rs", index % 1_000)
+            })
+        })
+        .collect::<Vec<_>>();
+    nodes.push(json!({
+        "id": EXPECTED_ID,
+        "label": "solve_dependencies",
+        "qualifiedName": "resolver::solve_dependencies",
+        "kind": "function",
+        "source_file": "src/dependencies.rs"
+    }));
+    let document = serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": false,
+        "graph": {},
+        "nodes": nodes,
+        "links": []
+    }))?;
+    Ok(Graph::from_document(document)?)
+}
+
+fn warm_samples(
+    graph: &Graph,
+    terms: &[String],
+    profile: TextRankProfile,
+) -> Result<Vec<Duration>, Box<dyn Error>> {
+    (0..WARM_SAMPLES)
+        .map(|_| measure(graph, terms, profile).map(|measurement| measurement.elapsed))
+        .collect()
+}
+
+fn measure(
+    graph: &Graph,
+    terms: &[String],
+    profile: TextRankProfile,
+) -> Result<Measurement, Box<dyn Error>> {
+    let started = Instant::now();
+    let result = score_nodes_with_profile(graph, terms, true, profile);
+    let elapsed = started.elapsed();
+    let top_id = result
+        .scores
+        .ranked
+        .first()
+        .map(|candidate| graph.node(candidate.node).id.as_str())
+        .ok_or("qualification query returned no candidates")?;
+    if top_id != EXPECTED_ID {
+        return Err(format!(
+            "{} returned {top_id:?}, expected {EXPECTED_ID:?}",
+            profile.as_str()
+        )
+        .into());
+    }
+    Ok(Measurement {
+        profile,
+        elapsed,
+        candidate_count: result.scores.ranked.len(),
+        candidates_truncated: result.candidates_truncated,
+        top_id: top_id.to_owned(),
+    })
+}
+
+fn profile_report(first: Measurement, warm: &[Duration]) -> Value {
+    json!({
+        "profile": first.profile.as_str(),
+        "firstQueryMicroseconds": micros(first.elapsed),
+        "warmP50Microseconds": micros(percentile(warm, 50)),
+        "warmP95Microseconds": micros(percentile(warm, 95)),
+        "candidateCount": first.candidate_count,
+        "candidatesTruncated": first.candidates_truncated,
+        "topId": first.top_id,
+    })
+}
+
+fn percentile(samples: &[Duration], percentile: usize) -> Duration {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let index = sorted
+        .len()
+        .saturating_mul(percentile)
+        .div_ceil(100)
+        .saturating_sub(1)
+        .min(sorted.len().saturating_sub(1));
+    sorted[index]
+}
+
+fn micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
+
+struct Measurement {
+    profile: TextRankProfile,
+    elapsed: Duration,
+    candidate_count: usize,
+    candidates_truncated: bool,
+    top_id: String,
+}

--- a/crates/compass-query/src/bm25.rs
+++ b/crates/compass-query/src/bm25.rs
@@ -1,0 +1,294 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use compass_model::{
+    Graph, LexicalTermFrequency, NodeIndex, canonical_code_token, identifier_tokens,
+};
+
+pub(crate) const BM25_PROFILE_V1: &str = "text-ranker/bm25-v1";
+pub(crate) const DEFAULT_BM25_CANDIDATE_LIMIT: usize = 512;
+const MAX_BM25_QUERY_TERMS: usize = 32;
+const K1: f64 = 1.2;
+const B: f64 = 0.75;
+const LABEL_WEIGHT: f64 = 4.0;
+const IDENTIFIER_WEIGHT: f64 = 3.0;
+const KIND_WEIGHT: f64 = 1.0;
+const SOURCE_WEIGHT: f64 = 0.5;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct Bm25Candidate {
+    pub(crate) node: NodeIndex,
+    pub(crate) score: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct Bm25Results {
+    pub(crate) ranked: Vec<Bm25Candidate>,
+    pub(crate) best_by_term: BTreeMap<String, NodeIndex>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct CandidateScore {
+    score: f64,
+}
+
+pub(crate) fn retrieve(graph: &Graph, terms: &[String], limit: usize) -> Bm25Results {
+    let (terms, terms_truncated) = normalized_terms(terms);
+    if terms.is_empty() {
+        return Bm25Results {
+            truncated: terms_truncated,
+            ..Bm25Results::default()
+        };
+    }
+
+    let index = graph.lexical_index();
+    let document_count = index.document_count();
+    if document_count == 0 {
+        return Bm25Results {
+            truncated: terms_truncated,
+            ..Bm25Results::default()
+        };
+    }
+    let average_document_length = index.average_document_length().max(1.0);
+    let mut scores = BTreeMap::<NodeIndex, CandidateScore>::new();
+    let mut best_by_term = BTreeMap::<String, Bm25Candidate>::new();
+
+    for term in &terms {
+        let postings = index.postings(term);
+        if postings.is_empty() {
+            continue;
+        }
+        let idf = inverse_document_frequency(document_count, postings.len());
+        for posting in postings {
+            let Some(document_length) = index.document_length(posting.node) else {
+                continue;
+            };
+            let term_score = bm25_term_score(
+                weighted_frequency(posting.frequency),
+                f64::from(document_length),
+                average_document_length,
+                idf,
+            );
+            if term_score <= 0.0 || !term_score.is_finite() {
+                continue;
+            }
+            scores.entry(posting.node).or_default().score += term_score;
+            let candidate = Bm25Candidate {
+                node: posting.node,
+                score: term_score,
+            };
+            if best_by_term
+                .get(term)
+                .is_none_or(|current| compare_candidates(graph, &candidate, current).is_lt())
+            {
+                best_by_term.insert(term.clone(), candidate);
+            }
+        }
+    }
+
+    let mut ranked = scores
+        .into_iter()
+        .filter_map(|(node, score)| {
+            score.score.is_finite().then_some(Bm25Candidate {
+                node,
+                score: score.score,
+            })
+        })
+        .collect::<Vec<_>>();
+    ranked.sort_by(|left, right| compare_candidates(graph, left, right));
+    let candidate_truncated = ranked.len() > limit;
+    ranked = retain_pinned_candidates(graph, ranked, best_by_term.values().copied(), limit);
+
+    Bm25Results {
+        ranked,
+        best_by_term: best_by_term
+            .into_iter()
+            .map(|(term, candidate)| (term, candidate.node))
+            .collect(),
+        truncated: terms_truncated || candidate_truncated,
+    }
+}
+
+fn normalized_terms(terms: &[String]) -> (Vec<String>, bool) {
+    let mut normalized = BTreeSet::new();
+    let mut truncated = false;
+    for term in terms {
+        for token in identifier_tokens(term) {
+            let token = canonical_code_token(token);
+            if !is_searchable(&token) || normalized.contains(&token) {
+                continue;
+            }
+            if normalized.len() >= MAX_BM25_QUERY_TERMS {
+                truncated = true;
+                break;
+            }
+            normalized.insert(token);
+        }
+        if truncated {
+            break;
+        }
+    }
+    (normalized.into_iter().collect(), truncated)
+}
+
+fn is_searchable(term: &str) -> bool {
+    !term.is_empty()
+        && (!term.chars().all(|character| character.is_ascii_lowercase())
+            || term.chars().count() > 2)
+}
+
+fn inverse_document_frequency(document_count: usize, document_frequency: usize) -> f64 {
+    let documents = document_count as f64;
+    let frequency = document_frequency as f64;
+    ((documents - frequency + 0.5) / (frequency + 0.5) + 1.0).ln()
+}
+
+fn weighted_frequency(frequency: LexicalTermFrequency) -> f64 {
+    f64::from(frequency.label) * LABEL_WEIGHT
+        + f64::from(frequency.identifier) * IDENTIFIER_WEIGHT
+        + f64::from(frequency.kind) * KIND_WEIGHT
+        + f64::from(frequency.source) * SOURCE_WEIGHT
+}
+
+fn bm25_term_score(
+    term_frequency: f64,
+    document_length: f64,
+    average_document_length: f64,
+    idf: f64,
+) -> f64 {
+    if term_frequency <= 0.0 || average_document_length <= 0.0 {
+        return 0.0;
+    }
+    let numerator = term_frequency * (K1 + 1.0);
+    let denominator =
+        term_frequency + K1 * (1.0 - B + B * (document_length / average_document_length));
+    if denominator <= 0.0 {
+        0.0
+    } else {
+        idf * (numerator / denominator)
+    }
+}
+
+fn retain_pinned_candidates(
+    graph: &Graph,
+    ranked: Vec<Bm25Candidate>,
+    pinned: impl IntoIterator<Item = Bm25Candidate>,
+    limit: usize,
+) -> Vec<Bm25Candidate> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let ranked_by_node = ranked
+        .iter()
+        .map(|candidate| (candidate.node, *candidate))
+        .collect::<BTreeMap<_, _>>();
+    let mut selected = pinned
+        .into_iter()
+        .filter_map(|candidate| ranked_by_node.get(&candidate.node).copied())
+        .collect::<Vec<_>>();
+    selected.sort_by(|left, right| compare_candidates(graph, left, right));
+    selected.dedup_by_key(|candidate| candidate.node);
+    if selected.len() > limit {
+        selected.truncate(limit);
+        return selected;
+    }
+
+    let mut selected_nodes = selected
+        .iter()
+        .map(|candidate| candidate.node)
+        .collect::<BTreeSet<_>>();
+    for candidate in ranked {
+        if selected.len() >= limit {
+            break;
+        }
+        if selected_nodes.insert(candidate.node) {
+            selected.push(candidate);
+        }
+    }
+    selected.sort_by(|left, right| compare_candidates(graph, left, right));
+    selected
+}
+
+fn compare_candidates(graph: &Graph, left: &Bm25Candidate, right: &Bm25Candidate) -> Ordering {
+    right
+        .score
+        .total_cmp(&left.score)
+        .then_with(|| graph.node(left.node).id.cmp(&graph.node(right.node).id))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use compass_model::Graph;
+
+    use super::{BM25_PROFILE_V1, retrieve};
+
+    fn graph() -> Graph {
+        let document = serde_json::from_value(json!({
+            "directed": true,
+            "multigraph": false,
+            "graph": {},
+            "nodes": [{
+                "id": "n:dependency-solve",
+                "label": "solve_dependencies",
+                "kind": "function",
+                "source_file": "src/dependencies.py"
+            }, {
+                "id": "n:dependency-fixture",
+                "label": "dependency_fixture",
+                "kind": "variable",
+                "source_file": "tests/generated/dependencies.py"
+            }, {
+                "id": "n:route-register",
+                "label": "route_register",
+                "kind": "function",
+                "source_file": "src/routes.py"
+            }, {
+                "id": "n:route-helper",
+                "label": "route_helper",
+                "kind": "function",
+                "source_file": "src/helpers.py"
+            }],
+            "links": []
+        }))
+        .unwrap_or_else(|_| std::process::abort());
+        Graph::from_document(document).unwrap_or_else(|_| std::process::abort())
+    }
+
+    #[test]
+    fn fielded_bm25_is_deterministic_bounded_and_term_complete() {
+        let graph = graph();
+        let terms = ["dependencies".to_owned(), "solved".to_owned()];
+        let first = retrieve(&graph, &terms, 2);
+        let second = retrieve(&graph, &terms, 2);
+
+        assert_eq!(BM25_PROFILE_V1, "text-ranker/bm25-v1");
+        assert_eq!(first, second);
+        assert_eq!(first.ranked.len(), 2);
+        assert_eq!(graph.node(first.ranked[0].node).id, "n:dependency-solve");
+        assert_eq!(
+            graph.node(first.best_by_term["dependency"]).id,
+            "n:dependency-solve"
+        );
+        assert_eq!(
+            graph.node(first.best_by_term["solve"]).id,
+            "n:dependency-solve"
+        );
+        assert!(!first.truncated);
+    }
+
+    #[test]
+    fn fielded_bm25_surfaces_candidate_truncation_and_no_answer() {
+        let graph = graph();
+        let bounded = retrieve(&graph, &["route".to_owned()], 1);
+        assert_eq!(bounded.ranked.len(), 1);
+        assert!(bounded.truncated);
+
+        let missing = retrieve(&graph, &["quantum".to_owned()], 512);
+        assert!(missing.ranked.is_empty());
+        assert!(missing.best_by_term.is_empty());
+        assert!(!missing.truncated);
+    }
+}

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod affected;
 mod benchmark;
-#[allow(dead_code)]
 mod bm25;
 mod code_query;
 mod cql;
@@ -39,12 +38,15 @@ pub use relevance::{
     QUERY_QUALIFICATION_SCHEMA_V1, QualificationReport, QueryClass, QueryObservation,
     RelevanceError, RelevanceMetrics, WorkCounts, qualification_report, score,
 };
-pub use score::{QueryScores, ScoredNode, find_node, pick_scored_endpoint, score_nodes};
+pub use score::{
+    ProfiledQueryScores, QueryScores, ScoredNode, TEXT_RANKER_BM25_V1, TEXT_RANKER_LEGACY_V1,
+    TextRankProfile, find_node, pick_scored_endpoint, score_nodes, score_nodes_with_profile,
+};
 pub use text::{normalize_context_filters, query_terms, sanitize_label, search_tokens};
 pub use traversal::{
-    DEFAULT_TEXT_TOKEN_BUDGET, TextPageOptions, TextPaginationError, TraversalMode,
-    query_graph_text, query_graph_text_page, render_explanation, render_explanation_page,
-    render_shortest_path,
+    DEFAULT_TEXT_TOKEN_BUDGET, ProfiledTextPageOptions, TextPageOptions, TextPaginationError,
+    TraversalMode, query_graph_text, query_graph_text_page, query_graph_text_page_with_profile,
+    render_explanation, render_explanation_page, render_shortest_path,
 };
 
 #[cfg(test)]

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod affected;
 mod benchmark;
+#[allow(dead_code)]
+mod bm25;
 mod code_query;
 mod cql;
 mod graph_engine;

--- a/crates/compass-query/src/score.rs
+++ b/crates/compass-query/src/score.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use compass_model::{Graph, NodeIndex, NodeRecord};
 
+use crate::bm25::{self, BM25_PROFILE_V1, DEFAULT_BM25_CANDIDATE_LIMIT};
 use crate::text::{canonical_query_token, search_tokens, strip_diacritics};
 
 const EXACT_MATCH_BONUS: f64 = 1000.0;
@@ -23,6 +24,33 @@ pub struct QueryScores {
     pub best_seed_by_term: HashMap<String, NodeIndex>,
 }
 
+pub const TEXT_RANKER_LEGACY_V1: &str = "text-ranker/legacy-v1";
+pub const TEXT_RANKER_BM25_V1: &str = BM25_PROFILE_V1;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TextRankProfile {
+    #[default]
+    LegacyV1,
+    Bm25V1,
+}
+
+impl TextRankProfile {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyV1 => TEXT_RANKER_LEGACY_V1,
+            Self::Bm25V1 => TEXT_RANKER_BM25_V1,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProfiledQueryScores {
+    pub profile: TextRankProfile,
+    pub candidates_truncated: bool,
+    pub scores: QueryScores,
+}
+
 struct NodeText {
     node: NodeIndex,
     normalized_label: String,
@@ -32,6 +60,41 @@ struct NodeText {
 
 #[must_use]
 pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool) -> QueryScores {
+    score_nodes_with_profile(
+        graph,
+        terms,
+        collect_per_term_seeds,
+        TextRankProfile::LegacyV1,
+    )
+    .scores
+}
+
+#[must_use]
+pub fn score_nodes_with_profile(
+    graph: &Graph,
+    terms: &[String],
+    collect_per_term_seeds: bool,
+    profile: TextRankProfile,
+) -> ProfiledQueryScores {
+    let (scores, candidates_truncated) = match profile {
+        TextRankProfile::LegacyV1 => (
+            score_nodes_legacy(graph, terms, collect_per_term_seeds),
+            false,
+        ),
+        TextRankProfile::Bm25V1 => score_nodes_bm25(graph, terms, collect_per_term_seeds),
+    };
+    ProfiledQueryScores {
+        profile,
+        candidates_truncated,
+        scores,
+    }
+}
+
+fn score_nodes_legacy(
+    graph: &Graph,
+    terms: &[String],
+    collect_per_term_seeds: bool,
+) -> QueryScores {
     if let [exact_id] = terms
         && exact_id.starts_with("sha256:")
         && let Some(node) = graph.node_index(exact_id)
@@ -48,6 +111,75 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
             },
         };
     }
+    let normalized_terms = normalized_query_terms(terms);
+    if normalized_terms.is_empty() {
+        return QueryScores::default();
+    }
+    let node_text = graph
+        .nodes()
+        .map(|(node, record)| node_text(node, record))
+        .collect::<Vec<_>>();
+    let idf = compute_idf(&node_text, &normalized_terms);
+    score_prepared_nodes(
+        graph,
+        &normalized_terms,
+        &node_text,
+        &idf,
+        collect_per_term_seeds,
+        &HashMap::new(),
+    )
+}
+
+fn score_nodes_bm25(
+    graph: &Graph,
+    terms: &[String],
+    collect_per_term_seeds: bool,
+) -> (QueryScores, bool) {
+    if let [exact_id] = terms
+        && exact_id.starts_with("sha256:")
+        && graph.node_index(exact_id).is_some()
+    {
+        return (
+            score_nodes_legacy(graph, terms, collect_per_term_seeds),
+            false,
+        );
+    }
+    let normalized_terms = normalized_query_terms(terms);
+    if normalized_terms.is_empty() {
+        return (QueryScores::default(), false);
+    }
+    let retrieved = bm25::retrieve(graph, &normalized_terms, DEFAULT_BM25_CANDIDATE_LIMIT);
+    let node_text = retrieved
+        .ranked
+        .iter()
+        .map(|candidate| node_text(candidate.node, graph.node(candidate.node)))
+        .collect::<Vec<_>>();
+    let idf = normalized_terms
+        .iter()
+        .map(|term| (term.clone(), 1.0))
+        .collect::<HashMap<_, _>>();
+    let fallback_scores = retrieved
+        .ranked
+        .iter()
+        .map(|candidate| (candidate.node, candidate.score))
+        .collect::<HashMap<_, _>>();
+    let mut scores = score_prepared_nodes(
+        graph,
+        &normalized_terms,
+        &node_text,
+        &idf,
+        collect_per_term_seeds,
+        &fallback_scores,
+    );
+    if collect_per_term_seeds {
+        for (term, node) in retrieved.best_by_term {
+            scores.best_seed_by_term.entry(term).or_insert(node);
+        }
+    }
+    (scores, retrieved.truncated)
+}
+
+fn normalized_query_terms(terms: &[String]) -> Vec<String> {
     let mut normalized_terms = Vec::new();
     let mut seen = HashSet::new();
     for term in terms {
@@ -58,26 +190,31 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
             }
         }
     }
-    let term_count = normalized_terms.len();
-    if term_count == 0 {
-        return QueryScores::default();
+    normalized_terms
+}
+
+fn node_text(node: NodeIndex, record: &NodeRecord) -> NodeText {
+    let label = record.string("label");
+    let normalized_label = normalized_label_with_text(record, &label);
+    let bare_label = normalized_label.trim_end_matches(['(', ')']).to_owned();
+    let label_tokens = canonical_label_tokens(&label);
+    NodeText {
+        node,
+        normalized_label,
+        bare_label,
+        label_tokens,
     }
-    let node_text = graph
-        .nodes()
-        .map(|(node, record)| {
-            let label = record.string("label");
-            let normalized_label = normalized_label_with_text(record, &label);
-            let bare_label = normalized_label.trim_end_matches(['(', ')']).to_owned();
-            let label_tokens = canonical_label_tokens(&label);
-            NodeText {
-                node,
-                normalized_label,
-                bare_label,
-                label_tokens,
-            }
-        })
-        .collect::<Vec<_>>();
-    let idf = compute_idf(&node_text, &normalized_terms);
+}
+
+fn score_prepared_nodes(
+    graph: &Graph,
+    normalized_terms: &[String],
+    node_text: &[NodeText],
+    idf: &HashMap<String, f64>,
+    collect_per_term_seeds: bool,
+    fallback_scores: &HashMap<NodeIndex, f64>,
+) -> QueryScores {
+    let term_count = normalized_terms.len();
     let joined = normalized_terms.join(" ");
     let joined_weight = normalized_terms
         .iter()
@@ -88,7 +225,7 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
     let mut ranked = Vec::new();
     let mut best: HashMap<String, BestSeed> = HashMap::new();
     let mut tie_breakers = HashMap::new();
-    for text in &node_text {
+    for text in node_text {
         let node_index = text.node;
         let node = graph.node(node_index);
         let norm_label = text.normalized_label.as_str();
@@ -113,7 +250,7 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
 
         let mut matched = 0_usize;
         let mut tiered = 0.0;
-        for term in &normalized_terms {
+        for term in normalized_terms {
             let weight = idf.get(term).copied().unwrap_or(1.0);
             let mut tier_value = 0.0;
             let mut substring_value = 0.0;
@@ -164,6 +301,9 @@ pub fn score_nodes(graph: &Graph, terms: &[String], collect_per_term_seeds: bool
         }
         let coverage = matched as f64 / term_count as f64;
         score += tiered * coverage.powi(2);
+        if score <= 0.0 {
+            score = fallback_scores.get(&node_index).copied().unwrap_or(0.0);
+        }
         if score > 0.0 {
             let tie =
                 *tie_breaker.get_or_insert_with(|| SeedTieBreaker::new(graph, node_index, node));
@@ -549,8 +689,8 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        BestSeed, QueryScores, ScoredNode, pick_seeds, query_match_tier, score_nodes,
-        singleton_score,
+        BestSeed, QueryScores, ScoredNode, TextRankProfile, pick_seeds, query_match_tier,
+        score_nodes, score_nodes_with_profile, singleton_score,
     };
 
     fn seed(score: f64, degree: usize, label_len: usize, id: &str) -> BestSeed {
@@ -651,6 +791,15 @@ mod tests {
             scores.best_seed_by_term.get(&id),
             Some(&scores.ranked[0].node)
         );
+        let bm25 = score_nodes_with_profile(
+            &graph,
+            std::slice::from_ref(&id),
+            true,
+            TextRankProfile::Bm25V1,
+        );
+        assert_eq!(bm25.scores.ranked, scores.ranked);
+        assert_eq!(bm25.scores.best_seed_by_term, scores.best_seed_by_term);
+        assert!(!bm25.candidates_truncated);
         Ok(())
     }
 
@@ -857,6 +1006,15 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(seeds[..2], ["save-method", "model-production"]);
+
+        let bm25 = score_nodes_with_profile(&graph, &terms, true, TextRankProfile::Bm25V1);
+        let bm25_seeds = pick_seeds(&graph, &bm25.scores, 3, 0.2)
+            .into_iter()
+            .map(|index| graph.node(index).id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(bm25_seeds[..2], ["save-method", "model-production"]);
+        assert!(!bm25_seeds.contains(&"save-variable"));
+        assert!(!bm25_seeds.contains(&"model-test"));
         Ok(())
     }
 }

--- a/crates/compass-query/src/text.rs
+++ b/crates/compass-query/src/text.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
-use unicode_normalization::UnicodeNormalization;
-use unicode_normalization::char::is_combining_mark;
+pub use compass_model::strip_diacritics;
+use compass_model::{canonical_code_token, identifier_tokens};
 
 const QUERY_STOPWORDS: &[&str] = &[
     "how",
@@ -164,15 +164,8 @@ const QUERY_STOPWORDS: &[&str] = &[
 ];
 
 #[must_use]
-pub fn strip_diacritics(text: &str) -> String {
-    text.nfkd()
-        .filter(|character| !is_combining_mark(*character))
-        .collect()
-}
-
-#[must_use]
 pub fn search_tokens(text: &str) -> Vec<String> {
-    unicode_words(&split_identifier_words(&strip_diacritics(text)).to_lowercase())
+    identifier_tokens(text)
         .into_iter()
         .map(canonical_search_token)
         .collect()
@@ -308,42 +301,6 @@ pub fn infer_context_filters(question: &str) -> Vec<String> {
         .collect()
 }
 
-fn unicode_words(text: &str) -> Vec<String> {
-    let mut words = Vec::new();
-    let mut current = String::new();
-    for character in text.chars() {
-        if character.is_alphanumeric() || character == '_' {
-            current.push(character);
-        } else if !current.is_empty() {
-            words.push(std::mem::take(&mut current));
-        }
-    }
-    if !current.is_empty() {
-        words.push(current);
-    }
-    words
-}
-
-fn split_identifier_words(text: &str) -> String {
-    let characters = text.chars().collect::<Vec<_>>();
-    let mut words = String::with_capacity(text.len());
-    for (index, &character) in characters.iter().enumerate() {
-        let previous = index.checked_sub(1).and_then(|at| characters.get(at));
-        let next = characters.get(index + 1);
-        let boundary = character.is_uppercase()
-            && previous.is_some_and(|value| {
-                value.is_lowercase()
-                    || value.is_numeric()
-                    || (value.is_uppercase() && next.is_some_and(|next| next.is_lowercase()))
-            });
-        if boundary {
-            words.push(' ');
-        }
-        words.push(character);
-    }
-    words
-}
-
 fn canonical_search_token(token: String) -> String {
     match token.as_str() {
         "resolution" | "resolved" | "resolver" | "resolving" => "resolve".to_owned(),
@@ -356,96 +313,7 @@ pub(crate) fn canonical_query_token(token: String) -> String {
         return token;
     }
 
-    match token.as_str() {
-        // Keep a small explicit table for common irregular or spelling-changing
-        // forms. The generic suffix rules below intentionally stay conservative
-        // so a natural-language query cannot rewrite an arbitrary identifier.
-        "resolution" | "resolved" | "resolver" | "resolving" => "resolve".to_owned(),
-        "solved" | "solving" => "solve".to_owned(),
-        "compiled" | "compiling" => "compile".to_owned(),
-        "registered" | "registering" => "register".to_owned(),
-        "routing" => "route".to_owned(),
-        "aliases" => "alias".to_owned(),
-        "using" => "use".to_owned(),
-        "searched" | "searching" => "search".to_owned(),
-        "represented" | "representing" => "represent".to_owned(),
-        "created" | "creating" => "create".to_owned(),
-        "mapped" | "mapping" => "map".to_owned(),
-        "tracked" | "tracking" => "track".to_owned(),
-        "enabled" | "enabling" => "enable".to_owned(),
-        "sent" | "sending" => "send".to_owned(),
-        "opened" | "opening" => "open".to_owned(),
-        "loaded" | "loading" => "load".to_owned(),
-        "formatted" | "formatting" => "format".to_owned(),
-        "parsed" | "parsing" => "parse".to_owned(),
-        "dispatched" | "dispatching" => "dispatch".to_owned(),
-        "implemented" | "implementing" => "implement".to_owned(),
-        "handled" | "handling" => "handle".to_owned(),
-        _ => canonical_query_suffix(token),
-    }
-}
-
-fn canonical_query_suffix(token: String) -> String {
-    if let Some(stem) = token.strip_suffix("ies")
-        && stem.len() >= 2
-    {
-        return format!("{stem}y");
-    }
-
-    if token.ends_with("sses")
-        || token.ends_with("xes")
-        || token.ends_with("zes")
-        || token.ends_with("ches")
-        || token.ends_with("shes")
-        || token.ends_with("uses")
-    {
-        return token[..token.len().saturating_sub(2)].to_owned();
-    }
-
-    if let Some(stem) = token.strip_suffix('s')
-        && !stem.ends_with(['s', 'u', 'i'])
-        && !stem.ends_with('a')
-        && stem.len() >= 3
-    {
-        return stem.to_owned();
-    }
-
-    if let Some(stem) = token.strip_suffix("ing")
-        && stem.len() >= 3
-    {
-        return add_silent_e_or_remove_double(stem);
-    }
-
-    if let Some(stem) = token.strip_suffix("ied")
-        && stem.len() >= 2
-    {
-        return format!("{stem}y");
-    }
-
-    if let Some(stem) = token.strip_suffix("ed")
-        && stem.len() >= 3
-    {
-        return add_silent_e_or_remove_double(stem);
-    }
-
-    token
-}
-
-fn add_silent_e_or_remove_double(stem: &str) -> String {
-    let mut characters = stem.chars().collect::<Vec<_>>();
-    if characters.len() >= 2 && characters[characters.len() - 1] == characters[characters.len() - 2]
-    {
-        characters.pop();
-    }
-    let mut value = characters.into_iter().collect::<String>();
-    if value.ends_with("at")
-        || value.ends_with("abl")
-        || value.ends_with("il")
-        || value.ends_with('v')
-    {
-        value.push('e');
-    }
-    value
+    canonical_code_token(token)
 }
 
 fn is_chinese(character: char) -> bool {

--- a/crates/compass-query/src/traversal.rs
+++ b/crates/compass-query/src/traversal.rs
@@ -4,7 +4,10 @@ use compass_model::{Graph, NodeIndex};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-use crate::score::{find_exact_nodes, find_node, pick_scored_endpoint, pick_seeds, score_nodes};
+use crate::score::{
+    TextRankProfile, find_exact_nodes, find_node, pick_scored_endpoint, pick_seeds, score_nodes,
+    score_nodes_with_profile,
+};
 use crate::text::{infer_context_filters, normalize_context_filters, query_terms, sanitize_label};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -19,6 +22,12 @@ pub const DEFAULT_TEXT_TOKEN_BUDGET: usize = 2_000;
 pub struct TextPageOptions {
     pub token_budget: usize,
     pub page: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProfiledTextPageOptions {
+    pub page: TextPageOptions,
+    pub rank_profile: TextRankProfile,
 }
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
@@ -76,14 +85,48 @@ pub fn query_graph_text_page(
     explicit_contexts: &[String],
     overlay: &HashMap<String, Map<String, Value>>,
 ) -> Result<String, TextPaginationError> {
-    let TextPageOptions { token_budget, page } = options;
+    query_graph_text_page_with_profile(
+        graph,
+        question,
+        mode,
+        depth,
+        ProfiledTextPageOptions {
+            page: options,
+            rank_profile: TextRankProfile::LegacyV1,
+        },
+        explicit_contexts,
+        overlay,
+    )
+}
+
+pub fn query_graph_text_page_with_profile(
+    graph: &Graph,
+    question: &str,
+    mode: TraversalMode,
+    depth: usize,
+    options: ProfiledTextPageOptions,
+    explicit_contexts: &[String],
+    overlay: &HashMap<String, Map<String, Value>>,
+) -> Result<String, TextPaginationError> {
+    let ProfiledTextPageOptions {
+        page: TextPageOptions { token_budget, page },
+        rank_profile: profile,
+    } = options;
     validate_pagination(token_budget, page)?;
     let terms = query_terms(question);
-    let scores = score_nodes(graph, &terms, true);
-    let seeds = pick_seeds(graph, &scores, 3, 0.2);
+    let profiled_scores = score_nodes_with_profile(graph, &terms, true, profile);
+    let seeds = pick_seeds(graph, &profiled_scores.scores, 3, 0.2);
     if seeds.is_empty() {
         return if page == 1 {
-            Ok("No matching nodes found.".to_owned())
+            if profile == TextRankProfile::LegacyV1 {
+                Ok("No matching nodes found.".to_owned())
+            } else {
+                Ok(format!(
+                    "No matching nodes found. Ranker: {}. Candidate retrieval: {}.",
+                    profile.as_str(),
+                    retrieval_state(profiled_scores.candidates_truncated)
+                ))
+            }
         } else {
             Err(TextPaginationError::PageOutOfRange {
                 requested: page,
@@ -113,6 +156,13 @@ pub fn query_graph_text_page(
         format!("Traversal: {} depth={depth}", mode.upper()),
         format!("Start: [{labels}]"),
     ];
+    if profile != TextRankProfile::LegacyV1 {
+        header.push(format!("Ranker: {}", profile.as_str()));
+        header.push(format!(
+            "Candidate retrieval: {}",
+            retrieval_state(profiled_scores.candidates_truncated)
+        ));
+    }
     if !contexts.is_empty() {
         header.push(format!(
             "Context: {} ({})",
@@ -131,6 +181,10 @@ pub fn query_graph_text_page(
         "facts",
     )?;
     Ok(format!("{header}\n\n{page}"))
+}
+
+fn retrieval_state(truncated: bool) -> &'static str {
+    if truncated { "truncated" } else { "complete" }
 }
 
 pub fn render_shortest_path(

--- a/crates/compass-query/tests/natural_query_golden.rs
+++ b/crates/compass-query/tests/natural_query_golden.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
 use compass_model::Graph;
-use compass_query::{TraversalMode, query_graph_text, query_terms, score_nodes};
+use compass_query::{
+    ProfiledTextPageOptions, TextPageOptions, TextPaginationError, TextRankProfile, TraversalMode,
+    query_graph_text, query_graph_text_page_with_profile, query_terms, score_nodes,
+    score_nodes_with_profile,
+};
 use serde_json::json;
 
 fn golden_graph() -> Result<Graph, Box<dyn std::error::Error>> {
@@ -128,6 +132,28 @@ fn reviewed_language_baseline_graph() -> Result<Graph, Box<dyn std::error::Error
     }))?)?)
 }
 
+fn profiled_text_query(
+    graph: &Graph,
+    question: &str,
+    rank_profile: TextRankProfile,
+) -> Result<String, TextPaginationError> {
+    query_graph_text_page_with_profile(
+        graph,
+        question,
+        TraversalMode::Bfs,
+        0,
+        ProfiledTextPageOptions {
+            page: TextPageOptions {
+                token_budget: 2_000,
+                page: 1,
+            },
+            rank_profile,
+        },
+        &[],
+        &HashMap::new(),
+    )
+}
+
 #[test]
 fn natural_query_golden_cases_retrieve_reviewed_symbols() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -249,5 +275,114 @@ fn reviewed_language_baseline_preserves_ids_anchors_and_no_answer()
     let no_answer = score_nodes(&graph, &query_terms("quantum banana synchronization"), true);
     assert!(no_answer.ranked.is_empty());
     assert!(no_answer.best_seed_by_term.is_empty());
+    Ok(())
+}
+
+#[test]
+fn bm25_shadow_profile_is_deterministic_and_keeps_legacy_as_default()
+-> Result<(), Box<dyn std::error::Error>> {
+    let graph = reviewed_language_baseline_graph()?;
+    let cases = [
+        ("how are dependencies solved", "py:solve-dependencies"),
+        ("how are log records represented", "rs:log-record"),
+        ("how are object values mapped", "ts:map-values"),
+        ("where is cafe parsed", "unicode:cafe-parser"),
+    ];
+
+    for (question, expected_id) in cases {
+        let terms = query_terms(question);
+        let legacy = score_nodes(&graph, &terms, true);
+        let explicit_legacy =
+            score_nodes_with_profile(&graph, &terms, true, TextRankProfile::LegacyV1);
+        assert_eq!(legacy.ranked, explicit_legacy.scores.ranked);
+        assert_eq!(
+            legacy.best_seed_by_term,
+            explicit_legacy.scores.best_seed_by_term
+        );
+        assert!(!explicit_legacy.candidates_truncated);
+
+        let first = score_nodes_with_profile(&graph, &terms, true, TextRankProfile::Bm25V1);
+        let second = score_nodes_with_profile(&graph, &terms, true, TextRankProfile::Bm25V1);
+        assert_eq!(first.scores.ranked, second.scores.ranked);
+        assert_eq!(
+            first.scores.best_seed_by_term,
+            second.scores.best_seed_by_term
+        );
+        assert_eq!(
+            first
+                .scores
+                .ranked
+                .first()
+                .map(|candidate| graph.node(candidate.node).id.as_str()),
+            Some(expected_id),
+            "question: {question:?}"
+        );
+        assert!(!first.candidates_truncated);
+    }
+
+    let default_output = query_graph_text(
+        &graph,
+        "how are dependencies solved",
+        TraversalMode::Bfs,
+        0,
+        2_000,
+        &[],
+        &HashMap::new(),
+    );
+    let explicit_legacy_output = profiled_text_query(
+        &graph,
+        "how are dependencies solved",
+        TextRankProfile::LegacyV1,
+    )?;
+    assert_eq!(default_output, explicit_legacy_output);
+
+    let bm25_output = profiled_text_query(
+        &graph,
+        "how are dependencies solved",
+        TextRankProfile::Bm25V1,
+    )?;
+    assert!(bm25_output.contains("Ranker: text-ranker/bm25-v1"));
+    assert!(bm25_output.contains("Candidate retrieval: complete"));
+    assert!(bm25_output.contains("src=fastapi/dependencies/utils.py"));
+    assert!(!bm25_output.contains("mapValuesFixture"));
+
+    let no_answer = score_nodes_with_profile(
+        &graph,
+        &query_terms("quantum banana synchronization"),
+        true,
+        TextRankProfile::Bm25V1,
+    );
+    assert!(no_answer.scores.ranked.is_empty());
+    assert!(no_answer.scores.best_seed_by_term.is_empty());
+    assert!(!no_answer.candidates_truncated);
+    Ok(())
+}
+
+#[test]
+fn bm25_shadow_profile_surfaces_candidate_truncation() -> Result<(), Box<dyn std::error::Error>> {
+    let nodes = (0..520)
+        .map(|index| {
+            json!({
+                "id": format!("route:{index:03}"),
+                "label": format!("route_{index:03}"),
+                "kind": "function",
+                "source_file": format!("src/routes/{index:03}.rs")
+            })
+        })
+        .collect::<Vec<_>>();
+    let graph = Graph::from_document(serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": false,
+        "graph": {},
+        "nodes": nodes,
+        "links": []
+    }))?)?;
+    let profiled =
+        score_nodes_with_profile(&graph, &query_terms("route"), true, TextRankProfile::Bm25V1);
+    assert_eq!(profiled.scores.ranked.len(), 512);
+    assert!(profiled.candidates_truncated);
+
+    let rendered = profiled_text_query(&graph, "route", TextRankProfile::Bm25V1)?;
+    assert!(rendered.contains("Candidate retrieval: truncated"));
     Ok(())
 }

--- a/crates/compass-query/tests/natural_query_golden.rs
+++ b/crates/compass-query/tests/natural_query_golden.rs
@@ -82,6 +82,52 @@ fn compound_identifier_graph() -> Result<Graph, Box<dyn std::error::Error>> {
     }))?)?)
 }
 
+fn reviewed_language_baseline_graph() -> Result<Graph, Box<dyn std::error::Error>> {
+    Ok(Graph::from_document(serde_json::from_value(json!({
+        "directed": true,
+        "multigraph": false,
+        "graph": {},
+        "nodes": [
+            {
+                "id": "py:solve-dependencies",
+                "label": "solve_dependencies",
+                "kind": "function",
+                "source_file": "fastapi/dependencies/utils.py",
+                "source_location": "L540"
+            },
+            {
+                "id": "rs:log-record",
+                "label": "log_record_represent",
+                "kind": "struct",
+                "source_file": "src/record.rs",
+                "source_location": "L18"
+            },
+            {
+                "id": "ts:map-values",
+                "label": "mapValues",
+                "kind": "function",
+                "source_file": "src/object/mapValues.ts",
+                "source_location": "L11"
+            },
+            {
+                "id": "ts:map-values-test",
+                "label": "mapValuesFixture",
+                "kind": "variable",
+                "source_file": "tests/generated/mapValues.test.ts",
+                "source_location": "L8"
+            },
+            {
+                "id": "unicode:cafe-parser",
+                "label": "CaféParser",
+                "kind": "class",
+                "source_file": "src/parsers/cafe.rs",
+                "source_location": "L25"
+            }
+        ],
+        "links": []
+    }))?)?)
+}
+
 #[test]
 fn natural_query_golden_cases_retrieve_reviewed_symbols() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -160,5 +206,48 @@ fn natural_query_golden_prefers_a_matching_compound_identifier()
         rendered.contains("mapValues"),
         "unexpected output: {rendered}"
     );
+    Ok(())
+}
+
+#[test]
+fn reviewed_language_baseline_preserves_ids_anchors_and_no_answer()
+-> Result<(), Box<dyn std::error::Error>> {
+    let graph = reviewed_language_baseline_graph()?;
+    let cases = [
+        ("how are dependencies solved", "py:solve-dependencies"),
+        ("how are log records represented", "rs:log-record"),
+        ("how are object values mapped", "ts:map-values"),
+        ("where is cafe parsed", "unicode:cafe-parser"),
+    ];
+
+    for (question, expected_id) in cases {
+        let expected = graph
+            .node_index(expected_id)
+            .ok_or("reviewed baseline node is missing")?;
+        for _ in 0..3 {
+            let scores = score_nodes(&graph, &query_terms(question), true);
+            assert_eq!(
+                scores.ranked.first().map(|candidate| candidate.node),
+                Some(expected),
+                "question: {question:?}"
+            );
+        }
+    }
+
+    let rendered = query_graph_text(
+        &graph,
+        "how are dependencies solved",
+        TraversalMode::Bfs,
+        0,
+        2_000,
+        &[],
+        &HashMap::new(),
+    );
+    assert!(rendered.contains("src=fastapi/dependencies/utils.py"));
+    assert!(!rendered.contains("mapValuesFixture"));
+
+    let no_answer = score_nodes(&graph, &query_terms("quantum banana synchronization"), true);
+    assert!(no_answer.ranked.is_empty());
+    assert!(no_answer.best_seed_by_term.is_empty());
     Ok(())
 }

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -37,7 +37,9 @@ family may still request a bounded materialized export.
 - preserves parallel edges for multigraph documents;
 - builds ID lookup;
 - builds incoming/outgoing adjacency;
-- builds `QueryIndex` and a schema fingerprint.
+- builds `QueryIndex` and a schema fingerprint;
+- registers a lazy graph-derived lexical index that is constructed only when
+  an opted-in text ranker requests it.
 
 Read commands can force stored direction when compatibility documents require
 it.
@@ -139,7 +141,7 @@ question
         -> compass.query/1
      -> generic, historical, contradictory, or traversal-controlled
         -> query_terms()
-        -> score_nodes()
+        -> score_nodes() [default legacy profile]
         -> choose anchors
         -> query_graph_text() with BFS/DFS and budget
         -> focused text subgraph
@@ -165,7 +167,8 @@ golden judgment.
 
 ### Scoring
 
-`score_nodes` uses indexed label/attribute evidence to rank candidates.
+`score_nodes` retains the established `text-ranker/legacy-v1` behavior: it
+prepares label evidence and scans the loaded graph to rank candidates.
 `find_node` and `pick_scored_endpoint` support commands that need one entity.
 When at least two query terms are exact components of one compound identifier,
 that co-occurrence receives a bounded ranking boost. Per-query label
@@ -174,6 +177,29 @@ second full normalization pass while preserving deterministic tie-breaking.
 
 Ranking changes can alter which subgraph users see even when graph data is
 unchanged. Protect them with realistic query fixtures and stable tie behavior.
+
+#### Shadow BM25 profile
+
+`score_nodes_with_profile` and `query_graph_text_page_with_profile` expose the
+opt-in `text-ranker/bm25-v1` library profile. The CLI and MCP defaults do not
+select it. The profile lazily derives an in-memory index from the validated
+graph's stable ID, display label, qualified name, kind, and source path fields.
+`graph.json` remains authoritative; the index is disposable, local, and reused
+only for the lifetime of the loaded graph.
+
+The index records deterministic postings, per-field term frequencies, document
+lengths, corpus size, and average document length. Candidate retrieval uses
+field weights 4.0 for labels, 3.0 for identifiers, 1.0 for kinds, and 0.5 for
+source paths with BM25 `k1=1.2` and `b=0.75`. Retrieval is capped at 512 nodes,
+retains the best candidate for each query term, and reports truncation. The
+existing exact-name tiers, source-backed/callable preference, generated/test
+penalty, stable ID tie-break, seed selection, traversal, provenance rendering,
+and pagination then operate over those candidates.
+
+This is qualification code, not a default cutover. Typed JSON FTS5 and store
+postings are unchanged, and FTS5's backend-specific `bm25()` score is not used.
+Promotion requires a separately reviewed relevance, cold-start, warm-latency,
+and memory decision.
 
 ### Traversal
 

--- a/scripts/qualify_text_ranker_bm25.sh
+++ b/scripts/qualify_text_ranker_bm25.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${CARGO_TARGET_DIR:-}" ]; then
+  echo "CARGO_TARGET_DIR must name this checkout's external target directory" >&2
+  exit 2
+fi
+
+cargo build \
+  -p compass-query \
+  --example text_ranker_profile_qualification \
+  --release \
+  --locked
+
+executable="$CARGO_TARGET_DIR/release/examples/text_ranker_profile_qualification"
+if [ "$(uname -s)" = "Windows_NT" ]; then
+  executable="${executable}.exe"
+fi
+
+if [ ! -x "$executable" ]; then
+  echo "qualification executable is missing: $executable" >&2
+  exit 1
+fi
+
+run_profile() {
+  profile="$1"
+  echo "text ranker qualification: $profile" >&2
+  case "$(uname -s)" in
+    Darwin)
+      /usr/bin/time -l "$executable" "--$profile"
+      ;;
+    Linux)
+      /usr/bin/time -v "$executable" "--$profile"
+      ;;
+    *)
+      "$executable" "--$profile"
+      echo "peak resident memory was not measured on this platform" >&2
+      ;;
+  esac
+}
+
+run_profile legacy
+run_profile bm25


### PR DESCRIPTION
## Summary

- consolidate deterministic Unicode/code-identifier normalization shared by graph indexing and text queries
- add reviewed natural-query goldens for Python, Rust, TypeScript, Unicode, generated/test distractors, exact IDs, no-answer, determinism, and truncation
- add a lazy graph-derived lexical index and bounded fielded BM25 retrieval profile (`text-ranker/bm25-v1`)
- name the deterministic full-graph scanner precisely as `text-ranker/full-scan-v1`
- preserve exact-name/structural reranking, seed selection, traversal direction, provenance, pagination, and stable node-ID tie-breaking
- expose BM25 only through an explicit library profile; the CLI, MCP, typed FTS5 search, store search, and default text ranker are unchanged
- add a reproducible 100,000-node release qualification harness and document the measured tradeoffs

## Why

Generic and traversal-controlled natural-language queries currently normalize and scan every loaded graph node on each request. The shadow profile tests whether a deterministic native lexical index can improve warm retrieval without making natural-language answers authoritative or introducing embeddings, services, credentials, external-product dependencies, or a graph schema change.

This is stacked on #205 and implements the shadow phase of #206. Follow-up #208 specifies persistent and incremental index generations, coherent graph/index reloads, recovery behavior, and the evidence-gated default cutover.

## Qualification decision

**Recommendation: keep BM25 opt-in; do not promote it in this PR.**

The compact reviewed language baseline is tied: both profiles score 1.0 for Success@1, MRR, Recall@5/20, and nDCG on four answerable cases, plus 1.0 no-answer precision on one negative case. That proves no regression on this small set, but it does not prove the required Recall@5 improvement.

One release-mode 100,000-node macOS development run (31 warm samples per profile) measured:

| Profile | First query | Warm p50 | Warm p95 | Maximum RSS |
| --- | ---: | ---: | ---: | ---: |
| `text-ranker/full-scan-v1` | 158.868 ms | 155.983 ms | 157.671 ms | 281,444,352 B |
| `text-ranker/bm25-v1` | 366.502 ms | 0.005 ms | 0.010 ms | 322,453,504 B |

This rare-term synthetic workload shows a strong warm-index benefit, but BM25 first use was about 131% slower and maximum RSS about 14.6% higher. The warm microsecond result is timer-sensitive and is not a universal performance claim. These observations fail the current cold-start/memory promotion thresholds.

Run the comparison with:

```bash
CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-<checkout> \
  scripts/qualify_text_ranker_bm25.sh
```

## Compatibility

- `graph.json` remains the portable authority and its schema is unchanged.
- The lexical index is in-memory, lazy, disposable, deterministic, and local.
- Existing default text-query output remains byte-identical.
- Typed `compass.query/1`, JSON FTS5, and immutable store-posting behavior are unchanged.
- Candidate retrieval is capped at 512 and reports truncation explicitly.
- No new runtime dependency, service, model credential, vector database, or external-product boundary is introduced.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-query --all-targets --all-features --locked`
- `cargo clippy -p compass-query --all-targets --all-features --locked -- -D warnings`
- `cargo test -p compass-cli --test compass_product --locked`
- `sh scripts/check_product_boundary.sh`
- `cargo test -p compass-cypher --test tck --locked`
- `cargo test -p compass-query --test opencypher_tck --locked`
- `python3 scripts/check_compassql_support.py`
- `python3 scripts/qualify_query_relevance.py`
- `scripts/qualify_text_ranker_bm25.sh`

All passed. The linker emitted the repository's existing debug compact-unwind size warning during the CLI integration build; tests still passed.
