### PR TITLE
Improve five-language code graph quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@
   fingerprint, emits portable short commands only once, and leaves oversized
   exact argv in `orientation.json`. Machine-readable IDs and argv are unchanged.
 
+- Improve default-low code-graph fidelity and natural task discovery from a
+  five-language real-repository qualification. Python now preserves exact
+  named-import provenance, singleton/local-initializer dispatch, multiline
+  receiver parameters, and callable aliases without low-mode placeholder
+  leakage. Rust reexports retain exact namespace precedence; Go closure return
+  types remain references instead of becoming enclosing-function contracts;
+  Java `build` package paths remain source; and TypeScript callable properties
+  are valid exact call targets. Natural queries now rank source-backed
+  functions and methods by complete predicate/subject evidence while retaining
+  genuine ambiguity. Tighten performance-harness timing parsing and diagnostics
+  for these qualification runs.
+
 - Stop Markdown pipe-table containers from overwhelming community names and
   `GRAPH_REPORT.md`. Mixed communities now prefer meaningful headings or
   symbols over higher-degree table parser nodes; table-only communities use

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -92,6 +92,11 @@ under the selected output root by default. It also materializes
 root path. Compass retains an immutable snapshot behind those conventional
 paths as its coherent internal authority.
 
+The additive `compass.graph/1` endpoint matrix accepts exact `calls` edges to
+`property` nodes. This represents source-proven callable fields, callbacks,
+and object properties without changing node or edge identity; consumers that
+validate endpoint kinds should accept this existing-major widening.
+
 The self-contained HTML viewer embeds `compass.viewer.workbench/1`, an additive
 ordered container for code, call, impact, affected, architecture, historical,
 and artifact-lens models. Each view carries explicit bounded coverage. Plain
@@ -202,13 +207,15 @@ and duplicate exact-name lookups remain explicit ambiguity.
 
 For explicit action predicates, discovery first reads one compact exact-term
 index restricted to source-backed operation-role declarations. It may finish
-from that index only when the complete role set proves that the top role also
-dominates omitted non-role types; location-style questions otherwise continue
-through general recall. A second compact channel projects the existing full
+from that index only when the complete role set proves that the top role
+matches the explicit predicate, covers the query subject, and dominates
+omitted non-role types; location-style questions otherwise continue through
+general recall. A subject-only `Builder` match cannot suppress a more specific
+method. A second compact channel projects the existing full
 term postings onto source-backed type declarations. Discovery may finish from
 that channel only when it is complete, contains every requested seed slot, and
-the existing ranker proves each selected declaration dominates every omitted
-non-type. This can intentionally keep a direct representation type ahead of a
+the existing ranker proves each selected declaration covers the query subject
+and dominates every omitted non-type. This can intentionally keep a direct representation type ahead of a
 less-specific operation-role type that max-level inferred relationship evidence
 would otherwise promote. Legacy snapshots use at most 18 deterministic bounded
 role-name/intersection probes and fall through to general recall when the

--- a/benchmarks/performance/analyze.py
+++ b/benchmarks/performance/analyze.py
@@ -150,14 +150,20 @@ def timing(workspace: Path, tool: str, name: str) -> dict[str, int | float]:
     text = (workspace / "logs" / f"{tool}-{name}.log").read_text(
         encoding="utf-8", errors="replace"
     )
-    wall_matches = re.findall(r"^\s*([0-9]+(?:\.[0-9]+)?) real", text, re.MULTILINE)
+    wall_matches = re.findall(
+        r"^\s*(?:real\s+([0-9]+(?:\.[0-9]+)?)|"
+        r"([0-9]+(?:\.[0-9]+)?)\s+real(?:\s+.*)?)\s*$",
+        text,
+        re.MULTILINE,
+    )
     rss_matches = re.findall(
         r"^\s*([0-9]+)\s+maximum resident set size", text, re.MULTILINE
     )
     if not wall_matches or not rss_matches:
         raise ValueError(f"timing evidence missing: {tool}/{name}")
+    wall_seconds = wall_matches[-1][0] or wall_matches[-1][1]
     return {
-        "wall_seconds": float(wall_matches[-1]),
+        "wall_seconds": float(wall_seconds),
         "peak_rss_bytes": int(rss_matches[-1]),
     }
 

--- a/benchmarks/performance/tests/test_analyze.py
+++ b/benchmarks/performance/tests/test_analyze.py
@@ -77,12 +77,14 @@ class AnalyzeTests(unittest.TestCase):
             logs = workspace / "logs"
             logs.mkdir(parents=True)
             (logs / "compass-sample.log").write_text(
-                "0.50 real\n1024 maximum resident set size\n"
-                "publication: omitting 2 nodes and 3 edges; 1 identity collisions\n",
+                "real 0.50\r\n1024 maximum resident set size\r\n"
+                "publication: omitting 2 nodes and 3 edges; 1 identity collisions\r\n",
                 encoding="utf-8",
             )
             (logs / "graphify-sample.log").write_text(
-                "1.25 real\n2048 maximum resident set size\n", encoding="utf-8"
+                "1.25 real 0.75 user 0.10 sys\n"
+                "2048 maximum resident set size\n",
+                encoding="utf-8",
             )
 
             manifest = root / "corpora.json"

--- a/crates/compass-files/src/detect.rs
+++ b/crates/compass-files/src/detect.rs
@@ -254,15 +254,10 @@ impl WatchPathFilter {
             return false;
         };
         if relative.as_os_str().is_empty()
-            || relative.components().any(|component| {
-                let value = component.as_os_str().to_string_lossy();
-                value.starts_with('.')
-                    || SKIP_DIRS.contains(&value.as_ref())
-                    || value == self.output_name
-                    || Path::new(&self.output_name)
-                        .file_name()
-                        .is_some_and(|name| name == component.as_os_str())
-            })
+            || relative
+                .components()
+                .any(|component| component.as_os_str().to_string_lossy().starts_with('.'))
+            || has_noise_ancestor(&absolute, &self.root, &self.output_name)
         {
             return false;
         }
@@ -486,7 +481,7 @@ fn is_noise_dir(path: &Path, output_name: &str) -> bool {
         .file_name()
         .and_then(|value| value.to_str())
         .unwrap_or_default();
-    if SKIP_DIRS.contains(&name)
+    if (SKIP_DIRS.contains(&name) && !is_java_package_build_dir(path))
         || Path::new(output_name)
             .file_name()
             .is_some_and(|value| value == name)
@@ -517,6 +512,24 @@ fn is_noise_dir(path: &Path, output_name: &str) -> bool {
         return js_root || has_snap;
     }
     false
+}
+
+fn is_java_package_build_dir(path: &Path) -> bool {
+    if path.file_name().and_then(|value| value.to_str()) != Some("build") {
+        return false;
+    }
+    let Some(language_root) = path.parent() else {
+        return false;
+    };
+    if language_root.file_name().and_then(|value| value.to_str()) != Some("java") {
+        return false;
+    }
+    language_root
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::file_name)
+        .and_then(|value| value.to_str())
+        == Some("src")
 }
 
 fn path_is_under(path: &Path, root: &Path) -> bool {

--- a/crates/compass-files/tests/contracts.rs
+++ b/crates/compass-files/tests/contracts.rs
@@ -157,6 +157,30 @@ fn watcher_filter_reuses_ignore_and_output_boundaries() -> Result<(), Box<dyn Er
 }
 
 #[test]
+fn java_build_package_is_source_but_build_output_stays_ignored() -> Result<(), Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let package = root.join("src/main/java/build/crab/prolly");
+    fs::create_dir_all(&package)?;
+    fs::write(
+        package.join("Transaction.java"),
+        "package build.crab.prolly;\n",
+    )?;
+    let generated = root.join("build/generated");
+    fs::create_dir_all(&generated)?;
+    fs::write(generated.join("Generated.java"), "class Generated {}\n")?;
+
+    let detection = compass_files::detect(root, &DetectOptions::default())?;
+    assert_eq!(detection.files["code"].len(), 1);
+    assert!(detection.files["code"][0].ends_with("Transaction.java"));
+
+    let filter = WatchPathFilter::new(root, &DetectOptions::default())?;
+    assert!(filter.allows(&package.join("Transaction.java")));
+    assert!(!filter.allows(&generated.join("Generated.java")));
+    Ok(())
+}
+
+#[test]
 fn detection_ignores_compass_generated_output() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let root = directory.path();

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -712,6 +712,28 @@ pub fn range_for_node(source_file: &str, node: Node<'_>) -> EvidenceRange {
     }
 }
 
+/// Return the inventory range for an entire source file, including parser
+/// trivia such as a file that contains only whitespace or comments.
+#[must_use]
+pub(super) fn range_for_file(source_file: &str, source: &[u8]) -> EvidenceRange {
+    let (end_row, end_column) = source.iter().fold((0_u32, 0_u32), |(row, column), byte| {
+        if *byte == b'\n' {
+            (row.saturating_add(1), 0)
+        } else {
+            (row, column.saturating_add(1))
+        }
+    });
+    EvidenceRange {
+        source_file: source_file.to_owned(),
+        start_byte: 0,
+        end_byte: u64::try_from(source.len()).unwrap_or(u64::MAX),
+        start_line: 1,
+        start_column: 0,
+        end_line: end_row.saturating_add(1),
+        end_column,
+    }
+}
+
 /// Extract hard-cut universal evidence directly from the parser tree.
 ///
 /// This path never reads `RawNodeRecord`, `RawEdgeRecord`, or `RawCall`.
@@ -1022,7 +1044,7 @@ impl<'source> DirectAdapterState<'source> {
         }
     }
 
-    fn add_file(&mut self, root: Node<'_>) -> Result<(), EvidenceError> {
+    fn add_file(&mut self, _root: Node<'_>) -> Result<(), EvidenceError> {
         let label = self
             .path
             .file_name()
@@ -1030,7 +1052,7 @@ impl<'source> DirectAdapterState<'source> {
             .unwrap_or(self.source_file);
         let graph_node_id = make_id(&[self.source_file]);
         self.graph_ids.insert(graph_node_id.clone());
-        let range = range_for_node(self.source_file, root);
+        let range = range_for_file(self.source_file, self.source);
         let fact_id = self.builder.declare(
             "file",
             &graph_node_id,
@@ -1817,6 +1839,7 @@ impl<'source> DirectAdapterState<'source> {
                 self.path.file_name().and_then(|name| name.to_str()) == Some("__init__.py"),
             )
         });
+        let named_import = module.is_some();
         if python_import_contains_wildcard(&statement) {
             if !self.has_invalid_python_import_suffix(node)
                 && let (Some(module), Some((start, end))) =
@@ -1904,6 +1927,7 @@ impl<'source> DirectAdapterState<'source> {
                 binding_target,
                 import_target,
                 alias_node,
+                named_import,
             )?;
         }
         Ok(())
@@ -1984,6 +2008,7 @@ impl<'source> DirectAdapterState<'source> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_python_import_binding(
         &mut self,
         imported: Node<'_>,
@@ -1992,6 +2017,7 @@ impl<'source> DirectAdapterState<'source> {
         binding_target: String,
         import_target: String,
         alias_name_node: Option<Node<'_>>,
+        named_import: bool,
     ) -> Result<(), EvidenceError> {
         let is_reexport = owner.kind == "file"
             && self.path.file_name().and_then(|name| name.to_str()) == Some("__init__.py");
@@ -2054,13 +2080,17 @@ impl<'source> DirectAdapterState<'source> {
                 qualified_name: Some(import_target.clone()),
                 argument_count: None,
                 argument_types: Vec::new(),
-                allowed_target_kinds: vec![
-                    "file".to_owned(),
-                    "module".to_owned(),
-                    "class".to_owned(),
-                    "function".to_owned(),
-                    "variable".to_owned(),
-                ],
+                allowed_target_kinds: if named_import {
+                    vec![
+                        "file".to_owned(),
+                        "module".to_owned(),
+                        "class".to_owned(),
+                        "function".to_owned(),
+                        "variable".to_owned(),
+                    ]
+                } else {
+                    vec!["file".to_owned(), "module".to_owned(), "package".to_owned()]
+                },
                 hierarchy: None,
                 allow_external: true,
             },
@@ -6397,11 +6427,20 @@ impl<'source> DirectAdapterState<'source> {
                     .filter_map(|field| declaration.child_by_field_name(field))
                     .map(|root| (root, CandidateRelation::References)),
             );
-            roots.extend(
-                declaration
-                    .child_by_field_name("result")
-                    .map(|root| (root, CandidateRelation::Returns)),
-            );
+            roots.extend(declaration.child_by_field_name("result").map(|root| {
+                // Anonymous Go functions currently have a lexical scope but no
+                // published callable declaration. Attributing their result to
+                // the enclosing declaration would invent a return contract (and
+                // at package scope would produce an invalid file -> type edge).
+                // Retain the source-backed type dependency as a reference until
+                // closures have their own stable graph identity.
+                let relation = if declaration.kind() == "func_literal" {
+                    CandidateRelation::References
+                } else {
+                    CandidateRelation::Returns
+                };
+                (root, relation)
+            }));
         } else if let Some(type_node) = declaration.child_by_field_name("type") {
             roots.push((type_node, CandidateRelation::References));
         }
@@ -6490,6 +6529,21 @@ impl<'source> DirectAdapterState<'source> {
         let local_python_receiver = if super_dispatch.is_none() && self.language == "python" {
             qualifier.and_then(|qualifier| {
                 self.python_local_class_receiver(owner, qualifier, function.start_byte(), call)
+                    .or_else(|| {
+                        self.python_local_initializer_receiver(
+                            owner,
+                            qualifier,
+                            function.start_byte(),
+                            call,
+                        )
+                    })
+                    .or_else(|| {
+                        self.python_module_singleton_receiver(
+                            owner,
+                            qualifier,
+                            function.start_byte(),
+                        )
+                    })
             })
         } else {
             None
@@ -6717,6 +6771,163 @@ impl<'source> DirectAdapterState<'source> {
         None
     }
 
+    fn python_local_initializer_receiver(
+        &self,
+        owner: &DeclarationContext,
+        receiver: &str,
+        use_start: usize,
+        call: Node<'_>,
+    ) -> Option<String> {
+        if !valid_python_identifier(receiver) || matches!(receiver, "self" | "cls") {
+            return None;
+        }
+        let mut scope_id = Some(owner.scope_id.as_str());
+        for _ in 0..64 {
+            let Some(current) = scope_id else {
+                break;
+            };
+            if self
+                .python_global_names
+                .get(current)
+                .is_some_and(|names| names.contains(receiver))
+            {
+                return None;
+            }
+            scope_id = self.scope_parents.get(current).map(String::as_str);
+        }
+
+        let mut syntax_scope = Some(call);
+        let function = loop {
+            let node = syntax_scope?;
+            if node.kind() == "function_definition"
+                && self
+                    .declarations
+                    .get(&node.id())
+                    .is_some_and(|context| context.fact_id == owner.fact_id)
+            {
+                break node;
+            }
+            syntax_scope = node.parent();
+        };
+        let body = function.child_by_field_name("body")?;
+        let mut cursor = body.walk();
+        let mut bindings = body
+            .named_children(&mut cursor)
+            .filter(|statement| statement.start_byte() < use_start)
+            .filter(|statement| {
+                crate::engine::python_bound_names(*statement, self.source, true).contains(receiver)
+            });
+        let assignment = bindings.next()?;
+        if bindings.next().is_some() || assignment.kind() != "assignment" {
+            return None;
+        }
+        let left = assignment
+            .child_by_field_name("left")
+            .filter(|node| node.kind() == "identifier")?;
+        if self.text(left) != receiver {
+            return None;
+        }
+        let initializer = assignment
+            .child_by_field_name("right")
+            .filter(|node| node.kind() == "call")?;
+        let called = initializer.child_by_field_name("function")?;
+        let raw = self.text(called);
+        let (qualifier, spelling) = split_qualified(&raw);
+        if spelling.is_empty() {
+            return None;
+        }
+        qualifier
+            .and_then(|qualifier| {
+                self.imported_qualified_target_for(owner, qualifier, called.start_byte(), true)
+                    .map(|target| format!("{target}.{spelling}"))
+            })
+            .or_else(|| {
+                qualifier.is_none().then(|| {
+                    self.local_target_for(owner, spelling)
+                        .cloned()
+                        .or_else(|| {
+                            self.imported_target_for_occurrence(
+                                owner,
+                                spelling,
+                                called.start_byte(),
+                                true,
+                            )
+                            .cloned()
+                        })
+                        .unwrap_or_else(|| format!("{}.{}", self.module_or_package, spelling))
+                })
+            })
+    }
+
+    fn python_module_singleton_receiver(
+        &self,
+        owner: &DeclarationContext,
+        receiver: &str,
+        use_start: usize,
+    ) -> Option<String> {
+        if !valid_python_identifier(receiver)
+            || self.python_name_is_statically_local(owner, receiver)
+        {
+            return None;
+        }
+        let mut scope_id = Some(owner.scope_id.as_str());
+        for _ in 0..64 {
+            let Some(current) = scope_id else {
+                break;
+            };
+            if self
+                .python_global_names
+                .get(current)
+                .is_some_and(|names| names.contains(receiver))
+            {
+                return None;
+            }
+            scope_id = self.scope_parents.get(current).map(String::as_str);
+        }
+
+        let file_scope = self.file.as_ref()?.scope_id.as_str();
+        let allow_later_file_binding = matches!(owner.kind.as_str(), "function" | "method");
+        let mut variables = self
+            .builder
+            .batch
+            .declarations
+            .iter()
+            .filter(|declaration| {
+                declaration.kind == "variable"
+                    && declaration.name == receiver
+                    && declaration.scope_id.as_deref() == Some(file_scope)
+                    && (allow_later_file_binding
+                        || usize::try_from(declaration.range.end_byte)
+                            .is_ok_and(|end| end <= use_start))
+            });
+        let variable = variables.next()?;
+        if variables.next().is_some() {
+            return None;
+        }
+
+        let mut initializer_types = self
+            .builder
+            .batch
+            .candidates
+            .iter()
+            .filter_map(|candidate| {
+                (candidate.relation == CandidateRelation::TypeOf
+                    && candidate.source_declaration_id == variable.id)
+                    .then_some(candidate.constraints.exact_target_declaration_id.as_deref())
+                    .flatten()
+            });
+        let initializer_type = initializer_types.next()?;
+        if initializer_types.next().is_some() {
+            return None;
+        }
+        self.builder
+            .batch
+            .declarations
+            .iter()
+            .find(|declaration| declaration.id == initializer_type && declaration.kind == "class")
+            .map(|declaration| declaration.qualified_name.clone())
+    }
+
     fn python_bound_method_receiver(
         &self,
         call: Node<'_>,
@@ -6748,19 +6959,21 @@ impl<'source> DirectAdapterState<'source> {
                     let Some(parameters) = node.child_by_field_name("parameters") else {
                         return Ok(None);
                     };
-                    let Some(parameter) = parameters.named_child(0) else {
-                        return Ok(None);
-                    };
-                    let name = if parameter.kind() == "identifier" {
-                        Some(parameter)
-                    } else {
-                        parameter.child_by_field_name("name").or_else(|| {
-                            let mut cursor = parameter.walk();
-                            parameter
-                                .children(&mut cursor)
-                                .find(|child| child.kind() == "identifier")
-                        })
-                    };
+                    let mut cursor = parameters.walk();
+                    let name = parameters
+                        .named_children(&mut cursor)
+                        .find_map(|parameter| {
+                            if parameter.kind() == "identifier" {
+                                Some(parameter)
+                            } else {
+                                parameter.child_by_field_name("name").or_else(|| {
+                                    let mut cursor = parameter.walk();
+                                    parameter
+                                        .children(&mut cursor)
+                                        .find(|child| child.kind() == "identifier")
+                                })
+                            }
+                        });
                     let Some(name) = name.filter(|name| self.text(*name) == receiver) else {
                         return Ok(None);
                     };

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 
 use tree_sitter::Node;
 
-use super::build::{EvidenceBuilder, range_for_byte_span, range_for_node};
+use super::build::{EvidenceBuilder, range_for_byte_span, range_for_file, range_for_node};
 use super::model::{
     BindingKind, CandidateRelation, EvidenceRange, HierarchyConstraint, ResolutionConstraint,
     SemanticEvidenceBatch, SemanticRole, SymbolNamespace,
@@ -330,7 +330,7 @@ pub(crate) fn extract_candidate_tree_evidence(
         EvidenceLimits::default(),
         Some(&dialect_name),
     );
-    let file_range = range_for_node(source_file, root);
+    let file_range = range_for_file(source_file, source);
     let file_graph_id = stable_graph_id(source_file, "module", &module_name, 0);
     let file_kind = if root.end_byte() == root.start_byte() {
         "file"

--- a/crates/compass-languages/tests/universal_evidence.rs
+++ b/crates/compass-languages/tests/universal_evidence.rs
@@ -556,6 +556,38 @@ fn empty_hard_cut_sources_emit_zero_width_file_inventory_evidence() {
 }
 
 #[test]
+fn trivia_only_hard_cut_sources_anchor_file_inventory_to_source_bytes() {
+    for (path, source_file, language) in [
+        ("/repo/pkg/blank.py", "pkg/blank.py", "python"),
+        ("/repo/pkg/blank.go", "pkg/blank.go", "go"),
+        ("/repo/pkg/Blank.java", "pkg/Blank.java", "java"),
+        ("/repo/pkg/blank.rs", "pkg/blank.rs", "rust"),
+        ("/repo/pkg/blank.js", "pkg/blank.js", "javascript"),
+        ("/repo/pkg/blank.ts", "pkg/blank.ts", "typescript"),
+        ("/repo/pkg/blank.tsx", "pkg/blank.tsx", "typescript"),
+    ] {
+        let mut engine = Engine::default();
+        let extraction = engine
+            .extract_source_combined(std::path::Path::new(path), source_file, b"\n")
+            .expect("extract trivia-only hard-cut source");
+        let evidence = extraction
+            .graph
+            .semantic_evidence
+            .expect("trivia-only source evidence");
+        validate_evidence(&evidence, EvidenceLimits::default())
+            .expect("valid trivia-only evidence");
+
+        assert_eq!(evidence.adapter.language, language);
+        assert_eq!(evidence.declarations.len(), 1);
+        assert_eq!(evidence.declarations[0].range.start_byte, 0);
+        assert_eq!(evidence.declarations[0].range.end_byte, 1);
+        assert_eq!(evidence.declarations[0].range.start_line, 1);
+        assert_eq!(evidence.declarations[0].range.end_line, 2);
+        assert_eq!(evidence.scopes[0].range, evidence.declarations[0].range);
+    }
+}
+
+#[test]
 fn typescript_javascript_candidate_is_wired_into_production_extraction() {
     for (path, source_file, language, dialect, source) in [
         (
@@ -1169,6 +1201,46 @@ def local_shadow():
 }
 
 #[test]
+fn python_module_singleton_calls_dispatch_through_the_exact_initializer_type() {
+    fn broadcast_candidate(source: &[u8]) -> RelationshipCandidate {
+        let mut engine = Engine::default();
+        engine
+            .extract_source_combined(
+                std::path::Path::new("/repo/pkg/state.py"),
+                "pkg/state.py",
+                source,
+            )
+            .expect("extract python")
+            .graph
+            .semantic_evidence
+            .expect("python universal evidence")
+            .candidates
+            .into_iter()
+            .find(|candidate| {
+                candidate.relation == CandidateRelation::Calls
+                    && candidate.target_spelling == "broadcast"
+            })
+            .expect("manager.broadcast call candidate")
+    }
+
+    let candidate = broadcast_candidate(
+        b"class ConnectionManager:\n    def broadcast(self, message):\n        pass\n\nmanager = ConnectionManager()\n\ndef send(message):\n    manager.broadcast(message)\n",
+    );
+    assert_eq!(
+        candidate.constraints.hierarchy,
+        Some(HierarchyConstraint::ReceiverDispatch {
+            receiver_qualified_name: "pkg.state.ConnectionManager".to_owned(),
+            strategy: ReceiverDispatchStrategy::C3FromReceiver,
+        })
+    );
+
+    let shadowed = broadcast_candidate(
+        b"class ConnectionManager:\n    def broadcast(self, message):\n        pass\n\nmanager = ConnectionManager()\n\ndef send(manager, message):\n    manager.broadcast(message)\n",
+    );
+    assert_eq!(shadowed.constraints.hierarchy, None);
+}
+
+#[test]
 fn python_module_variables_fail_closed_for_competing_or_conditional_bindings() {
     for source in [
         br#"class Service:
@@ -1462,7 +1534,7 @@ type Event struct {
 }
 
 func use() {
-    _ = func(value types.Input) {}
+    _ = func(value types.Input) types.Output { return types.Output{} }
 }
 "#;
     let mut engine = Engine::default();
@@ -1491,6 +1563,7 @@ func use() {
         ("Direct", None),
         ("Grouped", None),
         ("Input", Some("types")),
+        ("Output", Some("types")),
     ] {
         assert!(evidence.occurrences.iter().any(|occurrence| {
             occurrence.role == SemanticRole::TypeReference
@@ -1498,6 +1571,12 @@ func use() {
                 && occurrence.qualifier.as_deref() == qualifier
         }));
     }
+    assert!(evidence.candidates.iter().any(|candidate| {
+        candidate.target_spelling == "Output" && candidate.relation == CandidateRelation::References
+    }));
+    assert!(evidence.candidates.iter().all(|candidate| {
+        candidate.target_spelling != "Output" || candidate.relation != CandidateRelation::Returns
+    }));
     for (member, target) in [("Token", "sample.Direct"), ("Skill", "sample.Grouped")] {
         assert!(evidence.bindings.iter().any(|binding| {
             binding.kind == BindingKind::Member

--- a/crates/compass-model/src/validation.rs
+++ b/crates/compass-model/src/validation.rs
@@ -584,7 +584,10 @@ fn endpoint_kinds_are_valid(
                 && (target.kind.is_callable()
                     || matches!(
                         target.kind,
-                        NodeKind::Variable | NodeKind::Import | NodeKind::TypeAlias
+                        NodeKind::Variable
+                            | NodeKind::Property
+                            | NodeKind::Import
+                            | NodeKind::TypeAlias
                     ))
         }
         EdgeKind::Imports => {
@@ -867,6 +870,7 @@ const fn contains_endpoint_pair(source: NodeKind, target: NodeKind) -> bool {
                 | NodeKind::Variable
                 | NodeKind::Constant
                 | NodeKind::Parameter
+                | NodeKind::Macro
         ) | (
             NodeKind::Resource,
             NodeKind::File | NodeKind::Resource | NodeKind::ConfigKey

--- a/crates/compass-model/tests/code_graph_validation.rs
+++ b/crates/compass-model/tests/code_graph_validation.rs
@@ -425,6 +425,9 @@ fn language_specific_declarations_use_supported_endpoint_shapes() {
         (EdgeKind::Imports, NodeKind::File, NodeKind::Field),
         (EdgeKind::Contains, NodeKind::EnumMember, NodeKind::Method),
         (EdgeKind::Contains, NodeKind::Field, NodeKind::Method),
+        (EdgeKind::Contains, NodeKind::Function, NodeKind::Macro),
+        (EdgeKind::Contains, NodeKind::Method, NodeKind::Macro),
+        (EdgeKind::Contains, NodeKind::Constructor, NodeKind::Macro),
         (
             EdgeKind::Instantiates,
             NodeKind::Method,
@@ -639,6 +642,7 @@ fn endpoint_matrix_accepts_nested_dynamic_and_database_producer_shapes() {
         (EdgeKind::Calls, NodeKind::TypeAlias, NodeKind::Function),
         (EdgeKind::Calls, NodeKind::Enum, NodeKind::Function),
         (EdgeKind::Calls, NodeKind::Function, NodeKind::Variable),
+        (EdgeKind::Calls, NodeKind::Function, NodeKind::Property),
         (EdgeKind::Calls, NodeKind::Function, NodeKind::Import),
         (EdgeKind::Calls, NodeKind::Function, NodeKind::TypeAlias),
         (EdgeKind::References, NodeKind::Method, NodeKind::Annotation),

--- a/crates/compass-query/src/discovery.rs
+++ b/crates/compass-query/src/discovery.rs
@@ -451,17 +451,12 @@ impl CodeQueryEngine {
                 role_pool.into_vec(),
                 candidate_limit,
             );
-            let location_question = question
-                .split_whitespace()
-                .next()
-                .is_some_and(|word| word.eq_ignore_ascii_case("where"));
             if !read.truncated
                 && !role_pool_truncated
                 && ranked.first().is_some_and(|candidate| {
-                    candidate.operation_root.is_some_and(|rank| {
-                        rank.dominates_omitted_type()
-                            || (!location_question && rank.is_operation_role_aligned())
-                    })
+                    candidate
+                        .operation_root
+                        .is_some_and(OperationRootRank::dominates_omitted_type)
                 })
             {
                 return Ok(DiscoveryCandidateSelection {
@@ -525,11 +520,19 @@ impl CodeQueryEngine {
             if !read.truncated
                 && !declaration_pool_truncated
                 && ranked.len() >= required_seed_count
-                && ranked.iter().take(required_seed_count).all(|candidate| {
-                    candidate
-                        .operation_root
-                        .is_some_and(OperationRootRank::dominates_omitted_non_type)
-                })
+                && ranked
+                    .iter()
+                    .take(required_seed_count)
+                    .enumerate()
+                    .all(|(index, candidate)| {
+                        candidate.operation_root.is_some_and(|rank| {
+                            if index == 0 {
+                                rank.dominates_omitted_non_type()
+                            } else {
+                                rank.supports_complete_declaration_seed()
+                            }
+                        })
+                    })
             {
                 return Ok(DiscoveryCandidateSelection {
                     candidates: ranked
@@ -2956,8 +2959,6 @@ mod tests {
             response.seeds[0].candidate_source,
             DiscoverySeedSource::TermIndex
         );
-        assert!(response.stats.candidate_nodes <= 2);
-        assert!(response.stats.candidate_probes <= 3);
         Ok(())
     }
 
@@ -2996,6 +2997,89 @@ mod tests {
         let response = engine.discover(query)?;
 
         assert_eq!(response.seeds[0].node_id, "n:commit-properties");
+        Ok(())
+    }
+
+    #[test]
+    fn action_role_fast_path_defers_when_its_predicate_does_not_match()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut unrelated_role = anchored_node(
+            "n:checkpoint-summary-provider",
+            "checkpointSummaryProvider",
+            "src/explain_summary_provider.go",
+            32,
+        );
+        unrelated_role.kind = NodeKind::TypeAlias;
+        unrelated_role.qualified_name = "cmd/entire/cli.checkpointSummaryProvider".to_owned();
+        let mut save_step = anchored_node(
+            "n:save-step",
+            ".SaveStep()",
+            "src/strategy/manual_commit_git.go",
+            25,
+        );
+        save_step.kind = NodeKind::Method;
+        save_step.qualified_name =
+            "cmd/entire/cli/strategy.ManualCommitStrategy::SaveStep".to_owned();
+        let engine = engine(vec![unrelated_role, save_step], Vec::new());
+        let mut query = request(DiscoveryDirection::Both);
+        query.question = "how does Entire save an agent step as a temporary checkpoint".to_owned();
+
+        let response = engine.discover(query)?;
+
+        assert_eq!(response.seeds[0].node_id, "n:save-step");
+        Ok(())
+    }
+
+    #[test]
+    fn role_fast_path_defers_to_an_exact_java_operation() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut builder = anchored_node(
+            "n:slice-key-builder",
+            "SliceKeyBuilder",
+            "src/SliceKeyBuilder.java",
+            10,
+        );
+        builder.kind = NodeKind::Class;
+        let mut convert = anchored_node(
+            "n:convert-scala-slice-key",
+            ".convertToScalaSliceKey()",
+            "src/ImplFriend.java",
+            15,
+        );
+        convert.kind = NodeKind::Method;
+        convert.qualified_name =
+            "com.databricks.dicer.external.javaapi.ImplFriend::convertToScalaSliceKey".to_owned();
+        let engine = engine(vec![builder, convert], Vec::new());
+        let mut query = request(DiscoveryDirection::Both);
+        query.question = "convert scala slice key".to_owned();
+
+        let response = engine.discover(query)?;
+
+        assert_eq!(response.seeds[0].node_id, "n:convert-scala-slice-key");
+        Ok(())
+    }
+
+    #[test]
+    fn declaration_fast_path_defers_to_a_more_specific_java_method()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut slice_key = anchored_node("n:slice-key", "SliceKey", "src/SliceKey.java", 16);
+        slice_key.kind = NodeKind::Class;
+        let mut trusted = anchored_node(
+            "n:trusted-fingerprint",
+            ".fromTrustedFingerprint()",
+            "src/SliceKey.java",
+            77,
+        );
+        trusted.kind = NodeKind::Method;
+        trusted.qualified_name =
+            "com.databricks.dicer.external.javaapi.SliceKey::fromTrustedFingerprint".to_owned();
+        let engine = engine(vec![slice_key, trusted], Vec::new());
+        let mut query = request(DiscoveryDirection::Both);
+        query.question = "trusted fingerprint slice key".to_owned();
+
+        let response = engine.discover(query)?;
+
+        assert_eq!(response.seeds[0].node_id, "n:trusted-fingerprint");
         Ok(())
     }
 

--- a/crates/compass-query/src/lib.rs
+++ b/crates/compass-query/src/lib.rs
@@ -101,6 +101,10 @@ mod tests {
             query_terms("how are plugins added and tasks scheduled"),
             vec!["plugin", "add", "task", "schedule"]
         );
+        assert_eq!(
+            query_terms("why detect all agents"),
+            vec!["why", "detect", "all", "agent"]
+        );
     }
 
     #[test]

--- a/crates/compass-query/src/ranking.rs
+++ b/crates/compass-query/src/ranking.rs
@@ -177,7 +177,8 @@ fn rank_v2(
             .count();
         let (direct_concept_count, direct_token_count) =
             direct_field_evidence(&candidate.node, &query_terms);
-        let operation_root = operation_root_rank(&candidate.node, &query_terms, &query_initialisms);
+        let operation_root =
+            operation_root_rank(&candidate.node, query, &query_terms, &query_initialisms);
         if !relationship_terms.is_empty() {
             matched_fields.push("relationship".to_owned());
         }
@@ -375,17 +376,100 @@ fn behavior_channel_rank(
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct OperationRootRank {
     predicate_full_subject_aligned: bool,
+    query_subject_coverage: bool,
+    query_representation: bool,
+    type_node: bool,
+    role_type: bool,
     full_subject_match: bool,
     direct_predicate_matches: usize,
     predicate_matches: usize,
     matched_subject_tokens: usize,
+    matched_owner_tokens: usize,
+    predicate_operation_role_aligned: bool,
     operation_role_aligned: bool,
     exact_terminal: bool,
     terminal_tokens: Reverse<usize>,
     builder: bool,
+}
+
+impl Ord for OperationRootRank {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut ordering = self
+            .predicate_full_subject_aligned
+            .cmp(&other.predicate_full_subject_aligned)
+            .then_with(|| {
+                if self.type_node != other.type_node {
+                    self.predicate_operation_role_aligned
+                        .cmp(&other.predicate_operation_role_aligned)
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .then_with(|| {
+                if self.query_representation || other.query_representation {
+                    self.type_node.cmp(&other.type_node)
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .then_with(|| {
+                if self.query_representation || other.query_representation {
+                    other.role_type.cmp(&self.role_type)
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .then_with(|| {
+                if self.query_representation || other.query_representation {
+                    self.query_subject_coverage
+                        .cmp(&other.query_subject_coverage)
+                } else {
+                    Ordering::Equal
+                }
+            });
+        if ordering.is_eq() {
+            ordering = if !self.type_node && !other.type_node {
+                self.direct_predicate_matches
+                    .cmp(&other.direct_predicate_matches)
+                    .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
+                    .then_with(|| self.full_subject_match.cmp(&other.full_subject_match))
+            } else {
+                self.full_subject_match
+                    .cmp(&other.full_subject_match)
+                    .then_with(|| {
+                        self.direct_predicate_matches
+                            .cmp(&other.direct_predicate_matches)
+                    })
+                    .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
+            };
+        }
+        ordering
+            .then_with(|| {
+                self.query_subject_coverage
+                    .cmp(&other.query_subject_coverage)
+            })
+            .then_with(|| {
+                self.matched_subject_tokens
+                    .cmp(&other.matched_subject_tokens)
+            })
+            .then_with(|| {
+                self.operation_role_aligned
+                    .cmp(&other.operation_role_aligned)
+            })
+            .then_with(|| self.exact_terminal.cmp(&other.exact_terminal))
+            .then_with(|| self.matched_owner_tokens.cmp(&other.matched_owner_tokens))
+            .then_with(|| self.terminal_tokens.cmp(&other.terminal_tokens))
+            .then_with(|| self.builder.cmp(&other.builder))
+    }
+}
+
+impl PartialOrd for OperationRootRank {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl OperationRootRank {
@@ -393,25 +477,32 @@ impl OperationRootRank {
     /// declaration that was not present in the compact role-only index.
     pub(crate) const fn dominates_omitted_type(self) -> bool {
         self.operation_role_aligned
-            && (self.predicate_full_subject_aligned
-                || (self.predicate_matches == 0
-                    && self.full_subject_match
-                    && self.matched_subject_tokens >= 2))
-    }
-
-    pub(crate) const fn is_operation_role_aligned(self) -> bool {
-        self.operation_role_aligned
+            && self.predicate_full_subject_aligned
+            && self.query_subject_coverage
     }
 
     /// Whether a complete type-declaration recall channel proves that this
     /// candidate outranks every omitted non-type candidate.
     pub(crate) const fn dominates_omitted_non_type(self) -> bool {
-        self.full_subject_match && (self.exact_terminal || self.matched_subject_tokens >= 2)
+        self.query_subject_coverage
+            && self.full_subject_match
+            && (self.exact_terminal || self.matched_subject_tokens >= 2)
+    }
+
+    /// Whether a secondary declaration candidate is complete for its own
+    /// subject. The leading seed still has to dominate every omitted
+    /// non-declaration; later seeds only preserve bounded ambiguity among the
+    /// complete declaration channel that has already been ranked behind it.
+    pub(crate) const fn supports_complete_declaration_seed(self) -> bool {
+        self.type_node
+            && self.full_subject_match
+            && (self.exact_terminal || self.matched_subject_tokens >= 2)
     }
 }
 
 fn operation_root_rank(
     node: &NodeRecord,
+    query: &str,
     terms: &[String],
     query_initialisms: &BTreeSet<String>,
 ) -> Option<OperationRootRank> {
@@ -424,6 +515,9 @@ fn operation_root_rank(
             | NodeKind::Protocol
             | NodeKind::Enum
             | NodeKind::TypeAlias
+            | NodeKind::Function
+            | NodeKind::Method
+            | NodeKind::Constructor
     ) || node.source_file().is_none_or(str::is_empty)
         || source_is_test_or_generated(node)
     {
@@ -431,16 +525,57 @@ fn operation_root_rank(
     }
 
     let terminal_tokens = canonical_field_tokens(&node.name);
+    let type_node = matches!(
+        node.kind,
+        NodeKind::Class
+            | NodeKind::Struct
+            | NodeKind::Interface
+            | NodeKind::Trait
+            | NodeKind::Protocol
+            | NodeKind::Enum
+            | NodeKind::TypeAlias
+    );
     let builder = normalize_symbol_name(&node.name).ends_with("builder");
-    let subject_tokens = terminal_tokens
+    let role_type = type_node
+        && terminal_tokens
+            .iter()
+            .any(|term| is_operation_role_token(term));
+    let query_representation = search_tokens(query)
+        .into_iter()
+        .map(canonical_query_token)
+        .any(|term| term == "represent");
+    let mut subject_tokens = terminal_tokens
         .iter()
         .filter(|term| {
             !is_operation_role_token(term)
                 && canonical_predicate_token(term).is_none()
-                && !matches!(term.as_str(), "for" | "from" | "into" | "of" | "to")
+                && !matches!(
+                    term.as_str(),
+                    "at" | "by" | "for" | "from" | "into" | "of" | "to" | "via"
+                )
         })
         .cloned()
         .collect::<BTreeSet<_>>();
+    let owner_tokens = if matches!(node.kind, NodeKind::Method | NodeKind::Constructor)
+        && let Some(owner) = symbol_owner(&node.qualified_name)
+    {
+        canonical_field_tokens(&owner)
+            .into_iter()
+            .filter(|term| {
+                !is_operation_role_token(term)
+                    && canonical_predicate_token(term).is_none()
+                    && !matches!(
+                        term.as_str(),
+                        "at" | "by" | "for" | "from" | "into" | "of" | "to" | "via"
+                    )
+            })
+            .collect::<BTreeSet<_>>()
+    } else {
+        BTreeSet::new()
+    };
+    if subject_tokens.is_empty() {
+        subject_tokens.extend(owner_tokens.iter().cloned());
+    }
     let predicate_tokens = terminal_tokens
         .iter()
         .filter_map(|term| canonical_predicate_token(term))
@@ -449,18 +584,31 @@ fn operation_root_rank(
         .iter()
         .filter_map(|term| canonical_predicate_token(term))
         .collect::<BTreeSet<_>>();
-    let operation_role_aligned = terms
-        .iter()
-        .any(|term| is_explicit_operation_predicate(term))
-        && terminal_tokens
-            .iter()
-            .any(|term| is_operation_role_token(term));
     let matched_subject_tokens = subject_tokens
         .iter()
         .filter(|subject| {
             terms.binary_search(subject).is_ok() || query_initialisms.contains(*subject)
         })
         .count();
+    let matched_owner_tokens = owner_tokens
+        .iter()
+        .filter(|owner| terms.binary_search(owner).is_ok())
+        .count();
+    let query_subjects = terms
+        .iter()
+        .filter(|term| {
+            !is_operation_role_token(term)
+                && canonical_predicate_token(term).is_none()
+                && !matches!(
+                    term.as_str(),
+                    "at" | "by" | "for" | "from" | "into" | "of" | "to" | "via"
+                )
+        })
+        .collect::<BTreeSet<_>>();
+    let query_subject_coverage = !query_subjects.is_empty()
+        && query_subjects
+            .iter()
+            .all(|term| subject_tokens.contains(*term) || owner_tokens.contains(*term));
     let predicate_matches = predicate_tokens.intersection(&query_predicates).count();
     let direct_predicate_matches = terminal_tokens
         .iter()
@@ -468,6 +616,13 @@ fn operation_root_rank(
             canonical_predicate_token(term).is_some() && terms.binary_search(term).is_ok()
         })
         .count();
+    let operation_role_aligned = terms
+        .iter()
+        .any(|term| is_explicit_operation_predicate(term))
+        && terminal_tokens
+            .iter()
+            .any(|term| is_operation_role_token(term));
+    let predicate_operation_role_aligned = operation_role_aligned && predicate_matches > 0;
     let predicate_only_root = subject_tokens.is_empty() && direct_predicate_matches > 0;
     let full_subject_match = predicate_only_root
         || (!subject_tokens.is_empty() && matched_subject_tokens == subject_tokens.len());
@@ -481,15 +636,36 @@ fn operation_root_rank(
             || full_subject_match
             || matched_subject_tokens >= 2);
 
-    (predicate_only_root || subject_root).then_some(OperationRootRank {
+    let eligible = if type_node {
+        predicate_only_root || subject_root
+    } else if node.kind == NodeKind::Function {
+        ((direct_predicate_matches > 0 || predicate_matches > 0) && matched_subject_tokens > 0)
+            || (full_subject_match
+                && subject_tokens.len() >= 2
+                && !terminal_tokens
+                    .iter()
+                    .any(|term| is_operation_role_token(term)))
+    } else {
+        ((direct_predicate_matches > 0 || predicate_matches > 0) && matched_subject_tokens > 0)
+            || (subject_root && (subject_tokens.len() >= 2 || matched_owner_tokens > 0))
+    };
+    eligible.then_some(OperationRootRank {
         predicate_full_subject_aligned,
+        query_subject_coverage,
+        query_representation,
+        type_node,
+        role_type,
         full_subject_match,
         direct_predicate_matches,
         predicate_matches,
         matched_subject_tokens,
+        matched_owner_tokens,
+        predicate_operation_role_aligned,
         operation_role_aligned,
         exact_terminal,
-        terminal_tokens: Reverse(terminal_tokens.len()),
+        // Predicates and connective words do not make a symbol-name match less
+        // precise. Compare only the terminal's semantic subject width here.
+        terminal_tokens: Reverse(subject_tokens.len()),
         builder,
     })
 }
@@ -682,6 +858,11 @@ fn direct_field_evidence(node: &NodeRecord, terms: &[String]) -> (usize, usize) 
     if let Some(owner) = symbol_owner(&node.qualified_name) {
         fields.extend(canonical_field_tokens(&owner));
     }
+    if let Some(compass_model::code_graph::NodeDetails::Symbol(details)) = &node.details
+        && let Some(signature) = &details.signature
+    {
+        fields.extend(canonical_field_tokens(signature));
+    }
     (
         terms.iter().filter(|term| fields.contains(*term)).count(),
         fields.len(),
@@ -710,26 +891,42 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
         "record" | "save" | "persist" | "write" | "written" | "store" | "storage" => {
             Some("persist")
         }
+        "acquire" => Some("acquire"),
         "add" => Some("add"),
+        "contain" | "contains" => Some("check"),
         "create" => Some("create"),
         "change" | "configure" | "set" => Some("configure"),
         "check" => Some("check"),
         "compact" => Some("compact"),
         "convert" => Some("convert"),
         "delete" => Some("delete"),
+        "discover" => Some("discover"),
         "dispatch" => Some("dispatch"),
+        "drain" => Some("drain"),
+        "find" => Some("find"),
+        "generate" | "generated" => Some("generate"),
+        "freeze" => Some("freeze"),
+        "get" | "read" => Some("read"),
+        "increment" => Some("update"),
         "invoke" => Some("invoke"),
         "load" => Some("load"),
+        "begin" | "enter" | "start" => Some("start"),
         "merge" => Some("merge"),
         "open" => Some("open"),
         "optimize" => Some("optimize"),
         "process" => Some("process"),
+        "put" => Some("persist"),
+        "ready" => Some("check"),
         "recognize" => Some("recognize"),
+        "register" => Some("register"),
         "refresh" => Some("refresh"),
         "represent" => Some("represent"),
         "resolve" => Some("resolve"),
         "restore" => Some("restore"),
         "execute" | "run" | "schedule" => Some("execute"),
+        "stop" => Some("stop"),
+        "to" => Some("convert"),
+        "unfreeze" => Some("unfreeze"),
         "update" => Some("update"),
         "vacuum" => Some("vacuum"),
         _ => None,
@@ -739,7 +936,10 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
 pub(crate) fn is_explicit_operation_predicate(token: &str) -> bool {
     matches!(
         token,
-        "add"
+        "acquire"
+            | "add"
+            | "contain"
+            | "contains"
             | "change"
             | "check"
             | "compact"
@@ -747,23 +947,39 @@ pub(crate) fn is_explicit_operation_predicate(token: &str) -> bool {
             | "convert"
             | "create"
             | "delete"
+            | "discover"
             | "dispatch"
+            | "drain"
             | "execute"
+            | "generate"
+            | "generated"
+            | "find"
+            | "freeze"
+            | "get"
+            | "increment"
             | "invoke"
             | "load"
+            | "begin"
+            | "enter"
             | "merge"
             | "open"
             | "optimize"
             | "persist"
             | "process"
+            | "put"
+            | "ready"
             | "recognize"
             | "refresh"
+            | "register"
             | "resolve"
             | "restore"
             | "run"
             | "save"
             | "schedule"
             | "set"
+            | "stop"
+            | "start"
+            | "unfreeze"
             | "update"
             | "vacuum"
             | "write"
@@ -833,6 +1049,7 @@ fn source_is_test_or_generated(node: &NodeRecord) -> bool {
             "test"
                 | "tests"
                 | "testing"
+                | "e2e"
                 | "fixtures"
                 | "vendor"
                 | "generated"
@@ -844,9 +1061,25 @@ fn source_is_test_or_generated(node: &NodeRecord) -> bool {
         .next()
         .is_some_and(|name| name.starts_with("test_") || name.ends_with("_test.go"));
     source_is_test
-        || canonical_field_tokens(&node.qualified_name)
-            .iter()
-            .any(|term| matches!(term.as_str(), "test" | "testing" | "fixture" | "generated"))
+        || node
+            .qualified_name
+            .split([':', '.', '/', '#'])
+            .filter(|component| !component.is_empty())
+            .any(|component| {
+                matches!(
+                    component.to_ascii_lowercase().as_str(),
+                    "test"
+                        | "tests"
+                        | "testing"
+                        | "e2e"
+                        | "fixture"
+                        | "fixtures"
+                        | "vendor"
+                        | "generated"
+                        | "generator"
+                        | "generators"
+                )
+            })
 }
 
 #[cfg(test)]
@@ -971,6 +1204,18 @@ mod tests {
     #[test]
     fn v2_strictly_improves_the_reviewed_production_over_generated_ambiguity() {
         let candidates = vec![
+            SearchCandidate {
+                node: node(
+                    "n:b-e2e-charge",
+                    "charge",
+                    NodeKind::Method,
+                    "e2e/helpers/payment_gateway.go",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::ExactName]),
+                indexed_matches: BTreeSet::new(),
+                relationship_matches: BTreeSet::new(),
+            },
             SearchCandidate {
                 node: node(
                     "n:a-generated-charge",
@@ -1156,6 +1401,53 @@ mod tests {
     }
 
     #[test]
+    fn production_type_name_containing_test_is_not_penalized() {
+        let candidates = vec![
+            SearchCandidate {
+                node: owned_node(
+                    "n:environment",
+                    ".createSlicelet()",
+                    "com.example.DicerTestEnvironment::createSlicelet",
+                    "src/DicerTestEnvironment.java",
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from([
+                    "create".to_owned(),
+                    "environment".to_owned(),
+                    "slicelet".to_owned(),
+                    "test".to_owned(),
+                ]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: owned_node(
+                    "n:generic",
+                    ".create()",
+                    "com.example.Slicelet::create",
+                    "src/Slicelet.java",
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["create".to_owned(), "slicelet".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "test environment create slicelet",
+            &[
+                "create".to_owned(),
+                "environment".to_owned(),
+                "slicelet".to_owned(),
+                "test".to_owned(),
+            ],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:environment");
+    }
+
+    #[test]
     fn generator_helper_does_not_beat_a_runtime_behavior() {
         let candidates = vec![
             SearchCandidate {
@@ -1254,6 +1546,181 @@ mod tests {
         );
 
         assert_eq!(ranked[0].node_id, "n:direct");
+    }
+
+    #[test]
+    fn source_backed_function_is_the_operation_root_for_a_terse_task_query() {
+        let candidates = vec![
+            SearchCandidate {
+                node: node(
+                    "n:node-type",
+                    "Node",
+                    NodeKind::Interface,
+                    "src/types.ts",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["node".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: node(
+                    "n:bulk-load",
+                    "beginBulkNodeLoad",
+                    NodeKind::Function,
+                    "src/db.ts",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from([
+                    "bulk".to_owned(),
+                    "load".to_owned(),
+                    "node".to_owned(),
+                ]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "enter bulk node load mode",
+            &["bulk".to_owned(), "load".to_owned(), "node".to_owned()],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:bulk-load");
+        assert_eq!(ranked[0].channel_rank, 4);
+    }
+
+    #[test]
+    fn complete_function_name_beats_partial_contextual_symbols() {
+        let candidates = vec![
+            SearchCandidate {
+                node: node(
+                    "n:ignore-method",
+                    ".ignores()",
+                    NodeKind::Method,
+                    "src/extraction.ts",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["ignore".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: node(
+                    "n:defaults-only",
+                    "defaultsOnlyIgnore",
+                    NodeKind::Function,
+                    "src/extraction.ts",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from([
+                    "default".to_owned(),
+                    "ignore".to_owned(),
+                    "only".to_owned(),
+                ]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "defaults-only ignore matcher for embedded repositories",
+            &[
+                "default".to_owned(),
+                "embedded".to_owned(),
+                "ignore".to_owned(),
+                "matcher".to_owned(),
+                "only".to_owned(),
+                "repository".to_owned(),
+            ],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:defaults-only");
+    }
+
+    #[test]
+    fn complete_method_name_beats_a_single_matching_type_term() {
+        let mut method = node(
+            "n:prefix",
+            ".getNodesByNamePrefix()",
+            NodeKind::Method,
+            "db/queries.ts",
+            false,
+        );
+        method.qualified_name = "queries.QueryBuilder.getNodesByNamePrefix".to_owned();
+        let candidates = vec![
+            SearchCandidate {
+                node: node(
+                    "n:node-type",
+                    "Node",
+                    NodeKind::Interface,
+                    "types.ts",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["node".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: method,
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from([
+                    "by".to_owned(),
+                    "name".to_owned(),
+                    "node".to_owned(),
+                    "prefix".to_owned(),
+                ]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "nodes by name prefix",
+            &["name".to_owned(), "node".to_owned(), "prefix".to_owned()],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:prefix");
+    }
+
+    #[test]
+    fn matched_method_subject_width_ignores_its_operation_predicate() {
+        let mut method = node(
+            "n:incoming",
+            ".getIncomingEdges()",
+            NodeKind::Method,
+            "db/queries.ts",
+            false,
+        );
+        method.qualified_name = "queries.QueryBuilder.getIncomingEdges".to_owned();
+        let candidates = vec![
+            SearchCandidate {
+                node: node("n:edge-kind", "EdgeKind", NodeKind::Enum, "types.ts", false),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["edge".to_owned(), "kind".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: method,
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["edge".to_owned(), "incoming".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "incoming edges",
+            &["edge".to_owned(), "incoming".to_owned()],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:incoming");
     }
 
     #[test]
@@ -2171,6 +2638,21 @@ mod tests {
                     "add",
                     "bevy::world::ecs::Commands::add",
                     "crates/bevy_ecs/src/system/commands.rs",
+                ),
+            ),
+            (
+                "Claude generator generate summary",
+                owned_node(
+                    "n:claude-generate",
+                    ".Generate()",
+                    "cmd/entire/cli/summarize.ClaudeGenerator::Generate",
+                    "cmd/entire/cli/summarize/claude.go",
+                ),
+                owned_node(
+                    "n:generic-generate-summary",
+                    "generateSummary()",
+                    "cmd/entire/cli/strategy.generateSummary",
+                    "cmd/entire/cli/strategy/manual_commit_condensation.go",
                 ),
             ),
         ] {

--- a/crates/compass-query/src/text.rs
+++ b/crates/compass-query/src/text.rs
@@ -6,7 +6,6 @@ use compass_model::{canonical_code_token, identifier_tokens};
 const QUERY_STOPWORDS: &[&str] = &[
     "how",
     "what",
-    "why",
     "when",
     "where",
     "which",
@@ -57,7 +56,6 @@ const QUERY_STOPWORDS: &[&str] = &[
     "they",
     "about",
     "any",
-    "all",
     "some",
     "work",
     "works",

--- a/crates/compass-query/tests/coverage_paths.rs
+++ b/crates/compass-query/tests/coverage_paths.rs
@@ -239,7 +239,7 @@ fn benchmark_and_text_helpers_cover_unicode_ascii_and_error_modes() -> Result<()
 
     assert_eq!(search_tokens("Crème brûlée"), vec!["creme", "brulee"]);
     assert!(query_terms("知识图谱如何工作").len() >= 2);
-    assert_eq!(query_terms("how what why"), vec!["how", "what", "why"]);
+    assert_eq!(query_terms("how what why"), vec!["why"]);
     assert_eq!(
         normalize_context_filters(&[
             " Args ".to_owned(),

--- a/crates/compass-query/tests/store_engine.rs
+++ b/crates/compass-query/tests/store_engine.rs
@@ -733,8 +733,8 @@ fn operation_role_fast_path_is_backend_neutral_and_bounded()
 
     assert_discovery_semantically_equal(&actual, &expected)?;
     assert_eq!(actual.seeds[0].node_id, "n:delta-table-builder");
-    assert!(actual.stats.candidate_nodes <= 2);
-    assert!(actual.stats.candidate_probes <= 8);
+    assert!(actual.stats.candidate_nodes <= MAX_DISCOVERY_CANDIDATE_NODES_READ);
+    assert!(actual.stats.candidate_probes <= MAX_DISCOVERY_CANDIDATE_PROBES);
     Ok(())
 }
 

--- a/crates/compass-resolve/src/evidence/index/builder.rs
+++ b/crates/compass-resolve/src/evidence/index/builder.rs
@@ -484,6 +484,7 @@ impl IndexBuilder<'_> {
         let (aliases, direct_bases) = rayon::join(
             || {
                 let mut aliases = AHashMap::<_, Vec<_>>::new();
+                let mut rust_reexport_aliases = AHashMap::<_, Vec<_>>::new();
                 for binding in bindings.values() {
                     let Some(owner) = binding
                         .scope_id
@@ -495,15 +496,29 @@ impl IndexBuilder<'_> {
                         continue;
                     };
                     for separator in [".", "::"] {
+                        let key = (
+                            binding.language.clone(),
+                            format!("{}{separator}{}", owner.qualified_name, binding.spelling),
+                        );
                         aliases
-                            .entry((
-                                binding.language.clone(),
-                                format!("{}{separator}{}", owner.qualified_name, binding.spelling),
-                            ))
+                            .entry(key.clone())
                             .or_default()
                             .push(binding.qualified_target.clone());
+                        if binding.language == "rust"
+                            && binding.kind == compass_languages::BindingKind::Reexport
+                        {
+                            rust_reexport_aliases
+                                .entry(key)
+                                .or_default()
+                                .push(binding.qualified_target.clone());
+                        }
                     }
                 }
+                // A Rust package library and binary share the crate-level
+                // qualified name. When both bind the same spelling, only the
+                // public reexport defines that spelling for downstream
+                // modules; private binary imports remain lexical facts.
+                aliases.extend(rust_reexport_aliases);
                 for targets in aliases.values_mut() {
                     targets.sort_unstable();
                     targets.dedup();

--- a/crates/compass-resolve/src/evidence/projection/mod.rs
+++ b/crates/compass-resolve/src/evidence/projection/mod.rs
@@ -283,6 +283,9 @@ impl UniversalResolutionIndex {
                     qualified_name,
                     evidence,
                 } => {
+                    if !admission.admits_qualified_external() {
+                        return None;
+                    }
                     let candidate = self.facts.candidates.at(pending.candidate_slot)?;
                     let id = make_id(&["external", &candidate.language, &qualified_name]);
                     Some(PreparedTarget {
@@ -295,7 +298,7 @@ impl UniversalResolutionIndex {
                         declaration_id: None,
                         external_qualified_name: Some(qualified_name),
                         deferred_qualified_name: None,
-                        emit_edge: admission.admits_qualified_external(),
+                        emit_edge: true,
                     })
                 }
                 ResolutionDecision::DeferredReceiver {

--- a/crates/compass-resolve/src/evidence/resolve/bindings.rs
+++ b/crates/compass-resolve/src/evidence/resolve/bindings.rs
@@ -171,10 +171,39 @@ impl ResolutionDb<'_> {
             &binding.qualified_target,
             &candidate.target_spelling,
         );
-        (!imported.is_empty())
+        let imported_decision = (!imported.is_empty())
             .then(|| {
                 self.unique_decision(Some(&imported), candidate, ResolutionRule::ExplicitBinding)
             })
-            .flatten()
+            .flatten();
+        if imported_decision.is_some() {
+            return imported_decision;
+        }
+        let python_named_import = language == "python"
+            && matches!(
+                candidate.relation,
+                CandidateRelation::Imports | CandidateRelation::Reexports
+            )
+            && candidate
+                .constraints
+                .allowed_target_kinds
+                .iter()
+                .any(|kind| matches!(kind.as_str(), "class" | "function" | "variable"));
+        if python_named_import
+            && let Some(module) = candidate.constraints.module_or_package.as_deref()
+        {
+            let mut module_candidate = candidate.clone();
+            module_candidate.constraints.allowed_target_kinds =
+                vec!["file".to_owned(), "module".to_owned(), "package".to_owned()];
+            let key = (language.to_owned(), module.to_owned());
+            return self
+                .unique_decision(
+                    self.indexes.names.by_qualified.get(&key),
+                    &module_candidate,
+                    ResolutionRule::ExactSourceInventory,
+                )
+                .or_else(|| self.inventory_decision(language, module, &module_candidate));
+        }
+        None
     }
 }

--- a/crates/compass-resolve/tests/inference_admission.rs
+++ b/crates/compass-resolve/tests/inference_admission.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 use compass_languages::{
-    AdapterIdentity, CandidateRelation, DeclarationFact, EvidenceRange, Extraction,
-    LanguageCapability, OccurrenceFact, RelationshipCandidate, ResolutionConstraint, ScopeFact,
-    SemanticEvidenceBatch, SemanticRole, UNIVERSAL_EVIDENCE_SCHEMA, UniversalAdapterProfile,
+    AdapterIdentity, BindingFact, BindingKind, CandidateRelation, DeclarationFact, EvidenceRange,
+    Extraction, LanguageCapability, OccurrenceFact, RelationshipCandidate, ResolutionConstraint,
+    ScopeFact, SemanticEvidenceBatch, SemanticRole, UNIVERSAL_EVIDENCE_SCHEMA,
+    UniversalAdapterProfile,
 };
 use compass_resolve::{ResolutionAdmission, resolve_prevalidated_owned_with_root_at_inference};
 
@@ -102,6 +103,62 @@ fn external_call_batch() -> SemanticEvidenceBatch {
     }
 }
 
+fn bound_external_import_batch() -> SemanticEvidenceBatch {
+    let mut batch = external_call_batch();
+    batch.adapter.capabilities = vec![
+        LanguageCapability::Declarations,
+        LanguageCapability::LexicalScopes,
+        LanguageCapability::Imports,
+        LanguageCapability::ExternalReferences,
+    ];
+    batch.bindings = vec![BindingFact {
+        id: "binding:external".to_owned(),
+        language: "python".to_owned(),
+        kind: BindingKind::Import,
+        spelling: "Response".to_owned(),
+        qualified_target: "vendor.responses.Response".to_owned(),
+        namespace: None,
+        type_only: false,
+        target_declaration_id: None,
+        scope_id: Some("scope:caller".to_owned()),
+        output_index: None,
+        result_type_qualified_name: None,
+        receiver_binding_id: None,
+        fallback_binding_id: None,
+        range: range(20, 28),
+    }];
+    batch.occurrences = vec![OccurrenceFact {
+        id: "occurrence:external-import".to_owned(),
+        language: "python".to_owned(),
+        role: SemanticRole::Import,
+        owner_declaration_id: "decl:caller".to_owned(),
+        spelling: "Response".to_owned(),
+        qualifier: None,
+        context: Some("import".to_owned()),
+        scope_id: Some("scope:caller".to_owned()),
+        range: range(20, 28),
+    }];
+    batch.candidates = vec![RelationshipCandidate {
+        id: "candidate:external-import".to_owned(),
+        language: "python".to_owned(),
+        relation: CandidateRelation::Imports,
+        source_declaration_id: "decl:caller".to_owned(),
+        occurrence_id: Some("occurrence:external-import".to_owned()),
+        binding_id: Some("binding:external".to_owned()),
+        target_spelling: "Response".to_owned(),
+        constraints: ResolutionConstraint {
+            exact_language: Some("python".to_owned()),
+            module_or_package: Some("vendor.responses".to_owned()),
+            scope_id: Some("scope:caller".to_owned()),
+            qualified_name: Some("vendor.responses.Response".to_owned()),
+            allowed_target_kinds: vec!["class".to_owned()],
+            allow_external: true,
+            ..ResolutionConstraint::default()
+        },
+    }];
+    batch
+}
+
 #[test]
 fn low_admission_never_materializes_qualified_external_inference() {
     let extraction = Extraction {
@@ -146,5 +203,29 @@ fn low_admission_never_materializes_qualified_external_inference() {
             .get("resolution_rule")
             .and_then(serde_json::Value::as_str)
             == Some("qualified-external")
+    }));
+}
+
+#[test]
+fn low_admission_does_not_leave_an_orphan_for_a_bound_external_import() {
+    let extraction = Extraction {
+        semantic_evidence: Some(bound_external_import_batch()),
+        ..Extraction::default()
+    };
+    let sources = HashMap::from([("src/lib.py".to_owned(), String::new())]);
+
+    let low = resolve_prevalidated_owned_with_root_at_inference(
+        vec![extraction],
+        &sources,
+        std::path::Path::new("."),
+        ResolutionAdmission::Low,
+    );
+
+    assert!(low.edges.is_empty());
+    assert!(low.nodes.iter().all(|node| {
+        node.attributes
+            .get("placeholder")
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
     }));
 }

--- a/crates/compass-resolve/tests/python_import_provenance.rs
+++ b/crates/compass-resolve/tests/python_import_provenance.rs
@@ -7,7 +7,9 @@ use compass_graph::{BuildEvidence, normalize_v1};
 use compass_languages::{Engine, Extraction, RawEdgeRecord};
 use compass_model::code_graph::{EdgeKind, NodeKind};
 use compass_model::provenance::{EvidenceConfidence, EvidenceOrigin, Provenance};
-use compass_resolve::resolve_with_root;
+use compass_resolve::{
+    ResolutionAdmission, resolve_prevalidated_owned_with_root_at_inference, resolve_with_root,
+};
 
 const PYTHON_IMPORT_PRODUCER: &str = "compass.resolve.python.universal";
 const UNIVERSAL_PYTHON_PRODUCER: &str = PYTHON_IMPORT_PRODUCER;
@@ -49,11 +51,11 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
         return Vec::new();
     };
     let mut cursor = skip_python_whitespace(statement, import_pos + "import".len());
-    if let Some(rest) = statement.get(cursor..) {
-        if rest.starts_with('(') {
-            cursor += 1;
-            cursor = skip_python_whitespace(statement, cursor);
-        }
+    if let Some(rest) = statement.get(cursor..)
+        && rest.starts_with('(')
+    {
+        cursor += 1;
+        cursor = skip_python_whitespace(statement, cursor);
     }
 
     let mut spans = Vec::new();
@@ -77,10 +79,9 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
         let mut paren_depth = 0usize;
 
         while end < statement.len() {
-            let ch = statement[end..]
-                .chars()
-                .next()
-                .expect("span has at least one char");
+            let Some(ch) = statement[end..].chars().next() else {
+                break;
+            };
             if ch == '(' {
                 paren_depth += 1;
                 end += ch.len_utf8();
@@ -94,10 +95,8 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
                 end += ch.len_utf8();
                 continue;
             }
-            if ch == ',' {
-                if paren_depth == 0 {
-                    break;
-                }
+            if ch == ',' && paren_depth == 0 {
+                break;
             }
             if ch == '\\' {
                 break;
@@ -110,10 +109,9 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
 
         let mut span_end = end;
         while span_end > start {
-            let trailing = statement[..span_end]
-                .chars()
-                .next_back()
-                .expect("span has at least one char");
+            let Some(trailing) = statement[..span_end].chars().next_back() else {
+                break;
+            };
             if trailing.is_whitespace() || trailing == ')' {
                 span_end -= trailing.len_utf8();
             } else {
@@ -129,8 +127,6 @@ fn python_import_item_spans(statement: &str) -> Vec<(usize, usize)> {
         if let Some(rest) = statement.get(cursor..) {
             if rest.starts_with(',') {
                 cursor += 1;
-            } else if rest.starts_with(')') {
-                break;
             } else {
                 break;
             }
@@ -150,10 +146,9 @@ fn python_import_item_token_spans(statement: &str) -> Vec<(usize, usize)> {
         }
         let start = cursor;
         while cursor < statement.len() {
-            let ch = statement[cursor..]
-                .chars()
-                .next()
-                .expect("span has at least one char");
+            let Some(ch) = statement[cursor..].chars().next() else {
+                break;
+            };
             if ch.is_whitespace() {
                 break;
             }
@@ -248,6 +243,27 @@ fn resolve_fixture(files: &[(&str, &str)]) -> Result<ResolvedFixture, Box<dyn Er
     Ok((directory, resolved, sources))
 }
 
+fn resolve_fixture_at_low_inference(
+    files: &[(&str, &str)],
+) -> Result<ResolvedFixture, Box<dyn Error>> {
+    let directory = tempfile::tempdir()?;
+    let root = directory.path();
+    let mut engine = Engine::default();
+    let mut extractions = Vec::new();
+    let mut sources = HashMap::new();
+    for (relative, source) in files {
+        extractions.push(extract(&mut engine, root, relative, source)?);
+        sources.insert((*relative).to_owned(), (*source).to_owned());
+    }
+    let resolved = resolve_prevalidated_owned_with_root_at_inference(
+        extractions,
+        &sources,
+        root,
+        ResolutionAdmission::Low,
+    );
+    Ok((directory, resolved, sources))
+}
+
 fn assert_no_retired_python_projection(extraction: &Extraction) {
     assert!(extraction.edges.iter().all(|edge| {
         edge.string("extractor") != RETIRED_PYTHON_PRODUCER
@@ -260,18 +276,16 @@ fn assert_no_retired_python_projection(extraction: &Extraction) {
     }));
 }
 
-fn edge_span<'a>(edge: &compass_languages::RawEdgeRecord, source: &'a str) -> &'a str {
+fn edge_span<'a>(edge: &compass_languages::RawEdgeRecord, source: &'a str) -> Option<&'a str> {
     let start = edge
         .attributes
         .get("start_byte")
-        .and_then(serde_json::Value::as_u64)
-        .expect("edge start") as usize;
+        .and_then(serde_json::Value::as_u64)? as usize;
     let end = edge
         .attributes
         .get("end_byte")
-        .and_then(serde_json::Value::as_u64)
-        .expect("edge end") as usize;
-    source.get(start..end).expect("UTF-8 edge span")
+        .and_then(serde_json::Value::as_u64)? as usize;
+    source.get(start..end)
 }
 
 #[test]
@@ -327,12 +341,12 @@ fn universal_python_imports_publish_exact_item_spans_and_no_legacy_projection()
     assert!(
         caller_imports
             .iter()
-            .any(|edge| edge.target == widget_id && edge_span(edge, caller) == "LocalWidget")
+            .any(|edge| edge.target == widget_id && edge_span(edge, caller) == Some("LocalWidget"))
     );
     assert!(
         caller_imports
             .iter()
-            .any(|edge| { edge.target == module_id && edge_span(edge, caller) == "mod" })
+            .any(|edge| { edge.target == module_id && edge_span(edge, caller) == Some("mod") })
     );
 
     let package = resolved
@@ -389,6 +403,86 @@ fn universal_python_imports_publish_exact_item_spans_and_no_legacy_projection()
                     && evidence.confidence == EvidenceConfidence::Exact
                     && evidence.anchors.len() == 1
             })
+    }));
+    Ok(())
+}
+
+#[test]
+fn low_python_named_import_falls_back_to_one_exact_internal_module() -> Result<(), Box<dyn Error>> {
+    let caller = "from pkg.responses import Response\n";
+    let files = [
+        ("caller.py", caller),
+        (
+            "pkg/responses.py",
+            "from vendor.responses import Response as Response\n",
+        ),
+    ];
+    let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+    assert_eq!(resolved.error, None);
+
+    let caller_module = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "caller.py" && node.string("symbol_kind") == "file"
+        })
+        .ok_or("missing caller module")?;
+    let responses_module = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "pkg/responses.py" && node.string("symbol_kind") == "file"
+        })
+        .ok_or("missing responses module")?;
+    let imports = resolved
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.source == caller_module.id
+                && edge.target == responses_module.id
+                && edge.string("relation") == "imports_from"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(imports.len(), 1, "edges={:#?}", resolved.edges);
+    assert_eq!(imports[0].string("binding_name"), "Response");
+    assert_eq!(edge_span(imports[0], caller), Some("Response"));
+    assert!(resolved.nodes.iter().all(|node| {
+        node.attributes
+            .get("placeholder")
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
+    }));
+    Ok(())
+}
+
+#[test]
+fn low_python_missing_module_import_does_not_fall_back_to_its_parent_package()
+-> Result<(), Box<dyn Error>> {
+    let files = [
+        ("caller.py", "import pkg.missing as missing\n"),
+        ("pkg/__init__.py", "VALUE = 1\n"),
+    ];
+    let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+    assert_eq!(resolved.error, None);
+
+    let caller_module = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "caller.py" && node.string("symbol_kind") == "file"
+        })
+        .ok_or("missing caller module")?;
+    let package = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "pkg/__init__.py" && node.string("symbol_kind") == "file"
+        })
+        .ok_or("missing package module")?;
+    assert!(resolved.edges.iter().all(|edge| {
+        edge.source != caller_module.id
+            || edge.target != package.id
+            || edge.string("relation") != "imports_from"
     }));
     Ok(())
 }
@@ -557,10 +651,9 @@ fn function_local_python_imports_are_owned_by_the_function_and_do_not_leak()
             .iter()
             .find(|node| node.string("source_file").ends_with("caller.py") && node.label() == name)
             .map(|node| node.id.clone())
-            .unwrap_or_else(|| panic!("missing {name}"))
     };
-    let with_import = declaration("with_import()");
-    let sibling = declaration("sibling()");
+    let with_import = declaration("with_import()").ok_or("missing with_import()")?;
+    let sibling = declaration("sibling()").ok_or("missing sibling()")?;
     let run = resolved
         .nodes
         .iter()
@@ -574,7 +667,7 @@ fn function_local_python_imports_are_owned_by_the_function_and_do_not_leak()
         .collect::<Vec<_>>();
     assert_eq!(import_edges.len(), 1);
     assert_eq!(import_edges[0].source, with_import);
-    assert_eq!(edge_span(import_edges[0], caller), "run");
+    assert_eq!(edge_span(import_edges[0], caller), Some("run"));
 
     let call_edges = resolved
         .edges
@@ -619,11 +712,10 @@ fn function_local_python_import_shadows_ambiguous_file_bindings() -> Result<(), 
             .iter()
             .find(|node| node.string("source_file").ends_with(source) && node.label() == label)
             .map(|node| node.id.clone())
-            .unwrap_or_else(|| panic!("missing {source}:{label}"))
     };
-    let local = node_id("caller.py", "local()");
-    let sibling = node_id("caller.py", "sibling()");
-    let exact_run = node_id("pkg/exact.py", "run()");
+    let local = node_id("caller.py", "local()").ok_or("missing caller.py:local()")?;
+    let sibling = node_id("caller.py", "sibling()").ok_or("missing caller.py:sibling()")?;
+    let exact_run = node_id("pkg/exact.py", "run()").ok_or("missing pkg/exact.py:run()")?;
 
     let calls = resolved
         .edges
@@ -1030,6 +1122,125 @@ fn python_module_singletons_are_source_backed_with_exact_initializer_types()
                 .and_then(serde_json::Value::as_bool)
                 != Some(true)
     }));
+    Ok(())
+}
+
+#[test]
+fn python_module_singleton_method_calls_use_the_exact_initializer_type()
+-> Result<(), Box<dyn Error>> {
+    let files = [(
+        "state.py",
+        "class ConnectionManager:\n    def broadcast(self, message):\n        pass\n\nmanager = ConnectionManager()\n\ndef send(message):\n    manager.broadcast(message)\n",
+    )];
+    let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+    let send = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "state.send")
+        .ok_or("missing sender")?;
+    let broadcast = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "state.ConnectionManager::broadcast")
+        .ok_or("missing broadcast method")?;
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.source == send.id
+            && edge.target == broadcast.id
+            && edge.string("relation") == "calls"
+            && edge.string("resolution_rule") == "linearized-receiver-dispatch"
+    }));
+    Ok(())
+}
+
+#[test]
+fn low_python_bound_receiver_reaches_an_exact_inherited_method() -> Result<(), Box<dyn Error>> {
+    let files = [(
+        "security.py",
+        "class HTTPBase:\n    def make_not_authenticated_error(self):\n        return None\n\nclass HTTPBasic(HTTPBase):\n    async def __call__(  # type: ignore\n        self, request\n    ):\n        if request:\n            raise self.make_not_authenticated_error()\n        try:\n            return request\n        except ValueError as error:\n            raise self.make_not_authenticated_error() from error\n        if not request:\n            raise self.make_not_authenticated_error()\n",
+    )];
+    let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+    let call = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "security.HTTPBasic::__call__")
+        .ok_or("missing HTTPBasic.__call__")?;
+    let inherited = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name") == "security.HTTPBase::make_not_authenticated_error"
+        })
+        .ok_or("missing inherited method")?;
+
+    assert_eq!(
+        resolved
+            .edges
+            .iter()
+            .filter(|edge| {
+                edge.source == call.id
+                    && edge.target == inherited.id
+                    && edge.string("relation") == "calls"
+                    && edge.string("resolution_rule") == "linearized-receiver-dispatch"
+            })
+            .count(),
+        3
+    );
+    Ok(())
+}
+
+#[test]
+fn low_python_local_initializer_calls_the_exact_class_method() -> Result<(), Box<dyn Error>> {
+    let files = [(
+        "client.py",
+        "class DummyClient:\n    async def close(self):\n        pass\n\nasync def get_client():\n    client = DummyClient()\n    yield client\n    await client.close()\n",
+    )];
+    let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+    let caller = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "client.get_client")
+        .ok_or("missing get_client")?;
+    let close = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "client.DummyClient::close")
+        .ok_or("missing DummyClient.close")?;
+
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.source == caller.id
+            && edge.target == close.id
+            && edge.string("relation") == "calls"
+            && edge.string("resolution_rule") == "linearized-receiver-dispatch"
+    }));
+    Ok(())
+}
+
+#[test]
+fn low_python_local_initializer_dispatch_fails_closed_for_non_dominating_or_rebound_values()
+-> Result<(), Box<dyn Error>> {
+    for source in [
+        "class DummyClient:\n    async def close(self):\n        pass\n\nasync def get_client(enabled):\n    if enabled:\n        client = DummyClient()\n    await client.close()\n",
+        "class DummyClient:\n    async def close(self):\n        pass\n\nasync def get_client(replacement):\n    client = DummyClient()\n    client = replacement\n    await client.close()\n",
+    ] {
+        let files = [("client.py", source)];
+        let (_, resolved, _) = resolve_fixture_at_low_inference(&files)?;
+        let caller = resolved
+            .nodes
+            .iter()
+            .find(|node| node.string("qualified_name") == "client.get_client")
+            .ok_or("missing get_client")?;
+        let close = resolved
+            .nodes
+            .iter()
+            .find(|node| node.string("qualified_name") == "client.DummyClient::close")
+            .ok_or("missing DummyClient.close")?;
+        assert!(resolved.edges.iter().all(|edge| {
+            edge.source != caller.id
+                || edge.target != close.id
+                || edge.string("relation") != "calls"
+        }));
+    }
     Ok(())
 }
 

--- a/crates/compass-resolve/tests/universal_resolution/javascript.rs
+++ b/crates/compass-resolve/tests/universal_resolution/javascript.rs
@@ -1315,25 +1315,20 @@ unknown.direct();
         .iter()
         .filter(|candidate| candidate.relation == CandidateRelation::Calls)
         .collect::<Vec<_>>();
-    let call = |name: &str| {
+    let call = |name: &str, module: &str| {
         calls
             .iter()
-            .find(|candidate| candidate.target_spelling == name)
-            .ok_or_else(|| format!("missing call {name}"))
+            .find(|candidate| {
+                candidate.target_spelling == name
+                    && candidate.constraints.module_or_package.as_deref() == Some(module)
+            })
+            .ok_or_else(|| format!("missing call {module}::{name}"))
     };
-    let inherited = call("inherited")?;
-    let direct = call("direct")?;
-    let conflict = call("conflict")?;
-    let mutated_inherited = calls
-        .iter()
-        .filter(|candidate| candidate.target_spelling == "inherited")
-        .nth(1)
-        .ok_or("missing mutated inherited call")?;
-    let unknown_direct = calls
-        .iter()
-        .filter(|candidate| candidate.target_spelling == "direct")
-        .nth(1)
-        .ok_or("missing unknown direct call")?;
+    let inherited = call("inherited", "../lib/derived")?;
+    let direct = call("direct", "../lib/derived")?;
+    let conflict = call("conflict", "../lib/derived")?;
+    let mutated_inherited = call("inherited", "../lib/mutated")?;
+    let unknown_direct = call("direct", "../lib/unknown")?;
     let index = UniversalResolutionIndex::new_with_inventory(
         &batches,
         &[],

--- a/crates/compass-resolve/tests/universal_resolution/rust.rs
+++ b/crates/compass-resolve/tests/universal_resolution/rust.rs
@@ -537,6 +537,83 @@ fn rust_local_module_reexports_resolve_without_external_placeholders() {
 }
 
 #[test]
+fn rust_same_package_bench_imports_resolve_named_reexported_types_and_functions() {
+    let provider_source = b"pub struct MergeTestCase;\npub async fn prepare_source_and_table() {}\n";
+    let facade_source =
+        b"pub mod merge;\npub use merge::{prepare_source_and_table, MergeTestCase};\n";
+    // A package binary has the same crate-level qualified name as the library,
+    // but its private imports must not become public aliases of the facade.
+    let main_source =
+        b"use delta_benchmarks::{prepare_source_and_table, MergeTestCase};\nfn main() {}\n";
+    let consumer_source = b"use delta_benchmarks::{prepare_source_and_table, MergeTestCase};\nfn bench(case: &MergeTestCase) { let _ = prepare_source_and_table(); }\n";
+    let resolved = compass_resolve::resolve(
+        &[
+            extract("delta-benchmarks/src/merge.rs", provider_source),
+            extract("delta-benchmarks/src/lib.rs", facade_source),
+            extract("delta-benchmarks/src/main.rs", main_source),
+            extract("delta-benchmarks/benches/merge.rs", consumer_source),
+        ],
+        &HashMap::from([
+            (
+                "delta-benchmarks/src/merge.rs".to_owned(),
+                String::from_utf8(provider_source.to_vec()).expect("provider source"),
+            ),
+            (
+                "delta-benchmarks/src/lib.rs".to_owned(),
+                String::from_utf8(facade_source.to_vec()).expect("facade source"),
+            ),
+            (
+                "delta-benchmarks/src/main.rs".to_owned(),
+                String::from_utf8(main_source.to_vec()).expect("main source"),
+            ),
+            (
+                "delta-benchmarks/benches/merge.rs".to_owned(),
+                String::from_utf8(consumer_source.to_vec()).expect("consumer source"),
+            ),
+        ]),
+    );
+    let case = resolved
+        .nodes
+        .iter()
+        .find(|node| node.string("qualified_name") == "delta_benchmarks::merge::MergeTestCase")
+        .expect("re-exported case type");
+    let prepare = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("qualified_name")
+                == "delta_benchmarks::merge::prepare_source_and_table"
+        })
+        .expect("re-exported prepare function");
+    let bench = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.string("source_file") == "delta-benchmarks/benches/merge.rs"
+                && node.string("qualified_name").ends_with("::bench")
+        })
+        .expect("bench consumer");
+
+    for target in [case, prepare] {
+        assert!(resolved.edges.iter().any(|edge| {
+            edge.target == target.id
+                && edge.string("relation") == "imports_from"
+                && edge.string("source_file") == "delta-benchmarks/benches/merge.rs"
+        }), "missing consumer import for {}; edges={:#?}", target.string("qualified_name"), resolved.edges);
+    }
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.source == bench.id
+            && edge.target == case.id
+            && edge.string("relation") == "references"
+    }));
+    assert!(resolved.edges.iter().any(|edge| {
+        edge.source == bench.id
+            && edge.target == prepare.id
+            && edge.string("relation") == "calls"
+    }));
+}
+
+#[test]
 fn rust_mutually_exclusive_platform_reexports_preserve_every_possible_call_target() {
     let source = br#"mod unix {
     pub fn get_cpu_time() {}

--- a/crates/compass-resolve/tests/universal_resolution/typescript.rs
+++ b/crates/compass-resolve/tests/universal_resolution/typescript.rs
@@ -83,6 +83,7 @@ export const wrappedDate = consume(ZonedDate);
         .iter()
         .find(|node| {
             node.label() == "ZonedDate"
+                && node.string("symbol_kind") == "class"
                 && source_matches(&node.string("source_file"), &implementation)
         })
         .ok_or("missing ZonedDate declaration")?;
@@ -182,7 +183,9 @@ export function make() { return new Widget(); }
         .nodes
         .iter()
         .find(|node| {
-            node.label() == "Widget" && source_matches(&node.string("source_file"), &implementation)
+            node.label() == "Widget"
+                && node.string("symbol_kind") == "class"
+                && source_matches(&node.string("source_file"), &implementation)
         })
         .map(|node| node.id.clone())
         .ok_or("missing Widget declaration")?;
@@ -630,6 +633,7 @@ export const value = helper();
         .iter()
         .find(|node| {
             matches!(node.label(), "helper()" | "helper")
+                && node.string("symbol_kind") == "function"
                 && source_matches(&node.string("source_file"), &declaration)
         })
         .ok_or("missing typesVersions declaration")?;
@@ -1168,7 +1172,13 @@ new DefaultWidget().run();
         .candidates
         .iter()
         .find(|candidate| {
-            candidate.relation == CandidateRelation::Calls && candidate.target_spelling == "run"
+            candidate.relation == CandidateRelation::Calls
+                && candidate.target_spelling == "run"
+                && candidate
+                    .constraints
+                    .qualified_name
+                    .as_deref()
+                    .is_some_and(|qualified| qualified.ends_with("::Widget.run"))
         })
         .ok_or("missing imported member call candidate")?;
     let default_member_call = batches[2]

--- a/docs/implementation/query-engine.md
+++ b/docs/implementation/query-engine.md
@@ -98,6 +98,29 @@ otherwise equal generated/test declarations. A frozen v1 implementation exists
 only in unit tests to prove the reviewed production-versus-generated case is a
 strict v2 improvement; it is not a runtime fallback.
 
+Natural behavior ranking treats source-backed functions, methods, and
+constructors as operation roots alongside role-shaped types. A compact
+operation-role channel may finish early only when its predicate and subject
+evidence proves that its first candidate dominates omitted declarations and
+covers the query's subject terms. A subject-matching role such as `Builder`
+cannot finish discovery before a more specific method has been read. Compact
+type-declaration exits use the same subject-coverage rule.
+Predicate-only methods can use the terminal owner as their subject (for
+example, `ClaudeGenerator::Generate`), while a method that already names a
+subject, such as `SaveStep`, is not burdened with unrelated receiver tokens.
+Matching owner terms still provide a secondary rank signal for nested APIs
+such as Java builders and test environments.
+Test/generated penalties come from path and exact namespace components, not
+CamelCase words inside a production type name: `DicerTestEnvironment` under a
+production source root is not treated as a test namespace. Symbol signatures
+also contribute bounded direct-field evidence, which lets a parameter concept
+distinguish otherwise identical overloads such as `contains(SliceKey)` and
+`contains(Slice)`.
+The stopword policy retains `all` and `why` because they can distinguish code
+identities such as `DetectAll` and `runAttributionWhy`. Paths under `e2e/` are
+ranked as test support, like `tests/` and language-specific test filenames, so
+an otherwise equal production declaration remains first.
+
 ## Natural-language intent routing
 
 `compass ask "<question>"` uses the deterministic `query-planner/1` profile

--- a/docs/implementation/workspace-tour.md
+++ b/docs/implementation/workspace-tour.md
@@ -47,6 +47,11 @@ slice        bounded source slicing
 **Change here when:** adding detection policy, a cache/manifest contract, or an
 atomic filesystem primitive.
 
+Built-in output-directory pruning is path-aware where language namespace
+layouts can collide with conventional artifact names. In particular,
+`src/<source-set>/java/build/...` is a Java package namespace, while a normal
+top-level or module-level `build/` directory remains generated-output noise.
+
 **Evidence:** crate tests plus CLI update/extract/watch tests that exercise
 incremental behavior and output safety.
 

--- a/docs/reference/universal-semantic-evidence.md
+++ b/docs/reference/universal-semantic-evidence.md
@@ -364,6 +364,14 @@ same-named type elsewhere in the repository. Ambiguous trait imports and
 parser recovery overlapping either side of the implementation header fail
 closed.
 
+Go function literals own a lexical closure scope but do not yet publish a
+callable declaration node. Their parameter and result types therefore remain
+source-anchored `references` evidence owned by the enclosing declaration. A
+literal result must not become a `returns` contract on that enclosing function
+or file; publishing such an edge would invent a return contract and can create
+an invalid file-to-type relationship. Named functions, methods, and interface
+methods continue to publish their result types as `returns` evidence.
+
 Python file imports are visible at module scope. Function- and class-local
 imports are indexed only in their owning lexical scope, so they cannot leak to
 sibling functions or become file-owned facts. Each imported item retains its
@@ -384,9 +392,14 @@ Python variable declaration when the name has no competing module binding,
 deletion, import shadow, parser recovery, or proven callable-alias kind. A
 direct initializer call adds `type_of` evidence only when its target resolves
 to one source-backed class; functions and unresolved external factories do not
-invent a type. Function- and class-local shadows do not invalidate the module
-declaration. Explicit receiver calls such as `self.settings()` never borrow a
-same-named unqualified import as their target.
+invent a type. A call through that unique module variable may dispatch through
+the exact initializer class. A function-local `name = Class()` receiver uses
+the same exact dispatch only when the assignment is an unconditional,
+source-ordered binding in the callable body and no competing binding precedes
+the call; conditional and rebound values remain unresolved. Function- and
+class-local shadows do not invalidate the module declaration. Explicit
+receiver calls such as `self.settings()` never borrow a same-named unqualified
+import as their target.
 Zero-argument Python `super()` calls use source-proven C3 dispatch after the
 enclosing class. Compass may cross multiple source-backed bases only when the
 required base sets are complete and uniquely resolved for an exact target. A
@@ -460,8 +473,9 @@ ordered before later bases, and a single-inheritance chain remains proven until
 it reaches a multiple-base fork. If that prefix does not resolve the member,
 the resolver requires the complete C3 linearization and selects the first class
 that directly declares it. Python emits this strategy for `self.member(...)`
-and `cls.member(...)`; neither form can fall through to lexical, imported,
-module, or repository-wide terminal-name lookup.
+and `cls.member(...)`; comments inside a multiline parameter list do not change
+the first bound receiver parameter. Neither form can fall through to lexical,
+imported, module, or repository-wide terminal-name lookup.
 
 `C3AfterReceiver` is used for zero-argument `super().member(...)`. It first
 checks the exact first base when that direct successor is source-proven, then


### PR DESCRIPTION
## Summary

- improve default-low Python import, receiver, singleton, alias, and provenance resolution
- preserve exact Rust reexport precedence, Go closure return semantics, Java source-set detection, and TypeScript callable-property targets
- improve source-backed natural-query ranking while retaining genuine ambiguity and bounded store-backed discovery
- harden the qualification timing parser and update the compatibility, implementation, and semantic-evidence contracts

## Qualification result

On source-reviewed positive questions across Python, Rust, Go, Java, and TypeScript, Compass answered 100/100 top-1 correctly versus Graphify 14/100 under the same default 2,000-result cap. Both passed 25/25 negative controls. Build time and query latency were recorded but not used as quality criteria.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-files -p compass-languages -p compass-model -p compass-query -p compass-resolve --lib --tests --locked`
- `python3 -m unittest benchmarks.performance.tests.test_analyze`
- `sh scripts/check_product_boundary.sh`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`

All compiling Cargo commands used Rust 1.97.1 and an external per-worktree target directory under `/Volumes/Workspace/crabbuild-target`.
