### PR TITLE
Fix Markdown table identities for Compass v0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
   neighbor focus controls, and clearer icon-backed Callers, Callees, and Impact
   actions while preserving accessible labels and stable ordering.
 
+- Ensure multiple Markdown tables under one heading receive section-scoped
+  structural identities, preventing graph publication collisions when their
+  headers differ.
+
 ## 0.3.21 - 2026-08-25
 
 - Add source-proven Python graph intelligence with artifact-only SCIP

--- a/crates/compass-languages/src/markdown.rs
+++ b/crates/compass-languages/src/markdown.rs
@@ -905,8 +905,13 @@ impl State<'_, '_> {
             .map(|cell| truncate_utf8(&normalize_table_text(&cell.text), MAX_TABLE_CELL_BYTES))
             .collect::<Vec<_>>()
             .join("\u{1f}");
-        let table_key = format!("{source_section}\u{1e}{header_signature}");
-        let occurrence = self.table_occurrences.entry(table_key).or_default();
+        // Table ordinals are scoped to the containing section, not to the
+        // header signature. Different tables can share a section and must
+        // still receive distinct qualified names and structural identities.
+        let occurrence = self
+            .table_occurrences
+            .entry(source_section.clone())
+            .or_default();
         *occurrence = occurrence.saturating_add(1);
         let table_ordinal = *occurrence;
         let table_qualified_name = format!("{source_section}::pipe_table#{table_ordinal}");

--- a/crates/compass-languages/tests/markdown_coverage.rs
+++ b/crates/compass-languages/tests/markdown_coverage.rs
@@ -523,6 +523,60 @@ fn markdown_tables_publish_semantic_rows_and_retain_cell_links() -> Result<(), B
 }
 
 #[test]
+fn markdown_tables_with_different_headers_keep_section_scoped_identities()
+-> Result<(), Box<dyn Error>> {
+    let source = br#"# Event Object
+
+| Field | Type | Description |
+| --- | --- | --- |
+| name | string | Event name |
+
+| Value | Name | Description |
+| --- | --- | --- |
+| 1 | ready | Ready event |
+"#;
+    let extraction = Engine::default().extract_source(
+        std::path::Path::new("docs/architecture/external-agent-protocol.md"),
+        source,
+    )?;
+    let tables = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.attributes.get("document_kind") == Some(&serde_json::json!("pipe_table"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(tables.len(), 2);
+    assert_eq!(
+        tables
+            .iter()
+            .map(|node| node.string("qualified_name"))
+            .collect::<Vec<_>>(),
+        [
+            "Event Object::pipe_table#1".to_owned(),
+            "Event Object::pipe_table#2".to_owned(),
+        ]
+    );
+    assert_ne!(tables[0].id, tables[1].id);
+    let header_names = extraction
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.attributes.get("document_kind") == Some(&serde_json::json!("pipe_table_header"))
+        })
+        .map(|node| node.string("qualified_name"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        header_names,
+        [
+            "Event Object::pipe_table#1::pipe_table_header#1".to_owned(),
+            "Event Object::pipe_table#2::pipe_table_header#1".to_owned(),
+        ]
+    );
+    Ok(())
+}
+
+#[test]
 fn markdown_table_limits_are_truthful_and_later_blocks_survive() -> Result<(), Box<dyn Error>> {
     let directory = tempfile::tempdir()?;
     let path = directory.path().join("limits.md");


### PR DESCRIPTION
## Summary

- Scope Markdown pipe-table ordinals to their containing section so tables
  with different headers receive distinct structural identities.
- Add regression coverage for multiple differently headed tables under one
  heading.
- Document the release-visible graph publication fix in `CHANGELOG.md`.

## Why

The first `compass-v0.3.22` release workflow correctly stopped during the
code-graph qualification gate because two tables in `entire-cli` shared the
same qualified identity. This fix addresses that deterministic collision
before publishing the release.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p compass-languages --test markdown_coverage --locked`
- `cargo test -p compass-graph --test markdown_identity --locked`
- `cargo clippy -p compass-languages --lib --locked -- -D warnings`
- Exact pinned `entire-cli@683a10d3773ee4830ee791f39d76d8092ef1b0cf`
  qualification: passed with zero validation errors and zero identity
  collisions.

The broader package test Clippy target remains blocked by pre-existing
`expect_used` violations in unrelated framework-pack tests; the production
library Clippy gate passes.
