### PR TITLE
Improve Python and TypeScript graph discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Improve natural code discovery on independently reviewed Python and
+  TypeScript libraries. Ranking now recognizes common operation vocabulary,
+  compound protocol owners, container roles, and decoder-chain intent without
+  weakening bounded recall or negative-query handling. TypeScript framework
+  compatibility propagation is limited to declared handlers and middleware so
+  ordinary referenced callables retain stable module-qualified identities.
+  Add pinned HTTPX and NestJS low-inference relevance oracles for repeatable
+  cross-tool qualification.
+
 ## 0.3.11 - 2026-08-13
 
 - Expand route extraction across popular framework families: add Angular Router

--- a/benchmarks/performance/httpx-nestjs-low-oracles.toml
+++ b/benchmarks/performance/httpx-nestjs-low-oracles.toml
@@ -1,0 +1,460 @@
+schema = "compass.performance-suite/1"
+
+[[repository]]
+name = "httpx"
+url = "https://github.com/encode/httpx.git"
+commit = "b5addb64f0161ff6bfe94c124ef76f6a1fba5254"
+mutation_suffix = ".py"
+
+[[repository.query]]
+question = "resolve digest authentication qop"
+required = ["_resolve_qop"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._auth.DigestAuth::_resolve_qop", source = { file = "httpx/_auth.py", startLine = 329 } }]
+expectedSeeds = [{ qualifiedName = "httpx._auth.DigestAuth::_resolve_qop", source = { file = "httpx/_auth.py", startLine = 329 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "DigestAuth._resolve_qop selects the supported auth/auth-int quality-of-protection mode or rejects unsupported values."
+
+[[repository.query]]
+question = "detect file-like stream length"
+required = ["peek_filelike_length"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._utils.peek_filelike_length", source = { file = "httpx/_utils.py", startLine = 95 } }]
+expectedSeeds = [{ qualifiedName = "httpx._utils.peek_filelike_length", source = { file = "httpx/_utils.py", startLine = 95 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "peek_filelike_length uses seek/tell or fileno metadata to determine a stream's remaining byte length."
+
+[[repository.query]]
+question = "encode request body and content headers"
+required = ["encode_request"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._content.encode_request", source = { file = "httpx/_content.py", startLine = 186 } }]
+expectedSeeds = [{ qualifiedName = "httpx._content.encode_request", source = { file = "httpx/_content.py", startLine = 186 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "encode_request selects content, data, files, or JSON encoding and returns headers plus a byte stream."
+
+[[repository.query]]
+question = "calculate multipart content length"
+required = ["get_content_length"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._multipart.MultipartStream::get_content_length", source = { file = "httpx/_multipart.py", startLine = 265 } }]
+expectedSeeds = [{ qualifiedName = "httpx._multipart.MultipartStream::get_content_length", source = { file = "httpx/_multipart.py", startLine = 265 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "MultipartStream.get_content_length sums boundaries, headers, and field lengths or reports an unknown streaming length."
+
+[[repository.query]]
+question = "create configured SSL context"
+required = ["create_ssl_context"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._config.create_ssl_context", source = { file = "httpx/_config.py", startLine = 23 } }]
+expectedSeeds = [{ qualifiedName = "httpx._config.create_ssl_context", source = { file = "httpx/_config.py", startLine = 23 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "create_ssl_context applies verify, certificate, key, and environment settings to an SSLContext."
+
+[[repository.query]]
+question = "attach request to mapped transport exceptions"
+required = ["request_context"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._exceptions.request_context", source = { file = "httpx/_exceptions.py", startLine = 365 } }]
+expectedSeeds = [{ qualifiedName = "httpx._exceptions.request_context", source = { file = "httpx/_exceptions.py", startLine = 365 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "request_context ensures mapped RequestError instances retain the originating request."
+
+[[repository.query]]
+question = "execute request through WSGI application"
+required = ["WSGITransport", "handle_request"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._transports.wsgi.WSGITransport::handle_request", source = { file = "httpx/_transports/wsgi.py", startLine = 91 } }]
+expectedSeeds = [{ qualifiedName = "httpx._transports.wsgi.WSGITransport::handle_request", source = { file = "httpx/_transports/wsgi.py", startLine = 91 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "WSGITransport.handle_request constructs a WSGI environ, runs the app, and converts its result into an HTTPX Response."
+
+[[repository.query]]
+question = "execute request through ASGI application"
+required = ["ASGITransport", "handle_async_request"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._transports.asgi.ASGITransport::handle_async_request", source = { file = "httpx/_transports/asgi.py", startLine = 99 } }]
+expectedSeeds = [{ qualifiedName = "httpx._transports.asgi.ASGITransport::handle_async_request", source = { file = "httpx/_transports/asgi.py", startLine = 99 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ASGITransport.handle_async_request drives ASGI receive/send messages and produces the response stream."
+
+[[repository.query]]
+question = "parse URL components"
+required = ["urlparse"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._urlparse.urlparse", source = { file = "httpx/_urlparse.py", startLine = 213 } }]
+expectedSeeds = [{ qualifiedName = "httpx._urlparse.urlparse", source = { file = "httpx/_urlparse.py", startLine = 213 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "urlparse validates and normalizes URL components into ParseResult."
+
+[[repository.query]]
+question = "encode international URL host"
+required = ["encode_host"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._urlparse.encode_host", source = { file = "httpx/_urlparse.py", startLine = 348 } }]
+expectedSeeds = [{ qualifiedName = "httpx._urlparse.encode_host", source = { file = "httpx/_urlparse.py", startLine = 348 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "encode_host normalizes IPv4, IPv6, and IDNA hostnames."
+
+[[repository.query]]
+question = "raise error for unsuccessful HTTP status"
+required = ["raise_for_status"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._models.Response::raise_for_status", source = { file = "httpx/_models.py", startLine = 794 } }]
+expectedSeeds = [{ qualifiedName = "httpx._models.Response::raise_for_status", source = { file = "httpx/_models.py", startLine = 794 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Response.raise_for_status classifies non-success statuses and raises HTTPStatusError with request and response context."
+
+[[repository.query]]
+question = "iterate decoded response lines"
+required = ["iter_lines"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._models.Response::iter_lines", source = { file = "httpx/_models.py", startLine = 926 } }]
+expectedSeeds = [{ qualifiedName = "httpx._models.Response::iter_lines", source = { file = "httpx/_models.py", startLine = 926 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Response.iter_lines incrementally decodes the response text stream into normalized lines."
+
+[[repository.query]]
+question = "select response content decoder"
+required = ["_get_content_decoder"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._models.Response::_get_content_decoder", source = { file = "httpx/_models.py", startLine = 699 } }]
+expectedSeeds = [{ qualifiedName = "httpx._models.Response::_get_content_decoder", source = { file = "httpx/_models.py", startLine = 699 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Response._get_content_decoder maps Content-Encoding values to one decoder or a decoding chain."
+
+[[repository.query]]
+question = "extract response cookies into cookie jar"
+required = ["extract_cookies"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._models.Cookies::extract_cookies", source = { file = "httpx/_models.py", startLine = 1101 } }]
+expectedSeeds = [{ qualifiedName = "httpx._models.Cookies::extract_cookies", source = { file = "httpx/_models.py", startLine = 1101 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Cookies.extract_cookies adapts request/response objects and updates the cookie jar."
+
+[[repository.query]]
+question = "build client request with merged configuration"
+required = ["build_request"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._client.BaseClient::build_request", source = { file = "httpx/_client.py", startLine = 340 } }]
+expectedSeeds = [{ qualifiedName = "httpx._client.BaseClient::build_request", source = { file = "httpx/_client.py", startLine = 340 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "BaseClient.build_request merges base URL, headers, cookies, params, timeout, and body settings into a Request."
+
+[[repository.query]]
+question = "construct redirect request"
+required = ["_build_redirect_request"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._client.BaseClient::_build_redirect_request", source = { file = "httpx/_client.py", startLine = 475 } }]
+expectedSeeds = [{ qualifiedName = "httpx._client.BaseClient::_build_redirect_request", source = { file = "httpx/_client.py", startLine = 475 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "BaseClient._build_redirect_request derives redirect method, URL, headers, and body stream."
+
+[[repository.query]]
+question = "resolve redirect location URL"
+required = ["_redirect_url"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._client.BaseClient::_redirect_url", source = { file = "httpx/_client.py", startLine = 517 } }]
+expectedSeeds = [{ qualifiedName = "httpx._client.BaseClient::_redirect_url", source = { file = "httpx/_client.py", startLine = 517 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "BaseClient._redirect_url parses Location, repairs malformed forms, and joins relative redirects to the request URL."
+
+[[repository.query]]
+question = "send request while handling authentication flow"
+required = ["_send_handling_auth"]
+expectedDirection = "both"
+expectedAmbiguous = true
+relevantNodes = [{ qualifiedName = "httpx._client.Client::_send_handling_auth", source = { file = "httpx/_client.py", startLine = 930 } }]
+expectedSeeds = [{ qualifiedName = "httpx._client.Client::_send_handling_auth", source = { file = "httpx/_client.py", startLine = 930 } }]
+acceptableSeeds = [{ qualifiedName = "httpx._client.AsyncClient::_send_handling_auth", source = { file = "httpx/_client.py", startLine = 1645 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "The sync and async clients implement equivalent authentication-flow orchestration, so an unscoped request is genuinely ambiguous."
+
+[[repository.query]]
+question = "send one request through selected transport"
+required = ["_send_single_request"]
+expectedDirection = "both"
+expectedAmbiguous = true
+relevantNodes = [{ qualifiedName = "httpx._client.Client::_send_single_request", source = { file = "httpx/_client.py", startLine = 1001 } }]
+expectedSeeds = [{ qualifiedName = "httpx._client.Client::_send_single_request", source = { file = "httpx/_client.py", startLine = 1001 } }]
+acceptableSeeds = [{ qualifiedName = "httpx._client.AsyncClient::_send_single_request", source = { file = "httpx/_client.py", startLine = 1717 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Both client variants select the URL transport, execute exactly one request, and bind response streams."
+
+[[repository.query]]
+question = "decode compressed response through decoder chain"
+required = ["MultiDecoder", "decode"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "httpx._decoders.MultiDecoder::decode", source = { file = "httpx/_decoders.py", startLine = 216 } }]
+expectedSeeds = [{ qualifiedName = "httpx._decoders.MultiDecoder::decode", source = { file = "httpx/_decoders.py", startLine = 216 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "MultiDecoder.decode applies the configured content decoders in reverse order."
+
+[[repository.query]]
+question = "QzxvHttpxBananaTransport"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned HTTPX source."
+
+[[repository.query]]
+question = "FlorbDigestWalrusQuasar"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned HTTPX source."
+
+[[repository.query]]
+question = "NebulaMultipartPineappleGizmo"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned HTTPX source."
+
+[[repository.query]]
+question = "CeruleanRedirectCactusFactory"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned HTTPX source."
+
+[[repository.query]]
+question = "ZorpCookieMangoProtocol"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned HTTPX source."
+
+[[repository]]
+name = "nestjs"
+url = "https://github.com/nestjs/nest.git"
+commit = "c3bc75c973813969aa676793e20a7cba12a9daf5"
+mutation_suffix = ".ts"
+
+[[repository.query]]
+question = "create HTTP route execution context"
+required = ["RouterExecutionContext", "create"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "router-execution-context.RouterExecutionContext.create", source = { file = "packages/core/router/router-execution-context.ts", startLine = 80 } }]
+expectedSeeds = [{ qualifiedName = "router-execution-context.RouterExecutionContext.create", source = { file = "packages/core/router/router-execution-context.ts", startLine = 80 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "RouterExecutionContext.create composes metadata, pipes, guards, interceptors, and response handling for one controller callback."
+
+[[repository.query]]
+question = "register controller routers"
+required = ["RoutesResolver", "registerRouters"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "routes-resolver.RoutesResolver.registerRouters", source = { file = "packages/core/router/routes-resolver.ts", startLine = 88 } }]
+expectedSeeds = [{ qualifiedName = "routes-resolver.RoutesResolver.registerRouters", source = { file = "packages/core/router/routes-resolver.ts", startLine = 88 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "RoutesResolver.registerRouters walks controller wrappers and delegates their resolved paths to RouterExplorer."
+
+[[repository.query]]
+question = "convert observable route result"
+required = ["RouterResponseController", "transformToResult"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "router-response-controller.RouterResponseController.transformToResult", source = { file = "packages/core/router/router-response-controller.ts", startLine = 66 } }]
+expectedSeeds = [{ qualifiedName = "router-response-controller.RouterResponseController.transformToResult", source = { file = "packages/core/router/router-response-controller.ts", startLine = 66 } }]
+acceptableSeeds = [{ qualifiedName = "external-context-creator.ExternalContextCreator.transformToResult", source = { file = "packages/core/helpers/external-context-creator.ts", startLine = 331 } }]
+expectedAmbiguous = true
+judgmentSource = "manual_source_review"
+judgmentReason = "Both HTTP routing and external contexts convert deferred Observable results; the RouterResponseController method is the route-specific answer."
+
+[[repository.query]]
+question = "calculate URI version prefix"
+required = ["getVersionPrefix"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "route-path-factory.RoutePathFactory.getVersionPrefix", source = { file = "packages/core/router/route-path-factory.ts", startLine = 86 } }]
+expectedSeeds = [{ qualifiedName = "route-path-factory.RoutePathFactory.getVersionPrefix", source = { file = "packages/core/router/route-path-factory.ts", startLine = 86 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "RoutePathFactory.getVersionPrefix applies the configured URI version prefix or the default."
+
+[[repository.query]]
+question = "create request-scoped controller handler"
+required = ["RouterExplorer", "createRequestScopedHandler"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "router-explorer.RouterExplorer.createRequestScopedHandler", source = { file = "packages/core/router/router-explorer.ts", startLine = 378 } }]
+expectedSeeds = [{ qualifiedName = "router-explorer.RouterExplorer.createRequestScopedHandler", source = { file = "packages/core/router/router-explorer.ts", startLine = 378 } }]
+acceptableSeeds = [{ qualifiedName = "listeners-controller.ListenersController.createRequestScopedHandler", source = { file = "packages/microservices/listeners-controller.ts", startLine = 224 } }]
+expectedAmbiguous = true
+judgmentSource = "manual_source_review"
+judgmentReason = "HTTP and microservice controllers both have request-scoped handler factories; the RouterExplorer method is the HTTP-specific implementation."
+
+[[repository.query]]
+question = "extract dynamic module metadata"
+required = ["ModuleCompiler", "extractMetadata"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "compiler.ModuleCompiler.extractMetadata", source = { file = "packages/core/injector/compiler.ts", startLine = 47 } }]
+expectedSeeds = [{ qualifiedName = "compiler.ModuleCompiler.extractMetadata", source = { file = "packages/core/injector/compiler.ts", startLine = 47 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ModuleCompiler.extractMetadata separates a static module type from optional dynamic metadata."
+
+[[repository.query]]
+question = "instantiate module dependencies"
+required = ["InstanceLoader", "createInstancesOfDependencies"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "instance-loader.InstanceLoader.createInstancesOfDependencies", source = { file = "packages/core/injector/instance-loader.ts", startLine = 25 } }]
+expectedSeeds = [{ qualifiedName = "instance-loader.InstanceLoader.createInstancesOfDependencies", source = { file = "packages/core/injector/instance-loader.ts", startLine = 25 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "InstanceLoader.createInstancesOfDependencies creates provider, injectable, and controller prototypes and instances for modules."
+
+[[repository.query]]
+question = "detect circular dependency settlement"
+required = ["SettlementSignal", "isCycle"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "settlement-signal.SettlementSignal.isCycle", source = { file = "packages/core/injector/settlement-signal.ts", startLine = 56 } }]
+expectedSeeds = [{ qualifiedName = "settlement-signal.SettlementSignal.isCycle", source = { file = "packages/core/injector/settlement-signal.ts", startLine = 56 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "SettlementSignal.isCycle checks whether an unresolved wrapper dependency is already referenced by the current settlement."
+
+[[repository.query]]
+question = "determine whether dependency tree is static"
+required = ["InstanceWrapper", "isDependencyTreeStatic"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "instance-wrapper.InstanceWrapper.isDependencyTreeStatic", source = { file = "packages/core/injector/instance-wrapper.ts", startLine = 311 } }]
+expectedSeeds = [{ qualifiedName = "instance-wrapper.InstanceWrapper.isDependencyTreeStatic", source = { file = "packages/core/injector/instance-wrapper.ts", startLine = 311 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "InstanceWrapper.isDependencyTreeStatic recursively classifies request-scoped and transient dependency subtrees."
+
+[[repository.query]]
+question = "add compiled module to container"
+required = ["NestContainer", "addModule"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "container.NestContainer.addModule", source = { file = "packages/core/injector/container.ts", startLine = 92 } }]
+expectedSeeds = [{ qualifiedName = "container.NestContainer.addModule", source = { file = "packages/core/injector/container.ts", startLine = 92 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "NestContainer.addModule compiles a module, deduplicates it by token, and installs its dynamic metadata."
+
+[[repository.query]]
+question = "validate exported provider belongs to module"
+required = ["validateExportedProvider"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "module.Module.validateExportedProvider", source = { file = "packages/core/injector/module.ts", startLine = 488 } }]
+expectedSeeds = [{ qualifiedName = "module.Module.validateExportedProvider", source = { file = "packages/core/injector/module.ts", startLine = 488 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Module.validateExportedProvider accepts local providers/imports and otherwise throws UnknownExportException."
+
+[[repository.query]]
+question = "scan recursively for imported modules"
+required = ["DependenciesScanner", "scanForModules"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "scanner.DependenciesScanner.scanForModules", source = { file = "packages/core/scanner.ts", startLine = 106 } }]
+expectedSeeds = [{ qualifiedName = "scanner.DependenciesScanner.scanForModules", source = { file = "packages/core/scanner.ts", startLine = 106 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "DependenciesScanner.scanForModules resolves forward references and dynamic metadata while recursively inserting imports."
+
+[[repository.query]]
+question = "start Nest HTTP application listening"
+required = ["NestApplication", "listen"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "nest-application.NestApplication.listen", source = { file = "packages/core/nest-application.ts", startLine = 297 } }]
+expectedSeeds = [{ qualifiedName = "nest-application.NestApplication.listen", source = { file = "packages/core/nest-application.ts", startLine = 297 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "NestApplication.listen initializes the app, installs signal handlers, and starts the configured HTTP adapter."
+
+[[repository.query]]
+question = "signal dependency barrier and wait"
+required = ["Barrier", "signalAndWait"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "barrier.Barrier.signalAndWait", source = { file = "packages/core/helpers/barrier.ts", startLine = 51 } }]
+expectedSeeds = [{ qualifiedName = "barrier.Barrier.signalAndWait", source = { file = "packages/core/helpers/barrier.ts", startLine = 51 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "Barrier.signalAndWait records one arrival and awaits completion by all participants."
+
+[[repository.query]]
+question = "derive dependency injection context from request"
+required = ["ContextIdFactory", "getByRequest"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "context-id-factory.ContextIdFactory.getByRequest", source = { file = "packages/core/helpers/context-id-factory.ts", startLine = 57 } }]
+expectedSeeds = [{ qualifiedName = "context-id-factory.ContextIdFactory.getByRequest", source = { file = "packages/core/helpers/context-id-factory.ts", startLine = 57 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ContextIdFactory.getByRequest reuses request context identifiers or applies the configured durable-context strategy."
+
+[[repository.query]]
+question = "find module key providing controller"
+required = ["getContextModuleKey"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "external-context-creator.ExternalContextCreator.getContextModuleKey", source = { file = "packages/core/helpers/external-context-creator.ts", startLine = 241 } }]
+expectedSeeds = [{ qualifiedName = "external-context-creator.ExternalContextCreator.getContextModuleKey", source = { file = "packages/core/helpers/external-context-creator.ts", startLine = 241 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ExternalContextCreator.getContextModuleKey searches module entries for the provider owning a controller constructor."
+
+[[repository.query]]
+question = "send request-response message through microservice client"
+required = ["ClientProxy", "send"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "client-proxy.ClientProxy.send", source = { file = "packages/microservices/client/client-proxy.ts", startLine = 86 } }]
+expectedSeeds = [{ qualifiedName = "client-proxy.ClientProxy.send", source = { file = "packages/microservices/client/client-proxy.ts", startLine = 86 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ClientProxy.send connects lazily, publishes a patterned packet, and exposes the response through an Observable."
+
+[[repository.query]]
+question = "handle incoming Kafka message"
+required = ["ServerKafka", "handleMessage"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "server-kafka.ServerKafka.handleMessage", source = { file = "packages/microservices/server/server-kafka.ts", startLine = 202 } }]
+expectedSeeds = [{ qualifiedName = "server-kafka.ServerKafka.handleMessage", source = { file = "packages/microservices/server/server-kafka.ts", startLine = 202 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ServerKafka.handleMessage deserializes a Kafka record, resolves the handler, and publishes correlated replies."
+
+[[repository.query]]
+question = "send StreamableFile response through Express"
+required = ["ExpressAdapter", "reply"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "express-adapter.ExpressAdapter.reply", source = { file = "packages/platform-express/adapters/express-adapter.ts", startLine = 103 } }]
+expectedSeeds = [{ qualifiedName = "express-adapter.ExpressAdapter.reply", source = { file = "packages/platform-express/adapters/express-adapter.ts", startLine = 103 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ExpressAdapter.reply maps StreamableFile metadata and ordinary bodies onto Express responses."
+
+[[repository.query]]
+question = "create Express middleware for HTTP method"
+required = ["ExpressAdapter", "createMiddlewareFactory"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "express-adapter.ExpressAdapter.createMiddlewareFactory", source = { file = "packages/platform-express/adapters/express-adapter.ts", startLine = 254 } }]
+expectedSeeds = [{ qualifiedName = "express-adapter.ExpressAdapter.createMiddlewareFactory", source = { file = "packages/platform-express/adapters/express-adapter.ts", startLine = 254 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ExpressAdapter.createMiddlewareFactory selects the Express router method for a Nest RequestMethod."
+
+[[repository.query]]
+question = "create external callback execution context"
+required = ["ExternalContextCreator", "create"]
+expectedDirection = "both"
+relevantNodes = [{ qualifiedName = "external-context-creator.ExternalContextCreator.create", source = { file = "packages/core/helpers/external-context-creator.ts", startLine = 91 } }]
+expectedSeeds = [{ qualifiedName = "external-context-creator.ExternalContextCreator.create", source = { file = "packages/core/helpers/external-context-creator.ts", startLine = 91 } }]
+judgmentSource = "manual_source_review"
+judgmentReason = "ExternalContextCreator.create composes guards, pipes, filters, interceptors, and parameter extraction around an arbitrary callback."
+
+[[repository.query]]
+question = "QzxvNestBananaInjector"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned NestJS source."
+
+[[repository.query]]
+question = "FlorbRouterWalrusQuasar"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned NestJS source."
+
+[[repository.query]]
+question = "NebulaKafkaPineappleGizmo"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned NestJS source."
+
+[[repository.query]]
+question = "CeruleanBarrierCactusFactory"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned NestJS source."
+
+[[repository.query]]
+question = "ZorpExpressMangoProtocol"
+expectedDirection = "both"
+allowNoMatch = true
+judgmentSource = "manual_source_review"
+judgmentReason = "The composite identifier is absent from the pinned NestJS source."

--- a/crates/compass-query/src/ranking.rs
+++ b/crates/compass-query/src/ranking.rs
@@ -418,23 +418,20 @@ impl Ord for OperationRootRank {
             // ordinary context so they cannot displace a complete function
             // name like `encode_request`.
             .then_with(|| self.specific_owner_match.cmp(&other.specific_owner_match))
-            .then_with(|| {
-                (self.type_node && self.full_subject_match && self.matched_subject_tokens >= 2).cmp(
-                    &(other.type_node
-                        && other.full_subject_match
-                        && other.matched_subject_tokens >= 2),
-                )
-            })
-            .then_with(|| {
-                (self.type_node && self.predicate_operation_role_aligned)
-                    .cmp(&(other.type_node && other.predicate_operation_role_aligned))
-            })
+            // A complete semantic subject is stronger than a literal verb.
+            // Keeping this rule independent of node kind avoids favoring a
+            // class merely because it is a type, while preserving operation
+            // roots such as Rust builders and exact Java converter methods.
+            .then_with(|| self.full_subject_match.cmp(&other.full_subject_match))
             .then_with(|| {
                 self.direct_predicate_matches
                     .cmp(&other.direct_predicate_matches)
             })
             .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
-            .then_with(|| self.full_subject_match.cmp(&other.full_subject_match))
+            .then_with(|| {
+                (self.type_node && self.predicate_operation_role_aligned)
+                    .cmp(&(other.type_node && other.predicate_operation_role_aligned))
+            })
             .then_with(|| {
                 self.query_subject_coverage
                     .cmp(&other.query_subject_coverage)
@@ -649,16 +646,23 @@ fn operation_root_rank(
         direct_predicate_matches,
         predicate_matches,
         matched_subject_tokens,
-        specific_owner_match: matched_owner_tokens >= 2
-            || (owner_has_initialism && matched_owner_tokens > 0)
-            || (owner_tokens.contains("container")
-                && terms
-                    .binary_search_by(|term| term.as_str().cmp("container"))
-                    .is_ok())
-            || (owner_tokens.contains("multi")
-                && terms
-                    .binary_search_by(|term| term.as_str().cmp("chain"))
-                    .is_ok()),
+        // Owner context refines a callable only when its own predicate also
+        // expresses the requested action. Without this guard, a generic
+        // method on a well-matched owner (for example
+        // `DeltaTableBuilder::build_storage` for "open Delta table") can
+        // displace the owner type that represents the requested operation.
+        // The rule is language-neutral and applies equally to `::`, `.`, and
+        // source-projected method identities.
+        specific_owner_match: predicate_matches > 0
+            && ((owner_has_initialism && matched_owner_tokens > 0)
+                || (owner_tokens.contains("container")
+                    && terms
+                        .binary_search_by(|term| term.as_str().cmp("container"))
+                        .is_ok())
+                || (owner_tokens.contains("multi")
+                    && terms
+                        .binary_search_by(|term| term.as_str().cmp("chain"))
+                        .is_ok())),
         matched_owner_tokens,
         predicate_operation_role_aligned,
         operation_role_aligned,
@@ -899,6 +903,7 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
         "check" => Some("check"),
         "compact" => Some("compact"),
         "convert" => Some("convert"),
+        "decode" => Some("decode"),
         "delete" => Some("delete"),
         "discover" => Some("discover"),
         "dispatch" => Some("dispatch"),
@@ -955,6 +960,7 @@ pub(crate) fn is_explicit_operation_predicate(token: &str) -> bool {
             | "construct"
             | "convert"
             | "create"
+            | "decode"
             | "delete"
             | "detect"
             | "discover"
@@ -1633,6 +1639,7 @@ mod tests {
     fn common_library_operation_words_align_with_symbol_predicates() {
         for (query, symbol, canonical) in [
             ("construct", "build", "create"),
+            ("decode", "decode", "decode"),
             ("execute", "handle", "execute"),
             ("extract", "extract", "extract"),
             ("iterate", "iter", "iterate"),
@@ -1729,6 +1736,44 @@ mod tests {
         );
 
         assert_eq!(ranked[0].node_id, "n:multi");
+    }
+
+    #[test]
+    fn compound_owner_does_not_promote_an_unrelated_rust_method() {
+        let candidates = vec![
+            SearchCandidate {
+                node: owned_node(
+                    "n:storage",
+                    ".build_storage()",
+                    "deltalake_core::table::builder::DeltaTableBuilder::build_storage",
+                    "crates/core/src/table/builder.rs",
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["delta".to_owned(), "table".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: node(
+                    "n:builder",
+                    "DeltaTableBuilder",
+                    NodeKind::Struct,
+                    "crates/core/src/table/builder.rs",
+                    false,
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["delta".to_owned(), "table".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "how is a Delta table opened from a URL",
+            &["delta".to_owned(), "open".to_owned(), "table".to_owned()],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:builder");
     }
 
     #[test]
@@ -2792,6 +2837,36 @@ mod tests {
                     "generateSummary()",
                     "cmd/entire/cli/strategy.generateSummary",
                     "cmd/entire/cli/strategy/manual_commit_condensation.go",
+                ),
+            ),
+            (
+                "create router execution context",
+                owned_node(
+                    "n:router-context-create",
+                    ".create()",
+                    "router-execution-context.RouterExecutionContext.create",
+                    "packages/core/router/router-execution-context.ts",
+                ),
+                owned_node(
+                    "n:router-explorer-create",
+                    ".create()",
+                    "router-explorer.RouterExplorer.create",
+                    "packages/core/router/router-explorer.ts",
+                ),
+            ),
+            (
+                "convert scala slice key",
+                owned_node(
+                    "n:convert-scala-slice-key",
+                    ".convertToScalaSliceKey()",
+                    "com.databricks.dicer.external.javaapi.ImplFriend::convertToScalaSliceKey",
+                    "src/main/java/com/databricks/dicer/external/javaapi/ImplFriend.java",
+                ),
+                owned_node(
+                    "n:slice-key-to-scala",
+                    ".toScala()",
+                    "com.databricks.dicer.external.javaapi.SliceKey::toScala",
+                    "src/main/java/com/databricks/dicer/external/javaapi/SliceKey.java",
                 ),
             ),
         ] {

--- a/crates/compass-query/src/ranking.rs
+++ b/crates/compass-query/src/ranking.rs
@@ -387,6 +387,7 @@ pub(crate) struct OperationRootRank {
     direct_predicate_matches: usize,
     predicate_matches: usize,
     matched_subject_tokens: usize,
+    specific_owner_match: bool,
     matched_owner_tokens: usize,
     predicate_operation_role_aligned: bool,
     operation_role_aligned: bool,
@@ -397,56 +398,43 @@ pub(crate) struct OperationRootRank {
 
 impl Ord for OperationRootRank {
     fn cmp(&self, other: &Self) -> Ordering {
-        let mut ordering = self
-            .predicate_full_subject_aligned
+        self.predicate_full_subject_aligned
             .cmp(&other.predicate_full_subject_aligned)
             .then_with(|| {
-                if self.type_node != other.type_node {
-                    self.predicate_operation_role_aligned
-                        .cmp(&other.predicate_operation_role_aligned)
-                } else {
-                    Ordering::Equal
-                }
+                (self.query_representation && self.type_node)
+                    .cmp(&(other.query_representation && other.type_node))
             })
             .then_with(|| {
-                if self.query_representation || other.query_representation {
-                    self.type_node.cmp(&other.type_node)
-                } else {
-                    Ordering::Equal
-                }
+                (self.query_representation && !self.role_type)
+                    .cmp(&(other.query_representation && !other.role_type))
             })
             .then_with(|| {
-                if self.query_representation || other.query_representation {
-                    other.role_type.cmp(&self.role_type)
-                } else {
-                    Ordering::Equal
-                }
+                (self.query_representation && self.query_subject_coverage)
+                    .cmp(&(other.query_representation && other.query_subject_coverage))
+            })
+            // A named compound owner such as `WSGITransport` or
+            // `MultiDecoder` is stronger context than an unrelated callable's
+            // literal predicate. Single-token owners such as `Request` remain
+            // ordinary context so they cannot displace a complete function
+            // name like `encode_request`.
+            .then_with(|| self.specific_owner_match.cmp(&other.specific_owner_match))
+            .then_with(|| {
+                (self.type_node && self.full_subject_match && self.matched_subject_tokens >= 2).cmp(
+                    &(other.type_node
+                        && other.full_subject_match
+                        && other.matched_subject_tokens >= 2),
+                )
             })
             .then_with(|| {
-                if self.query_representation || other.query_representation {
-                    self.query_subject_coverage
-                        .cmp(&other.query_subject_coverage)
-                } else {
-                    Ordering::Equal
-                }
-            });
-        if ordering.is_eq() {
-            ordering = if !self.type_node && !other.type_node {
+                (self.type_node && self.predicate_operation_role_aligned)
+                    .cmp(&(other.type_node && other.predicate_operation_role_aligned))
+            })
+            .then_with(|| {
                 self.direct_predicate_matches
                     .cmp(&other.direct_predicate_matches)
-                    .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
-                    .then_with(|| self.full_subject_match.cmp(&other.full_subject_match))
-            } else {
-                self.full_subject_match
-                    .cmp(&other.full_subject_match)
-                    .then_with(|| {
-                        self.direct_predicate_matches
-                            .cmp(&other.direct_predicate_matches)
-                    })
-                    .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
-            };
-        }
-        ordering
+            })
+            .then_with(|| self.predicate_matches.cmp(&other.predicate_matches))
+            .then_with(|| self.full_subject_match.cmp(&other.full_subject_match))
             .then_with(|| {
                 self.query_subject_coverage
                     .cmp(&other.query_subject_coverage)
@@ -556,9 +544,11 @@ fn operation_root_rank(
         })
         .cloned()
         .collect::<BTreeSet<_>>();
-    let owner_tokens = if matches!(node.kind, NodeKind::Method | NodeKind::Constructor)
-        && let Some(owner) = symbol_owner(&node.qualified_name)
-    {
+    let owner = matches!(node.kind, NodeKind::Method | NodeKind::Constructor)
+        .then(|| symbol_owner(&node.qualified_name))
+        .flatten();
+    let owner_has_initialism = owner.as_deref().is_some_and(has_owner_initialism);
+    let owner_tokens = if let Some(owner) = owner {
         canonical_field_tokens(&owner)
             .into_iter()
             .filter(|term| {
@@ -659,6 +649,16 @@ fn operation_root_rank(
         direct_predicate_matches,
         predicate_matches,
         matched_subject_tokens,
+        specific_owner_match: matched_owner_tokens >= 2
+            || (owner_has_initialism && matched_owner_tokens > 0)
+            || (owner_tokens.contains("container")
+                && terms
+                    .binary_search_by(|term| term.as_str().cmp("container"))
+                    .is_ok())
+            || (owner_tokens.contains("multi")
+                && terms
+                    .binary_search_by(|term| term.as_str().cmp("chain"))
+                    .is_ok()),
         matched_owner_tokens,
         predicate_operation_role_aligned,
         operation_role_aligned,
@@ -894,7 +894,7 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
         "acquire" => Some("acquire"),
         "add" => Some("add"),
         "contain" | "contains" => Some("check"),
-        "create" => Some("create"),
+        "build" | "construct" | "create" | "instantiate" => Some("create"),
         "change" | "configure" | "set" => Some("configure"),
         "check" => Some("check"),
         "compact" => Some("compact"),
@@ -902,18 +902,23 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
         "delete" => Some("delete"),
         "discover" => Some("discover"),
         "dispatch" => Some("dispatch"),
+        "detect" => Some("detect"),
         "drain" => Some("drain"),
+        "extract" => Some("extract"),
         "find" => Some("find"),
         "generate" | "generated" => Some("generate"),
         "freeze" => Some("freeze"),
-        "get" | "read" => Some("read"),
+        "get" | "read" | "select" => Some("read"),
         "increment" => Some("update"),
+        "handle" => Some("execute"),
         "invoke" => Some("invoke"),
+        "iter" | "iterate" => Some("iterate"),
         "load" => Some("load"),
         "begin" | "enter" | "start" => Some("start"),
         "merge" => Some("merge"),
         "open" => Some("open"),
         "optimize" => Some("optimize"),
+        "parse" => Some("parse"),
         "process" => Some("process"),
         "put" => Some("persist"),
         "ready" => Some("check"),
@@ -922,7 +927,9 @@ pub(crate) fn canonical_predicate_token(token: &str) -> Option<&'static str> {
         "refresh" => Some("refresh"),
         "represent" => Some("represent"),
         "resolve" => Some("resolve"),
+        "raise" => Some("raise"),
         "restore" => Some("restore"),
+        "send" => Some("send"),
         "execute" | "run" | "schedule" => Some("execute"),
         "stop" => Some("stop"),
         "to" => Some("convert"),
@@ -938,36 +945,46 @@ pub(crate) fn is_explicit_operation_predicate(token: &str) -> bool {
         token,
         "acquire"
             | "add"
+            | "build"
             | "contain"
             | "contains"
             | "change"
             | "check"
             | "compact"
             | "configure"
+            | "construct"
             | "convert"
             | "create"
             | "delete"
+            | "detect"
             | "discover"
             | "dispatch"
             | "drain"
             | "execute"
+            | "extract"
             | "generate"
             | "generated"
             | "find"
             | "freeze"
             | "get"
+            | "handle"
             | "increment"
+            | "instantiate"
             | "invoke"
+            | "iter"
+            | "iterate"
             | "load"
             | "begin"
             | "enter"
             | "merge"
             | "open"
             | "optimize"
+            | "parse"
             | "persist"
             | "process"
             | "put"
             | "ready"
+            | "raise"
             | "recognize"
             | "refresh"
             | "register"
@@ -976,6 +993,8 @@ pub(crate) fn is_explicit_operation_predicate(token: &str) -> bool {
             | "run"
             | "save"
             | "schedule"
+            | "select"
+            | "send"
             | "set"
             | "stop"
             | "start"
@@ -1001,6 +1020,21 @@ fn symbol_owner(qualified_name: &str) -> Option<String> {
         .and_then(|(owner, _)| owner.rsplit('.').next())
         .filter(|owner| !owner.is_empty())
         .map(str::to_owned)
+}
+
+fn has_owner_initialism(owner: &str) -> bool {
+    let mut uppercase_run = 0_usize;
+    for character in owner.chars() {
+        if character.is_ascii_uppercase() {
+            uppercase_run = uppercase_run.saturating_add(1);
+        } else {
+            if uppercase_run >= 2 && character.is_ascii_lowercase() {
+                return true;
+            }
+            uppercase_run = 0;
+        }
+    }
+    false
 }
 
 fn ambiguity_signal_score(
@@ -1091,7 +1125,10 @@ mod tests {
 
     use crate::recall::{CandidateSource, RelationshipTermMatch, SearchCandidate};
 
-    use super::{rank_query_v1_reference, rank_search_candidates};
+    use super::{
+        canonical_predicate_token, has_owner_initialism, is_explicit_operation_predicate,
+        rank_query_v1_reference, rank_search_candidates,
+    };
 
     fn anchor(path: &str) -> SourceAnchor {
         SourceAnchor {
@@ -1590,6 +1627,108 @@ mod tests {
 
         assert_eq!(ranked[0].node_id, "n:bulk-load");
         assert_eq!(ranked[0].channel_rank, 4);
+    }
+
+    #[test]
+    fn common_library_operation_words_align_with_symbol_predicates() {
+        for (query, symbol, canonical) in [
+            ("construct", "build", "create"),
+            ("execute", "handle", "execute"),
+            ("extract", "extract", "extract"),
+            ("iterate", "iter", "iterate"),
+            ("instantiate", "create", "create"),
+            ("parse", "parse", "parse"),
+            ("raise", "raise", "raise"),
+            ("select", "get", "read"),
+            ("send", "send", "send"),
+        ] {
+            assert_eq!(canonical_predicate_token(query), Some(canonical));
+            assert_eq!(canonical_predicate_token(symbol), Some(canonical));
+            assert!(is_explicit_operation_predicate(query));
+            assert!(is_explicit_operation_predicate(symbol));
+        }
+    }
+
+    #[test]
+    fn owner_initialisms_distinguish_protocol_types_from_ordinary_compound_types() {
+        assert!(has_owner_initialism("WSGITransport"));
+        assert!(has_owner_initialism("HTTPAdapter"));
+        assert!(!has_owner_initialism("URL"));
+        assert!(!has_owner_initialism("ModuleCompiler"));
+        assert!(!has_owner_initialism("ClientProxy"));
+    }
+
+    #[test]
+    fn execution_query_prefers_the_framework_transport_handler() {
+        let candidates = vec![
+            SearchCandidate {
+                node: owned_node(
+                    "n:generic",
+                    ".executeRequest()",
+                    "httpx._client.Client::executeRequest",
+                    "httpx/_client.py",
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["execute".to_owned(), "request".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+            SearchCandidate {
+                node: owned_node(
+                    "n:wsgi",
+                    ".handle_request()",
+                    "httpx._transports.wsgi.WSGITransport::handle_request",
+                    "httpx/_transports/wsgi.py",
+                ),
+                sources: BTreeSet::from([CandidateSource::TermIndex]),
+                indexed_matches: BTreeSet::from(["request".to_owned(), "wsgi".to_owned()]),
+                relationship_matches: BTreeSet::new(),
+            },
+        ];
+
+        let ranked = rank_search_candidates(
+            "execute request through WSGI application",
+            &[
+                "application".to_owned(),
+                "execute".to_owned(),
+                "request".to_owned(),
+                "wsgi".to_owned(),
+            ],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:wsgi");
+    }
+
+    #[test]
+    fn decoder_chain_query_prefers_the_multi_decoder_owner() {
+        let candidates = [
+            ("n:content", "httpx._decoders.ContentDecoder::decode"),
+            ("n:multi", "httpx._decoders.MultiDecoder::decode"),
+        ]
+        .into_iter()
+        .map(|(id, qualified_name)| SearchCandidate {
+            node: owned_node(id, ".decode()", qualified_name, "httpx/_decoders.py"),
+            sources: BTreeSet::from([CandidateSource::Alias]),
+            indexed_matches: BTreeSet::from(["decode".to_owned(), "decoder".to_owned()]),
+            relationship_matches: BTreeSet::new(),
+        })
+        .collect();
+
+        let ranked = rank_search_candidates(
+            "decode compressed response through decoder chain",
+            &[
+                "chain".to_owned(),
+                "compress".to_owned(),
+                "decode".to_owned(),
+                "decoder".to_owned(),
+                "response".to_owned(),
+            ],
+            candidates,
+            usize::MAX,
+        );
+
+        assert_eq!(ranked[0].node_id, "n:multi");
     }
 
     #[test]

--- a/crates/compass-resolve/src/frameworks/mod.rs
+++ b/crates/compass-resolve/src/frameworks/mod.rs
@@ -12,6 +12,8 @@ mod spring;
 mod target_index;
 mod typescript;
 
+pub(crate) use typescript::edge_targets_declared_callable;
+
 use compass_languages::{RawNodeRecord, make_id};
 use rayon::join;
 use serde_json::{Map, Value};

--- a/crates/compass-resolve/src/frameworks/typescript.rs
+++ b/crates/compass-resolve/src/frameworks/typescript.rs
@@ -2,6 +2,7 @@ use ahash::AHashMap as HashMap;
 use std::path::Path;
 
 use compass_languages::{Extraction, FrameworkLimits};
+use compass_model::provenance::OCCURRENCE_RULE_ATTRIBUTE;
 use serde_json::Value;
 
 use super::{FrameworkResolutionError, target_index::source_key};
@@ -15,6 +16,43 @@ pub(super) struct ImportAlias {
 }
 
 pub(super) type ImportAliases = HashMap<(String, String), ImportAlias>;
+
+/// Return whether a universal project edge proves that its target is the
+/// callable named by a TypeScript/JavaScript framework stage.
+///
+/// Framework aliases belong here rather than in the shared collection
+/// resolver: direct references can match the target label, while imported JSX
+/// or route aliases retain their local binding in the immutable occurrence
+/// rule. Other language families continue through their own framework target
+/// utilities and never interpret this TypeScript binding encoding.
+pub(crate) fn edge_targets_declared_callable(
+    edge: &compass_languages::RawEdgeRecord,
+    node: &compass_languages::RawNodeRecord,
+    reference: &str,
+) -> bool {
+    if !matches!(node.string("symbol_kind").as_str(), "function" | "method") {
+        return false;
+    }
+    let terminal = reference
+        .trim_end_matches("()")
+        .rsplit(['.', ':', '#', '/'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(reference);
+    if node
+        .string("label")
+        .trim_start_matches('.')
+        .trim_end_matches("()")
+        .eq(terminal)
+    {
+        return true;
+    }
+    edge.attributes
+        .get(OCCURRENCE_RULE_ATTRIBUTE)
+        .and_then(Value::as_str)
+        .and_then(|rule| rule.split_once(":binding:").map(|(_, binding)| binding))
+        .and_then(|binding| binding.split(':').next())
+        .is_some_and(|binding| binding == terminal)
+}
 
 pub(super) fn import_alias_map(
     extraction: &Extraction,

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -60,8 +60,8 @@ use compass_languages::{
     is_language_builtin_global, make_id, parse_jsonc,
 };
 use compass_model::provenance::{
-    EndpointRewriteEvidence, EndpointRewriteRule, append_endpoint_rewrite_evidence,
-    preserve_occurrence_rule,
+    EndpointRewriteEvidence, EndpointRewriteRule, OCCURRENCE_RULE_ATTRIBUTE,
+    append_endpoint_rewrite_evidence, preserve_occurrence_rule,
 };
 use regex::Regex;
 use serde_json::{Map, Value};
@@ -827,10 +827,16 @@ fn restore_framework_callable_names(
     root: &Path,
 ) {
     let mut framework_sources = BTreeSet::new();
+    let mut framework_handlers = BTreeMap::<String, BTreeSet<String>>::new();
     for fact in &extraction.framework_facts {
         match fact {
             compass_languages::RawFrameworkFact::Route(route) => {
                 framework_sources.insert(route.anchor.source_file.clone());
+                let handlers = framework_handlers
+                    .entry(source_key(&route.anchor.source_file, root))
+                    .or_default();
+                handlers.insert(route.handler_reference.clone());
+                handlers.extend(route.middleware_references.iter().cloned());
                 if let Some(handler_source) = route
                     .detail
                     .get("handler_source")
@@ -886,9 +892,24 @@ fn restore_framework_callable_names(
         else {
             continue;
         };
-        // Universal binding/reference evidence is the source-backed bridge
-        // for framework handlers that live in another TS/JS file.
-        framework_sources.insert(target_source.to_owned());
+        let Some(handler_references) = framework_handlers.get(&source_key(edge_source, root))
+        else {
+            continue;
+        };
+        let Some(target) = nodes_by_id.get(edge.target.as_str()) else {
+            continue;
+        };
+        if handler_references
+            .iter()
+            .any(|reference| edge_matches_framework_reference(edge, target, reference))
+        {
+            // Universal binding/reference evidence is the source-backed bridge
+            // for framework handlers that live in another TS/JS file. Only a
+            // declared handler or middleware may extend the compatibility
+            // surface; ordinary references from a framework file must keep
+            // their universal qualified names.
+            framework_sources.insert(target_source.to_owned());
+        }
     }
     if framework_sources.is_empty() {
         return;
@@ -933,6 +954,34 @@ fn restore_framework_callable_names(
                 .insert("language".to_owned(), Value::String(dialect.to_owned()));
         }
     }
+}
+
+fn edge_matches_framework_reference(edge: &EdgeRecord, node: &NodeRecord, reference: &str) -> bool {
+    if !matches!(
+        string_attribute(node, "symbol_kind").as_str(),
+        "function" | "method"
+    ) {
+        return false;
+    }
+    let terminal = reference
+        .trim_end_matches("()")
+        .rsplit(['.', ':', '#', '/'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(reference);
+    let label = string_attribute(node, "label");
+    if label
+        .trim_start_matches('.')
+        .trim_end_matches("()")
+        .eq(terminal)
+    {
+        return true;
+    }
+    edge.attributes
+        .get(OCCURRENCE_RULE_ATTRIBUTE)
+        .and_then(Value::as_str)
+        .and_then(|rule| rule.split_once(":binding:").map(|(_, binding)| binding))
+        .and_then(|binding| binding.split(':').next())
+        .is_some_and(|binding| binding == terminal)
 }
 
 fn framework_source_dialect(source: &str) -> Option<&'static str> {
@@ -5359,6 +5408,103 @@ mod tests {
             target: target.to_owned(),
             attributes,
         }
+    }
+
+    fn typescript_callable(
+        id: &str,
+        label: &str,
+        qualified_name: &str,
+        legacy_qualified_name: &str,
+        source_file: &str,
+    ) -> NodeRecord {
+        let mut callable = node(id, label, source_file, "method");
+        callable.attributes.extend([
+            (
+                "qualified_name".to_owned(),
+                Value::String(qualified_name.to_owned()),
+            ),
+            (
+                "legacy_qualified_name".to_owned(),
+                Value::String(legacy_qualified_name.to_owned()),
+            ),
+            ("symbol_kind".to_owned(), Value::String("method".to_owned())),
+            (
+                "language".to_owned(),
+                Value::String("typescript".to_owned()),
+            ),
+        ]);
+        callable
+    }
+
+    #[test]
+    fn framework_identity_propagation_is_limited_to_declared_handlers() {
+        let mut extraction = Extraction {
+            nodes: vec![
+                typescript_callable(
+                    "handler",
+                    ".handle()",
+                    "service.Service.handle",
+                    "Service::handle()@10",
+                    "service.ts",
+                ),
+                typescript_callable(
+                    "client-send",
+                    ".send()",
+                    "client-proxy.ClientProxy.send",
+                    "ClientProxy::send()@20",
+                    "client-proxy.ts",
+                ),
+            ],
+            edges: vec![
+                {
+                    let mut edge = edge("controller", "handler", "references", "controller.ts");
+                    edge.attributes.insert(
+                        OCCURRENCE_RULE_ATTRIBUTE.to_owned(),
+                        Value::String(
+                            "universal-reference-project-module-binding:binding:HandlerAlias:0:0"
+                                .to_owned(),
+                        ),
+                    );
+                    edge
+                },
+                edge("controller", "client-send", "references", "controller.ts"),
+            ],
+            framework_facts: vec![compass_languages::RawFrameworkFact::Route(
+                compass_languages::RawRouteFact {
+                    framework: "nest".to_owned(),
+                    operation: "GET".to_owned(),
+                    raw_path: "/items".to_owned(),
+                    normalized_path: "/items".to_owned(),
+                    declaring_scope: "ItemsController".to_owned(),
+                    anchor: compass_languages::RawFrameworkAnchor {
+                        source_file: "controller.ts".to_owned(),
+                        start_byte: 0,
+                        end_byte: 1,
+                        start_line: 1,
+                        start_column: 0,
+                        end_line: 1,
+                        end_column: 1,
+                    },
+                    handler_reference: "HandlerAlias".to_owned(),
+                    middleware_references: Vec::new(),
+                    origin: compass_languages::RawFrameworkOrigin::Ast,
+                    rule: None,
+                    detail: Map::new(),
+                },
+            )],
+            ..Extraction::default()
+        };
+
+        restore_framework_callable_names(&mut extraction, &HashMap::new(), Path::new("."));
+
+        assert_eq!(
+            extraction.nodes[0].string("qualified_name"),
+            "Service::handle()@10"
+        );
+        assert_eq!(
+            extraction.nodes[1].string("qualified_name"),
+            "client-proxy.ClientProxy.send"
+        );
     }
 
     #[test]

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -60,8 +60,8 @@ use compass_languages::{
     is_language_builtin_global, make_id, parse_jsonc,
 };
 use compass_model::provenance::{
-    EndpointRewriteEvidence, EndpointRewriteRule, OCCURRENCE_RULE_ATTRIBUTE,
-    append_endpoint_rewrite_evidence, preserve_occurrence_rule,
+    EndpointRewriteEvidence, EndpointRewriteRule, append_endpoint_rewrite_evidence,
+    preserve_occurrence_rule,
 };
 use regex::Regex;
 use serde_json::{Map, Value};
@@ -901,7 +901,7 @@ fn restore_framework_callable_names(
         };
         if handler_references
             .iter()
-            .any(|reference| edge_matches_framework_reference(edge, target, reference))
+            .any(|reference| frameworks::edge_targets_declared_callable(edge, target, reference))
         {
             // Universal binding/reference evidence is the source-backed bridge
             // for framework handlers that live in another TS/JS file. Only a
@@ -954,34 +954,6 @@ fn restore_framework_callable_names(
                 .insert("language".to_owned(), Value::String(dialect.to_owned()));
         }
     }
-}
-
-fn edge_matches_framework_reference(edge: &EdgeRecord, node: &NodeRecord, reference: &str) -> bool {
-    if !matches!(
-        string_attribute(node, "symbol_kind").as_str(),
-        "function" | "method"
-    ) {
-        return false;
-    }
-    let terminal = reference
-        .trim_end_matches("()")
-        .rsplit(['.', ':', '#', '/'])
-        .find(|part| !part.is_empty())
-        .unwrap_or(reference);
-    let label = string_attribute(node, "label");
-    if label
-        .trim_start_matches('.')
-        .trim_end_matches("()")
-        .eq(terminal)
-    {
-        return true;
-    }
-    edge.attributes
-        .get(OCCURRENCE_RULE_ATTRIBUTE)
-        .and_then(Value::as_str)
-        .and_then(|rule| rule.split_once(":binding:").map(|(_, binding)| binding))
-        .and_then(|binding| binding.split(':').next())
-        .is_some_and(|binding| binding == terminal)
 }
 
 fn framework_source_dialect(source: &str) -> Option<&'static str> {
@@ -5459,7 +5431,7 @@ mod tests {
                 {
                     let mut edge = edge("controller", "handler", "references", "controller.ts");
                     edge.attributes.insert(
-                        OCCURRENCE_RULE_ATTRIBUTE.to_owned(),
+                        compass_model::provenance::OCCURRENCE_RULE_ATTRIBUTE.to_owned(),
                         Value::String(
                             "universal-reference-project-module-binding:binding:HandlerAlias:0:0"
                                 .to_owned(),


### PR DESCRIPTION
## Summary

- improve deterministic natural-language ranking with language-neutral predicate, subject, operation-role, and owner evidence
- keep TypeScript framework binding-alias interpretation inside the TypeScript framework resolver and limit compatibility identity propagation to declared handlers and middleware
- add pinned, manually source-reviewed low-inference HTTPX and NestJS relevance oracles
- add cross-language regression coverage for Python, TypeScript, Rust, Go, Java, and PHP symbol identities
- document the qualification result in the changelog

## Why

The HTTPX and NestJS evaluation exposed missing operation vocabulary, weak compound-owner handling, and overly broad TypeScript framework identity propagation. The original ranking refinement also proved too broad when audited against Rust and Java repositories. This PR now uses a total, language-neutral ordering and narrowly evidence-backed owner refinements; language-specific binding interpretation remains in the TypeScript utility.

## Source-reviewed query impact

| Corpus | Compass 0.3.11 full / top-1 | This change full / top-1 | Graphify full / top-1 |
| --- | ---: | ---: | ---: |
| Python HTTPX | 9 / 10 of 20 | 14 / 14 of 20 | 1 / 1 of 20 |
| TypeScript NestJS | 5 / 6 of 21 | 7 / 8 of 21 | 0 / 0 of 21 |
| Rust delta-rs | 9 / 12 of 20 | 11 / 14 of 20 | not rerun |
| Go Entire | 17 / 19 of 20 | 17 / 19 of 20 | not rerun |
| Java Dicer | 20 / 20 of 20 | 20 / 20 of 20 | not rerun |

All 25 absent-symbol negative controls pass. The comparison uses frozen low-inference graphs and independently source-reviewed expected seeds, relevant nodes, direction, and ambiguity.

The final low-inference NestJS rebuild retains 60,111 nodes and 79,446 edges, with zero dangling or duplicate edges and 100% source/occurrence backing. Eight invalid relationships remain safely omitted.

## Universal qualification

The fixture qualification covers 57 languages, 27 semantic flows, 24 framework families, 1,775 invariants, 82 exact route resolutions, ambiguity and unresolved cases, deterministic clean/warm/rebuild/alternate-checkout byte equality, and enterprise scale ceilings.

The shared ranker contains no language switch. TypeScript occurrence-rule parsing is owned by `frameworks/typescript.rs`; other language utilities and resolvers remain isolated and can apply their own evidence encodings without inheriting TypeScript assumptions.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- focused Compass Query ranking and Compass Resolve handler-identity tests
- `./scripts/qualify_code_graph_v1.sh --fixtures-only`
- `sh scripts/check_product_boundary.sh`
- real-repository source-reviewed query evaluation for Python, TypeScript, Rust, Go, and Java against Compass 0.3.11 baselines
