### PR TITLE
Expand popular framework route extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Unreleased
 
+- Expand route extraction across popular framework families: add Angular Router
+  typed and provider-backed route configs, Echo and Fiber receiver-aware Go
+  routes, ASP.NET Core Minimal APIs and nested route groups, and deterministic
+  cross-module Express, Fastify, and Hono router mounts. Ambiguous imported
+  routers remain local rather than receiving an invented prefix. Advance
+  extraction semantics to v11 so affected cached facts rebuild.
+
 - Complete Axum route composition across local router variables, `nest` and
   `merge` chains, cross-module router factories, state-wrapped handlers, and
   ordered `layer` or `route_layer` middleware with import-aware targets.
   Ambiguous or cyclic Rust router targets now remain uncomposed instead of
-  inventing an endpoint, and extraction semantics advance to v10 so cached
-  route facts rebuild. The Routes and handlers HTML lens now uses a
+  inventing an endpoint. The Routes and handlers HTML lens now uses a
   hierarchical layout and minimally qualified labels for same-named handlers.
 
 - Reduce `GRAPH_REPORT.md` token use from opaque graph identities. Markdown now

--- a/crates/compass-languages/src/frameworks/csharp.rs
+++ b/crates/compass-languages/src/frameworks/csharp.rs
@@ -1,15 +1,18 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use regex::Regex;
-use serde_json::Map;
+use serde_json::{Map, Value};
 use tree_sitter::Node;
 
 use super::evidence::{EvidenceKind, EvidenceSet};
-use super::text::{join_route_path, line_anchor, normalize_route_path, text};
+use super::text::{anchor, join_route_path, line_anchor, normalize_route_path, text};
 use super::{RawFrameworkFact, RawFrameworkOrigin, RawRouteFact};
 
-pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFrameworkFact> {
-    let body = text(source);
+pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrameworkFact> {
+    let mut masked = source.to_vec();
+    mask_comments(root, &mut masked);
+    let body = text(&masked);
     let evidence = EvidenceSet::new()
         .direct_if(
             body.contains("Microsoft.AspNetCore.Mvc"),
@@ -22,6 +25,12 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
             "aspnet",
             EvidenceKind::DecoratorOrAttribute,
             "ApiController",
+        )
+        .direct_if(
+            body.contains("WebApplication.CreateBuilder") && body.contains(".Map"),
+            "aspnet",
+            EvidenceKind::Receiver,
+            "ASP.NET Core WebApplication minimal route receiver",
         );
     if !evidence.activates("aspnet") {
         return Vec::new();
@@ -47,7 +56,7 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
     let mut pending_route = None::<String>;
     let mut pending_action_route = None::<String>;
     let mut pending_http = Vec::<(String, String, usize, String)>::new();
-    let mut facts = Vec::new();
+    let mut facts = collect_minimal_api_routes(path, source, body);
     let mut offset = 0_usize;
     for line in body.split_inclusive('\n') {
         if let Some(capture) = route_attribute.captures(line)
@@ -130,6 +139,99 @@ pub(super) fn detect(path: &Path, source: &[u8], _root: Node<'_>) -> Vec<RawFram
             }
         }
         offset = offset.saturating_add(line.len());
+    }
+    facts
+}
+
+fn mask_comments(node: Node<'_>, source: &mut [u8]) {
+    if node.kind() == "comment" {
+        for byte in source
+            .get_mut(node.start_byte()..node.end_byte())
+            .into_iter()
+            .flatten()
+            .filter(|byte| **byte != b'\n' && **byte != b'\r')
+        {
+            *byte = b' ';
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        mask_comments(child, source);
+    }
+}
+
+fn collect_minimal_api_routes(path: &Path, source: &[u8], body: &str) -> Vec<RawFrameworkFact> {
+    if !body.contains("WebApplication.CreateBuilder") {
+        return Vec::new();
+    }
+    let Ok(group_pattern) = Regex::new(
+        r#"(?m)\b(?:var|RouteGroupBuilder)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.MapGroup\(\s*"([^"]*)"\s*\)"#,
+    ) else {
+        return Vec::new();
+    };
+    let mut prefixes = HashMap::<String, String>::new();
+    for capture in group_pattern.captures_iter(body) {
+        let (Some(child), Some(parent), Some(prefix)) =
+            (capture.get(1), capture.get(2), capture.get(3))
+        else {
+            continue;
+        };
+        let parent_prefix = prefixes
+            .get(parent.as_str())
+            .map(String::as_str)
+            .unwrap_or_default();
+        prefixes.insert(
+            child.as_str().to_owned(),
+            join_route_path(parent_prefix, prefix.as_str()),
+        );
+    }
+
+    let Ok(route_pattern) = Regex::new(
+        r#"(?s)\b([A-Za-z_]\w*)\.Map(Get|Post|Put|Patch|Delete|Options|Head)\s*\(\s*"([^"]*)"\s*,\s*([^,;\r\n]+)"#,
+    ) else {
+        return Vec::new();
+    };
+    let Ok(reference_pattern) = Regex::new(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$") else {
+        return Vec::new();
+    };
+    let mut facts = Vec::new();
+    for capture in route_pattern.captures_iter(body) {
+        let (Some(whole), Some(receiver), Some(operation), Some(raw_path), Some(handler)) = (
+            capture.get(0),
+            capture.get(1),
+            capture.get(2),
+            capture.get(3),
+            capture.get(4),
+        ) else {
+            continue;
+        };
+        let handler = handler.as_str().trim().trim_end_matches(')').trim();
+        let (handler_reference, detail) = if reference_pattern.is_match(handler) {
+            (handler.to_owned(), Map::new())
+        } else {
+            (
+                format!("opaque_minimal_handler_at_{}", whole.start()),
+                Map::from_iter([("opaque_handler".into(), Value::Bool(true))]),
+            )
+        };
+        let receiver_prefix = prefixes
+            .get(receiver.as_str())
+            .map(String::as_str)
+            .unwrap_or_default();
+        facts.push(RawFrameworkFact::Route(RawRouteFact {
+            framework: "aspnet".to_owned(),
+            operation: operation.as_str().to_ascii_uppercase(),
+            raw_path: raw_path.as_str().to_owned(),
+            normalized_path: join_route_path(receiver_prefix, raw_path.as_str()),
+            declaring_scope: receiver.as_str().to_owned(),
+            anchor: anchor(path, source, whole.start(), whole.end()),
+            handler_reference,
+            middleware_references: Vec::new(),
+            origin: RawFrameworkOrigin::Ast,
+            rule: None,
+            detail,
+        }));
     }
     facts
 }

--- a/crates/compass-languages/src/frameworks/go.rs
+++ b/crates/compass-languages/src/frameworks/go.rs
@@ -35,6 +35,18 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
             "gorilla",
             EvidenceKind::Import,
             "github.com/gorilla/mux",
+        )
+        .direct_if(
+            body.contains("github.com/labstack/echo/"),
+            "echo",
+            EvidenceKind::Import,
+            "github.com/labstack/echo",
+        )
+        .direct_if(
+            body.contains("github.com/gofiber/fiber/"),
+            "fiber",
+            EvidenceKind::Import,
+            "github.com/gofiber/fiber",
         );
     let framework = if evidence.activates("gin") {
         "gin"
@@ -42,11 +54,15 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
         "chi"
     } else if evidence.activates("gorilla") {
         "gorilla"
+    } else if evidence.activates("echo") {
+        "echo"
+    } else if evidence.activates("fiber") {
+        "fiber"
     } else {
         return Vec::new();
     };
     let Ok(receiver_types) = Regex::new(
-        r#"\b([A-Za-z_]\w*)\s+(?:\*\s*)?(gin\.Engine|chi\.Router|mux\.Router)\b|\b([A-Za-z_]\w*)\s*:?=\s*(?:gin\.(?:New|Default)|chi\.NewRouter|mux\.NewRouter)\s*\("#,
+        r#"\b([A-Za-z_]\w*)\s+(?:\*\s*)?(gin\.Engine|chi\.Router|mux\.Router|echo\.(?:Echo|Group)|fiber\.(?:App|Router))\b|\b([A-Za-z_]\w*)\s*:?=\s*(?:gin\.(?:New|Default)|chi\.NewRouter|mux\.NewRouter|echo\.New|fiber\.New)\s*\("#,
     ) else {
         return Vec::new();
     };
@@ -63,6 +79,8 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
                 "gin.Engine" => Some("gin"),
                 "chi.Router" => Some("chi"),
                 "mux.Router" => Some("gorilla"),
+                "echo.Echo" | "echo.Group" => Some("echo"),
+                "fiber.App" | "fiber.Router" => Some("fiber"),
                 _ => None,
             })
             .or_else(|| {
@@ -76,6 +94,10 @@ pub(super) fn detect(path: &Path, source: &[u8], root: Node<'_>) -> Vec<RawFrame
                             Some("chi")
                         } else if value.contains("mux.") {
                             Some("gorilla")
+                        } else if value.contains("echo.") {
+                            Some("echo")
+                        } else if value.contains("fiber.") {
+                            Some("fiber")
                         } else {
                             None
                         }
@@ -169,9 +191,9 @@ fn collect_go_route_calls(
                 .map(|(handler, middleware)| (handler.clone(), middleware.to_vec()))
         {
             let normalized_path = if route_prefix.is_empty() {
-                normalize_route_path(&raw_path)
+                normalize_go_route_path(&raw_path)
             } else {
-                join_route_path(&route_prefix, &raw_path)
+                normalize_go_route_path(&join_route_path(&route_prefix, &raw_path))
             };
             let operations = if method.eq_ignore_ascii_case("handlefunc") {
                 method_operations(node, source).unwrap_or_else(|| {
@@ -192,7 +214,7 @@ fn collect_go_route_calls(
             for operation in operations {
                 facts.push(RawFrameworkFact::Route(RawRouteFact {
                     framework: framework.to_owned(),
-                    operation,
+                    operation: canonical_operation(&operation),
                     raw_path: raw_path.clone(),
                     normalized_path: normalized_path.clone(),
                     declaring_scope: receiver.clone(),
@@ -353,7 +375,25 @@ fn matches_method(method: &str) -> bool {
             | "Options"
             | "Head"
             | "HandleFunc"
+            | "Any"
+            | "All"
     )
+}
+
+fn canonical_operation(operation: &str) -> String {
+    if matches!(operation, "Any" | "All" | "ANY" | "ALL") {
+        "ANY".to_owned()
+    } else {
+        operation.to_ascii_uppercase()
+    }
+}
+
+fn normalize_go_route_path(path: &str) -> String {
+    let normalized = normalize_route_path(path);
+    let Ok(parameters) = Regex::new(r"/:([A-Za-z_][A-Za-z0-9_]*)") else {
+        return normalized;
+    };
+    parameters.replace_all(&normalized, "/{$1}").into_owned()
 }
 
 fn method_operations(node: Node<'_>, source: &[u8]) -> Option<Vec<String>> {

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -327,6 +327,7 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         "typescript-web",
         &["javascript", "typescript", "tsx"],
         &[
+            "@angular/router",
             "@nestjs/common",
             "react-router",
             "react-router-dom",

--- a/crates/compass-languages/src/frameworks/typescript.rs
+++ b/crates/compass-languages/src/frameworks/typescript.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use regex::Regex;
@@ -57,6 +57,7 @@ pub(super) fn detect_express(
         "express application/router",
     );
     if evidence.activates("express") {
+        collect_express_mount_facts(root, source, path, &receivers, &imports, &mut facts);
         collect_express_routes(root, source, path, &receivers, &mounts, &mut facts);
     }
     facts
@@ -161,6 +162,7 @@ fn detect_node_router(
     }
     let mounts = node_router_mounts(root, source, &receivers, kind);
     let mut facts = Vec::new();
+    collect_node_router_mount_facts(root, source, path, &receivers, &imports, kind, &mut facts);
     collect_node_router_routes(root, source, path, &receivers, &mounts, kind, &mut facts);
     facts
 }
@@ -208,6 +210,16 @@ fn collect_node_router_receivers(
     kind: NodeRouterKind,
     receivers: &mut HashSet<String>,
 ) {
+    if matches!(kind, NodeRouterKind::Fastify)
+        && matches!(node.kind(), "required_parameter" | "optional_parameter")
+        && node_text(node, source).contains("FastifyInstance")
+        && let Some(name) = node
+            .child_by_field_name("pattern")
+            .or_else(|| node.child_by_field_name("name"))
+        && is_identifier(node_text(name, source))
+    {
+        receivers.insert(node_text(name, source).to_owned());
+    }
     if node.kind() == "variable_declarator"
         && let (Some(name), Some(value)) = (
             node.child_by_field_name("name"),
@@ -334,6 +346,59 @@ fn collect_node_router_mounts(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn collect_node_router_mount_facts(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    receivers: &HashSet<String>,
+    imports: &[ImportAlias],
+    kind: NodeRouterKind,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some((parent, method)) = node_text(function, source).trim().rsplit_once('.')
+        && receivers.contains(parent)
+        && ((matches!(kind, NodeRouterKind::Hono) && method == "route")
+            || (matches!(kind, NodeRouterKind::Fastify) && method == "register"))
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let arguments = split_arguments(node_text(arguments, source));
+        let (target, prefix) = if method == "route" {
+            (
+                arguments.get(1).map(String::as_str),
+                arguments.first().and_then(|value| string_literal(value)),
+            )
+        } else {
+            (
+                arguments.first().map(String::as_str),
+                arguments.get(1).and_then(|value| {
+                    object_property_text(value, "prefix").and_then(|value| string_literal(&value))
+                }),
+            )
+        };
+        if let (Some(target), Some(prefix)) = (target.map(str::trim), prefix)
+            && is_identifier(target)
+            && (receivers.contains(target) || imports.iter().any(|alias| alias.local == target))
+        {
+            facts.push(router_mount_fact(
+                kind.framework(),
+                path,
+                node,
+                parent,
+                target,
+                &prefix,
+                imports,
+            ));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_node_router_mount_facts(child, source, path, receivers, imports, kind, facts);
+    }
+}
+
 fn collect_node_router_routes(
     node: Node<'_>,
     source: &[u8],
@@ -400,6 +465,9 @@ fn collect_node_router_routes(
                 let (handler, middleware, mut detail) = router_stages(&raw_stages, kind, node);
                 if let Some(handler) = handler {
                     detail.insert("receiver".into(), Value::String(receiver.to_owned()));
+                    if let Some(prefix) = mounts.get(receiver).filter(|prefix| !prefix.is_empty()) {
+                        detail.insert("mount_prefix".into(), Value::String(prefix.clone()));
+                    }
                     for operation in methods {
                         facts.push(RawFrameworkFact::Route(RawRouteFact {
                             framework: kind.framework().to_owned(),
@@ -458,24 +526,19 @@ fn collect_node_router_routes(
                 return;
             };
             let (handler, opaque) = handler_from_value(&handler_value, node);
-            let mut detail = Map::from_iter([(
-                "receiver".into(),
-                Value::String(
-                    function
-                        .rsplit_once('.')
-                        .map(|(receiver, _)| receiver)
-                        .unwrap_or_default()
-                        .to_owned(),
-                ),
-            )]);
-            if opaque {
-                detail.insert("opaque_handler".into(), Value::Bool(true));
-            }
-            let middleware = object_hook_references(object);
             let receiver = function
                 .rsplit_once('.')
                 .map(|(receiver, _)| receiver)
                 .unwrap_or_default();
+            let mut detail =
+                Map::from_iter([("receiver".into(), Value::String(receiver.to_owned()))]);
+            if let Some(prefix) = mounts.get(receiver).filter(|prefix| !prefix.is_empty()) {
+                detail.insert("mount_prefix".into(), Value::String(prefix.clone()));
+            }
+            if opaque {
+                detail.insert("opaque_handler".into(), Value::Bool(true));
+            }
+            let middleware = object_hook_references(object);
             for operation in methods {
                 facts.push(RawFrameworkFact::Route(RawRouteFact {
                     framework: "fastify".to_owned(),
@@ -666,6 +729,12 @@ pub(super) fn detect_non_express(
     let mut facts = Vec::new();
     let evidence = EvidenceSet::new()
         .direct_if(
+            imports_module("@angular/router"),
+            "angular-router",
+            EvidenceKind::Import,
+            "@angular/router",
+        )
+        .direct_if(
             imports_module("@nestjs/"),
             "nestjs",
             EvidenceKind::Import,
@@ -685,6 +754,9 @@ pub(super) fn detect_non_express(
         );
     if evidence.activates("nestjs") {
         collect_nest_routes(root, source, path, &mut facts);
+    }
+    if evidence.activates("angular-router") {
+        collect_angular_router_routes(root, source, path, &mut facts);
     }
     if evidence.activates("react-router") {
         collect_react_router_routes(root, source, path, &mut facts, "");
@@ -1058,6 +1130,9 @@ fn collect_express_routes(
                 };
                 if !handler.is_empty() {
                     detail.insert("receiver".into(), Value::String(receiver.to_owned()));
+                    if let Some(prefix) = mounts.get(receiver).filter(|prefix| !prefix.is_empty()) {
+                        detail.insert("mount_prefix".into(), Value::String(prefix.clone()));
+                    }
                     facts.push(RawFrameworkFact::Route(RawRouteFact {
                         framework: "express".to_owned(),
                         operation: if method == "all" {
@@ -1150,6 +1225,70 @@ fn collect_express_mounts(
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
         collect_express_mounts(child, source, receivers, mounts);
     }
+}
+
+fn collect_express_mount_facts(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    receivers: &HashSet<String>,
+    imports: &[ImportAlias],
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && let Some((parent, "use")) = node_text(function, source).trim().rsplit_once('.')
+        && receivers.contains(parent)
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let arguments = split_arguments(node_text(arguments, source));
+        if let (Some(prefix), Some(target)) = (
+            arguments
+                .first()
+                .and_then(|argument| string_literal(argument)),
+            arguments.get(1).map(|argument| argument.trim()),
+        ) && is_identifier(target)
+            && (receivers.contains(target) || imports.iter().any(|alias| alias.local == target))
+        {
+            facts.push(router_mount_fact(
+                "express", path, node, parent, target, &prefix, imports,
+            ));
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_express_mount_facts(child, source, path, receivers, imports, facts);
+    }
+}
+
+fn router_mount_fact(
+    framework: &str,
+    path: &Path,
+    node: Node<'_>,
+    parent: &str,
+    target: &str,
+    prefix: &str,
+    imports: &[ImportAlias],
+) -> RawFrameworkFact {
+    let target_module = imports
+        .iter()
+        .find(|alias| alias.local == target)
+        .map(|alias| alias.module.clone())
+        .unwrap_or_default();
+    RawFrameworkFact::Domain(RawDomainFact {
+        framework: framework.to_owned(),
+        kind: "router_mount".to_owned(),
+        name: target.to_owned(),
+        declaring_scope: module_scope(path),
+        anchor: anchor(path, node),
+        origin: RawFrameworkOrigin::Ast,
+        detail: Map::from_iter([
+            ("parent_receiver".into(), Value::String(parent.to_owned())),
+            ("target_receiver".into(), Value::String(target.to_owned())),
+            ("target_module".into(), Value::String(target_module)),
+            ("mount_prefix".into(), Value::String(prefix.to_owned())),
+        ]),
+    })
 }
 
 fn collect_nest_routes(
@@ -1404,6 +1543,84 @@ fn collect_vue_router_routes(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor).filter(|child| child.is_named()) {
         collect_vue_router_routes(child, source, path, facts);
+    }
+}
+
+fn collect_angular_router_routes(
+    root: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    let mut arrays = BTreeMap::new();
+    collect_named_route_arrays(root, source, &mut arrays);
+    let mut collected = HashSet::new();
+    for array in arrays.values().filter(|array| {
+        array
+            .parent()
+            .is_some_and(|declaration| node_text(declaration, source).contains(": Routes"))
+    }) {
+        if collected.insert(array.id()) {
+            collect_route_config_with_parent(*array, source, path, "angular-router", facts, "");
+        }
+    }
+    collect_angular_config_calls(root, source, path, &arrays, &mut collected, facts);
+}
+
+fn collect_named_route_arrays<'tree>(
+    node: Node<'tree>,
+    source: &[u8],
+    arrays: &mut BTreeMap<String, Node<'tree>>,
+) {
+    if node.kind() == "variable_declarator"
+        && let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        )
+        && name.kind() == "identifier"
+        && value.kind() == "array"
+    {
+        arrays.insert(node_text(name, source).to_owned(), value);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_named_route_arrays(child, source, arrays);
+    }
+}
+
+fn collect_angular_config_calls(
+    node: Node<'_>,
+    source: &[u8],
+    path: &Path,
+    arrays: &BTreeMap<String, Node<'_>>,
+    collected: &mut HashSet<usize>,
+    facts: &mut Vec<RawFrameworkFact>,
+) {
+    if node.kind() == "call_expression"
+        && let Some(function) = node.child_by_field_name("function")
+        && matches!(
+            node_text(function, source).trim().rsplit('.').next(),
+            Some("provideRouter" | "forRoot" | "forChild" | "resetConfig")
+        )
+        && let Some(arguments) = node.child_by_field_name("arguments")
+    {
+        let mut cursor = arguments.walk();
+        if let Some(argument) = arguments.named_children(&mut cursor).next() {
+            let array = if argument.kind() == "array" {
+                Some(argument)
+            } else if argument.kind() == "identifier" {
+                arrays.get(node_text(argument, source)).copied()
+            } else {
+                None
+            };
+            if let Some(array) = array.filter(|array| collected.insert(array.id())) {
+                collect_route_config_with_parent(array, source, path, "angular-router", facts, "");
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor).filter(|child| child.is_named()) {
+        collect_angular_config_calls(child, source, path, arrays, collected, facts);
     }
 }
 
@@ -1727,7 +1944,13 @@ fn direct_object_identifier_property(node: Node<'_>, source: &[u8], name: &str) 
 }
 
 fn direct_object_handler_property(node: Node<'_>, source: &[u8]) -> Option<(String, bool)> {
-    for name in ["component", "element", "Component"] {
+    for name in [
+        "component",
+        "element",
+        "Component",
+        "loadComponent",
+        "loadChildren",
+    ] {
         let Some(value) = direct_object_property(node, source, name) else {
             continue;
         };

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -18,7 +18,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/10";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/11";
 mod go;
 mod groovy;
 mod html;

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -2,6 +2,7 @@ mod axum;
 mod domain;
 mod jvm;
 mod native;
+mod node;
 mod php;
 mod python;
 mod qualification;
@@ -35,6 +36,21 @@ const ROUTE_EXPANSION_ADAPTERS: &[RouteExpansionAdapter] = &[
         pack_id: "axum-web",
         frameworks: &["axum"],
         expand: axum::expand_routes,
+    },
+    RouteExpansionAdapter {
+        pack_id: "express-web",
+        frameworks: &["express"],
+        expand: node::expand_routes,
+    },
+    RouteExpansionAdapter {
+        pack_id: "fastify-web",
+        frameworks: &["fastify"],
+        expand: node::expand_routes,
+    },
+    RouteExpansionAdapter {
+        pack_id: "hono-web",
+        frameworks: &["hono"],
+        expand: node::expand_routes,
     },
     RouteExpansionAdapter {
         pack_id: "python-web",

--- a/crates/compass-resolve/src/frameworks/node.rs
+++ b/crates/compass-resolve/src/frameworks/node.rs
@@ -1,0 +1,314 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use compass_languages::{
+    FrameworkLimitError, FrameworkLimits, RawDomainFact, RawFrameworkAnchor, RawFrameworkFact,
+    RawRouteFact,
+};
+use serde_json::Value;
+
+use super::routes::FrameworkResolutionError;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct RouterKey {
+    scope: String,
+    receiver: String,
+}
+
+#[derive(Clone)]
+struct RouterMount {
+    parent: RouterKey,
+    prefix: String,
+    anchor: RawFrameworkAnchor,
+}
+
+pub(super) fn expand_routes(
+    facts: &[RawFrameworkFact],
+    routes: Vec<RawRouteFact>,
+    limits: FrameworkLimits,
+) -> Result<Vec<RawRouteFact>, FrameworkResolutionError> {
+    let mounts = facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Domain(domain)
+                if domain.kind == "router_mount"
+                    && domain
+                        .detail
+                        .get("target_module")
+                        .and_then(Value::as_str)
+                        .is_some_and(|module| module.starts_with('.')) =>
+            {
+                Some(domain)
+            }
+            RawFrameworkFact::Route(_)
+            | RawFrameworkFact::Domain(_)
+            | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    if mounts.is_empty() {
+        return Ok(routes);
+    }
+
+    let mut owners = BTreeSet::new();
+    for route in &routes {
+        if let Some(receiver) = route.detail.get("receiver").and_then(Value::as_str) {
+            owners.insert(RouterKey {
+                scope: normalize_scope(&route.declaring_scope),
+                receiver: receiver.to_owned(),
+            });
+        }
+    }
+    for mount in &mounts {
+        if let Some(parent) = mount.detail.get("parent_receiver").and_then(Value::as_str) {
+            owners.insert(RouterKey {
+                scope: normalize_scope(&mount.declaring_scope),
+                receiver: parent.to_owned(),
+            });
+        }
+    }
+
+    let mut incoming = BTreeMap::<RouterKey, Vec<RouterMount>>::new();
+    for mount in mounts {
+        let Some((parent, target)) = resolve_mount(mount, &owners) else {
+            continue;
+        };
+        incoming.entry(target).or_default().push(RouterMount {
+            parent,
+            prefix: mount
+                .detail
+                .get("mount_prefix")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned(),
+            anchor: mount.anchor.clone(),
+        });
+    }
+    for values in incoming.values_mut() {
+        values.sort_by(|left, right| {
+            (
+                &left.parent,
+                &left.prefix,
+                &left.anchor.source_file,
+                left.anchor.start_byte,
+                left.anchor.end_byte,
+            )
+                .cmp(&(
+                    &right.parent,
+                    &right.prefix,
+                    &right.anchor.source_file,
+                    right.anchor.start_byte,
+                    right.anchor.end_byte,
+                ))
+        });
+        values.dedup_by(|left, right| {
+            left.parent == right.parent
+                && left.prefix == right.prefix
+                && left.anchor == right.anchor
+        });
+    }
+
+    let mut output = Vec::new();
+    for route in routes {
+        let Some(receiver) = route.detail.get("receiver").and_then(Value::as_str) else {
+            output.push(route);
+            continue;
+        };
+        let start = RouterKey {
+            scope: normalize_scope(&route.declaring_scope),
+            receiver: receiver.to_owned(),
+        };
+        if !incoming.contains_key(&start) {
+            output.push(route);
+            continue;
+        }
+        let local_prefix = route
+            .detail
+            .get("mount_prefix")
+            .and_then(Value::as_str)
+            .filter(|prefix| !prefix.is_empty())
+            .map(str::to_owned);
+        let initial_raw_path = local_prefix.as_deref().map_or_else(
+            || route.raw_path.clone(),
+            |prefix| compose_paths(prefix, &route.raw_path),
+        );
+        let initial_prefixes = local_prefix.into_iter().collect::<Vec<_>>();
+        let mut expanded = Vec::new();
+        let mut queue = VecDeque::from([(
+            start.clone(),
+            route.normalized_path.clone(),
+            initial_raw_path,
+            initial_prefixes,
+            Vec::<RawFrameworkAnchor>::new(),
+            BTreeSet::from([start]),
+        )]);
+        while let Some((owner, path, raw_path, prefixes, anchors, visited)) = queue.pop_front() {
+            let Some(parent_mounts) = incoming.get(&owner) else {
+                let mut composed = route.clone();
+                composed.normalized_path = path;
+                composed.raw_path = raw_path;
+                composed.detail.insert(
+                    "mount_prefix".into(),
+                    Value::String(
+                        prefixes
+                            .iter()
+                            .fold(String::new(), |path, prefix| compose_paths(prefix, &path)),
+                    ),
+                );
+                composed
+                    .detail
+                    .insert("mount_anchors".into(), anchors_value(&anchors));
+                expanded.push(composed);
+                continue;
+            };
+            if visited.len() > limits.max_include_depth {
+                return Err(FrameworkLimitError {
+                    limit: "max_include_depth",
+                    maximum: limits.max_include_depth,
+                    observed: visited.len(),
+                }
+                .into());
+            }
+            for mount in parent_mounts {
+                if visited.contains(&mount.parent) {
+                    continue;
+                }
+                let mut next_prefixes = prefixes.clone();
+                next_prefixes.push(mount.prefix.clone());
+                let mut next_anchors = anchors.clone();
+                next_anchors.push(mount.anchor.clone());
+                let mut next_visited = visited.clone();
+                next_visited.insert(mount.parent.clone());
+                queue.push_back((
+                    mount.parent.clone(),
+                    compose_paths(&mount.prefix, &path),
+                    compose_paths(&mount.prefix, &raw_path),
+                    next_prefixes,
+                    next_anchors,
+                    next_visited,
+                ));
+            }
+        }
+        if expanded.is_empty() {
+            output.push(route);
+        } else {
+            output.extend(expanded);
+        }
+    }
+    let mut per_file = BTreeMap::new();
+    for route in &output {
+        *per_file
+            .entry(route.anchor.source_file.as_str())
+            .or_insert(0_usize) += 1;
+    }
+    for count in per_file.into_values() {
+        limits.check_facts(count)?;
+    }
+    Ok(output)
+}
+
+fn resolve_mount(
+    mount: &RawDomainFact,
+    owners: &BTreeSet<RouterKey>,
+) -> Option<(RouterKey, RouterKey)> {
+    let parent_receiver = mount
+        .detail
+        .get("parent_receiver")
+        .and_then(Value::as_str)?;
+    let target_receiver = mount
+        .detail
+        .get("target_receiver")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let target_module = mount.detail.get("target_module").and_then(Value::as_str)?;
+    let parent_scope = normalize_scope(&mount.declaring_scope);
+    let target_scope = resolve_relative_scope(&parent_scope, target_module)?;
+    let candidates = owners
+        .iter()
+        .filter(|owner| {
+            owner.scope == target_scope
+                || owner.scope == format!("{target_scope}.index")
+                || owner.scope.ends_with(&format!(".{target_scope}"))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let target = candidates
+        .iter()
+        .find(|owner| owner.receiver == target_receiver)
+        .cloned()
+        .or_else(|| (candidates.len() == 1).then(|| candidates[0].clone()))?;
+    Some((
+        RouterKey {
+            scope: parent_scope,
+            receiver: parent_receiver.to_owned(),
+        },
+        target,
+    ))
+}
+
+fn resolve_relative_scope(parent_scope: &str, module: &str) -> Option<String> {
+    if !module.starts_with('.') {
+        return None;
+    }
+    let mut segments = parent_scope
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    segments.pop();
+    let normalized_module = module.replace('\\', "/");
+    for segment in normalized_module.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            value => segments.push(
+                value
+                    .trim_end_matches(".tsx")
+                    .trim_end_matches(".ts")
+                    .trim_end_matches(".jsx")
+                    .trim_end_matches(".js"),
+            ),
+        }
+    }
+    (!segments.is_empty()).then(|| segments.join("."))
+}
+
+fn normalize_scope(value: &str) -> String {
+    value
+        .replace(['/', '\\'], ".")
+        .trim_matches('.')
+        .trim_end_matches(".tsx")
+        .trim_end_matches(".ts")
+        .trim_end_matches(".jsx")
+        .trim_end_matches(".js")
+        .to_owned()
+}
+
+fn compose_paths(prefix: &str, path: &str) -> String {
+    let prefix = prefix.trim_matches('/');
+    let path = path.trim_matches('/');
+    match (prefix.is_empty(), path.is_empty()) {
+        (true, true) => "/".to_owned(),
+        (true, false) => format!("/{path}"),
+        (false, true) => format!("/{prefix}"),
+        (false, false) => format!("/{prefix}/{path}"),
+    }
+}
+
+fn anchors_value(anchors: &[RawFrameworkAnchor]) -> Value {
+    Value::Array(
+        anchors
+            .iter()
+            .map(|anchor| {
+                serde_json::json!({
+                    "sourceFile": anchor.source_file,
+                    "startByte": anchor.start_byte,
+                    "endByte": anchor.end_byte,
+                    "startLine": anchor.start_line,
+                    "startColumn": anchor.start_column,
+                    "endLine": anchor.end_line,
+                    "endColumn": anchor.end_column,
+                })
+            })
+            .collect(),
+    )
+}

--- a/crates/compass-resolve/tests/native_routes.rs
+++ b/crates/compass-resolve/tests/native_routes.rs
@@ -61,6 +61,69 @@ fn go_frameworks_require_imports_and_resolve_handlers() -> Result<(), Box<dyn Er
             .all(|route| route.state == ResolutionState::Exact)
     );
     assert!(extract("go/near_matches.go")?.framework_facts.is_empty());
+
+    for (framework, source, expected_path) in [
+        (
+            "echo",
+            br#"package web
+import "github.com/labstack/echo/v4"
+func show(c echo.Context) error { return nil }
+func routes() {
+  e := echo.New()
+  api := e.Group("/api")
+  api.GET("/users/:id", show)
+}
+"#
+            .as_slice(),
+            "/api/users/{id}",
+        ),
+        (
+            "fiber",
+            br#"package web
+import "github.com/gofiber/fiber/v3"
+func auth(c fiber.Ctx) error { return c.Next() }
+func show(c fiber.Ctx) error { return nil }
+func routes() {
+  app := fiber.New()
+  api := app.Group("/api")
+  api.Get("/users/:id", auth, show)
+}
+"#
+            .as_slice(),
+            "/api/users/{id}",
+        ),
+    ] {
+        let extraction = Engine::default().extract_source(Path::new("routes.go"), source)?;
+        let route = extraction
+            .framework_facts
+            .iter()
+            .find_map(|fact| match fact {
+                RawFrameworkFact::Route(route)
+                    if route.framework == framework && route.normalized_path == expected_path =>
+                {
+                    Some(route)
+                }
+                RawFrameworkFact::Route(_)
+                | RawFrameworkFact::Domain(_)
+                | RawFrameworkFact::Annotation(_) => None,
+            })
+            .ok_or("missing Echo/Fiber route")?;
+        assert_eq!(route.handler_reference, "show");
+        if framework == "fiber" {
+            assert_eq!(route.middleware_references, ["auth"]);
+        }
+    }
+
+    let near_match = Engine::default().extract_source(
+        Path::new("routes.go"),
+        br#"package web
+func routes() {
+  e := echo.New()
+  e.GET("/invented", show)
+}
+"#,
+    )?;
+    assert!(near_match.framework_facts.is_empty());
     Ok(())
 }
 
@@ -135,6 +198,58 @@ fn aspnet_composes_controller_and_action_templates() -> Result<(), Box<dyn Error
             && route.state == ResolutionState::Exact
     }));
     assert!(extract("csharp/NearMatches.cs")?.framework_facts.is_empty());
+
+    let minimal = Engine::default().extract_source(
+        Path::new("Program.cs"),
+        br#"var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+var api = app.MapGroup("/api");
+var users = api.MapGroup("/users");
+users.MapGet("/{id:int}", UserHandlers.Show);
+app.MapPost("/users", (User user) => Results.Created($"/users/{user.Id}", user));
+app.Run();
+"#,
+    )?;
+    let minimal_routes = minimal
+        .framework_facts
+        .iter()
+        .filter_map(|fact| match fact {
+            RawFrameworkFact::Route(route) if route.framework == "aspnet" => Some(route),
+            RawFrameworkFact::Route(_)
+            | RawFrameworkFact::Domain(_)
+            | RawFrameworkFact::Annotation(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let exact = minimal_routes
+        .iter()
+        .find(|route| route.normalized_path == "/api/users/{id:int}")
+        .ok_or("missing ASP.NET Minimal API route group")?;
+    assert_eq!(exact.operation, "GET");
+    assert_eq!(exact.handler_reference, "UserHandlers.Show");
+    let inline = minimal_routes
+        .iter()
+        .find(|route| route.normalized_path == "/users")
+        .ok_or("missing ASP.NET Minimal API inline route")?;
+    assert_eq!(inline.operation, "POST");
+    assert!(
+        inline
+            .handler_reference
+            .starts_with("opaque_minimal_handler_at_")
+    );
+    assert_eq!(
+        inline.detail.get("opaque_handler"),
+        Some(&serde_json::Value::Bool(true))
+    );
+
+    let near_match = Engine::default().extract_source(
+        Path::new("Program.cs"),
+        br#"var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+// app.MapGet("/invented", Handler);
+/* app.MapPost("/also-invented", Handler); */
+"#,
+    )?;
+    assert!(near_match.framework_facts.is_empty());
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/typescript_routes.rs
+++ b/crates/compass-resolve/tests/typescript_routes.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -182,6 +182,222 @@ unknown.get("/not-a-route", listUsers);
             && route.normalized_path == "/v2/batch"
     }));
     assert!(!routes(&extraction).any(|route| route.normalized_path == "/not-a-route"));
+    Ok(())
+}
+
+#[test]
+fn angular_router_extracts_typed_named_configs_and_nested_lazy_routes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let extraction = Engine::default().extract_source(
+        Path::new("src/app.routes.ts"),
+        br#"import { provideRouter, Routes } from "@angular/router";
+import { AdminPage } from "./admin.page";
+const routes: Routes = [
+  {
+    path: "admin",
+    component: AdminPage,
+    children: [
+      { path: "users/:id", loadComponent: () => import("./user.page").then(m => m.UserPage) },
+    ],
+  },
+];
+export const providers = [provideRouter(routes)];
+"#,
+    )?;
+    let admin = routes(&extraction)
+        .find(|route| route.framework == "angular-router" && route.normalized_path == "/admin")
+        .ok_or("missing Angular parent route")?;
+    assert_eq!(admin.handler_reference, "AdminPage");
+
+    let lazy = routes(&extraction)
+        .find(|route| {
+            route.framework == "angular-router" && route.normalized_path == "/admin/users/{id}"
+        })
+        .ok_or("missing Angular lazy child route")?;
+    assert!(
+        lazy.handler_reference
+            .starts_with("opaque_route_handler_at_")
+    );
+    assert_eq!(
+        lazy.detail.get("opaque_handler"),
+        Some(&serde_json::Value::Bool(true))
+    );
+    assert_eq!(
+        routes(&extraction)
+            .filter(|route| route.framework == "angular-router")
+            .count(),
+        2,
+        "typed config and provideRouter must not duplicate the same routes"
+    );
+
+    let near_match = Engine::default().extract_source(
+        Path::new("src/not-router.ts"),
+        br#"const routes = [{ path: "admin", component: AdminPage }];"#,
+    )?;
+    assert!(!routes(&near_match).any(|route| route.framework == "angular-router"));
+    Ok(())
+}
+
+#[test]
+fn node_router_mounts_compose_across_modules_and_fail_closed_on_ambiguity()
+-> Result<(), Box<dyn std::error::Error>> {
+    for (framework, parent, child, expected_path) in [
+        (
+            "express",
+            br#"import express from "express";
+import api from "./api";
+const app = express();
+app.use("/api", api);
+"#
+            .as_slice(),
+            br#"import express from "express";
+const router = express.Router();
+function listUsers() {}
+router.get("/users", listUsers);
+export default router;
+"#
+            .as_slice(),
+            "/api/users",
+        ),
+        (
+            "hono",
+            br#"import { Hono } from "hono";
+import api from "./api";
+const app = new Hono();
+app.route("/v1", api);
+"#
+            .as_slice(),
+            br#"import { Hono } from "hono";
+const router = new Hono();
+function listUsers() {}
+router.get("/users", listUsers);
+export default router;
+"#
+            .as_slice(),
+            "/v1/users",
+        ),
+        (
+            "fastify",
+            br#"import fastify from "fastify";
+import api from "./api";
+const app = fastify();
+app.register(api, { prefix: "/internal" });
+"#
+            .as_slice(),
+            br#"import type { FastifyInstance } from "fastify";
+function listUsers() {}
+export default async function api(router: FastifyInstance) {
+  router.get("/users", listUsers);
+}
+"#
+            .as_slice(),
+            "/internal/users",
+        ),
+    ] {
+        let mut engine = Engine::default();
+        let parent_path = "src/server.ts";
+        let child_path = "src/api.ts";
+        let files = [
+            engine.extract_source(Path::new(parent_path), parent)?,
+            engine.extract_source(Path::new(child_path), child)?,
+        ];
+        let sources = HashMap::from([
+            (parent_path.to_owned(), String::from_utf8(parent.to_vec())?),
+            (child_path.to_owned(), String::from_utf8(child.to_vec())?),
+        ]);
+        let mut extraction = resolve(&files, &sources);
+        if framework == "express" {
+            let original_nodes = extraction.nodes.clone();
+            let original_edges = extraction.edges.clone();
+            let error = resolve_and_publish_framework_routes(
+                &mut extraction,
+                FrameworkLimits {
+                    max_include_depth: 0,
+                    ..FrameworkLimits::default()
+                },
+            )
+            .err()
+            .ok_or("expected an explicit cross-module mount depth error")?;
+            assert!(error.to_string().contains("max_include_depth"));
+            assert_eq!(extraction.nodes, original_nodes);
+            assert_eq!(extraction.edges, original_edges);
+        }
+        let resolved =
+            resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+        assert!(
+            resolved.iter().any(|route| {
+                route.route.framework == framework && route.route.normalized_path == expected_path
+            }),
+            "missing {framework} cross-module route {expected_path}"
+        );
+
+        let forward_shapes = resolved
+            .iter()
+            .map(|route| {
+                (
+                    route.route.framework.clone(),
+                    route.route.operation.clone(),
+                    route.route.normalized_path.clone(),
+                    route.route.handler_reference.clone(),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        let reverse_files = [
+            engine.extract_source(Path::new(child_path), child)?,
+            engine.extract_source(Path::new(parent_path), parent)?,
+        ];
+        let mut reverse_extraction = resolve(&reverse_files, &sources);
+        let reverse = resolve_and_publish_framework_routes(
+            &mut reverse_extraction,
+            FrameworkLimits::default(),
+        )?;
+        let reverse_shapes = reverse
+            .iter()
+            .map(|route| {
+                (
+                    route.route.framework.clone(),
+                    route.route.operation.clone(),
+                    route.route.normalized_path.clone(),
+                    route.route.handler_reference.clone(),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(forward_shapes, reverse_shapes, "{framework} input order");
+    }
+
+    let mut engine = Engine::default();
+    let parent_path = "src/server.ts";
+    let child_path = "src/api.ts";
+    let parent = br#"import express from "express";
+import api from "./api";
+const app = express();
+app.use("/api", api);
+"#;
+    let child = br#"import express from "express";
+const users = express.Router();
+const admin = express.Router();
+function listUsers() {}
+users.get("/users", listUsers);
+admin.get("/admin", listUsers);
+export default users;
+"#;
+    let files = [
+        engine.extract_source(Path::new(parent_path), parent)?,
+        engine.extract_source(Path::new(child_path), child)?,
+    ];
+    let sources = HashMap::from([
+        (parent_path.to_owned(), String::from_utf8(parent.to_vec())?),
+        (child_path.to_owned(), String::from_utf8(child.to_vec())?),
+    ]);
+    let mut extraction = resolve(&files, &sources);
+    let resolved =
+        resolve_and_publish_framework_routes(&mut extraction, FrameworkLimits::default())?;
+    assert!(
+        resolved
+            .iter()
+            .all(|route| !route.route.normalized_path.starts_with("/api/")),
+        "an ambiguous imported router must not receive an invented mount"
+    );
     Ok(())
 }
 

--- a/docs/reference/framework-routes.md
+++ b/docs/reference/framework-routes.md
@@ -48,9 +48,10 @@ Compass activates a framework pack only when the repository contains direct evid
 
 ### JavaScript and TypeScript frameworks
 
-- **Express**: `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths and ordered middleware chains; opaque inline callbacks remain unresolved
-- **Fastify**: `fastify()` receivers; HTTP method calls and `route({ method, url, handler })` objects; literal `prefix` registrations, ordered hook stages such as `preHandler`, and opaque inline callbacks remain unresolved
-- **Hono**: `new Hono()` receivers; HTTP method calls, `on([methods], path, handler)` arrays, `basePath` chains, and literal `route(prefix, child)` mounts with ordered middleware stages
+- **Express**: `express()` and `Router()` receivers; `get`, `post`, `put`, `patch`, `delete`, `options`, `head`, and `all`; literal paths, ordered middleware chains, and literal `use(prefix, importedRouter)` mounts across modules; opaque inline callbacks remain unresolved
+- **Fastify**: `fastify()` receivers; HTTP method calls and `route({ method, url, handler })` objects; literal `register(importedPlugin, { prefix })` mounts across modules, ordered hook stages such as `preHandler`, and opaque inline callbacks remain unresolved
+- **Hono**: `new Hono()` receivers; HTTP method calls, `on([methods], path, handler)` arrays, `basePath` chains, and literal `route(prefix, child)` mounts within and across modules with ordered middleware stages
+- **Angular Router**: typed `Routes` arrays and arrays passed to `provideRouter`, `RouterModule.forRoot`, `RouterModule.forChild`, or `resetConfig`; nested literal paths; component targets; and opaque lazy `loadComponent` or `loadChildren` targets
 - **Next.js**: App Router `page.*` and `route.*` files under `app` or `src/app`, Pages Router pages and `pages/api` handlers, dynamic segments, route groups, named HTTP exports, and project activation from the `next` dependency or `next.config.*`
 - **Remix**: flat and nested route modules under `app/routes`, `routes`, or `src/routes`; `_index`, dotted nested segments, `$param` and splat names; and `PAGE`, `LOADER`, and `ACTION` operations from default, loader, and action exports. Project activation uses `@remix-run/*` dependencies or `remix.config.*`.
 - **NestJS**: `Controller` HTTP method decorators and `RequestMapping`; GraphQL `Resolver` `Query` and `Mutation` operations at `/graphql`; typed GraphQL field details; `WebSocketGateway` `SubscribeMessage`; `MessagePattern` and `EventPattern` transport registrations
@@ -74,7 +75,7 @@ HTTP endpoints.
 
 ### Go, Rust, and native server frameworks
 
-- **Gin, chi, and gorilla/mux**: imported router registrations, grouped or closure prefixes, Gin middleware chains, chi method calls, and gorilla `HandleFunc(...).Methods(...)`, including `PathPrefix(...).Subrouter()` chains
+- **Gin, Echo, Fiber, chi, and gorilla/mux**: imported router registrations, grouped or closure prefixes, ordered Gin/Fiber middleware chains, Echo and Fiber HTTP method calls, chi method calls, and gorilla `HandleFunc(...).Methods(...)`, including `PathPrefix(...).Subrouter()` chains
 - **Axum, actix-web, and Rocket**: Axum literal `nest` and `merge` composition
   across local router variables and uniquely resolved module factory calls,
   state-wrapped handlers, ordered `layer` and `route_layer` middleware, and
@@ -84,7 +85,7 @@ HTTP endpoints.
   imports or qualified macros. Ambiguous or cyclic Axum module factory targets
   remain local and uncomposed.
 - **Vapor**: grouped literal and path-component prefixes, closure groups, `app.on(...)`, and HTTP registrations with explicit `use:` handlers; opaque closures remain visible as unresolved handlers
-- **ASP.NET Core**: MVC controller and action templates, `[controller]` and `[action]` tokens, HTTP method attributes, and absolute `/` or `~/` action-template overrides
+- **ASP.NET Core**: MVC controller and action templates, `[controller]` and `[action]` tokens, HTTP method attributes, and absolute `/` or `~/` action-template overrides; Minimal API `MapGet`, `MapPost`, `MapPut`, `MapPatch`, `MapDelete`, `MapOptions`, and `MapHead` registrations; and nested literal `MapGroup` prefixes
 
 ## Special route contracts
 


### PR DESCRIPTION
## Summary

- add Angular Router typed/provider route configs, Echo and Fiber grouped routes, and ASP.NET Core Minimal API route groups
- compose imported Express, Hono, and Fastify routers across modules through framework-owned static resolver adapters
- preserve exact handlers and anchors while leaving ambiguous mounts local, enforcing explicit limits, and publishing atomically
- advance extraction semantics to v11 and document the expanded route surface

## Motivation

Compass already recognized many framework-local registrations, but popular ecosystems still had important gaps: Angular configs, Echo/Fiber routes, Minimal APIs, and cross-module Node router mounts. This change fills that first cross-language slice without adding central framework dispatch branches or allowing one framework adapter to mutate another.

## Verification

```text
cargo fmt --all -- --check
cargo clippy --workspace --lib --bins --locked -- -D warnings
cargo test --workspace --lib --bins --locked
cargo test -p compass-resolve --test native_routes --test typescript_routes --locked
./scripts/qualify_code_graph_v1.sh --fixtures-only
```

All commands above pass. The broader pre-existing `cargo clippy -p compass-resolve --all-targets` test lint remains blocked by unrelated `expect`/`panic` and collapsible-if violations in `framework_qualification.rs` and `python_import_provenance.rs`; the required workspace lib/bin lint passes.

## Compatibility and documentation

The public graph and CLI schemas are unchanged. Extraction semantics advance from v10 to v11 so cached facts rebuild and expose the new additive route evidence. `docs/reference/framework-routes.md` and `CHANGELOG.md` describe the supported shapes.

## Checklist

- [x] The change is focused and excludes unrelated formatting or generated files
- [x] Tests cover changed behavior, or this pull request changes documentation only
- [x] User-facing commands, flags, limits, and examples are documented
- [x] Compatibility or migration effects are described
- [x] No credentials, private source code, or sensitive report details are included
- [x] I agree to license my contribution under `MIT OR Apache-2.0`
- [x] I followed the [Compass code of conduct](https://github.com/crabbuild/compass/blob/main/CODE_OF_CONDUCT.md)