### PR TITLE
Improve graph report labels and token efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Stop Markdown pipe-table containers from overwhelming community names and
+  `GRAPH_REPORT.md`. Mixed communities now prefer meaningful headings or
+  symbols over higher-degree table parser nodes; table-only communities use
+  deterministic source-anchored `Table (path:line)` labels and are counted as
+  omitted from the architecture-focused report directory while remaining
+  queryable in the graph. Advance graph publication semantics to v4 so existing
+  build state is regenerated with the corrected analysis.
+
 - Make `GRAPH_REPORT.md` a more complete, label-first architecture entry map.
   The compact Agent Orientation still highlights the leading communities, while
   the bounded Community Directory now retains up to 4,096 ranked non-empty

--- a/crates/compass-graph/src/cluster.rs
+++ b/crates/compass-graph/src/cluster.rs
@@ -47,6 +47,7 @@ struct CommunityLabelCandidate {
     community: usize,
     base: String,
     context: Option<String>,
+    context_required: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -444,24 +445,32 @@ pub fn label_communities_by_hub(
             .iter()
             .filter_map(|member| positions.get(member.as_str()).map(|index| (member, *index)))
             .min_by(|(left_id, left), (right_id, right)| {
-                degrees[*right]
-                    .cmp(&degrees[*left])
+                is_pipe_table_structure(&document.nodes[*left])
+                    .cmp(&is_pipe_table_structure(&document.nodes[*right]))
+                    .then_with(|| degrees[*right].cmp(&degrees[*left]))
                     .then_with(|| left_id.cmp(right_id))
             });
         let fallback = format!("Community {community}");
-        let (base, context) = hub
+        let (base, context, context_required) = hub
             .and_then(|(_, index)| document.nodes.get(index))
             .map(|node| {
+                let table_structure = is_pipe_table_structure(node);
                 (
-                    concise_community_label(node).unwrap_or_else(|| fallback.clone()),
+                    if table_structure {
+                        "Table".to_owned()
+                    } else {
+                        concise_community_label(node).unwrap_or_else(|| fallback.clone())
+                    },
                     community_label_context(node),
+                    table_structure,
                 )
             })
-            .unwrap_or((fallback, None));
+            .unwrap_or((fallback, None, false));
         candidates.push(CommunityLabelCandidate {
             community: *community,
             base,
             context,
+            context_required,
         });
     }
 
@@ -473,7 +482,7 @@ pub fn label_communities_by_hub(
         .into_iter()
         .map(|candidate| {
             let duplicate = base_counts.get(&candidate.base).copied().unwrap_or(0) > 1;
-            let label = if duplicate {
+            let label = if duplicate || candidate.context_required {
                 candidate.context.map_or_else(
                     || format!("{} (community {})", candidate.base, candidate.community),
                     |context| format!("{} ({context})", candidate.base),
@@ -509,6 +518,13 @@ pub fn label_communities_by_hub(
     }
 
     labels.into_iter().collect()
+}
+
+fn is_pipe_table_structure(node: &NodeRecord) -> bool {
+    matches!(
+        node.string("document_kind").as_str(),
+        "pipe_table" | "pipe_table_header" | "pipe_table_row" | "pipe_table_cell"
+    )
 }
 
 fn concise_community_label(node: &NodeRecord) -> Option<String> {
@@ -1794,6 +1810,78 @@ mod tests {
                 (0, "shared (src/left.rs:L10)".to_owned()),
                 (1, "shared (src/right.rs:L20)".to_owned()),
                 (2, "unique".to_owned()),
+            ])
+        );
+    }
+
+    #[test]
+    fn meaningful_document_anchor_outranks_pipe_table_hub() {
+        let mut document = graph(
+            &["heading", "table", "header", "row", "cell-a", "cell-b"],
+            &[
+                ("heading", "table"),
+                ("table", "header"),
+                ("table", "row"),
+                ("header", "cell-a"),
+                ("row", "cell-b"),
+            ],
+        );
+        document.nodes[0]
+            .attributes
+            .insert("label".to_owned(), json!("Storage contract"));
+        document.nodes[0]
+            .attributes
+            .insert("document_kind".to_owned(), json!("heading"));
+        for (index, kind) in [
+            (1, "pipe_table"),
+            (2, "pipe_table_header"),
+            (3, "pipe_table_row"),
+            (4, "pipe_table_cell"),
+            (5, "pipe_table_cell"),
+        ] {
+            document.nodes[index]
+                .attributes
+                .insert("label".to_owned(), json!(kind.replace('_', " ")));
+            document.nodes[index]
+                .attributes
+                .insert("document_kind".to_owned(), json!(kind));
+        }
+        let communities = BTreeMap::from([(
+            0,
+            document.nodes.iter().map(|node| node.id.clone()).collect(),
+        )]);
+
+        assert_eq!(
+            label_communities_by_hub(&document, &communities),
+            BTreeMap::from([(0, "Storage contract".to_owned())])
+        );
+    }
+
+    #[test]
+    fn pipe_table_only_communities_use_source_anchored_table_labels() {
+        let mut document = graph(&["left", "right"], &[]);
+        for (index, line) in [(0, 12), (1, 44)] {
+            document.nodes[index]
+                .attributes
+                .insert("label".to_owned(), json!("pipe table"));
+            document.nodes[index]
+                .attributes
+                .insert("document_kind".to_owned(), json!("pipe_table"));
+            document.nodes[index]
+                .attributes
+                .insert("source_file".to_owned(), json!("docs/reference/outputs.md"));
+            document.nodes[index]
+                .attributes
+                .insert("line_start".to_owned(), json!(line));
+        }
+        let communities =
+            BTreeMap::from([(3, vec!["left".to_owned()]), (8, vec!["right".to_owned()])]);
+
+        assert_eq!(
+            label_communities_by_hub(&document, &communities),
+            BTreeMap::from([
+                (3, "Table (reference/outputs.md:L12)".to_owned()),
+                (8, "Table (reference/outputs.md:L44)".to_owned()),
             ])
         );
     }

--- a/crates/compass-graph/src/v1.rs
+++ b/crates/compass-graph/src/v1.rs
@@ -35,7 +35,7 @@ use crate::inference::{InferenceLevel, prefilter_extraction_inference};
 use crate::quarantine::{PublicationOutcome, QuarantineCollector};
 
 /// Version of the normalization and publication contract behind graph schema v1.
-pub const V1_PUBLICATION_SEMANTICS_VERSION: &str = "compass.graph.publication/3";
+pub const V1_PUBLICATION_SEMANTICS_VERSION: &str = "compass.graph.publication/4";
 use sha2::{Digest, Sha256};
 
 const TRUSTED_NODE_RECORD: &str = TRUSTED_NODE_RECORD_ATTRIBUTE;

--- a/crates/compass-output/src/report.rs
+++ b/crates/compass-output/src/report.rs
@@ -442,6 +442,7 @@ pub fn agent_orientation(
     let hub_total = god_node_list.len();
     let hubs = god_node_list
         .iter()
+        .filter(|node| !graph.is_pipe_table_structure_node_id(&node.id))
         .filter(|node| graph.node_identity_and_anchor_are_safe(&node.id, &node.label))
         .take(HUB_LIMIT)
         .map(|node| build_hub(&graph, node, &node_communities))
@@ -905,11 +906,17 @@ fn build_communities(
                 .iter()
                 .filter(|member| !graph.is_file_node_id(member))
                 .collect::<Vec<_>>();
-            (!real.is_empty()).then_some((*community, real))
+            (!real.is_empty()).then_some((
+                *community,
+                real.iter()
+                    .all(|member| graph.is_pipe_table_structure_node_id(member)),
+                real,
+            ))
         })
         .collect::<Vec<_>>();
     let total = eligible.len();
-    eligible.sort_by(|(left_id, left_members), (right_id, right_members)| {
+    eligible.retain(|(_, pipe_table_only, _)| !pipe_table_only);
+    eligible.sort_by(|(left_id, _, left_members), (right_id, _, right_members)| {
         right_members
             .len()
             .cmp(&left_members.len())
@@ -931,7 +938,7 @@ fn build_communities(
         .into_iter()
         .take(COMMUNITY_LIMIT)
         .enumerate()
-        .map(|(rank, (community, members))| {
+        .map(|(rank, (community, _, members))| {
             let detailed = rank < DETAILED_COMMUNITY_LIMIT;
             let mut representatives = members
                 .iter()
@@ -939,7 +946,12 @@ fn build_communities(
                 .collect::<Vec<_>>();
             // Stable sorting preserves the deterministic community-member order
             // when two candidates have equal connectivity.
-            representatives.sort_by_key(|right| std::cmp::Reverse(graph.degree(&right.id)));
+            representatives.sort_by(|left, right| {
+                graph
+                    .is_pipe_table_structure_node_id(&left.id)
+                    .cmp(&graph.is_pipe_table_structure_node_id(&right.id))
+                    .then_with(|| graph.degree(&right.id).cmp(&graph.degree(&left.id)))
+            });
             representatives.truncate(if detailed {
                 REPRESENTATIVE_LIMIT
             } else {
@@ -1078,6 +1090,7 @@ fn build_risks(
         .filter(|node| {
             graph.degree(&node.id) <= 1
                 && !graph.is_file_node_id(&node.id)
+                && !graph.is_pipe_table_structure_node_id(&node.id)
                 && !is_concept_node(node)
                 && node.string("file_type") != "rationale"
         })
@@ -1085,11 +1098,16 @@ fn build_risks(
     let thin = communities
         .values()
         .filter(|members| {
-            let count = members
-                .iter()
-                .filter(|member| !graph.is_file_node_id(member))
-                .count();
-            count > 0 && count < min_size
+            let mut count = 0_usize;
+            let mut pipe_table_only = true;
+            for member in *members {
+                if graph.is_file_node_id(member) {
+                    continue;
+                }
+                count = count.saturating_add(1);
+                pipe_table_only &= graph.is_pipe_table_structure_node_id(member);
+            }
+            count > 0 && count < min_size && !pipe_table_only
         })
         .count();
     let mut risks = Vec::new();
@@ -2008,7 +2026,9 @@ fn render_orientation_markdown_with_community_limit(
         ),
         String::new(),
         "## Architecture Map".to_owned(),
-        "- Leading communities are ranked by member count, connectivity, label, and stable ID. See the complete bounded directory later in this report."
+        "- Leading communities are ranked by member count, connectivity, label, and stable ID. See the complete bounded directory of architecture-relevant communities later in this report."
+            .to_owned(),
+        "- Markdown communities containing only pipe-table parser blocks are excluded from this architecture view and counted in omitted coverage; their source-backed nodes remain available in the graph."
             .to_owned(),
         disclosure(SectionOmission::from_total_shown(
             model.omissions.communities.total,
@@ -2312,7 +2332,9 @@ fn append_community_directory(
     lines.extend([
         String::new(),
         "## Community Directory".to_owned(),
-        "- Start here, then use labels with `compass path` or the exact scope with `compass query`. Communities are ranked by member count, connectivity, label, and stable ID."
+        "- Start here, then use labels with `compass path` or the exact scope with `compass query`. Architecture-relevant communities are ranked by member count, connectivity, label, and stable ID."
+            .to_owned(),
+        "- Markdown communities containing only pipe-table parser blocks are excluded and counted in omitted coverage; mixed communities retain their meaningful headings or symbols as entry points."
             .to_owned(),
         disclosure(model.omissions.communities),
     ]);
@@ -2646,6 +2668,15 @@ impl<'a> ReportGraph<'a> {
             && Path::new(source).file_name().and_then(|name| name.to_str()) == Some(label.as_str()))
             || (label.starts_with('.') && label.ends_with("()"))
             || (label.ends_with("()") && self.degree(id) <= 1)
+    }
+
+    fn is_pipe_table_structure_node_id(&self, id: &str) -> bool {
+        self.positions.get(id).is_some_and(|node| {
+            matches!(
+                node.string("document_kind").as_str(),
+                "pipe_table" | "pipe_table_header" | "pipe_table_row" | "pipe_table_cell"
+            )
+        })
     }
 }
 

--- a/crates/compass-output/tests/orientation.rs
+++ b/crates/compass-output/tests/orientation.rs
@@ -375,6 +375,96 @@ fn report_is_a_label_first_directory_of_all_bounded_communities() -> Result<(), 
 }
 
 #[test]
+fn report_omits_pipe_table_only_communities_from_architecture_directory()
+-> Result<(), Box<dyn Error>> {
+    let document: GraphDocument = serde_json::from_value(json!({
+        "directed": true,
+        "graph": {},
+        "nodes": [
+            {
+                "id": "runtime",
+                "label": "Runtime",
+                "source_file": "src/runtime.rs",
+                "file_type": "code"
+            },
+            {
+                "id": "table",
+                "label": "pipe table",
+                "source_file": "docs/reference.md",
+                "source_location": "L10",
+                "file_type": "document",
+                "document_kind": "pipe_table"
+            },
+            {
+                "id": "row",
+                "label": "pipe table row",
+                "source_file": "docs/reference.md",
+                "source_location": "L12",
+                "file_type": "document",
+                "document_kind": "pipe_table_row"
+            }
+        ],
+        "links": [
+            {"source": "table", "target": "row", "relation": "contains"}
+        ]
+    }))?;
+    let communities = BTreeMap::from([
+        (0, vec!["runtime".to_owned()]),
+        (1, vec!["table".to_owned(), "row".to_owned()]),
+    ]);
+    let labels = BTreeMap::from([
+        (0, "Runtime".to_owned()),
+        (1, "Table (docs/reference.md:L10)".to_owned()),
+    ]);
+    let mut options = ReportOptions::new("table-report");
+    options.min_community_size = 1;
+    options.today = Some("2026-08-12");
+
+    let model = agent_orientation(
+        &document,
+        &communities,
+        &BTreeMap::new(),
+        &labels,
+        &[GodNode {
+            id: "table".to_owned(),
+            label: "pipe table".to_owned(),
+            degree: 2,
+        }],
+        &[],
+        &DetectionSummary::default(),
+        TokenCost::default(),
+        None,
+        None,
+        &options,
+    );
+
+    assert_eq!(model.communities.len(), 1);
+    assert_eq!(model.communities[0].label, "Runtime");
+    assert!(model.hubs.is_empty());
+    assert_eq!(
+        model.omissions.hubs,
+        compass_output::SectionOmission {
+            total: 1,
+            shown: 0,
+            omitted: 1,
+        }
+    );
+    assert_eq!(
+        model.omissions.communities,
+        compass_output::SectionOmission {
+            total: 2,
+            shown: 1,
+            omitted: 1,
+        }
+    );
+    let report = render_agent_report_markdown(&model, false)?;
+    assert!(report.contains("only pipe-table parser blocks are excluded"));
+    assert!(!report.contains("Table (docs/reference.md:L10)"));
+    assert!(!report.contains("pipe table row"));
+    Ok(())
+}
+
+#[test]
 fn nonportable_argv_preserves_exact_punctuation_without_markdown_structure()
 -> Result<(), Box<dyn Error>> {
     const SPECIAL: &str = r"Exact O'Reilly * [node] C:\path <tag> ``` $HOME | # ! &";

--- a/docs/reference/outputs.md
+++ b/docs/reference/outputs.md
@@ -226,12 +226,20 @@ The report can include:
 It is intended for people and can evolve in prose/format. Do not parse it when
 structured data or command JSON exists.
 
-Community evidence labels use the highest-connectivity member's concise name
-when it is unique. When multiple communities share that name, Compass adds a
-compact source or wiring-site anchor and, only if needed, the graph-local
-community ID. These labels are deterministic navigation aids, not community
-identity; consumers that need identity should use the community ID and member
-set instead.
+Community evidence labels prefer a meaningful symbol or document heading over
+Markdown pipe-table parser blocks, even when a table container has more
+structural edges. A community containing only pipe-table blocks receives a
+source-anchored `Table (path:line)` label. When other communities share a hub
+name, Compass adds a compact source or wiring-site anchor and, only if needed,
+the graph-local community ID. These labels are deterministic navigation aids,
+not community identity; consumers that need identity should use the community
+ID and member set instead.
+
+The Architecture Map and Community Directory omit communities made entirely
+of Markdown pipe-table parser blocks. Those communities count toward the
+report's omitted-community coverage and their source-backed nodes remain in
+the graph; the report does not present parser partitions as architectural
+subsystems.
 
 The report begins with a bounded Agent Orientation for first-session or broad
 repository context. `orientation.json` is the versioned machine form of that


### PR DESCRIPTION
## Summary

- prefer meaningful symbols and Markdown headings over pipe-table parser nodes when selecting deterministic community labels
- give table-only communities source-anchored `Table (path:line)` labels and omit them from the architecture-focused report while preserving graph identity and queryability
- remove redundant IDs when a label plus source anchor uniquely identifies a node
- compact unavoidable IDs longer than 48 characters to a recognizable prefix/suffix plus deterministic fingerprint
- avoid duplicating portable commands and retain oversized exact argv only in `orientation.json`
- keep all machine-readable IDs and argv unchanged

## Root cause

Markdown tables are projected as table/header/row/cell nodes connected by `contains` edges. Community naming selected the highest-degree node without distinguishing parser-structural nodes, so table containers frequently won and produced generic `pipe table` labels. The report then presented those parser partitions as architectural communities.

The Markdown renderer also repeated opaque graph identities anywhere labels collided, even when distinct source anchors already disambiguated the records. Long exact IDs and duplicate command/argv representations inflated reports consumed by agents without adding useful context.

## User impact

Graph topology, community identity, exact queryability, and machine contracts remain intact. Human-facing reports now prioritize architecture labels and source anchors, use compact fingerprinted references only where an ID is necessary, and point readers to `orientation.json` for oversized exact argv. This lowers report token use while preserving enough visible identity to distinguish records.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p compass-output --locked` (71 passed)
- `cargo clippy -p compass-output --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`

All Cargo commands used the worktree-specific target directory under `/Volumes/Workspace/crabbuild-target`.
