### PR TITLE
Release Compass 0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,6 @@
 
 ## Unreleased
 
-- Harden Markdown intelligence within `compass.graph/1`. Pipe tables retain
-  table, header, row, and cell nodes while gaining stable semantic identities,
-  header-qualified labels, exact cell-owned references, bounded per-table
-  extraction, and topology-aware containment handling. Nested YAML frontmatter
-  now publishes exact source-backed config-key hierarchies with stable escaped
-  paths, conservative semantic labels, bounded parsing, and fail-closed unsafe
-  syntax handling. Published document nodes remain graph-v1 resources; no graph
-  schema migration is required.
-
-- Make community detail graphs easier to scan in both exported HTML and VS
-  Code by grouping node kinds into accessible color-and-shape families,
-  coloring edges by relationship purpose while retaining confidence strokes,
-  and showing a compact legend for the categories present in the subgraph.
-
 - Refactor universal language metadata around `UniversalEvidenceProducer` and
   `UniversalEvidencePipeline`. `UniversalCandidate`/`UniversalComplete` are
   now the clearer lifecycle states `Qualifying`/`Qualified`; the serialized
@@ -71,6 +57,22 @@
   already materialized. Rebuilding does not order or allowlist Compass release
   numbers: it preserves matching user-selected options, replaces engine-owned
   fingerprint fields, and keeps original historical realizations immutable.
+
+## 0.3.22 - 2026-08-27
+
+- Harden Markdown intelligence within `compass.graph/1`. Pipe tables retain
+  table, header, row, and cell nodes while gaining stable semantic identities,
+  header-qualified labels, exact cell-owned references, bounded per-table
+  extraction, and topology-aware containment handling. Nested YAML frontmatter
+  now publishes exact source-backed config-key hierarchies with stable escaped
+  paths, conservative semantic labels, bounded parsing, and fail-closed unsafe
+  syntax handling. Published document nodes remain graph-v1 resources; no graph
+  schema migration is required.
+
+- Improve exported HTML and VS Code graph inspectors with deterministic incoming
+  and outgoing relationship groups, relationship summaries, direction counts,
+  neighbor focus controls, and clearer icon-backed Callers, Callees, and Impact
+  actions while preserving accessible labels and stable ordering.
 
 ## 0.3.21 - 2026-08-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-agent-graph"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "compass-store",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "glob",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-agent-graph",
  "compass-analysis",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-agent-graph",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "regex",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "axum",
  "compass-agent-graph",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "base64 0.22.1",
  "compass-files",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ocr"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "image",
  "oar-ocr",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-agent-graph",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "base64 0.22.1",
  "compass-agent-graph",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-qualification"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-cypher",
  "compass-graph",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store-redb"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-graph",
  "compass-model",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-ingest",
  "compass-whisper",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "compass-whisper"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "3"
 exclude = ["fuzz", "vendor/gemm-common"]
 
 [workspace.package]
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT OR Apache-2.0"

--- a/crates/compass-agent-graph/Cargo.toml
+++ b/crates/compass-agent-graph/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-analysis/Cargo.toml
+++ b/crates/compass-analysis/Cargo.toml
@@ -12,8 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 rayon.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/crates/compass-cargo/Cargo.toml
+++ b/crates/compass-cargo/Cargo.toml
@@ -16,7 +16,7 @@ glob.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-cli/Cargo.toml
+++ b/crates/compass-cli/Cargo.toml
@@ -19,7 +19,7 @@ name = "compass"
 path = "src/bin/compass.rs"
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.21" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.22" }
 ctrlc.workspace = true
 flate2.workspace = true
 glob.workspace = true
@@ -36,32 +36,32 @@ time.workspace = true
 tokio.workspace = true
 toml.workspace = true
 ureq.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.21" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-program = { path = "../compass-program", version = "0.3.21" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.21" }
-compass-cargo = { path = "../compass-cargo", version = "0.3.21" }
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.21" }
-compass-global = { path = "../compass-global", version = "0.3.21" }
-compass-history = { path = "../compass-history", version = "0.3.21" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.21" }
-compass-ingest = { path = "../compass-ingest", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-media = { path = "../compass-media", version = "0.3.21" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.21" }
-compass-mcp = { path = "../compass-mcp", version = "0.3.21" }
-compass-output = { path = "../compass-output", version = "0.3.21" }
-compass-postgres = { path = "../compass-postgres", version = "0.3.21" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.21" }
-compass-prs = { path = "../compass-prs", version = "0.3.21" }
-compass-query = { path = "../compass-query", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.21" }
-compass-semantic = { path = "../compass-semantic", version = "0.3.21" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.21" }
+compass-core = { path = "../compass-core", version = "0.3.22" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-program = { path = "../compass-program", version = "0.3.22" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.22" }
+compass-cargo = { path = "../compass-cargo", version = "0.3.22" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.22" }
+compass-global = { path = "../compass-global", version = "0.3.22" }
+compass-history = { path = "../compass-history", version = "0.3.22" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.22" }
+compass-ingest = { path = "../compass-ingest", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-media = { path = "../compass-media", version = "0.3.22" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.22" }
+compass-mcp = { path = "../compass-mcp", version = "0.3.22" }
+compass-output = { path = "../compass-output", version = "0.3.22" }
+compass-postgres = { path = "../compass-postgres", version = "0.3.22" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.22" }
+compass-prs = { path = "../compass-prs", version = "0.3.22" }
+compass-query = { path = "../compass-query", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.22" }
+compass-semantic = { path = "../compass-semantic", version = "0.3.22" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.22" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-core/Cargo.toml
+++ b/crates/compass-core/Cargo.toml
@@ -12,10 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.21" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-program = { path = "../compass-program", version = "0.3.21" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.22" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-program = { path = "../compass-program", version = "0.3.22" }
 ahash.workspace = true
 rayon.workspace = true
 notify.workspace = true
@@ -25,22 +25,22 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.21" }
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
-compass-media = { path = "../compass-media", version = "0.3.21" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-history = { path = "../compass-history", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
-compass-output = { path = "../compass-output", version = "0.3.21" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.21" }
-compass-prs = { path = "../compass-prs", version = "0.3.21" }
-compass-query = { path = "../compass-query", version = "0.3.21" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.21" }
-compass-resolve = { path = "../compass-resolve", version = "0.3.21" }
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-google-workspace = { path = "../compass-google-workspace", version = "0.3.22" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
+compass-media = { path = "../compass-media", version = "0.3.22" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-history = { path = "../compass-history", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
+compass-output = { path = "../compass-output", version = "0.3.22" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.22" }
+compass-prs = { path = "../compass-prs", version = "0.3.22" }
+compass-query = { path = "../compass-query", version = "0.3.22" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.22" }
+compass-resolve = { path = "../compass-resolve", version = "0.3.22" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.22" }
 
 [lints]
 workspace = true

--- a/crates/compass-cypher/Cargo.toml
+++ b/crates/compass-cypher/Cargo.toml
@@ -17,7 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 
 [dev-dependencies]
 toml.workspace = true

--- a/crates/compass-global/Cargo.toml
+++ b/crates/compass-global/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-google-workspace/Cargo.toml
+++ b/crates/compass-google-workspace/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-compass-media = { path = "../compass-media", version = "0.3.21" }
+compass-media = { path = "../compass-media", version = "0.3.22" }
 url.workspace = true
 wait-timeout.workspace = true
 

--- a/crates/compass-graph/Cargo.toml
+++ b/crates/compass-graph/Cargo.toml
@@ -19,9 +19,9 @@ sha1.workspace = true
 sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
 rayon.workspace = true
 rmp-serde.workspace = true
 unicode-casefold.workspace = true

--- a/crates/compass-graphdb/Cargo.toml
+++ b/crates/compass-graphdb/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 rustls-platform-verifier.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 url.workspace = true
 
 [lints]

--- a/crates/compass-history/Cargo.toml
+++ b/crates/compass-history/Cargo.toml
@@ -21,10 +21,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 
 [target.'cfg(windows)'.dependencies]
 # `replace_atomic` uses MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), providing the

--- a/crates/compass-ingest/Cargo.toml
+++ b/crates/compass-ingest/Cargo.toml
@@ -19,8 +19,8 @@ sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-languages/Cargo.toml
+++ b/crates/compass-languages/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 ahash.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-program = { path = "../compass-program", version = "0.3.21" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-program = { path = "../compass-program", version = "0.3.22" }
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
@@ -25,7 +25,7 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
 tree-sitter.workspace = true
 tree-sitter-dm.workspace = true
 tree-sitter-html.workspace = true

--- a/crates/compass-mcp/Cargo.toml
+++ b/crates/compass-mcp/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.21" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.22" }
 axum.workspace = true
 rmcp.workspace = true
 serde_json.workspace = true
@@ -20,19 +20,19 @@ time.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tower-http.workspace = true
-compass-core = { path = "../compass-core", version = "0.3.21" }
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-history = { path = "../compass-history", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-output = { path = "../compass-output", version = "0.3.21" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.21" }
-compass-prs = { path = "../compass-prs", version = "0.3.21" }
-compass-query = { path = "../compass-query", version = "0.3.21" }
-compass-reflect = { path = "../compass-reflect", version = "0.3.21" }
+compass-core = { path = "../compass-core", version = "0.3.22" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-history = { path = "../compass-history", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-output = { path = "../compass-output", version = "0.3.22" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.22" }
+compass-prs = { path = "../compass-prs", version = "0.3.22" }
+compass-query = { path = "../compass-query", version = "0.3.22" }
+compass-reflect = { path = "../compass-reflect", version = "0.3.22" }
 
 [dev-dependencies]
-compass-store = { path = "../compass-store", version = "0.3.21" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
 rmcp = { workspace = true, features = ["client"] }
 tempfile.workspace = true
 

--- a/crates/compass-media/Cargo.toml
+++ b/crates/compass-media/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 
 [dependencies]
 base64.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-ocr = { path = "../compass-ocr", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-ocr = { path = "../compass-ocr", version = "0.3.22" }
 hayro.workspace = true
 image.workspace = true
 oxidize-pdf.workspace = true

--- a/crates/compass-output/Cargo.toml
+++ b/crates/compass-output/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.21" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.22" }
 ahash.workspace = true
 rayon.workspace = true
 serde.workspace = true
@@ -21,14 +21,14 @@ sha1.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-cypher = { path = "../compass-cypher", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-history = { path = "../compass-history", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.21" }
-compass-query = { path = "../compass-query", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-history = { path = "../compass-history", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.22" }
+compass-query = { path = "../compass-query", version = "0.3.22" }
 unicode-normalization.workspace = true
 url.workspace = true
 

--- a/crates/compass-postgres/Cargo.toml
+++ b/crates/compass-postgres/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
 tokio-postgres-rustls.workspace = true
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-pr-intelligence/Cargo.toml
+++ b/crates/compass-pr-intelligence/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.21" }
+compass-semantic-diff = { path = "../compass-semantic-diff", version = "0.3.22" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-program/Cargo.toml
+++ b/crates/compass-program/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ahash.workspace = true
 base64.workspace = true
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
 protobuf.workspace = true
 rayon.workspace = true
 scip.workspace = true

--- a/crates/compass-prs/Cargo.toml
+++ b/crates/compass-prs/Cargo.toml
@@ -17,9 +17,9 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.21" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-pr-intelligence = { path = "../compass-pr-intelligence", version = "0.3.22" }
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/crates/compass-query/Cargo.toml
+++ b/crates/compass-query/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.21" }
+compass-agent-graph = { path = "../compass-agent-graph", version = "0.3.22" }
 base64.workspace = true
 regex.workspace = true
 rusqlite.workspace = true
@@ -20,12 +20,12 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-compass-cypher = { path = "../compass-cypher", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
 unicode-normalization.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -33,9 +33,9 @@ libc = "0.2"
 rustix.workspace = true
 
 [dev-dependencies]
-compass-graphdb = { path = "../compass-graphdb", version = "0.3.21" }
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.21" }
+compass-graphdb = { path = "../compass-graphdb", version = "0.3.22" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.22" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-reflect/Cargo.toml
+++ b/crates/compass-reflect/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compass-resolve/Cargo.toml
+++ b/crates/compass-resolve/Cargo.toml
@@ -19,15 +19,15 @@ serde.workspace = true
 serde_json.workspace = true
 sha1.workspace = true
 thiserror.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-program = { path = "../compass-program", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-program = { path = "../compass-program", version = "0.3.22" }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
 tempfile.workspace = true

--- a/crates/compass-semantic-diff/Cargo.toml
+++ b/crates/compass-semantic-diff/Cargo.toml
@@ -12,18 +12,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-analysis = { path = "../compass-analysis", version = "0.3.21" }
-compass-history = { path = "../compass-history", version = "0.3.21" }
-compass-ir = { path = "../compass-ir", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
+compass-analysis = { path = "../compass-analysis", version = "0.3.22" }
+compass-history = { path = "../compass-history", version = "0.3.22" }
+compass-ir = { path = "../compass-ir", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-compass-languages = { path = "../compass-languages", version = "0.3.21" }
-compass-program = { path = "../compass-program", version = "0.3.21" }
+compass-languages = { path = "../compass-languages", version = "0.3.22" }
+compass-program = { path = "../compass-program", version = "0.3.22" }
 
 [lints]
 workspace = true

--- a/crates/compass-semantic/Cargo.toml
+++ b/crates/compass-semantic/Cargo.toml
@@ -22,8 +22,8 @@ sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
-compass-files = { path = "../compass-files", version = "0.3.21" }
-compass-media = { path = "../compass-media", version = "0.3.21" }
+compass-files = { path = "../compass-files", version = "0.3.22" }
+compass-media = { path = "../compass-media", version = "0.3.22" }
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true

--- a/crates/compass-store-qualification/Cargo.toml
+++ b/crates/compass-store-qualification/Cargo.toml
@@ -15,12 +15,12 @@ name = "compass-store-qualification"
 path = "src/main.rs"
 
 [dependencies]
-compass-cypher = { path = "../compass-cypher", version = "0.3.21" }
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-query = { path = "../compass-query", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21" }
-compass-store-redb = { path = "../compass-store-redb", version = "0.3.21" }
+compass-cypher = { path = "../compass-cypher", version = "0.3.22" }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-query = { path = "../compass-query", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
+compass-store-redb = { path = "../compass-store-redb", version = "0.3.22" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/compass-store-redb/Cargo.toml
+++ b/crates/compass-store-redb/Cargo.toml
@@ -12,14 +12,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-compass-store = { path = "../compass-store", version = "0.3.21" }
+compass-store = { path = "../compass-store", version = "0.3.22" }
 redb.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-compass-graph = { path = "../compass-graph", version = "0.3.21" }
-compass-model = { path = "../compass-model", version = "0.3.21" }
-compass-store = { path = "../compass-store", version = "0.3.21", features = ["test-support"] }
+compass-graph = { path = "../compass-graph", version = "0.3.22" }
+compass-model = { path = "../compass-model", version = "0.3.22" }
+compass-store = { path = "../compass-store", version = "0.3.22", features = ["test-support"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/compass-transcribe/Cargo.toml
+++ b/crates/compass-transcribe/Cargo.toml
@@ -28,8 +28,8 @@ rubato.workspace = true
 ureq.workspace = true
 url.workspace = true
 wait-timeout.workspace = true
-compass-ingest = { version = "0.3.21", path = "../compass-ingest" }
-compass-whisper = { version = "0.3.21", path = "../compass-whisper", optional = true }
+compass-ingest = { version = "0.3.22", path = "../compass-ingest" }
+compass-whisper = { version = "0.3.22", path = "../compass-whisper", optional = true }
 
 [lints]
 workspace = true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Compass Codegraph",
   "description": "Explore, query, and understand how your codebase evolves with Compass.",
   "publisher": "crabbuild",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "compass-analysis"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-ir",
  "compass-model",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cargo"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "glob",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cli"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-analysis",
  "compass-cargo",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "compass-core"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "compass-cypher"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "regex",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "compass-files"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "atomicwrites",
  "glob",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "compass-global"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "compass-google-workspace"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-media",
  "serde_json",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graph"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-languages",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "compass-graphdb"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-model",
  "rustls",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "compass-history"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "atomicwrites",
  "compass-analysis",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ingest"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-languages",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "compass-ir"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "compass-languages"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "compass-mcp"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "axum",
  "compass-core",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "compass-media"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "oxidize-pdf",
  "roxmltree",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "compass-model"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "rayon",
  "rmp-serde",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "compass-output"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-analysis",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "compass-postgres"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-languages",
  "rustls",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "compass-pr-intelligence"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-semantic-diff",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "compass-program"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "compass-prs"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "compass-query"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "base64 0.22.1",
  "compass-analysis",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "compass-reflect"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-files",
  "compass-model",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "compass-resolve"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "ahash",
  "compass-files",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "compass-semantic-diff"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-analysis",
  "compass-history",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "compass-store"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "compass-transcribe"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "compass-ingest",
  "rubato",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,16 +12,16 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 serde_json = "1"
 tempfile = "3"
-compass-model = { version = "0.3.21", path = "../crates/compass-model" }
-compass-cli = { version = "0.3.21", path = "../crates/compass-cli" }
-compass-cypher = { version = "0.3.21", path = "../crates/compass-cypher" }
-compass-files = { version = "0.3.21", path = "../crates/compass-files" }
-compass-graph = { version = "0.3.21", path = "../crates/compass-graph" }
-compass-languages = { version = "0.3.21", path = "../crates/compass-languages" }
-compass-output = { version = "0.3.21", path = "../crates/compass-output" }
-compass-query = { version = "0.3.21", path = "../crates/compass-query" }
-compass-semantic = { version = "0.3.21", path = "../crates/compass-semantic" }
-compass-transcribe = { version = "0.3.21", path = "../crates/compass-transcribe", default-features = false }
+compass-model = { version = "0.3.22", path = "../crates/compass-model" }
+compass-cli = { version = "0.3.22", path = "../crates/compass-cli" }
+compass-cypher = { version = "0.3.22", path = "../crates/compass-cypher" }
+compass-files = { version = "0.3.22", path = "../crates/compass-files" }
+compass-graph = { version = "0.3.22", path = "../crates/compass-graph" }
+compass-languages = { version = "0.3.22", path = "../crates/compass-languages" }
+compass-output = { version = "0.3.22", path = "../crates/compass-output" }
+compass-query = { version = "0.3.22", path = "../crates/compass-query" }
+compass-semantic = { version = "0.3.22", path = "../crates/compass-semantic" }
+compass-transcribe = { version = "0.3.22", path = "../crates/compass-transcribe", default-features = false }
 
 [[bin]]
 name = "graph_input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     },
     "editors/vscode": {
       "name": "crabbuild-compass-vscode",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@compass/viewer": "0.1.0",

--- a/tests/qualification/code-graph-v1-semantic.json
+++ b/tests/qualification/code-graph-v1-semantic.json
@@ -1746,7 +1746,7 @@
   ],
   "languages": {
     "source": "corpus",
-    "producerVersion": "compass-languages/0.3.21"
+    "producerVersion": "compass-languages/0.3.22"
   },
   "occurrences": [
     {


### PR DESCRIPTION
## Summary

- Bump the Compass workspace, internal crates, VS Code extension, lockfiles, and qualification producer metadata to `0.3.22`.
- Document the Markdown graph intelligence and HTML/VS Code graph inspector improvements already landed on `origin/main`.
- Keep graph-v1 compatibility and deterministic release metadata intact.

## Release scope

This is the release metadata change for Compass `0.3.22`, based on the exact `origin/main` merge commit. Once merged, the annotated `compass-v0.3.22` tag will run the cross-platform release workflow for aarch64/x86_64 macOS, Linux, and Windows artifacts.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --lib --bins --locked -- -D warnings`
- `cargo test --workspace --lib --bins --locked`
- `cargo test -p compass-cli --test compass_product --locked`
- `scripts/check_product_boundary.sh`
- `scripts/test_release_scripts.sh`
- `scripts/qualify_code_graph_v1.sh --fixtures-only`
- `npm run typecheck:js`
- `npm run test:js`
- `node scripts/check_viewer_assets.mjs`
