### PR TITLE
chore(vscode): bump extension to 0.3.19

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.19
+
 - Keep code graphs static and selectable by default, run force layout only on
   explicit request, and keep every completed relayout paused. Simplify the
   layout picker and group Settings and Filters together with distinct icons.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",


### PR DESCRIPTION
## Summary

- bump the Compass VS Code extension package version to 0.3.19
- synchronize the workspace lockfile
- move the pending extension release notes under the 0.3.19 heading

## Verification

- `npm run typecheck -w editors/vscode`
- `npm run test -w editors/vscode` (143 passed)
- `npm run package -w editors/vscode`
- `npm run smoke:vsix -w editors/vscode`
- verified packaged VSIX manifest identity version is 0.3.19