### PR TITLE
Release Compass 0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
   numbers: it preserves matching user-selected options, replaces engine-owned
   fingerprint fields, and keeps original historical realizations immutable.
 
+## 0.3.14 - 2026-08-14
+
+- Allow `compass review` to reconcile either compared revision from any
+  reconstructable repository profile or preferred realization. Review now
+  replaces engine-owned fingerprint fields with the running contract, keeps
+  user-selected options aligned, and leaves historical realizations immutable;
+  persisted Compass release numbers are provenance rather than a compatibility
+  allowlist.
+
+- Filter unshadowed JavaScript, TypeScript, Python, Go, Rust, Java, and Swift
+  built-in globals from call-target publication so constructors, coercion
+  helpers, language preludes, and common global methods do not become noisy
+  graph hubs. Source-proven local and imported declarations retain precedence,
+  and extraction semantics advance to v2 so cached graphs rebuild correctly.
+
 ## 0.3.13 - 2026-08-14
 
 - Make `compass review` recover automatically when one compared revision still

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "glob",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "regex",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "axum",
  "compass-core",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "base64",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "base64",
  "compass-analysis",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,30 +35,30 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.13" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-program = { path = "../compass-program", version = "0.3.13" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.13" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.13" }
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.13" }
-compass-global = { path = "../compass-global", version = "0.3.13" }
-compass-history = { path = "../compass-history", version = "0.3.13" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.13" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.13" }
-compass-output = { path = "../compass-output", version = "0.3.13" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.13" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.13" }
-compass-prs = { path = "../compass-prs", version = "0.3.13" }
-compass-query = { path = "../compass-query", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.13" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.13" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.13" }
+compass-core = { path = "../compass-core", version = "0.3.14" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-program = { path = "../compass-program", version = "0.3.14" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.14" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.14" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.14" }
+compass-global = { path = "../compass-global", version = "0.3.14" }
+compass-history = { path = "../compass-history", version = "0.3.14" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.14" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.14" }
+compass-output = { path = "../compass-output", version = "0.3.14" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.14" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.14" }
+compass-prs = { path = "../compass-prs", version = "0.3.14" }
+compass-query = { path = "../compass-query", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.14" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.14" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.14" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-program = { path = "../compass-program", version = "0.3.13" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-program = { path = "../compass-program", version = "0.3.14" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,20 +24,20 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.13" }
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-history = { path = "../compass-history", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13" }
-compass-output = { path = "../compass-output", version = "0.3.13" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.13" }
-compass-prs = { path = "../compass-prs", version = "0.3.13" }
-compass-query = { path = "../compass-query", version = "0.3.13" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.13" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.13" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.14" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-history = { path = "../compass-history", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
+compass-output = { path = "../compass-output", version = "0.3.14" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.14" }
+compass-prs = { path = "../compass-prs", version = "0.3.14" }
+compass-query = { path = "../compass-query", version = "0.3.14" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.14" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.14" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.14" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.13" }
+compass-media = { path = "../compass-media", version = "0.3.14" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-program = { path = "../compass-program", version = "0.3.13" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-program = { path = "../compass-program", version = "0.3.14" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,19 +19,19 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.13" }
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-history = { path = "../compass-history", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-output = { path = "../compass-output", version = "0.3.13" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.13" }
-compass-prs = { path = "../compass-prs", version = "0.3.13" }
-compass-query = { path = "../compass-query", version = "0.3.13" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.13" }
+compass-core = { path = "../compass-core", version = "0.3.14" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-history = { path = "../compass-history", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-output = { path = "../compass-output", version = "0.3.14" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.14" }
+compass-prs = { path = "../compass-prs", version = "0.3.14" }
+compass-query = { path = "../compass-query", version = "0.3.14" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.14" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.13" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,14 +20,14 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-history = { path = "../compass-history", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.13" }
-compass-query = { path = "../compass-query", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-history = { path = "../compass-history", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.14" }
+compass-query = { path = "../compass-query", version = "0.3.14" }
 unicode-normalization.workspace = true
 url.workspace = true
 

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.13" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.14" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.13" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.14" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -19,12 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -32,9 +32,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.13" }
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.13" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.14" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.14" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-program = { path = "../compass-program", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-program = { path = "../compass-program", version = "0.3.14" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.13" }
-compass-history = { path = "../compass-history", version = "0.3.13" }
-compass-ir = { path = "../compass-ir", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.14" }
+compass-history = { path = "../compass-history", version = "0.3.14" }
+compass-ir = { path = "../compass-ir", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.13" }
-compass-program = { path = "../compass-program", version = "0.3.13" }
+compass-languages = { path = "../compass-languages", version = "0.3.14" }
+compass-program = { path = "../compass-program", version = "0.3.14" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.13" }
-compass-media = { path = "../compass-media", version = "0.3.13" }
+compass-files = { path = "../compass-files", version = "0.3.14" }
+compass-media = { path = "../compass-media", version = "0.3.14" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.13" }
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-query = { path = "../compass-query", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.13" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.14" }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-query = { path = "../compass-query", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.14" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.13" }
+compass-store = { path = "../compass-store", version = "0.3.14" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.13" }
-compass-model = { path = "../compass-model", version = "0.3.13" }
-compass-store = { path = "../compass-store", version = "0.3.13", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.14" }
+compass-model = { path = "../compass-model", version = "0.3.14" }
+compass-store = { path = "../compass-store", version = "0.3.14", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.13", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.13", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.14", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.14", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "glob",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "regex",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "axum",
  "compass-core",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "base64",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "base64",
  "compass-analysis",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.13", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.13", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.13", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.13", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.13", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.13", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.13", path = "../crates/compass-output" }
-compass-query = { version = "0.3.13", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.13", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.13", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.14", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.14", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.14", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.14", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.14", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.14", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.14", path = "../crates/compass-output" }
+compass-query = { version = "0.3.14", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.14", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.14", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1686,7 +1686,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.13"
+    "producerVersion": "compass-languages/0.3.14"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary
- bump Compass workspace, internal crates, locks, qualification producer, and VS Code metadata to 0.3.14
- preserve the Unreleased section and add curated 0.3.14 changelog notes for review-profile reconciliation and built-in filtering

## Validation
- cargo metadata --locked --no-deps
- cargo check --workspace --all-targets --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins --locked -- -D warnings
- cargo test --workspace --lib --bins --locked
- cargo test -p compass-cli --test compass_product --locked
- sh scripts/check_product_boundary.sh
- sh scripts/test_release_scripts.sh
- ./scripts/qualify_code_graph_v1.sh --fixtures-only

Release artifacts will be built and published by the tagged release workflow after merge.