### PR TITLE
Release Compass 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,33 @@
   repository-relative identity for universal framework facts so shallow source
   paths are published instead of being mistaken for temporary-directory paths.
 
+## 0.3.8 - 2026-08-11
+
+- Make evidence-first structural inference the default, with explicit
+  `--inference-level low|medium|high|max` controls. Low builds preserve
+  exact/source-backed relationships, bind the level into cache/build identity,
+  and remain deterministic.
+
+- Improve natural and agent discovery with indexed identifier/subword and
+  relationship-term recall, bounded caller/operation-role discovery,
+  capacity-aware traversal, focused default neighborhoods, and constant-work
+  proven no-answer behavior while preserving ambiguity, direction, provenance,
+  and bounded contracts.
+
+- Reduce resolver/query memory and latency with compact deterministic
+  fact/occurrence tables, bounded AST-cache publication, shared readers/object
+  caching, targeted index release, and pinned discovery/delta/performance
+  qualification.
+
+- Add typed pull-request risk review over immutable target, PR-head, and
+  synthetic-merge realizations, with deterministic cmpprv1 findings,
+  completeness/advisory risk projections, CLI/MCP surfaces, a fork-safe
+  read-only GitHub Action, and cycle-aware dependency topology.
+
+- Harden PHP symbol resolution and graph publication determinism, preserve
+  wildcard/import source anchors and directed multigraph evidence, and improve
+  community labels/report references.
+
 ## 0.3.7 - 2026-08-08
 
 - Improve natural-language query recall and ranking with bounded exact, alias,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "regex",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "axum",
  "compass-core",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "base64",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64",
  "compass-analysis",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,30 +35,30 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.7" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.7" }
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-program = { path = "../compass-program", version = "0.3.7" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.7" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.7" }
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.7" }
-compass-global = { path = "../compass-global", version = "0.3.7" }
-compass-history = { path = "../compass-history", version = "0.3.7" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.7" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.7" }
-compass-output = { path = "../compass-output", version = "0.3.7" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.7" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.7" }
-compass-prs = { path = "../compass-prs", version = "0.3.7" }
-compass-query = { path = "../compass-query", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.7" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.7" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.7" }
+compass-core = { path = "../compass-core", version = "0.3.8" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-program = { path = "../compass-program", version = "0.3.8" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.8" }
+compass-global = { path = "../compass-global", version = "0.3.8" }
+compass-history = { path = "../compass-history", version = "0.3.8" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.8" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.8" }
+compass-output = { path = "../compass-output", version = "0.3.8" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.8" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
+compass-prs = { path = "../compass-prs", version = "0.3.8" }
+compass-query = { path = "../compass-query", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.8" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.8" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.7" }
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-program = { path = "../compass-program", version = "0.3.7" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-program = { path = "../compass-program", version = "0.3.8" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,18 +24,18 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.7" }
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-history = { path = "../compass-history", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7" }
-compass-output = { path = "../compass-output", version = "0.3.7" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.7" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.7" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.7" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-history = { path = "../compass-history", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-output = { path = "../compass-output", version = "0.3.8" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.8" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.8" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.7" }
+compass-media = { path = "../compass-media", version = "0.3.8" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.7" }
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-program = { path = "../compass-program", version = "0.3.7" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-program = { path = "../compass-program", version = "0.3.8" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,18 +19,18 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.7" }
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-history = { path = "../compass-history", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-output = { path = "../compass-output", version = "0.3.7" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.7" }
-compass-prs = { path = "../compass-prs", version = "0.3.7" }
-compass-query = { path = "../compass-query", version = "0.3.7" }
+compass-core = { path = "../compass-core", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-history = { path = "../compass-history", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-output = { path = "../compass-output", version = "0.3.8" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
+compass-prs = { path = "../compass-prs", version = "0.3.8" }
+compass-query = { path = "../compass-query", version = "0.3.8" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.7" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,13 +20,13 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-history = { path = "../compass-history", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.7" }
-compass-query = { path = "../compass-query", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-history = { path = "../compass-history", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
+compass-query = { path = "../compass-query", version = "0.3.8" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.7" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.7" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -19,12 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.7" }
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -32,9 +32,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.7" }
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.7" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.8" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-program = { path = "../compass-program", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-program = { path = "../compass-program", version = "0.3.8" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.7" }
-compass-history = { path = "../compass-history", version = "0.3.7" }
-compass-ir = { path = "../compass-ir", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
+compass-history = { path = "../compass-history", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.7" }
-compass-program = { path = "../compass-program", version = "0.3.7" }
+compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-program = { path = "../compass-program", version = "0.3.8" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.7" }
-compass-media = { path = "../compass-media", version = "0.3.7" }
+compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-media = { path = "../compass-media", version = "0.3.8" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.7" }
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-query = { path = "../compass-query", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.7" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-query = { path = "../compass-query", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.8" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.7" }
+compass-store = { path = "../compass-store", version = "0.3.8" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.7" }
-compass-model = { path = "../compass-model", version = "0.3.7" }
-compass-store = { path = "../compass-store", version = "0.3.7", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.8", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.7", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.7", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.8", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.8", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -846,6 +846,7 @@ dependencies = [
  "compass-model",
  "compass-output",
  "compass-postgres",
+ "compass-pr-intelligence",
  "compass-program",
  "compass-prs",
  "compass-query",
@@ -874,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -886,9 +887,11 @@ dependencies = [
  "compass-languages",
  "compass-model",
  "compass-output",
+ "compass-pr-intelligence",
  "compass-program",
  "compass-reflect",
  "compass-resolve",
+ "compass-semantic-diff",
  "compass-store",
  "notify",
  "num_cpus",
@@ -902,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "regex",
@@ -914,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -951,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -963,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -976,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -997,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1009,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1029,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1047,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1057,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1086,13 +1089,16 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "axum",
  "compass-core",
  "compass-files",
  "compass-graph",
+ "compass-history",
  "compass-model",
+ "compass-output",
+ "compass-pr-intelligence",
  "compass-prs",
  "compass-query",
  "rmcp",
@@ -1105,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1115,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1123,11 +1129,12 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.19",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "compass-output"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1135,6 +1142,7 @@ dependencies = [
  "compass-graph",
  "compass-history",
  "compass-model",
+ "compass-pr-intelligence",
  "compass-query",
  "rayon",
  "serde",
@@ -1148,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1161,8 +1169,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compass-pr-intelligence"
+version = "0.3.8"
+dependencies = [
+ "compass-semantic-diff",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "compass-program"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "base64",
@@ -1178,12 +1197,14 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
+ "compass-pr-intelligence",
  "regex",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.19",
  "time",
  "wait-timeout",
@@ -1191,8 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
+ "base64",
  "compass-analysis",
  "compass-cypher",
  "compass-graph",
@@ -1212,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1226,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1243,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1264,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1278,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1289,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.7", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.7", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.7", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.7", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.7", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.7", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.7", path = "../crates/compass-output" }
-compass-query = { version = "0.3.7", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.7", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.7", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.8", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.8", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.8", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.8", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.8", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.8", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.8", path = "../crates/compass-output" }
+compass-query = { version = "0.3.8", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.8", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.8", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1686,7 +1686,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.7"
+    "producerVersion": "compass-languages/0.3.8"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary\n\n- Bump the Compass workspace and internal crate release metadata to 0.3.8, including both Cargo locks, the VS Code extension, npm lock metadata, and qualification producer identity.\n- Document the 0.3.8 release highlights in CHANGELOG.md.\n- Base the release on origin/main at 8b383d10db33430b1ebef6ddf98a93ed84b294fe.\n\n## Validation\n\n- cargo fmt --all -- --check\n- cargo check --workspace --all-targets --locked\n- cargo check --manifest-path fuzz/Cargo.toml --locked\n- cargo clippy --workspace --lib --bins --locked -- -D warnings\n- cargo test --workspace --lib --bins --locked\n- cargo test -p compass-cli --test compass_product --locked\n- scripts/check_product_boundary.sh\n- scripts/test_release_scripts.sh\n- scripts/qualify_code_graph_v1.sh --fixtures-only\n- npm run typecheck:js\n- npm run test:js\n- scripts/check_viewer_assets.mjs\n\nThe release workflow will build the six macOS, Linux, and Windows architecture archives and publish the validated manifest, checksums, and installers.