### PR TITLE
Complete internal version reset to v1

### DIFF
--- a/crates/compass-core/src/pipeline.rs
+++ b/crates/compass-core/src/pipeline.rs
@@ -184,6 +184,7 @@ pub enum BuildPurpose {
 const OUTPUT_STATS_FILE: &str = "output-stats.json";
 const AST_FACT_DIGESTS_FILE: &str = "ast-fact-digests.json";
 const AST_FACT_DIGESTS_SCHEMA: &str = "compass.ast-fact-digests/1";
+const AST_FACT_DIGESTS_PROFILE: &str = "compass.ast-fact-digests/profile/1";
 const MAX_AST_FACT_DIGEST_ENTRIES: usize = 100_000;
 const MAX_AST_FACT_DIGEST_FILE_BYTES: usize = 16 * 1024 * 1024;
 const GRAPH_OVERVIEW_FILE: &str = "graph-overview.json";
@@ -443,7 +444,7 @@ fn build_profile_digest(profile: &BuildProfile, output_dir: &Path) -> Result<Str
         source,
     })?;
     let mut digest = Sha256::new();
-    digest.update(b"compass.ast-fact-digests/profile/3");
+    digest.update(AST_FACT_DIGESTS_PROFILE.as_bytes());
     digest.update([0]);
     for component in [
         compass_model::code_graph::CODE_GRAPH_SCHEMA_V1,


### PR DESCRIPTION
## What changed

- reset the remaining AST fact-digest profile identity from `profile/3` to `profile/1`
- name the profile identity beside the already-reset `compass.ast-fact-digests/1` schema

## Why

PR #244 reset Compass-owned pre-release extraction, cache, publication, store, query, overview, qualification, and semantic-diff identities to v1, but this internal digest domain separator was missed. Keeping it at v3 contradicted the intended hard reset and the compatibility documentation.

Package releases, dependency versions, and external protocol versions are intentionally unchanged.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/Workspace/crabbuild-target/compass-v1-reset cargo test -p compass-core --lib --locked` (74 passed)
- audited active production source for Compass-owned version identities above v1
