### PR TITLE
Improve graph report community navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 - Make `GRAPH_REPORT.md` a more complete, label-first architecture entry map.
   The compact Agent Orientation still highlights the leading communities, while
-  the bounded Community Directory now retains up to 128 ranked non-empty
-  communities, including thin communities, and eight high-connectivity entry
+  the bounded Community Directory now retains up to 256 ranked non-empty
+  communities, including thin communities, and twelve high-connectivity entry
   points per community, with exact omission counts. Numeric community scopes
   remain only where they are useful for copyable
   `compass query --scope community:<id>` follow-up.
+  Raise the full report to 256,000 characters, the compact orientation to
+  16,000 characters, and the shared orientation/MCP resource envelope to 4 MiB.
 
 - Add bounded `compass.task-context/1` packets through `compass context` and
   MCP `task_context`, with exact target resolution, digest-verified source,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Make `GRAPH_REPORT.md` a more complete, label-first architecture entry map.
+  The compact Agent Orientation still highlights the leading communities, while
+  the bounded Community Directory now retains up to 128 ranked non-empty
+  communities, including thin communities, and eight high-connectivity entry
+  points per community, with exact omission counts. Numeric community scopes
+  remain only where they are useful for copyable
+  `compass query --scope community:<id>` follow-up.
+
 - Add bounded `compass.task-context/1` packets through `compass context` and
   MCP `task_context`, with exact target resolution, digest-verified source,
   provenance, linked reflection memory, deterministic omissions, work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 - Make `GRAPH_REPORT.md` a more complete, label-first architecture entry map.
   The compact Agent Orientation still highlights the leading communities, while
-  the bounded Community Directory now retains up to 256 ranked non-empty
-  communities, including thin communities, and twelve high-connectivity entry
-  points per community, with exact omission counts. Numeric community scopes
-  remain only where they are useful for copyable
-  `compass query --scope community:<id>` follow-up.
+  the bounded Community Directory now retains up to 4,096 ranked non-empty
+  communities, including thin communities. The top 32 receive full boundary
+  evidence and up to twelve high-connectivity entry points; every remaining
+  retained community receives a compact ranked index row with its best anchored
+  entry point. Numeric community scopes remain only where they are useful for
+  copyable `compass query --scope community:<id>` follow-up.
   Raise the full report to 256,000 characters, the compact orientation to
   16,000 characters, and the shared orientation/MCP resource envelope to 4 MiB.
 

--- a/crates/compass-mcp/src/lib.rs
+++ b/crates/compass-mcp/src/lib.rs
@@ -25,8 +25,8 @@ use compass_model::query_contract::{
 };
 use compass_model::{Graph, GraphDocument, NodeIndex};
 use compass_output::{
-    AgentOrientation, render_agent_report_markdown, render_orientation_json,
-    validate_orientation_graph_identity,
+    AgentOrientation, ORIENTATION_JSON_MAX_BYTES, render_agent_report_markdown,
+    render_orientation_json, validate_orientation_graph_identity,
 };
 use compass_prs::{
     ChangeRequestSource, LocalGitChangeRequestSource, ProcessRunner, SystemRunner,
@@ -52,7 +52,7 @@ const MAX_QUERY_LOG_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_QUERY_LOG_RECORD_BYTES: usize = 128 * 1024;
 const MAX_LOGGED_QUESTION_BYTES: usize = 4_096;
 const MAX_MCP_STRUCTURED_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
-const MAX_MCP_RESOURCE_BYTES: usize = 1024 * 1024;
+const MAX_MCP_RESOURCE_BYTES: usize = ORIENTATION_JSON_MAX_BYTES;
 const MCP_TOOL_RESULT_SCHEMA: &str = "compass.mcp.tool-result/1";
 const MCP_TRANSPORT_TRUNCATION_SCHEMA: &str = "compass.mcp.transport-truncation/1";
 

--- a/crates/compass-output/src/lib.rs
+++ b/crates/compass-output/src/lib.rs
@@ -52,15 +52,16 @@ pub use lenses::{
 pub use obsidian::{ObsidianExport, ObsidianOptions, export_obsidian, node_filenames};
 pub use report::{
     AgentOrientation, BoundedCoverage, DetectionSummary, FreshnessBasis, FreshnessStatus,
-    ORIENTATION_MARKDOWN_MAX_CHARS, ORIENTATION_SCHEMA, OrientationAmbiguousEdge,
-    OrientationCommunity, OrientationCommunityLink, OrientationConnection, OrientationCycle,
-    OrientationDetails, OrientationEvidenceStatus, OrientationGraphSummary, OrientationHealth,
-    OrientationHub, OrientationHyperedge, OrientationLearnedQuestion, OrientationNodeReference,
-    OrientationOmissions, OrientationPublicationDiagnostic, OrientationQuery, OrientationRisk,
-    OrientationSourceAnchor, OrientationWorkMemory, PublicationStatus, REPORT_MARKDOWN_MAX_CHARS,
-    ReportOptions, SectionOmission, TokenCost, WorkingTreeState, agent_orientation,
-    generate_report, graph_artifact_identity, render_agent_report_markdown,
-    render_orientation_json, render_orientation_markdown, validate_orientation_graph_identity,
+    ORIENTATION_JSON_MAX_BYTES, ORIENTATION_MARKDOWN_MAX_CHARS, ORIENTATION_SCHEMA,
+    OrientationAmbiguousEdge, OrientationCommunity, OrientationCommunityLink,
+    OrientationConnection, OrientationCycle, OrientationDetails, OrientationEvidenceStatus,
+    OrientationGraphSummary, OrientationHealth, OrientationHub, OrientationHyperedge,
+    OrientationLearnedQuestion, OrientationNodeReference, OrientationOmissions,
+    OrientationPublicationDiagnostic, OrientationQuery, OrientationRisk, OrientationSourceAnchor,
+    OrientationWorkMemory, PublicationStatus, REPORT_MARKDOWN_MAX_CHARS, ReportOptions,
+    SectionOmission, TokenCost, WorkingTreeState, agent_orientation, generate_report,
+    graph_artifact_identity, render_agent_report_markdown, render_orientation_json,
+    render_orientation_markdown, validate_orientation_graph_identity,
 };
 pub use review::{
     MAX_REVIEW_RENDER_BYTES, RenderedReview, render_readiness_json, render_readiness_markdown,

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -16,13 +16,20 @@ use crate::OutputError;
 pub const ORIENTATION_SCHEMA: &str = "compass.orientation/1";
 pub const ORIENTATION_MARKDOWN_MAX_CHARS: usize = 8_000;
 pub const REPORT_MARKDOWN_MAX_CHARS: usize = 64_000;
+const ORIENTATION_JSON_MAX_BYTES: usize = 1024 * 1024 - 1;
 
-const COMMUNITY_LIMIT: usize = 6;
+// The compact Agent Orientation shows only the leading communities, while the
+// full report keeps a substantially wider directory for repository navigation.
+// Both limits are explicit so an adversarial graph cannot grow output without
+// bound.
+const ORIENTATION_COMMUNITY_LIMIT: usize = 6;
+const COMMUNITY_LIMIT: usize = 128;
 const HUB_LIMIT: usize = 8;
 const RISK_LIMIT: usize = 8;
 const QUERY_LIMIT: usize = 8;
 const DETAIL_LIMIT: usize = 12;
-const REPRESENTATIVE_LIMIT: usize = 3;
+const ORIENTATION_REPRESENTATIVE_LIMIT: usize = 3;
+const REPRESENTATIVE_LIMIT: usize = 8;
 const COMMUNITY_LINK_LIMIT: usize = 2;
 const MIX_LIMIT: usize = 8;
 const ARGV_LIMIT: usize = 8;
@@ -422,13 +429,8 @@ pub fn agent_orientation(
     let node_communities = invert_communities(communities);
     let graph = ReportGraph::new(document, &node_communities);
     let cycle_probe = find_import_cycles(document, 5, DETAIL_LIMIT.saturating_add(1));
-    let (community_models, community_total) = build_communities(
-        &graph,
-        communities,
-        cohesion_scores,
-        community_labels,
-        options.min_community_size,
-    );
+    let (community_models, community_total) =
+        build_communities(&graph, communities, cohesion_scores, community_labels);
     let hub_total = god_node_list.len();
     let hubs = god_node_list
         .iter()
@@ -547,6 +549,7 @@ pub fn agent_orientation(
         details,
     };
     sanitize_orientation_model(&mut model);
+    fit_orientation_json_budget(&mut model);
     fit_orientation_budget(&mut model);
     fit_report_budget(&mut model, options.obsidian);
     model
@@ -886,28 +889,49 @@ fn build_communities(
     communities: &Communities,
     cohesion_scores: &BTreeMap<usize, f64>,
     labels: &BTreeMap<usize, String>,
-    min_size: usize,
 ) -> (Vec<OrientationCommunity>, usize) {
-    let eligible = communities
+    let mut eligible = communities
         .iter()
         .filter_map(|(community, members)| {
             let real = members
                 .iter()
                 .filter(|member| !graph.is_file_node_id(member))
                 .collect::<Vec<_>>();
-            (real.len() >= min_size).then_some((*community, real))
+            (!real.is_empty()).then_some((*community, real))
         })
         .collect::<Vec<_>>();
     let total = eligible.len();
+    eligible.sort_by(|(left_id, left_members), (right_id, right_members)| {
+        right_members
+            .len()
+            .cmp(&left_members.len())
+            .then_with(|| {
+                let left_edges = graph
+                    .community_connectivity
+                    .get(left_id)
+                    .map_or(0, |value| value.incident_edge_count);
+                let right_edges = graph
+                    .community_connectivity
+                    .get(right_id)
+                    .map_or(0, |value| value.incident_edge_count);
+                right_edges.cmp(&left_edges)
+            })
+            .then_with(|| labels.get(left_id).cmp(&labels.get(right_id)))
+            .then_with(|| left_id.cmp(right_id))
+    });
     let models = eligible
         .into_iter()
         .take(COMMUNITY_LIMIT)
         .map(|(community, members)| {
-            let representatives = members
+            let mut representatives = members
                 .iter()
                 .filter_map(|member| graph.node_reference(member))
-                .take(REPRESENTATIVE_LIMIT)
                 .collect::<Vec<_>>();
+            // Stable sorting preserves the deterministic community-member order
+            // when two candidates have equal connectivity.
+            representatives
+                .sort_by(|left, right| graph.degree(&right.id).cmp(&graph.degree(&left.id)));
+            representatives.truncate(REPRESENTATIVE_LIMIT);
             let representative_coverage =
                 SectionOmission::from_total_shown(members.len(), representatives.len());
             let connectivity = graph.community_connectivity.get(&community);
@@ -1784,7 +1808,10 @@ fn orientation_strings_are_bounded(model: &AgentOrientation) -> bool {
 }
 
 fn fit_orientation_budget(model: &mut AgentOrientation) {
-    while char_count(&render_orientation_markdown_unchecked(model)) > ORIENTATION_MARKDOWN_MAX_CHARS
+    while char_count(&render_orientation_markdown_with_community_limit(
+        model,
+        ORIENTATION_COMMUNITY_LIMIT,
+    )) > ORIENTATION_MARKDOWN_MAX_CHARS
     {
         if model.suggested_queries.pop().is_some() {
             model
@@ -1798,16 +1825,33 @@ fn fit_orientation_budget(model: &mut AgentOrientation) {
                 .set_shown(model.learned_questions.len());
         } else if model.risks.pop().is_some() {
             model.omissions.risks.set_shown(model.risks.len());
-        } else if model.communities.pop().is_some() {
-            model
-                .omissions
-                .communities
-                .set_shown(model.communities.len());
         } else if model.hubs.pop().is_some() {
             model.omissions.hubs.set_shown(model.hubs.len());
         } else {
             break;
         }
+    }
+}
+
+fn fit_orientation_json_budget(model: &mut AgentOrientation) {
+    loop {
+        let Ok(rendered) = serde_json::to_vec_pretty(model) else {
+            break;
+        };
+        if rendered.len() <= ORIENTATION_JSON_MAX_BYTES || model.communities.is_empty() {
+            break;
+        }
+        let scaled = model
+            .communities
+            .len()
+            .saturating_mul(ORIENTATION_JSON_MAX_BYTES)
+            / rendered.len();
+        let next = scaled.min(model.communities.len().saturating_sub(1));
+        model.communities.truncate(next);
+        model
+            .omissions
+            .communities
+            .set_shown(model.communities.len());
     }
 }
 
@@ -1843,6 +1887,11 @@ fn fit_report_budget(model: &mut AgentOrientation, obsidian: bool) {
                 .omissions
                 .surprising_connections
                 .set_shown(model.details.surprising_connections.len());
+        } else if model.communities.pop().is_some() {
+            model
+                .omissions
+                .communities
+                .set_shown(model.communities.len());
         } else {
             break;
         }
@@ -1850,8 +1899,33 @@ fn fit_report_budget(model: &mut AgentOrientation, obsidian: bool) {
 }
 
 fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
+    let mut community_limit = ORIENTATION_COMMUNITY_LIMIT.min(model.communities.len());
+    loop {
+        let rendered = render_orientation_markdown_with_community_limit(model, community_limit);
+        if char_count(&rendered) <= ORIENTATION_MARKDOWN_MAX_CHARS || community_limit == 0 {
+            return rendered;
+        }
+        community_limit = community_limit.saturating_sub(1);
+    }
+}
+
+fn render_orientation_markdown_with_community_limit(
+    model: &AgentOrientation,
+    community_limit: usize,
+) -> String {
     let evidence = &model.evidence_status;
     let summary = &model.graph_summary;
+    let community_labels = community_label_index(model);
+    let shown_communities = community_limit.min(model.communities.len());
+    let mut hub_label_counts = BTreeMap::<&str, usize>::new();
+    for hub in &model.hubs {
+        let label = if hub.label.is_empty() {
+            hub.id.as_str()
+        } else {
+            hub.label.as_str()
+        };
+        *hub_label_counts.entry(label).or_default() += 1;
+    }
     let mut lines = vec![
         "# Agent Orientation".to_owned(),
         String::new(),
@@ -1905,22 +1979,35 @@ fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
         ),
         String::new(),
         "## Architecture Map".to_owned(),
-        disclosure(model.omissions.communities),
+        "- Leading communities are ranked by member count, connectivity, label, and stable ID. See the complete bounded directory later in this report."
+            .to_owned(),
+        disclosure(SectionOmission::from_total_shown(
+            model.omissions.communities.total,
+            shown_communities,
+        )),
     ];
-    for community in &model.communities {
-        lines.push(format!("### Community {}", community.id));
+    for community in model.communities.iter().take(shown_communities) {
         lines.push(format!(
-            "- Evidence label: {} · members: {} · cohesion: {}",
-            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS),
+            "### {}",
+            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS)
+        ));
+        lines.push(format!(
+            "- Query scope: community:{} · members: {} · cohesion: {}",
+            community.id,
             community.member_count,
             community
                 .cohesion
                 .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.2}")),
         ));
+        let representative_count =
+            ORIENTATION_REPRESENTATIVE_LIMIT.min(community.representatives.len());
         lines.push(format!(
-            "- Representatives ({}): {}",
-            inline_disclosure(community.representative_coverage),
-            node_references(&community.representatives)
+            "- Entry points ({}): {}",
+            inline_disclosure(SectionOmission::from_total_shown(
+                community.member_count,
+                representative_count,
+            )),
+            node_references(&community.representatives[..representative_count])
         ));
         lines.push(format!(
             "- Incident edges: {} · adjacent communities: {} · strongest adjacent ({}): {}",
@@ -1930,7 +2017,7 @@ fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
                 community.adjacent_community_count,
                 community.strongest_adjacent.len(),
             )),
-            community_link_list(&community.strongest_adjacent),
+            community_link_list(&community.strongest_adjacent, &community_labels),
         ));
         if let (Some(incoming_total), Some(outgoing_total), Some(incoming), Some(outgoing)) = (
             community.incoming_community_count,
@@ -1944,12 +2031,12 @@ fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
                     incoming_total,
                     incoming.len(),
                 )),
-                community_link_list(incoming),
+                community_link_list(incoming, &community_labels),
                 inline_disclosure(SectionOmission::from_total_shown(
                     outgoing_total,
                     outgoing.len(),
                 )),
-                community_link_list(outgoing),
+                community_link_list(outgoing, &community_labels),
             ));
         }
     }
@@ -1964,13 +2051,27 @@ fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
         disclosure(model.omissions.hubs),
     ]);
     for hub in &model.hubs {
+        let label = if hub.label.is_empty() {
+            hub.id.as_str()
+        } else {
+            hub.label.as_str()
+        };
+        let mut identity = markdown_value(label, MARKDOWN_VALUE_MAX_CHARS);
+        if hub_label_counts.get(label).copied().unwrap_or_default() > 1 && hub.id.as_str() != label
+        {
+            identity.push_str(&format!(
+                " [id: {}]",
+                markdown_value(&hub.id, MARKDOWN_VALUE_MAX_CHARS)
+            ));
+        }
         let mut evidence = format!(
-            "- ID: {} · label: {} · anchor: {} · community: {} · incident edges: {}",
-            markdown_value(&hub.id, MARKDOWN_VALUE_MAX_CHARS),
-            markdown_value(&hub.label, MARKDOWN_VALUE_MAX_CHARS),
+            "- Hub: {} · anchor: {} · community: {} · incident edges: {}",
+            identity,
             optional_anchor(hub.anchor.as_ref()),
-            hub.community_id
-                .map_or_else(|| "unknown".to_owned(), |value| value.to_string()),
+            hub.community_id.map_or_else(
+                || "unknown".to_owned(),
+                |value| community_label_or_scope(value, &community_labels),
+            ),
             hub.incident_edge_count,
         );
         if let (Some(incoming), Some(outgoing)) = (hub.incoming, hub.outgoing) {
@@ -2037,6 +2138,7 @@ fn render_orientation_markdown_unchecked(model: &AgentOrientation) -> String {
 }
 
 fn render_report_markdown(model: &AgentOrientation, obsidian: bool) -> String {
+    let community_labels = community_label_index(model);
     let mut lines = vec![
         render_orientation_markdown_unchecked(model),
         String::new(),
@@ -2059,6 +2161,7 @@ fn render_report_markdown(model: &AgentOrientation, obsidian: bool) -> String {
             markdown_value(warning, MARKDOWN_VALUE_MAX_CHARS)
         ));
     }
+    append_community_directory(&mut lines, model, obsidian, &community_labels);
     lines.extend([
         String::new(),
         "## Surprising Connections".to_owned(),
@@ -2101,32 +2204,6 @@ fn render_report_markdown(model: &AgentOrientation, obsidian: bool) -> String {
             inline_disclosure(hyperedge.member_coverage),
             value_list(&hyperedge.members),
             markdown_value(&hyperedge.confidence, MARKDOWN_VALUE_MAX_CHARS),
-        ));
-    }
-    lines.extend([
-        String::new(),
-        "## Community Details".to_owned(),
-        disclosure(model.omissions.communities),
-    ]);
-    for community in &model.communities {
-        lines.push(format!("### Community {}", community.id));
-        lines.push(format!(
-            "- Evidence label: {}",
-            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS)
-        ));
-        if obsidian {
-            lines.push(format!(
-                "- Obsidian note: {}",
-                markdown_value(
-                    &safe_community_name(&community.label),
-                    MARKDOWN_VALUE_MAX_CHARS
-                )
-            ));
-        }
-        lines.push(format!(
-            "- Representatives ({}): {}",
-            inline_disclosure(community.representative_coverage),
-            node_references(&community.representatives)
         ));
     }
     lines.extend([
@@ -2195,6 +2272,79 @@ fn render_report_markdown(model: &AgentOrientation, obsidian: bool) -> String {
         ));
     }
     lines.join("\n")
+}
+
+fn append_community_directory(
+    lines: &mut Vec<String>,
+    model: &AgentOrientation,
+    obsidian: bool,
+    community_labels: &BTreeMap<usize, &str>,
+) {
+    lines.extend([
+        String::new(),
+        "## Community Directory".to_owned(),
+        "- Start here, then use labels with `compass path` or the exact scope with `compass query`. Communities are ranked by member count and connectivity."
+            .to_owned(),
+        disclosure(model.omissions.communities),
+    ]);
+    for community in &model.communities {
+        lines.push(format!(
+            "### {}",
+            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS)
+        ));
+        lines.push(format!(
+            "- Query scope: community:{} · members: {} · cohesion: {} · incident edges: {} · adjacent communities: {}",
+            community.id,
+            community.member_count,
+            community
+                .cohesion
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.2}")),
+            community.incident_edge_count,
+            community.adjacent_community_count,
+        ));
+        if obsidian {
+            lines.push(format!(
+                "- Obsidian note: {}",
+                markdown_value(
+                    &safe_community_name(&community.label),
+                    MARKDOWN_VALUE_MAX_CHARS
+                )
+            ));
+        }
+        lines.push(format!(
+            "- Entry points ({}): {}",
+            inline_disclosure(community.representative_coverage),
+            node_references(&community.representatives)
+        ));
+        lines.push(format!(
+            "- Strongest adjacent ({}): {}",
+            inline_disclosure(SectionOmission::from_total_shown(
+                community.adjacent_community_count,
+                community.strongest_adjacent.len(),
+            )),
+            community_link_list(&community.strongest_adjacent, &community_labels),
+        ));
+        if let (Some(incoming_total), Some(outgoing_total), Some(incoming), Some(outgoing)) = (
+            community.incoming_community_count,
+            community.outgoing_community_count,
+            community.strongest_incoming.as_ref(),
+            community.strongest_outgoing.as_ref(),
+        ) {
+            lines.push(format!(
+                "- Strongest incoming ({}): {} · outgoing ({}): {}",
+                inline_disclosure(SectionOmission::from_total_shown(
+                    incoming_total,
+                    incoming.len(),
+                )),
+                community_link_list(incoming, &community_labels),
+                inline_disclosure(SectionOmission::from_total_shown(
+                    outgoing_total,
+                    outgoing.len(),
+                )),
+                community_link_list(outgoing, &community_labels),
+            ));
+        }
+    }
 }
 
 struct ReportGraph<'a> {
@@ -2797,21 +2947,61 @@ fn node_references(values: &[OrientationNodeReference]) -> String {
     if values.is_empty() {
         return "none".to_owned();
     }
+    let mut label_counts = BTreeMap::<&str, usize>::new();
+    for value in values {
+        let label = if value.label.is_empty() {
+            value.id.as_str()
+        } else {
+            value.label.as_str()
+        };
+        *label_counts.entry(label).or_default() += 1;
+    }
     values
         .iter()
         .map(|value| {
-            format!(
-                "id={} label={} anchor={}",
-                markdown_value(&value.id, MARKDOWN_VALUE_MAX_CHARS),
-                markdown_value(&value.label, MARKDOWN_VALUE_MAX_CHARS),
-                optional_anchor(value.anchor.as_ref()),
-            )
+            let label = if value.label.is_empty() {
+                value.id.as_str()
+            } else {
+                value.label.as_str()
+            };
+            let mut rendered = markdown_value(label, MARKDOWN_VALUE_MAX_CHARS);
+            if label_counts.get(label).copied().unwrap_or_default() > 1
+                && value.id.as_str() != label
+            {
+                rendered.push_str(&format!(
+                    " [id: {}]",
+                    markdown_value(&value.id, MARKDOWN_VALUE_MAX_CHARS)
+                ));
+            }
+            if let Some(anchor) = value.anchor.as_ref() {
+                rendered.push_str(" — ");
+                rendered.push_str(&optional_anchor(Some(anchor)));
+            }
+            rendered
         })
         .collect::<Vec<_>>()
         .join("; ")
 }
 
-fn community_link_list(values: &[OrientationCommunityLink]) -> String {
+fn community_label_index(model: &AgentOrientation) -> BTreeMap<usize, &str> {
+    model
+        .communities
+        .iter()
+        .map(|community| (community.id, community.label.as_str()))
+        .collect()
+}
+
+fn community_label_or_scope(community: usize, labels: &BTreeMap<usize, &str>) -> String {
+    labels.get(&community).map_or_else(
+        || format!("community:{community}"),
+        |label| markdown_value(label, MARKDOWN_VALUE_MAX_CHARS),
+    )
+}
+
+fn community_link_list(
+    values: &[OrientationCommunityLink],
+    labels: &BTreeMap<usize, &str>,
+) -> String {
     if values.is_empty() {
         return "none".to_owned();
     }
@@ -2819,8 +3009,11 @@ fn community_link_list(values: &[OrientationCommunityLink]) -> String {
         .iter()
         .map(|value| {
             format!(
-                "community {} ({}; {})",
-                value.community_id,
+                "{} ({} edges; {})",
+                labels.get(&value.community_id).map_or_else(
+                    || format!("community:{}", value.community_id),
+                    |label| markdown_value(label, MARKDOWN_VALUE_MAX_CHARS),
+                ),
                 value.count,
                 mix(&value.relation_mix, value.relation_mix_coverage)
             )

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -939,8 +939,7 @@ fn build_communities(
                 .collect::<Vec<_>>();
             // Stable sorting preserves the deterministic community-member order
             // when two candidates have equal connectivity.
-            representatives
-                .sort_by(|left, right| graph.degree(&right.id).cmp(&graph.degree(&left.id)));
+            representatives.sort_by_key(|right| std::cmp::Reverse(graph.degree(&right.id)));
             representatives.truncate(if detailed {
                 REPRESENTATIVE_LIMIT
             } else {
@@ -1856,10 +1855,7 @@ fn fit_orientation_budget(model: &mut AgentOrientation) {
 }
 
 fn fit_orientation_json_budget(model: &mut AgentOrientation) {
-    loop {
-        let Ok(rendered) = serde_json::to_vec_pretty(model) else {
-            break;
-        };
+    while let Ok(rendered) = serde_json::to_vec_pretty(model) {
         if rendered.len() <= ORIENTATION_JSON_FIT_BYTES || model.communities.is_empty() {
             break;
         }
@@ -2050,7 +2046,7 @@ fn render_orientation_markdown_with_community_limit(
                 community.adjacent_community_count,
                 community.strongest_adjacent.len(),
             )),
-            community_link_list(&community.strongest_adjacent, &community_labels),
+            community_link_list(&community.strongest_adjacent, community_labels),
         ));
         if let (Some(incoming_total), Some(outgoing_total), Some(incoming), Some(outgoing)) = (
             community.incoming_community_count,
@@ -2064,12 +2060,12 @@ fn render_orientation_markdown_with_community_limit(
                     incoming_total,
                     incoming.len(),
                 )),
-                community_link_list(incoming, &community_labels),
+                community_link_list(incoming, community_labels),
                 inline_disclosure(SectionOmission::from_total_shown(
                     outgoing_total,
                     outgoing.len(),
                 )),
-                community_link_list(outgoing, &community_labels),
+                community_link_list(outgoing, community_labels),
             ));
         }
     }
@@ -2370,7 +2366,7 @@ fn append_community_directory(
                 community.adjacent_community_count,
                 community.strongest_adjacent.len(),
             )),
-            community_link_list(&community.strongest_adjacent, &community_labels),
+            community_link_list(&community.strongest_adjacent, community_labels),
         ));
         if let (Some(incoming_total), Some(outgoing_total), Some(incoming), Some(outgoing)) = (
             community.incoming_community_count,
@@ -2384,12 +2380,12 @@ fn append_community_directory(
                     incoming_total,
                     incoming.len(),
                 )),
-                community_link_list(incoming, &community_labels),
+                community_link_list(incoming, community_labels),
                 inline_disclosure(SectionOmission::from_total_shown(
                     outgoing_total,
                     outgoing.len(),
                 )),
-                community_link_list(outgoing, &community_labels),
+                community_link_list(outgoing, community_labels),
             ));
         }
     }

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -14,23 +14,29 @@ use sha2::{Digest, Sha256};
 use crate::OutputError;
 
 pub const ORIENTATION_SCHEMA: &str = "compass.orientation/1";
-pub const ORIENTATION_MARKDOWN_MAX_CHARS: usize = 8_000;
-pub const REPORT_MARKDOWN_MAX_CHARS: usize = 64_000;
-const ORIENTATION_JSON_MAX_BYTES: usize = 1024 * 1024 - 1;
+pub const ORIENTATION_MARKDOWN_MAX_CHARS: usize = 16_000;
+pub const REPORT_MARKDOWN_MAX_CHARS: usize = 256_000;
+pub const ORIENTATION_JSON_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+const PUBLICATION_IDENTITY_RESERVE: usize = 1024;
+const ORIENTATION_MARKDOWN_FIT_CHARS: usize =
+    ORIENTATION_MARKDOWN_MAX_CHARS - PUBLICATION_IDENTITY_RESERVE;
+const REPORT_MARKDOWN_FIT_CHARS: usize = REPORT_MARKDOWN_MAX_CHARS - PUBLICATION_IDENTITY_RESERVE;
+const ORIENTATION_JSON_FIT_BYTES: usize = ORIENTATION_JSON_MAX_BYTES - PUBLICATION_IDENTITY_RESERVE;
 
 // The compact Agent Orientation shows only the leading communities, while the
 // full report keeps a substantially wider directory for repository navigation.
 // Both limits are explicit so an adversarial graph cannot grow output without
 // bound.
-const ORIENTATION_COMMUNITY_LIMIT: usize = 6;
-const COMMUNITY_LIMIT: usize = 128;
-const HUB_LIMIT: usize = 8;
+const ORIENTATION_COMMUNITY_LIMIT: usize = 12;
+const COMMUNITY_LIMIT: usize = 256;
+const HUB_LIMIT: usize = 16;
 const RISK_LIMIT: usize = 8;
-const QUERY_LIMIT: usize = 8;
+const QUERY_LIMIT: usize = 16;
 const DETAIL_LIMIT: usize = 12;
-const ORIENTATION_REPRESENTATIVE_LIMIT: usize = 3;
-const REPRESENTATIVE_LIMIT: usize = 8;
-const COMMUNITY_LINK_LIMIT: usize = 2;
+const ORIENTATION_REPRESENTATIVE_LIMIT: usize = 4;
+const REPRESENTATIVE_LIMIT: usize = 12;
+const COMMUNITY_LINK_LIMIT: usize = 4;
 const MIX_LIMIT: usize = 8;
 const ARGV_LIMIT: usize = 8;
 const NESTED_ID_LIMIT: usize = 8;
@@ -1811,7 +1817,7 @@ fn fit_orientation_budget(model: &mut AgentOrientation) {
     while char_count(&render_orientation_markdown_with_community_limit(
         model,
         ORIENTATION_COMMUNITY_LIMIT,
-    )) > ORIENTATION_MARKDOWN_MAX_CHARS
+    )) > ORIENTATION_MARKDOWN_FIT_CHARS
     {
         if model.suggested_queries.pop().is_some() {
             model
@@ -1838,13 +1844,13 @@ fn fit_orientation_json_budget(model: &mut AgentOrientation) {
         let Ok(rendered) = serde_json::to_vec_pretty(model) else {
             break;
         };
-        if rendered.len() <= ORIENTATION_JSON_MAX_BYTES || model.communities.is_empty() {
+        if rendered.len() <= ORIENTATION_JSON_FIT_BYTES || model.communities.is_empty() {
             break;
         }
         let scaled = model
             .communities
             .len()
-            .saturating_mul(ORIENTATION_JSON_MAX_BYTES)
+            .saturating_mul(ORIENTATION_JSON_FIT_BYTES)
             / rendered.len();
         let next = scaled.min(model.communities.len().saturating_sub(1));
         model.communities.truncate(next);
@@ -1856,7 +1862,7 @@ fn fit_orientation_json_budget(model: &mut AgentOrientation) {
 }
 
 fn fit_report_budget(model: &mut AgentOrientation, obsidian: bool) {
-    while char_count(&render_report_markdown(model, obsidian)) > REPORT_MARKDOWN_MAX_CHARS {
+    while char_count(&render_report_markdown(model, obsidian)) > REPORT_MARKDOWN_FIT_CHARS {
         if model.details.publication_diagnostics.pop().is_some() {
             model
                 .omissions

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -29,13 +29,15 @@ const ORIENTATION_JSON_FIT_BYTES: usize = ORIENTATION_JSON_MAX_BYTES - PUBLICATI
 // Both limits are explicit so an adversarial graph cannot grow output without
 // bound.
 const ORIENTATION_COMMUNITY_LIMIT: usize = 12;
-const COMMUNITY_LIMIT: usize = 256;
+const DETAILED_COMMUNITY_LIMIT: usize = 32;
+const COMMUNITY_LIMIT: usize = 4_096;
 const HUB_LIMIT: usize = 16;
 const RISK_LIMIT: usize = 8;
 const QUERY_LIMIT: usize = 16;
 const DETAIL_LIMIT: usize = 12;
 const ORIENTATION_REPRESENTATIVE_LIMIT: usize = 4;
 const REPRESENTATIVE_LIMIT: usize = 12;
+const COMPACT_REPRESENTATIVE_LIMIT: usize = 1;
 const COMMUNITY_LINK_LIMIT: usize = 4;
 const MIX_LIMIT: usize = 8;
 const ARGV_LIMIT: usize = 8;
@@ -928,7 +930,9 @@ fn build_communities(
     let models = eligible
         .into_iter()
         .take(COMMUNITY_LIMIT)
-        .map(|(community, members)| {
+        .enumerate()
+        .map(|(rank, (community, members))| {
+            let detailed = rank < DETAILED_COMMUNITY_LIMIT;
             let mut representatives = members
                 .iter()
                 .filter_map(|member| graph.node_reference(member))
@@ -937,15 +941,23 @@ fn build_communities(
             // when two candidates have equal connectivity.
             representatives
                 .sort_by(|left, right| graph.degree(&right.id).cmp(&graph.degree(&left.id)));
-            representatives.truncate(REPRESENTATIVE_LIMIT);
+            representatives.truncate(if detailed {
+                REPRESENTATIVE_LIMIT
+            } else {
+                COMPACT_REPRESENTATIVE_LIMIT
+            });
             let representative_coverage =
                 SectionOmission::from_total_shown(members.len(), representatives.len());
             let connectivity = graph.community_connectivity.get(&community);
             let incident_edge_count = connectivity.map_or(0, |value| value.incident_edge_count);
             let adjacent_community_count = connectivity.map_or(0, |value| value.adjacent.len());
-            let strongest_adjacent = connectivity
-                .map(|value| rank_community_links(&value.adjacent))
-                .unwrap_or_default();
+            let strongest_adjacent = if detailed {
+                connectivity
+                    .map(|value| rank_community_links(&value.adjacent))
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
             let (
                 incoming_community_count,
                 outgoing_community_count,
@@ -955,16 +967,20 @@ fn build_communities(
                 (
                     Some(connectivity.map_or(0, |value| value.incoming.len())),
                     Some(connectivity.map_or(0, |value| value.outgoing.len())),
-                    Some(
+                    Some(if detailed {
                         connectivity
                             .map(|value| rank_community_links(&value.incoming))
-                            .unwrap_or_default(),
-                    ),
-                    Some(
+                            .unwrap_or_default()
+                    } else {
+                        Vec::new()
+                    }),
+                    Some(if detailed {
                         connectivity
                             .map(|value| rank_community_links(&value.outgoing))
-                            .unwrap_or_default(),
-                    ),
+                            .unwrap_or_default()
+                    } else {
+                        Vec::new()
+                    }),
                 )
             } else {
                 (None, None, None, None)
@@ -1862,7 +1878,11 @@ fn fit_orientation_json_budget(model: &mut AgentOrientation) {
 }
 
 fn fit_report_budget(model: &mut AgentOrientation, obsidian: bool) {
-    while char_count(&render_report_markdown(model, obsidian)) > REPORT_MARKDOWN_FIT_CHARS {
+    loop {
+        let rendered_chars = char_count(&render_report_markdown(model, obsidian));
+        if rendered_chars <= REPORT_MARKDOWN_FIT_CHARS {
+            break;
+        }
         if model.details.publication_diagnostics.pop().is_some() {
             model
                 .omissions
@@ -1893,7 +1913,14 @@ fn fit_report_budget(model: &mut AgentOrientation, obsidian: bool) {
                 .omissions
                 .surprising_connections
                 .set_shown(model.details.surprising_connections.len());
-        } else if model.communities.pop().is_some() {
+        } else if !model.communities.is_empty() {
+            let scaled = model
+                .communities
+                .len()
+                .saturating_mul(REPORT_MARKDOWN_FIT_CHARS)
+                / rendered_chars;
+            let next = scaled.min(model.communities.len().saturating_sub(1));
+            model.communities.truncate(next);
             model
                 .omissions
                 .communities
@@ -2289,13 +2316,24 @@ fn append_community_directory(
     lines.extend([
         String::new(),
         "## Community Directory".to_owned(),
-        "- Start here, then use labels with `compass path` or the exact scope with `compass query`. Communities are ranked by member count and connectivity."
+        "- Start here, then use labels with `compass path` or the exact scope with `compass query`. Communities are ranked by member count, connectivity, label, and stable ID."
             .to_owned(),
         disclosure(model.omissions.communities),
     ]);
-    for community in &model.communities {
+    let detailed_count = DETAILED_COMMUNITY_LIMIT.min(model.communities.len());
+    lines.extend([
+        "### Detailed Communities".to_owned(),
+        format!(
+            "- Detail coverage: retained={} · detailed={} · compact={} · report-wide omitted={}",
+            model.communities.len(),
+            detailed_count,
+            model.communities.len().saturating_sub(detailed_count),
+            model.omissions.communities.omitted,
+        ),
+    ]);
+    for community in model.communities.iter().take(detailed_count) {
         lines.push(format!(
-            "### {}",
+            "#### {}",
             markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS)
         ));
         lines.push(format!(
@@ -2350,6 +2388,50 @@ fn append_community_directory(
                 community_link_list(outgoing, &community_labels),
             ));
         }
+    }
+    let compact = &model.communities[detailed_count..];
+    if !compact.is_empty() || model.omissions.communities.omitted > 0 {
+        lines.extend([
+            "### Remaining Communities (Compact Ranked Index)".to_owned(),
+            disclosure(SectionOmission::from_total_shown(
+                model
+                    .omissions
+                    .communities
+                    .total
+                    .saturating_sub(detailed_count),
+                compact.len(),
+            )),
+        ]);
+    }
+    for (offset, community) in compact.iter().enumerate() {
+        let entry = community.representatives.first().map_or_else(
+            || "unknown".to_owned(),
+            |value| node_references(std::slice::from_ref(value)),
+        );
+        lines.push(format!(
+            "- {}. {} · scope=community:{} · members={} · cohesion={} · incident edges={} · adjacent communities={} · leading entry: {}{}",
+            detailed_count.saturating_add(offset).saturating_add(1),
+            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS),
+            community.id,
+            community.member_count,
+            community
+                .cohesion
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.2}")),
+            community.incident_edge_count,
+            community.adjacent_community_count,
+            entry,
+            if obsidian {
+                format!(
+                    " · Obsidian note: {}",
+                    markdown_value(
+                        &safe_community_name(&community.label),
+                        MARKDOWN_VALUE_MAX_CHARS
+                    )
+                )
+            } else {
+                String::new()
+            },
+        ));
     }
 }
 

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -2046,7 +2046,7 @@ fn render_orientation_markdown_with_community_limit(
                 community.adjacent_community_count,
                 community.strongest_adjacent.len(),
             )),
-            community_link_list(&community.strongest_adjacent, community_labels),
+            community_link_list(&community.strongest_adjacent, &community_labels),
         ));
         if let (Some(incoming_total), Some(outgoing_total), Some(incoming), Some(outgoing)) = (
             community.incoming_community_count,
@@ -2060,12 +2060,12 @@ fn render_orientation_markdown_with_community_limit(
                     incoming_total,
                     incoming.len(),
                 )),
-                community_link_list(incoming, community_labels),
+                community_link_list(incoming, &community_labels),
                 inline_disclosure(SectionOmission::from_total_shown(
                     outgoing_total,
                     outgoing.len(),
                 )),
-                community_link_list(outgoing, community_labels),
+                community_link_list(outgoing, &community_labels),
             ));
         }
     }

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -2346,6 +2346,10 @@ fn append_community_directory(
             community.incident_edge_count,
             community.adjacent_community_count,
         ));
+        lines.push(format!(
+            "- Evidence label: {}",
+            markdown_value(&community.label, MARKDOWN_VALUE_MAX_CHARS)
+        ));
         if obsidian {
             lines.push(format!(
                 "- Obsidian note: {}",

--- a/crates/compass-output/tests/orientation.rs
+++ b/crates/compass-output/tests/orientation.rs
@@ -226,6 +226,7 @@ fn orientation_is_bounded_deterministic_and_markdown_safe() -> Result<(), Box<dy
                         | "## Publication Diagnostic Evidence"
                 ) || line
                     .strip_prefix("### ")
+                    .or_else(|| line.strip_prefix("#### "))
                     .is_some_and(|label| !label.is_empty())
             })
     );
@@ -283,7 +284,7 @@ fn orientation_is_bounded_deterministic_and_markdown_safe() -> Result<(), Box<dy
 
 #[test]
 fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), Box<dyn Error>> {
-    let nodes = (0..1_401)
+    let nodes = (0..1_402)
         .map(|index| {
             json!({
                 "id": format!("internal::node::{index}"),
@@ -309,6 +310,10 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
             )
         })
         .collect::<BTreeMap<_, _>>();
+    communities
+        .get_mut(&139)
+        .ok_or("missing ranking fixture community")?
+        .push("internal::node::1401".to_owned());
     communities.insert(140, vec!["internal::node::1400".to_owned()]);
     let labels = (0..141)
         .map(|community| (community, format!("Subsystem {community}")))
@@ -331,12 +336,22 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
     );
 
     assert_eq!(model.communities.len(), 141);
+    assert_eq!(model.communities[0].id, 139);
+    assert_eq!(model.communities[0].member_count, 11);
     assert!(
         model
             .communities
             .iter()
+            .take(32)
             .filter(|community| community.member_count == 10)
             .all(|community| community.representatives.len() == 10)
+    );
+    assert!(
+        model
+            .communities
+            .iter()
+            .skip(32)
+            .all(|community| community.representatives.len() == 1)
     );
     let orientation = render_orientation_markdown(&model)?;
     assert!(orientation.contains("Coverage: total=141 · shown=12 · omitted=129"));
@@ -344,9 +359,15 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
 
     let report = render_agent_report_markdown(&model, false)?;
     assert!(report.contains("## Community Directory"));
+    assert!(report.contains("### Detailed Communities"));
+    assert!(report.contains("### Remaining Communities (Compact Ranked Index)"));
+    assert!(report.contains("retained=141 · detailed=32 · compact=109"));
     for community in 0..141 {
-        assert!(report.contains(&format!("### Subsystem {community}")));
-        assert!(report.contains(&format!("Query scope: community:{community}")));
+        assert!(report.contains(&format!("Subsystem {community}")));
+        assert!(
+            report.contains(&format!("Query scope: community:{community}"))
+                || report.contains(&format!("scope=community:{community}"))
+        );
     }
     assert!(report.contains("Entry points (total=10 shown=10 omitted=0)"));
     assert!(!report.contains("id=internal::node::"));
@@ -436,6 +457,8 @@ fn nonportable_argv_preserves_exact_punctuation_without_markdown_structure()
                         | "## Suggested Compass Queries"
                         | "## Learned Graph Questions"
                         | "### Exact O'Reilly ∗ ［node］ C:＼path ‹tag› ʼʼʼ $HOME ｜ ＃ ！ &"
+                        | "### Detailed Communities"
+                        | "#### Exact O'Reilly ∗ ［node］ C:＼path ‹tag› ʼʼʼ $HOME ｜ ＃ ！ &"
                 )
             })
     );

--- a/crates/compass-output/tests/orientation.rs
+++ b/crates/compass-output/tests/orientation.rs
@@ -283,7 +283,7 @@ fn orientation_is_bounded_deterministic_and_markdown_safe() -> Result<(), Box<dy
 
 #[test]
 fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), Box<dyn Error>> {
-    let nodes = (0..101)
+    let nodes = (0..1_401)
         .map(|index| {
             json!({
                 "id": format!("internal::node::{index}"),
@@ -299,7 +299,7 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
         "nodes": nodes,
         "links": []
     }))?;
-    let mut communities = (0..10)
+    let mut communities = (0..140)
         .map(|community| {
             (
                 community,
@@ -309,8 +309,8 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
             )
         })
         .collect::<BTreeMap<_, _>>();
-    communities.insert(10, vec!["internal::node::100".to_owned()]);
-    let labels = (0..11)
+    communities.insert(140, vec!["internal::node::1400".to_owned()]);
+    let labels = (0..141)
         .map(|community| (community, format!("Subsystem {community}")))
         .collect::<BTreeMap<_, _>>();
     let mut options = ReportOptions::new("community-directory");
@@ -330,25 +330,25 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
         &options,
     );
 
-    assert_eq!(model.communities.len(), 11);
+    assert_eq!(model.communities.len(), 141);
     assert!(
         model
             .communities
             .iter()
             .filter(|community| community.member_count == 10)
-            .all(|community| community.representatives.len() == 8)
+            .all(|community| community.representatives.len() == 10)
     );
     let orientation = render_orientation_markdown(&model)?;
-    assert!(orientation.contains("Coverage: total=11 · shown=6 · omitted=5"));
+    assert!(orientation.contains("Coverage: total=141 · shown=12 · omitted=129"));
     assert!(!orientation.contains("### Community 0"));
 
     let report = render_agent_report_markdown(&model, false)?;
     assert!(report.contains("## Community Directory"));
-    for community in 0..11 {
+    for community in 0..141 {
         assert!(report.contains(&format!("### Subsystem {community}")));
         assert!(report.contains(&format!("Query scope: community:{community}")));
     }
-    assert!(report.contains("Entry points (total=10 shown=8 omitted=2)"));
+    assert!(report.contains("Entry points (total=10 shown=10 omitted=0)"));
     assert!(!report.contains("id=internal::node::"));
     Ok(())
 }

--- a/crates/compass-output/tests/orientation.rs
+++ b/crates/compass-output/tests/orientation.rs
@@ -6,8 +6,8 @@ use compass_model::GraphDocument;
 use compass_output::{
     DetectionSummary, FreshnessBasis, FreshnessStatus, ORIENTATION_MARKDOWN_MAX_CHARS,
     OrientationHealth, PublicationStatus, REPORT_MARKDOWN_MAX_CHARS, ReportOptions, TokenCost,
-    WorkingTreeState, agent_orientation, generate_report, render_orientation_json,
-    render_orientation_markdown,
+    WorkingTreeState, agent_orientation, generate_report, render_agent_report_markdown,
+    render_orientation_json, render_orientation_markdown,
 };
 use serde_json::{Value, json};
 
@@ -220,13 +220,13 @@ fn orientation_is_bounded_deterministic_and_markdown_safe() -> Result<(), Box<dy
                         | "## Surprising Connections"
                         | "## Import Cycles"
                         | "## Hyperedges"
-                        | "## Community Details"
+                        | "## Community Directory"
                         | "## Ambiguous Edge Evidence"
                         | "## Work-Memory Observations"
                         | "## Publication Diagnostic Evidence"
                 ) || line
-                    .strip_prefix("### Community ")
-                    .is_some_and(|id| id.chars().all(|value| value.is_ascii_digit()))
+                    .strip_prefix("### ")
+                    .is_some_and(|label| !label.is_empty())
             })
     );
     for (section, shown) in [
@@ -278,6 +278,78 @@ fn orientation_is_bounded_deterministic_and_markdown_safe() -> Result<(), Box<dy
     assert!(json.contains("<script>x</script>"));
     let restored: compass_output::AgentOrientation = serde_json::from_str(&json)?;
     assert_eq!(restored, model);
+    Ok(())
+}
+
+#[test]
+fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), Box<dyn Error>> {
+    let nodes = (0..101)
+        .map(|index| {
+            json!({
+                "id": format!("internal::node::{index}"),
+                "label": format!("Entry {index:03}"),
+                "source_file": format!("src/module_{index}.rs"),
+                "file_type": "code"
+            })
+        })
+        .collect::<Vec<_>>();
+    let document: GraphDocument = serde_json::from_value(json!({
+        "directed": true,
+        "graph": {},
+        "nodes": nodes,
+        "links": []
+    }))?;
+    let mut communities = (0..10)
+        .map(|community| {
+            (
+                community,
+                (0..10)
+                    .map(|offset| format!("internal::node::{}", community * 10 + offset))
+                    .collect(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    communities.insert(10, vec!["internal::node::100".to_owned()]);
+    let labels = (0..11)
+        .map(|community| (community, format!("Subsystem {community}")))
+        .collect::<BTreeMap<_, _>>();
+    let mut options = ReportOptions::new("community-directory");
+    options.min_community_size = 1;
+    options.today = Some("2026-08-12");
+    let model = agent_orientation(
+        &document,
+        &communities,
+        &BTreeMap::new(),
+        &labels,
+        &[],
+        &[],
+        &DetectionSummary::default(),
+        TokenCost::default(),
+        None,
+        None,
+        &options,
+    );
+
+    assert_eq!(model.communities.len(), 11);
+    assert!(
+        model
+            .communities
+            .iter()
+            .filter(|community| community.member_count == 10)
+            .all(|community| community.representatives.len() == 8)
+    );
+    let orientation = render_orientation_markdown(&model)?;
+    assert!(orientation.contains("Coverage: total=11 · shown=6 · omitted=5"));
+    assert!(!orientation.contains("### Community 0"));
+
+    let report = render_agent_report_markdown(&model, false)?;
+    assert!(report.contains("## Community Directory"));
+    for community in 0..11 {
+        assert!(report.contains(&format!("### Subsystem {community}")));
+        assert!(report.contains(&format!("Query scope: community:{community}")));
+    }
+    assert!(report.contains("Entry points (total=10 shown=8 omitted=2)"));
+    assert!(!report.contains("id=internal::node::"));
     Ok(())
 }
 
@@ -363,7 +435,7 @@ fn nonportable_argv_preserves_exact_punctuation_without_markdown_structure()
                         | "## Important Diagnostics"
                         | "## Suggested Compass Queries"
                         | "## Learned Graph Questions"
-                        | "### Community 0"
+                        | "### Exact O'Reilly ∗ ［node］ C:＼path ‹tag› ʼʼʼ $HOME ｜ ＃ ！ &"
                 )
             })
     );

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -241,6 +241,15 @@ validates the graph generation and exact streamed `graph.json` digest before
 `compass://orientation` returns it. `compass://report` renders the human report
 from that validated model; it never trusts an adjacent Markdown file by name.
 
+The Architecture Map highlights up to six leading communities. The later
+Community Directory is the broader navigation index: it ranks every non-empty
+community, including thin communities, by member count and connectivity, shows
+as many as fit within the explicit report bound (up to 128), and lists up to
+eight high-connectivity entry points with source anchors for each. Every bounded
+list reports exact shown and omitted counts. Headings and boundary links prefer
+evidence labels; graph-local numeric IDs remain visible as `community:<id>`
+query scopes where an agent needs an exact follow-up command.
+
 ## `graph.html`
 
 Optional interactive visualization. It may be absent when:

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -244,13 +244,18 @@ from that validated model; it never trusts an adjacent Markdown file by name.
 The Architecture Map highlights up to twelve leading communities. The later
 Community Directory is the broader navigation index: it ranks every non-empty
 community, including thin communities, by member count and connectivity, shows
-as many as fit within the 256,000-character report bound (up to 256), and lists
-up to twelve high-connectivity entry points with source anchors for each. The
-compact orientation remains bounded to 16,000 characters, while its JSON and
-the MCP resource transport share a 4 MiB envelope. Every bounded list reports
-exact shown and omitted counts. Headings and boundary links prefer evidence
-labels; graph-local numeric IDs remain visible as `community:<id>` query scopes
-where an agent needs an exact follow-up command.
+as many as fit within the 256,000-character report bound (up to 4,096), and
+splits presentation into two tiers. The top 32 ranked communities receive full
+detail with up to twelve high-connectivity entry points and four strongest
+links per direction. Every remaining retained community receives a compact
+one-line index entry containing its rank, evidence label, exact query scope,
+member count, cohesion, connectivity, and best source-anchored entry point.
+
+The compact orientation remains bounded to 16,000 characters, while its JSON
+and the MCP resource transport share a 4 MiB envelope. Every bounded list
+reports exact shown and omitted counts. Headings and boundary links prefer
+evidence labels; graph-local numeric IDs remain visible as `community:<id>`
+query scopes where an agent needs an exact follow-up command.
 
 ## `graph.html`
 

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -241,14 +241,16 @@ validates the graph generation and exact streamed `graph.json` digest before
 `compass://orientation` returns it. `compass://report` renders the human report
 from that validated model; it never trusts an adjacent Markdown file by name.
 
-The Architecture Map highlights up to six leading communities. The later
+The Architecture Map highlights up to twelve leading communities. The later
 Community Directory is the broader navigation index: it ranks every non-empty
 community, including thin communities, by member count and connectivity, shows
-as many as fit within the explicit report bound (up to 128), and lists up to
-eight high-connectivity entry points with source anchors for each. Every bounded
-list reports exact shown and omitted counts. Headings and boundary links prefer
-evidence labels; graph-local numeric IDs remain visible as `community:<id>`
-query scopes where an agent needs an exact follow-up command.
+as many as fit within the 256,000-character report bound (up to 256), and lists
+up to twelve high-connectivity entry points with source anchors for each. The
+compact orientation remains bounded to 16,000 characters, while its JSON and
+the MCP resource transport share a 4 MiB envelope. Every bounded list reports
+exact shown and omitted counts. Headings and boundary links prefer evidence
+labels; graph-local numeric IDs remain visible as `community:<id>` query scopes
+where an agent needs an exact follow-up command.
 
 ## `graph.html`
 


### PR DESCRIPTION
## Summary

- turn `GRAPH_REPORT.md` into a label-first architecture entry map
- deterministically rank non-empty communities by member count, connectivity, label, and stable ID
- give the top 32 communities full boundary evidence and up to twelve source-anchored entry points
- include every remaining retained community in a compact ranked index with its scope, size, cohesion, connectivity, and best anchored entry point
- retain up to 4,096 communities subject to the report and transport safety envelopes, with exact omission accounting
- highlight up to twelve leading communities and retain sixteen hubs and suggested queries
- move the Community Directory before diagnostics and keep numeric IDs primarily for exact query scopes or duplicate-label disambiguation
- raise the full report to 256,000 characters, the compact orientation to 16,000 characters, and the shared orientation/MCP envelope to 4 MiB

## Why

The report model capped the architecture map at six communities and three representatives per community. It also gave every retained community the same verbose shape and foregrounded numeric IDs. That made the report both incomplete and noisy as an AI agent's initial repository map.

Graphify's older report could iterate every non-thin community because it did not enforce Compass's coherent Markdown, orientation, and MCP publication envelopes. This change preserves those safety boundaries while separating complete navigation coverage from expensive detail.

## Impact

Agents can scan all communities in ordinary repositories, get rich evidence for the most important ones, and then use exact `community:<id>` scopes with `compass query` or labels with `compass path`. The scale regression covers 141 communities, proves size-based ranking, and verifies detailed-versus-compact rendering. The `compass.orientation/1` field shape is unchanged; extreme graphs still report exact omissions rather than exhausting memory or transport capacity.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `sh scripts/check_product_boundary.sh`

Rust tests and Clippy were not run because the repository-required `/Volumes/Workspace` build volume is not mounted. Repository policy forbids falling back to a local Cargo target directory.
