### PR TITLE
Hard-cut review profiles to the current engine contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Unreleased
 
 - Allow `compass review` on `0.3.x` to rebuild comparable realizations from
-  repository profiles and preferred realizations persisted by Compass `0.1.10`
-  or later, including when both compared revisions are already materialized.
-  The upgrade preserves matching user-selected options, refreshes engine-owned
-  fingerprint fields, and keeps original historical realizations immutable.
+  any older repository profile or preferred realization whose persisted shape
+  remains reconstructable, including when both compared revisions are already
+  materialized. The upgrade preserves matching user-selected options, refreshes
+  engine-owned fingerprint fields, and keeps original historical realizations
+  immutable.
 
 ## 0.3.13 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased
 
 - Allow `compass review` on `0.3.x` to rebuild comparable realizations from
-  build profiles persisted by Compass `0.1.10` or later. The upgrade preserves
-  user-selected options, refreshes engine-owned fingerprint fields, and keeps
-  the original historical realization immutable.
+  repository profiles and preferred realizations persisted by Compass `0.1.10`
+  or later, including when both compared revisions are already materialized.
+  The upgrade preserves matching user-selected options, refreshes engine-owned
+  fingerprint fields, and keeps original historical realizations immutable.
 
 ## 0.3.13 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Allow `compass review` on `0.3.x` to rebuild comparable realizations from
+  build profiles persisted by Compass `0.1.10` or later. The upgrade preserves
+  user-selected options, refreshes engine-owned fingerprint fields, and keeps
+  the original historical realization immutable.
+
 ## 0.3.13 - 2026-08-14
 
 - Make `compass review` recover automatically when one compared revision still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 - Allow `compass review` on `0.3.x` to rebuild comparable realizations from
-  any older repository profile or preferred realization whose persisted shape
-  remains reconstructable, including when both compared revisions are already
-  materialized. The upgrade preserves matching user-selected options, refreshes
-  engine-owned fingerprint fields, and keeps original historical realizations
-  immutable.
+  any repository profile or preferred realization whose persisted user-option
+  shape remains reconstructable, including when both compared revisions are
+  already materialized. Rebuilding does not order or allowlist Compass release
+  numbers: it preserves matching user-selected options, replaces engine-owned
+  fingerprint fields, and keeps original historical realizations immutable.
 
 ## 0.3.13 - 2026-08-14
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -330,13 +330,15 @@ integer rubric is version 1; each deterministic gate has its own rule version.
 Presentation formats and the reusable GitHub Action consume this report and do
 not redefine its semantics.
 
-When only one side of a review has a preferred realization whose build profile
-was persisted by Compass `0.1.10` or later, the `0.3.x` line advances
+When either side of a review has a preferred realization or repository history
+profile persisted by Compass `0.1.10` or later, the `0.3.x` line advances
 engine-owned profile fields and materializes both revisions with the running
-binary. User-selected build options are preserved, while the older realization
-remains immutable and queryable. Profiles older than `0.1.10`, newer than the
-running binary, or targeting a future release line still fail explicitly rather
-than being guessed or downgraded.
+binary. This also applies when both revisions already have preferred
+realizations. Reconciliation proceeds only when their user-selected options are
+identical after engine advancement. Older realizations remain immutable and
+queryable. Profiles older than `0.1.10`, newer than the running binary,
+targeting a future release line, or retaining different user options still fail
+explicitly rather than being guessed or downgraded.
 
 Dependency findings in `compass.semantic_diff.report/1` may now carry the
 optional strict `dependency_topology` object. It records source/target community

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -331,16 +331,16 @@ Presentation formats and the reusable GitHub Action consume this report and do
 not redefine its semantics.
 
 When either side of a review has a preferred realization or repository history
-profile from an older Compass release, the `0.3.x` line advances engine-owned
-profile fields and validates whether the persisted profile shape can still be
-reconstructed before materializing both revisions with the running binary.
-This also applies when both revisions already have preferred realizations.
-Reconciliation proceeds only when their user-selected options are identical
-after engine advancement. Older realizations remain immutable and queryable.
-Malformed or unsupported profile shapes, versions newer than the running
-binary, and different user options still fail explicitly rather than being
-guessed or downgraded. Future running minor lines must re-qualify this migration
-before inheriting it.
+profile with noncurrent engine fields, Compass replaces every engine-owned
+field with the running contract and then validates the complete reconstructed
+profile before materializing both revisions. The persisted `compass_version`
+is provenance, not a compatibility gate: review does not parse, order, or
+allowlist release numbers. This also applies when both revisions already have
+preferred realizations. Reconciliation proceeds only when their user-selected
+options are identical after reconstruction. Historical realizations remain
+immutable and queryable. Malformed or unsupported profile shapes and different
+user options fail explicitly. When the supported profile shape changes, Compass
+uses a hard cutover rather than accumulating release-specific migrations.
 
 Dependency findings in `compass.semantic_diff.report/1` may now carry the
 optional strict `dependency_topology` object. It records source/target community

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -331,14 +331,16 @@ Presentation formats and the reusable GitHub Action consume this report and do
 not redefine its semantics.
 
 When either side of a review has a preferred realization or repository history
-profile persisted by Compass `0.1.10` or later, the `0.3.x` line advances
-engine-owned profile fields and materializes both revisions with the running
-binary. This also applies when both revisions already have preferred
-realizations. Reconciliation proceeds only when their user-selected options are
-identical after engine advancement. Older realizations remain immutable and
-queryable. Profiles older than `0.1.10`, newer than the running binary,
-targeting a future release line, or retaining different user options still fail
-explicitly rather than being guessed or downgraded.
+profile from an older Compass release, the `0.3.x` line advances engine-owned
+profile fields and validates whether the persisted profile shape can still be
+reconstructed before materializing both revisions with the running binary.
+This also applies when both revisions already have preferred realizations.
+Reconciliation proceeds only when their user-selected options are identical
+after engine advancement. Older realizations remain immutable and queryable.
+Malformed or unsupported profile shapes, versions newer than the running
+binary, and different user options still fail explicitly rather than being
+guessed or downgraded. Future running minor lines must re-qualify this migration
+before inheriting it.
 
 Dependency findings in `compass.semantic_diff.report/1` may now carry the
 optional strict `dependency_topology` object. It records source/target community

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -330,11 +330,13 @@ integer rubric is version 1; each deterministic gate has its own rule version.
 Presentation formats and the reusable GitHub Action consume this report and do
 not redefine its semantics.
 
-When only one side of a review has a preferred realization from an older patch
-release in the same supported `0.3.x` line, Compass advances engine-owned
-profile fields and materializes both revisions with the running binary. The
-older realization remains immutable and queryable. Newer profiles and profiles
-from another release line still fail explicitly rather than being downgraded.
+When only one side of a review has a preferred realization whose build profile
+was persisted by Compass `0.1.10` or later, the `0.3.x` line advances
+engine-owned profile fields and materializes both revisions with the running
+binary. User-selected build options are preserved, while the older realization
+remains immutable and queryable. Profiles older than `0.1.10`, newer than the
+running binary, or targeting a future release line still fail explicitly rather
+than being guessed or downgraded.
 
 Dependency findings in `compass.semantic_diff.report/1` may now carry the
 optional strict `dependency_topology` object. It records source/target community

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -15,10 +15,9 @@ use compass_history::{
     HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
 };
 
-// Compass 0.1.10 is the earliest released build-profile shape qualified for
-// current-option reconstruction. Pin the target minor as well: before 1.0, a
-// future minor must re-evaluate this migration instead of inheriting it.
-const COMPATIBLE_PROFILE_UPGRADE_FLOOR: semver::Version = semver::Version::new(0, 1, 10);
+// Pin the target minor: before 1.0, a future minor must re-evaluate this
+// migration instead of inheriting it. Persisted profiles are admitted by their
+// reconstructable shape, not by an allowlisted historical Compass release.
 const COMPATIBLE_PROFILE_TARGET_MAJOR: u64 = 0;
 const COMPATIBLE_PROFILE_TARGET_MINOR: u64 = 3;
 
@@ -307,7 +306,6 @@ impl HistoryBuildOptions {
 fn is_compatible_profile_upgrade(persisted: &semver::Version, current: &semver::Version) -> bool {
     current.major == COMPATIBLE_PROFILE_TARGET_MAJOR
         && current.minor == COMPATIBLE_PROFILE_TARGET_MINOR
-        && persisted >= &COMPATIBLE_PROFILE_UPGRADE_FLOOR
         && persisted < current
 }
 
@@ -1634,10 +1632,10 @@ mod tests {
     }
 
     #[test]
-    fn compatible_0_1_10_profiles_advance_engine_fields_and_preserve_user_options()
+    fn reconstructable_older_profiles_advance_engine_fields_without_a_release_floor()
     -> Result<(), Box<dyn std::error::Error>> {
         let mut profile = HistoryBuildOptions::defaults()?.profile();
-        profile.insert("compass_version", "0.1.10")?;
+        profile.insert("compass_version", "0.0.0")?;
         profile.insert("pipeline_version", "compass-core/older")?;
         profile.insert("resolution", "2")?;
 
@@ -1650,9 +1648,23 @@ mod tests {
         assert_eq!(upgraded.value("pipeline_version"), Some("compass-core/v1"));
         assert_eq!(upgraded.value("resolution"), Some("2"));
 
-        let below_floor = semver::Version::new(0, 1, 9);
+        let mut unsupported = HistoryBuildOptions::defaults()?.profile();
+        unsupported.insert("compass_version", "0.0.0")?;
+        unsupported.insert("future_option", "enabled")?;
+        let error = HistoryBuildOptions::from_compatible_profile(unsupported)
+            .err()
+            .ok_or("unsupported older profile unexpectedly accepted")?;
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported persisted build-profile field")
+        );
+
         let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))?;
-        assert!(!is_compatible_profile_upgrade(&below_floor, &current));
+        assert!(is_compatible_profile_upgrade(
+            &semver::Version::new(0, 0, 0),
+            &current
+        ));
         assert!(!is_compatible_profile_upgrade(&current, &current));
         assert!(!is_compatible_profile_upgrade(
             &semver::Version::new(1, 0, 0),

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -15,6 +15,13 @@ use compass_history::{
     HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
 };
 
+// Compass 0.1.10 is the earliest released build-profile shape qualified for
+// current-option reconstruction. Pin the target minor as well: before 1.0, a
+// future minor must re-evaluate this migration instead of inheriting it.
+const COMPATIBLE_PROFILE_UPGRADE_FLOOR: semver::Version = semver::Version::new(0, 1, 10);
+const COMPATIBLE_PROFILE_TARGET_MAJOR: u64 = 0;
+const COMPATIBLE_PROFILE_TARGET_MINOR: u64 = 3;
+
 #[derive(Clone, Debug)]
 pub(crate) struct HistoryBuildOptions {
     profile: BuildProfile,
@@ -128,10 +135,7 @@ impl HistoryBuildOptions {
                 "running compass_version is not a semantic version".to_owned(),
             )
         })?;
-        if persisted.major != current.major
-            || persisted.minor != current.minor
-            || persisted >= current
-        {
+        if !is_compatible_profile_upgrade(&persisted, &current) {
             return Err(HistoryError::InvalidFingerprint(format!(
                 "persisted compass_version {persisted} cannot be upgraded by {}",
                 env!("CARGO_PKG_VERSION")
@@ -298,6 +302,13 @@ impl HistoryBuildOptions {
             code_only: values.code_only,
         })
     }
+}
+
+fn is_compatible_profile_upgrade(persisted: &semver::Version, current: &semver::Version) -> bool {
+    current.major == COMPATIBLE_PROFILE_TARGET_MAJOR
+        && current.minor == COMPATIBLE_PROFILE_TARGET_MINOR
+        && persisted >= &COMPATIBLE_PROFILE_UPGRADE_FLOOR
+        && persisted < current
 }
 
 fn insert_current_engine_profile(
@@ -1619,6 +1630,34 @@ mod tests {
             .err()
             .ok_or("future profile unexpectedly accepted")?;
         assert!(error.to_string().contains("cannot be upgraded"));
+        Ok(())
+    }
+
+    #[test]
+    fn compatible_0_1_10_profiles_advance_engine_fields_and_preserve_user_options()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut profile = HistoryBuildOptions::defaults()?.profile();
+        profile.insert("compass_version", "0.1.10")?;
+        profile.insert("pipeline_version", "compass-core/older")?;
+        profile.insert("resolution", "2")?;
+
+        let upgraded = HistoryBuildOptions::from_compatible_profile(profile)?.profile();
+
+        assert_eq!(
+            upgraded.value("compass_version"),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(upgraded.value("pipeline_version"), Some("compass-core/v1"));
+        assert_eq!(upgraded.value("resolution"), Some("2"));
+
+        let below_floor = semver::Version::new(0, 1, 9);
+        let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))?;
+        assert!(!is_compatible_profile_upgrade(&below_floor, &current));
+        assert!(!is_compatible_profile_upgrade(&current, &current));
+        assert!(!is_compatible_profile_upgrade(
+            &semver::Version::new(1, 0, 0),
+            &current
+        ));
         Ok(())
     }
 

--- a/crates/compass-cli/src/history_build.rs
+++ b/crates/compass-cli/src/history_build.rs
@@ -15,12 +15,6 @@ use compass_history::{
     HISTORY_GRAPH_SCHEMA, HistoryError, MAX_DIAGNOSTIC_BYTES,
 };
 
-// Pin the target minor: before 1.0, a future minor must re-evaluate this
-// migration instead of inheriting it. Persisted profiles are admitted by their
-// reconstructable shape, not by an allowlisted historical Compass release.
-const COMPATIBLE_PROFILE_TARGET_MAJOR: u64 = 0;
-const COMPATIBLE_PROFILE_TARGET_MINOR: u64 = 3;
-
 #[derive(Clone, Debug)]
 pub(crate) struct HistoryBuildOptions {
     profile: BuildProfile,
@@ -115,30 +109,11 @@ impl HistoryBuildOptions {
         })
     }
 
-    pub(crate) fn from_compatible_profile(mut profile: BuildProfile) -> Result<Self, HistoryError> {
-        let persisted = profile.value("compass_version").ok_or_else(|| {
-            HistoryError::InvalidFingerprint(
+    pub(crate) fn from_rebuild_profile(mut profile: BuildProfile) -> Result<Self, HistoryError> {
+        if profile.value("compass_version").is_none() {
+            return Err(HistoryError::InvalidFingerprint(
                 "persisted compass_version is missing from build profile".to_owned(),
-            )
-        })?;
-        if persisted == env!("CARGO_PKG_VERSION") {
-            return Self::from_profile(profile);
-        }
-        let persisted = semver::Version::parse(persisted).map_err(|_| {
-            HistoryError::InvalidFingerprint(
-                "persisted compass_version is not a semantic version".to_owned(),
-            )
-        })?;
-        let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).map_err(|_| {
-            HistoryError::InvalidFingerprint(
-                "running compass_version is not a semantic version".to_owned(),
-            )
-        })?;
-        if !is_compatible_profile_upgrade(&persisted, &current) {
-            return Err(HistoryError::InvalidFingerprint(format!(
-                "persisted compass_version {persisted} cannot be upgraded by {}",
-                env!("CARGO_PKG_VERSION")
-            )));
+            ));
         }
         let deep = match profile.value("semantic_mode") {
             Some("standard") => false,
@@ -301,12 +276,6 @@ impl HistoryBuildOptions {
             code_only: values.code_only,
         })
     }
-}
-
-fn is_compatible_profile_upgrade(persisted: &semver::Version, current: &semver::Version) -> bool {
-    current.major == COMPATIBLE_PROFILE_TARGET_MAJOR
-        && current.minor == COMPATIBLE_PROFILE_TARGET_MINOR
-        && persisted < current
 }
 
 fn insert_current_engine_profile(
@@ -1598,78 +1567,39 @@ mod tests {
     }
 
     #[test]
-    fn compatible_patch_profiles_advance_engine_fields_and_preserve_user_options()
+    fn rebuild_profiles_replace_engine_identity_without_release_comparison()
     -> Result<(), Box<dyn std::error::Error>> {
-        let mut profile = HistoryBuildOptions::defaults()?.profile();
-        let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))?;
-        let mut previous = current.clone();
-        previous.patch = previous
-            .patch
-            .checked_sub(1)
-            .ok_or("patch release fixture")?;
-        profile.insert("compass_version", &previous.to_string())?;
-        profile.insert("pipeline_version", "compass-core/older")?;
-        profile.insert("resolution", "2")?;
+        for persisted_engine in ["historical-engine", "999.0.0", env!("CARGO_PKG_VERSION")] {
+            let mut profile = HistoryBuildOptions::defaults()?.profile();
+            profile.insert("compass_version", persisted_engine)?;
+            profile.insert("pipeline_version", "compass-core/other")?;
+            profile.insert("resolution", "2")?;
 
-        let upgraded = HistoryBuildOptions::from_compatible_profile(profile)?.profile();
+            let rebuilt = HistoryBuildOptions::from_rebuild_profile(profile)?.profile();
 
-        assert_eq!(
-            upgraded.value("compass_version"),
-            Some(env!("CARGO_PKG_VERSION"))
-        );
-        assert_eq!(upgraded.value("pipeline_version"), Some("compass-core/v1"));
-        assert_eq!(upgraded.value("resolution"), Some("2"));
-
-        let mut future_profile = upgraded;
-        let mut future = current;
-        future.patch = future.patch.saturating_add(1);
-        future_profile.insert("compass_version", &future.to_string())?;
-        let error = HistoryBuildOptions::from_compatible_profile(future_profile)
-            .err()
-            .ok_or("future profile unexpectedly accepted")?;
-        assert!(error.to_string().contains("cannot be upgraded"));
+            assert_eq!(
+                rebuilt.value("compass_version"),
+                Some(env!("CARGO_PKG_VERSION"))
+            );
+            assert_eq!(rebuilt.value("pipeline_version"), Some("compass-core/v1"));
+            assert_eq!(rebuilt.value("resolution"), Some("2"));
+        }
         Ok(())
     }
 
     #[test]
-    fn reconstructable_older_profiles_advance_engine_fields_without_a_release_floor()
-    -> Result<(), Box<dyn std::error::Error>> {
-        let mut profile = HistoryBuildOptions::defaults()?.profile();
-        profile.insert("compass_version", "0.0.0")?;
-        profile.insert("pipeline_version", "compass-core/older")?;
-        profile.insert("resolution", "2")?;
-
-        let upgraded = HistoryBuildOptions::from_compatible_profile(profile)?.profile();
-
-        assert_eq!(
-            upgraded.value("compass_version"),
-            Some(env!("CARGO_PKG_VERSION"))
-        );
-        assert_eq!(upgraded.value("pipeline_version"), Some("compass-core/v1"));
-        assert_eq!(upgraded.value("resolution"), Some("2"));
-
+    fn rebuild_profiles_hard_fail_unsupported_shapes() -> Result<(), Box<dyn std::error::Error>> {
         let mut unsupported = HistoryBuildOptions::defaults()?.profile();
-        unsupported.insert("compass_version", "0.0.0")?;
+        unsupported.insert("compass_version", "historical-engine")?;
         unsupported.insert("future_option", "enabled")?;
-        let error = HistoryBuildOptions::from_compatible_profile(unsupported)
+        let error = HistoryBuildOptions::from_rebuild_profile(unsupported)
             .err()
-            .ok_or("unsupported older profile unexpectedly accepted")?;
+            .ok_or("unsupported profile unexpectedly accepted")?;
         assert!(
             error
                 .to_string()
                 .contains("unsupported persisted build-profile field")
         );
-
-        let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))?;
-        assert!(is_compatible_profile_upgrade(
-            &semver::Version::new(0, 0, 0),
-            &current
-        ));
-        assert!(!is_compatible_profile_upgrade(&current, &current));
-        assert!(!is_compatible_profile_upgrade(
-            &semver::Version::new(1, 0, 0),
-            &current
-        ));
         Ok(())
     }
 

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -144,10 +144,14 @@ pub(crate) fn resolve_or_materialize(
     rebuild: bool,
     replace_corrupt: bool,
 ) -> Result<(HistoryStore, PublishedVersion), String> {
+    let requested_profile = options.profile();
     let existing = HistoryStore::open_existing(repository).map_err(|error| error.to_string())?;
     if !rebuild && let Some(history) = existing {
         match history.preferred(&commit) {
-            Ok(Some(preferred)) => return Ok((history, preferred)),
+            Ok(Some(preferred)) if preferred.version.build_profile == requested_profile => {
+                return Ok((history, preferred));
+            }
+            Ok(Some(_)) => {}
             Ok(None) => {}
             Err(error) => return Err(error.to_string()),
         }
@@ -160,7 +164,7 @@ pub(crate) fn resolve_or_materialize(
     let queue = HistoryQueue::for_repository(repository).map_err(|error| error.to_string())?;
     let request = JobRequest {
         commit: commit.clone(),
-        profile: options.profile(),
+        profile: requested_profile,
     };
     let job_id = if rebuild {
         queue.enqueue_rebuild(request, replace_corrupt)
@@ -258,11 +262,35 @@ pub(crate) fn resolve_comparable_pair(
         return Err("the requested fingerprint is not materialized at both commits".to_owned());
     }
     let (history, old, new) = match (old, new) {
-        (Some(old), Some(new)) => (
-            existing.ok_or_else(|| "history store disappeared".to_owned())?,
-            old,
-            new,
-        ),
+        (Some(old), Some(new)) => {
+            if old.version.build_profile == new.version.build_profile {
+                (
+                    existing.ok_or_else(|| "history store disappeared".to_owned())?,
+                    old,
+                    new,
+                )
+            } else {
+                let old_options =
+                    HistoryBuildOptions::from_compatible_profile(old.version.build_profile.clone())
+                        .map_err(|error| error.to_string())?;
+                let new_options =
+                    HistoryBuildOptions::from_compatible_profile(new.version.build_profile.clone())
+                        .map_err(|error| error.to_string())?;
+                if old_options.profile() == new_options.profile() {
+                    let (_, old) =
+                        resolve_or_materialize(repository, old_commit, &old_options, false, false)?;
+                    let (history, new) =
+                        resolve_or_materialize(repository, new_commit, &new_options, false, false)?;
+                    (history, old, new)
+                } else {
+                    (
+                        existing.ok_or_else(|| "history store disappeared".to_owned())?,
+                        old,
+                        new,
+                    )
+                }
+            }
+        }
         (Some(old), None) => {
             let options =
                 HistoryBuildOptions::from_compatible_profile(old.version.build_profile.clone())

--- a/crates/compass-cli/src/history_commands.rs
+++ b/crates/compass-cli/src/history_commands.rs
@@ -144,11 +144,35 @@ pub(crate) fn resolve_or_materialize(
     rebuild: bool,
     replace_corrupt: bool,
 ) -> Result<(HistoryStore, PublishedVersion), String> {
+    resolve_or_materialize_inner(repository, commit, options, rebuild, replace_corrupt, false)
+}
+
+fn resolve_or_materialize_matching_profile(
+    repository: &Repository,
+    commit: CommitId,
+    options: &HistoryBuildOptions,
+    rebuild: bool,
+    replace_corrupt: bool,
+) -> Result<(HistoryStore, PublishedVersion), String> {
+    resolve_or_materialize_inner(repository, commit, options, rebuild, replace_corrupt, true)
+}
+
+fn resolve_or_materialize_inner(
+    repository: &Repository,
+    commit: CommitId,
+    options: &HistoryBuildOptions,
+    rebuild: bool,
+    replace_corrupt: bool,
+    require_profile_match: bool,
+) -> Result<(HistoryStore, PublishedVersion), String> {
     let requested_profile = options.profile();
     let existing = HistoryStore::open_existing(repository).map_err(|error| error.to_string())?;
     if !rebuild && let Some(history) = existing {
         match history.preferred(&commit) {
-            Ok(Some(preferred)) if preferred.version.build_profile == requested_profile => {
+            Ok(Some(preferred))
+                if !require_profile_match
+                    || preferred.version.build_profile == requested_profile =>
+            {
                 return Ok((history, preferred));
             }
             Ok(Some(_)) => {}
@@ -215,7 +239,7 @@ pub(crate) fn resolve_or_materialize(
 fn configured_build_options(repository: &Repository) -> Result<HistoryBuildOptions, String> {
     let config = HistoryConfig::load(repository).map_err(|error| error.to_string())?;
     if let Some(profile) = config.profile {
-        return HistoryBuildOptions::from_compatible_profile(profile)
+        return HistoryBuildOptions::from_rebuild_profile(profile)
             .map_err(|error| error.to_string());
     }
     HistoryBuildOptions::defaults().map_err(|error| error.to_string())
@@ -262,67 +286,94 @@ pub(crate) fn resolve_comparable_pair(
         return Err("the requested fingerprint is not materialized at both commits".to_owned());
     }
     let (history, old, new) = match (old, new) {
+        (Some(old), Some(new)) if required_fingerprint.is_some() => (
+            existing.ok_or_else(|| "history store disappeared".to_owned())?,
+            old,
+            new,
+        ),
         (Some(old), Some(new)) => {
-            if old.version.build_profile == new.version.build_profile {
-                (
-                    existing.ok_or_else(|| "history store disappeared".to_owned())?,
-                    old,
-                    new,
-                )
+            let old_options =
+                HistoryBuildOptions::from_rebuild_profile(old.version.build_profile.clone())
+                    .map_err(|error| error.to_string())?;
+            let new_options =
+                HistoryBuildOptions::from_rebuild_profile(new.version.build_profile.clone())
+                    .map_err(|error| error.to_string())?;
+            if old_options.profile() == new_options.profile() {
+                let (_, old) = resolve_or_materialize_matching_profile(
+                    repository,
+                    old_commit,
+                    &old_options,
+                    false,
+                    false,
+                )?;
+                let (history, new) = resolve_or_materialize_matching_profile(
+                    repository,
+                    new_commit,
+                    &new_options,
+                    false,
+                    false,
+                )?;
+                (history, old, new)
             } else {
-                let old_options =
-                    HistoryBuildOptions::from_compatible_profile(old.version.build_profile.clone())
-                        .map_err(|error| error.to_string())?;
-                let new_options =
-                    HistoryBuildOptions::from_compatible_profile(new.version.build_profile.clone())
-                        .map_err(|error| error.to_string())?;
-                if old_options.profile() == new_options.profile() {
-                    let (_, old) =
-                        resolve_or_materialize(repository, old_commit, &old_options, false, false)?;
-                    let (history, new) =
-                        resolve_or_materialize(repository, new_commit, &new_options, false, false)?;
-                    (history, old, new)
-                } else {
-                    (
-                        existing.ok_or_else(|| "history store disappeared".to_owned())?,
-                        old,
-                        new,
-                    )
-                }
+                return Err(format!(
+                    "realizations retain different user-selected build options after current-engine reconstruction\n\nOLD {} ({}) profile: {}\nNEW {} ({}) profile: {}\n\nBuild a comparable realization:\n  compass history build {} --profile-from {}",
+                    old.version.git_commit,
+                    old.id,
+                    old.version.profile_digest,
+                    new.version.git_commit,
+                    new.id,
+                    new.version.profile_digest,
+                    new.version.git_commit,
+                    old.version.git_commit,
+                ));
             }
         }
         (Some(old), None) => {
             let options =
-                HistoryBuildOptions::from_compatible_profile(old.version.build_profile.clone())
+                HistoryBuildOptions::from_rebuild_profile(old.version.build_profile.clone())
                     .map_err(|error| error.to_string())?;
             let old = if old.version.build_profile == options.profile() {
                 old
             } else {
-                resolve_or_materialize(repository, old_commit, &options, true, false)?.1
+                resolve_or_materialize_matching_profile(
+                    repository, old_commit, &options, true, false,
+                )?
+                .1
             };
-            let (history, new) =
-                resolve_or_materialize(repository, new_commit, &options, false, false)?;
+            let (history, new) = resolve_or_materialize_matching_profile(
+                repository, new_commit, &options, false, false,
+            )?;
             (history, old, new)
         }
         (None, Some(new)) => {
             let options =
-                HistoryBuildOptions::from_compatible_profile(new.version.build_profile.clone())
+                HistoryBuildOptions::from_rebuild_profile(new.version.build_profile.clone())
                     .map_err(|error| error.to_string())?;
             let new = if new.version.build_profile == options.profile() {
                 new
             } else {
-                resolve_or_materialize(repository, new_commit, &options, true, false)?.1
+                resolve_or_materialize_matching_profile(
+                    repository, new_commit, &options, true, false,
+                )?
+                .1
             };
-            let (history, old) =
-                resolve_or_materialize(repository, old_commit, &options, false, false)?;
+            let (history, old) = resolve_or_materialize_matching_profile(
+                repository, old_commit, &options, false, false,
+            )?;
             (history, old, new)
         }
         (None, None) => {
             let options = configured_build_options(repository)?;
-            let (_, old) =
-                resolve_or_materialize(repository, old_commit.clone(), &options, false, false)?;
-            let (history, new) =
-                resolve_or_materialize(repository, new_commit, &options, false, false)?;
+            let (_, old) = resolve_or_materialize_matching_profile(
+                repository,
+                old_commit.clone(),
+                &options,
+                false,
+                false,
+            )?;
+            let (history, new) = resolve_or_materialize_matching_profile(
+                repository, new_commit, &options, false, false,
+            )?;
             (history, old, new)
         }
     };
@@ -1894,7 +1945,7 @@ fn execute_build(
     let parsed = parse_build_command(command, args).map_err(usage)?;
     let commit = repository.resolve(&parsed.revision).map_err(runtime)?;
     let options = if let Some(source) = &parsed.profile_from {
-        HistoryBuildOptions::from_compatible_profile(
+        HistoryBuildOptions::from_rebuild_profile(
             stored_profile(repository, source).map_err(runtime)?,
         )
         .map_err(runtime)?
@@ -1937,7 +1988,7 @@ fn execute_build(
     } else {
         false
     };
-    let (_history, published) = resolve_or_materialize(
+    let (_history, published) = resolve_or_materialize_matching_profile(
         repository,
         commit,
         &options,

--- a/crates/compass-cli/tests/history_cli.rs
+++ b/crates/compass-cli/tests/history_cli.rs
@@ -51,10 +51,29 @@ fn current_history_profile() -> Result<compass_history::BuildProfile, compass_hi
         ("program_analyzer_version", "1"),
         ("enabled_features", "workspace-default"),
         ("direction", "native-source-semantics"),
-        ("semantic_prompt_sha256", "fixture-prompt"),
+        ("cluster_algorithm", "seeded-louvain/v1"),
+        ("cluster_seed", "42"),
+        ("gitignore", "true"),
+        ("code_only", "true"),
+        ("cargo", "false"),
+        ("dedup_llm", "false"),
+        ("semantic_mode", "standard"),
+        ("provider", "none"),
+        ("model", "none"),
+        ("resolution", "1"),
+        ("exclude_hubs", "none"),
+        ("token_budget", "default"),
+        ("provider_endpoint", "none"),
+        ("provider_temperature", "none"),
+        ("provider_max_output_tokens", "none"),
+        ("provider_region", "none"),
     ] {
         profile.insert(key, value)?;
     }
+    profile.insert(
+        "semantic_prompt_sha256",
+        &compass_semantic::extraction_prompt_sha256(false),
+    )?;
     Ok(profile)
 }
 
@@ -1464,35 +1483,6 @@ fn diff_emits_semantic_text_json_html_and_rejects_removed_flags()
 
     let empty = run(compass, directory.path(), &["diff", "HEAD", "HEAD"])?;
     assert!(String::from_utf8_lossy(&empty.stdout).contains("0 likely breaks"));
-    let history = HistoryStore::open_existing(&repository)?.ok_or("missing history store")?;
-    let mut incompatible_profile = current_history_profile()?;
-    incompatible_profile.insert("compass_version", "incompatible")?;
-    let incompatible = history.publish(PublishRequest {
-        commit: new_commit,
-        parents: repository.parents(&repository.resolve("HEAD")?)?,
-        profile: incompatible_profile,
-        fingerprint: std::iter::repeat_n('d', 64)
-            .collect::<String>()
-            .parse::<ExtractionFingerprint>()?,
-        artifacts: new_artifacts,
-        completion: CompletionEvidence {
-            extraction_succeeded: true,
-            allow_partial: false,
-            semantic_files_expected: 0,
-            semantic_files_completed: 0,
-            failed_chunks: 0,
-        },
-        make_preferred: true,
-    })?;
-    let head = repository.resolve("HEAD")?;
-    let current = history
-        .preferred(&head)?
-        .ok_or("missing current preferred realization")?;
-    assert!(history.compare_and_set_preferred(&head, Some(&current.id), &incompatible.id)?);
-    drop(history);
-    let mismatch = run(compass, directory.path(), &["diff", "HEAD~1", "HEAD"])?;
-    assert_eq!(mismatch.status.code(), Some(1));
-    assert!(String::from_utf8_lossy(&mismatch.stderr).contains("incompatible graph engines"));
     Ok(())
 }
 

--- a/crates/compass-cli/tests/review_cli.rs
+++ b/crates/compass-cli/tests/review_cli.rs
@@ -6,7 +6,7 @@ use compass_history::{
 };
 use compass_pr_intelligence::{GateState, MergeOutcome, PullRequestReport, RiskBand};
 
-const SYNTHETIC_OLDER_COMPASS_VERSION: &str = "0.0.0";
+const SYNTHETIC_ENGINE_IDENTITY: &str = "historical-engine";
 
 fn git(root: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
     let output = Command::new("git")
@@ -52,7 +52,7 @@ fn publish_historical_base(root: &Path, commit: &str) -> Result<(), Box<dyn std:
     let current = history.preferred(&commit)?.ok_or("seeded realization")?;
     let completed = history.artifacts(&current.id)?;
     let mut historical_profile = current.version.build_profile;
-    historical_profile.insert("compass_version", SYNTHETIC_OLDER_COMPASS_VERSION)?;
+    historical_profile.insert("compass_version", SYNTHETIC_ENGINE_IDENTITY)?;
     history.publish(PublishRequest {
         commit: commit.clone(),
         parents: repository.parents(&commit)?,
@@ -78,7 +78,7 @@ fn persist_historical_repository_profile(root: &Path) -> Result<(), Box<dyn std:
     let mut profile = HistoryConfig::load(&repository)?
         .profile
         .ok_or("enabled profile")?;
-    profile.insert("compass_version", SYNTHETIC_OLDER_COMPASS_VERSION)?;
+    profile.insert("compass_version", SYNTHETIC_ENGINE_IDENTITY)?;
     HistoryConfig::enable(&repository, profile)?;
     Ok(())
 }
@@ -164,7 +164,7 @@ fn local_review_writes_round_trippable_exact_report() -> Result<(), Box<dyn std:
 }
 
 #[test]
-fn local_review_rebuilds_a_comparable_pair_from_an_older_profile()
+fn local_review_rebuilds_a_comparable_pair_from_a_noncurrent_profile()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
@@ -205,13 +205,13 @@ fn local_review_rebuilds_a_comparable_pair_from_an_older_profile()
     );
     assert!(history.list(Some(&base))?.iter().any(|realization| {
         realization.version.build_profile.value("compass_version")
-            == Some(SYNTHETIC_OLDER_COMPASS_VERSION)
+            == Some(SYNTHETIC_ENGINE_IDENTITY)
     }));
     Ok(())
 }
 
 #[test]
-fn local_review_upgrades_an_older_persisted_profile_after_a_current_graph_build()
+fn local_review_rebuilds_a_persisted_profile_after_a_current_graph_build()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
@@ -242,7 +242,7 @@ fn local_review_upgrades_an_older_persisted_profile_after_a_current_graph_build(
             .profile
             .and_then(|profile| profile.value("compass_version").map(str::to_owned))
             .as_deref(),
-        Some(SYNTHETIC_OLDER_COMPASS_VERSION)
+        Some(SYNTHETIC_ENGINE_IDENTITY)
     );
 
     let reviewed = run(
@@ -280,9 +280,9 @@ fn local_review_upgrades_an_older_persisted_profile_after_a_current_graph_build(
     Ok(())
 }
 
-#[test]
-fn local_review_reconciles_existing_compatible_realizations()
--> Result<(), Box<dyn std::error::Error>> {
+fn assert_review_reconciles_existing_realizations(
+    noncurrent_head: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
     git(directory.path(), &["checkout", "--quiet", "-b", "feature"])?;
@@ -302,16 +302,20 @@ fn local_review_reconciles_existing_compatible_realizations()
     git(directory.path(), &["commit", "--quiet", "-m", "target"])?;
     let base = git(directory.path(), &["rev-parse", "HEAD"])?;
     publish_historical_base(directory.path(), &base)?;
-    let built = run(
-        directory.path(),
-        &["history", "build", &head, "--code-only"],
-    )?;
-    assert!(
-        built.status.success(),
-        "stdout={} stderr={}",
-        String::from_utf8_lossy(&built.stdout),
-        String::from_utf8_lossy(&built.stderr)
-    );
+    if noncurrent_head {
+        publish_historical_base(directory.path(), &head)?;
+    } else {
+        let built = run(
+            directory.path(),
+            &["history", "build", &head, "--code-only"],
+        )?;
+        assert!(
+            built.status.success(),
+            "stdout={} stderr={}",
+            String::from_utf8_lossy(&built.stdout),
+            String::from_utf8_lossy(&built.stderr)
+        );
+    }
 
     let reviewed = run(
         directory.path(),
@@ -342,6 +346,18 @@ fn local_review_reconciles_existing_compatible_realizations()
         );
     }
     Ok(())
+}
+
+#[test]
+fn local_review_reconciles_existing_different_engine_profiles()
+-> Result<(), Box<dyn std::error::Error>> {
+    assert_review_reconciles_existing_realizations(false)
+}
+
+#[test]
+fn local_review_hard_cuts_over_matching_noncurrent_engine_profiles()
+-> Result<(), Box<dyn std::error::Error>> {
+    assert_review_reconciles_existing_realizations(true)
 }
 
 #[test]

--- a/crates/compass-cli/tests/review_cli.rs
+++ b/crates/compass-cli/tests/review_cli.rs
@@ -48,7 +48,7 @@ fn publish_historical_base(root: &Path, commit: &str) -> Result<(), Box<dyn std:
     let current = history.preferred(&commit)?.ok_or("seeded realization")?;
     let completed = history.artifacts(&current.id)?;
     let mut historical_profile = current.version.build_profile;
-    historical_profile.insert("compass_version", "0.3.9")?;
+    historical_profile.insert("compass_version", "0.1.10")?;
     history.publish(PublishRequest {
         commit: commit.clone(),
         parents: repository.parents(&commit)?,
@@ -142,7 +142,7 @@ fn local_review_writes_round_trippable_exact_report() -> Result<(), Box<dyn std:
 }
 
 #[test]
-fn local_review_rebuilds_a_comparable_pair_after_a_compass_patch_upgrade()
+fn local_review_rebuilds_a_comparable_pair_from_compass_0_1_10()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
@@ -182,7 +182,7 @@ fn local_review_rebuilds_a_comparable_pair_after_a_compass_patch_upgrade()
         Some(env!("CARGO_PKG_VERSION"))
     );
     assert!(history.list(Some(&base))?.iter().any(|realization| {
-        realization.version.build_profile.value("compass_version") == Some("0.3.9")
+        realization.version.build_profile.value("compass_version") == Some("0.1.10")
     }));
     Ok(())
 }

--- a/crates/compass-cli/tests/review_cli.rs
+++ b/crates/compass-cli/tests/review_cli.rs
@@ -6,6 +6,8 @@ use compass_history::{
 };
 use compass_pr_intelligence::{GateState, MergeOutcome, PullRequestReport, RiskBand};
 
+const SYNTHETIC_OLDER_COMPASS_VERSION: &str = "0.0.0";
+
 fn git(root: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
     let output = Command::new("git")
         .args(arguments)
@@ -50,7 +52,7 @@ fn publish_historical_base(root: &Path, commit: &str) -> Result<(), Box<dyn std:
     let current = history.preferred(&commit)?.ok_or("seeded realization")?;
     let completed = history.artifacts(&current.id)?;
     let mut historical_profile = current.version.build_profile;
-    historical_profile.insert("compass_version", "0.1.10")?;
+    historical_profile.insert("compass_version", SYNTHETIC_OLDER_COMPASS_VERSION)?;
     history.publish(PublishRequest {
         commit: commit.clone(),
         parents: repository.parents(&commit)?,
@@ -76,7 +78,7 @@ fn persist_historical_repository_profile(root: &Path) -> Result<(), Box<dyn std:
     let mut profile = HistoryConfig::load(&repository)?
         .profile
         .ok_or("enabled profile")?;
-    profile.insert("compass_version", "0.1.10")?;
+    profile.insert("compass_version", SYNTHETIC_OLDER_COMPASS_VERSION)?;
     HistoryConfig::enable(&repository, profile)?;
     Ok(())
 }
@@ -162,7 +164,7 @@ fn local_review_writes_round_trippable_exact_report() -> Result<(), Box<dyn std:
 }
 
 #[test]
-fn local_review_rebuilds_a_comparable_pair_from_compass_0_1_10()
+fn local_review_rebuilds_a_comparable_pair_from_an_older_profile()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
@@ -202,13 +204,14 @@ fn local_review_rebuilds_a_comparable_pair_from_compass_0_1_10()
         Some(env!("CARGO_PKG_VERSION"))
     );
     assert!(history.list(Some(&base))?.iter().any(|realization| {
-        realization.version.build_profile.value("compass_version") == Some("0.1.10")
+        realization.version.build_profile.value("compass_version")
+            == Some(SYNTHETIC_OLDER_COMPASS_VERSION)
     }));
     Ok(())
 }
 
 #[test]
-fn local_review_upgrades_a_persisted_0_1_10_profile_after_a_current_graph_build()
+fn local_review_upgrades_an_older_persisted_profile_after_a_current_graph_build()
 -> Result<(), Box<dyn std::error::Error>> {
     let directory = tempfile::tempdir()?;
     initialize(directory.path())?;
@@ -239,7 +242,7 @@ fn local_review_upgrades_a_persisted_0_1_10_profile_after_a_current_graph_build(
             .profile
             .and_then(|profile| profile.value("compass_version").map(str::to_owned))
             .as_deref(),
-        Some("0.1.10")
+        Some(SYNTHETIC_OLDER_COMPASS_VERSION)
     );
 
     let reviewed = run(

--- a/crates/compass-cli/tests/review_cli.rs
+++ b/crates/compass-cli/tests/review_cli.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use compass_history::{ExtractionFingerprint, HistoryStore, PublishRequest, Repository};
-use compass_pr_intelligence::{GateState, PullRequestReport, RiskBand};
+use compass_history::{
+    ExtractionFingerprint, HistoryConfig, HistoryStore, PublishRequest, Repository,
+};
+use compass_pr_intelligence::{GateState, MergeOutcome, PullRequestReport, RiskBand};
 
 fn git(root: &Path, arguments: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
     let output = Command::new("git")
@@ -58,6 +60,24 @@ fn publish_historical_base(root: &Path, commit: &str) -> Result<(), Box<dyn std:
         completion: completed.completion,
         make_preferred: true,
     })?;
+    Ok(())
+}
+
+fn persist_historical_repository_profile(root: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let enabled = run(root, &["history", "enable", "--code-only"])?;
+    if !enabled.status.success() {
+        return Err(format!(
+            "could not enable history: {}",
+            String::from_utf8_lossy(&enabled.stderr)
+        )
+        .into());
+    }
+    let repository = Repository::discover(root)?;
+    let mut profile = HistoryConfig::load(&repository)?
+        .profile
+        .ok_or("enabled profile")?;
+    profile.insert("compass_version", "0.1.10")?;
+    HistoryConfig::enable(&repository, profile)?;
     Ok(())
 }
 
@@ -184,6 +204,140 @@ fn local_review_rebuilds_a_comparable_pair_from_compass_0_1_10()
     assert!(history.list(Some(&base))?.iter().any(|realization| {
         realization.version.build_profile.value("compass_version") == Some("0.1.10")
     }));
+    Ok(())
+}
+
+#[test]
+fn local_review_upgrades_a_persisted_0_1_10_profile_after_a_current_graph_build()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    initialize(directory.path())?;
+    let base = git(directory.path(), &["rev-parse", "HEAD"])?;
+    git(directory.path(), &["checkout", "--quiet", "-b", "feature"])?;
+    std::fs::write(
+        directory.path().join("feature.rs"),
+        "pub fn feature() -> u8 { 2 }\n",
+    )?;
+    git(directory.path(), &["add", "feature.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "feature"])?;
+    let head = git(directory.path(), &["rev-parse", "HEAD"])?;
+    persist_historical_repository_profile(directory.path())?;
+
+    let built = run(
+        directory.path(),
+        &["extract", ".", "--code-only", "--no-viz"],
+    )?;
+    assert!(
+        built.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+    let repository = Repository::discover(directory.path())?;
+    assert_eq!(
+        HistoryConfig::load(&repository)?
+            .profile
+            .and_then(|profile| profile.value("compass_version").map(str::to_owned))
+            .as_deref(),
+        Some("0.1.10")
+    );
+
+    let reviewed = run(
+        directory.path(),
+        &[
+            "review", "--base", &base, "--head", &head, "--format", "json",
+        ],
+    )?;
+    assert!(
+        reviewed.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&reviewed.stdout),
+        String::from_utf8_lossy(&reviewed.stderr)
+    );
+    let report = PullRequestReport::from_json(&reviewed.stdout)?;
+    assert_eq!(report.identity.revisions.target_head, base);
+    assert_eq!(report.identity.revisions.pull_request_head, head);
+    let comparison = report
+        .identity
+        .revisions
+        .merge_result
+        .object_id()
+        .unwrap_or(&report.identity.revisions.pull_request_head)
+        .to_owned();
+
+    let history = HistoryStore::open_existing(&repository)?.ok_or("history store")?;
+    for revision in [base, comparison] {
+        let commit = repository.resolve(&revision)?;
+        let preferred = history.preferred(&commit)?.ok_or("preferred realization")?;
+        assert_eq!(
+            preferred.version.build_profile.value("compass_version"),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn local_review_reconciles_existing_compatible_realizations()
+-> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    initialize(directory.path())?;
+    git(directory.path(), &["checkout", "--quiet", "-b", "feature"])?;
+    std::fs::write(
+        directory.path().join("lib.rs"),
+        "pub fn shared() -> u8 { 2 }\n",
+    )?;
+    git(directory.path(), &["add", "lib.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "feature"])?;
+    let head = git(directory.path(), &["rev-parse", "HEAD"])?;
+    git(directory.path(), &["checkout", "--quiet", "main"])?;
+    std::fs::write(
+        directory.path().join("lib.rs"),
+        "pub fn shared() -> u8 { 3 }\n",
+    )?;
+    git(directory.path(), &["add", "lib.rs"])?;
+    git(directory.path(), &["commit", "--quiet", "-m", "target"])?;
+    let base = git(directory.path(), &["rev-parse", "HEAD"])?;
+    publish_historical_base(directory.path(), &base)?;
+    let built = run(
+        directory.path(),
+        &["history", "build", &head, "--code-only"],
+    )?;
+    assert!(
+        built.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&built.stdout),
+        String::from_utf8_lossy(&built.stderr)
+    );
+
+    let reviewed = run(
+        directory.path(),
+        &[
+            "review", "--base", &base, "--head", &head, "--format", "json",
+        ],
+    )?;
+    assert!(
+        reviewed.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&reviewed.stdout),
+        String::from_utf8_lossy(&reviewed.stderr)
+    );
+    let report = PullRequestReport::from_json(&reviewed.stdout)?;
+    assert!(matches!(
+        report.identity.revisions.merge_result,
+        MergeOutcome::Conflicted { .. }
+    ));
+
+    let repository = Repository::discover(directory.path())?;
+    let history = HistoryStore::open_existing(&repository)?.ok_or("history store")?;
+    for revision in [base, head] {
+        let commit = repository.resolve(&revision)?;
+        let preferred = history.preferred(&commit)?.ok_or("preferred realization")?;
+        assert_eq!(
+            preferred.version.build_profile.value("compass_version"),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
     Ok(())
 }
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -356,13 +356,15 @@ semantic or exact report. Compass checks graph-engine compatibility explicitly
 before comparing the complete build profiles.
 
 `compass review` handles an older preferred realization or repository history
-profile from Compass `0.1.10` or later automatically. This includes comparisons
-where both revisions already have preferred realizations. Compass advances the
-engine fields and rebuilds a current-version pair only when both sides retain
+profile automatically when its persisted shape remains reconstructable. This
+includes comparisons where both revisions already have preferred realizations.
+Compass advances the engine fields, validates the complete reconstructed
+profile, and rebuilds a current-version pair only when both sides retain
 identical user-selected options. It leaves older immutable realizations intact.
-A profile older than `0.1.10`, newer than the running binary, from another
-release line, or carrying genuinely different user options remains an explicit
-compatibility error.
+A malformed or unsupported profile shape, a version newer than the running
+binary, or genuinely different user options remains an explicit compatibility
+error. Future running minor lines must re-qualify this migration before
+inheriting it.
 
 ## 7. Export a realization
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -355,16 +355,16 @@ There is no profile-mismatch override: unlike profiles do not produce a
 semantic or exact report. Compass checks graph-engine compatibility explicitly
 before comparing the complete build profiles.
 
-`compass review` handles an older preferred realization or repository history
-profile automatically when its persisted shape remains reconstructable. This
-includes comparisons where both revisions already have preferred realizations.
-Compass advances the engine fields, validates the complete reconstructed
-profile, and rebuilds a current-version pair only when both sides retain
-identical user-selected options. It leaves older immutable realizations intact.
-A malformed or unsupported profile shape, a version newer than the running
-binary, or genuinely different user options remains an explicit compatibility
-error. Future running minor lines must re-qualify this migration before
-inheriting it.
+`compass review` handles a preferred realization or repository history profile
+with noncurrent engine fields automatically when its persisted user-option
+shape remains reconstructable. This includes comparisons where both revisions
+already have preferred realizations. Compass replaces engine-owned fields with
+the running contract, validates the complete reconstructed profile, and rebuilds
+a current pair only when both sides retain identical user-selected options. It
+does not parse, order, or allowlist the persisted Compass release number, and it
+leaves historical realizations intact. A malformed or unsupported profile shape
+or genuinely different user options remains an explicit compatibility error.
+Profile-shape changes use a hard cutover instead of release-specific migrations.
 
 ## 7. Export a realization
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -355,11 +355,12 @@ There is no profile-mismatch override: unlike profiles do not produce a
 semantic or exact report. Compass checks graph-engine compatibility explicitly
 before comparing the complete build profiles.
 
-`compass review` handles an older preferred realization from a compatible
-`0.3.x` patch release automatically when it must materialize the other side.
-It preserves user-selected profile options, rebuilds a current-version pair,
-and leaves the older immutable realization intact. A profile from a newer
-binary or another release line remains an explicit compatibility error.
+`compass review` handles an older preferred realization with a compatible
+profile from Compass `0.1.10` or later automatically when it must materialize
+the other side. It preserves user-selected profile options, rebuilds a
+current-version pair, and leaves the older immutable realization intact. A
+profile older than `0.1.10`, newer than the running binary, or from another
+release line remains an explicit compatibility error.
 
 ## 7. Export a realization
 

--- a/docs/guides/versioned-history.md
+++ b/docs/guides/versioned-history.md
@@ -355,12 +355,14 @@ There is no profile-mismatch override: unlike profiles do not produce a
 semantic or exact report. Compass checks graph-engine compatibility explicitly
 before comparing the complete build profiles.
 
-`compass review` handles an older preferred realization with a compatible
-profile from Compass `0.1.10` or later automatically when it must materialize
-the other side. It preserves user-selected profile options, rebuilds a
-current-version pair, and leaves the older immutable realization intact. A
-profile older than `0.1.10`, newer than the running binary, or from another
-release line remains an explicit compatibility error.
+`compass review` handles an older preferred realization or repository history
+profile from Compass `0.1.10` or later automatically. This includes comparisons
+where both revisions already have preferred realizations. Compass advances the
+engine fields and rebuilds a current-version pair only when both sides retain
+identical user-selected options. It leaves older immutable realizations intact.
+A profile older than `0.1.10`, newer than the running binary, from another
+release line, or carrying genuinely different user options remains an explicit
+compatibility error.
 
 ## 7. Export a realization
 


### PR DESCRIPTION
## What changed

- remove all Compass release-number parsing, ordering, floors, and allowlists from review/history profile reconstruction
- treat persisted compass_version as provenance only, then replace all engine-owned fields with the running engine contract
- validate the complete reconstructed user-option shape and hard-fail unsupported fields or malformed values
- reconcile comparisons when one, both-different, or both-matching preferred realizations use noncurrent engine identities
- require exact requested profiles only for review reconciliation and explicit history builds; query and export continue reading the selected immutable historical realization
- preserve explicitly requested fingerprints as exact immutable selections

## Root cause

Review used Compass release numbers as a proxy for profile compatibility. It also bypassed current-engine reconstruction when both revisions already had preferred realizations, especially when their profiles matched. A globally applied preferred-profile check then risked making read-only historical query and export rebuild selected history under mutable repository configuration.

## Contract policy

Normal review does not parse, order, or allowlist a persisted Compass release string. It reconstructs the profile under the current engine and validates the actual supported option contract. If that profile shape changes in the future, Compass should hard-cut to the new contract and reject unsupported shapes rather than add release-specific migrations.

Compass version remains in the extraction fingerprint as engine provenance. Exact fingerprint comparisons and queued materialization profiles retain strict identity checks; these are integrity checks, not release compatibility policy. Binary self-update semver selection is unrelated and remains intact.

## User impact

Compass review rebuilds a current comparable pair whenever persisted user options remain supported and identical, regardless of the persisted engine-version text. Historical realizations remain immutable and queryable. Different user options or unsupported shapes fail explicitly.

## Verification

- cargo fmt --all -- --check
- cargo clippy -p compass-cli --all-targets --all-features --locked -- -D warnings
- cargo test -p compass-cli --test review_cli --locked (7 passed)
- cargo test -p compass-cli --test history_cli --locked (24 passed)
- unit regressions cover non-semver, numerically future-looking, and current engine identities plus unsupported shape rejection
- cargo test -p compass-cli --test compass_product --locked (8 passed)
- sh scripts/check_product_boundary.sh
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked