### PR TITLE
CI: avoid Playwright Ubuntu install hang

### DIFF
--- a/.github/workflows/compass-ci.yml
+++ b/.github/workflows/compass-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24.13.1"
+          node-version: "24.15.0" # Playwright browser extraction workaround on Ubuntu 24.04.
           cache: npm
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24.13.1"
+          node-version: "24.15.0" # Playwright browser extraction workaround on Ubuntu 24.04.
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium

--- a/.github/workflows/compass-vscode-release.yml
+++ b/.github/workflows/compass-vscode-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: "24.13.1"
+          node-version: "24.15.0" # Playwright browser extraction workaround on Ubuntu 24.04.
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- Pin Node.js 24.15.0 for the Ubuntu CI jobs that run Playwright browser installation.
- Apply the same pin to the manual VS Code release workflow.

The previous 0.3.17 release PR merged before this follow-up fix was pushed, so this PR intentionally contains only the CI workaround.

## Motivation

The Ubuntu 24.04 `npx playwright install --with-deps chromium` step stalled indefinitely in both `javascript-and-vscode` and `code-graph-v1-fixtures`. Playwright's documented issue reports Node 24.15 as the workaround for this browser-extraction hang.

## Validation

- Workflow YAML parsed successfully with Ruby's YAML parser.
- The release branch remains based on the merged 0.3.17 tree.
- Local JavaScript, Playwright, Rust, and code-graph gates passed before the CI stall.
