### PR TITLE
Fix 0.3.20 code-graph qualification for generated Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
 
 ## 0.3.20 - 2026-08-24
 
+- Keep large generated Go/OpenAPI sources within bounded framework extraction
+  budgets, preserving zero-error qualification for complete enterprise graphs.
+
 - Add Grounded Agent Graph overlays with citation-backed node, edge, Challenge,
   and Retraction operations, immutable CAS-activated revisions, exact rebase,
   historical composition, bounded audit, and read-only ingestion preparation.

--- a/crates/compass-languages/src/frameworks/mod.rs
+++ b/crates/compass-languages/src/frameworks/mod.rs
@@ -128,6 +128,24 @@ impl FrameworkPack {
         semantics_version: u32,
         detector: SourceDetector,
     ) -> Self {
+        Self::source_versioned_with_limits(
+            id,
+            languages,
+            dependency_markers,
+            semantics_version,
+            FrameworkLimits::DEFAULT,
+            detector,
+        )
+    }
+
+    const fn source_versioned_with_limits(
+        id: &'static str,
+        languages: &'static [&'static str],
+        dependency_markers: &'static [&'static str],
+        semantics_version: u32,
+        limits: FrameworkLimits,
+        detector: SourceDetector,
+    ) -> Self {
         Self {
             id,
             semantics_version,
@@ -136,7 +154,7 @@ impl FrameworkPack {
             dependency_markers,
             configuration_markers: &[],
             manifest_policy: FrameworkManifestPolicy::Advisory,
-            limits: FrameworkLimits::DEFAULT,
+            limits,
             adapter: FrameworkPackAdapter::Source(detector),
         }
     }
@@ -368,7 +386,20 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
     FrameworkPack::source_versioned("python-web", &["python"], &[], 1, detect_python),
     FrameworkPack::universal(&pack::PHP_FRAMEWORKS_DESCRIPTOR, php::detect),
     FrameworkPack::universal(&pack::RAILS_RUBY_DESCRIPTOR, ruby::detect_universal),
-    FrameworkPack::source_versioned("go-web", &["go"], &[], 1, detect_go),
+    FrameworkPack::source_versioned_with_limits(
+        "go-web",
+        &["go"],
+        &[],
+        1,
+        FrameworkLimits {
+            // Generated OpenAPI Go files in the pinned qualification corpus
+            // exceed the shared 100k budget while remaining within the
+            // bounded parser-inspection ceiling.
+            max_syntax_nodes: 200_000,
+            ..FrameworkLimits::DEFAULT
+        },
+        detect_go,
+    ),
     FrameworkPack::source_versioned("axum-web", &["rust"], &["axum"], 1, detect_axum),
     FrameworkPack::source_versioned("rust-web", &["rust"], &[], 1, detect_rust),
     FrameworkPack::universal(&pack::VAPOR_SWIFT_DESCRIPTOR, detect_swift_universal),
@@ -505,7 +536,13 @@ const FRAMEWORK_PACKS: &[FrameworkPack] = &[
         dependency_markers: &[],
         configuration_markers: &[],
         manifest_policy: FrameworkManifestPolicy::Advisory,
-        limits: FrameworkLimits::DEFAULT,
+        limits: FrameworkLimits {
+            // Generated OpenAPI Go files can also activate the language-wide
+            // enterprise detector, which does not traverse syntax but still
+            // shares this pack-level preflight budget.
+            max_syntax_nodes: 200_000,
+            ..FrameworkLimits::DEFAULT
+        },
         adapter: FrameworkPackAdapter::Source(detect_enterprise),
     },
     FrameworkPack::config_versioned(
@@ -1074,7 +1111,7 @@ fn is_play_routes(path: &Path) -> bool {
 mod tests {
     use std::collections::HashSet;
 
-    use super::{FRAMEWORK_PACKS, FrameworkPackKind};
+    use super::{FRAMEWORK_PACKS, FrameworkLimits, FrameworkPackKind};
 
     #[test]
     fn framework_pack_registry_ids_are_unique_and_well_formed() {
@@ -1142,6 +1179,29 @@ mod tests {
                 assert!(!pack.dependency_markers.is_empty());
             }
         }
+    }
+
+    #[test]
+    fn go_web_uses_explicit_budget_for_large_generated_sources() {
+        let go_web = FRAMEWORK_PACKS
+            .iter()
+            .find(|pack| pack.id == "go-web")
+            .expect("go-web framework pack");
+        assert_eq!(go_web.limits.max_syntax_nodes, 200_000);
+        assert_eq!(
+            FrameworkLimits::DEFAULT.max_syntax_nodes,
+            100_000,
+            "the expanded budget must not change the shared default"
+        );
+    }
+
+    #[test]
+    fn enterprise_domain_pack_matches_large_source_budget() {
+        let enterprise = FRAMEWORK_PACKS
+            .iter()
+            .find(|pack| pack.id == "enterprise-domain-facts")
+            .expect("enterprise-domain-facts framework pack");
+        assert_eq!(enterprise.limits.max_syntax_nodes, 200_000);
     }
 
     #[test]

--- a/crates/compass-languages/src/frameworks/typescript_syntax.rs
+++ b/crates/compass-languages/src/frameworks/typescript_syntax.rs
@@ -25,7 +25,10 @@ pub(crate) fn has_default_export_keyword(node: Node<'_>) -> bool {
 
 pub(crate) const SYNTAX_VIEW_VERSION: &str = "compass.frontend-syntax/2";
 pub(crate) const MAX_SYNTAX_DEPTH: usize = 256;
-pub(crate) const MAX_SYNTAX_NODES: usize = 100_000;
+/// Shared traversal ceiling. Individual framework packs may choose a lower
+/// budget; the view must be able to distinguish those pack-level limits from
+/// the hard parser-inspection ceiling.
+pub(crate) const MAX_SYNTAX_NODES: usize = 200_000;
 pub(crate) const MAX_STATIC_DEPTH: usize = 32;
 pub(crate) const MAX_STATIC_ITEMS: usize = 2_048;
 pub(crate) const MAX_STATIC_BYTES: usize = 64 * 1024;


### PR DESCRIPTION
## Summary
- raise the bounded parser-inspection ceiling so pack-specific budgets can distinguish large generated sources
- give `go-web` and the language-wide enterprise pack an explicit 200k syntax-node budget while retaining the 100k shared default
- record the qualification hardening in the 0.3.20 changelog

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p compass-languages --lib --locked` (67 passed)
- `cargo test -p compass-languages --test engine_edge_coverage --locked` (40 passed)
- `cargo test -p compass-cli --test compass_product --locked` (8 passed)
- `sh scripts/check_product_boundary.sh`
- `sh scripts/test_release_scripts.sh`
- exact pinned `entire-cli@683a10d3773ee4830ee791f39d76d8092ef1b0cf` qualification (0 validation errors)

The existing `compass-v0.3.20` tag has no GitHub release because its first workflow run failed this gate. After this PR is green and merged, the unpublished tag will be replaced with the corrected merge commit and the release workflow rerun.
