### PR TITLE
Release Compass 0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,93 +2,6 @@
 
 ## Unreleased
 
-- Add Grounded Agent Graph overlays: authorized agents can submit citation-
-  backed node, edge, Challenge, and Retraction operations without mutating the
-  source-derived Base Graph. Compass deterministically issues `GROUNDED`,
-  publishes immutable CAS-activated revisions with bounded audit, supports
-  exact rebase and historical composition, and exposes exact effective reads
-  through CLI, MCP, CompassQL, task context, export, and the viewer. Writes and
-  stronger curated masks remain deny-by-default capabilities. Add read-only
-  ingestion preparation so agents can obtain canonical Base references and
-  source evidence without implementing Compass digest rules themselves. Extend
-  the bundled coding-agent skill with explicit continuous enrichment: bounded
-  milestone batches, revision pinning, source-change rebase gates, and
-  session-end receipts.
-
-- Add versioned `compass.task-context/2` framework evidence for React and
-  frontend workflows, including pack versions, route stages, render direction,
-  runtime boundaries, configuration dependencies, provenance, and bounded
-  qualification states.
-
-- Complete the React frontend framework graph hardening slice: exact JSX
-  `renders` relationships, component/hook/client/server role evidence, typed
-  Next.js, React Router/Remix, TanStack Router, and Vite semantics, bounded
-  project/configuration precedence and cache invalidation, strict viewer/query
-  contracts, and the seven-family independent precision/recall and release
-  performance gates. TanStack Start remains explicitly pre-stable.
-
-- Replace the predefined flat call-flow architecture model with the native
-  `compass.viewer.architecture/1` projection. Production source scope is fixed
-  before grouping, generated/vendor/test/documentation content cannot shape Production,
-  relationships have explicit classes and lenses, owner/leaf groups use
-  source-grounded unique names, overview overflow is exact omission metadata
-  rather than `Other`, and HTML plus VS Code share the same Rust semantics.
-  Add architecture quality diagnostics, complete-group search, compact
-  index-based memberships, bounded
-  drill-down, explicit versioned overlays, and migration guidance for direct
-  `compass.viewer.callflow/1` consumers.
-
-- Add bounded native PDF, DOCX, PPTX, and XLSX document artifacts and graph
-  projection, gap-free semantic slicing, pure-Rust PDF rasterization, optional
-  local PP-OCRv6 OCR, explicit pinned model management, and the
-  `document inspect` and `models` command families. OCR remains off by default
-  and requires no Python, Tesseract, office suite, or system PDF installation.
-  Harden document reads against files that grow while being read, validate
-  cached and OCR-derived artifact coherence, bound aggregate raster work and
-  per-tile deadlines, and serialize model installation while rejecting symlinked
-  model artifacts and markers.
-  Preserve Intel macOS builds by excluding the unavailable ONNX runtime on that
-  target; native document processing remains available and managed OCR reports
-  an explicit unsupported-platform error before downloading model weights.
-  The graph viewer now exposes combined/native/OCR evidence tabs, confidence
-  and page/slide/sheet locators, bounded OCR region previews, coverage warnings,
-  and a managed model status/install card during initialization.
-
-- Make semantic provider choice explicit and repeatable with `--backend`,
-  `--model`, `COMPASS_BACKEND`, and `COMPASS_MODEL`. Credential guidance now
-  covers all built-in providers and custom provider environment keys without
-  exposing secrets in Compass configuration or artifacts.
-
-- Hard-cut Swift, Dart, Scala, and Groovy/Gradle onto version-1 qualifying
-  universal evidence pipelines. The bounded AST-first producer publishes
-  declarations, scopes, bindings, occurrences, and conservative relationship
-  candidates with exact language constraints; Swift Vapor routes now use the
-  `vapor-swift` evidence-backed pack, bounded `pubspec.yaml`/`build.sbt`/
-  `Package.swift`/Gradle project metadata participates in fingerprints, and
-  legacy Swift member-table plus broad JVM stub rewiring no longer selects
-  targets for these languages.
-
-- Complete the independent SwiftSyntax, Dart Analyzer, scala.meta, and Groovy
-  CompilationUnit qualification providers. Clean pinned Swift, Dart, Scala,
-  and Groovy corpora now pass the graph-backed precision/recall audits and
-  fixture performance gates; the four production pipelines remain
-  `Qualifying` pending a separate promotion decision.
-
-- Turn the VS Code codebase query view into a multi-command workbench with
-  separate Ask, Explain, and CompassQL composers and durable result tabs.
-  Typed Ask diagnostics, symbol relationships, source links, and CompassQL rows
-  now render as readable UI instead of raw JSON. Typed `compass ask` also
-  accepts `--at REV` for immutable revision graphs.
-
-- Let VS Code users open a call graph by entering a function name, qualified
-  name, or stable symbol ID in the Call Graph pane, with callers, callees, or
-  both selectable before tracing. The existing cursor workflow remains
-  available in the same pane.
-
-- Keep Codebase Evolution strict when a stored revision uses an unsupported
-  artifact layout, and offer to rebuild the affected revision with the current
-  Compass version instead of mapping legacy history records.
-
 - Make community detail graphs easier to scan in both exported HTML and VS
   Code by grouping node kinds into accessible color-and-shape families,
   coloring edges by relationship purpose while retaining confidence strokes,
@@ -149,6 +62,43 @@
   already materialized. Rebuilding does not order or allowlist Compass release
   numbers: it preserves matching user-selected options, replaces engine-owned
   fingerprint fields, and keeps original historical realizations immutable.
+
+## 0.3.20 - 2026-08-24
+
+- Add Grounded Agent Graph overlays with citation-backed node, edge, Challenge,
+  and Retraction operations, immutable CAS-activated revisions, exact rebase,
+  historical composition, bounded audit, and read-only ingestion preparation.
+  Continuous enrichment is now documented in the bundled coding-agent skill.
+
+- Add versioned `compass.task-context/2` framework evidence for React and
+  frontend workflows, including route stages, render direction, runtime
+  boundaries, configuration dependencies, provenance, and qualification state.
+
+- Harden React frontend graph extraction with exact JSX `renders` edges,
+  component/hook/client/server role evidence, typed Next.js, React
+  Router/Remix, TanStack Router, and Vite semantics, bounded configuration
+  precedence, and strict viewer/query contracts.
+
+- Replace the flat call-flow model with the native
+  `compass.viewer.architecture/1` projection, including production-first
+  scoping, explicit relationship classes, source-grounded group names, exact
+  overflow metadata, bounded drill-down, and shared HTML/VS Code semantics.
+
+- Add bounded native PDF, DOCX, PPTX, and XLSX artifacts with pure-Rust
+  rasterization, optional managed PP-OCRv6, pinned model management, document
+  inspection, OCR evidence views, and explicit Intel-macOS limitations.
+
+- Make semantic provider and model selection explicit with `--backend`,
+  `--model`, `COMPASS_BACKEND`, and `COMPASS_MODEL`, while keeping credentials
+  out of Compass configuration and artifacts.
+
+- Move Swift, Dart, Scala, and Groovy/Gradle onto qualifying universal
+  evidence pipelines and complete their independent precision/recall and
+  fixture performance qualification providers.
+
+- Turn the VS Code codebase query view into a multi-command Ask, Explain, and
+  CompassQL workbench, add direct symbol-based caller/callee graphs, and keep
+  historical views strict about unsupported artifact layouts.
 
 ## 0.3.19 - 2026-08-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-agent-graph"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "compass-store",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "glob",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-agent-graph",
  "compass-analysis",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-agent-graph",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "regex",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "axum",
  "compass-agent-graph",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-ocr",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ocr"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "image",
  "oar-ocr",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-agent-graph",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "base64 0.22.1",
  "compass-agent-graph",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.19"
+version = "0.3.20"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-agent-graph/Cargo.toml
+++ b/crates/compass-agent-graph/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -19,7 +19,7 @@ name = "compass"
 path = "src/bin/compass.rs"
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.19" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.20" }
 ctrlc.workspace = true
 flate2.workspace = true
 glob.workspace = true
@@ -36,32 +36,32 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.19" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-program = { path = "../compass-program", version = "0.3.19" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.19" }
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.19" }
-compass-global = { path = "../compass-global", version = "0.3.19" }
-compass-history = { path = "../compass-history", version = "0.3.19" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.19" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-media = { path = "../compass-media", version = "0.3.19" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.19" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.19" }
-compass-output = { path = "../compass-output", version = "0.3.19" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.19" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
-compass-prs = { path = "../compass-prs", version = "0.3.19" }
-compass-query = { path = "../compass-query", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.19" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
+compass-core = { path = "../compass-core", version = "0.3.20" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-program = { path = "../compass-program", version = "0.3.20" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.20" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.20" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.20" }
+compass-global = { path = "../compass-global", version = "0.3.20" }
+compass-history = { path = "../compass-history", version = "0.3.20" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.20" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-media = { path = "../compass-media", version = "0.3.20" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.20" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.20" }
+compass-output = { path = "../compass-output", version = "0.3.20" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.20" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.20" }
+compass-prs = { path = "../compass-prs", version = "0.3.20" }
+compass-query = { path = "../compass-query", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.20" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.20" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.20" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,10 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.19" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-program = { path = "../compass-program", version = "0.3.19" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.20" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-program = { path = "../compass-program", version = "0.3.20" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -25,22 +25,22 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.19" }
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
-compass-media = { path = "../compass-media", version = "0.3.19" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-history = { path = "../compass-history", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
-compass-output = { path = "../compass-output", version = "0.3.19" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
-compass-prs = { path = "../compass-prs", version = "0.3.19" }
-compass-query = { path = "../compass-query", version = "0.3.19" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.19" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.20" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
+compass-media = { path = "../compass-media", version = "0.3.20" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-history = { path = "../compass-history", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
+compass-output = { path = "../compass-output", version = "0.3.20" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.20" }
+compass-prs = { path = "../compass-prs", version = "0.3.20" }
+compass-query = { path = "../compass-query", version = "0.3.20" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.20" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.20" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.20" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.19" }
+compass-media = { path = "../compass-media", version = "0.3.20" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-program = { path = "../compass-program", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-program = { path = "../compass-program", version = "0.3.20" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.19" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.20" }
 axum.workspace = true
 rmcp.workspace = true
 serde_json.workspace = true
@@ -20,19 +20,19 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.19" }
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-history = { path = "../compass-history", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-output = { path = "../compass-output", version = "0.3.19" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
-compass-prs = { path = "../compass-prs", version = "0.3.19" }
-compass-query = { path = "../compass-query", version = "0.3.19" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.19" }
+compass-core = { path = "../compass-core", version = "0.3.20" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-history = { path = "../compass-history", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-output = { path = "../compass-output", version = "0.3.20" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.20" }
+compass-prs = { path = "../compass-prs", version = "0.3.20" }
+compass-query = { path = "../compass-query", version = "0.3.20" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.20" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-media/Cargo.toml
+++ b/crates/compass-media/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.20" }
 hayro.workspace = true
 image.workspace = true
 oxidize-pdf.workspace = true

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.19" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.20" }
 ahash.workspace = true
 rayon.workspace = true
 serde.workspace = true
@@ -21,14 +21,14 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-history = { path = "../compass-history", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
-compass-query = { path = "../compass-query", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-history = { path = "../compass-history", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.20" }
+compass-query = { path = "../compass-query", version = "0.3.20" }
 unicode-normalization.workspace = true
 url.workspace = true
 

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.19" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.20" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.19" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.20" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.19" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.20" }
 base64.workspace = true
 regex.workspace = true
 rusqlite.workspace = true
@@ -20,12 +20,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -33,9 +33,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.19" }
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.19" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.20" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.20" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-program = { path = "../compass-program", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-program = { path = "../compass-program", version = "0.3.20" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.19" }
-compass-history = { path = "../compass-history", version = "0.3.19" }
-compass-ir = { path = "../compass-ir", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.20" }
+compass-history = { path = "../compass-history", version = "0.3.20" }
+compass-ir = { path = "../compass-ir", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.19" }
-compass-program = { path = "../compass-program", version = "0.3.19" }
+compass-languages = { path = "../compass-languages", version = "0.3.20" }
+compass-program = { path = "../compass-program", version = "0.3.20" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.19" }
-compass-media = { path = "../compass-media", version = "0.3.19" }
+compass-files = { path = "../compass-files", version = "0.3.20" }
+compass-media = { path = "../compass-media", version = "0.3.20" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.19" }
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-query = { path = "../compass-query", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.19" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.20" }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-query = { path = "../compass-query", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.20" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.19" }
+compass-store = { path = "../compass-store", version = "0.3.20" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.19" }
-compass-model = { path = "../compass-model", version = "0.3.19" }
-compass-store = { path = "../compass-store", version = "0.3.19", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.20" }
+compass-model = { path = "../compass-model", version = "0.3.20" }
+compass-store = { path = "../compass-store", version = "0.3.20", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.19", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.19", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.20", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.20", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "glob",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "axum",
  "compass-core",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "base64 0.22.1",
  "compass-analysis",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.19", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.19", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.19", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.19", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.19", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.19", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.19", path = "../crates/compass-output" }
-compass-query = { version = "0.3.19", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.19", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.19", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.20", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.20", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.20", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.20", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.20", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.20", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.20", path = "../crates/compass-output" }
+compass-query = { version = "0.3.20", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.20", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.20", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1746,7 +1746,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.19"
+    "producerVersion": "compass-languages/0.3.20"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- Bump the Compass workspace and internal package metadata to 0.3.20.
- Align the VS Code package metadata and qualification producer with 0.3.20.
- Move the pending user-facing changes into the 0.3.20 changelog section dated 2026-08-24.

## Release highlights

- Grounded Agent Graph overlays with citation-backed operations, immutable revisions, exact rebase, and bounded audit.
- React/frontend graph hardening and the native architecture viewer projection.
- Native document artifacts with managed OCR and explicit platform behavior.
- Explicit semantic provider/model selection and qualifying Swift, Dart, Scala, and Groovy pipelines.
- VS Code Ask/Explain/CompassQL workbench and direct caller/callee graphs.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `sh scripts/check_product_boundary.sh`
- `sh scripts/test_release_scripts.sh`
- JSON parsing, metadata consistency, and `git diff --check`
- Full platform builds and release qualification are intentionally delegated to the required GitHub Actions release/PR workflows for this remote-only release request.

The separate local Marketplace publishing workflow edit is not included in this PR.
