### PR TITLE
Filter language built-ins from code graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,12 +123,12 @@
   genuine ambiguity. Tighten performance-harness timing parsing and diagnostics
   for these qualification runs.
 
-- Exclude unshadowed JavaScript, TypeScript, Python, Go, and Swift built-in
-  globals from call-target publication so constructors, coercion functions,
-  standard-library types, and common global methods do not become noisy graph
-  hubs. Source-proven same-file declarations and explicit bindings retain
-  precedence. Advance extraction semantics to v2 so cached graphs rebuild
-  with the denser call topology.
+- Exclude unshadowed JavaScript, TypeScript, Python, Go, Rust, Java, and Swift
+  built-in globals from call-target publication so constructors, coercion
+  functions, prelude and `java.lang` types, and common global methods do not
+  become noisy graph hubs. Source-proven same-file, same-package, and imported
+  declarations retain precedence. Advance extraction semantics to v2 so
+  cached graphs rebuild with the denser call topology.
 
 - Stop Markdown pipe-table containers from overwhelming community names and
   `GRAPH_REPORT.md`. Mixed communities now prefer meaningful headings or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@
   genuine ambiguity. Tighten performance-harness timing parsing and diagnostics
   for these qualification runs.
 
+- Exclude unshadowed JavaScript, TypeScript, Python, Go, and Swift built-in
+  globals from call-target publication so constructors, coercion functions,
+  standard-library types, and common global methods do not become noisy graph
+  hubs. Source-proven same-file declarations and explicit bindings retain
+  precedence. Advance extraction semantics to v2 so cached graphs rebuild
+  with the denser call topology.
+
 - Stop Markdown pipe-table containers from overwhelming community names and
   `GRAPH_REPORT.md`. Mixed communities now prefer meaningful headings or
   symbols over higher-degree table parser nodes; table-only communities use

--- a/crates/compass-languages/src/builtins.rs
+++ b/crates/compass-languages/src/builtins.rs
@@ -97,6 +97,75 @@ const GO_BUILTIN_GLOBALS: &[&str] = &[
     "min", "new", "panic", "print", "println", "real", "recover",
 ];
 
+const SWIFT_BUILTIN_GLOBALS: &[&str] = &[
+    "String",
+    "Int",
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    "UInt",
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    "Double",
+    "Float",
+    "Bool",
+    "Character",
+    "Sendable",
+    "Codable",
+    "Decodable",
+    "Encodable",
+    "Equatable",
+    "Hashable",
+    "Identifiable",
+    "Comparable",
+    "CaseIterable",
+    "RawRepresentable",
+    "CustomStringConvertible",
+    "CustomDebugStringConvertible",
+    "AnyObject",
+    "LocalizedError",
+    "Data",
+    "Date",
+    "UUID",
+    "Decimal",
+    "Calendar",
+    "Locale",
+    "TimeZone",
+    "Bundle",
+    "URL",
+    "IndexPath",
+    "IndexSet",
+    "NotificationCenter",
+    "UserDefaults",
+    "FileManager",
+    "URLSession",
+    "URLRequest",
+    "URLComponents",
+    "JSONDecoder",
+    "JSONEncoder",
+    "DateFormatter",
+    "NumberFormatter",
+    "ISO8601DateFormatter",
+    "NSObject",
+    "NSString",
+    "NSError",
+    "NSLock",
+    "NSAttributedString",
+    "DispatchQueue",
+    "DispatchGroup",
+    "OperationQueue",
+    "RunLoop",
+    "Error",
+    "View",
+    "Color",
+    "Font",
+    "filter",
+    "print",
+];
+
 /// Return whether `name` is an unresolved global supplied by `language`.
 ///
 /// This deliberately is not a union table: the same spelling can be a normal
@@ -108,6 +177,26 @@ pub fn is_language_builtin_global(language: &str, name: &str) -> bool {
         "javascript" | "typescript" | "tsx" => JAVASCRIPT_BUILTIN_GLOBALS.contains(&name),
         "python" => PYTHON_BUILTIN_GLOBALS.contains(&name),
         "go" => GO_BUILTIN_GLOBALS.contains(&name),
+        "swift" => SWIFT_BUILTIN_GLOBALS.contains(&name),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_language_builtin_global;
+
+    #[test]
+    fn builtin_globals_are_language_scoped_and_case_sensitive() {
+        assert!(is_language_builtin_global("typescript", "Promise"));
+        assert!(is_language_builtin_global("python", "len"));
+        assert!(is_language_builtin_global("go", "make"));
+        assert!(is_language_builtin_global("swift", "Data"));
+        assert!(is_language_builtin_global("swift", "Sendable"));
+
+        assert!(!is_language_builtin_global("rust", "Promise"));
+        assert!(!is_language_builtin_global("python", "Promise"));
+        assert!(!is_language_builtin_global("swift", "data"));
+        assert!(!is_language_builtin_global("swift", "ProjectService"));
     }
 }

--- a/crates/compass-languages/src/builtins.rs
+++ b/crates/compass-languages/src/builtins.rs
@@ -45,6 +45,31 @@ const JAVASCRIPT_BUILTIN_GLOBALS: &[&str] = &[
     "AbortSignal",
     "TextEncoder",
     "TextDecoder",
+    "ArrayBuffer",
+    "SharedArrayBuffer",
+    "DataView",
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "BigInt64Array",
+    "BigUint64Array",
+    "AggregateError",
+    "WeakRef",
+    "FinalizationRegistry",
+    "eval",
+    "fetch",
+    "queueMicrotask",
+    "structuredClone",
+    "setTimeout",
+    "setInterval",
+    "clearTimeout",
+    "clearInterval",
     "console",
 ];
 
@@ -90,11 +115,231 @@ const PYTHON_BUILTIN_GLOBALS: &[&str] = &[
     "delattr",
     "vars",
     "dir",
+    "ascii",
+    "aiter",
+    "anext",
+    "bin",
+    "breakpoint",
+    "bytearray",
+    "chr",
+    "classmethod",
+    "compile",
+    "complex",
+    "divmod",
+    "eval",
+    "exec",
+    "format",
+    "frozenset",
+    "globals",
+    "help",
+    "hex",
+    "input",
+    "issubclass",
+    "locals",
+    "memoryview",
+    "oct",
+    "object",
+    "ord",
+    "pow",
+    "property",
+    "slice",
+    "staticmethod",
+    "__import__",
+    // Built-in exception constructors are especially prone to becoming hubs.
+    "BaseException",
+    "Exception",
+    "ArithmeticError",
+    "AssertionError",
+    "AttributeError",
+    "EOFError",
+    "ImportError",
+    "IndexError",
+    "KeyError",
+    "LookupError",
+    "MemoryError",
+    "NameError",
+    "NotImplementedError",
+    "OSError",
+    "ReferenceError",
+    "RuntimeError",
+    "StopIteration",
+    "SyntaxError",
+    "SystemError",
+    "SystemExit",
+    "TypeError",
+    "ValueError",
+    "Warning",
+    "ZeroDivisionError",
 ];
 
 const GO_BUILTIN_GLOBALS: &[&str] = &[
-    "append", "cap", "clear", "close", "complex", "copy", "delete", "imag", "len", "make", "max",
-    "min", "new", "panic", "print", "println", "real", "recover",
+    "any",
+    "bool",
+    "byte",
+    "comparable",
+    "complex64",
+    "complex128",
+    "error",
+    "float32",
+    "float64",
+    "int",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "rune",
+    "string",
+    "uint",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "uintptr",
+    "append",
+    "cap",
+    "clear",
+    "close",
+    "complex",
+    "copy",
+    "delete",
+    "imag",
+    "len",
+    "make",
+    "max",
+    "min",
+    "new",
+    "panic",
+    "print",
+    "println",
+    "real",
+    "recover",
+];
+
+const RUST_BUILTIN_GLOBALS: &[&str] = &[
+    // Primitive types are valid call receivers (`u32::from(value)`).
+    "bool",
+    "char",
+    "str",
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "isize",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "usize",
+    "f32",
+    "f64",
+    // Rust prelude types, variants, traits, and functions.
+    "Box",
+    "Option",
+    "Result",
+    "String",
+    "Vec",
+    "Some",
+    "None",
+    "Ok",
+    "Err",
+    "AsMut",
+    "AsRef",
+    "Borrow",
+    "BorrowMut",
+    "Clone",
+    "Copy",
+    "Default",
+    "DoubleEndedIterator",
+    "Drop",
+    "Eq",
+    "ExactSizeIterator",
+    "Extend",
+    "Fn",
+    "FnMut",
+    "FnOnce",
+    "From",
+    "FromIterator",
+    "Into",
+    "IntoIterator",
+    "Iterator",
+    "Ord",
+    "PartialEq",
+    "PartialOrd",
+    "Send",
+    "Sized",
+    "Sync",
+    "ToOwned",
+    "ToString",
+    "align_of",
+    "align_of_val",
+    "drop",
+    "size_of",
+    "size_of_val",
+];
+
+const JAVA_BUILTIN_GLOBALS: &[&str] = &[
+    // java.lang is imported implicitly by the Java language.
+    "AbstractMethodError",
+    "Appendable",
+    "ArithmeticException",
+    "ArrayIndexOutOfBoundsException",
+    "AssertionError",
+    "AutoCloseable",
+    "Boolean",
+    "Byte",
+    "Character",
+    "CharSequence",
+    "Class",
+    "ClassCastException",
+    "ClassLoader",
+    "ClassNotFoundException",
+    "Cloneable",
+    "Comparable",
+    "Deprecated",
+    "Double",
+    "Enum",
+    "Error",
+    "Exception",
+    "Float",
+    "FunctionalInterface",
+    "Integer",
+    "IllegalArgumentException",
+    "IllegalStateException",
+    "IndexOutOfBoundsException",
+    "InterruptedException",
+    "Iterable",
+    "LinkageError",
+    "Long",
+    "Math",
+    "Number",
+    "NullPointerException",
+    "Object",
+    "Override",
+    "Process",
+    "ProcessBuilder",
+    "Readable",
+    "Record",
+    "Runnable",
+    "Runtime",
+    "RuntimeException",
+    "SecurityException",
+    "Short",
+    "StackTraceElement",
+    "StrictMath",
+    "String",
+    "StringBuffer",
+    "StringBuilder",
+    "SuppressWarnings",
+    "System",
+    "Thread",
+    "ThreadGroup",
+    "ThreadLocal",
+    "Throwable",
+    "UnsupportedOperationException",
+    "VirtualMachineError",
+    "Void",
 ];
 
 const SWIFT_BUILTIN_GLOBALS: &[&str] = &[
@@ -177,20 +422,46 @@ pub fn is_language_builtin_global(language: &str, name: &str) -> bool {
         "javascript" | "typescript" | "tsx" => JAVASCRIPT_BUILTIN_GLOBALS.contains(&name),
         "python" => PYTHON_BUILTIN_GLOBALS.contains(&name),
         "go" => GO_BUILTIN_GLOBALS.contains(&name),
+        "rust" => RUST_BUILTIN_GLOBALS.contains(&name),
+        "java" => JAVA_BUILTIN_GLOBALS.contains(&name),
         "swift" => SWIFT_BUILTIN_GLOBALS.contains(&name),
+        _ => false,
+    }
+}
+
+/// Return whether a qualified target denotes a standard symbol implicitly
+/// supplied by the language rather than a source or imported declaration.
+///
+/// Callers must use this only after source, import, and lexical resolution.
+#[must_use]
+pub fn is_language_builtin_qualified_target(language: &str, qualified_name: &str) -> bool {
+    match language {
+        "rust" => qualified_name
+            .split("::")
+            .next()
+            .is_some_and(|name| is_language_builtin_global(language, name)),
+        "java" => qualified_name
+            .strip_prefix("java.lang.")
+            .and_then(|name| name.split(['.', ':']).next())
+            .is_some_and(|name| is_language_builtin_global(language, name)),
         _ => false,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_language_builtin_global;
+    use super::{is_language_builtin_global, is_language_builtin_qualified_target};
 
     #[test]
     fn builtin_globals_are_language_scoped_and_case_sensitive() {
         assert!(is_language_builtin_global("typescript", "Promise"));
         assert!(is_language_builtin_global("python", "len"));
         assert!(is_language_builtin_global("go", "make"));
+        assert!(is_language_builtin_global("go", "string"));
+        assert!(is_language_builtin_global("rust", "Vec"));
+        assert!(is_language_builtin_global("rust", "u32"));
+        assert!(is_language_builtin_global("java", "String"));
+        assert!(is_language_builtin_global("java", "Math"));
         assert!(is_language_builtin_global("swift", "Data"));
         assert!(is_language_builtin_global("swift", "Sendable"));
 
@@ -198,5 +469,23 @@ mod tests {
         assert!(!is_language_builtin_global("python", "Promise"));
         assert!(!is_language_builtin_global("swift", "data"));
         assert!(!is_language_builtin_global("swift", "ProjectService"));
+    }
+
+    #[test]
+    fn qualified_builtin_targets_are_language_scoped() {
+        assert!(is_language_builtin_qualified_target("rust", "Vec::new"));
+        assert!(is_language_builtin_qualified_target("rust", "u32::from"));
+        assert!(is_language_builtin_qualified_target(
+            "java",
+            "java.lang.String::valueOf"
+        ));
+        assert!(!is_language_builtin_qualified_target(
+            "rust",
+            "crate::Vec::new"
+        ));
+        assert!(!is_language_builtin_qualified_target(
+            "java",
+            "example.String::valueOf"
+        ));
     }
 }

--- a/crates/compass-languages/src/evidence/build.rs
+++ b/crates/compass-languages/src/evidence/build.rs
@@ -3282,7 +3282,7 @@ impl<'source> DirectAdapterState<'source> {
         self.imported_target_for_occurrence(owner, spelling, use_start, true)
             .cloned()
             .or_else(|| self.local_target_for(owner, spelling).cloned())
-            .or_else(|| java_lang_type(spelling).map(str::to_owned))
+            .or_else(|| java_lang_type(spelling))
             .or_else(|| Some(format!("{}.{}", self.module_or_package, spelling)))
     }
 
@@ -8257,28 +8257,8 @@ fn java_primitive_type(name: &str) -> bool {
     )
 }
 
-fn java_lang_type(name: &str) -> Option<&'static str> {
-    match name {
-        "String" => Some("java.lang.String"),
-        "Object" => Some("java.lang.Object"),
-        "Class" => Some("java.lang.Class"),
-        "Integer" => Some("java.lang.Integer"),
-        "Long" => Some("java.lang.Long"),
-        "Double" => Some("java.lang.Double"),
-        "Float" => Some("java.lang.Float"),
-        "Boolean" => Some("java.lang.Boolean"),
-        "Byte" => Some("java.lang.Byte"),
-        "Short" => Some("java.lang.Short"),
-        "Character" => Some("java.lang.Character"),
-        "Number" => Some("java.lang.Number"),
-        "Appendable" => Some("java.lang.Appendable"),
-        "Throwable" => Some("java.lang.Throwable"),
-        "Exception" => Some("java.lang.Exception"),
-        "RuntimeException" => Some("java.lang.RuntimeException"),
-        "Enum" => Some("java.lang.Enum"),
-        "Record" => Some("java.lang.Record"),
-        _ => None,
-    }
+fn java_lang_type(name: &str) -> Option<String> {
+    crate::builtins::is_language_builtin_global("java", name).then(|| format!("java.lang.{name}"))
 }
 
 fn rust_container_kind(kind: &str) -> Option<&'static str> {
@@ -9096,40 +9076,7 @@ fn rust_primitive_type(raw: &str) -> bool {
 }
 
 fn rust_prelude_symbol(raw: &str) -> bool {
-    matches!(
-        raw,
-        "Box"
-            | "Clone"
-            | "Copy"
-            | "Default"
-            | "DoubleEndedIterator"
-            | "Drop"
-            | "Eq"
-            | "Err"
-            | "ExactSizeIterator"
-            | "Extend"
-            | "Fn"
-            | "FnMut"
-            | "FnOnce"
-            | "From"
-            | "Into"
-            | "Iterator"
-            | "None"
-            | "Ok"
-            | "Option"
-            | "Ord"
-            | "PartialEq"
-            | "PartialOrd"
-            | "Result"
-            | "Send"
-            | "Sized"
-            | "Some"
-            | "String"
-            | "Sync"
-            | "ToOwned"
-            | "ToString"
-            | "Vec"
-    )
+    crate::builtins::is_language_builtin_global("rust", raw)
 }
 
 fn rust_deferred_owner(raw: &str) -> bool {

--- a/crates/compass-languages/src/evidence/typescript.rs
+++ b/crates/compass-languages/src/evidence/typescript.rs
@@ -4142,11 +4142,6 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         true
     }
 
-    fn builtin_global_target(&self, scope_id: &str, name: &str) -> Option<(String, String)> {
-        self.is_unshadowed_builtin(scope_id, name)
-            .then(|| (format!("global::{name}"), "javascript.global".to_owned()))
-    }
-
     fn builtin_receiver_name(&self, scope_id: &str, object: Node<'tree>) -> Option<String> {
         match object.kind() {
             "identifier" | "type_identifier" | "jsx_identifier" => {
@@ -4166,25 +4161,20 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
         }
     }
 
-    fn builtin_member_target(
+    fn is_builtin_member_target(
         &self,
         scope_id: &str,
         object: Node<'tree>,
         property_name: &str,
-    ) -> Option<(String, String)> {
-        let receiver = self.builtin_receiver_name(scope_id, object)?;
-        let known = if object.kind() == "new_expression" {
+    ) -> bool {
+        let Some(receiver) = self.builtin_receiver_name(scope_id, object) else {
+            return false;
+        };
+        if object.kind() == "new_expression" {
             known_builtin_instance_member(&receiver, property_name)
         } else {
             known_builtin_static_member(&receiver, property_name)
-        };
-        if !known {
-            return None;
         }
-        Some((
-            format!("global::{receiver}.{property_name}"),
-            "javascript.global".to_owned(),
-        ))
     }
 
     fn builtin_type_target(&self, scope_id: &str, name: &str) -> Option<(String, String)> {
@@ -5092,39 +5082,9 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             );
             let Some(resolution) = resolution else {
                 if let Some(object) = object
-                    && let Some((target, module)) =
-                        self.builtin_member_target(scope_id, object, &property_name)
+                    && self.is_builtin_member_target(scope_id, object, &property_name)
                 {
-                    return self.add_external_resolution_candidate(
-                        property,
-                        scope_id,
-                        if construction {
-                            CandidateRelation::Constructs
-                        } else {
-                            CandidateRelation::Calls
-                        },
-                        if construction {
-                            SemanticRole::Construction
-                        } else {
-                            SemanticRole::Call
-                        },
-                        &property_name,
-                        Some(&node_text(self.source, function)),
-                        member_context,
-                        &target,
-                        &module,
-                        argument_count,
-                        argument_types,
-                        &[
-                            "function",
-                            "method",
-                            "constructor",
-                            "class",
-                            "variable",
-                            "property",
-                            "external",
-                        ],
-                    );
+                    return Ok(());
                 }
                 // A dynamic receiver, proxy, or ambiguous member is not a
                 // safe call target. Preserve its source occurrence as
@@ -5353,31 +5313,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
             &argument_types,
         );
         let Some(resolution) = resolution else {
-            if let Some((qualified_target, module)) =
-                self.builtin_global_target(scope_id, &spelling)
-            {
-                return self.add_external_resolution_candidate(
-                    target,
-                    scope_id,
-                    if construction {
-                        CandidateRelation::Constructs
-                    } else {
-                        CandidateRelation::Calls
-                    },
-                    if construction {
-                        SemanticRole::Construction
-                    } else {
-                        SemanticRole::Call
-                    },
-                    &spelling,
-                    None,
-                    call_context,
-                    &qualified_target,
-                    &module,
-                    argument_count,
-                    argument_types,
-                    &["function", "class", "external"],
-                );
+            if self.is_unshadowed_builtin(scope_id, &spelling) {
+                return Ok(());
             }
             return self.add_unresolved_candidate(
                 target,
@@ -5910,24 +5847,8 @@ impl<'source, 'tree> CandidateState<'source, 'tree> {
                 ],
             );
         }
-        if let Some((target, module)) = self.builtin_member_target(scope_id, object, &property_name)
-        {
-            return self.add_external_resolution_candidate(
-                property,
-                scope_id,
-                CandidateRelation::AccessesMember,
-                SemanticRole::MemberAccess,
-                &property_name,
-                Some(&node_text(self.source, object)),
-                "builtin_member",
-                &target,
-                &module,
-                None,
-                Vec::new(),
-                &[
-                    "property", "method", "function", "class", "variable", "external",
-                ],
-            );
+        if self.is_builtin_member_target(scope_id, object, &property_name) {
+            return Ok(());
         }
         // A local variable without a source-proven nominal type is still a
         // real member occurrence, but its target is not safe to derive from

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -17,7 +17,7 @@ mod fortran;
 pub mod frameworks;
 
 /// Version of the extraction contract consumed by graph publication.
-pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/1";
+pub const EXTRACTION_SEMANTICS_VERSION: &str = "compass.languages.extraction/2";
 mod go;
 mod groovy;
 mod html;

--- a/crates/compass-languages/src/lib.rs
+++ b/crates/compass-languages/src/lib.rs
@@ -50,7 +50,7 @@ pub use adapters::{
     AdapterProfile, AdapterRegistry, AdapterRegistryError, UniversalAdapterProfile,
 };
 #[doc(hidden)]
-pub use builtins::is_language_builtin_global;
+pub use builtins::{is_language_builtin_global, is_language_builtin_qualified_target};
 pub use evidence::{
     AdapterIdentity, BindingFact, BindingKind, CandidateRelation, DeclarationFact, EvidenceBuilder,
     EvidenceDiagnostic, EvidenceError, EvidenceErrorCode, EvidenceLimits, EvidenceRange,

--- a/crates/compass-languages/src/swift.rs
+++ b/crates/compass-languages/src/swift.rs
@@ -5,7 +5,7 @@ use crate::{RawEdgeRecord as EdgeRecord, RawNodeRecord as NodeRecord};
 use serde_json::{Map, Value, json};
 use tree_sitter::Node;
 
-use crate::{Extraction, RawCall, file_stem, make_id};
+use crate::{Extraction, RawCall, file_stem, is_language_builtin_global, make_id};
 
 pub(crate) fn extract(path: &Path, source: &[u8], root: Node<'_>) -> Extraction {
     let source_file = path.to_string_lossy().into_owned();
@@ -169,12 +169,18 @@ impl<'tree> State<'_, 'tree> {
             }
             let relation = self.classify_base(&base, kind, first);
             first = false;
+            if !self.should_publish_type_reference(&base) {
+                continue;
+            }
             let target = self.ensure_named(&base);
             self.add_edge(&id, &target, relation, line(node), None);
             if let Some(arguments) = first_descendant(user_type, "type_arguments") {
                 let mut refs = Vec::new();
                 collect_type_refs(arguments, self.source, true, &mut refs);
                 for (reference, _) in refs {
+                    if !self.should_publish_type_reference(&reference) {
+                        continue;
+                    }
                     let target = self.ensure_named(&reference);
                     if target != id {
                         self.add_edge(&id, &target, "references", line(node), Some("generic_arg"));
@@ -214,15 +220,17 @@ impl<'tree> State<'_, 'tree> {
             let mut references = Vec::new();
             collect_type_refs(annotation, self.source, false, &mut references);
             for (reference, generic) in &references {
-                let target = self.ensure_named(reference);
-                if target != class_id {
-                    self.add_edge(
-                        class_id,
-                        &target,
-                        "references",
-                        line(node),
-                        Some(if *generic { "generic_arg" } else { "field" }),
-                    );
+                if self.should_publish_type_reference(reference) {
+                    let target = self.ensure_named(reference);
+                    if target != class_id {
+                        self.add_edge(
+                            class_id,
+                            &target,
+                            "references",
+                            line(node),
+                            Some(if *generic { "generic_arg" } else { "field" }),
+                        );
+                    }
                 }
                 if property_type.is_none() && !generic {
                     property_type = Some(reference.clone());
@@ -251,6 +259,9 @@ impl<'tree> State<'_, 'tree> {
             let mut references = Vec::new();
             collect_type_refs(parameters, self.source, false, &mut references);
             for (reference, generic) in references {
+                if !self.should_publish_type_reference(&reference) {
+                    continue;
+                }
                 let target = self.ensure_named(&reference);
                 if target != enum_id {
                     self.add_edge(
@@ -326,19 +337,21 @@ impl<'tree> State<'_, 'tree> {
             }
             let mut parameter_type = None;
             for (reference, generic) in references {
-                let target = self.ensure_named(&reference);
-                if target != id {
-                    self.add_edge(
-                        &id,
-                        &target,
-                        "references",
-                        line(node),
-                        Some(if generic {
-                            "generic_arg"
-                        } else {
-                            "parameter_type"
-                        }),
-                    );
+                if self.should_publish_type_reference(&reference) {
+                    let target = self.ensure_named(&reference);
+                    if target != id {
+                        self.add_edge(
+                            &id,
+                            &target,
+                            "references",
+                            line(node),
+                            Some(if generic {
+                                "generic_arg"
+                            } else {
+                                "parameter_type"
+                            }),
+                        );
+                    }
                 }
                 if parameter_type.is_none() && !generic {
                     parameter_type = Some(reference);
@@ -357,6 +370,9 @@ impl<'tree> State<'_, 'tree> {
             let mut references = Vec::new();
             collect_type_refs(return_type, self.source, false, &mut references);
             for (reference, generic) in references {
+                if !self.should_publish_type_reference(&reference) {
+                    continue;
+                }
                 let target = self.ensure_named(&reference);
                 if target != id {
                     self.add_edge(
@@ -427,7 +443,6 @@ impl<'tree> State<'_, 'tree> {
         }
         if node.kind() == "call_expression"
             && let Some(call) = swift_call(node, self.source)
-            && !matches!(call.name.as_str(), "filter" | "print")
         {
             if let Some(target) = labels
                 .get(&call.name)
@@ -442,7 +457,7 @@ impl<'tree> State<'_, 'tree> {
                     self.add_edge(caller, target, "calls", line(node), Some("call"));
                     crate::facts::stamp_last_edge_range(&mut self.extraction, node);
                 }
-            } else {
+            } else if !is_language_builtin_global("swift", &call.name) {
                 self.extraction.raw_calls_mut().push(RawCall {
                     caller_nid: caller.to_owned(),
                     callee: call.name,
@@ -484,6 +499,12 @@ impl<'tree> State<'_, 'tree> {
             });
         }
         id
+    }
+
+    fn should_publish_type_reference(&self, name: &str) -> bool {
+        !is_language_builtin_global("swift", name)
+            || self.protocols.contains(name)
+            || self.classes.contains(name)
     }
 
     fn text(&self, node: Node<'_>) -> &str {

--- a/crates/compass-languages/tests/callable_builtin_semantics.rs
+++ b/crates/compass-languages/tests/callable_builtin_semantics.rs
@@ -194,22 +194,17 @@ fn unresolved_javascript_and_python_builtins_remain_suppressed() -> Result<(), B
                 extraction.raw_calls
             );
             if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
-                assert_eq!(
-                    evidence
-                        .candidates
-                        .iter()
-                        .filter(|candidate| candidate.constraints.allow_external)
-                        .map(|candidate| candidate.target_spelling.as_str())
-                        .collect::<HashSet<_>>(),
-                    HashSet::from(["Map", "parseInt", "Array"]),
+                assert!(
+                    evidence.candidates.iter().all(|candidate| {
+                        candidate.relation != CandidateRelation::Calls
+                            || !matches!(
+                                candidate.target_spelling.as_str(),
+                                "Map" | "parseInt" | "Array"
+                            )
+                    }),
                     "{path:?}: candidates={:?}",
                     evidence.candidates
                 );
-                assert!(evidence.candidates.iter().all(|candidate| {
-                    !candidate.constraints.allow_external
-                        || candidate.constraints.module_or_package.as_deref()
-                            == Some("javascript.global")
-                }));
             } else {
                 assert!(
                     !evidence

--- a/crates/compass-resolve/src/evidence/languages/java.rs
+++ b/crates/compass-resolve/src/evidence/languages/java.rs
@@ -3,6 +3,34 @@
 use super::super::*;
 
 impl ResolutionDb<'_> {
+    pub(in crate::evidence) fn resolve_java_same_package_builtin_collision(
+        &self,
+        candidate: &RelationshipCandidate,
+    ) -> Option<ResolutionDecision> {
+        let module = candidate.constraints.module_or_package.as_deref()?;
+        if module == "java.lang" {
+            return None;
+        }
+        let builtin = candidate
+            .constraints
+            .qualified_name
+            .as_deref()?
+            .strip_prefix("java.lang.")?;
+        let builtin_type = builtin.split("::").next()?;
+        if !compass_languages::is_language_builtin_global("java", builtin_type) {
+            return None;
+        }
+        let same_package = format!("{module}.{builtin}");
+        self.unique_decision(
+            self.indexes
+                .names
+                .by_qualified
+                .get(&(candidate.language.clone(), same_package)),
+            candidate,
+            ResolutionRule::UniqueModuleOrPackage,
+        )
+    }
+
     pub(in crate::evidence) fn unique_java_applicable_overload<'a>(
         &self,
         overloads: &[&'a DeclarationFact],

--- a/crates/compass-resolve/src/evidence/languages/policy.rs
+++ b/crates/compass-resolve/src/evidence/languages/policy.rs
@@ -54,7 +54,8 @@ impl LanguagePolicyKind {
                     candidate,
                 ))
             }
-            Self::Java | Self::Generic => None,
+            Self::Java => db.resolve_java_same_package_builtin_collision(candidate),
+            Self::Generic => None,
         }
     }
 

--- a/crates/compass-resolve/src/evidence/mod.rs
+++ b/crates/compass-resolve/src/evidence/mod.rs
@@ -8,7 +8,7 @@ use ahash::{AHashMap, AHashSet};
 use compass_languages::{
     BindingFact, CandidateRelation, DeclarationFact, EvidenceLimits, EvidenceRange,
     HierarchyConstraint, ReceiverDispatchStrategy, RelationshipCandidate, SemanticEvidenceBatch,
-    make_id, validate_evidence,
+    is_language_builtin_qualified_target, make_id, validate_evidence,
 };
 use compass_model::provenance::{NODE_PROVENANCE_ANCHOR_ATTRIBUTE, OCCURRENCE_RULE_ATTRIBUTE};
 use rayon::prelude::*;

--- a/crates/compass-resolve/src/evidence/resolve/pipeline.rs
+++ b/crates/compass-resolve/src/evidence/resolve/pipeline.rs
@@ -282,6 +282,9 @@ impl ResolutionDb<'_> {
         else {
             return StageOutcome::Continue;
         };
+        if is_language_builtin_qualified_target(context.language, &qualified_name) {
+            return StageOutcome::Decided(ResolutionDecision::Unresolved);
+        }
         StageOutcome::Decided(ResolutionDecision::QualifiedExternal {
             qualified_name,
             evidence: ResolutionEvidence {

--- a/crates/compass-resolve/src/lib.rs
+++ b/crates/compass-resolve/src/lib.rs
@@ -5550,6 +5550,7 @@ fn language_name_from_source(source: &str) -> Option<&'static str> {
         "go" => Some("go"),
         "rs" => Some("rust"),
         "java" => Some("java"),
+        "swift" => Some("swift"),
         _ => None,
     }
 }
@@ -5978,6 +5979,33 @@ mod tests {
             candidate.source == "js-caller"
                 && candidate.target == "js-target"
                 && relation(candidate) == "calls"
+        }));
+    }
+
+    #[test]
+    fn swift_builtin_cross_file_resolution_is_filtered_but_same_file_shadowing_is_kept() {
+        let mut cross_file = Extraction {
+            nodes: vec![
+                node("caller", "caller()", "Sources/Use.swift", "function"),
+                node("data", "Data", "Sources/Model.swift", "constructor"),
+            ],
+            raw_calls: Some(vec![raw("caller", "Data", "Sources/Use.swift")]),
+            ..Extraction::default()
+        };
+        resolve_cross_file_calls(&mut cross_file, &HashMap::new());
+        assert!(cross_file.edges.is_empty());
+
+        let mut same_file = Extraction {
+            nodes: vec![
+                node("caller", "caller()", "Sources/Use.swift", "function"),
+                node("data", "Data", "Sources/Use.swift", "constructor"),
+            ],
+            raw_calls: Some(vec![raw("caller", "Data", "Sources/Use.swift")]),
+            ..Extraction::default()
+        };
+        resolve_cross_file_calls(&mut same_file, &HashMap::new());
+        assert!(same_file.edges.iter().any(|edge| {
+            edge.source == "caller" && edge.target == "data" && relation(edge) == "calls"
         }));
     }
 

--- a/crates/compass-resolve/tests/builtin_resolution.rs
+++ b/crates/compass-resolve/tests/builtin_resolution.rs
@@ -92,3 +92,133 @@ fn deferred_resolution_does_not_cross_language_families_for_builtin_spellings()
     );
     Ok(())
 }
+
+#[test]
+fn typescript_builtin_calls_and_members_do_not_publish_external_hubs() -> Result<(), Box<dyn Error>>
+{
+    let path = Path::new("src/builtins.ts");
+    let source = br#"
+export function normalize(input: unknown) {
+    const text = String(input);
+    const count = Number(input);
+    console.log(text);
+    Promise.resolve(count);
+    return new Date();
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let evidence = extracted
+        .semantic_evidence
+        .as_ref()
+        .ok_or("missing TypeScript semantic evidence")?;
+
+    assert!(evidence.candidates.iter().all(|candidate| {
+        !matches!(
+            candidate.relation,
+            compass_languages::CandidateRelation::Calls
+                | compass_languages::CandidateRelation::Constructs
+                | compass_languages::CandidateRelation::AccessesMember
+        ) || !matches!(
+            candidate.target_spelling.as_str(),
+            "String" | "Number" | "log" | "resolve" | "Date"
+        )
+    }));
+
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    assert!(
+        call_edges(&resolved).is_empty(),
+        "edges={:?}",
+        resolved.edges
+    );
+    assert!(resolved.nodes.iter().all(|node| {
+        node.attributes
+            .get("module")
+            .and_then(serde_json::Value::as_str)
+            != Some("javascript.global")
+    }));
+    Ok(())
+}
+
+#[test]
+fn typescript_source_shadowing_of_builtin_name_remains_resolvable() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("src/caller.ts");
+    let source = b"export function String(value: number) { return value; }\n\
+                   export function caller() { return String(7); }\n";
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+    let target = resolved
+        .nodes
+        .iter()
+        .find(|node| {
+            node.label() == "String()"
+                && node.string("source_file").replace('\\', "/") == "src/caller.ts"
+        })
+        .ok_or("missing source-defined String")?;
+
+    assert!(
+        call_edges(&resolved)
+            .iter()
+            .any(|edge| edge.target == target.id),
+        "nodes={:?} edges={:?}",
+        resolved.nodes,
+        resolved.edges
+    );
+    assert!(resolved.nodes.iter().all(|node| {
+        node.attributes
+            .get("module")
+            .and_then(serde_json::Value::as_str)
+            != Some("javascript.global")
+    }));
+    Ok(())
+}
+
+#[test]
+fn swift_builtin_globals_are_dropped_but_same_file_shadowing_is_kept() -> Result<(), Box<dyn Error>>
+{
+    let path = Path::new("Sources/Calls.swift");
+    let source = br#"
+struct Payload: Codable, Sendable {
+    let data: Data
+}
+func print() {}
+func projectCall() {}
+func run(identifier: UUID) {
+    print()
+    projectCall()
+    _ = Data()
+    _ = UUID()
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let raw_names = extracted
+        .raw_calls
+        .iter()
+        .flatten()
+        .map(|call| call.callee.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!raw_names.contains(&"Data"));
+    assert!(!raw_names.contains(&"UUID"));
+    assert!(
+        extracted
+            .nodes
+            .iter()
+            .all(|node| { !matches!(node.label(), "Codable" | "Sendable" | "Data" | "UUID") })
+    );
+    let call_targets = call_edges(&extracted)
+        .into_iter()
+        .filter_map(|edge| extracted.nodes.iter().find(|node| node.id == edge.target))
+        .map(compass_languages::RawNodeRecord::label)
+        .collect::<Vec<_>>();
+    assert!(call_targets.contains(&"print()"));
+    assert!(call_targets.contains(&"projectCall()"));
+    Ok(())
+}

--- a/crates/compass-resolve/tests/builtin_resolution.rs
+++ b/crates/compass-resolve/tests/builtin_resolution.rs
@@ -14,6 +14,13 @@ fn call_edges(
         .collect()
 }
 
+fn is_external_node(node: &compass_languages::RawNodeRecord) -> bool {
+    node.attributes
+        .get("external")
+        .and_then(serde_json::Value::as_bool)
+        == Some(true)
+}
+
 #[test]
 fn deferred_java_builtin_collision_keeps_repeated_exact_call_sites() -> Result<(), Box<dyn Error>> {
     let path = Path::new("src/Collisions.java");
@@ -220,5 +227,331 @@ func run(identifier: UUID) {
         .collect::<Vec<_>>();
     assert!(call_targets.contains(&"print()"));
     assert!(call_targets.contains(&"projectCall()"));
+    Ok(())
+}
+
+#[test]
+fn rust_prelude_and_primitive_calls_do_not_publish_external_hubs() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("src/builtins.rs");
+    let source = br#"
+fn normalize(value: i64) {
+    let _ = Vec::new();
+    let _ = String::from("value");
+    let _ = Box::new(value);
+    let _ = u32::try_from(value);
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+
+    assert!(
+        call_edges(&resolved).is_empty(),
+        "edges={:?}",
+        resolved.edges
+    );
+    assert!(resolved.nodes.iter().all(|node| {
+        !is_external_node(node)
+            || !["Vec::new", "String::from", "Box::new", "u32::try_from"]
+                .contains(&node.string("qualified_name").as_str())
+    }));
+    Ok(())
+}
+
+#[test]
+fn rust_source_shadowing_of_prelude_name_remains_resolvable() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("src/shadowed.rs");
+    let source = br#"
+struct Vec;
+impl Vec {
+    fn new() -> Self { Vec }
+}
+fn caller() { let _ = Vec::new(); }
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+
+    assert!(
+        call_edges(&resolved).iter().any(|edge| {
+            resolved.nodes.iter().any(|node| {
+                node.id == edge.target
+                    && node.string("qualified_name").ends_with("::Vec::new")
+                    && node.string("source_file").replace('\\', "/") == "src/shadowed.rs"
+            })
+        }),
+        "nodes={:?} edges={:?}",
+        resolved.nodes,
+        resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn rust_imported_shadowing_of_prelude_name_remains_resolvable() -> Result<(), Box<dyn Error>> {
+    let type_path = Path::new("src/names.rs");
+    let type_source = br#"
+pub struct Vec;
+impl Vec {
+    pub fn new() -> Self { Vec }
+}
+"#;
+    let caller_path = Path::new("src/lib.rs");
+    let caller_source = br#"
+mod names;
+use crate::names::Vec;
+pub fn caller() { let _ = Vec::new(); }
+"#;
+    let mut engine = Engine::default();
+    let type_extraction = engine.extract_source(type_path, type_source)?;
+    let caller_extraction = engine.extract_source(caller_path, caller_source)?;
+    let sources = HashMap::from([
+        (
+            type_path.to_string_lossy().into_owned(),
+            String::from_utf8(type_source.to_vec())?,
+        ),
+        (
+            caller_path.to_string_lossy().into_owned(),
+            String::from_utf8(caller_source.to_vec())?,
+        ),
+    ]);
+    let resolved = compass_resolve::resolve(&[type_extraction, caller_extraction], &sources);
+
+    assert!(
+        call_edges(&resolved).iter().any(|edge| {
+            resolved.nodes.iter().any(|node| {
+                node.id == edge.target
+                    && node.string("qualified_name").ends_with("::names::Vec::new")
+                    && node.string("source_file").replace('\\', "/") == "src/names.rs"
+            })
+        }),
+        "nodes={:?} edges={:?}",
+        resolved.nodes,
+        resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn java_lang_types_calls_and_constructions_do_not_publish_external_hubs()
+-> Result<(), Box<dyn Error>> {
+    let path = Path::new("src/Builtins.java");
+    let source = br#"
+class Builtins {
+    void normalize(Object value) {
+        String.valueOf(value);
+        Math.max(1, 2);
+        new String();
+    }
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+
+    assert!(
+        resolved.nodes.iter().all(|node| {
+            !is_external_node(node) || !node.string("qualified_name").starts_with("java.lang.")
+        }),
+        "nodes={:?}",
+        resolved.nodes
+    );
+    assert!(
+        call_edges(&resolved).is_empty(),
+        "edges={:?}",
+        resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn java_source_shadowing_of_java_lang_name_remains_resolvable() -> Result<(), Box<dyn Error>> {
+    let path = Path::new("src/Shadowed.java");
+    let source = br#"
+class String {
+    static String valueOf(Object value) { return new String(); }
+}
+class Caller {
+    void run() { String.valueOf(null); }
+}
+"#;
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+
+    assert!(
+        call_edges(&resolved).iter().any(|edge| {
+            resolved.nodes.iter().any(|node| {
+                node.id == edge.target
+                    && node.string("qualified_name").ends_with(".String::valueOf")
+                    && node.string("source_file").replace('\\', "/") == "src/Shadowed.java"
+            })
+        }),
+        "nodes={:?} edges={:?}",
+        resolved.nodes,
+        resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn java_same_package_shadowing_of_java_lang_name_remains_resolvable() -> Result<(), Box<dyn Error>>
+{
+    let type_path = Path::new("src/example/String.java");
+    let type_source = br#"
+package example;
+class String {
+    static String valueOf(Object value) { return new String(); }
+}
+"#;
+    let caller_path = Path::new("src/example/Caller.java");
+    let caller_source = br#"
+package example;
+class Caller {
+    void run() { String.valueOf(null); }
+}
+"#;
+    let mut engine = Engine::default();
+    let type_extraction = engine.extract_source(type_path, type_source)?;
+    let caller_extraction = engine.extract_source(caller_path, caller_source)?;
+    let sources = HashMap::from([
+        (
+            type_path.to_string_lossy().into_owned(),
+            String::from_utf8(type_source.to_vec())?,
+        ),
+        (
+            caller_path.to_string_lossy().into_owned(),
+            String::from_utf8(caller_source.to_vec())?,
+        ),
+    ]);
+    let resolved = compass_resolve::resolve(&[type_extraction, caller_extraction], &sources);
+
+    assert!(
+        call_edges(&resolved).iter().any(|edge| {
+            resolved.nodes.iter().any(|node| {
+                node.id == edge.target
+                    && node.string("qualified_name") == "example.String::valueOf"
+                    && node.string("source_file").replace('\\', "/") == "src/example/String.java"
+            })
+        }),
+        "nodes={:?} edges={:?}",
+        resolved.nodes,
+        resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn python_builtins_are_suppressed_but_source_shadowing_is_resolved() -> Result<(), Box<dyn Error>> {
+    let builtin_path = Path::new("src/builtins.py");
+    let builtin_source = b"def caller(values):\n    return len(list(map(str, values)))\n";
+    let shadow_path = Path::new("src/shadowed.py");
+    let shadow_source = b"def len(value):\n    return 7\n\ndef caller():\n    return len([])\n";
+    let mut engine = Engine::default();
+    let builtin = engine.extract_source(builtin_path, builtin_source)?;
+    let shadow = engine.extract_source(shadow_path, shadow_source)?;
+    let sources = HashMap::from([
+        (
+            builtin_path.to_string_lossy().into_owned(),
+            String::from_utf8(builtin_source.to_vec())?,
+        ),
+        (
+            shadow_path.to_string_lossy().into_owned(),
+            String::from_utf8(shadow_source.to_vec())?,
+        ),
+    ]);
+
+    let builtin_resolved = compass_resolve::resolve(&[builtin], &sources);
+    assert!(call_edges(&builtin_resolved).is_empty());
+    let shadow_resolved = compass_resolve::resolve(&[shadow], &sources);
+    assert!(
+        call_edges(&shadow_resolved).iter().any(|edge| {
+            shadow_resolved
+                .nodes
+                .iter()
+                .any(|node| node.id == edge.target && node.label() == "len()")
+        }),
+        "nodes={:?} edges={:?}",
+        shadow_resolved.nodes,
+        shadow_resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn go_predeclared_calls_are_suppressed_but_source_shadowing_is_resolved()
+-> Result<(), Box<dyn Error>> {
+    let builtin_path = Path::new("src/builtins.go");
+    let builtin_source =
+        b"package sample\nfunc caller(values []int) int { return len(append(values, 1)) }\n";
+    let shadow_path = Path::new("src/shadowed.go");
+    let shadow_source = b"package sample\nfunc len(values []int) int { return 7 }\nfunc caller() int { return len(nil) }\n";
+    let mut engine = Engine::default();
+    let builtin = engine.extract_source(builtin_path, builtin_source)?;
+    let shadow = engine.extract_source(shadow_path, shadow_source)?;
+    let sources = HashMap::from([
+        (
+            builtin_path.to_string_lossy().into_owned(),
+            String::from_utf8(builtin_source.to_vec())?,
+        ),
+        (
+            shadow_path.to_string_lossy().into_owned(),
+            String::from_utf8(shadow_source.to_vec())?,
+        ),
+    ]);
+
+    let builtin_resolved = compass_resolve::resolve(&[builtin], &sources);
+    assert!(call_edges(&builtin_resolved).is_empty());
+    let shadow_resolved = compass_resolve::resolve(&[shadow], &sources);
+    assert!(
+        call_edges(&shadow_resolved).iter().any(|edge| {
+            shadow_resolved
+                .nodes
+                .iter()
+                .any(|node| node.id == edge.target && node.label() == "len()")
+        }),
+        "nodes={:?} edges={:?}",
+        shadow_resolved.nodes,
+        shadow_resolved.edges
+    );
+    Ok(())
+}
+
+#[test]
+fn javascript_expanded_builtin_globals_do_not_publish_external_hubs() -> Result<(), Box<dyn Error>>
+{
+    let path = Path::new("src/builtins.js");
+    let source =
+        b"export function run(value) { Uint8Array(value); setTimeout(run, 0); fetch(value); }\n";
+    let extracted = Engine::default().extract_source(path, source)?;
+    let sources = HashMap::from([(
+        path.to_string_lossy().into_owned(),
+        String::from_utf8(source.to_vec())?,
+    )]);
+    let resolved = compass_resolve::resolve(&[extracted], &sources);
+
+    assert!(
+        call_edges(&resolved).is_empty(),
+        "edges={:?}",
+        resolved.edges
+    );
+    assert!(resolved.nodes.iter().all(|node| {
+        node.attributes
+            .get("module")
+            .and_then(serde_json::Value::as_str)
+            != Some("javascript.global")
+    }));
     Ok(())
 }

--- a/docs/concepts/graph-model.md
+++ b/docs/concepts/graph-model.md
@@ -280,8 +280,11 @@ LeafParser --USES--> Token     AppContext
 
 A god node is highly connected relative to the graph. It can reveal a critical
 hub or a design smell, but it can also be a legitimate shared abstraction.
-Compass's report filters some common built-in noise; it does not make a final
-architectural judgment.
+Compass excludes known, unshadowed language globals from call-target
+publication and filters additional common noise from reports. A source-proven
+declaration or explicit binding with the same spelling still takes precedence;
+Compass does not make a final architectural judgment about the hubs that
+remain.
 
 ## Hyperedges
 

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -211,7 +211,8 @@ A god node has unusually high degree. It may be:
 - a noisy or overly broad extraction target.
 
 Degree identifies connectivity, not quality or business importance. Compass
-filters common built-in noise in reports, but interpretation still matters.
+does not publish calls to known, unshadowed language globals and filters
+additional common built-in noise in reports, but interpretation still matters.
 
 ## Stage 5: atomic publication
 

--- a/docs/concepts/how-it-works.md
+++ b/docs/concepts/how-it-works.md
@@ -211,8 +211,11 @@ A god node has unusually high degree. It may be:
 - a noisy or overly broad extraction target.
 
 Degree identifies connectivity, not quality or business importance. Compass
-does not publish calls to known, unshadowed language globals and filters
-additional common built-in noise in reports, but interpretation still matters.
+does not publish calls to known, unshadowed JavaScript/TypeScript globals,
+Python built-ins, Go predeclared identifiers, Rust prelude symbols, Java
+`java.lang` types, or Swift standard-library/Foundation globals. Source and
+explicit import resolution take precedence over this filter. Reports also
+filter additional common built-in noise, but interpretation still matters.
 
 ## Stage 5: atomic publication
 


### PR DESCRIPTION
## Summary

- centralize language-scoped built-in filtering for JavaScript/TypeScript, Python, Go, Rust, Java, and Swift
- suppress external graph hubs for browser/ECMAScript globals, Python built-ins and exceptions, Go predeclared functions/types, Rust prelude and primitive receivers, Java `java.lang` types, and Swift standard-library/Foundation symbols
- preserve source-defined collisions through same-file, lexical, explicit-import, Rust module, and Java same-package resolution

## Why

AST call extraction can treat constructors, coercions, standard-library globals, and common built-in members as repository call targets. Publishing those targets creates high-degree nodes such as `String`, `Promise.resolve`, `Vec::new`, `Math.max`, `len`, `make`, `Data`, and `Codable` that reduce the information density of code graphs.

The filter remains language-scoped. Universal resolution attempts source declarations, imports, ownership, lexical matches, and package/module matches before suppressing a built-in external fallback, so real project declarations with the same spelling still win.

## Impact

This changes graph topology without changing the graph schema. Extraction semantics advance to v2 so existing cached facts rebuild automatically.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compass-languages --lib --locked`
- `cargo test -p compass-languages --test callable_builtin_semantics --locked`
- `cargo test -p compass-resolve --lib --locked`
- `cargo test -p compass-resolve --test builtin_resolution --locked` (14 language/noise/shadowing tests)
- `cargo clippy -p compass-languages -p compass-resolve --lib --locked -- -D warnings`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `./scripts/qualify_code_graph_v1.sh --fixtures-only` (57 languages; clean/warm/rebuild/alternate-checkout byte equality)
- `sh scripts/check_product_boundary.sh`
