### PR TITLE
Release Compass 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,16 @@
   repository-relative identity for universal framework facts so shallow source
   paths are published instead of being mistaken for temporary-directory paths.
 
+## 0.3.9 - 2026-08-12
+
+- Add the versioned `compass.viewer.workbench/1` export contract and a shared
+  navigation shell for offline HTML and VS Code. `compass export html` now
+  supports repeatable code, call, impact, affected, architecture, history, and
+  artifact lenses, relationship/evidence/node-kind/language filters,
+  deterministic depth layouts, bounded camera controls, 1–4-hop selection
+  isolation, minimap navigation, keyboard shortcuts, and the `workbench-json`
+  machine export while preserving `compass.viewer.graph/1` compatibility.
+
 ## 0.3.8 - 2026-08-11
 
 - Make evidence-first structural inference the default, with explicit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "regex",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "axum",
  "compass-core",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "base64",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64",
  "compass-analysis",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,30 +35,30 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.8" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-program = { path = "../compass-program", version = "0.3.8" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.8" }
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.8" }
-compass-global = { path = "../compass-global", version = "0.3.8" }
-compass-history = { path = "../compass-history", version = "0.3.8" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.8" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.8" }
-compass-output = { path = "../compass-output", version = "0.3.8" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.8" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
-compass-prs = { path = "../compass-prs", version = "0.3.8" }
-compass-query = { path = "../compass-query", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.8" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.8" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
+compass-core = { path = "../compass-core", version = "0.3.9" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-program = { path = "../compass-program", version = "0.3.9" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.9" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.9" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.9" }
+compass-global = { path = "../compass-global", version = "0.3.9" }
+compass-history = { path = "../compass-history", version = "0.3.9" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.9" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.9" }
+compass-output = { path = "../compass-output", version = "0.3.9" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.9" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.9" }
+compass-prs = { path = "../compass-prs", version = "0.3.9" }
+compass-query = { path = "../compass-query", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.9" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.9" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.9" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-program = { path = "../compass-program", version = "0.3.8" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-program = { path = "../compass-program", version = "0.3.9" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,18 +24,18 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.8" }
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-history = { path = "../compass-history", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8" }
-compass-output = { path = "../compass-output", version = "0.3.8" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.8" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.8" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.9" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-history = { path = "../compass-history", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
+compass-output = { path = "../compass-output", version = "0.3.9" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.9" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.9" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.9" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.9" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.8" }
+compass-media = { path = "../compass-media", version = "0.3.9" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-program = { path = "../compass-program", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-program = { path = "../compass-program", version = "0.3.9" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,18 +19,18 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.8" }
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-history = { path = "../compass-history", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-output = { path = "../compass-output", version = "0.3.8" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
-compass-prs = { path = "../compass-prs", version = "0.3.8" }
-compass-query = { path = "../compass-query", version = "0.3.8" }
+compass-core = { path = "../compass-core", version = "0.3.9" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-history = { path = "../compass-history", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-output = { path = "../compass-output", version = "0.3.9" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.9" }
+compass-prs = { path = "../compass-prs", version = "0.3.9" }
+compass-query = { path = "../compass-query", version = "0.3.9" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,14 +20,14 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-history = { path = "../compass-history", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
-compass-query = { path = "../compass-query", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-history = { path = "../compass-history", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.9" }
+compass-query = { path = "../compass-query", version = "0.3.9" }
 unicode-normalization.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.8" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.9" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.8" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.9" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -19,12 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -32,9 +32,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.8" }
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.8" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.9" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.9" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-program = { path = "../compass-program", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-program = { path = "../compass-program", version = "0.3.9" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.8" }
-compass-history = { path = "../compass-history", version = "0.3.8" }
-compass-ir = { path = "../compass-ir", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.9" }
+compass-history = { path = "../compass-history", version = "0.3.9" }
+compass-ir = { path = "../compass-ir", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.8" }
-compass-program = { path = "../compass-program", version = "0.3.8" }
+compass-languages = { path = "../compass-languages", version = "0.3.9" }
+compass-program = { path = "../compass-program", version = "0.3.9" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.8" }
-compass-media = { path = "../compass-media", version = "0.3.8" }
+compass-files = { path = "../compass-files", version = "0.3.9" }
+compass-media = { path = "../compass-media", version = "0.3.9" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.8" }
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-query = { path = "../compass-query", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.8" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.9" }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-query = { path = "../compass-query", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.9" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.8" }
+compass-store = { path = "../compass-store", version = "0.3.9" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.8" }
-compass-model = { path = "../compass-model", version = "0.3.8" }
-compass-store = { path = "../compass-store", version = "0.3.8", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.9" }
+compass-model = { path = "../compass-model", version = "0.3.9" }
+compass-store = { path = "../compass-store", version = "0.3.9", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.8", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.8", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.9", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.9", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "regex",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "axum",
  "compass-core",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-cypher",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "base64",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64",
  "compass-analysis",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.8", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.8", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.8", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.8", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.8", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.8", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.8", path = "../crates/compass-output" }
-compass-query = { version = "0.3.8", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.8", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.8", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.9", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.9", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.9", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.9", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.9", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.9", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.9", path = "../crates/compass-output" }
+compass-query = { version = "0.3.9", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.9", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.9", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1686,7 +1686,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.8"
+    "producerVersion": "compass-languages/0.3.9"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- Sync from origin/main at 19fc5a12 and bump Compass-owned release metadata to 0.3.9.
- Add the 0.3.9 changelog entry for the versioned viewer workbench/export and graph exploration controls.
- Keep Cargo, fuzz, VS Code, package-lock, and qualification producer versions aligned.

## Validation
- cargo metadata --locked
- cargo check --workspace --all-targets --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked
- cargo test -p compass-cli --test compass_product --locked
- scripts/check_product_boundary.sh
- scripts/test_release_scripts.sh
- qualify_code_graph_v1.sh --fixtures-only
- npm ci; npm run typecheck:js; npm run test:js; node scripts/check_viewer_assets.mjs

## Release notes
The release will publish native macOS, Linux, and Windows archives with SHA-256 checksums, manifest, and installers.