### PR TITLE
Fix review fingerprint upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Make `compass review` recover automatically when one compared revision still
+  prefers a realization from an older compatible `0.3.x` patch release. Compass
+  now preserves user-selected build options, advances engine-owned fingerprint
+  fields, and publishes a new current-version comparable pair without rewriting
+  the historical realization. Materialization also verifies the requested
+  profile before reusing a preferred realization.
+
 - Hard-cut PHP production extraction to the version-1 universal candidate with
   modern declarations, namespaces, grouped and aliased imports, traits,
   attributes, enum cases, promoted properties, calls, construction, typed

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -330,6 +330,12 @@ integer rubric is version 1; each deterministic gate has its own rule version.
 Presentation formats and the reusable GitHub Action consume this report and do
 not redefine its semantics.
 
+When only one side of a review has a preferred realization from an older patch
+release in the same supported `0.3.x` line, Compass advances engine-owned
+profile fields and materializes both revisions with the running binary. The
+older realization remains immutable and queryable. Newer profiles and profiles
+from another release line still fail explicitly rather than being downgraded.
+
 Dependency findings in `compass.semantic_diff.report/1` may now carry the
 optional strict `dependency_topology` object. It records source/target community
 IDs when present and bounded directed-cycle participation when the snapshot

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -109,6 +109,47 @@ impl HistoryBuildOptions {
         })
     }
 
+    pub(crate) fn from_compatible_profile(mut profile: BuildProfile) -> Result<Self, HistoryError> {
+        let persisted = profile.value("compass_version").ok_or_else(|| {
+            HistoryError::InvalidFingerprint(
+                "persisted compass_version is missing from build profile".to_owned(),
+            )
+        })?;
+        if persisted == env!("CARGO_PKG_VERSION") {
+            return Self::from_profile(profile);
+        }
+        let persisted = semver::Version::parse(persisted).map_err(|_| {
+            HistoryError::InvalidFingerprint(
+                "persisted compass_version is not a semantic version".to_owned(),
+            )
+        })?;
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).map_err(|_| {
+            HistoryError::InvalidFingerprint(
+                "running compass_version is not a semantic version".to_owned(),
+            )
+        })?;
+        if persisted.major != current.major
+            || persisted.minor != current.minor
+            || persisted >= current
+        {
+            return Err(HistoryError::InvalidFingerprint(format!(
+                "persisted compass_version {persisted} cannot be upgraded by {}",
+                env!("CARGO_PKG_VERSION")
+            )));
+        }
+        let deep = match profile.value("semantic_mode") {
+            Some("standard") => false,
+            Some("deep") => true,
+            _ => {
+                return Err(HistoryError::InvalidFingerprint(
+                    "persisted semantic mode is invalid".to_owned(),
+                ));
+            }
+        };
+        insert_current_engine_profile(&mut profile, deep)?;
+        Self::from_profile(profile)
+    }
+
     pub(crate) fn builder(
         &self,
         executable: PathBuf,
@@ -145,36 +186,8 @@ impl HistoryBuildOptions {
             resolve_provider(&mut values)?;
         }
         let mut profile = BuildProfile::default();
+        insert_current_engine_profile(&mut profile, values.deep)?;
         for (key, value) in [
-            ("compass_version", env!("CARGO_PKG_VERSION").to_owned()),
-            ("graph_schema", HISTORY_GRAPH_SCHEMA.to_owned()),
-            ("extractor_version", "compass-languages/v1".to_owned()),
-            ("resolver_version", "compass-resolve/v1".to_owned()),
-            ("pipeline_version", "compass-core/v1".to_owned()),
-            (
-                "program_provider_policy",
-                "offline-artifacts-first".to_owned(),
-            ),
-            (
-                "program_ir_schema",
-                compass_ir::PROGRAM_SCHEMA_VERSION.to_string(),
-            ),
-            (
-                "program_merger_version",
-                compass_program::MERGER_VERSION.to_string(),
-            ),
-            (
-                "program_analysis_schema",
-                compass_analysis::ANALYSIS_SCHEMA_VERSION.to_string(),
-            ),
-            (
-                "program_analyzer_version",
-                compass_analysis::ANALYZER_VERSION.to_string(),
-            ),
-            ("enabled_features", "workspace-default".to_owned()),
-            ("direction", "native-source-semantics".to_owned()),
-            ("cluster_algorithm", "seeded-louvain/v1".to_owned()),
-            ("cluster_seed", "42".to_owned()),
             ("gitignore", values.gitignore.to_string()),
             ("code_only", values.code_only.to_string()),
             ("cargo", values.cargo.to_string()),
@@ -182,10 +195,6 @@ impl HistoryBuildOptions {
             (
                 "semantic_mode",
                 if values.deep { "deep" } else { "standard" }.to_owned(),
-            ),
-            (
-                "semantic_prompt_sha256",
-                compass_semantic::extraction_prompt_sha256(values.deep),
             ),
             (
                 "provider",
@@ -289,6 +298,50 @@ impl HistoryBuildOptions {
             code_only: values.code_only,
         })
     }
+}
+
+fn insert_current_engine_profile(
+    profile: &mut BuildProfile,
+    deep: bool,
+) -> Result<(), HistoryError> {
+    for (key, value) in [
+        ("compass_version", env!("CARGO_PKG_VERSION").to_owned()),
+        ("graph_schema", HISTORY_GRAPH_SCHEMA.to_owned()),
+        ("extractor_version", "compass-languages/v1".to_owned()),
+        ("resolver_version", "compass-resolve/v1".to_owned()),
+        ("pipeline_version", "compass-core/v1".to_owned()),
+        (
+            "program_provider_policy",
+            "offline-artifacts-first".to_owned(),
+        ),
+        (
+            "program_ir_schema",
+            compass_ir::PROGRAM_SCHEMA_VERSION.to_string(),
+        ),
+        (
+            "program_merger_version",
+            compass_program::MERGER_VERSION.to_string(),
+        ),
+        (
+            "program_analysis_schema",
+            compass_analysis::ANALYSIS_SCHEMA_VERSION.to_string(),
+        ),
+        (
+            "program_analyzer_version",
+            compass_analysis::ANALYZER_VERSION.to_string(),
+        ),
+        ("enabled_features", "workspace-default".to_owned()),
+        ("direction", "native-source-semantics".to_owned()),
+        ("cluster_algorithm", "seeded-louvain/v1".to_owned()),
+        ("cluster_seed", "42".to_owned()),
+        (
+            "semantic_prompt_sha256",
+            compass_semantic::extraction_prompt_sha256(deep),
+        ),
+    ] {
+        profile.insert(key, &value)?;
+    }
+    Ok(())
 }
 
 fn validate_persisted_profile(profile: &BuildProfile) -> Result<(), HistoryError> {
@@ -1532,6 +1585,40 @@ mod tests {
             result,
             Err(error) if error.to_string().contains(HISTORY_GRAPH_SCHEMA)
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn compatible_patch_profiles_advance_engine_fields_and_preserve_user_options()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut profile = HistoryBuildOptions::defaults()?.profile();
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))?;
+        let mut previous = current.clone();
+        previous.patch = previous
+            .patch
+            .checked_sub(1)
+            .ok_or("patch release fixture")?;
+        profile.insert("compass_version", &previous.to_string())?;
+        profile.insert("pipeline_version", "compass-core/older")?;
+        profile.insert("resolution", "2")?;
+
+        let upgraded = HistoryBuildOptions::from_compatible_profile(profile)?.profile();
+
+        assert_eq!(
+            upgraded.value("compass_version"),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(upgraded.value("pipeline_version"), Some("compass-core/v1"));
+        assert_eq!(upgraded.value("resolution"), Some("2"));
+
+        let mut future_profile = upgraded;
+        let mut future = current;
+        future.patch = future.patch.saturating_add(1);
+        future_profile.insert("compass_version", &future.to_string())?;
+        let error = HistoryBuildOptions::from_compatible_profile(future_profile)
+            .err()
+            .ok_or("future profile unexpectedly accepted")?;
+        assert!(error.to_string().contains("cannot be upgraded"));
         Ok(())
     }
 

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -211,7 +211,8 @@ pub(crate) fn resolve_or_materialize(
 fn configured_build_options(repository: &Repository) -> Result<HistoryBuildOptions, String> {
     let config = HistoryConfig::load(repository).map_err(|error| error.to_string())?;
     if let Some(profile) = config.profile {
-        return HistoryBuildOptions::from_profile(profile).map_err(|error| error.to_string());
+        return HistoryBuildOptions::from_compatible_profile(profile)
+            .map_err(|error| error.to_string());
     }
     HistoryBuildOptions::defaults().map_err(|error| error.to_string())
 }
@@ -263,15 +264,27 @@ pub(crate) fn resolve_comparable_pair(
             new,
         ),
         (Some(old), None) => {
-            let options = HistoryBuildOptions::from_profile(old.version.build_profile.clone())
-                .map_err(|error| error.to_string())?;
+            let options =
+                HistoryBuildOptions::from_compatible_profile(old.version.build_profile.clone())
+                    .map_err(|error| error.to_string())?;
+            let old = if old.version.build_profile == options.profile() {
+                old
+            } else {
+                resolve_or_materialize(repository, old_commit, &options, true, false)?.1
+            };
             let (history, new) =
                 resolve_or_materialize(repository, new_commit, &options, false, false)?;
             (history, old, new)
         }
         (None, Some(new)) => {
-            let options = HistoryBuildOptions::from_profile(new.version.build_profile.clone())
-                .map_err(|error| error.to_string())?;
+            let options =
+                HistoryBuildOptions::from_compatible_profile(new.version.build_profile.clone())
+                    .map_err(|error| error.to_string())?;
+            let new = if new.version.build_profile == options.profile() {
+                new
+            } else {
+                resolve_or_materialize(repository, new_commit, &options, true, false)?.1
+            };
             let (history, old) =
                 resolve_or_materialize(repository, old_commit, &options, false, false)?;
             (history, old, new)
@@ -1853,8 +1866,10 @@ fn execute_build(
     let parsed = parse_build_command(command, args).map_err(usage)?;
     let commit = repository.resolve(&parsed.revision).map_err(runtime)?;
     let options = if let Some(source) = &parsed.profile_from {
-        HistoryBuildOptions::from_profile(stored_profile(repository, source).map_err(runtime)?)
-            .map_err(runtime)?
+        HistoryBuildOptions::from_compatible_profile(
+            stored_profile(repository, source).map_err(runtime)?,
+        )
+        .map_err(runtime)?
     } else if parsed.use_repository_profile {
         configured_build_options(repository).map_err(runtime)?
     } else {

--- a/crates/compass-cli/tests/review_cli.rs
+++ b/crates/compass-cli/tests/review_cli.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
+use compass_history::{ExtractionFingerprint, HistoryStore, PublishRequest, Repository};
 use compass_pr_intelligence::{GateState, PullRequestReport, RiskBand};
 
 fn git(root: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
@@ -29,6 +30,34 @@ fn initialize(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write(root.join("lib.rs"), "pub fn shared() -> u8 { 1 }\n")?;
     git(root, &["add", "lib.rs"])?;
     git(root, &["commit", "--quiet", "-m", "base"])?;
+    Ok(())
+}
+
+fn publish_historical_base(root: &Path, commit: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let seeded = run(root, &["history", "build", commit, "--code-only"])?;
+    if !seeded.status.success() {
+        return Err(format!(
+            "could not seed current history: {}",
+            String::from_utf8_lossy(&seeded.stderr)
+        )
+        .into());
+    }
+    let repository = Repository::discover(root)?;
+    let commit = repository.resolve(commit)?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("seeded history store")?;
+    let current = history.preferred(&commit)?.ok_or("seeded realization")?;
+    let completed = history.artifacts(&current.id)?;
+    let mut historical_profile = current.version.build_profile;
+    historical_profile.insert("compass_version", "0.3.9")?;
+    history.publish(PublishRequest {
+        commit: commit.clone(),
+        parents: repository.parents(&commit)?,
+        profile: historical_profile,
+        fingerprint: "a".repeat(64).parse::<ExtractionFingerprint>()?,
+        artifacts: completed.artifacts,
+        completion: completed.completion,
+        make_preferred: true,
+    })?;
     Ok(())
 }
 
@@ -109,6 +138,52 @@ fn local_review_writes_round_trippable_exact_report() -> Result<(), Box<dyn std:
     assert!(bounded.stdout.is_empty());
     assert!(String::from_utf8_lossy(&bounded.stderr).contains("PR review output is"));
     assert_eq!(std::fs::read_to_string(preserved_path)?, "preserve-me");
+    Ok(())
+}
+
+#[test]
+fn local_review_rebuilds_a_comparable_pair_after_a_compass_patch_upgrade()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    initialize(directory.path())?;
+    let base = git(directory.path(), &["rev-parse", "HEAD"])?;
+    git(directory.path(), &["checkout", "--quiet", "-b", "feature"])?;
+    std::fs::write(
+        directory.path().join("feature.rs"),
+        "pub fn feature() -> u8 { 2 }\n",
+    )?;
+    git(directory.path(), &["add", "feature.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "feature"])?;
+    let head = git(directory.path(), &["rev-parse", "HEAD"])?;
+    publish_historical_base(directory.path(), &base)?;
+
+    let output = run(
+        directory.path(),
+        &[
+            "review", "--base", &base, "--head", &head, "--format", "json",
+        ],
+    )?;
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report = PullRequestReport::from_json(&output.stdout)?;
+    assert_eq!(report.identity.revisions.target_head, base);
+    assert_eq!(report.identity.revisions.pull_request_head, head);
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("history store")?;
+    let base = repository.resolve(&base)?;
+    let preferred = history.preferred(&base)?.ok_or("preferred base")?;
+    assert_eq!(
+        preferred.version.build_profile.value("compass_version"),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+    assert!(history.list(Some(&base))?.iter().any(|realization| {
+        realization.version.build_profile.value("compass_version") == Some("0.3.9")
+    }));
     Ok(())
 }
 

--- a/crates/compass-core/src/history.rs
+++ b/crates/compass-core/src/history.rs
@@ -261,6 +261,7 @@ pub fn materialize_history_with_observer(
     let (existing, corrupt) = observe_preferred(store, &request.commit, &activity)?;
     if !request.rebuild
         && let Some(existing) = existing
+        && existing.version.build_profile == request.profile
     {
         return Ok(existing);
     }

--- a/crates/compass-core/tests/history_materialize.rs
+++ b/crates/compass-core/tests/history_materialize.rs
@@ -316,6 +316,47 @@ fn materializer_builds_target_without_reconstructing_an_ancestor()
 }
 
 #[test]
+fn materializer_does_not_reuse_a_preferred_realization_with_another_profile()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    git(directory.path(), &["init", "--quiet"])?;
+    git(directory.path(), &["config", "user.name", "Compass Test"])?;
+    git(
+        directory.path(),
+        &["config", "user.email", "compass@example.invalid"],
+    )?;
+    std::fs::write(directory.path().join("service.rs"), "fn service() {}\n")?;
+    git(directory.path(), &["add", "service.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "service"])?;
+    let repository = Repository::discover(directory.path())?;
+    let commit = repository.resolve("HEAD")?;
+    let store = HistoryStore::create(&repository)?;
+    let builder = RecordingBuilder::default();
+
+    let first = materialize_history(
+        &store,
+        &builder,
+        request(&repository, commit.clone(), false)?,
+    )?;
+    let mut changed = request(&repository, commit.clone(), false)?;
+    changed.profile.insert("profile_variant", "second")?;
+    let second = materialize_history(&store, &builder, changed)?;
+
+    assert_ne!(first.id, second.id);
+    assert_eq!(builder.builds()?, 2);
+    assert_eq!(
+        second.version.build_profile.value("profile_variant"),
+        Some("second")
+    );
+    assert_eq!(store.list(Some(&commit))?.len(), 2);
+    assert_eq!(
+        store.preferred(&commit)?.map(|version| version.id),
+        Some(second.id)
+    );
+    Ok(())
+}
+
+#[test]
 fn incomplete_builder_output_is_never_published() -> Result<(), Box<dyn std::error::Error>> {
     struct IncompleteBuilder;
     impl CompleteGraphBuilder for IncompleteBuilder {

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -355,6 +355,12 @@ There is no profile-mismatch override: unlike profiles do not produce a
 semantic or exact report. Compass checks graph-engine compatibility explicitly
 before comparing the complete build profiles.
 
+`compass review` handles an older preferred realization from a compatible
+`0.3.x` patch release automatically when it must materialize the other side.
+It preserves user-selected profile options, rebuilds a current-version pair,
+and leaves the older immutable realization intact. A profile from a newer
+binary or another release line remains an explicit compatibility error.
+
 ## 7. Export a realization
 
 Canonical graph JSON:


### PR DESCRIPTION
## Summary

- automatically advance engine-owned history profile fields when `compass review` encounters an older compatible `0.3.x` patch realization
- preserve user-selected build options and publish a new current-version comparable pair without mutating historical realizations
- require the core materializer to match the requested profile before reusing a preferred realization
- document the compatibility behavior and add CLI/core regressions

## Root cause

When one review revision was already materialized by an older Compass patch and the other was missing, pair resolution copied the persisted profile verbatim. Strict validation then rejected its old `compass_version`. The core materializer also returned any preferred realization without checking whether its build profile matched the request.

## Impact

After upgrading to Compass 0.3.12, `compass review` can transparently rebuild compatible older 0.3.x history into a comparable current pair. Newer versions and other release lines still fail explicitly.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-cli --test review_cli --locked`
- `cargo test -p compass-core --test history_materialize --locked`
- `cargo test -p compass-cli --test history_cli --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `sh scripts/check_product_boundary.sh`

All Cargo builds used the repository-required external `CARGO_TARGET_DIR`.
