### PR TITLE
Release Compass 0.3.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,6 @@
 
 ## Unreleased
 
-- Make `compass explain` resolve the exact qualified names returned by typed
-  graph search, preserving ambiguity instead of selecting a duplicate. In the
-  VS Code Explain composer, Enter now accepts and explains the highlighted
-  graph suggestion rather than submitting the incomplete token.
-
-- Turn the VS Code codebase query view into a multi-command workbench with
-  separate Ask, Explain, and CompassQL composers and durable result tabs.
-  Typed Ask diagnostics, symbol relationships, source links, and CompassQL rows
-  now render as readable UI instead of raw JSON. Active commands use a visible
-  top indicator, inputs offer bounded completions from the active code graph,
-  Enter runs the active command, and Shift+Enter inserts a new line. Historical
-  panels complete against their selected immutable revision. Typed `compass
-  ask` also accepts `--at REV` for immutable revision graphs.
-
-- Let VS Code users open a call graph by entering a function name, qualified
-  name, or stable symbol ID in the Call Graph pane, with callers, callees, or
-  both selectable before tracing. The symbol field now completes callable
-  functions, methods, constructors, and properties from the selected
-  repository's active code graph, with keyboard navigation and bounded error
-  recovery. The existing cursor workflow remains available in the same pane.
-
-- Keep Codebase Evolution strict when a stored revision uses an unsupported
-  artifact layout, and offer to rebuild the affected revision with the current
-  Compass version instead of mapping legacy history records.
-
 - Make community detail graphs easier to scan in both exported HTML and VS
   Code by grouping node kinds into accessible color-and-shape families,
   coloring edges by relationship purpose while retaining confidence strokes,
@@ -87,6 +62,33 @@
   already materialized. Rebuilding does not order or allowlist Compass release
   numbers: it preserves matching user-selected options, replaces engine-owned
   fingerprint fields, and keeps original historical realizations immutable.
+
+## 0.3.19 - 2026-08-21
+
+- Make `compass explain` resolve the exact qualified names returned by typed
+  graph search, preserving ambiguity instead of selecting a duplicate. In the
+  VS Code Explain composer, Enter now accepts and explains the highlighted
+  graph suggestion rather than submitting the incomplete token.
+
+- Turn the VS Code codebase query view into a multi-command workbench with
+  separate Ask, Explain, and CompassQL composers and durable result tabs.
+  Typed Ask diagnostics, symbol relationships, source links, and CompassQL rows
+  now render as readable UI instead of raw JSON. Active commands use a visible
+  top indicator, inputs offer bounded completions from the active code graph,
+  Enter runs the active command, and Shift+Enter inserts a new line. Historical
+  panels complete against their selected immutable revision. Typed `compass
+  ask` also accepts `--at REV` for immutable revision graphs.
+
+- Let VS Code users open a call graph by entering a function name, qualified
+  name, or stable symbol ID in the Call Graph pane, with callers, callees, or
+  both selectable before tracing. The symbol field now completes callable
+  functions, methods, constructors, and properties from the selected
+  repository's active code graph, with keyboard navigation and bounded error
+  recovery. The existing cursor workflow remains available in the same pane.
+
+- Keep Codebase Evolution strict when a stored revision uses an unsupported
+  artifact layout, and offer to rebuild the affected revision with the current
+  Compass version instead of mapping legacy history records.
 
 ## 0.3.18 - 2026-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "glob",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "regex",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "axum",
  "compass-core",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "base64 0.22.1",
  "compass-analysis",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.18"
+version = "0.3.19"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -35,30 +35,30 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.18" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-program = { path = "../compass-program", version = "0.3.18" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.18" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.18" }
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.18" }
-compass-global = { path = "../compass-global", version = "0.3.18" }
-compass-history = { path = "../compass-history", version = "0.3.18" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.18" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.18" }
-compass-output = { path = "../compass-output", version = "0.3.18" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.18" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.18" }
-compass-prs = { path = "../compass-prs", version = "0.3.18" }
-compass-query = { path = "../compass-query", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.18" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.18" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.18" }
+compass-core = { path = "../compass-core", version = "0.3.19" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-program = { path = "../compass-program", version = "0.3.19" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.19" }
+compass-global = { path = "../compass-global", version = "0.3.19" }
+compass-history = { path = "../compass-history", version = "0.3.19" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.19" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.19" }
+compass-output = { path = "../compass-output", version = "0.3.19" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.19" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
+compass-prs = { path = "../compass-prs", version = "0.3.19" }
+compass-query = { path = "../compass-query", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.19" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,9 +12,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-program = { path = "../compass-program", version = "0.3.18" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-program = { path = "../compass-program", version = "0.3.19" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -24,20 +24,20 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.18" }
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-history = { path = "../compass-history", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18" }
-compass-output = { path = "../compass-output", version = "0.3.18" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.18" }
-compass-prs = { path = "../compass-prs", version = "0.3.18" }
-compass-query = { path = "../compass-query", version = "0.3.18" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.18" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.18" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-history = { path = "../compass-history", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-output = { path = "../compass-output", version = "0.3.19" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
+compass-prs = { path = "../compass-prs", version = "0.3.19" }
+compass-query = { path = "../compass-query", version = "0.3.19" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.19" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.18" }
+compass-media = { path = "../compass-media", version = "0.3.19" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-program = { path = "../compass-program", version = "0.3.18" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-program = { path = "../compass-program", version = "0.3.19" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -19,19 +19,19 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.18" }
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-history = { path = "../compass-history", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-output = { path = "../compass-output", version = "0.3.18" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.18" }
-compass-prs = { path = "../compass-prs", version = "0.3.18" }
-compass-query = { path = "../compass-query", version = "0.3.18" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.18" }
+compass-core = { path = "../compass-core", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-history = { path = "../compass-history", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-output = { path = "../compass-output", version = "0.3.19" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
+compass-prs = { path = "../compass-prs", version = "0.3.19" }
+compass-query = { path = "../compass-query", version = "0.3.19" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.18" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -20,14 +20,14 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-history = { path = "../compass-history", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.18" }
-compass-query = { path = "../compass-query", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-history = { path = "../compass-history", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
+compass-query = { path = "../compass-query", version = "0.3.19" }
 unicode-normalization.workspace = true
 url.workspace = true
 

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.18" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.18" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -19,12 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -32,9 +32,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.18" }
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.18" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.19" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-program = { path = "../compass-program", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-program = { path = "../compass-program", version = "0.3.19" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.18" }
-compass-history = { path = "../compass-history", version = "0.3.18" }
-compass-ir = { path = "../compass-ir", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
+compass-history = { path = "../compass-history", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.18" }
-compass-program = { path = "../compass-program", version = "0.3.18" }
+compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-program = { path = "../compass-program", version = "0.3.19" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.18" }
-compass-media = { path = "../compass-media", version = "0.3.18" }
+compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-media = { path = "../compass-media", version = "0.3.19" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.18" }
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-query = { path = "../compass-query", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.18" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-query = { path = "../compass-query", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.19" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.18" }
+compass-store = { path = "../compass-store", version = "0.3.19" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.18" }
-compass-model = { path = "../compass-model", version = "0.3.18" }
-compass-store = { path = "../compass-store", version = "0.3.18", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.19", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.18", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.18", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.19", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.19", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "glob",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "axum",
  "compass-core",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "base64 0.22.1",
  "compass-analysis",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.18", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.18", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.18", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.18", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.18", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.18", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.18", path = "../crates/compass-output" }
-compass-query = { version = "0.3.18", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.18", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.18", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.19", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.19", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.19", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.19", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.19", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.19", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.19", path = "../crates/compass-output" }
+compass-query = { version = "0.3.19", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.19", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.19", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1735,7 +1735,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.18"
+    "producerVersion": "compass-languages/0.3.19"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- bump the Compass workspace and internal package metadata to 0.3.19;
- update lockfiles and code-graph qualification producer metadata;
- record the 0.3.19 user-facing changes in `CHANGELOG.md`.

## Release notes

- VS Code now provides a multi-command Ask, Explain, and CompassQL workbench with durable result tabs, typed diagnostics, source links, and bounded graph completions.
- Call Graph accepts function names, qualified names, and stable symbol IDs, with caller/callee direction controls and keyboard-safe completion.
- `compass explain` preserves exact qualified-name identity and ambiguity; Codebase Evolution prompts to rebuild unsupported historical artifact layouts.

Full notes will be published with the `compass-v0.3.19` release, including the changelog and comparison links.

## Validation

- `git diff --check`
- static metadata/JSON/package-lock consistency checks
- GitHub CI checks (including the release workflow's pinned Rust, product, packaging, and cross-platform build gates)

Local Cargo gates were not run because the required `/Volumes/Workspace` target volume is unavailable; GitHub Actions will provide the authoritative build and platform validation.
